### PR TITLE
SearchRequestBuilder.toString modifies the SearchRequestBuilder wiping any source set.

### DIFF
--- a/src/main/java/org/elasticsearch/action/count/CountRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/count/CountRequestBuilder.java
@@ -24,7 +24,10 @@ import org.elasticsearch.action.support.QuerySourceBuilder;
 import org.elasticsearch.action.support.broadcast.BroadcastOperationRequestBuilder;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.index.query.QueryBuilder;
+
+import java.io.IOException;
 
 /**
  * A count action request builder.
@@ -143,4 +146,22 @@ public class CountRequestBuilder extends BroadcastOperationRequestBuilder<CountR
         }
         return sourceBuilder;
     }
+
+    @Override
+    public String toString() {
+        if (request.source() != null) {
+            try {
+                return XContentHelper.convertToJson(request.source(), false, false);
+            } catch (IOException |NullPointerException e) {
+                return request().source().toUtf8();
+            }
+        } else {
+            if (sourceBuilder != null){
+                return sourceBuilder().toString();
+            } else {
+                return "{}"; //Nothing has been set return the empty query
+            }
+        }
+    }
+
 }

--- a/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
@@ -1097,7 +1097,11 @@ public class SearchRequestBuilder extends ActionRequestBuilder<SearchRequest, Se
 
     @Override
     public String toString() {
-        return internalBuilder().toString();
+        if (request.source() != null) {
+            return request.source().toUtf8();
+        } else {
+            return internalBuilder().toString();
+        }
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
@@ -1106,7 +1106,11 @@ public class SearchRequestBuilder extends ActionRequestBuilder<SearchRequest, Se
                 return request().source().toUtf8();
             }
         } else {
-            return internalBuilder().toString();
+            if (sourceBuilder != null) {
+                return sourceBuilder.toString();
+            } else {
+                return "{}"; //Nothing has been set return the empty query
+            }
         }
     }
 

--- a/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.index.query.FilterBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.script.ScriptService;
@@ -41,6 +42,7 @@ import org.elasticsearch.search.sort.SortBuilder;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.search.suggest.SuggestBuilder;
 
+import java.io.IOException;
 import java.util.Map;
 
 /**
@@ -1098,7 +1100,11 @@ public class SearchRequestBuilder extends ActionRequestBuilder<SearchRequest, Se
     @Override
     public String toString() {
         if (request.source() != null) {
-            return request.source().toUtf8();
+            try {
+                return XContentHelper.convertToJson(request.source(), false, false);
+            } catch (IOException|NullPointerException e) {
+                return request().source().toUtf8();
+            }
         } else {
             return internalBuilder().toString();
         }

--- a/src/test/java/org/elasticsearch/action/count/CountRequestBuilderTests.java
+++ b/src/test/java/org/elasticsearch/action/count/CountRequestBuilderTests.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.count;
+
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class CountRequestBuilderTests extends ElasticsearchIntegrationTest {
+    //This would work better as a TestCase but CountRequestBuilder construction
+    //requires a client
+
+    @Test
+    public void testSearchRequestBuilderToString(){
+        try
+        {
+            CountRequestBuilder countRequestBuilder = new CountRequestBuilder(client());
+            XContentBuilder contentBuilder = XContentFactory.jsonBuilder();
+            contentBuilder.startObject()
+                    .field("query")
+                    .startObject()
+                    .field("match_all")
+                    .startObject()
+                    .endObject()
+                    .endObject()
+                    .endObject();
+            countRequestBuilder.setSource(contentBuilder.bytes());
+            assertEquals(countRequestBuilder.toString(), XContentHelper.convertToJson(contentBuilder.bytes(), false, false));
+        } catch (IOException ie) {
+            throw new ElasticsearchException("Unable to create content builder", ie);
+        }
+        try
+        {
+            CountRequestBuilder countRequestBuilder = new CountRequestBuilder(client());
+            XContentBuilder contentBuilder = XContentFactory.jsonBuilder();
+            logger.debug(contentBuilder.toString()); //This should not affect things
+            contentBuilder.startObject()
+                    .field("query")
+                    .startObject()
+                    .field("match_all")
+                    .startObject()
+                    .endObject()
+                    .endObject()
+                    .endObject();
+            countRequestBuilder.setSource(contentBuilder.bytes());
+            assertEquals(countRequestBuilder.toString(), XContentHelper.convertToJson(contentBuilder.bytes(), false, false));
+
+        } catch (IOException ie) {
+            throw new ElasticsearchException("Unable to create content builder", ie);
+        }
+    }
+
+}

--- a/src/test/java/org/elasticsearch/action/search/SearchRequestBuilderTests.java
+++ b/src/test/java/org/elasticsearch/action/search/SearchRequestBuilderTests.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.search;
+
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.junit.Test;
+
+public class SearchRequestBuilderTests extends ElasticsearchIntegrationTest {
+    //This would work better as a TestCase but SearchRequestBuilder construction
+    //requires a client
+
+    @Test
+    public void testSearchRequestBuilderToString(){
+        {
+            SearchRequestBuilder srb = new SearchRequestBuilder(client());
+            String querySource = "{\"query\":{\"match_all\":{}}}";
+            srb.setSource("{\"query\":{\"match_all\":{}}}");
+            assertEquals(srb.toString(), querySource);
+        }
+        {
+            SearchRequestBuilder srb = new SearchRequestBuilder(client());
+            logger.debug(srb.toString()); //This really shouldn't do anything
+            String querySource = "{\"query\":{\"match_all\":{}}}";
+            srb.setSource("{\"query\":{\"match_all\":{}}}");
+            assertEquals(srb.toString(), querySource);
+
+        }
+    }
+}


### PR DESCRIPTION
This fixes #7317.
SearchRequestBuilder.toString now attempts to render the request's source before falling back to using the internal builder.

Closes #5576 
Closes #5555
