### PR TITLE
Make the list of buckets for terms and histogram returned as a java.util.List.

### DIFF
--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogram.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogram.java
@@ -20,7 +20,7 @@ package org.elasticsearch.search.aggregations.bucket.histogram;
 
 import org.joda.time.DateTime;
 
-import java.util.Collection;
+import java.util.List;
 
 /**
  * A {@code date_histogram} aggregation.
@@ -37,7 +37,7 @@ public interface DateHistogram extends Histogram {
     }
 
     @Override
-    Collection<? extends DateHistogram.Bucket> getBuckets();
+    List<? extends DateHistogram.Bucket> getBuckets();
 
     @Override
     Bucket getBucketByKey(String key);

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/Histogram.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/Histogram.java
@@ -21,8 +21,8 @@ package org.elasticsearch.search.aggregations.bucket.histogram;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
 
-import java.util.Collection;
 import java.util.Comparator;
+import java.util.List;
 
 /**
  * A {@code histogram} aggregation. Defines multiple buckets, each representing an interval in a histogram.
@@ -44,7 +44,7 @@ public interface Histogram extends MultiBucketsAggregation {
     /**
      * @return  The buckets of this histogram (each bucket representing an interval in the histogram)
      */
-    Collection<? extends Bucket> getBuckets();
+    List<? extends Bucket> getBuckets();
 
     /**
      * Returns a bucket by the key associated with it.

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalHistogram.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalHistogram.java
@@ -40,7 +40,6 @@ import org.elasticsearch.search.aggregations.support.format.ValueFormatterStream
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.ListIterator;
 
@@ -230,7 +229,7 @@ public class InternalHistogram<B extends InternalHistogram.Bucket> extends Inter
     }
 
     @Override
-    public Collection<B> getBuckets() {
+    public List<B> getBuckets() {
         return buckets;
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalTerms.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalTerms.java
@@ -120,9 +120,9 @@ public abstract class InternalTerms extends InternalAggregation implements Terms
     }
 
     @Override
-    public Collection<Terms.Bucket> getBuckets() {
+    public List<Terms.Bucket> getBuckets() {
         Object o = buckets;
-        return (Collection<Terms.Bucket>) o;
+        return (List<Terms.Bucket>) o;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/Terms.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/Terms.java
@@ -22,8 +22,8 @@ import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
 
-import java.util.Collection;
 import java.util.Comparator;
+import java.util.List;
 
 /**
  * A {@code terms} aggregation. Defines multiple bucket, each associated with a unique term for a specific field.
@@ -70,7 +70,10 @@ public interface Terms extends MultiBucketsAggregation {
 
     }
 
-    Collection<Bucket> getBuckets();
+    /**
+     * Return the sorted list of the buckets in this terms aggregation.
+     */
+    List<Bucket> getBuckets();
 
     Bucket getBucketByKey(String term);
     


### PR DESCRIPTION
The terms and histogram aggregations always have an order. So it would make the
response easier to consume to return the buckets as a list instead of a
collection in order to make it easier to do things like getting the first/last
buckets.
