### PR TITLE
Avoid overwriting classloader on plugin initialization

### DIFF
--- a/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -210,7 +210,7 @@ public class PluginsService extends AbstractComponent {
         ImmutableSettings.Builder builder = ImmutableSettings.settingsBuilder()
                 .put(this.settings);
         for (Tuple<PluginInfo, Plugin> plugin : plugins) {
-            builder.put(plugin.v2().additionalSettings());
+            builder.put(plugin.v2().additionalSettings().getAsMap());
         }
         return builder.build();
     }


### PR DESCRIPTION
This fix is for issue #6931. The plugin initialization code in PluginsService.updatedSettings overrides any custom classloader set in Settings on node initialization. I have changed the call to use an overloaded version that does not reset the classloader variable.

Test suite completed without any errors.
