### PR TITLE
Use node's cluster name as a default for an incoming cluster state who misses it

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteResponse.java
@@ -23,7 +23,6 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.routing.allocation.RoutingExplanations;
-import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -61,7 +60,7 @@ public class ClusterRerouteResponse extends AcknowledgedResponse {
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        state = ClusterState.Builder.readFrom(in, null);
+        state = ClusterState.Builder.readFrom(in, null, null);
         readAcknowledged(in);
         if (in.getVersion().onOrAfter(Version.V_1_1_0)) {
             explanations = RoutingExplanations.readFrom(in);

--- a/src/main/java/org/elasticsearch/action/admin/cluster/state/ClusterStateResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/state/ClusterStateResponse.java
@@ -55,7 +55,7 @@ public class ClusterStateResponse extends ActionResponse {
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
         clusterName = ClusterName.readClusterName(in);
-        clusterState = ClusterState.Builder.readFrom(in, null);
+        clusterState = ClusterState.Builder.readFrom(in, null, clusterName);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/cluster/ClusterState.java
+++ b/src/main/java/org/elasticsearch/cluster/ClusterState.java
@@ -562,8 +562,14 @@ public class ClusterState implements ToXContent {
             return os.bytes().toBytes();
         }
 
-        public static ClusterState fromBytes(byte[] data, DiscoveryNode localNode) throws IOException {
-            return readFrom(new BytesStreamInput(data, false), localNode);
+        /**
+         * @param data               input bytes
+         * @param localNode          used to set the local node in the cluster state.
+         * @param defaultClusterName this cluster name will be used of if the deserialized cluster state does not have a name set
+         *                           (which is only introduced in version 1.1.1)
+         */
+        public static ClusterState fromBytes(byte[] data, DiscoveryNode localNode, ClusterName defaultClusterName) throws IOException {
+            return readFrom(new BytesStreamInput(data, false), localNode, defaultClusterName);
         }
 
         public static void writeTo(ClusterState state, StreamOutput out) throws IOException {
@@ -589,8 +595,14 @@ public class ClusterState implements ToXContent {
             }
         }
 
-        public static ClusterState readFrom(StreamInput in, @Nullable DiscoveryNode localNode) throws IOException {
-            ClusterName clusterName = null;
+        /**
+         * @param in                 input stream
+         * @param localNode          used to set the local node in the cluster state. can be null.
+         * @param defaultClusterName this cluster name will be used of receiving a cluster state from a node on version older than 1.1.1
+         *                           or if the sending node did not set a cluster name
+         */
+        public static ClusterState readFrom(StreamInput in, @Nullable DiscoveryNode localNode, @Nullable ClusterName defaultClusterName) throws IOException {
+            ClusterName clusterName = defaultClusterName;
             if (in.getVersion().onOrAfter(Version.V_1_1_1)) {
                 // it might be null even if it comes from a >= 1.1.1 node since it's origin might be an older node
                 if (in.readBoolean()) {

--- a/src/main/java/org/elasticsearch/discovery/local/LocalDiscovery.java
+++ b/src/main/java/org/elasticsearch/discovery/local/LocalDiscovery.java
@@ -301,7 +301,7 @@ public class LocalDiscovery extends AbstractLifecycleComponent<Discovery> implem
                 if (discovery.master) {
                     continue;
                 }
-                final ClusterState nodeSpecificClusterState = ClusterState.Builder.fromBytes(clusterStateBytes, discovery.localNode);
+                final ClusterState nodeSpecificClusterState = ClusterState.Builder.fromBytes(clusterStateBytes, discovery.localNode, clusterName);
                 nodeSpecificClusterState.status(ClusterState.ClusterStateStatus.RECEIVED);
                 // ignore cluster state messages that do not include "me", not in the game yet...
                 if (nodeSpecificClusterState.nodes().localNode() != null) {

--- a/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -154,7 +154,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
         this.nodesFD = new NodesFaultDetection(settings, threadPool, transportService);
         this.nodesFD.addListener(new NodeFailureListener());
 
-        this.publishClusterState = new PublishClusterStateAction(settings, transportService, this, new NewClusterStateListener(), discoverySettings);
+        this.publishClusterState = new PublishClusterStateAction(settings, transportService, this, new NewClusterStateListener(), discoverySettings, clusterName);
         this.pingService.setNodesProvider(this);
         this.membership = new MembershipAction(settings, clusterService, transportService, this, new MembershipListener());
 

--- a/src/main/java/org/elasticsearch/discovery/zen/membership/MembershipAction.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/membership/MembershipAction.java
@@ -159,7 +159,8 @@ public class MembershipAction extends AbstractComponent {
         @Override
         public void readFrom(StreamInput in) throws IOException {
             super.readFrom(in);
-            clusterState = ClusterState.Builder.readFrom(in, nodesProvider.nodes().localNode());
+            // we don't care about cluster name. This cluster state is never used.
+            clusterState = ClusterState.Builder.readFrom(in, nodesProvider.nodes().localNode(), null);
         }
 
         @Override
@@ -219,7 +220,8 @@ public class MembershipAction extends AbstractComponent {
         public void readFrom(StreamInput in) throws IOException {
             super.readFrom(in);
             if (in.getVersion().before(Version.V_1_4_0)) {
-                ClusterState.Builder.readFrom(in, nodesProvider.nodes().localNode());
+                // cluster name doesn't matter...
+                ClusterState.Builder.readFrom(in, nodesProvider.nodes().localNode(), null);
             }
         }
 

--- a/src/main/java/org/elasticsearch/discovery/zen/publish/PublishClusterStateAction.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/publish/PublishClusterStateAction.java
@@ -21,6 +21,7 @@ package org.elasticsearch.discovery.zen.publish;
 
 import com.google.common.collect.Maps;
 import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -63,14 +64,16 @@ public class PublishClusterStateAction extends AbstractComponent {
     private final DiscoveryNodesProvider nodesProvider;
     private final NewClusterStateListener listener;
     private final DiscoverySettings discoverySettings;
+    private final ClusterName clusterName;
 
     public PublishClusterStateAction(Settings settings, TransportService transportService, DiscoveryNodesProvider nodesProvider,
-                                     NewClusterStateListener listener, DiscoverySettings discoverySettings) {
+                                     NewClusterStateListener listener, DiscoverySettings discoverySettings, ClusterName clusterName) {
         super(settings);
         this.transportService = transportService;
         this.nodesProvider = nodesProvider;
         this.listener = listener;
         this.discoverySettings = discoverySettings;
+        this.clusterName = clusterName;
         transportService.registerHandler(ACTION_NAME, new PublishClusterStateRequestHandler());
     }
 
@@ -169,7 +172,7 @@ public class PublishClusterStateAction extends AbstractComponent {
                 in = CachedStreamInput.cachedHandles(request.bytes().streamInput());
             }
             in.setVersion(request.version());
-            ClusterState clusterState = ClusterState.Builder.readFrom(in, nodesProvider.nodes().localNode());
+            ClusterState clusterState = ClusterState.Builder.readFrom(in, nodesProvider.nodes().localNode(), clusterName);
             clusterState.status(ClusterState.ClusterStateStatus.RECEIVED);
             logger.debug("received cluster state version {}", clusterState.version());
             listener.onNewClusterState(clusterState, new NewClusterStateListener.NewStateProcessed() {

--- a/src/test/java/org/elasticsearch/cluster/serialization/ClusterSerializationTests.java
+++ b/src/test/java/org/elasticsearch/cluster/serialization/ClusterSerializationTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.cluster.serialization;
 
+import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
@@ -49,13 +50,14 @@ public class ClusterSerializationTests extends ElasticsearchAllocationTestCase {
 
         DiscoveryNodes nodes = DiscoveryNodes.builder().put(newNode("node1")).put(newNode("node2")).put(newNode("node3")).localNodeId("node1").masterNodeId("node2").build();
 
-        ClusterState clusterState = ClusterState.builder(org.elasticsearch.cluster.ClusterName.DEFAULT).nodes(nodes).metaData(metaData).routingTable(routingTable).build();
+        ClusterState clusterState = ClusterState.builder(new ClusterName("clusterName1")).nodes(nodes).metaData(metaData).routingTable(routingTable).build();
 
         AllocationService strategy = createAllocationService();
         clusterState = ClusterState.builder(clusterState).routingTable(strategy.reroute(clusterState).routingTable()).build();
 
-        ClusterState serializedClusterState = ClusterState.Builder.fromBytes(ClusterState.Builder.toBytes(clusterState), newNode("node1"));
+        ClusterState serializedClusterState = ClusterState.Builder.fromBytes(ClusterState.Builder.toBytes(clusterState), newNode("node1"), new ClusterName("clusterName2"));
 
+        assertThat(serializedClusterState.getClusterName().value(), equalTo(clusterState.getClusterName().value()));
         assertThat(serializedClusterState.routingTable().prettyPrint(), equalTo(clusterState.routingTable().prettyPrint()));
     }
 


### PR DESCRIPTION
The ClusterState has a reference to the cluster name since version 1.1.0 (df7474b9fcf849bbfea4222c1d2aa58b6669e52a) . However, if the state was  sent from a master of an older version, this name can be set to null. This is unexpected and can cause bugs. The bad part is that it will never correct itself until a full cluster restart where the cluster state is rebuilt using the code of the latest version.

This commit changes the default to the node's cluster name.

 Relates to #7386
