### PR TITLE
Parsing command line args multiple times throws `AlreadySelectedException`

### DIFF
--- a/src/main/java/org/elasticsearch/common/cli/CliToolConfig.java
+++ b/src/main/java/org/elasticsearch/common/cli/CliToolConfig.java
@@ -148,7 +148,16 @@ public class CliToolConfig {
         }
 
         public Options options() {
-            return options;
+            // TODO Remove this when commons-cli 1.3 will be released
+            // and replace by return options;
+            // See https://issues.apache.org/jira/browse/CLI-183
+            Options copy = new Options();
+            for (Object oOption : options.getOptions()) {
+                Option option = (Option) oOption;
+                copy.addOption(option);
+            }
+            OptionsSource.VERBOSITY.populate(copy);
+            return copy;
         }
 
         public void printUsage(Terminal terminal) {

--- a/src/test/java/org/elasticsearch/common/cli/CliToolTests.java
+++ b/src/test/java/org/elasticsearch/common/cli/CliToolTests.java
@@ -22,6 +22,7 @@ package org.elasticsearch.common.cli;
 import com.google.common.collect.ImmutableMap;
 import org.apache.commons.cli.CommandLine;
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.junit.Test;
@@ -251,6 +252,23 @@ public class CliToolTests extends CliToolTestCase {
         } finally {
             System.clearProperty(Terminal.DEBUG_SYSTEM_PROPERTY);
         }
+    }
+
+    @Test
+    public void testMultipleLaunch() throws Exception {
+        Terminal terminal = new MockTerminal();
+        final AtomicReference<Boolean> executed = new AtomicReference<>(false);
+        final NamedCommand cmd = new NamedCommand("cmd", terminal) {
+            @Override
+            public CliTool.ExitStatus execute(Settings settings, Environment env) {
+                executed.set(true);
+                return CliTool.ExitStatus.OK;
+            }
+        };
+        SingleCmdTool tool = new SingleCmdTool("tool", terminal, cmd);
+        tool.parse("cmd", Strings.splitStringByCommaToArray("--verbose"));
+        tool.parse("cmd", Strings.splitStringByCommaToArray("--silent"));
+        tool.parse("cmd", Strings.splitStringByCommaToArray("--help"));
     }
 
     private void assertStatus(int status, CliTool.ExitStatus expectedStatus) {


### PR DESCRIPTION
This issue has been fixed in commons-cli:1.3 project which sadly has not been released yet.
See https://issues.apache.org/jira/browse/CLI-183

This patch builds another list of options with no selected groups by default.

When commons-cli:1.3 will be released, we need to remove this patch.
