### PR TITLE
Indexed Scripts/Templates: Return error message on 404

### DIFF
--- a/rest-api-spec/test/script/10_basic.yaml
+++ b/rest-api-spec/test/script/10_basic.yaml
@@ -57,7 +57,7 @@
     get_script:
       id: "foobar"
       lang: "groovy"
-  - match: { "error": "IndexedScriptMissingException[[foobar] not found]" }
+  - match: { "error": "Script [foobar] not found" }
   - match: { "status": 404 }
 
 
@@ -66,7 +66,7 @@
     delete_script:
       id: "foobar"
       lang: "groovy"
-  - match: { "error": "IndexedScriptMissingException[[foobar] not found]" }
+  - match: { "error": "Script [foobar] not found" }
   - match: { "status": 404 }
 
 

--- a/rest-api-spec/test/script/10_basic.yaml
+++ b/rest-api-spec/test/script/10_basic.yaml
@@ -51,3 +51,22 @@
         lang: "foobar"
         body: { "script" :  "_score * doc[\"myParent.weight\"].value" }
 
+
+  - do:
+    catch: missing
+    get_script:
+      id: "foobar"
+      lang: "groovy"
+  - match: { "error": "IndexedScriptMissingException[[foobar] not found]" }
+  - match: { "status": 404 }
+
+
+  - do:
+    catch: missing
+    delete_script:
+      id: "foobar"
+      lang: "groovy"
+  - match: { "error": "IndexedScriptMissingException[[foobar] not found]" }
+  - match: { "status": 404 }
+
+

--- a/rest-api-spec/test/template/10_basic.yaml
+++ b/rest-api-spec/test/template/10_basic.yaml
@@ -37,11 +37,11 @@
     get_template:
       id: "foobar"
   - match: { "status": 404 }
-  - match: { "error": "IndexedTemplateMissingException[[foobar] not found]" }
+  - match: { "error": "Template [foobar] not found" }
 
   - do:
     catch: missing
     delete_template:
       id: "foobar"
   - match: { "status": 404 }
-  - match: { "error": "IndexedTemplateMissingException[[foobar] not found]" }
+  - match: { "error": "Template [foobar] not found" }

--- a/rest-api-spec/test/template/10_basic.yaml
+++ b/rest-api-spec/test/template/10_basic.yaml
@@ -31,3 +31,17 @@
       put_template:
         id: "1"
         body: { "template": { "query": { "match{{}}_all": {}}, "size": "{{my_size}}" } }
+
+  - do:
+    catch: missing
+    get_template:
+      id: "foobar"
+  - match: { "status": 404 }
+  - match: { "error": "IndexedTemplateMissingException[[foobar] not found]" }
+
+  - do:
+    catch: missing
+    delete_template:
+      id: "foobar"
+  - match: { "status": 404 }
+  - match: { "error": "IndexedTemplateMissingException[[foobar] not found]" }

