### PR TITLE
Allows all options for expand_wildcards parameter

### DIFF
--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -48,6 +48,10 @@ to. If `open` is specified then the wildcard expression is expanded to only
 open indices and if `closed` is specified then the wildcard expression is
 expanded only to closed indices. Also both values (`open,closed`) can be
 specified to expand to all indices.
++
+If `none` is specified then wildcard expansion will be disabled and if `all` 
+is specified, wildcard expressions will expand to all indices (this is equivalent 
+to specifying `open,closed`). coming[1.4.0]
 
 The defaults settings for the above parameters depend on the api being used.
 

--- a/rest-api-spec/test/indices.get_mapping/50_wildcard_expansion.yaml
+++ b/rest-api-spec/test/indices.get_mapping/50_wildcard_expansion.yaml
@@ -1,0 +1,96 @@
+---
+setup:
+  - do:
+        indices.create:
+          index: test-xxx
+          body:
+              mappings:
+                type_1: {}
+  - do:
+        indices.create:
+          index: test-xxy
+          body:
+              mappings:
+                type_2: {}
+  - do:
+        indices.create:
+          index: test-xyy
+          body:
+              mappings:
+                type_3: {}
+  - do:
+        indices.create:
+          index: test-yyy
+          body:
+              mappings:
+                type_4: {}
+
+  - do:
+      indices.close:
+        index: test-xyy
+
+---
+"Get test-* with defaults":
+
+ - do:
+    indices.get_mapping:
+        index: test-x*
+
+ - match: { test-xxx.mappings.type_1.properties: {}}
+ - match: { test-xxy.mappings.type_2.properties: {}}
+
+---
+"Get test-* with wildcard_expansion=all":
+
+ - do:
+    indices.get_mapping:
+        index: test-x*
+        expand_wildcards: all
+
+ - match: { test-xxx.mappings.type_1.properties: {}}
+ - match: { test-xxy.mappings.type_2.properties: {}}
+ - match: { test-xyy.mappings.type_3.properties: {}}
+
+---
+"Get test-* with wildcard_expansion=open":
+
+ - do:
+    indices.get_mapping:
+        index: test-x*
+        expand_wildcards: open
+
+ - match: { test-xxx.mappings.type_1.properties: {}}
+ - match: { test-xxy.mappings.type_2.properties: {}}
+
+---
+"Get test-* with wildcard_expansion=closed":
+
+ - do:
+    indices.get_mapping:
+        index: test-x*
+        expand_wildcards: closed
+
+ - match: { test-xyy.mappings.type_3.properties: {}}
+
+---
+"Get test-* with wildcard_expansion=none":
+
+ - do:
+    catch: missing
+    indices.get_mapping:
+        index: test-x*
+        expand_wildcards: none
+
+---
+"Get test-* with wildcard_expansion=open,closed":
+
+ - do:
+    indices.get_mapping:
+        index: test-x*
+        expand_wildcards: open,closed
+
+ - match: { test-xxx.mappings.type_1.properties: {}}
+ - match: { test-xxy.mappings.type_2.properties: {}}
+ - match: { test-xyy.mappings.type_3.properties: {}}
+
+

--- a/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
+++ b/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
@@ -152,14 +152,23 @@ public class IndicesOptions {
             return defaultSettings;
         }
 
