### PR TITLE
Improve recovery / snapshot restoring file identity handling

### DIFF
--- a/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshot.java
+++ b/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshot.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.snapshots.blobstore;
 
 import com.google.common.collect.ImmutableList;
+import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.Version;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.Nullable;
@@ -196,6 +197,7 @@ public class BlobStoreIndexShardSnapshot {
             static final XContentBuilderString CHECKSUM = new XContentBuilderString("checksum");
             static final XContentBuilderString PART_SIZE = new XContentBuilderString("part_size");
             static final XContentBuilderString WRITTEN_BY = new XContentBuilderString("written_by");
+            static final XContentBuilderString META_HASH = new XContentBuilderString("meta_hash");
         }
 
         /**
@@ -221,6 +223,10 @@ public class BlobStoreIndexShardSnapshot {
             if (file.metadata.writtenBy() != null) {
                 builder.field(Fields.WRITTEN_BY, file.metadata.writtenBy());
             }
+
+            if (file.metadata.hash() != null && file.metadata().hash().length > 0) {
+                builder.field(Fields.META_HASH, file.metadata.hash());
+            }
             builder.endObject();
         }
 
@@ -239,6 +245,7 @@ public class BlobStoreIndexShardSnapshot {
             String checksum = null;
             ByteSizeValue partSize = null;
             Version writtenBy = null;
+            BytesRef metaHash = new BytesRef();
             if (token == XContentParser.Token.START_OBJECT) {
                 while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
                     if (token == XContentParser.Token.FIELD_NAME) {
@@ -257,6 +264,10 @@ public class BlobStoreIndexShardSnapshot {
                                 partSize = new ByteSizeValue(parser.longValue());
                             } else if ("written_by".equals(currentFieldName)) {
                                 writtenBy = Lucene.parseVersionLenient(parser.text(), null);
+                            } else if ("meta_hash".equals(currentFieldName)) {
+                                metaHash.bytes = parser.binaryValue();
+                                metaHash.offset = 0;
+                                metaHash.length = metaHash.bytes.length;
                             } else {
                                 throw new ElasticsearchParseException("unknown parameter [" + currentFieldName + "]");
                             }
@@ -269,7 +280,7 @@ public class BlobStoreIndexShardSnapshot {
                 }
             }
             // TODO: Verify???
-            return new FileInfo(name, new StoreFileMetaData(physicalName, length, checksum, writtenBy), partSize);
+            return new FileInfo(name, new StoreFileMetaData(physicalName, length, checksum, writtenBy, metaHash), partSize);
         }
 
     }

--- a/src/main/java/org/elasticsearch/index/store/StoreFileMetaData.java
+++ b/src/main/java/org/elasticsearch/index/store/StoreFileMetaData.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.store;
 
+import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.Version;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -42,22 +43,35 @@ public class StoreFileMetaData implements Streamable {
 
     private Version writtenBy;
 
+    private BytesRef hash;
+
     private StoreFileMetaData() {
     }
 
     public StoreFileMetaData(String name, long length) {
-        this(name, length, null, null);
+        this(name, length, null);
+    }
 
+    public StoreFileMetaData(String name, long length, String checksum) {
+        this(name, length, checksum, null, new BytesRef());
     }
 
     public StoreFileMetaData(String name, long length, String checksum, Version writtenBy) {
+        this(name, length, checksum, writtenBy, new BytesRef());
+    }
+
+    public StoreFileMetaData(String name, long length, String checksum, Version writtenBy, BytesRef hash) {
         this.name = name;
         this.length = length;
         this.checksum = checksum;
         this.writtenBy = writtenBy;
+        this.hash = hash;
     }
 
 
+    /**
+     * Returns the name of this file
+     */
     public String name() {
         return name;
     }
@@ -69,6 +83,12 @@ public class StoreFileMetaData implements Streamable {
         return length;
     }
 
