### PR TITLE
Introduced IndexTemplateFilter

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexClusterStateUpdateRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexClusterStateUpdateRequest.java
@@ -54,7 +54,7 @@ public class CreateIndexClusterStateUpdateRequest extends ClusterStateUpdateRequ
     private final Set<ClusterBlock> blocks = Sets.newHashSet();
 
 
-    CreateIndexClusterStateUpdateRequest(String cause, String index) {
+    public CreateIndexClusterStateUpdateRequest(String cause, String index) {
         this.cause = cause;
         this.index = index;
     }

--- a/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequest.java
@@ -123,7 +123,7 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
     /**
      * The index name to create.
      */
-    String index() {
+    public String index() {
         return index;
     }
 
@@ -133,17 +133,17 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
     }
 
     /**
-     * The settings to create the index with.
-     */
-    Settings settings() {
-        return settings;
-    }
-
-    /**
      * The cause for this index creation.
      */
     String cause() {
         return cause;
+    }
+
+    /**
+     * The settings to create the index with.
+     */
+    public Settings settings() {
+        return settings;
     }
 
     /**
@@ -416,11 +416,11 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
         return this;
     }
 
-    Map<String, String> mappings() {
+    public Map<String, String> mappings() {
         return this.mappings;
     }
 
-    Set<Alias> aliases() {
+    public Set<Alias> aliases() {
         return this.aliases;
     }
 
@@ -432,7 +432,7 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
         return this;
     }
 
-    Map<String, IndexMetaData.Custom> customs() {
+    public Map<String, IndexMetaData.Custom> customs() {
         return this.customs;
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/create/TransportCreateIndexAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/create/TransportCreateIndexAction.java
@@ -77,12 +77,7 @@ public class TransportCreateIndexAction extends TransportMasterNodeOperationActi
             cause = "api";
         }
 
-        CreateIndexClusterStateUpdateRequest updateRequest = new CreateIndexClusterStateUpdateRequest(cause, request.index())
-                .ackTimeout(request.timeout()).masterNodeTimeout(request.masterNodeTimeout())
-                .settings(request.settings()).mappings(request.mappings())
-                .aliases(request.aliases()).customs(request.customs());
-
-        createIndexService.createIndex(updateRequest, new ActionListener<ClusterStateUpdateResponse>() {
+        createIndexService.createIndex(cause, request, new ActionListener<ClusterStateUpdateResponse>() {
 
             @Override
             public void onResponse(ClusterStateUpdateResponse response) {

--- a/src/main/java/org/elasticsearch/cluster/ClusterModule.java
+++ b/src/main/java/org/elasticsearch/cluster/ClusterModule.java
@@ -20,7 +20,9 @@
 package org.elasticsearch.cluster;
 
 import com.google.common.collect.ImmutableList;
-import org.elasticsearch.cluster.action.index.*;
+import org.elasticsearch.cluster.action.index.MappingUpdatedAction;
+import org.elasticsearch.cluster.action.index.NodeIndexDeletedAction;
+import org.elasticsearch.cluster.action.index.NodeMappingRefreshAction;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
 import org.elasticsearch.cluster.metadata.*;
 import org.elasticsearch.cluster.node.DiscoveryNodeService;
@@ -32,8 +34,12 @@ import org.elasticsearch.cluster.settings.ClusterDynamicSettingsModule;
 import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.inject.Module;
 import org.elasticsearch.common.inject.SpawnModules;
+import org.elasticsearch.common.inject.multibindings.Multibinder;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.settings.IndexDynamicSettingsModule;
+
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  *
@@ -42,8 +48,14 @@ public class ClusterModule extends AbstractModule implements SpawnModules {
 
     private final Settings settings;
 
+    private Set<Class<? extends IndexTemplateFilter>> indexTemplateFilters = new HashSet<>();
+
     public ClusterModule(Settings settings) {
         this.settings = settings;
+    }
+
+    public void registerIndexTemplateFilter(Class<? extends IndexTemplateFilter> indexTemplateFilter) {
+        indexTemplateFilters.add(indexTemplateFilter);
     }
 
     @Override
@@ -76,5 +88,10 @@ public class ClusterModule extends AbstractModule implements SpawnModules {
         bind(MappingUpdatedAction.class).asEagerSingleton();
 
         bind(ClusterInfoService.class).to(InternalClusterInfoService.class).asEagerSingleton();
+
+        Multibinder<IndexTemplateFilter> mbinder = Multibinder.newSetBinder(binder(), IndexTemplateFilter.class);
+        for (Class<? extends IndexTemplateFilter> indexTemplateFilter : indexTemplateFilters) {
+            mbinder.addBinding().to(indexTemplateFilter);
+        }
     }
 }

--- a/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateFilter.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateFilter.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.metadata;
+
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+
+import java.util.Collection;
+
+/**
+ * Enables filtering the index templates that will be applied for an index, per create index request.
+ */
+public interface IndexTemplateFilter {
+
+    /**
+     * @return  {@code true} if the given template should be applied on the newly created index,
+     *          {@code false} otherwise.
+     */
+    boolean apply(CreateIndexRequest request, IndexTemplateMetaData template);
+
+    public static class Compound implements IndexTemplateFilter {
+
+        private IndexTemplateFilter[] filters;
+
+        public Compound(Collection<IndexTemplateFilter> filters) {
+            this(filters.toArray(new IndexTemplateFilter[filters.size()]));
+        }
+
+        public Compound(IndexTemplateFilter... filters) {
+            this.filters = filters;
+        }
+
+        @Override
+        public boolean apply(CreateIndexRequest request, IndexTemplateMetaData template) {
+            for (IndexTemplateFilter filter : filters) {
+                if (!filter.apply(request, template)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+}

--- a/src/test/java/org/elasticsearch/indices/template/IndexTemplateFilteringTests.java
+++ b/src/test/java/org/elasticsearch/indices/template/IndexTemplateFilteringTests.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.indices.template;
+
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsResponse;
+import org.elasticsearch.cluster.ClusterModule;
+import org.elasticsearch.cluster.metadata.IndexTemplateFilter;
+import org.elasticsearch.cluster.metadata.IndexTemplateMetaData;
+import org.elasticsearch.cluster.metadata.MappingMetaData;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.plugins.AbstractPlugin;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
+import org.elasticsearch.test.ElasticsearchIntegrationTest.Scope;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.core.IsNull.notNullValue;
+
+@ClusterScope(scope = Scope.SUITE)
+public class IndexTemplateFilteringTests extends ElasticsearchIntegrationTest{
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return ImmutableSettings.builder()
+                .put(super.nodeSettings(nodeOrdinal))
+                .put("plugin.types", TestPlugin.class.getName())
+                .build();
+    }
+
+    @Test
+    public void test() throws Exception {
+        client().admin().indices().preparePutTemplate("template1")
+                .setTemplate("test*")
+                .addMapping("type1", XContentFactory.jsonBuilder()
+                        .startObject()
+                            .startObject("type1")
+                                .startObject("properties")
+                                    .startObject("field1")
+                                        .field("type", "string")
+                                        .field("store", "no")
+                                    .endObject()
+                                .endObject()
+                            .endObject()
+                        .endObject())
+                .get();
+
+        client().admin().indices().preparePutTemplate("template2")
+                .setTemplate("test*")
+                .addMapping("type2", XContentFactory.jsonBuilder()
+                        .startObject()
+                        .startObject("type2")
+                        .startObject("properties")
+                        .startObject("field2")
+                        .field("type", "string")
+                        .field("store", "no")
+                        .endObject()
+                        .endObject()
+                        .endObject()
+                        .endObject())
+                .get();
+
+        prepareCreate("test").get();
+
+        GetMappingsResponse response = client().admin().indices().prepareGetMappings("test").get();
+        assertThat(response, notNullValue());
+        ImmutableOpenMap<String, MappingMetaData> metadata = response.getMappings().get("test");
+        assertThat(metadata.size(), is(1));
+        assertThat(metadata.get("type2"), notNullValue());
+    }
+
+
+    public static class TestFilter implements IndexTemplateFilter {
+        @Override
+        public boolean apply(CreateIndexRequest request, IndexTemplateMetaData template) {
+            return template.name().equals("template2");
+        }
+    }
+
+    public static class TestPlugin extends AbstractPlugin {
+        @Override
+        public String name() {
+            return "test-plugin";
+        }
+
+        @Override
+        public String description() {
+            return "";
+        }
+
+        public void onModule(ClusterModule module) {
+            module.registerIndexTemplateFilter(TestFilter.class);
+        }
+    }
+
+}


### PR DESCRIPTION
Added the ability to register filters on the index templates that are being applied when a new index is created. These filters will be able to filter out templates that should not be applied to newly created index.
