### PR TITLE
Adjusted BroadcastShardOperationResponse subclasses visibility

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotIndexShardStatus.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotIndexShardStatus.java
@@ -46,8 +46,8 @@ public class SnapshotIndexShardStatus extends BroadcastShardOperationResponse im
     private SnapshotIndexShardStatus() {
     }
 
-    SnapshotIndexShardStatus(String index, int shardId, SnapshotIndexShardStage stage) {
-        super(index, shardId);
+    SnapshotIndexShardStatus(ShardId shardId, SnapshotIndexShardStage stage) {
+        super(shardId);
         this.stage = stage;
         this.stats = new SnapshotStats();
     }
@@ -57,7 +57,7 @@ public class SnapshotIndexShardStatus extends BroadcastShardOperationResponse im
     }
 
     SnapshotIndexShardStatus(ShardId shardId, IndexShardSnapshotStatus indexShardStatus, String nodeId) {
-        super(shardId.getIndex(), shardId.getId());
+        super(shardId);
         switch (indexShardStatus.stage()) {
             case INIT:
                 stage = SnapshotIndexShardStage.INIT;

--- a/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportSnapshotsStatusAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportSnapshotsStatusAction.java
@@ -179,7 +179,7 @@ public class TransportSnapshotsStatusAction extends TransportMasterNodeOperation
                         default:
                             throw new ElasticsearchIllegalArgumentException("Unknown snapshot state " + shardEntry.getValue().state());
                     }
-                    SnapshotIndexShardStatus shardStatus = new SnapshotIndexShardStatus(shardEntry.getKey().getIndex(), shardEntry.getKey().getId(), stage);
+                    SnapshotIndexShardStatus shardStatus = new SnapshotIndexShardStatus(shardEntry.getKey(), stage);
                     shardStatusBuilder.add(shardStatus);
                 }
                 builder.add(new SnapshotStatus(entry.snapshotId(), entry.state(), shardStatusBuilder.build()));