+    /**
+     * Returns a string representation of the files checksum. Since Lucene 4.8 this is a CRC32 checksum written
+     * by lucene. Previously we use Adler32 on top of Lucene as the checksum algorithm, if {@link #hasLegacyChecksum()} returns
+     * <code>true</code> this is a Adler32 checksum.
+     * @return
+     */
     @Nullable
     public String checksum() {
         return this.checksum;
@@ -81,7 +101,7 @@ public class StoreFileMetaData implements Streamable {
         if (checksum == null || other.checksum == null) {
             return false;
         }
-        return length == other.length && checksum.equals(other.checksum);
+        return length == other.length && checksum.equals(other.checksum) && hash.equals(other.hash);
     }
 
     public static StoreFileMetaData readStoreFileMetaData(StreamInput in) throws IOException {
@@ -104,6 +124,9 @@ public class StoreFileMetaData implements Streamable {
             String versionString = in.readOptionalString();
             writtenBy = Lucene.parseVersionLenient(versionString, null);
         }
+        if (in.getVersion().onOrAfter(org.elasticsearch.Version.V_1_4_0)) {
+            hash = in.readBytesRef();
+        }
     }
 
     @Override
@@ -113,6 +136,9 @@ public class StoreFileMetaData implements Streamable {
         out.writeOptionalString(checksum);
         if (out.getVersion().onOrAfter(org.elasticsearch.Version.V_1_3_0)) {
             out.writeOptionalString(writtenBy == null ? null : writtenBy.name());
+        }
+        if (out.getVersion().onOrAfter(org.elasticsearch.Version.V_1_4_0)) {
+            out.writeBytesRef(hash);
         }
     }
 
@@ -129,5 +155,13 @@ public class StoreFileMetaData implements Streamable {
      */
     public boolean hasLegacyChecksum() {
         return checksum != null && ((writtenBy != null  && writtenBy.onOrAfter(Version.LUCENE_4_8)) == false);
+    }
+
+    /**
+     * Returns a variable length hash of the file represented by this metadata object. This can be the file
+     * itself if the file is small enough. If the length of the hash is <tt>0</tt> no hash value is available
+     */
+    public BytesRef hash() {
+        return hash;
     }
 }

--- a/src/test/java/org/elasticsearch/index/snapshots/blobstore/FileInfoTest.java
+++ b/src/test/java/org/elasticsearch/index/snapshots/blobstore/FileInfoTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.index.snapshots.blobstore;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.xcontent.*;
+import org.elasticsearch.index.store.StoreFileMetaData;
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+/**
+ */
+public class FileInfoTest extends ElasticsearchTestCase {
+
+    @Test
+    public void testToFromXContent() throws IOException {
+        final int iters = scaledRandomIntBetween(1, 10);
+        for (int iter = 0; iter < iters; iter++) {
+            final BytesRef hash = new BytesRef(scaledRandomIntBetween(0, 1024 * 1024));
+            hash.length = hash.bytes.length;
+            for (int i = 0; i < hash.length; i++) {
+                hash.bytes[i] = randomByte();
+            }
+            StoreFileMetaData meta = new StoreFileMetaData("foobar", randomInt(), randomAsciiOfLengthBetween(1, 10), TEST_VERSION_CURRENT, hash);
+            ByteSizeValue size = new ByteSizeValue(Math.max(0,Math.abs(randomLong())));
+            BlobStoreIndexShardSnapshot.FileInfo info = new BlobStoreIndexShardSnapshot.FileInfo("_foobar", meta, size);
+            XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON).prettyPrint();
+            BlobStoreIndexShardSnapshot.FileInfo.toXContent(info, builder, ToXContent.EMPTY_PARAMS);
+            byte[] xcontent = builder.bytes().toBytes();
+
+            final BlobStoreIndexShardSnapshot.FileInfo parsedInfo;
+            try (XContentParser parser = XContentFactory.xContent(XContentType.JSON).createParser(xcontent)) {
+                parser.nextToken();
+                parsedInfo = BlobStoreIndexShardSnapshot.FileInfo.fromXContent(parser);
+            }
+            assertThat(info.name(), equalTo(parsedInfo.name()));
+            assertThat(info.physicalName(), equalTo(parsedInfo.physicalName()));
+            assertThat(info.length(), equalTo(parsedInfo.length()));
+            assertThat(info.checksum(), equalTo(parsedInfo.checksum()));
+            assertThat(info.partBytes(), equalTo(parsedInfo.partBytes()));
+            assertThat(parsedInfo.metadata().hash().length, equalTo(hash.length));
+            assertThat(parsedInfo.metadata().hash(), equalTo(hash));
+            assertThat(parsedInfo.metadata().writtenBy(), equalTo(TEST_VERSION_CURRENT));
+            assertThat(parsedInfo.isSame(info.metadata()), is(true));
+        }
+    }
+}


### PR DESCRIPTION
This commit changes the way how files are selected for retransmission
on recovery / restore. Today this happens on a per-file basis where the
rather weak checksum and the file length in bytes is compared to check if
a file is identical. This is prone to fail in the case of a checksum collision
which can happen under certain circumstances.
The changes in this commit move the identity comparison to a per-commit / per-segment
level where files are only treated as identical iff all the other files in the
commit / segment are the same. This `all or nothing` strategy is reducing the chance for
a collision dramatically since we also use a strong hash to identify commits / segments
based on the content of the `.si` / `segments.N` file.
