### PR TITLE
Allow to get metadata from arbitrary commit points

### DIFF
--- a/src/main/java/org/elasticsearch/common/lucene/Lucene.java
+++ b/src/main/java/org/elasticsearch/common/lucene/Lucene.java
@@ -102,6 +102,15 @@ public class Lucene {
         return sis;
     }
 
+    /**
+     * Reads the segments infos from the given commit, failing if it fails to load
+     */
+    public static SegmentInfos readSegmentInfos(IndexCommit commit, Directory directory) throws IOException {
+        final SegmentInfos sis = new SegmentInfos();
+        sis.read(directory, commit.getSegmentsFileName());
+        return sis;
+    }
+
     public static void checkSegmentInfoIntegrity(final Directory directory) throws IOException {
         new SegmentInfos.FindSegmentsFile(directory) {
 

--- a/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardRepository.java
+++ b/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardRepository.java
@@ -425,7 +425,7 @@ public class BlobStoreIndexShardRepository extends AbstractComponent implements 
                 ArrayList<FileInfo> filesToSnapshot = newArrayList();
                 final Store.MetadataSnapshot metadata;
                 try {
-                    metadata = store.getMetadata();
+                    metadata = store.getMetadata(snapshotIndexCommit);
                 } catch (IOException e) {
                     throw new IndexShardSnapshotFailedException(shardId, "Failed to get store file metadata", e);
                 }

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoverySource.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoverySource.java
@@ -142,7 +142,7 @@ public class RecoverySource extends AbstractComponent {
                 try {
                     StopWatch stopWatch = new StopWatch().start();
                     final Store.MetadataSnapshot metadata;
-                    metadata = store.getMetadata();
+                    metadata = store.getMetadata(snapshot);
                     for (String name : snapshot.getFiles()) {
                         final StoreFileMetaData md = metadata.get(name);
                         if (md == null) {


### PR DESCRIPTION
Today we always use the latest commit point to return the metadata from
the store. This might cause problems for snapshot and restore since in
contrast to recovery it won't prevent concurrent flushes (lucene commits).
This can lead to all kinds of interesting effects if we are snapshotting
while flushing. This change uses the IndexCommit to open the metadata snapshot
from the store which is consistent with what we snapshot.
