### PR TITLE
Encapsulate AggregationBuilder name and make getter public

### DIFF
--- a/src/main/java/org/elasticsearch/search/aggregations/AbstractAggregationBuilder.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/AbstractAggregationBuilder.java
@@ -25,7 +25,7 @@ import org.elasticsearch.common.xcontent.ToXContent;
  */
 public abstract class AbstractAggregationBuilder implements ToXContent {
 
-    protected final String name;
+    private final String name;
     protected final String type;
 
     protected AbstractAggregationBuilder(String name, String type) {
@@ -33,4 +33,7 @@ public abstract class AbstractAggregationBuilder implements ToXContent {
         this.type = type;
     }
 
+    public String getName() {
+        return name;
+    }
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/AggregationBuilder.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/AggregationBuilder.java
@@ -100,7 +100,7 @@ public abstract class AggregationBuilder<B extends AggregationBuilder<B>> extend
 
     @Override
     public final XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(name);
+        builder.startObject(getName());
 
         builder.field(type);
         internalXContent(builder, params);

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/children/ChildrenBuilder.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/children/ChildrenBuilder.java
@@ -43,7 +43,7 @@ public class ChildrenBuilder extends AggregationBuilder<ChildrenBuilder> {
     protected XContentBuilder internalXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
         if (childType == null) {
-            throw new SearchSourceBuilderException("child_type must be set on children aggregation [" + name + "]");
+            throw new SearchSourceBuilderException("child_type must be set on children aggregation [" + getName() + "]");
         }
         builder.field("type", childType);
         return builder.endObject();

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FilterAggregationBuilder.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FilterAggregationBuilder.java
@@ -45,7 +45,7 @@ public class FilterAggregationBuilder extends AggregationBuilder<FilterAggregati
     @Override
     protected XContentBuilder internalXContent(XContentBuilder builder, Params params) throws IOException {
         if (filter == null) {
-            throw new SearchSourceBuilderException("filter must be set on filter aggregation [" + name + "]");
+            throw new SearchSourceBuilderException("filter must be set on filter aggregation [" + getName() + "]");
         }
         filter.toXContent(builder, params);
         return builder;

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/filters/FiltersAggregationBuilder.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/filters/FiltersAggregationBuilder.java
@@ -63,7 +63,7 @@ public class FiltersAggregationBuilder extends AggregationBuilder<FiltersAggrega
     protected XContentBuilder internalXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
         if (keyedFilters == null && nonKeyedFilters == null) {
-            throw new SearchSourceBuilderException("At least one filter must be set on filter aggregation [" + name + "]");
+            throw new SearchSourceBuilderException("At least one filter must be set on filter aggregation [" + getName() + "]");
         }
         if (keyedFilters != null && nonKeyedFilters != null) {
             throw new SearchSourceBuilderException("Cannot add both keyed and non-keyed filters to filters aggregation");

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramBuilder.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramBuilder.java
@@ -125,7 +125,7 @@ public class DateHistogramBuilder extends ValuesSourceAggregationBuilder<DateHis
     @Override
     protected XContentBuilder doInternalXContent(XContentBuilder builder, Params params) throws IOException {
         if (interval == null) {
-            throw new SearchSourceBuilderException("[interval] must be defined for histogram aggregation [" + name + "]");
+            throw new SearchSourceBuilderException("[interval] must be defined for histogram aggregation [" + getName() + "]");
         }
         if (interval instanceof Number) {
             interval = TimeValue.timeValueMillis(((Number) interval).longValue()).toString();

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/HistogramBuilder.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/HistogramBuilder.java
@@ -99,7 +99,7 @@ public class HistogramBuilder extends ValuesSourceAggregationBuilder<HistogramBu
     @Override
     protected XContentBuilder doInternalXContent(XContentBuilder builder, Params params) throws IOException {
         if (interval == null) {
-            throw new SearchSourceBuilderException("[interval] must be defined for histogram aggregation [" + name + "]");
+            throw new SearchSourceBuilderException("[interval] must be defined for histogram aggregation [" + getName() + "]");
         }
         builder.field("interval", interval);
 

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/NestedBuilder.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/NestedBuilder.java
@@ -45,7 +45,7 @@ public class NestedBuilder extends AggregationBuilder<NestedBuilder> {
     protected XContentBuilder internalXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
         if (path == null) {
-            throw new SearchSourceBuilderException("nested path must be set on nested aggregation [" + name + "]");
+            throw new SearchSourceBuilderException("nested path must be set on nested aggregation [" + getName() + "]");
         }
         builder.field("path", path);
         return builder.endObject();

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/range/AbstractRangeBuilder.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/range/AbstractRangeBuilder.java
@@ -70,7 +70,7 @@ public abstract class AbstractRangeBuilder<B extends AbstractRangeBuilder<B>> ex
     @Override
     protected XContentBuilder doInternalXContent(XContentBuilder builder, Params params) throws IOException {
         if (ranges.isEmpty()) {
-            throw new SearchSourceBuilderException("at least one range must be defined for range aggregation [" + name + "]");
+            throw new SearchSourceBuilderException("at least one range must be defined for range aggregation [" + getName() + "]");
         }
         builder.startArray("ranges");
         for (Range range : ranges) {

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/range/geodistance/GeoDistanceBuilder.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/range/geodistance/GeoDistanceBuilder.java
@@ -156,10 +156,10 @@ public class GeoDistanceBuilder extends AggregationBuilder<GeoDistanceBuilder> {
     protected XContentBuilder internalXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
         if (ranges.isEmpty()) {
-            throw new SearchSourceBuilderException("at least one range must be defined for geo_distance aggregation [" + name + "]");
+            throw new SearchSourceBuilderException("at least one range must be defined for geo_distance aggregation [" + getName() + "]");
         }
         if (point == null) {
-            throw new SearchSourceBuilderException("center point must be defined for geo_distance aggregation [" + name + "]");
+            throw new SearchSourceBuilderException("center point must be defined for geo_distance aggregation [" + getName() + "]");
         }
 
         if (field != null) {

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ipv4/IPv4RangeBuilder.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ipv4/IPv4RangeBuilder.java
@@ -47,7 +47,7 @@ public class IPv4RangeBuilder extends AbstractRangeBuilder<IPv4RangeBuilder> {
     public IPv4RangeBuilder addMaskRange(String key, String mask) {
         long[] fromTo = cidrMaskToMinMax(mask);
         if (fromTo == null) {
-            throw new SearchSourceBuilderException("invalid CIDR mask [" + mask + "] in ip_range aggregation [" + name + "]");
+            throw new SearchSourceBuilderException("invalid CIDR mask [" + mask + "] in ip_range aggregation [" + getName() + "]");
         }
         ranges.add(new Range(key, fromTo[0] < 0 ? null : fromTo[0], fromTo[1] < 0 ? null : fromTo[1]));
         return this;

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/MetricsAggregationBuilder.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/MetricsAggregationBuilder.java
@@ -35,7 +35,7 @@ public abstract class MetricsAggregationBuilder<B extends MetricsAggregationBuil
 
     @Override
     public final XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(name).startObject(type);
+        builder.startObject(getName()).startObject(type);
         internalXContent(builder, params);
         return builder.endObject().endObject();
     }

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/PercentilesBuilder.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/PercentilesBuilder.java
@@ -39,7 +39,7 @@ public class PercentilesBuilder extends ValuesSourceMetricsAggregationBuilder<Pe
         for (int i = 0; i < percentiles.length; i++) {
             if (percentiles[i] < 0 || percentiles[i] > 100) {
                 throw new IllegalArgumentException("the percents in the percentiles aggregation [" +
-                        name + "] must be in the [0, 100] range");
+                        getName() + "] must be in the [0, 100] range");
             }
         }
         this.percentiles = percentiles;

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/TopHitsBuilder.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/TopHitsBuilder.java
@@ -376,7 +376,7 @@ public class TopHitsBuilder extends AbstractAggregationBuilder {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(name).field(type);
+        builder.startObject(getName()).field(type);
         sourceBuilder().toXContent(builder, params);
         return builder.endObject();
     }

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/DateHistogramTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/DateHistogramTests.java
@@ -182,7 +182,7 @@ public class DateHistogramTests extends ElasticsearchIntegrationTest {
                 .addAggregation(new AbstractAggregationBuilder("histo", "date_histogram") {
                     @Override
                     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-                        return builder.startObject(name)
+                        return builder.startObject(getName())
                                 .startObject(type)
                                     .field("field", "date")
                                     .field("interval", "1d")


### PR DESCRIPTION
As mentioned in https://groups.google.com/forum/?#!msg/elasticsearch/fe9S2mECMEI/57xZK7i6V7MJ, I'd like the name of an AggregationBuilder to be public. I'm attempting to build a wrapper that will provide some type safety around the type of aggregation in the query and the result and not having access to the name is making the API much clunkier than it would otherwise be.
