### PR TITLE
Made it possible to disable the main transport handler in TransportShardSingleOperationAction

### DIFF
--- a/src/main/java/org/elasticsearch/action/get/TransportShardMultiGetAction.java
+++ b/src/main/java/org/elasticsearch/action/get/TransportShardMultiGetAction.java
@@ -58,6 +58,11 @@ public class TransportShardMultiGetAction extends TransportShardSingleOperationA
     }
 
     @Override
+    protected boolean isSubAction() {
+        return true;
+    }
+
+    @Override
     protected String executor() {
         return ThreadPool.Names.GET;
     }

--- a/src/main/java/org/elasticsearch/action/percolate/TransportShardMultiPercolateAction.java
+++ b/src/main/java/org/elasticsearch/action/percolate/TransportShardMultiPercolateAction.java
@@ -60,6 +60,11 @@ public class TransportShardMultiPercolateAction extends TransportShardSingleOper
     }
 
     @Override
+    protected boolean isSubAction() {
+        return true;
+    }
+
+    @Override
     protected String executor() {
         return ThreadPool.Names.PERCOLATE;
     }

--- a/src/main/java/org/elasticsearch/action/support/single/shard/TransportShardSingleOperationAction.java
+++ b/src/main/java/org/elasticsearch/action/support/single/shard/TransportShardSingleOperationAction.java
@@ -67,8 +67,19 @@ public abstract class TransportShardSingleOperationAction<Request extends Single
         this.transportShardAction = actionName + "[s]";
         this.executor = executor();
 
-        transportService.registerHandler(actionName, new TransportHandler());
+        if (!isSubAction()) {
+            transportService.registerHandler(actionName, new TransportHandler());
+        }
         transportService.registerHandler(transportShardAction, new ShardTransportHandler());
+    }
+
+    /**
+     * Tells whether the action is a main one or a subaction. Used to decide whether we need to register
+     * the main transport handler. In fact if the action is a subaction, its execute method
+     * will be called locally to its parent action.
+     */
+    protected boolean isSubAction() {
+        return false;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/termvector/TransportSingleShardMultiTermsVectorAction.java
+++ b/src/main/java/org/elasticsearch/action/termvector/TransportSingleShardMultiTermsVectorAction.java
@@ -50,6 +50,11 @@ public class TransportSingleShardMultiTermsVectorAction extends TransportShardSi
     }
 
     @Override
+    protected boolean isSubAction() {
+        return true;
+    }
+
+    @Override
     protected String executor() {
         return ThreadPool.Names.GET;
     }

--- a/src/main/java/org/elasticsearch/transport/ActionNames.java
+++ b/src/main/java/org/elasticsearch/transport/ActionNames.java
@@ -231,7 +231,7 @@ final class ActionNames {
         addShardAction(ExplainAction.NAME, "explain", builder);
         addShardAction(GetAction.NAME, "get", builder);
         builder.put(MultiGetAction.NAME, "mget");
-        addShardAction(MultiGetAction.NAME + "[shard]", "mget/shard", builder);
+        builder.put(MultiGetAction.NAME + "[shard][s]", "mget/shard/s");
 
         builder.put(GetIndexedScriptAction.NAME, "getIndexedScript");
         builder.put(PutIndexedScriptAction.NAME, "putIndexedScript");
@@ -240,12 +240,12 @@ final class ActionNames {
         builder.put(MoreLikeThisAction.NAME, "mlt");
 
         builder.put(MultiPercolateAction.NAME, "mpercolate");
-        addShardAction(MultiPercolateAction.NAME + "[shard]", "mpercolate/shard", builder);
+        builder.put(MultiPercolateAction.NAME + "[shard][s]", "mpercolate/shard/s");
 
         builder.put(MultiSearchAction.NAME, "msearch");
 
         builder.put(MultiTermVectorsAction.NAME, "mtv");
-        addShardAction(MultiTermVectorsAction.NAME + "[shard]", "mtv/shard", builder);
+        builder.put(MultiTermVectorsAction.NAME + "[shard][s]", "mtv/shard/s");
 
         addShardAction(PercolateAction.NAME, "percolate", builder);
 


### PR DESCRIPTION
`TransportShardSingleOperationAction` is currently subclassed by different transport actions. Some of them are internal only, meaning that their execution will take place only in the same node where their parent execution took place. That means that their main transport handler doesn't need to be registered, the only transport handler that's needed is the shard level one. 

Added abstract method `isSubAction` to the parent class that tells whether the action is a main one or a subaction, used to decide whether we need to register the main transport handler.
