### PR TITLE
Merge LongTermsAggregator and DoubleTermsAggregator.

### DIFF
--- a/src/main/java/org/elasticsearch/index/fielddata/SortableLongBitsNumericDocValues.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/SortableLongBitsNumericDocValues.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.fielddata;
+
+import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.util.NumericUtils;
+
+/**
+ * {@link NumericDocValues} instance that wraps a {@link NumericDoubleValues}
+ * and converts the doubles to sortable long bits using
+ * {@link NumericUtils#doubleToSortableLong(double)}.
+ */
+final class SortableLongBitsNumericDocValues extends NumericDocValues {
+
+    private final NumericDoubleValues values;
+
+    SortableLongBitsNumericDocValues(NumericDoubleValues values) {
+        this.values = values;
+    }
+
+    @Override
+    public long get(int docID) {
+        return NumericUtils.doubleToSortableLong(values.get(docID));
+    }
+
+    /** Return the wrapped values. */
+    public NumericDoubleValues getDoubleValues() {
+        return values;
+    }
+
+}

--- a/src/main/java/org/elasticsearch/index/fielddata/SortableLongBitsSortedNumericDocValues.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/SortableLongBitsSortedNumericDocValues.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.fielddata;
+
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.util.NumericUtils;
+
+/**
+ * {@link SortedNumericDocValues} instance that wraps a {@link SortedNumericDoubleValues}
+ * and converts the doubles to sortable long bits using
+ * {@link NumericUtils#doubleToSortableLong(double)}.
+ */
+final class SortableLongBitsSortedNumericDocValues extends SortedNumericDocValues {
+
+    private final SortedNumericDoubleValues values;
+
+    SortableLongBitsSortedNumericDocValues(SortedNumericDoubleValues values) {
+        this.values = values;
+    }
+
+    @Override
+    public void setDocument(int doc) {
+        values.setDocument(doc);
+    }
+
+    @Override
+    public long valueAt(int index) {
+        return NumericUtils.doubleToSortableLong(values.valueAt(index));
+    }
+
+    @Override
+    public int count() {
+        return values.count();
+    }
+
+    /** Return the wrapped values. */
+    public SortedNumericDoubleValues getDoubleValues() {
+        return values;
+    }
+}

--- a/src/main/java/org/elasticsearch/index/fielddata/SortableLongBitsToNumericDoubleValues.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/SortableLongBitsToNumericDoubleValues.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.fielddata;
+
+import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.util.NumericUtils;
+
+/**
+ * {@link NumericDoubleValues} instance that wraps a {@link NumericDocValues}
+ * and converts the doubles to sortable long bits using
+ * {@link NumericUtils#sortableLongToDouble(long)}.
+ */
+final class SortableLongBitsToNumericDoubleValues extends NumericDoubleValues {
+
+    private final NumericDocValues values;
+
+    SortableLongBitsToNumericDoubleValues(NumericDocValues values) {
+        this.values = values;
+    }
+
+    @Override
+    public double get(int docID) {
+        return NumericUtils.sortableLongToDouble(values.get(docID));
+    }
+
+    /** Return the wrapped values. */
+    public NumericDocValues getLongValues() {
+        return values;
+    }
+
+}

--- a/src/main/java/org/elasticsearch/index/fielddata/SortableLongBitsToSortedNumericDoubleValues.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/SortableLongBitsToSortedNumericDoubleValues.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.fielddata;
+
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.util.NumericUtils;
+
+/**
+ * {@link SortedNumericDoubleValues} instance that wraps a {@link SortedNumericDocValues}
+ * and converts the doubles to sortable long bits using
+ * {@link NumericUtils#sortableLongToDouble(long)}.
+ */
+final class SortableLongBitsToSortedNumericDoubleValues extends SortedNumericDoubleValues {
+
+    private final SortedNumericDocValues values;
+
+    SortableLongBitsToSortedNumericDoubleValues(SortedNumericDocValues values) {
+        this.values = values;
+    }
+
+    @Override
+    public void setDocument(int doc) {
+        values.setDocument(doc);
+    }
+
+    @Override
+    public double valueAt(int index) {
+        return NumericUtils.sortableLongToDouble(values.valueAt(index));
+    }
+
+    @Override
+    public int count() {
+        return values.count();
+    }
+
+    /** Return the wrapped values. */
+    public SortedNumericDocValues getLongValues() {
+        return values;
+    }
+
+}

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/SortedNumericDVIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/SortedNumericDVIndexFieldData.java
@@ -235,58 +235,10 @@ public class SortedNumericDVIndexFieldData extends DocValuesIndexFieldData imple
         public SortedNumericDoubleValues getDoubleValues() {
             try {
                 SortedNumericDocValues raw = DocValues.getSortedNumeric(reader, field);
-                
-                NumericDocValues single = DocValues.unwrapSingleton(raw);
-                if (single != null) {
-                    return FieldData.singleton(new SingleDoubleValues(single), DocValues.unwrapSingletonBits(raw));
-                } else {
-                    return new MultiDoubleValues(raw);
-                }
+                return FieldData.sortableLongBitsToDoubles(raw);
             } catch (IOException e) {
                 throw new ElasticsearchIllegalStateException("Cannot load doc values", e);
             }
-        }
-    }
-    
-    /** 
-     * Wraps a NumericDocValues and exposes a single 64-bit double per document.
-     */
-    static final class SingleDoubleValues extends NumericDoubleValues {
-        final NumericDocValues in;
-        
-        SingleDoubleValues(NumericDocValues in) {
-            this.in = in;
-        }
-
-        @Override
-        public double get(int docID) {
-            return NumericUtils.sortableLongToDouble(in.get(docID));
-        }
-    }
-    
-    /** 
-     * Wraps a SortedNumericDocValues and exposes multiple 64-bit doubles per document.
-     */
-    static final class MultiDoubleValues extends SortedNumericDoubleValues {
-        final SortedNumericDocValues in;
-        
-        MultiDoubleValues(SortedNumericDocValues in) {
-            this.in = in;
-        }
-
-        @Override
-        public void setDocument(int doc) {
-            in.setDocument(doc);
-        }
-
-        @Override
-        public double valueAt(int index) {
-            return NumericUtils.sortableLongToDouble(in.valueAt(index));
-        }
-
-        @Override
-        public int count() {
-            return in.count();
         }
     }
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongTerms.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongTerms.java
@@ -95,7 +95,7 @@ public class LongTerms extends InternalTerms {
         }
     }
 
