### PR TITLE
Fix explanation streaming

### DIFF
--- a/src/main/java/org/elasticsearch/common/lucene/Lucene.java
+++ b/src/main/java/org/elasticsearch/common/lucene/Lucene.java
@@ -442,7 +442,21 @@ public class Lucene {
     public static Explanation readExplanation(StreamInput in) throws IOException {
         float value = in.readFloat();
         String description = in.readString();
-        Explanation explanation = new Explanation(value, description);
+
+        Explanation explanation;
+        if (in.getVersion().onOrAfter(org.elasticsearch.Version.V_1_4_0)) {
+            if (in.readBoolean()) {
+                Boolean match = in.readOptionalBoolean();
+                explanation = new ComplexExplanation();
+                ((ComplexExplanation) explanation).setMatch(match);
+                explanation.setValue(value);
+                explanation.setDescription(description);
+            } else {
+                explanation = new Explanation(value, description);
+            }
+        } else {
+            explanation = new Explanation(value, description);
+        }
         if (in.readBoolean()) {
             int size = in.readVInt();
             for (int i = 0; i < size; i++) {
@@ -453,8 +467,17 @@ public class Lucene {
     }
 
     public static void writeExplanation(StreamOutput out, Explanation explanation) throws IOException {
+
         out.writeFloat(explanation.getValue());
         out.writeString(explanation.getDescription());
+        if (out.getVersion().onOrAfter(org.elasticsearch.Version.V_1_4_0)) {
+            if (explanation instanceof ComplexExplanation) {
+                out.writeBoolean(true);
+                out.writeOptionalBoolean(((ComplexExplanation) explanation).getMatch());
+            } else {
+                out.writeBoolean(false);
+            }
+        }
         Explanation[] subExplanations = explanation.getDetails();
         if (subExplanations == null) {
             out.writeBoolean(false);

--- a/src/main/java/org/elasticsearch/common/lucene/Lucene.java
+++ b/src/main/java/org/elasticsearch/common/lucene/Lucene.java
@@ -444,16 +444,12 @@ public class Lucene {
         String description = in.readString();
 
         Explanation explanation;
-        if (in.getVersion().onOrAfter(org.elasticsearch.Version.V_1_4_0)) {
-            if (in.readBoolean()) {
-                Boolean match = in.readOptionalBoolean();
-                explanation = new ComplexExplanation();
-                ((ComplexExplanation) explanation).setMatch(match);
-                explanation.setValue(value);
-                explanation.setDescription(description);
-            } else {
-                explanation = new Explanation(value, description);
-            }
+        if (in.getVersion().onOrAfter(org.elasticsearch.Version.V_1_4_0) && in.readBoolean()) {
+            Boolean match = in.readOptionalBoolean();
+            explanation = new ComplexExplanation();
+            ((ComplexExplanation) explanation).setMatch(match);
+            explanation.setValue(value);
+            explanation.setDescription(description);
         } else {
             explanation = new Explanation(value, description);
         }

--- a/src/main/java/org/elasticsearch/common/lucene/Lucene.java
+++ b/src/main/java/org/elasticsearch/common/lucene/Lucene.java
@@ -440,19 +440,17 @@ public class Lucene {
     }
 
     public static Explanation readExplanation(StreamInput in) throws IOException {
-        float value = in.readFloat();
-        String description = in.readString();
-
         Explanation explanation;
         if (in.getVersion().onOrAfter(org.elasticsearch.Version.V_1_4_0) && in.readBoolean()) {
             Boolean match = in.readOptionalBoolean();
             explanation = new ComplexExplanation();
             ((ComplexExplanation) explanation).setMatch(match);
-            explanation.setValue(value);
-            explanation.setDescription(description);
+
         } else {
-            explanation = new Explanation(value, description);
+            explanation = new Explanation();
         }
+        explanation.setValue(in.readFloat());
+        explanation.setDescription(in.readString());
         if (in.readBoolean()) {
             int size = in.readVInt();
             for (int i = 0; i < size; i++) {
@@ -464,8 +462,6 @@ public class Lucene {
 
     public static void writeExplanation(StreamOutput out, Explanation explanation) throws IOException {
 
-        out.writeFloat(explanation.getValue());
-        out.writeString(explanation.getDescription());
         if (out.getVersion().onOrAfter(org.elasticsearch.Version.V_1_4_0)) {
             if (explanation instanceof ComplexExplanation) {
                 out.writeBoolean(true);
@@ -474,6 +470,8 @@ public class Lucene {
                 out.writeBoolean(false);
             }
         }
+        out.writeFloat(explanation.getValue());
+        out.writeString(explanation.getDescription());
         Explanation[] subExplanations = explanation.getDetails();
         if (subExplanations == null) {
             out.writeBoolean(false);

--- a/src/main/java/org/elasticsearch/index/mapper/core/StringFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/StringFieldMapper.java
@@ -320,7 +320,7 @@ public class StringFieldMapper extends AbstractFieldMapper<String> implements Al
                 if (token == XContentParser.Token.FIELD_NAME) {
                     currentFieldName = parser.currentName();
                 } else {
-                    if ("value".equals(currentFieldName) || "_value".equals(currentFieldName)) {
+                    if ("value.j.java".equals(currentFieldName) || "_value".equals(currentFieldName)) {
                         value = parser.textOrNull();
                     } else if ("boost".equals(currentFieldName) || "_boost".equals(currentFieldName)) {
                         boost = parser.floatValue();

--- a/src/main/java/org/elasticsearch/index/mapper/core/StringFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/StringFieldMapper.java
@@ -320,7 +320,7 @@ public class StringFieldMapper extends AbstractFieldMapper<String> implements Al
                 if (token == XContentParser.Token.FIELD_NAME) {
                     currentFieldName = parser.currentName();
                 } else {
-                    if ("value.j.java".equals(currentFieldName) || "_value".equals(currentFieldName)) {
+                    if ("value".equals(currentFieldName) || "_value".equals(currentFieldName)) {
                         value = parser.textOrNull();
                     } else if ("boost".equals(currentFieldName) || "_boost".equals(currentFieldName)) {
                         boost = parser.floatValue();


### PR DESCRIPTION
Complex explanations were always read as Explanations. Depending
on if the response was streamed or not the explanation was
therefore generated by a ComplexExplanation or by a regular
Explanation.
