### PR TITLE
Ignore segments.gen on metadata snapshots

### DIFF
--- a/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/src/main/java/org/elasticsearch/index/store/Store.java
@@ -21,9 +21,11 @@ package org.elasticsearch.index.store;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterables;
 import org.apache.lucene.codecs.CodecUtil;
-import org.apache.lucene.index.*;
+import org.apache.lucene.index.CorruptIndexException;
+import org.apache.lucene.index.IndexCommit;
+import org.apache.lucene.index.SegmentCommitInfo;
+import org.apache.lucene.index.SegmentInfos;
 import org.apache.lucene.store.*;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.Version;
@@ -475,21 +477,17 @@ public class Store extends AbstractIndexShardComponent implements CloseableIndex
                     return ImmutableMap.of();
                 }
                 Version maxVersion = Version.LUCENE_3_0; // we don't know which version was used to write so we take the max version.
-                Set<String> added = new HashSet<>();
                 for (SegmentCommitInfo info : segmentCommitInfos) {
                     final Version version = Lucene.parseVersionLenient(info.info.getVersion(), Version.LUCENE_3_0);
                     if (version.onOrAfter(maxVersion)) {
                         maxVersion = version;
                     }
-                    for (String file : Iterables.concat(info.info.files(), info.files())) {
-                        if (!added.contains(file)) {
-                            String legacyChecksum = checksumMap.get(file);
-                            if (version.onOrAfter(Version.LUCENE_4_8) && legacyChecksum == null) {
-                                checksumFromLuceneFile(directory, file, builder, logger, version);
-                            } else {
-                                builder.put(file, new StoreFileMetaData(file, directory.fileLength(file), legacyChecksum, null));
-                            }
-                            added.add(file);
+                    for (String file : info.files()) {
+                        String legacyChecksum = checksumMap.get(file);
+                        if (version.onOrAfter(Version.LUCENE_4_8) && legacyChecksum == null) {
+                            checksumFromLuceneFile(directory, file, builder, logger, version);
+                        } else {
+                            builder.put(file, new StoreFileMetaData(file, directory.fileLength(file), legacyChecksum, null));
                         }
                     }
                 }

--- a/src/test/java/org/elasticsearch/index/store/StoreTest.java
+++ b/src/test/java/org/elasticsearch/index/store/StoreTest.java
@@ -24,10 +24,7 @@ import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.SortedDocValuesField;
 import org.apache.lucene.document.TextField;
-import org.apache.lucene.index.CorruptIndexException;
-import org.apache.lucene.index.DirectoryReader;
-import org.apache.lucene.index.IndexWriter;
-import org.apache.lucene.index.Term;
+import org.apache.lucene.index.*;
 import org.apache.lucene.store.*;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.IOUtils;
@@ -147,7 +144,7 @@ public class StoreTest extends ElasticsearchLuceneTestCase {
         Store.LegacyChecksums checksums = new Store.LegacyChecksums();
         Map<String, StoreFileMetaData> legacyMeta = new HashMap<>();
         for (String file : store.directory().listAll()) {
-            if (file.equals("write.lock")) {
+            if (file.equals("write.lock") || file.equals(IndexFileNames.SEGMENTS_GEN)) {
                 continue;
             }
             try (IndexInput input = store.directory().openInput(file, IOContext.READONCE)) {
@@ -494,7 +491,7 @@ public class StoreTest extends ElasticsearchLuceneTestCase {
 
     public static void assertConsistent(Store store, Store.MetadataSnapshot metadata) throws IOException {
         for (String file : store.directory().listAll()) {
-            if (!"write.lock".equals(file) && !Store.isChecksum(file)) {
+            if (!"write.lock".equals(file) && !IndexFileNames.SEGMENTS_GEN.equals(file) && !Store.isChecksum(file)) {
                 assertTrue(file + " is not in the map: " + metadata.asMap().size() + " vs. " + store.directory().listAll().length, metadata.asMap().containsKey(file));
             } else {
                 assertFalse(file + " is not in the map: " + metadata.asMap().size() + " vs. " + store.directory().listAll().length, metadata.asMap().containsKey(file));


### PR DESCRIPTION
The `segments.gen` file is optional and might even change while we read it. It's safer to just ignore that file in the snapshot instead.

we saw test failing with:

```
Caused by: org.apache.lucene.index.CorruptIndexException: codec footer mismatch: actual footer=0 vs expected footer=-1071082520 (resource: MockIndexInputWrapper(NIOFSIndexInput(path="/Users/igor/Projects/elasticsearch/data/shared-hoverfly.local-CHILD_VM=[0]-CLUSTER_SEED=[-3070528509192838244]-HASH=[138C74D8B6080338]/nodes/1/indices/test-idx/5/index/segments.gen")))
    at org.apache.lucene.codecs.CodecUtil.validateFooter(CodecUtil.java:235)
    at org.apache.lucene.codecs.CodecUtil.retrieveChecksum(CodecUtil.java:228)
    at org.elasticsearch.index.store.Store$MetadataSnapshot.checksumFromLuceneFile(Store.java:564)
    at org.elasticsearch.index.store.Store$MetadataSnapshot.buildMetadata(Store.java:498)
    at org.elasticsearch.index.store.Store$MetadataSnapshot.<init>(Store.java:459)
    at org.elasticsearch.index.store.Store.getMetadata(Store.java:154)
    at org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardRepository$SnapshotContext.snapshot(BlobStoreIndexShardRepository.java:428)
```

which can happen if commits happen concurrently since this file gets corrupted on purpose during a commit