-    private @Nullable ValueFormatter formatter;
+    @Nullable ValueFormatter formatter;
 
     LongTerms() {} // for serialization
 

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongTermsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongTermsAggregator.java
@@ -63,9 +63,13 @@ public class LongTermsAggregator extends TermsAggregator {
         return true;
     }
 
+    protected SortedNumericDocValues getValues(ValuesSource.Numeric valuesSource) {
+        return valuesSource.longValues();
+    }
+
     @Override
     public void setNextReader(AtomicReaderContext reader) {
-        values = valuesSource.longValues();
+        values = getValues(valuesSource);
     }
 
     @Override
@@ -77,14 +81,14 @@ public class LongTermsAggregator extends TermsAggregator {
         long previous = Long.MAX_VALUE;
         for (int i = 0; i < valuesCount; ++i) {
             final long val = values.valueAt(i);
-            if (previous != val || i != 0) {
-            long bucketOrdinal = bucketOrds.add(val);
-            if (bucketOrdinal < 0) { // already seen
-                bucketOrdinal = - 1 - bucketOrdinal;
-                collectExistingBucket(doc, bucketOrdinal);
-            } else {
-                collectBucket(doc, bucketOrdinal);
-            }
+            if (previous != val || i == 0) {
+                long bucketOrdinal = bucketOrds.add(val);
+                if (bucketOrdinal < 0) { // already seen
+                    bucketOrdinal = - 1 - bucketOrdinal;
+                    collectExistingBucket(doc, bucketOrdinal);
+                } else {
+                    collectBucket(doc, bucketOrdinal);
+                }
                 previous = val;
             }
         }

--- a/src/test/java/org/elasticsearch/index/fielddata/FieldDataTests.java
+++ b/src/test/java/org/elasticsearch/index/fielddata/FieldDataTests.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.fielddata;
+
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.util.NumericUtils;
+import org.elasticsearch.test.ElasticsearchTestCase;
+
+public class FieldDataTests extends ElasticsearchTestCase {
+
+    public void testSortableLongBitsToDoubles() {
+        final double value = randomDouble();
+        final long valueBits = NumericUtils.doubleToSortableLong(value);
+
+        NumericDocValues values = new NumericDocValues() {
+            @Override
+            public long get(int docID) {
+                return valueBits;
+            }
+        };
+
+        SortedNumericDoubleValues asMultiDoubles = FieldData.sortableLongBitsToDoubles(DocValues.singleton(values, null));
+        NumericDoubleValues asDoubles = FieldData.unwrapSingleton(asMultiDoubles);
+        assertNotNull(asDoubles);
+        assertEquals(value, asDoubles.get(0), 0);
+
+        NumericDocValues backToLongs = DocValues.unwrapSingleton(FieldData.toSortableLongBits(asMultiDoubles));
+        assertSame(values, backToLongs);
+
+        SortedNumericDocValues multiValues = new SortedNumericDocValues() {
+
+            @Override
+            public long valueAt(int index) {
+                return valueBits;
+            }
+
+            @Override
+            public void setDocument(int doc) {
+            }
+
+            @Override
+            public int count() {
+                return 1;
+            }
+        };
+
+        asMultiDoubles = FieldData.sortableLongBitsToDoubles(multiValues);
+        assertEquals(value, asMultiDoubles.valueAt(0), 0);
+        assertSame(multiValues, FieldData.toSortableLongBits(asMultiDoubles));
+    }
+
+    public void testDoublesToSortableLongBits() {
+        final double value = randomDouble();
+        final long valueBits = NumericUtils.doubleToSortableLong(value);
+
+        NumericDoubleValues values = new NumericDoubleValues() {
+            @Override
+            public double get(int docID) {
+                return value;
+            }
+        };
+
+        SortedNumericDocValues asMultiLongs = FieldData.toSortableLongBits(FieldData.singleton(values, null));
+        NumericDocValues asLongs = DocValues.unwrapSingleton(asMultiLongs);
+        assertNotNull(asLongs);
+        assertEquals(valueBits, asLongs.get(0));
+
+        SortedNumericDoubleValues multiValues = new SortedNumericDoubleValues() {
+            @Override
+            public double valueAt(int index) {
+                return value;
+            }
+
+            @Override
+            public void setDocument(int doc) {
+            }
+
+            @Override
+            public int count() {
+                return 1;
+            }
+        };
+
+        asMultiLongs = FieldData.toSortableLongBits(multiValues);
+        assertEquals(valueBits, asMultiLongs.valueAt(0));
+        assertSame(multiValues, FieldData.sortableLongBitsToDoubles(asMultiLongs));
+    }
+}


### PR DESCRIPTION
These two aggregators basically do exactly the same thing, they just interpret
bytes differently. This refactoring found an (unreleased) bug in the long terms
aggregator which didn't work correctly with duplicate values.
