### PR TITLE
Remove the logic to optionally sort/dedup values on the fly.

### DIFF
--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramParser.java
@@ -77,7 +77,6 @@ public class DateHistogramParser implements Aggregator.Parser {
 
         ValuesSourceParser vsParser = ValuesSourceParser.numeric(aggregationName, InternalDateHistogram.TYPE, context)
                 .targetValueType(ValueType.DATE)
-                .requiresSortedValues(true)
                 .formattable(true)
                 .build();
 

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/HistogramParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/HistogramParser.java
@@ -47,7 +47,6 @@ public class HistogramParser implements Aggregator.Parser {
     public AggregatorFactory parse(String aggregationName, XContentParser parser, SearchContext context) throws IOException {
 
         ValuesSourceParser vsParser = ValuesSourceParser.numeric(aggregationName, InternalHistogram.TYPE, context)
-                .requiresSortedValues(true)
                 .targetValueType(ValueType.NUMERIC)
                 .formattable(true)
                 .build();

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/range/RangeParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/range/RangeParser.java
@@ -47,7 +47,6 @@ public class RangeParser implements Aggregator.Parser {
         boolean keyed = false;
 
         ValuesSourceParser<ValuesSource.Numeric> vsParser = ValuesSourceParser.numeric(aggregationName, InternalRange.TYPE, context)
-                .requiresSortedValues(true)
                 .formattable(true)
                 .build();
 

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/range/date/DateRangeParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/range/date/DateRangeParser.java
@@ -47,7 +47,6 @@ public class DateRangeParser implements Aggregator.Parser {
 
         ValuesSourceParser<ValuesSource.Numeric> vsParser = ValuesSourceParser.numeric(aggregationName, InternalDateRange.TYPE, context)
                 .targetValueType(ValueType.DATE)
-                .requiresSortedValues(true)
                 .formattable(true)
                 .build();
 

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/range/geodistance/GeoDistanceParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/range/geodistance/GeoDistanceParser.java
@@ -69,9 +69,7 @@ public class GeoDistanceParser implements Aggregator.Parser {
     @Override
     public AggregatorFactory parse(String aggregationName, XContentParser parser, SearchContext context) throws IOException {
 
-        ValuesSourceParser<ValuesSource.GeoPoint> vsParser = ValuesSourceParser.geoPoint(aggregationName, InternalGeoDistance.TYPE, context)
-                .requiresSortedValues(true)
-                .build();
+        ValuesSourceParser<ValuesSource.GeoPoint> vsParser = ValuesSourceParser.geoPoint(aggregationName, InternalGeoDistance.TYPE, context).build();
 
         GeoPointParser geoPointParser = new GeoPointParser(aggregationName, InternalGeoDistance.TYPE, context, ORIGIN_FIELD);
 

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ipv4/IpRangeParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ipv4/IpRangeParser.java
@@ -47,7 +47,6 @@ public class IpRangeParser implements Aggregator.Parser {
 
         ValuesSourceParser<ValuesSource.Numeric> vsParser = ValuesSourceParser.numeric(aggregationName, InternalIPv4Range.TYPE, context)
                 .targetValueType(ValueType.IP)
-                .requiresSortedValues(true)
                 .formattable(false)
                 .build();
 

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsParser.java
@@ -56,8 +56,6 @@ public class SignificantTermsParser implements Aggregator.Parser {
         ValuesSourceParser vsParser = ValuesSourceParser.any(aggregationName, SignificantStringTerms.TYPE, context)
                 .scriptable(false)
                 .formattable(true)
-                .requiresSortedValues(true)
-                .requiresUniqueValues(true)
                 .build();
         IncludeExclude.Parser incExcParser = new IncludeExclude.Parser(aggregationName, SignificantStringTerms.TYPE, context);
         aggParser.parse(aggregationName, parser, context, vsParser, incExcParser);

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsParser.java
@@ -41,8 +41,7 @@ public class TermsParser implements Aggregator.Parser {
     @Override
     public AggregatorFactory parse(String aggregationName, XContentParser parser, SearchContext context) throws IOException {
         TermsParametersParser aggParser = new TermsParametersParser();
-        ValuesSourceParser vsParser = ValuesSourceParser.any(aggregationName, StringTerms.TYPE, context).scriptable(true).formattable(true)
-                .requiresSortedValues(true).requiresUniqueValues(true).build();
+        ValuesSourceParser vsParser = ValuesSourceParser.any(aggregationName, StringTerms.TYPE, context).scriptable(true).formattable(true).build();
         IncludeExclude.Parser incExcParser = new IncludeExclude.Parser(aggregationName, StringTerms.TYPE, context);
         aggParser.parse(aggregationName, parser, context, vsParser, incExcParser);
 

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/NumericValuesSourceMetricsAggregatorParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/NumericValuesSourceMetricsAggregatorParser.java
@@ -54,7 +54,6 @@ public abstract class NumericValuesSourceMetricsAggregatorParser<S extends Inter
     public AggregatorFactory parse(String aggregationName, XContentParser parser, SearchContext context) throws IOException {
 
         ValuesSourceParser<ValuesSource.Numeric> vsParser = ValuesSourceParser.numeric(aggregationName, aggType, context)
-                .requiresSortedValues(requiresSortedValues())
                 .build();
 
         XContentParser.Token token;

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/AbstractPercentilesParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/AbstractPercentilesParser.java
@@ -42,9 +42,7 @@ public abstract class AbstractPercentilesParser implements Aggregator.Parser {
     @Override
     public AggregatorFactory parse(String aggregationName, XContentParser parser, SearchContext context) throws IOException {
     
-        ValuesSourceParser<ValuesSource.Numeric> vsParser = ValuesSourceParser.numeric(aggregationName, InternalPercentiles.TYPE, context)
-                .requiresSortedValues(true)
-                .build();
+        ValuesSourceParser<ValuesSource.Numeric> vsParser = ValuesSourceParser.numeric(aggregationName, InternalPercentiles.TYPE, context).build();
     
         double[] keys = null;
         boolean keyed = true;

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/valuecount/ValueCountParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/valuecount/ValueCountParser.java
@@ -41,7 +41,6 @@ public class ValueCountParser implements Aggregator.Parser {
     public AggregatorFactory parse(String aggregationName, XContentParser parser, SearchContext context) throws IOException {
 
         ValuesSourceParser vsParser = ValuesSourceParser.any(aggregationName, InternalValueCount.TYPE, context)
-                .requiresUniqueValues(true)
                 .build();
 
         XContentParser.Token token;

--- a/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceParser.java
@@ -66,8 +66,6 @@ public class ValuesSourceParser<VS extends ValuesSource> {
         String lang = null;
         Map<String, Object> params = null;
         ValueType valueType = null;
-        boolean assumeUnique = false;
-        boolean assumeSorted = false;
         String format = null;
     }
 
@@ -120,16 +118,6 @@ public class ValuesSourceParser<VS extends ValuesSource> {
                     return false;
                 }
                 return true;
-            } else {
-                return false;
-            }
-            return true;
-        }
-        if (scriptable && token == XContentParser.Token.VALUE_BOOLEAN) {
-            if ("script_values_unique".equals(currentFieldName) || "scriptValuesUnique".equals(currentFieldName)) {
-                input.assumeUnique = parser.booleanValue();
-            } else if ("script_values_sorted".equals(currentFieldName) || "scriptValuesSorted".equals(currentFieldName)) {
-                input.assumeSorted = parser.booleanValue();
             } else {
                 return false;
             }
@@ -249,16 +237,6 @@ public class ValuesSourceParser<VS extends ValuesSource> {
 
         public Builder<VS> targetValueType(ValueType valueType) {
             parser.targetValueType = valueType;
-            return this;
-        }
-
-        public Builder<VS> requiresSortedValues(boolean requiresSortedValues) {
-            parser.requiresSortedValues = requiresSortedValues;
-            return this;
-        }
-
-        public Builder<VS> requiresUniqueValues(boolean requiresUniqueValues) {
-            parser.requiresUniqueValues = requiresUniqueValues;
             return this;
         }
 


### PR DESCRIPTION
These options are not used anymore. Instead numeric values can now contain dups
and it is the responsibility of the aggregation to deal with it (eg. terms).
And otherwise all values sources are now sorted, which is the contract of the
interfaces that they implement.
