### PR TITLE
Fixes BoundingBox across complete longitudinal range

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxFilterParser.java
@@ -155,10 +155,17 @@ public class GeoBoundingBoxFilterParser implements FilterParser {
 
         final GeoPoint topLeft = sparse.reset(top, left);  //just keep the object
         final GeoPoint bottomRight = new GeoPoint(bottom, right);
-        
+
         if (normalize) {
-            GeoUtils.normalizePoint(topLeft);
-            GeoUtils.normalizePoint(bottomRight);
+            // Special case: if the difference bettween the left and right is 360 and the right is greater than the left, we are asking for 
+            // the complete longitude range so need to set longitude to the complete longditude range
+            boolean completeLonRange = ((right - left) % 360 == 0 && right > left);
+            GeoUtils.normalizePoint(topLeft, true, !completeLonRange);
+            GeoUtils.normalizePoint(bottomRight, true, !completeLonRange);
+            if (completeLonRange) {
+                topLeft.resetLon(-180);
+                bottomRight.resetLon(180);
+            }
         }
 
         MapperService.SmartNameFieldMappers smartMappers = parseContext.smartFieldMappers(fieldName);


### PR DESCRIPTION
Adds a special case to the GeoBoundingBoxFilterParser so that the left of the box is not normalised int he case where left = -180 and right = 180.  Before this change the left would be normalised to 180 in this case and the filter would only match points with a longitude of 180 (or -180).

Closes #5218