--- a/src/main/java/org/elasticsearch/action/admin/indices/cache/clear/ShardClearIndicesCacheResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/cache/clear/ShardClearIndicesCacheResponse.java
@@ -20,10 +20,7 @@
 package org.elasticsearch.action.admin.indices.cache.clear;
 
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationResponse;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
-
-import java.io.IOException;
+import org.elasticsearch.index.shard.ShardId;
 
 /**
  *
@@ -33,17 +30,7 @@ class ShardClearIndicesCacheResponse extends BroadcastShardOperationResponse {
     ShardClearIndicesCacheResponse() {
     }
 
-    public ShardClearIndicesCacheResponse(String index, int shardId) {
-        super(index, shardId);
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-    }
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
+    ShardClearIndicesCacheResponse(ShardId shardId) {
+        super(shardId);
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/cache/clear/TransportClearIndicesCacheAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/cache/clear/TransportClearIndicesCacheAction.java
@@ -115,9 +115,9 @@ public class TransportClearIndicesCacheAction extends TransportBroadcastOperatio
 
     @Override
     protected ShardClearIndicesCacheResponse shardOperation(ShardClearIndicesCacheRequest request) throws ElasticsearchException {
-        IndexService service = indicesService.indexService(request.index());
+        IndexService service = indicesService.indexService(request.shardId().getIndex());
         if (service != null) {
-            IndexShard shard = service.shard(request.shardId());
+            IndexShard shard = service.shard(request.shardId().id());
             // we always clear the query cache
             service.cache().queryParserCache().clear();
             boolean clearedAtLeastOne = false;
@@ -168,7 +168,7 @@ public class TransportClearIndicesCacheAction extends TransportBroadcastOperatio
                 }
             }
         }
-        return new ShardClearIndicesCacheResponse(request.index(), request.shardId());
+        return new ShardClearIndicesCacheResponse(request.shardId());
     }
 
     /**

--- a/src/main/java/org/elasticsearch/action/admin/indices/flush/ShardFlushResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/flush/ShardFlushResponse.java
@@ -20,10 +20,7 @@
 package org.elasticsearch.action.admin.indices.flush;
 
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationResponse;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
-
-import java.io.IOException;
+import org.elasticsearch.index.shard.ShardId;
 
 /**
  *
@@ -34,17 +31,7 @@ class ShardFlushResponse extends BroadcastShardOperationResponse {
 
     }
 
-    public ShardFlushResponse(String index, int shardId) {
-        super(index, shardId);
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-    }
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
+    ShardFlushResponse(ShardId shardId) {
+        super(shardId);
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/flush/TransportFlushAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/flush/TransportFlushAction.java
@@ -106,10 +106,10 @@ public class TransportFlushAction extends TransportBroadcastOperationAction<Flus
 
     @Override
     protected ShardFlushResponse shardOperation(ShardFlushRequest request) throws ElasticsearchException {
-        IndexShard indexShard = indicesService.indexServiceSafe(request.index()).shardSafe(request.shardId());
+        IndexShard indexShard = indicesService.indexServiceSafe(request.shardId().getIndex()).shardSafe(request.shardId().id());
         indexShard.flush(new Engine.Flush().waitIfOngoing(request.waitIfOngoing()).
                 type(request.full() ? Engine.Flush.Type.NEW_WRITER : Engine.Flush.Type.COMMIT_TRANSLOG).force(request.force()));
-        return new ShardFlushResponse(request.index(), request.shardId());
+        return new ShardFlushResponse(request.shardId());
     }
 
     /**

--- a/src/main/java/org/elasticsearch/action/admin/indices/optimize/ShardOptimizeResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/optimize/ShardOptimizeResponse.java
@@ -20,10 +20,7 @@
 package org.elasticsearch.action.admin.indices.optimize;
 
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationResponse;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
-
-import java.io.IOException;
+import org.elasticsearch.index.shard.ShardId;
 
 /**
  *
@@ -33,17 +30,7 @@ class ShardOptimizeResponse extends BroadcastShardOperationResponse {
     ShardOptimizeResponse() {
     }
 
-    public ShardOptimizeResponse(String index, int shardId) {
-        super(index, shardId);
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-    }
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
+    ShardOptimizeResponse(ShardId shardId) {
+        super(shardId);
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/optimize/TransportOptimizeAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/optimize/TransportOptimizeAction.java
@@ -107,7 +107,7 @@ public class TransportOptimizeAction extends TransportBroadcastOperationAction<O
 
     @Override
     protected ShardOptimizeResponse shardOperation(ShardOptimizeRequest request) throws ElasticsearchException {
-        IndexShard indexShard = indicesService.indexServiceSafe(request.index()).shardSafe(request.shardId());
+        IndexShard indexShard = indicesService.indexServiceSafe(request.shardId().getIndex()).shardSafe(request.shardId().id());
         indexShard.optimize(new Engine.Optimize()
                 .waitForMerge(request.waitForMerge())
                 .maxNumSegments(request.maxNumSegments())
@@ -115,7 +115,7 @@ public class TransportOptimizeAction extends TransportBroadcastOperationAction<O
                 .flush(request.flush())
                 .force(request.force())
         );
-        return new ShardOptimizeResponse(request.index(), request.shardId());
+        return new ShardOptimizeResponse(request.shardId());
     }
 
     /**

--- a/src/main/java/org/elasticsearch/action/admin/indices/recovery/ShardRecoveryResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/recovery/ShardRecoveryResponse.java
@@ -20,10 +20,11 @@
 package org.elasticsearch.action.admin.indices.recovery;
 
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationResponse;
-import org.elasticsearch.common.xcontent.ToXContent;
-import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.recovery.RecoveryState;
 
 import java.io.IOException;
@@ -41,11 +42,10 @@ public class ShardRecoveryResponse extends BroadcastShardOperationResponse imple
     /**
      * Constructs shard recovery information for the given index and shard id.
      *
-     * @param index     Name of the index
      * @param shardId   Id of the shard
      */
