### PR TITLE
Update scripting.asciidoc

### DIFF
--- a/docs/reference/modules/scripting.asciidoc
+++ b/docs/reference/modules/scripting.asciidoc
@@ -319,7 +319,9 @@ The `doc['field_name']` can be used to access specific field data within
 a document (the document in question is usually derived by the context
 the script is used). Document fields are very fast to access since they
 end up being loaded into memory (all the relevant field values/tokens
-are loaded to memory).
+are loaded to memory). Note, however, that the `doc[...]` notation only 
+allows for simple valued fields (can’t return a json object from it) 
+and makes sense only on non-analyzed or single term based fields.
 
 The following data can be extracted from a field:
 


### PR DESCRIPTION
I was confused for a while why I couldn't access an object-valued field in a script using doc[...] until I found the explanation in the Script Fields documentation (http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-script-fields.html). I basically just copied the explanation from that page and added it here.
