### PR TITLE
Add an option to write the aggregation type in the response

### DIFF
--- a/src/main/java/org/elasticsearch/search/aggregations/InternalAggregation.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/InternalAggregation.java
@@ -155,6 +155,12 @@ public abstract class InternalAggregation implements Aggregation, ToXContent, St
     @Override
     public final XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(name);
+        if(params != null && params.paramAsBoolean("output_type", false)) {
+            builder.field(CommonFields.TYPE, type().name);
+        }
+        if(params != null && params.paramAsBoolean("output_concrete_type", false)) {
+            builder.field(CommonFields.CONCRETE_TYPE, getClass().getName());
+        }
         doXContentBody(builder, params);
         builder.endObject();
         return builder;
@@ -167,6 +173,8 @@ public abstract class InternalAggregation implements Aggregation, ToXContent, St
      */
     public static final class CommonFields {
         public static final XContentBuilderString BUCKETS = new XContentBuilderString("buckets");
+        public static final XContentBuilderString TYPE = new XContentBuilderString("_type");
+        public static final XContentBuilderString CONCRETE_TYPE = new XContentBuilderString("_concrete_type");
         public static final XContentBuilderString VALUE = new XContentBuilderString("value");
         public static final XContentBuilderString VALUES = new XContentBuilderString("values");
         public static final XContentBuilderString VALUE_AS_STRING = new XContentBuilderString("value_as_string");


### PR DESCRIPTION
This pull requests add two optional parameters to the aggregations toXContent, one to write the TYPE of the aggregation and the other to write the classname of the aggregation.

The type field exists for facets but not for aggregations. I believe these informations can be usefull to create mappers without having to either rely on the request or infering the type from the response.

Existing client will not be impacted because the new informations are optional, but they may start to use it.

Suggestions for the fields and parameters names are welcome.
Maybe writing class.getSimpleName() is more robust than class.getName() in regard of refactorings.

It would be wonderful if this could also be merged with branch 1.x.

ouput would be like : 

``` json
{  
   "_type":"terms",
   "_concrete_type":"org.elasticsearch.search.aggregations.bucket.terms.StringTerms",
   "doc_count_error_upper_bound":0,
   "buckets":[  
      {  
         "key":"val0",
         "doc_count":1
      }
   ]
}
```