--- a/src/main/java/org/elasticsearch/rest/action/script/RestDeleteIndexedScriptAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/script/RestDeleteIndexedScriptAction.java
@@ -54,15 +54,20 @@ public class RestDeleteIndexedScriptAction extends BaseRestHandler {
         scriptService.deleteScriptFromIndex(client,request.param("lang"), id, version, new RestBuilderListener<DeleteResponse>(channel) {
             @Override
             public RestResponse buildResponse(DeleteResponse result, XContentBuilder builder) throws Exception {
-                builder.startObject()
-                        .field(Fields.FOUND, result.isFound())
-                        .field(Fields._INDEX, result.getIndex())
-                        .field(Fields._TYPE, result.getType())
-                        .field(Fields._ID, result.getId())
-                        .field(Fields._VERSION, result.getVersion())
-                        .endObject();
                 RestStatus status = OK;
-                if (!result.isFound()) {
+                if (result.isFound()) {
+                    builder.startObject()
+                            .field(Fields.FOUND, result.isFound())
+                            .field(Fields._INDEX, result.getIndex())
+                            .field(Fields._TYPE, result.getType())
+                            .field(Fields._ID, result.getId())
+                            .field(Fields._VERSION, result.getVersion())
+                            .endObject();
+                } else {
+                    builder.startObject();
+                    builder.field("status", NOT_FOUND.getStatus());
+                    builder.field("error", "IndexedScriptMissingException[[" + id + "] not found]");
+                    builder.endObject();
                     status = NOT_FOUND;
                 }
                 return new BytesRestResponse(status, builder);

--- a/src/main/java/org/elasticsearch/rest/action/script/RestDeleteIndexedScriptAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/script/RestDeleteIndexedScriptAction.java
@@ -66,7 +66,7 @@ public class RestDeleteIndexedScriptAction extends BaseRestHandler {
                 } else {
                     builder.startObject();
                     builder.field("status", NOT_FOUND.getStatus());
-                    builder.field("error", "IndexedScriptMissingException[[" + id + "] not found]");
+                    builder.field("error", "Script [" + id + "] not found");
                     builder.endObject();
                     status = NOT_FOUND;
                 }

--- a/src/main/java/org/elasticsearch/rest/action/script/RestGetIndexedScriptAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/script/RestGetIndexedScriptAction.java
@@ -64,7 +64,7 @@ public class RestGetIndexedScriptAction extends BaseRestHandler {
                 if (!response.isExists()) {
                     builder.startObject();
                     builder.field("status", NOT_FOUND.getStatus());
-                    builder.field("error", "IndexedScriptMissingException[[" + request.param("id") + "] not found]");
+                    builder.field("error", "Script [" + request.param("id") + "] not found");
                     builder.endObject();
                     return new BytesRestResponse(NOT_FOUND, builder);
                 } else {

--- a/src/main/java/org/elasticsearch/rest/action/script/RestGetIndexedScriptAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/script/RestGetIndexedScriptAction.java
@@ -62,6 +62,10 @@ public class RestGetIndexedScriptAction extends BaseRestHandler {
             public RestResponse buildResponse(GetIndexedScriptResponse response) throws Exception {
                 XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
                 if (!response.isExists()) {
+                    builder.startObject();
+                    builder.field("status", NOT_FOUND.getStatus());
+                    builder.field("error", "IndexedScriptMissingException[[" + request.param("id") + "] not found]");
+                    builder.endObject();
                     return new BytesRestResponse(NOT_FOUND, builder);
                 } else {
                     try{

--- a/src/main/java/org/elasticsearch/rest/action/template/RestDeleteSearchTemplateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/template/RestDeleteSearchTemplateAction.java
@@ -64,7 +64,7 @@ public class RestDeleteSearchTemplateAction extends BaseRestHandler {
                 } else {
                     builder.startObject();
                     builder.field("status", NOT_FOUND.getStatus());
-                    builder.field("error", "IndexedTemplateMissingException[[" + id + "] not found]");
+                    builder.field("error", "Template [" + id + "] not found");
                     builder.endObject();
                     status = NOT_FOUND;
                 }

--- a/src/main/java/org/elasticsearch/rest/action/template/RestDeleteSearchTemplateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/template/RestDeleteSearchTemplateAction.java
@@ -52,15 +52,20 @@ public class RestDeleteSearchTemplateAction extends BaseRestHandler {
         scriptService.deleteScriptFromIndex(client,"mustache", id, version, new RestBuilderListener<DeleteResponse>(channel) {
             @Override
             public RestResponse buildResponse(DeleteResponse result, XContentBuilder builder) throws Exception {
-                builder.startObject()
-                        .field(Fields.FOUND, result.isFound())
-                        .field(Fields._INDEX, result.getIndex())
-                        .field(Fields._TYPE, result.getType())
-                        .field(Fields._ID, result.getId())
-                        .field(Fields._VERSION, result.getVersion())
-                        .endObject();
                 RestStatus status = OK;
-                if (!result.isFound()) {
+                if (result.isFound()) {
+                    builder.startObject()
+                            .field(Fields.FOUND, result.isFound())
+                            .field(Fields._INDEX, result.getIndex())
+                            .field(Fields._TYPE, result.getType())
+                            .field(Fields._ID, result.getId())
+                            .field(Fields._VERSION, result.getVersion())
+                            .endObject();
+                } else {
+                    builder.startObject();
+                    builder.field("status", NOT_FOUND.getStatus());
+                    builder.field("error", "IndexedTemplateMissingException[[" + id + "] not found]");
+                    builder.endObject();
                     status = NOT_FOUND;
                 }
                 return new BytesRestResponse(status, builder);

--- a/src/main/java/org/elasticsearch/rest/action/template/RestGetSearchTemplateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/template/RestGetSearchTemplateAction.java
@@ -59,6 +59,10 @@ public class RestGetSearchTemplateAction extends BaseRestHandler {
             public RestResponse buildResponse(GetIndexedScriptResponse response) throws Exception {
                 XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
                 if (!response.isExists()) {
+                    builder.startObject();
+                    builder.field("status", NOT_FOUND.getStatus());
+                    builder.field("error", "IndexedTemplateMissingException[[" + request.param("id") + "] not found]");
+                    builder.endObject();
                     return new BytesRestResponse(NOT_FOUND, builder);
                 } else {
                     try{

--- a/src/main/java/org/elasticsearch/rest/action/template/RestGetSearchTemplateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/template/RestGetSearchTemplateAction.java
@@ -61,7 +61,7 @@ public class RestGetSearchTemplateAction extends BaseRestHandler {
                 if (!response.isExists()) {
                     builder.startObject();
                     builder.field("status", NOT_FOUND.getStatus());
-                    builder.field("error", "IndexedTemplateMissingException[[" + request.param("id") + "] not found]");
+                    builder.field("error", "Template [" + request.param("id") + "] not found");
                     builder.endObject();
                     return new BytesRestResponse(NOT_FOUND, builder);
                 } else {


### PR DESCRIPTION
This commit adds support for messages such as :

```
{
  "status" : 404,
  "error" : "IndexedScriptMissingException[[asdasdasfe] missing]"
}
{
  "status" : 404,
  "error" : "IndexedSearchTemplateMissingException[[asdasdasdas] missing]"
}
```

When non existant indexed scripts and templates are requested from get and delete REST endpoints.

See #7325
