### PR TITLE
Report conflict when trying to disable `_ttl`

### DIFF
--- a/docs/reference/mapping/fields/ttl-field.asciidoc
+++ b/docs/reference/mapping/fields/ttl-field.asciidoc
@@ -5,6 +5,8 @@ A lot of documents naturally come with an expiration date. Documents can
 therefore have a `_ttl` (time to live), which will cause the expired
 documents to be deleted automatically.
 
+`_ttl` accepts two parameters which are described below, every other setting will be silently ignored.
+
 [float]
 ==== enabled
 
@@ -20,12 +22,7 @@ should be defined:
 }
 --------------------------------------------------
 
-[float]
-==== store / index
-
-By default the `_ttl` field has `store` set to `true` and `index` set to
-`not_analyzed`. Note that `index` property has to be set to
-`not_analyzed` in order for the purge process to work.
+`_ttl` can only be enabled once and never be disabled again.
 
 [float]
 ==== default

--- a/src/main/java/org/elasticsearch/index/mapper/internal/TTLFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/TTLFieldMapper.java
@@ -240,11 +240,15 @@ public class TTLFieldMapper extends LongFieldMapper implements InternalMapper, R
     public void merge(Mapper mergeWith, MergeContext mergeContext) throws MergeMappingException {
         TTLFieldMapper ttlMergeWith = (TTLFieldMapper) mergeWith;
         if (ttlMergeWith.defaultTTL != -1) {
-            this.defaultTTL = ttlMergeWith.defaultTTL;
+            if (!mergeContext.mergeFlags().simulate()) {
+                this.defaultTTL = ttlMergeWith.defaultTTL;
+            }
         }
         if ((ttlMergeWith.enabledState != enabledState) &&!(ttlMergeWith.enabledState == Defaults.ENABLED_STATE)) {
             if (ttlMergeWith.enabledState != EnabledAttributeMapper.DISABLED) {
-                this.enabledState = ttlMergeWith.enabledState;
+                if (!mergeContext.mergeFlags().simulate()) {
+                    this.enabledState = ttlMergeWith.enabledState;
+                }
             } else {
                 mergeContext.addConflict("_ttl cannot be disabled once it was enabled.");
             }

--- a/src/main/java/org/elasticsearch/index/mapper/internal/TTLFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/TTLFieldMapper.java
@@ -35,6 +35,7 @@ import org.elasticsearch.index.codec.postingsformat.PostingsFormatProvider;
 import org.elasticsearch.index.mapper.*;
 import org.elasticsearch.index.mapper.core.LongFieldMapper;
 import org.elasticsearch.index.mapper.core.NumberFieldMapper;
+import org.elasticsearch.index.query.GeoShapeFilterParser;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
@@ -225,7 +226,7 @@ public class TTLFieldMapper extends LongFieldMapper implements InternalMapper, R
             return builder;
         }
         builder.startObject(CONTENT_TYPE);
-        if (includeDefaults || enabledState.enabled != Defaults.ENABLED_STATE.enabled) {
+        if (includeDefaults || enabledState != Defaults.ENABLED_STATE) {
             builder.field("enabled", enabledState.enabled);
         }
         if (includeDefaults || defaultTTL != Defaults.DEFAULT && enabledState.enabled) {
@@ -238,12 +239,14 @@ public class TTLFieldMapper extends LongFieldMapper implements InternalMapper, R
     @Override
     public void merge(Mapper mergeWith, MergeContext mergeContext) throws MergeMappingException {
         TTLFieldMapper ttlMergeWith = (TTLFieldMapper) mergeWith;
-        if (!mergeContext.mergeFlags().simulate()) {
-            if (ttlMergeWith.defaultTTL != -1) {
-                this.defaultTTL = ttlMergeWith.defaultTTL;
-            }
-            if (ttlMergeWith.enabledState != enabledState && !ttlMergeWith.enabledState.unset()) {
+        if (ttlMergeWith.defaultTTL != -1) {
+            this.defaultTTL = ttlMergeWith.defaultTTL;
+        }
+        if ((ttlMergeWith.enabledState != enabledState) &&!(ttlMergeWith.enabledState == Defaults.ENABLED_STATE)) {
+            if (ttlMergeWith.enabledState != EnabledAttributeMapper.DISABLED) {
                 this.enabledState = ttlMergeWith.enabledState;
+            } else {
+                mergeContext.addConflict("_ttl cannot be disabled once it was enabled.");
             }
         }
     }


### PR DESCRIPTION
_ttl could never be disabled once it was enabled.
But when trying to, no conflict was reported.

relates to #777 and #7293
