### PR TITLE
Added support for empty field arrays in mappings

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/core/TypeParsers.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/TypeParsers.java
@@ -19,6 +19,13 @@
 
 package org.elasticsearch.index.mapper.core;
 
+import static org.elasticsearch.common.xcontent.support.XContentMapValues.*;
+import static org.elasticsearch.index.mapper.FieldMapper.DOC_VALUES_FORMAT;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import org.apache.lucene.index.FieldInfo.IndexOptions;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.Version;
@@ -33,14 +40,6 @@ import org.elasticsearch.index.mapper.ContentPath;
 import org.elasticsearch.index.mapper.FieldMapper.Loading;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-
-import static org.elasticsearch.common.xcontent.support.XContentMapValues.*;
-import static org.elasticsearch.index.mapper.FieldMapper.DOC_VALUES_FORMAT;
 
 /**
  *
@@ -248,7 +247,7 @@ public class TypeParsers {
     public static void parseMultiField(AbstractFieldMapper.Builder builder, String name, Map<String, Object> node, Mapper.TypeParser.ParserContext parserContext, String propName, Object propNode) {
         if (propName.equals("path")) {
             builder.multiFieldPathType(parsePathType(name, propNode.toString()));
-        } else if (propName.equals("fields")) {
+        } else if (propName.equals("fields") && propNode instanceof Map) {
             @SuppressWarnings("unchecked")
             Map<String, Object> multiFieldsPropNodes = (Map<String, Object>) propNode;
             for (Map.Entry<String, Object> multiFieldEntry : multiFieldsPropNodes.entrySet()) {

--- a/src/main/java/org/elasticsearch/index/mapper/object/ObjectMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/object/ObjectMapper.java
@@ -19,22 +19,7 @@
 
 package org.elasticsearch.index.mapper.object;
 
-import static com.google.common.collect.Lists.newArrayList;
-import static org.elasticsearch.common.xcontent.support.XContentMapValues.nodeBooleanValue;
-import static org.elasticsearch.index.mapper.MapperBuilders.*;
-import static org.elasticsearch.index.mapper.core.TypeParsers.parsePathType;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.TreeMap;
-
+import com.google.common.collect.Iterables;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.Term;
@@ -51,26 +36,20 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.mapper.ContentPath;
-import org.elasticsearch.index.mapper.FieldMapper;
-import org.elasticsearch.index.mapper.FieldMapperListener;
-import org.elasticsearch.index.mapper.InternalMapper;
-import org.elasticsearch.index.mapper.Mapper;
-import org.elasticsearch.index.mapper.MapperBuilders;
-import org.elasticsearch.index.mapper.MapperParsingException;
-import org.elasticsearch.index.mapper.MapperService;
-import org.elasticsearch.index.mapper.MergeContext;
-import org.elasticsearch.index.mapper.MergeMappingException;
-import org.elasticsearch.index.mapper.ObjectMapperListener;
-import org.elasticsearch.index.mapper.ParseContext;
+import org.elasticsearch.index.mapper.*;
 import org.elasticsearch.index.mapper.ParseContext.Document;
-import org.elasticsearch.index.mapper.StrictDynamicMappingException;
 import org.elasticsearch.index.mapper.internal.AllFieldMapper;
 import org.elasticsearch.index.mapper.internal.TypeFieldMapper;
 import org.elasticsearch.index.mapper.internal.UidFieldMapper;
 import org.elasticsearch.index.settings.IndexSettings;
 
-import com.google.common.collect.Iterables;
+import java.io.IOException;
+import java.util.*;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static org.elasticsearch.common.xcontent.support.XContentMapValues.nodeBooleanValue;
+import static org.elasticsearch.index.mapper.MapperBuilders.*;
+import static org.elasticsearch.index.mapper.core.TypeParsers.parsePathType;
 
 /**
  *
@@ -280,10 +259,11 @@ public class ObjectMapper implements Mapper, AllFieldMapper.IncludeInAll {
         protected static void parseProperties(ObjectMapper.Builder objBuilder, Map<String, Object> propsNode, ParserContext parserContext) {
             for (Map.Entry<String, Object> entry : propsNode.entrySet()) {
 	            String propName = entry.getKey();
+                //Should accept empty arrays, as a work around for when the user can't provide an empty Map. (PHP for example)
+                boolean isEmptyList = entry.getValue() instanceof List && ((List) entry.getValue()).isEmpty();
 
-	            if(entry.getValue() instanceof  Map) {
+                if(entry.getValue() instanceof  Map) {
 		            Map<String, Object> propNode = (Map<String, Object>) entry.getValue();
-
 		            String type;
 		            Object typeNode = propNode.get("type");
 		            if (typeNode != null) {
@@ -307,7 +287,9 @@ public class ObjectMapper implements Mapper, AllFieldMapper.IncludeInAll {
 			            throw new MapperParsingException("No handler for type [" + type + "] declared on field [" + propName + "]");
 		            }
 		            objBuilder.add(typeParser.parse(propName, propNode, parserContext));
-	            }
+	            } else if(!isEmptyList){
+                    throw new MapperParsingException("Expected map for property [fields] on field [" + propName + "] but got a " + propName.getClass());
+                }
             }
         }
 

--- a/src/test/java/org/elasticsearch/index/mapper/object/SimpleObjectMappingTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/object/SimpleObjectMappingTests.java
@@ -63,4 +63,61 @@ public class SimpleObjectMappingTests extends ElasticsearchSingleNodeTest {
                 .endObject().endObject().string();
         createIndex("test").mapperService().documentMapperParser().parse(mapping);
     }
+
+    @Test
+    public void testEmptyFieldsArrayMultiFields() throws Exception {
+        String mapping = XContentFactory.jsonBuilder()
+                                        .startObject()
+                                            .startObject("tweet")
+                                                .startObject("properties")
+                                                    .startObject("name")
+                                                        .field("type", "string")
+                                                        .field("index", "analyzed")
+                                                        .startArray("fields")
+                                                        .endArray()
+                                                    .endObject()
+                                                .endObject()
+                                            .endObject()
+                                        .endObject()
+                                        .string();
+        createIndex("test").mapperService().documentMapperParser().parse(mapping);
+    }
+
+    @Test
+    public void testEmptyFieldsArray() throws Exception {
+        String mapping = XContentFactory.jsonBuilder()
+                                        .startObject()
+                                            .startObject("tweet")
+                                                .startObject("properties")
+                                                    .startArray("fields")
+                                                    .endArray()
+                                                .endObject()
+                                            .endObject()
+                                        .endObject()
+                                        .string();
+        createIndex("test").mapperService().documentMapperParser().parse(mapping);
+    }
+
+    @Test
+    public void testFieldPropertiesArray() throws Exception {
+        String mapping = XContentFactory.jsonBuilder()
+                                        .startObject()
+                                            .startObject("tweet")
+                                                .startObject("properties")
+                                                    .startObject("name")
+                                                        .field("type", "string")
+                                                        .field("index", "analyzed")
+                                                        .startObject("fields")
+                                                            .startObject("raw")
+                                                                .field("type", "string")
+                                                                .field("index","not_analyzed")
+                                                            .endObject()
+                                                        .endObject()
+                                                    .endObject()
+                                                .endObject()
+                                            .endObject()
+                                        .endObject()
+                                        .string();
+        createIndex("test").mapperService().documentMapperParser().parse(mapping);
+    }
 }

--- a/src/test/java/org/elasticsearch/index/mapper/object/SimpleObjectMappingTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/object/SimpleObjectMappingTests.java
@@ -65,7 +65,7 @@ public class SimpleObjectMappingTests extends ElasticsearchSingleNodeTest {
     }
 
     @Test
-    public void testEmptyFieldsArrayMultiFields() throws Exception {
+    public void emptyFieldsArrayMultiFieldsTest() throws Exception {
         String mapping = XContentFactory.jsonBuilder()
                                         .startObject()
                                             .startObject("tweet")
@@ -83,8 +83,29 @@ public class SimpleObjectMappingTests extends ElasticsearchSingleNodeTest {
         createIndex("test").mapperService().documentMapperParser().parse(mapping);
     }
 
+    @Test(expected = MapperParsingException.class)
+    public void fieldsArrayMultiFieldsShouldThrowExceptionTest() throws Exception {
+        String mapping = XContentFactory.jsonBuilder()
+                .startObject()
+                    .startObject("tweet")
+                        .startObject("properties")
+                            .startObject("name")
+                                .field("type", "string")
+                                .field("index", "analyzed")
+                                .startArray("fields")
+                                    .field("test", "string")
+                                    .field("test2", "string")
+                                .endArray()
+                            .endObject()
+                        .endObject()
+                    .endObject()
+                .endObject()
+                .string();
+        createIndex("test").mapperService().documentMapperParser().parse(mapping);
+    }
+
     @Test
-    public void testEmptyFieldsArray() throws Exception {
+    public void emptyFieldsArrayTest() throws Exception {
         String mapping = XContentFactory.jsonBuilder()
                                         .startObject()
                                             .startObject("tweet")
@@ -98,8 +119,25 @@ public class SimpleObjectMappingTests extends ElasticsearchSingleNodeTest {
         createIndex("test").mapperService().documentMapperParser().parse(mapping);
     }
 
+    @Test(expected = MapperParsingException.class)
+    public void fieldsWithFilledArrayShouldThrowExceptionTest() throws Exception {
+        String mapping = XContentFactory.jsonBuilder()
+                .startObject()
+                    .startObject("tweet")
+                        .startObject("properties")
+                            .startArray("fields")
+                                .field("test", "string")
+                                .field("test2", "string")
+                            .endArray()
+                        .endObject()
+                    .endObject()
+                .endObject()
+                .string();
+        createIndex("test").mapperService().documentMapperParser().parse(mapping);
+    }
+
     @Test
-    public void testFieldPropertiesArray() throws Exception {
+    public void fieldPropertiesArrayTest() throws Exception {
         String mapping = XContentFactory.jsonBuilder()
                                         .startObject()
                                             .startObject("tweet")


### PR DESCRIPTION
Fix for #6133, added the ability to send empty arrays as part of an index mapping json. For single and multi field properties objects

Sorry for the import changes, IntelliJ doesn't like eclipse imports and fights it like the devil.

If the test are in a non standard format please advise. I just find them easier to read like this.