-        boolean expandWildcardsOpen = defaultSettings.expandWildcardsOpen();
-        boolean expandWildcardsClosed = defaultSettings.expandWildcardsClosed();
-        if (sWildcards != null) {
+        boolean expandWildcardsOpen = false;
+        boolean expandWildcardsClosed = false;
+        if (sWildcards == null) {
+            expandWildcardsOpen = defaultSettings.expandWildcardsOpen();
+            expandWildcardsClosed = defaultSettings.expandWildcardsClosed();
+        } else {
             String[] wildcards = Strings.splitStringByCommaToArray(sWildcards);
             for (String wildcard : wildcards) {
                 if ("open".equals(wildcard)) {
                     expandWildcardsOpen = true;
                 } else if ("closed".equals(wildcard)) {
+                    expandWildcardsClosed = true;
+                } else if ("none".equals(wildcard)) {
+                    expandWildcardsOpen = false;
+                    expandWildcardsClosed = false;
+                } else if ("all".equals(wildcard)) {
+                    expandWildcardsOpen = true;
                     expandWildcardsClosed = true;
                 } else {
                     throw new ElasticsearchIllegalArgumentException("No valid expand wildcard value [" + wildcard + "]");

--- a/src/test/java/org/elasticsearch/cluster/metadata/MetaDataTests.java
+++ b/src/test/java/org/elasticsearch/cluster/metadata/MetaDataTests.java
@@ -22,12 +22,15 @@ package org.elasticsearch.cluster.metadata;
 import com.google.common.collect.Sets;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.cluster.metadata.IndexMetaData.State;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.indices.IndexClosedException;
 import org.elasticsearch.indices.IndexMissingException;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.junit.Test;
+
+import java.util.HashSet;
 
 import static com.google.common.collect.Sets.newHashSet;
 import static org.hamcrest.Matchers.*;
@@ -505,6 +508,22 @@ public class MetaDataTests extends ElasticsearchTestCase {
         assertThat(newHashSet(md.convertFromWildcards(new String[]{"+testYYY", "+testX*"}, IndicesOptions.lenientExpandOpen())), equalTo(newHashSet("testXXX", "testXYY", "testYYY")));
     }
 
+    @Test
+    public void convertWildcardsOpenClosedIndicesTests() {
+        MetaData.Builder mdBuilder = MetaData.builder()
+                .put(indexBuilder("testXXX").state(State.OPEN))
+                .put(indexBuilder("testXXY").state(State.OPEN))
+                .put(indexBuilder("testXYY").state(State.CLOSE))
+                .put(indexBuilder("testYYY").state(State.OPEN))
+                .put(indexBuilder("testYYX").state(State.CLOSE))
+                .put(indexBuilder("kuku").state(State.OPEN));
+        MetaData md = mdBuilder.build();
+        // Can't test when wildcard expansion is turned off here as convertFromWildcards shouldn't be called in this case.  Tests for this are covered in the concreteIndices() tests
+        assertThat(newHashSet(md.convertFromWildcards(new String[]{"testX*"}, IndicesOptions.fromOptions(true, true, true, true))), equalTo(newHashSet("testXXX", "testXXY", "testXYY")));
+        assertThat(newHashSet(md.convertFromWildcards(new String[]{"testX*"}, IndicesOptions.fromOptions(true, true, false, true))), equalTo(newHashSet("testXYY")));
+        assertThat(newHashSet(md.convertFromWildcards(new String[]{"testX*"}, IndicesOptions.fromOptions(true, true, true, false))), equalTo(newHashSet("testXXX", "testXXY")));
+    }
+
     private IndexMetaData.Builder indexBuilder(String index) {
         return IndexMetaData.builder(index).settings(ImmutableSettings.settingsBuilder().put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1).put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0));
     }
@@ -543,6 +562,21 @@ public class MetaDataTests extends ElasticsearchTestCase {
                 .put(indexBuilder("kuku"));
         MetaData md = mdBuilder.build();
         assertThat(newHashSet(md.concreteIndices(IndicesOptions.lenientExpandOpen(), new String[]{})), equalTo(Sets.newHashSet("kuku", "testXXX")));
+    }
+
+    @Test
+    public void concreteIndicesWildcardExpansion() {
+        MetaData.Builder mdBuilder = MetaData.builder()
+                .put(indexBuilder("testXXX").state(State.OPEN))
+                .put(indexBuilder("testXXY").state(State.OPEN))
+                .put(indexBuilder("testXYY").state(State.CLOSE))
+                .put(indexBuilder("testYYY").state(State.OPEN))
+                .put(indexBuilder("testYYX").state(State.OPEN));
+        MetaData md = mdBuilder.build();
+        assertThat(newHashSet(md.concreteIndices(IndicesOptions.fromOptions(true, true, false, false), "testX*")), equalTo(new HashSet<String>()));
+        assertThat(newHashSet(md.concreteIndices(IndicesOptions.fromOptions(true, true, true, false), "testX*")), equalTo(newHashSet("testXXX", "testXXY")));
+        assertThat(newHashSet(md.concreteIndices(IndicesOptions.fromOptions(true, true, false, true), "testX*")), equalTo(newHashSet("testXYY")));
+        assertThat(newHashSet(md.concreteIndices(IndicesOptions.fromOptions(true, true, true, true), "testX*")), equalTo(newHashSet("testXXX", "testXXY", "testXYY")));
     }
 
     @Test


### PR DESCRIPTION
This change means that the default settings for expand_wildcards are only applied if the expand_wildcards parameter is not specified rather than being set upfront. It also adds the none and all options to the parameter to allow the user to specify no expansion and expansion to all indexes (equivalent to 'open,closed')

Closes #7258