-    public ShardRecoveryResponse(String index, int shardId) {
-        super(index, shardId);
+    ShardRecoveryResponse(ShardId shardId) {
+        super(shardId);
     }
 
     /**

--- a/src/main/java/org/elasticsearch/action/admin/indices/recovery/TransportRecoveryAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/recovery/TransportRecoveryAction.java
@@ -142,10 +142,10 @@ public class TransportRecoveryAction extends
     @Override
     protected ShardRecoveryResponse shardOperation(ShardRecoveryRequest request) throws ElasticsearchException {
 
-        InternalIndexService indexService = (InternalIndexService) indicesService.indexServiceSafe(request.index());
-        InternalIndexShard indexShard = (InternalIndexShard) indexService.shardSafe(request.shardId());
+        InternalIndexService indexService = (InternalIndexService) indicesService.indexServiceSafe(request.shardId().getIndex());
+        InternalIndexShard indexShard = (InternalIndexShard) indexService.shardSafe(request.shardId().id());
         ShardRouting shardRouting = indexShard.routingEntry();
-        ShardRecoveryResponse shardRecoveryResponse = new ShardRecoveryResponse(shardRouting.index(), shardRouting.id());
+        ShardRecoveryResponse shardRecoveryResponse = new ShardRecoveryResponse(request.shardId());
 
         RecoveryState state;
         RecoveryStatus recoveryStatus = indexShard.recoveryStatus();
@@ -158,7 +158,7 @@ public class TransportRecoveryAction extends
             state = recoveryStatus.recoveryState();
         } else {
             IndexShardGatewayService gatewayService =
-                    indexService.shardInjector(request.shardId()).getInstance(IndexShardGatewayService.class);
+                    indexService.shardInjector(request.shardId().id()).getInstance(IndexShardGatewayService.class);
             state = gatewayService.recoveryState();
         }
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/refresh/ShardRefreshResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/refresh/ShardRefreshResponse.java
@@ -20,10 +20,7 @@
 package org.elasticsearch.action.admin.indices.refresh;
 
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationResponse;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
-
-import java.io.IOException;
+import org.elasticsearch.index.shard.ShardId;
 
 /**
  *
@@ -33,17 +30,7 @@ class ShardRefreshResponse extends BroadcastShardOperationResponse {
     ShardRefreshResponse() {
     }
 
-    public ShardRefreshResponse(String index, int shardId) {
-        super(index, shardId);
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-    }
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
+    ShardRefreshResponse(ShardId shardId) {
+        super(shardId);
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportRefreshAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportRefreshAction.java
@@ -107,10 +107,10 @@ public class TransportRefreshAction extends TransportBroadcastOperationAction<Re
 
     @Override
     protected ShardRefreshResponse shardOperation(ShardRefreshRequest request) throws ElasticsearchException {
-        IndexShard indexShard = indicesService.indexServiceSafe(request.index()).shardSafe(request.shardId());
+        IndexShard indexShard = indicesService.indexServiceSafe(request.shardId().getIndex()).shardSafe(request.shardId().id());
         indexShard.refresh(new Engine.Refresh("api").force(request.force()));
         logger.trace("{} refresh request executed, force: [{}]", indexShard.shardId(), request.force());
-        return new ShardRefreshResponse(request.index(), request.shardId());
+        return new ShardRefreshResponse(request.shardId());
     }
 
     /**

--- a/src/main/java/org/elasticsearch/action/admin/indices/segments/ShardSegments.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/segments/ShardSegments.java
@@ -42,8 +42,8 @@ public class ShardSegments extends BroadcastShardOperationResponse implements It
     ShardSegments() {
     }
 
-    public ShardSegments(ShardRouting shardRouting, List<Segment> segments) {
-        super(shardRouting.index(), shardRouting.id());
+    ShardSegments(ShardRouting shardRouting, List<Segment> segments) {
+        super(shardRouting.shardId());
         this.shardRouting = shardRouting;
         this.segments = segments;
     }

--- a/src/main/java/org/elasticsearch/action/admin/indices/segments/TransportIndicesSegmentsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/segments/TransportIndicesSegmentsAction.java
@@ -129,8 +129,8 @@ public class TransportIndicesSegmentsAction extends TransportBroadcastOperationA
 
     @Override
     protected ShardSegments shardOperation(IndexShardSegmentRequest request) throws ElasticsearchException {
-        InternalIndexService indexService = (InternalIndexService) indicesService.indexServiceSafe(request.index());
-        InternalIndexShard indexShard = (InternalIndexShard) indexService.shardSafe(request.shardId());
+        InternalIndexService indexService = (InternalIndexService) indicesService.indexServiceSafe(request.shardId().getIndex());
+        InternalIndexShard indexShard = (InternalIndexShard) indexService.shardSafe(request.shardId().id());
         return new ShardSegments(indexShard.routingEntry(), indexShard.engine().segments());
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/stats/ShardStats.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/stats/ShardStats.java
@@ -44,7 +44,7 @@ public class ShardStats extends BroadcastShardOperationResponse implements ToXCo
     }
 
     public ShardStats(IndexShard indexShard, CommonStatsFlags flags) {
-        super(indexShard.routingEntry().index(), indexShard.routingEntry().id());
+        super(indexShard.routingEntry().shardId());
         this.shardRouting = indexShard.routingEntry();
         this.stats = new CommonStats(indexShard, flags);
     }

--- a/src/main/java/org/elasticsearch/action/admin/indices/stats/TransportIndicesStatsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/stats/TransportIndicesStatsAction.java
@@ -133,8 +133,8 @@ public class TransportIndicesStatsAction extends TransportBroadcastOperationActi
 
     @Override
     protected ShardStats shardOperation(IndexShardStatsRequest request) throws ElasticsearchException {
-        InternalIndexService indexService = (InternalIndexService) indicesService.indexServiceSafe(request.index());
-        InternalIndexShard indexShard = (InternalIndexShard) indexService.shardSafe(request.shardId());
+        InternalIndexService indexService = (InternalIndexService) indicesService.indexServiceSafe(request.shardId().getIndex());
+        InternalIndexShard indexShard = (InternalIndexShard) indexService.shardSafe(request.shardId().id());
 
         CommonStatsFlags flags = new CommonStatsFlags().clear();
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/status/ShardStatus.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/status/ShardStatus.java
@@ -69,7 +69,7 @@ public class ShardStatus extends BroadcastShardOperationResponse {
     }
 
     ShardStatus(ShardRouting shardRouting) {
-        super(shardRouting.index(), shardRouting.id());
+        super(shardRouting.shardId());
         this.shardRouting = shardRouting;
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/status/TransportIndicesStatusAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/status/TransportIndicesStatusAction.java
@@ -146,8 +146,8 @@ public class TransportIndicesStatusAction extends TransportBroadcastOperationAct
 
     @Override
     protected ShardStatus shardOperation(IndexShardStatusRequest request) throws ElasticsearchException {
-        InternalIndexService indexService = (InternalIndexService) indicesService.indexServiceSafe(request.index());
-        InternalIndexShard indexShard = (InternalIndexShard) indexService.shardSafe(request.shardId());
+        InternalIndexService indexService = (InternalIndexService) indicesService.indexServiceSafe(request.shardId().getIndex());
+        InternalIndexShard indexShard = (InternalIndexShard) indexService.shardSafe(request.shardId().id());
         ShardStatus shardStatus = new ShardStatus(indexShard.routingEntry());
         shardStatus.state = indexShard.state();
         final Store store = indexShard.store();
@@ -212,7 +212,7 @@ public class TransportIndicesStatusAction extends TransportBroadcastOperationAct
                         peerRecoveryStatus.recoveryState().getIndex().recoveredByteCount(), peerRecoveryStatus.recoveryState().getTranslog().currentTranslogOperations());
             }
 
-            IndexShardGatewayService gatewayService = indexService.shardInjector(request.shardId()).getInstance(IndexShardGatewayService.class);
+            IndexShardGatewayService gatewayService = indexService.shardInjector(request.shardId().id()).getInstance(IndexShardGatewayService.class);
             RecoveryState gatewayRecoveryState = gatewayService.recoveryState();
             if (gatewayRecoveryState != null) {
                 GatewayRecoveryStatus.Stage stage;

--- a/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ShardValidateQueryResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ShardValidateQueryResponse.java
@@ -22,6 +22,7 @@ package org.elasticsearch.action.admin.indices.validate.query;
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.shard.ShardId;
 
 import java.io.IOException;
 
@@ -42,8 +43,8 @@ class ShardValidateQueryResponse extends BroadcastShardOperationResponse {
 
     }
 
-    public ShardValidateQueryResponse(String index, int shardId, boolean valid, String explanation, String error) {
-        super(index, shardId);
+    ShardValidateQueryResponse(ShardId shardId, boolean valid, String explanation, String error) {
+        super(shardId);
         this.valid = valid;
         this.explanation = explanation;
         this.error = error;

--- a/src/main/java/org/elasticsearch/action/admin/indices/validate/query/TransportValidateQueryAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/validate/query/TransportValidateQueryAction.java
@@ -170,9 +170,9 @@ public class TransportValidateQueryAction extends TransportBroadcastOperationAct
 
     @Override
     protected ShardValidateQueryResponse shardOperation(ShardValidateQueryRequest request) throws ElasticsearchException {
-        IndexQueryParserService queryParserService = indicesService.indexServiceSafe(request.index()).queryParserService();
-        IndexService indexService = indicesService.indexServiceSafe(request.index());
-        IndexShard indexShard = indexService.shardSafe(request.shardId());
+        IndexService indexService = indicesService.indexServiceSafe(request.shardId().getIndex());
+        IndexQueryParserService queryParserService = indexService.queryParserService();
+        IndexShard indexShard = indexService.shardSafe(request.shardId().id());
 
         boolean valid;
         String explanation = null;
@@ -206,6 +206,6 @@ public class TransportValidateQueryAction extends TransportBroadcastOperationAct
             SearchContext.removeCurrent();
         }
 
-        return new ShardValidateQueryResponse(request.index(), request.shardId(), valid, explanation, error);
+        return new ShardValidateQueryResponse(request.shardId(), valid, explanation, error);
     }
 }

--- a/src/main/java/org/elasticsearch/action/count/ShardCountResponse.java
+++ b/src/main/java/org/elasticsearch/action/count/ShardCountResponse.java
@@ -23,6 +23,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.shard.ShardId;
 
 import java.io.IOException;
 
@@ -40,8 +41,8 @@ class ShardCountResponse extends BroadcastShardOperationResponse {
 
     }
 
-    public ShardCountResponse(String index, int shardId, long count, boolean terminatedEarly) {
-        super(index, shardId);
+    ShardCountResponse(ShardId shardId, long count, boolean terminatedEarly) {
+        super(shardId);
         this.count = count;
         this.terminatedEarly = terminatedEarly;
     }

--- a/src/main/java/org/elasticsearch/action/count/TransportCountAction.java
+++ b/src/main/java/org/elasticsearch/action/count/TransportCountAction.java
@@ -165,10 +165,10 @@ public class TransportCountAction extends TransportBroadcastOperationAction<Coun
 
     @Override
     protected ShardCountResponse shardOperation(ShardCountRequest request) throws ElasticsearchException {
-        IndexService indexService = indicesService.indexServiceSafe(request.index());
-        IndexShard indexShard = indexService.shardSafe(request.shardId());
+        IndexService indexService = indicesService.indexServiceSafe(request.shardId().getIndex());
+        IndexShard indexShard = indexService.shardSafe(request.shardId().id());
 
-        SearchShardTarget shardTarget = new SearchShardTarget(clusterService.localNode().id(), request.index(), request.shardId());
+        SearchShardTarget shardTarget = new SearchShardTarget(clusterService.localNode().id(), request.shardId().getIndex(), request.shardId().id());
         SearchContext context = new DefaultSearchContext(0,
                 new ShardSearchRequest().types(request.types())
                         .filteringAliases(request.filteringAliases())
@@ -204,7 +204,7 @@ public class TransportCountAction extends TransportBroadcastOperationAction<Coun
                 } else {
                     count = Lucene.count(context.searcher(), context.query());
                 }
-                return new ShardCountResponse(request.index(), request.shardId(), count, terminatedEarly);
+                return new ShardCountResponse(request.shardId(), count, terminatedEarly);
             } catch (Exception e) {
                 throw new QueryPhaseExecutionException(context, "failed to execute count", e);
             }

--- a/src/main/java/org/elasticsearch/action/exists/ShardExistsResponse.java
+++ b/src/main/java/org/elasticsearch/action/exists/ShardExistsResponse.java
@@ -22,18 +22,19 @@ package org.elasticsearch.action.exists;
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.shard.ShardId;
 
 import java.io.IOException;
 
-public class ShardExistsResponse extends BroadcastShardOperationResponse {
+class ShardExistsResponse extends BroadcastShardOperationResponse {
 
     private boolean exists;
 
     ShardExistsResponse() {
     }
 
-    public ShardExistsResponse(String index, int shardId, boolean exists) {
-        super(index, shardId);
+    ShardExistsResponse(ShardId shardId, boolean exists) {
+        super(shardId);
         this.exists = exists;
     }
 

--- a/src/main/java/org/elasticsearch/action/exists/TransportExistsAction.java
+++ b/src/main/java/org/elasticsearch/action/exists/TransportExistsAction.java
@@ -166,10 +166,10 @@ public class TransportExistsAction extends TransportBroadcastOperationAction<Exi
 
     @Override
     protected ShardExistsResponse shardOperation(ShardExistsRequest request) throws ElasticsearchException {
-        IndexService indexService = indicesService.indexServiceSafe(request.index());
-        IndexShard indexShard = indexService.shardSafe(request.shardId());
+        IndexService indexService = indicesService.indexServiceSafe(request.shardId().getIndex());
+        IndexShard indexShard = indexService.shardSafe(request.shardId().id());
 
-        SearchShardTarget shardTarget = new SearchShardTarget(clusterService.localNode().id(), request.index(), request.shardId());
+        SearchShardTarget shardTarget = new SearchShardTarget(clusterService.localNode().id(), request.shardId().getIndex(), request.shardId().id());
         SearchContext context = new DefaultSearchContext(0,
                 new ShardSearchRequest().types(request.types())
                         .filteringAliases(request.filteringAliases())
@@ -195,7 +195,7 @@ public class TransportExistsAction extends TransportBroadcastOperationAction<Exi
             try {
                 Lucene.EarlyTerminatingCollector existsCollector = Lucene.createExistsCollector();
                 Lucene.exists(context.searcher(), context.query(), existsCollector);
-                return new ShardExistsResponse(request.index(), request.shardId(), existsCollector.exists());
+                return new ShardExistsResponse(request.shardId(), existsCollector.exists());
             } catch (Exception e) {
                 throw new QueryPhaseExecutionException(context, "failed to execute exists", e);
             }

--- a/src/main/java/org/elasticsearch/action/percolate/PercolateShardResponse.java
+++ b/src/main/java/org/elasticsearch/action/percolate/PercolateShardResponse.java
@@ -23,6 +23,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.percolator.PercolateContext;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.facet.InternalFacets;
@@ -57,8 +58,8 @@ public class PercolateShardResponse extends BroadcastShardOperationResponse {
         hls = new ArrayList<>();
     }
 
-    public PercolateShardResponse(BytesRef[] matches, List<Map<String, HighlightField>> hls, long count, float[] scores, PercolateContext context, String index, int shardId) {
-        super(index, shardId);
+    public PercolateShardResponse(BytesRef[] matches, List<Map<String, HighlightField>> hls, long count, float[] scores, PercolateContext context, ShardId shardId) {
+        super(shardId);
         this.matches = matches;
         this.hls = hls;
         this.count = count;
@@ -76,20 +77,20 @@ public class PercolateShardResponse extends BroadcastShardOperationResponse {
         }
     }
 
-    public PercolateShardResponse(BytesRef[] matches, long count, float[] scores, PercolateContext context, String index, int shardId) {
-        this(matches, EMPTY_HL, count, scores, context, index, shardId);
+    public PercolateShardResponse(BytesRef[] matches, long count, float[] scores, PercolateContext context, ShardId shardId) {
+        this(matches, EMPTY_HL, count, scores, context, shardId);
     }
 
-    public PercolateShardResponse(BytesRef[] matches, List<Map<String, HighlightField>> hls, long count, PercolateContext context, String index, int shardId) {
-        this(matches, hls, count, EMPTY_SCORES, context, index, shardId);
+    public PercolateShardResponse(BytesRef[] matches, List<Map<String, HighlightField>> hls, long count, PercolateContext context, ShardId shardId) {
+        this(matches, hls, count, EMPTY_SCORES, context, shardId);
     }
 
-    public PercolateShardResponse(long count, PercolateContext context, String index, int shardId) {
-        this(EMPTY_MATCHES, EMPTY_HL, count, EMPTY_SCORES, context, index, shardId);
+    public PercolateShardResponse(long count, PercolateContext context, ShardId shardId) {
+        this(EMPTY_MATCHES, EMPTY_HL, count, EMPTY_SCORES, context, shardId);
     }
 
-    public PercolateShardResponse(PercolateContext context, String index, int shardId) {
-        this(EMPTY_MATCHES, EMPTY_HL, 0, EMPTY_SCORES, context, index, shardId);
+    public PercolateShardResponse(PercolateContext context, ShardId shardId) {
+        this(EMPTY_MATCHES, EMPTY_HL, 0, EMPTY_SCORES, context, shardId);
     }
 
     public BytesRef[] matches() {

--- a/src/main/java/org/elasticsearch/action/percolate/TransportPercolateAction.java
+++ b/src/main/java/org/elasticsearch/action/percolate/TransportPercolateAction.java
@@ -37,7 +37,6 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.engine.DocumentMissingException;
-import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.percolator.PercolateException;
 import org.elasticsearch.percolator.PercolatorService;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -189,9 +188,8 @@ public class TransportPercolateAction extends TransportBroadcastOperationAction<
         try {
             return percolatorService.percolate(request);
         } catch (Throwable e) {
-            logger.trace("[{}][{}] failed to percolate", e, request.index(), request.shardId());
-            ShardId shardId = new ShardId(request.index(), request.shardId());
-            throw new PercolateException(shardId, "failed to percolate", e);
+            logger.trace("{} failed to percolate", e, request.shardId());
+            throw new PercolateException(request.shardId(), "failed to percolate", e);
         }
     }
 

--- a/src/main/java/org/elasticsearch/action/suggest/ShardSuggestResponse.java
+++ b/src/main/java/org/elasticsearch/action/suggest/ShardSuggestResponse.java
@@ -22,6 +22,7 @@ package org.elasticsearch.action.suggest;
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.search.suggest.Suggest;
 
 import java.io.IOException;
@@ -37,8 +38,8 @@ class ShardSuggestResponse extends BroadcastShardOperationResponse {
         this.suggest = new Suggest();
     }
 
-    public ShardSuggestResponse(String index, int shardId, Suggest suggest) {
-        super(index, shardId);
+    ShardSuggestResponse(ShardId shardId, Suggest suggest) {
+        super(shardId);
         this.suggest = suggest;
     }
 

--- a/src/main/java/org/elasticsearch/action/suggest/TransportSuggestAction.java
+++ b/src/main/java/org/elasticsearch/action/suggest/TransportSuggestAction.java
@@ -144,8 +144,8 @@ public class TransportSuggestAction extends TransportBroadcastOperationAction<Su
 
     @Override
     protected ShardSuggestResponse shardOperation(ShardSuggestRequest request) throws ElasticsearchException {
-        IndexService indexService = indicesService.indexServiceSafe(request.index());
-        IndexShard indexShard = indexService.shardSafe(request.shardId());
+        IndexService indexService = indicesService.indexServiceSafe(request.shardId().getIndex());
+        IndexShard indexShard = indexService.shardSafe(request.shardId().id());
         final Engine.Searcher searcher = indexShard.acquireSearcher("suggest");
         ShardSuggestService shardSuggestService = indexShard.shardSuggestService();
         shardSuggestService.preSuggest();
@@ -158,11 +158,11 @@ public class TransportSuggestAction extends TransportBroadcastOperationAction<Su
                 if (parser.nextToken() != XContentParser.Token.START_OBJECT) {
                     throw new ElasticsearchIllegalArgumentException("suggest content missing");
                 }
-                final SuggestionSearchContext context = suggestPhase.parseElement().parseInternal(parser, indexService.mapperService(), request.index(), request.shardId());
+                final SuggestionSearchContext context = suggestPhase.parseElement().parseInternal(parser, indexService.mapperService(), request.shardId().getIndex(), request.shardId().id());
                 final Suggest result = suggestPhase.execute(context, searcher.reader());
-                return new ShardSuggestResponse(request.index(), request.shardId(), result);
+                return new ShardSuggestResponse(request.shardId(), result);
             }
-            return new ShardSuggestResponse(request.index(), request.shardId(), new Suggest());
+            return new ShardSuggestResponse(request.shardId(), new Suggest());
         } catch (Throwable ex) {
             throw new ElasticsearchException("failed to execute suggest", ex);
         } finally {

--- a/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastShardOperationRequest.java
+++ b/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastShardOperationRequest.java
@@ -47,10 +47,6 @@ public abstract class BroadcastShardOperationRequest extends TransportRequest im
         this.shardId = shardId;
     }
 
-    public String index() {
-        return this.shardId.getIndex();
-    }
-
     @Override
     public String[] indices() {
         return new String[]{shardId.getIndex()};
@@ -61,8 +57,8 @@ public abstract class BroadcastShardOperationRequest extends TransportRequest im
         return IndicesOptions.strictSingleIndexNoExpandForbidClosed();
     }
 
-    public int shardId() {
-        return this.shardId.id();
+    public ShardId shardId() {
+        return this.shardId;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastShardOperationResponse.java
+++ b/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastShardOperationResponse.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.support.broadcast;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.transport.TransportResponse;
 
 import java.io.IOException;
@@ -30,37 +31,33 @@ import java.io.IOException;
  */
 public abstract class BroadcastShardOperationResponse extends TransportResponse {
 
-    String index;
-    int shardId;
+    ShardId shardId;
 
     protected BroadcastShardOperationResponse() {
 
     }
 
-    protected BroadcastShardOperationResponse(String index, int shardId) {
-        this.index = index;
+    protected BroadcastShardOperationResponse(ShardId shardId) {
         this.shardId = shardId;
     }
 
     public String getIndex() {
-        return this.index;
+        return this.shardId.getIndex();
     }
 
     public int getShardId() {
-        return this.shardId;
+        return this.shardId.id();
     }
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        index = in.readString();
-        shardId = in.readVInt();
+        shardId = ShardId.readShardId(in);
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeString(index);
-        out.writeVInt(shardId);
+        shardId.writeTo(out);
     }
 }


### PR DESCRIPTION
Adjusted `BroadcastShardOperationResponse` subclasses visibility to package private when possible.
Also replaced `int`,`String` pair with `ShardId` that holds the same info and serializes it the same way.
Replaced shardId and index getters in `BroadcastOperationRequest` with a single `ShardId` getter that allows us to reuse the same object in responses.
