### PR TITLE
If _parent field points to a non existing parent type, then skip the has_parent query/filter

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/HasParentFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/HasParentFilterParser.java
@@ -18,26 +18,17 @@
  */
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.Filter;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.lucene.search.NotFilter;
-import org.elasticsearch.common.lucene.search.XBooleanFilter;
-import org.elasticsearch.common.lucene.search.XFilteredQuery;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.fielddata.plain.ParentChildIndexFieldData;
-import org.elasticsearch.index.mapper.DocumentMapper;
-import org.elasticsearch.index.mapper.internal.ParentFieldMapper;
 import org.elasticsearch.index.query.support.XContentStructure;
 import org.elasticsearch.index.search.child.CustomQueryWrappingFilter;
-import org.elasticsearch.index.search.child.ParentConstantScoreQuery;
 
 import java.io.IOException;
-import java.util.HashSet;
-import java.util.Set;
 
+import static org.elasticsearch.index.query.HasParentQueryParser.createParentQuery;
 import static org.elasticsearch.index.query.QueryParserUtils.ensureNotDeleteByQuery;
 
 /**
@@ -119,52 +110,14 @@ public class HasParentFilterParser implements FilterParser {
             return null;
         }
 
-        DocumentMapper parentDocMapper = parseContext.mapperService().documentMapper(parentType);
-        if (parentDocMapper == null) {
-            throw new QueryParsingException(parseContext.index(), "[has_parent] filter configured 'parent_type' [" + parentType + "] is not a valid type");
+        Query parentQuery = createParentQuery(query, parentType, false, parseContext);
+        if (parentQuery == null) {
+            return null;
         }
-
-        // wrap the query with type query
-        query = new XFilteredQuery(query, parseContext.cacheFilter(parentDocMapper.typeFilter(), null));
-
-        Set<String> parentTypes = new HashSet<>(5);
-        parentTypes.add(parentType);
-        ParentChildIndexFieldData parentChildIndexFieldData = null;
-        for (DocumentMapper documentMapper : parseContext.mapperService().docMappers(false)) {
-            ParentFieldMapper parentFieldMapper = documentMapper.parentFieldMapper();
-            if (parentFieldMapper.active()) {
-                DocumentMapper parentTypeDocumentMapper = parseContext.mapperService().documentMapper(parentFieldMapper.type());
-                parentChildIndexFieldData = parseContext.getForField(parentFieldMapper);
-                if (parentTypeDocumentMapper == null) {
-                    // Only add this, if this parentFieldMapper (also a parent)  isn't a child of another parent.
-                    parentTypes.add(parentFieldMapper.type());
-                }
-            }
-        }
-        if (parentChildIndexFieldData == null) {
-            throw new QueryParsingException(parseContext.index(), "[has_parent] no _parent field configured");
-        }
-
-        Filter parentFilter;
-        if (parentTypes.size() == 1) {
-            DocumentMapper documentMapper = parseContext.mapperService().documentMapper(parentTypes.iterator().next());
-            parentFilter = parseContext.cacheFilter(documentMapper.typeFilter(), null);
-        } else {
-            XBooleanFilter parentsFilter = new XBooleanFilter();
-            for (String parentTypeStr : parentTypes) {
-                DocumentMapper documentMapper = parseContext.mapperService().documentMapper(parentTypeStr);
-                Filter filter = parseContext.cacheFilter(documentMapper.typeFilter(), null);
-                parentsFilter.add(filter, BooleanClause.Occur.SHOULD);
-            }
-            parentFilter = parentsFilter;
-        }
-        Filter childrenFilter = parseContext.cacheFilter(new NotFilter(parentFilter), null);
-        Query parentConstantScoreQuery = new ParentConstantScoreQuery(parentChildIndexFieldData, query, parentType, childrenFilter);
-
         if (filterName != null) {
-            parseContext.addNamedFilter(filterName, new CustomQueryWrappingFilter(parentConstantScoreQuery));
+            parseContext.addNamedFilter(filterName, new CustomQueryWrappingFilter(parentQuery));
         }
-        return new CustomQueryWrappingFilter(parentConstantScoreQuery);
+        return new CustomQueryWrappingFilter(parentQuery);
     }
 
 }

--- a/src/main/java/org/elasticsearch/index/query/HasParentQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/HasParentQueryParser.java
@@ -129,15 +129,27 @@ public class HasParentQueryParser implements QueryParser {
         innerQuery.setBoost(boost);
         // wrap the query with type query
         innerQuery = new XFilteredQuery(innerQuery, parseContext.cacheFilter(parentDocMapper.typeFilter(), null));
+        Query query = createParentQuery(innerQuery, parentType, score, parseContext);
+        if (query == null) {
+            return null;
+        }
 
-        ParentChildIndexFieldData parentChildIndexFieldData = null;
+        query.setBoost(boost);
+        if (queryName != null) {
+            parseContext.addNamedFilter(queryName, new CustomQueryWrappingFilter(query));
+        }
+        return query;
+    }
+
+    static Query createParentQuery(Query innerQuery, String parentType, boolean score, QueryParseContext parseContext) {
         Set<String> parentTypes = new HashSet<>(5);
         parentTypes.add(parentType);
+        ParentChildIndexFieldData parentChildIndexFieldData = null;
         for (DocumentMapper documentMapper : parseContext.mapperService().docMappers(false)) {
             ParentFieldMapper parentFieldMapper = documentMapper.parentFieldMapper();
             if (parentFieldMapper.active()) {
-                parentChildIndexFieldData = parseContext.getForField(parentFieldMapper);
                 DocumentMapper parentTypeDocumentMapper = parseContext.mapperService().documentMapper(parentFieldMapper.type());
+                parentChildIndexFieldData = parseContext.getForField(parentFieldMapper);
                 if (parentTypeDocumentMapper == null) {
                     // Only add this, if this parentFieldMapper (also a parent)  isn't a child of another parent.
                     parentTypes.add(parentFieldMapper.type());
@@ -148,32 +160,34 @@ public class HasParentQueryParser implements QueryParser {
             throw new QueryParsingException(parseContext.index(), "[has_parent] no _parent field configured");
         }
 
-        Filter parentFilter;
+        Filter parentFilter = null;
         if (parentTypes.size() == 1) {
             DocumentMapper documentMapper = parseContext.mapperService().documentMapper(parentTypes.iterator().next());
-            parentFilter = parseContext.cacheFilter(documentMapper.typeFilter(), null);
+            if (documentMapper != null) {
+                parentFilter = parseContext.cacheFilter(documentMapper.typeFilter(), null);
+            }
         } else {
             XBooleanFilter parentsFilter = new XBooleanFilter();
             for (String parentTypeStr : parentTypes) {
                 DocumentMapper documentMapper = parseContext.mapperService().documentMapper(parentTypeStr);
-                Filter filter = parseContext.cacheFilter(documentMapper.typeFilter(), null);
-                parentsFilter.add(filter, BooleanClause.Occur.SHOULD);
+                if (documentMapper != null) {
+                    Filter filter = parseContext.cacheFilter(documentMapper.typeFilter(), null);
+                    parentsFilter.add(filter, BooleanClause.Occur.SHOULD);
+                }
             }
             parentFilter = parentsFilter;
         }
-        Filter childrenFilter = parseContext.cacheFilter(new NotFilter(parentFilter), null);
 
-        Query query;
+        if (parentFilter == null) {
+            return null;
+        }
+
+        Filter childrenFilter = parseContext.cacheFilter(new NotFilter(parentFilter), null);
         if (score) {
-            query = new ParentQuery(parentChildIndexFieldData, innerQuery, parentType, childrenFilter);
+            return new ParentQuery(parentChildIndexFieldData, innerQuery, parentType, childrenFilter);
         } else {
-            query = new ParentConstantScoreQuery(parentChildIndexFieldData, innerQuery, parentType, childrenFilter);
+            return new ParentConstantScoreQuery(parentChildIndexFieldData, innerQuery, parentType, childrenFilter);
         }
-        query.setBoost(boost);
-        if (queryName != null) {
-            parseContext.addNamedFilter(queryName, new CustomQueryWrappingFilter(query));
-        }
-        return query;
     }
 
 }

--- a/src/test/java/org/elasticsearch/search/child/SimpleChildQuerySearchTests.java
+++ b/src/test/java/org/elasticsearch/search/child/SimpleChildQuerySearchTests.java
@@ -2499,6 +2499,39 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
 
     }
 
+    @Test
+    public void testParentFieldToNonExistingType() {
+        assertAcked(prepareCreate("test").addMapping("parent").addMapping("child", "_parent", "type=parent2"));
+        client().prepareIndex("test", "parent", "1").setSource("{}").get();
+        client().prepareIndex("test", "child", "1").setParent("1").setSource("{}").get();
+        refresh();
+
+        try {
+            client().prepareSearch("test")
+                    .setQuery(QueryBuilders.hasChildQuery("child", matchAllQuery()))
+                    .get();
+            fail();
+        } catch (SearchPhaseExecutionException e) {
+        }
+
+        SearchResponse response = client().prepareSearch("test")
+                .setQuery(QueryBuilders.hasParentQuery("parent", matchAllQuery()))
+                .get();
+        assertHitCount(response, 0);
+
+        try {
+            client().prepareSearch("test")
+                    .setQuery(QueryBuilders.constantScoreQuery(FilterBuilders.hasChildFilter("child", matchAllQuery())))
+                    .get();
+            fail();
+        } catch (SearchPhaseExecutionException e) {
+        }
+
+        response = client().prepareSearch("test")
+                .setQuery(QueryBuilders.constantScoreQuery(FilterBuilders.hasParentFilter("parent", matchAllQuery())))
+                .get();
+        assertHitCount(response, 0);
+    }
 
     private static HasChildFilterBuilder hasChildFilter(String type, QueryBuilder queryBuilder) {
         HasChildFilterBuilder hasChildFilterBuilder = FilterBuilders.hasChildFilter(type, queryBuilder);


### PR DESCRIPTION
PR for #7349
