### PR TITLE
document field parsing: refactor to remove external value mechanism

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -36,6 +36,7 @@ import org.elasticsearch.index.mapper.core.AbstractFieldMapper;
 import org.elasticsearch.index.query.QueryParseContext;
 import org.elasticsearch.index.similarity.SimilarityProvider;
 
+import java.io.IOException;
 import java.util.List;
 
 /**
@@ -225,6 +226,17 @@ public interface FieldMapper<T> extends Mapper {
      * Returns the actual value of the field.
      */
     T value(Object value);
+
+    /**
+     * This method adds a field to the document but without going through the parsing process.
+     * It is used by methods that add additional values that are not parsed, for example GeoPointFieldMapper or TokenCountFieldMapper.
+     * It is also used when setting the value for multi fields.
+     *
+     * @param context the current parse context that holds the Document
+     * @param valueAndBoost holds value and the associated boost for the field
+     *
+     */
+    void addValue(ParseContext context, AbstractFieldMapper.ValueAndBoost valueAndBoost) throws IOException;
 
     /**
      * Returns the value that will be used as a result for search. Can be only of specific types... .

--- a/src/main/java/org/elasticsearch/index/mapper/ParseContext.java
+++ b/src/main/java/org/elasticsearch/index/mapper/ParseContext.java
@@ -344,16 +344,6 @@ public abstract class ParseContext {
         }
 
         @Override
-        public boolean externalValueSet() {
-            return in.externalValueSet();
-        }
-
-        @Override
-        public Object externalValue() {
-            return in.externalValue();
-        }
-
-        @Override
         public float docBoost() {
             return in.docBoost();
         }
@@ -771,47 +761,6 @@ public abstract class ParseContext {
     public abstract Analyzer analyzer();
 
     public abstract void analyzer(Analyzer analyzer);
-
-    /**
-     * Return a new context that will have the external value set.
-     */
-    public final ParseContext createExternalValueContext(final Object externalValue) {
-        return new FilterParseContext(this) {
-            @Override
-            public boolean externalValueSet() {
-                return true;
-            }
-            @Override
-            public Object externalValue() {
-                return externalValue;
-            }
-        };
-    }
-
-    public boolean externalValueSet() {
-        return false;
-    }
-
-    public Object externalValue() {
-        throw new ElasticsearchIllegalStateException("External value is not set");
-    }
-
-    /**
-     * Try to parse an externalValue if any
-     * @param clazz Expected class for external value
-     * @return null if no external value has been set or the value
-     */
-    public final <T> T parseExternalValue(Class<T> clazz) {
-        if (!externalValueSet() || externalValue() == null) {
-            return null;
-        }
-
-        if (!clazz.isInstance(externalValue())) {
-            throw new ElasticsearchIllegalArgumentException("illegal external value class ["
-                    + externalValue().getClass().getName() + "]. Should be " + clazz.getName());
-        }
-        return clazz.cast(externalValue());
-    }
 
     public abstract float docBoost();
 

--- a/src/main/java/org/elasticsearch/index/mapper/core/AbstractFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/AbstractFieldMapper.java
@@ -413,7 +413,8 @@ public abstract class AbstractFieldMapper<T> implements FieldMapper<T> {
         assert fields.isEmpty();
         ValueAndBoost valueAndBoost = null;
         try {
-            valueAndBoost = parseCreateField(context, fields);
+            valueAndBoost = parseField(context);
+            createField(context, fields, valueAndBoost);
             addFields(context, fields);
         } catch (Exception e) {
             throw new MapperParsingException("failed to parse [" + names.fullName() + "]", e);
@@ -471,9 +472,11 @@ public abstract class AbstractFieldMapper<T> implements FieldMapper<T> {
     }
 
     /**
-     * Parse the field value and populate <code>fields</code>.
+     * Parse the field value to ValueAndBoost.
      */
-    protected abstract ValueAndBoost parseCreateField(ParseContext context, List<Field> fields) throws IOException;
+    protected ValueAndBoost parseField(ParseContext context) throws IOException {
+        throw new UnsupportedOperationException(this.getClass().getName() + " cannot be set externally.");
+    }
 
     /**
      * Derived classes can override it to specify that boost value is set by derived classes.

--- a/src/main/java/org/elasticsearch/index/mapper/core/BinaryFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/BinaryFieldMapper.java
@@ -51,7 +51,6 @@ import java.util.Map;
 
 import static org.elasticsearch.common.xcontent.support.XContentMapValues.nodeBooleanValue;
 import static org.elasticsearch.index.mapper.MapperBuilders.binaryField;
-import static org.elasticsearch.index.mapper.core.TypeParsers.parseField;
 
 /**
  *
@@ -102,7 +101,7 @@ public class BinaryFieldMapper extends AbstractFieldMapper<BytesReference> {
         @Override
         public Mapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
             BinaryFieldMapper.Builder builder = binaryField(name);
-            parseField(builder, name, node, parserContext);
+            TypeParsers.parseField(builder, name, node, parserContext);
             for (Map.Entry<String, Object> entry : node.entrySet()) {
                 String fieldName = Strings.toUnderscoreCase(entry.getKey());
                 Object fieldNode = entry.getValue();
@@ -177,7 +176,7 @@ public class BinaryFieldMapper extends AbstractFieldMapper<BytesReference> {
     }
 
     @Override
-    protected ValueAndBoost parseCreateField(ParseContext context, List<Field> fields) throws IOException {
+    protected ValueAndBoost parseField(ParseContext context) throws IOException {
         if (!fieldType().stored() && !hasDocValues()) {
             return null;
         }
@@ -188,9 +187,7 @@ public class BinaryFieldMapper extends AbstractFieldMapper<BytesReference> {
             value = context.parser().binaryValue();
         }
         ValueAndBoost valueAndBoost = new ValueAndBoost(value, 1.0f);
-        createField(context, fields, valueAndBoost);
         return valueAndBoost;
-
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/mapper/core/BooleanFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/BooleanFieldMapper.java
@@ -106,7 +106,7 @@ public class BooleanFieldMapper extends AbstractFieldMapper<Boolean> {
         @Override
         public Mapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
             BooleanFieldMapper.Builder builder = booleanField(name);
-            parseField(builder, name, node, parserContext);
+            TypeParsers.parseField(builder, name, node, parserContext);
             for (Map.Entry<String, Object> entry : node.entrySet()) {
                 String propName = Strings.toUnderscoreCase(entry.getKey());
                 Object propNode = entry.getValue();
@@ -201,7 +201,7 @@ public class BooleanFieldMapper extends AbstractFieldMapper<Boolean> {
     }
 
     @Override
-    protected ValueAndBoost parseCreateField(ParseContext context, List<Field> fields) throws IOException {
+    protected ValueAndBoost parseField(ParseContext context) throws IOException {
         if (!fieldType().indexed() && !fieldType().stored()) {
             return null;
         }
@@ -220,7 +220,6 @@ public class BooleanFieldMapper extends AbstractFieldMapper<Boolean> {
             return null;
         }
         ValueAndBoost valueAndBoost = new ValueAndBoost(value, 1.0f);
-        createField(context, fields, valueAndBoost);
         return valueAndBoost;
     }
 

--- a/src/main/java/org/elasticsearch/index/mapper/core/CompletionFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/CompletionFieldMapper.java
@@ -244,7 +244,7 @@ public class CompletionFieldMapper extends AbstractFieldMapper<String> {
 
         if (token == XContentParser.Token.VALUE_STRING) {
             inputs.add(parser.text());
-            multiFields.parse(this, context);
+            multiFields.addValue(this, context, new ValueAndBoost(parser.text(), 1.0f));
         } else {
             String currentFieldName = null;
             while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
@@ -316,6 +316,10 @@ public class CompletionFieldMapper extends AbstractFieldMapper<String> {
             }
         }
 
+        createCompletionField(context, surfaceForm, payload, weight, inputs, contextConfig);
+    }
+
+    protected void createCompletionField(ParseContext context, String surfaceForm, BytesRef payload, long weight, List<String> inputs, SortedMap<String, ContextConfig> contextConfig) throws IOException {
         if(contextConfig == null) {
             contextConfig = Maps.newTreeMap();
             for (ContextMapping mapping : contextMapping.values()) {
@@ -341,6 +345,14 @@ public class CompletionFieldMapper extends AbstractFieldMapper<String> {
         }
     }
 
+    protected void createField(ParseContext context, List<Field> fields, ValueAndBoost valueAndBoost) throws IOException {
+        List<String> inputs = Lists.newArrayListWithExpectedSize(4);
+        if (valueAndBoost.value instanceof String) {
+            inputs.add((String)valueAndBoost.value);
+            multiFields.addValue(this, context, valueAndBoost);
+        }
+        createCompletionField(context, null, null, 1, inputs, null);
+    }
     /**
      * Get the context mapping associated with this completion field.
      */
@@ -433,7 +445,8 @@ public class CompletionFieldMapper extends AbstractFieldMapper<String> {
     }
 
     @Override
-    protected void parseCreateField(ParseContext context, List<Field> fields) throws IOException {
+    protected ValueAndBoost parseCreateField(ParseContext context, List<Field> fields) throws IOException {
+        return null;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/mapper/core/CompletionFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/CompletionFieldMapper.java
@@ -445,7 +445,7 @@ public class CompletionFieldMapper extends AbstractFieldMapper<String> {
     }
 
     @Override
-    protected ValueAndBoost parseCreateField(ParseContext context, List<Field> fields) throws IOException {
+    protected ValueAndBoost parseField(ParseContext context) throws IOException {
         return null;
     }
 

--- a/src/main/java/org/elasticsearch/index/mapper/core/Murmur3FieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/Murmur3FieldMapper.java
@@ -92,19 +92,21 @@ public class Murmur3FieldMapper extends LongFieldMapper {
     }
 
     @Override
-    protected ValueAndBoost innerParseCreateField(ParseContext context, List<Field> fields) throws IOException {
+    protected ValueAndBoost parseField(ParseContext context) throws IOException {
         final Object value;
         value = context.parser().textOrNull();
         ValueAndBoost valueAndBoost = null;
         if (value != null) {
             valueAndBoost = new ValueAndBoost(value, 1.0f);
-            createField(context, fields, valueAndBoost);
         }
         return valueAndBoost;
     }
 
     @Override
     public void createField(ParseContext context, List<Field> fields, ValueAndBoost valueAndBoost) throws IOException {
+        if (valueAndBoost == null) {
+            return;
+        }
         final BytesRef bytes = new BytesRef(valueAndBoost.value.toString());
         final long hash = MurmurHash3.hash128(bytes.bytes, bytes.offset, bytes.length, 0, new MurmurHash3.Hash128()).h1;
         super.createField(context, fields, new ValueAndBoost(hash, 1.0f));

--- a/src/main/java/org/elasticsearch/index/mapper/core/StringFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/StringFieldMapper.java
@@ -151,7 +151,7 @@ public class StringFieldMapper extends AbstractFieldMapper<String> implements Al
         @Override
         public Mapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
             StringFieldMapper.Builder builder = stringField(name);
-            parseField(builder, name, node, parserContext);
+            TypeParsers.parseField(builder, name, node, parserContext);
             for (Map.Entry<String, Object> entry : node.entrySet()) {
                 String propName = Strings.toUnderscoreCase(entry.getKey());
                 Object propNode = entry.getValue();
@@ -271,9 +271,8 @@ public class StringFieldMapper extends AbstractFieldMapper<String> implements Al
     }
 
     @Override
-    protected ValueAndBoost parseCreateField(ParseContext context, List<Field> fields) throws IOException {
+    protected ValueAndBoost parseField(ParseContext context) throws IOException {
         ValueAndBoost valueAndBoost = parseValueAndBoost(context, nullValue, boost);
-        createField(context, fields, valueAndBoost);
         return valueAndBoost;
     }
 

--- a/src/main/java/org/elasticsearch/index/mapper/core/TokenCountFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/TokenCountFieldMapper.java
@@ -124,9 +124,8 @@ public class TokenCountFieldMapper extends IntegerFieldMapper {
     }
 
     @Override
-    protected ValueAndBoost parseCreateField(ParseContext context, List<Field> fields) throws IOException {
+    protected ValueAndBoost parseField(ParseContext context) throws IOException {
         StringFieldMapper.ValueAndBoost valueAndBoost = StringFieldMapper.parseValueAndBoost(context, null /* Out null value is an int so we convert*/, boost);
-        createField(context, fields, new ValueAndBoost(valueAndBoost.value, valueAndBoost.boost));
         return valueAndBoost;
     }
 

--- a/src/main/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapper.java
@@ -52,10 +52,7 @@ import org.elasticsearch.index.mapper.object.ArrayValueMapperParser;
 import org.elasticsearch.index.similarity.SimilarityProvider;
 
 import java.io.IOException;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
+import java.util.*;
 
 import static org.elasticsearch.index.mapper.MapperBuilders.*;
 import static org.elasticsearch.index.mapper.core.TypeParsers.*;
@@ -73,6 +70,30 @@ import static org.elasticsearch.index.mapper.core.TypeParsers.*;
 public class GeoPointFieldMapper extends AbstractFieldMapper<GeoPoint> implements ArrayValueMapperParser {
 
     public static final String CONTENT_TYPE = "geo_point";
+
+    public static class GeoPointAndHash {
+        private final String originalString;
+        GeoPoint geoPoint = new GeoPoint();
+        String geoHash = null;
+
+        public GeoPointAndHash(GeoPoint geoPoint, String geoHash, String originalString) {
+            this.geoPoint = geoPoint;
+            this.geoHash = geoHash;
+            this.originalString = originalString;
+        }
+
+        @Override
+        public String toString() {
+            if (originalString != null) {
+                return originalString;
+            }
+            return geoPoint.getLat() + "," + geoPoint.getLon();
+        }
+
+        public String originalString() {
+            return originalString;
+        }
+    }
 
     public static class Names {
         public static final String LAT = "lat";
@@ -477,7 +498,7 @@ public class GeoPointFieldMapper extends AbstractFieldMapper<GeoPoint> implement
     }
 
     @Override
-    protected void parseCreateField(ParseContext context, List<Field> fields) throws IOException {
+    protected ValueAndBoost parseCreateField(ParseContext context, List<Field> fields) throws IOException {
         throw new UnsupportedOperationException("Parsing is implemented in parse(), this method should NEVER be called");
     }
 
@@ -486,73 +507,94 @@ public class GeoPointFieldMapper extends AbstractFieldMapper<GeoPoint> implement
         ContentPath.Type origPathType = context.path().pathType();
         context.path().pathType(pathType);
         context.path().add(name());
-
-        GeoPoint sparse = context.parseExternalValue(GeoPoint.class);
-        
-        if (sparse != null) {
-            parse(context, sparse, null);
-        } else {
-            sparse = new GeoPoint();
-            XContentParser.Token token = context.parser().currentToken();
+        List<GeoPointAndHash> geoPointAndHashs = new ArrayList<>();
+        XContentParser.Token token = context.parser().currentToken();
+        if (token == XContentParser.Token.START_ARRAY) {
+            token = context.parser().nextToken();
             if (token == XContentParser.Token.START_ARRAY) {
-                token = context.parser().nextToken();
-                if (token == XContentParser.Token.START_ARRAY) {
-                    // its an array of array of lon/lat [ [1.2, 1.3], [1.4, 1.5] ]
-                    while (token != XContentParser.Token.END_ARRAY) {
-                        parse(context, GeoUtils.parseGeoPoint(context.parser(), sparse), null);
-                        token = context.parser().nextToken();
+                // its an array of array of lon/lat [ [1.2, 1.3], [1.4, 1.5] ]
+                while (token != XContentParser.Token.END_ARRAY) {
+                    geoPointAndHashs.add(new GeoPointAndHash(GeoUtils.parseGeoPoint(context.parser(), new GeoPoint()), null, null));
+                    token = context.parser().nextToken();
+                }
+            } else {
+                if (token == XContentParser.Token.VALUE_NUMBER) {
+                    double lon = context.parser().doubleValue();
+                    token = context.parser().nextToken();
+                    double lat = context.parser().doubleValue();
+                    while ((token = context.parser().nextToken()) != XContentParser.Token.END_ARRAY) {
+
                     }
+                    geoPointAndHashs.add(new GeoPointAndHash(new GeoPoint().reset(lat, lon), null, null));
                 } else {
                     // its an array of other possible values
-                    if (token == XContentParser.Token.VALUE_NUMBER) {
-                        double lon = context.parser().doubleValue();
+                    while (token != XContentParser.Token.END_ARRAY) {
+                        if (token == XContentParser.Token.VALUE_STRING) {
+                            geoPointAndHashs.add(parsePointFromString(context.parser().text()));
+                        } else {
+                            geoPointAndHashs.add(new GeoPointAndHash(GeoUtils.parseGeoPoint(context.parser(), new GeoPoint()), null, null));
+                        }
                         token = context.parser().nextToken();
-                        double lat = context.parser().doubleValue();
-                        while ((token = context.parser().nextToken()) != XContentParser.Token.END_ARRAY) {
-
-                        }
-                        parse(context, sparse.reset(lat, lon), null);
-                    } else {
-                        while (token != XContentParser.Token.END_ARRAY) {
-                            if (token == XContentParser.Token.VALUE_STRING) {
-                                parsePointFromString(context, sparse, context.parser().text());
-                            } else {
-                                parse(context, GeoUtils.parseGeoPoint(context.parser(), sparse), null);
-                            }
-                            token = context.parser().nextToken();
-                        }
                     }
                 }
-            } else if (token == XContentParser.Token.VALUE_STRING) {
-                parsePointFromString(context, sparse, context.parser().text());
-            } else if (token != XContentParser.Token.VALUE_NULL) {
-                parse(context, GeoUtils.parseGeoPoint(context.parser(), sparse), null);
             }
+        } else if (token == XContentParser.Token.VALUE_STRING) {
+            geoPointAndHashs.add(parsePointFromString(context.parser().text()));
+        } else if (token != XContentParser.Token.VALUE_NULL) {
+            geoPointAndHashs.add(new GeoPointAndHash(GeoUtils.parseGeoPoint(context.parser(), new GeoPoint()), null, null));
+        }
+        for (GeoPointAndHash geoPointAndHash : geoPointAndHashs) {
+            ValueAndBoost valueAndBoost = new ValueAndBoost(geoPointAndHash, 1.0f);
+            addValue(context, valueAndBoost);
+            handleMultiFields(context, valueAndBoost);
         }
 
         context.path().remove();
         context.path().pathType(origPathType);
     }
 
-    private void parseGeohashField(ParseContext context, String geohash) throws IOException {
+    private void addGeohashField(ParseContext context, String geohash) throws IOException {
         int len = Math.min(geoHashPrecision, geohash.length());
         int min = enableGeohashPrefix ? 1 : geohash.length();
 
         for (int i = len; i >= min; i--) {
-            // side effect of this call is adding the field
-            geohashMapper.parse(context.createExternalValueContext(geohash.substring(0, i)));
+            geohashMapper.addValue(context, new StringFieldMapper.ValueAndBoost(geohash.substring(0, i), 1.0f));
         }
     }
 
-    private void parsePointFromString(ParseContext context, GeoPoint sparse, String point) throws IOException {
+    private GeoPointAndHash parsePointFromString(String point) throws IOException {
+        GeoPointAndHash geoPointAndHash;
         if (point.indexOf(',') < 0) {
-            parse(context, sparse.resetFromGeoHash(point), point);
+            geoPointAndHash = new GeoPointAndHash(new GeoPoint(), null, null);
+            geoPointAndHash.geoPoint.resetFromGeoHash(point);
+            geoPointAndHash.geoHash = point;
         } else {
-            parse(context, sparse.resetFromString(point), null);
+            geoPointAndHash = new GeoPointAndHash(new GeoPoint(), null, point);
+            geoPointAndHash.geoPoint.resetFromString(point);
         }
+        return geoPointAndHash;
     }
 
-    private void parse(ParseContext context, GeoPoint point, String geohash) throws IOException {
+    @Override
+    protected void createField(ParseContext context, List<Field> fields, ValueAndBoost valueAndBoost) throws IOException {
+        GeoPoint point = null;
+        String geohash = null;
+        String stringRepresentation = null;
+        if (valueAndBoost.value instanceof GeoPointAndHash) {
+            point = ((GeoPointAndHash)valueAndBoost.value).geoPoint;
+            geohash = ((GeoPointAndHash)valueAndBoost.value).geoHash;
+            stringRepresentation = ((GeoPointAndHash) valueAndBoost.value).originalString();
+        } else if (valueAndBoost.value instanceof GeoPoint) {
+           point = (GeoPoint)valueAndBoost.value;
+        } else if (valueAndBoost.value instanceof String) {
+            geohash = (String)valueAndBoost.value;
+            point = parsePointFromString(geohash).geoPoint;
+            stringRepresentation = (String)valueAndBoost.value;
+        }
+        if (point == null) {
+            return;
+        }
+
         if (normalizeLat || normalizeLon) {
             GeoUtils.normalizePoint(point, normalizeLat, normalizeLon);
         }
@@ -569,18 +611,21 @@ public class GeoPointFieldMapper extends AbstractFieldMapper<GeoPoint> implement
         }
 
         if (fieldType.indexed() || fieldType.stored()) {
-            Field field = new Field(names.indexName(), Double.toString(point.lat()) + ',' + Double.toString(point.lon()), fieldType);
+            if (stringRepresentation == null) {
+                stringRepresentation = Double.toString(point.lat()) + ',' + Double.toString(point.lon());
+            }
+            Field field = new Field(names.indexName(), stringRepresentation, fieldType);
             context.doc().add(field);
         }
         if (enableGeoHash) {
             if (geohash == null) {
                 geohash = GeoHashUtils.encode(point.lat(), point.lon());
             }
-            parseGeohashField(context, geohash);
+            addGeohashField(context, geohash);
         }
         if (enableLatLon) {
-            latMapper.parse(context.createExternalValueContext(point.lat()));
-            lonMapper.parse(context.createExternalValueContext(point.lon()));
+            latMapper.addValue(context, new NumberFieldMapper.ValueAndBoost(point.lat(), 1.0f));
+            lonMapper.addValue(context, new NumberFieldMapper.ValueAndBoost(point.lon(), 1.0f));
         }
         if (hasDocValues()) {
             CustomGeoPointDocValuesField field = (CustomGeoPointDocValuesField) context.doc().getByKey(names().indexName());
@@ -591,7 +636,7 @@ public class GeoPointFieldMapper extends AbstractFieldMapper<GeoPoint> implement
                 field.add(point.lat(), point.lon());
             }
         }
-        multiFields.parse(this, context);
+
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapper.java
@@ -228,7 +228,7 @@ public class GeoPointFieldMapper extends AbstractFieldMapper<GeoPoint> implement
         @Override
         public Mapper.Builder<?, ?> parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
             Builder builder = geoPointField(name);
-            parseField(builder, name, node, parserContext);
+            TypeParsers.parseField(builder, name, node, parserContext);
             for (Map.Entry<String, Object> entry : node.entrySet()) {
                 String fieldName = Strings.toUnderscoreCase(entry.getKey());
                 Object fieldNode = entry.getValue();
@@ -498,7 +498,7 @@ public class GeoPointFieldMapper extends AbstractFieldMapper<GeoPoint> implement
     }
 
     @Override
-    protected ValueAndBoost parseCreateField(ParseContext context, List<Field> fields) throws IOException {
+    protected ValueAndBoost parseField(ParseContext context) throws IOException {
         throw new UnsupportedOperationException("Parsing is implemented in parse(), this method should NEVER be called");
     }
 

--- a/src/main/java/org/elasticsearch/index/mapper/geo/GeoShapeFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/geo/GeoShapeFieldMapper.java
@@ -226,18 +226,20 @@ public class GeoShapeFieldMapper extends AbstractFieldMapper<String> {
     }
 
     @Override
-    protected ValueAndBoost parseCreateField(ParseContext context, List<Field> fields) throws IOException {
+    protected ValueAndBoost parseField(ParseContext context) throws IOException {
         ShapeBuilder shapeBuilder = ShapeBuilder.parse(context.parser());
         if (shapeBuilder == null) {
             return null;
         }
         Shape shape = shapeBuilder.build();
         ValueAndBoost valueAndBoost = new ValueAndBoost(shape, 1.0f);
-        createField(context, fields, valueAndBoost);
         return valueAndBoost;
     }
 
     protected void createField(ParseContext context, List<Field> fields, ValueAndBoost valueAndBoost) throws IOException {
+        if (valueAndBoost == null) {
+            return;
+        }
         Field[] fieldsL = defaultStrategy.createIndexableFields((Shape)valueAndBoost.value);
         if (fields == null || fieldsL.length == 0) {
             return;

--- a/src/main/java/org/elasticsearch/index/mapper/internal/AllFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/AllFieldMapper.java
@@ -209,9 +209,9 @@ public class AllFieldMapper extends AbstractFieldMapper<String> implements Inter
     }
 
     @Override
-    protected void parseCreateField(ParseContext context, List<Field> fields) throws IOException {
+    protected ValueAndBoost parseCreateField(ParseContext context, List<Field> fields) throws IOException {
         if (!enabled) {
-            return;
+            return null;
         }
         // reset the entries
         context.allEntries().reset();
@@ -225,6 +225,7 @@ public class AllFieldMapper extends AbstractFieldMapper<String> implements Inter
 
         Analyzer analyzer = findAnalyzer(context);
         fields.add(new AllField(names.indexName(), context.allEntries(), analyzer, fieldType));
+        return null;
     }
 
     private Analyzer findAnalyzer(ParseContext context) {
@@ -357,4 +358,5 @@ public class AllFieldMapper extends AbstractFieldMapper<String> implements Inter
     public boolean isGenerated() {
         return true;
     }
+
 }

--- a/src/main/java/org/elasticsearch/index/mapper/internal/BoostFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/BoostFieldMapper.java
@@ -111,8 +111,6 @@ public class BoostFieldMapper extends NumberFieldMapper<Float> implements Intern
         }
     }
 
-    private final Float nullValue;
-
     public BoostFieldMapper() {
         this(Defaults.NAME, Defaults.NAME);
     }
@@ -222,8 +220,8 @@ public class BoostFieldMapper extends NumberFieldMapper<Float> implements Intern
             return null;
         }
         return NumericRangeFilter.newFloatRange(names.indexName(), precisionStep,
-                nullValue,
-                nullValue,
+                (Float)nullValue,
+                (Float)nullValue,
                 true, true);
     }
 
@@ -251,13 +249,14 @@ public class BoostFieldMapper extends NumberFieldMapper<Float> implements Intern
     }
 
     @Override
-    protected void innerParseCreateField(ParseContext context, List<Field> fields) throws IOException {
+    protected ValueAndBoost innerParseCreateField(ParseContext context, List<Field> fields) throws IOException {
         final float value = parseFloatValue(context);
         if (Float.isNaN(value)) {
-            return;
+            return null;
         }
         context.docBoost(value);
         fields.add(new FloatFieldMapper.CustomFloatNumericField(this, value, fieldType));
+        return null;
     }
 
     private float parseFloatValue(ParseContext context) throws IOException {
@@ -266,7 +265,7 @@ public class BoostFieldMapper extends NumberFieldMapper<Float> implements Intern
             if (nullValue == null) {
                 return Float.NaN;
             }
-            value = nullValue;
+            value = (Float)nullValue;
         } else {
             value = context.parser().floatValue(coerce.value());
         }
@@ -315,5 +314,21 @@ public class BoostFieldMapper extends NumberFieldMapper<Float> implements Intern
     @Override
     public void merge(Mapper mergeWith, MergeContext mergeContext) throws MergeMappingException {
         // do nothing here, no merging, but also no exception
+    }
+
+    protected CustomNumericField createCustomNumericField(ValueAndBoost valueAndBoost) {
+        throw new UnsupportedOperationException("BoostFieldMapper does not support createCustomNumericField(..)");
+    }
+
+    protected Number parseNumber(String sValue) {
+        throw new UnsupportedOperationException("BoostFieldMapper does not support parseNumber(..)");
+    }
+
+    protected long convertToSortableNumber(Number value) {
+        throw new UnsupportedOperationException("BoostFieldMapper does not support convertToSortableNumber(..)");
+    }
+
+    protected Object readValueFromParser(XContentParser parser) throws IOException {
+        throw new UnsupportedOperationException("BoostFieldMapper does not support readValueFromParser(..)");
     }
 }

--- a/src/main/java/org/elasticsearch/index/mapper/internal/BoostFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/BoostFieldMapper.java
@@ -220,8 +220,8 @@ public class BoostFieldMapper extends NumberFieldMapper<Float> implements Intern
             return null;
         }
         return NumericRangeFilter.newFloatRange(names.indexName(), precisionStep,
-                (Float)nullValue,
-                (Float)nullValue,
+                (Float) nullValue,
+                (Float) nullValue,
                 true, true);
     }
 
@@ -249,14 +249,18 @@ public class BoostFieldMapper extends NumberFieldMapper<Float> implements Intern
     }
 
     @Override
-    protected ValueAndBoost innerParseCreateField(ParseContext context, List<Field> fields) throws IOException {
+    protected ValueAndBoost parseField(ParseContext context) throws IOException {
         final float value = parseFloatValue(context);
+        return new ValueAndBoost(value, 1.0f);
+    }
+    @Override
+    protected void createField(ParseContext context, List<Field> fields, ValueAndBoost valueAndBoost) throws IOException {
+        final float value = ((Number)valueAndBoost.value).floatValue();
         if (Float.isNaN(value)) {
-            return null;
+            return ;
         }
         context.docBoost(value);
         fields.add(new FloatFieldMapper.CustomFloatNumericField(this, value, fieldType));
-        return null;
     }
 
     private float parseFloatValue(ParseContext context) throws IOException {

--- a/src/main/java/org/elasticsearch/index/mapper/internal/FieldNamesFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/FieldNamesFieldMapper.java
@@ -213,9 +213,9 @@ public class FieldNamesFieldMapper extends AbstractFieldMapper<String> implement
     }
 
     @Override
-    protected void parseCreateField(ParseContext context, List<Field> fields) throws IOException {
+    protected ValueAndBoost parseCreateField(ParseContext context, List<Field> fields) throws IOException {
         if (!fieldType.indexed() && !fieldType.stored() && !hasDocValues()) {
-            return;
+            return null;
         }
         for (ParseContext.Document document : context.docs()) {
             final List<String> paths = new ArrayList<>();
@@ -233,6 +233,7 @@ public class FieldNamesFieldMapper extends AbstractFieldMapper<String> implement
                 }
             }
         }
+        return null;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/mapper/internal/FieldNamesFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/FieldNamesFieldMapper.java
@@ -38,6 +38,7 @@ import org.elasticsearch.index.codec.postingsformat.PostingsFormatProvider;
 import org.elasticsearch.index.fielddata.FieldDataType;
 import org.elasticsearch.index.mapper.*;
 import org.elasticsearch.index.mapper.core.AbstractFieldMapper;
+import org.elasticsearch.index.mapper.core.TypeParsers;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -109,7 +110,7 @@ public class FieldNamesFieldMapper extends AbstractFieldMapper<String> implement
         public Mapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
             if (parserContext.indexVersionCreated().onOrAfter(Version.V_1_3_0)) {
                 FieldNamesFieldMapper.Builder builder = fieldNames();
-                parseField(builder, builder.name, node, parserContext);
+                TypeParsers.parseField(builder, builder.name, node, parserContext);
                 return builder;
             } else {
               throw new ElasticsearchIllegalArgumentException("type="+CONTENT_TYPE+" is not supported on indices created before version 1.3.0 is your cluster running multiple datanode versions?");
@@ -213,9 +214,14 @@ public class FieldNamesFieldMapper extends AbstractFieldMapper<String> implement
     }
 
     @Override
-    protected ValueAndBoost parseCreateField(ParseContext context, List<Field> fields) throws IOException {
+    protected ValueAndBoost parseField(ParseContext context) throws IOException {
+        return null;
+    }
+
+    @Override
+    protected void createField(ParseContext context, List<Field> fields, ValueAndBoost valueAndBoost) throws IOException {
         if (!fieldType.indexed() && !fieldType.stored() && !hasDocValues()) {
-            return null;
+            return;
         }
         for (ParseContext.Document document : context.docs()) {
             final List<String> paths = new ArrayList<>();
@@ -233,7 +239,6 @@ public class FieldNamesFieldMapper extends AbstractFieldMapper<String> implement
                 }
             }
         }
-        return null;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/mapper/internal/IdFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/IdFieldMapper.java
@@ -297,7 +297,7 @@ public class IdFieldMapper extends AbstractFieldMapper<String> implements Intern
     }
 
     @Override
-    protected void parseCreateField(ParseContext context, List<Field> fields) throws IOException {
+    protected ValueAndBoost parseCreateField(ParseContext context, List<Field> fields) throws IOException {
         XContentParser parser = context.parser();
         if (parser.currentName() != null && parser.currentName().equals(Defaults.NAME) && parser.currentToken().isValue()) {
             // we are in the parse Phase
@@ -314,6 +314,7 @@ public class IdFieldMapper extends AbstractFieldMapper<String> implements Intern
         if (hasDocValues()) {
             fields.add(new BinaryDocValuesField(names.indexName(), new BytesRef(context.id())));
         }
+        return null;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/mapper/internal/IdFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/IdFieldMapper.java
@@ -45,6 +45,7 @@ import org.elasticsearch.index.codec.postingsformat.PostingsFormatService;
 import org.elasticsearch.index.fielddata.FieldDataType;
 import org.elasticsearch.index.mapper.*;
 import org.elasticsearch.index.mapper.core.AbstractFieldMapper;
+import org.elasticsearch.index.mapper.core.TypeParsers;
 import org.elasticsearch.index.query.QueryParseContext;
 
 import java.io.IOException;
@@ -105,7 +106,7 @@ public class IdFieldMapper extends AbstractFieldMapper<String> implements Intern
         @Override
         public Mapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
             IdFieldMapper.Builder builder = id();
-            parseField(builder, builder.name, node, parserContext);
+            TypeParsers.parseField(builder, builder.name, node, parserContext);
             for (Map.Entry<String, Object> entry : node.entrySet()) {
                 String fieldName = Strings.toUnderscoreCase(entry.getKey());
                 Object fieldNode = entry.getValue();
@@ -297,7 +298,7 @@ public class IdFieldMapper extends AbstractFieldMapper<String> implements Intern
     }
 
     @Override
-    protected ValueAndBoost parseCreateField(ParseContext context, List<Field> fields) throws IOException {
+    protected ValueAndBoost parseField(ParseContext context) throws IOException {
         XContentParser parser = context.parser();
         if (parser.currentName() != null && parser.currentName().equals(Defaults.NAME) && parser.currentToken().isValue()) {
             // we are in the parse Phase
@@ -308,13 +309,18 @@ public class IdFieldMapper extends AbstractFieldMapper<String> implements Intern
             context.id(id);
         } // else we are in the pre/post parse phase
 
+        return null;
+    }
+
+    @Override
+    protected void createField(ParseContext context, List<Field> fields, ValueAndBoost valueAndBoost) throws IOException {
+
         if (fieldType.indexed() || fieldType.stored()) {
             fields.add(new Field(names.indexName(), context.id(), fieldType));
         }
         if (hasDocValues()) {
             fields.add(new BinaryDocValuesField(names.indexName(), new BytesRef(context.id())));
         }
-        return null;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/mapper/internal/IndexFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/IndexFieldMapper.java
@@ -177,11 +177,12 @@ public class IndexFieldMapper extends AbstractFieldMapper<String> implements Int
     }
 
     @Override
-    protected void parseCreateField(ParseContext context, List<Field> fields) throws IOException {
+    protected ValueAndBoost parseCreateField(ParseContext context, List<Field> fields) throws IOException {
         if (!enabledState.enabled) {
-            return;
+            return null;
         }
         fields.add(new Field(names.indexName(), context.index(), fieldType));
+        return null;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/mapper/internal/IndexFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/IndexFieldMapper.java
@@ -34,6 +34,7 @@ import org.elasticsearch.index.codec.postingsformat.PostingsFormatProvider;
 import org.elasticsearch.index.fielddata.FieldDataType;
 import org.elasticsearch.index.mapper.*;
 import org.elasticsearch.index.mapper.core.AbstractFieldMapper;
+import org.elasticsearch.index.mapper.core.TypeParsers;
 
 import java.io.IOException;
 import java.util.List;
@@ -93,7 +94,7 @@ public class IndexFieldMapper extends AbstractFieldMapper<String> implements Int
         @Override
         public Mapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
             IndexFieldMapper.Builder builder = MapperBuilders.index();
-            parseField(builder, builder.name, node, parserContext);
+            TypeParsers.parseField(builder, builder.name, node, parserContext);
 
             for (Map.Entry<String, Object> entry : node.entrySet()) {
                 String fieldName = Strings.toUnderscoreCase(entry.getKey());
@@ -177,12 +178,16 @@ public class IndexFieldMapper extends AbstractFieldMapper<String> implements Int
     }
 
     @Override
-    protected ValueAndBoost parseCreateField(ParseContext context, List<Field> fields) throws IOException {
+    protected ValueAndBoost parseField(ParseContext context) throws IOException {
+        return null;
+    }
+
+    @Override
+    protected void createField(ParseContext context, List<Field> fields, ValueAndBoost valueAndBoost) throws IOException {
         if (!enabledState.enabled) {
-            return null;
+            return;
         }
         fields.add(new Field(names.indexName(), context.index(), fieldType));
-        return null;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/mapper/internal/ParentFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/ParentFieldMapper.java
@@ -189,9 +189,9 @@ public class ParentFieldMapper extends AbstractFieldMapper<Uid> implements Inter
     }
 
     @Override
-    protected void parseCreateField(ParseContext context, List<Field> fields) throws IOException {
+    protected ValueAndBoost parseCreateField(ParseContext context, List<Field> fields) throws IOException {
         if (!active()) {
-            return;
+            return null;
         }
 
         if (context.parser().currentName() != null && context.parser().currentName().equals(Defaults.NAME)) {
@@ -216,6 +216,7 @@ public class ParentFieldMapper extends AbstractFieldMapper<Uid> implements Inter
             }
         }
         // we have parent mapping, yet no value was set, ignore it...
+        return null;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/mapper/internal/RoutingFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/RoutingFieldMapper.java
@@ -192,17 +192,18 @@ public class RoutingFieldMapper extends AbstractFieldMapper<String> implements I
     }
 
     @Override
-    protected void parseCreateField(ParseContext context, List<Field> fields) throws IOException {
+    protected ValueAndBoost parseCreateField(ParseContext context, List<Field> fields) throws IOException {
         if (context.sourceToParse().routing() != null) {
             String routing = context.sourceToParse().routing();
             if (routing != null) {
                 if (!fieldType.indexed() && !fieldType.stored()) {
                     context.ignoredValue(names.indexName(), routing);
-                    return;
+                    return null;
                 }
                 fields.add(new Field(names.indexName(), routing, fieldType));
             }
         }
+        return null;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/mapper/internal/SizeFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/SizeFieldMapper.java
@@ -142,14 +142,15 @@ public class SizeFieldMapper extends IntegerFieldMapper implements RootMapper {
     }
 
     @Override
-    protected void innerParseCreateField(ParseContext context, List<Field> fields) throws IOException {
+    protected ValueAndBoost innerParseCreateField(ParseContext context, List<Field> fields) throws IOException {
         if (!enabledState.enabled) {
-            return;
+            return null;
         }
         if (context.flyweight()) {
-            return;
+            return null;
         }
         fields.add(new CustomIntegerNumericField(this, context.source().length(), fieldType));
+        return null;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/mapper/internal/SizeFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/SizeFieldMapper.java
@@ -142,15 +142,22 @@ public class SizeFieldMapper extends IntegerFieldMapper implements RootMapper {
     }
 
     @Override
-    protected ValueAndBoost innerParseCreateField(ParseContext context, List<Field> fields) throws IOException {
+    protected ValueAndBoost parseField(ParseContext context) throws IOException {
         if (!enabledState.enabled) {
             return null;
         }
         if (context.flyweight()) {
             return null;
         }
+        return new ValueAndBoost(context.source().length(), 1.0f);
+    }
+
+    @Override
+    protected void createField(ParseContext context, List<Field> fields, ValueAndBoost valueAndBoost) throws IOException {
+        if (valueAndBoost == null) {
+            return;
+        }
         fields.add(new CustomIntegerNumericField(this, context.source().length(), fieldType));
-        return null;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/mapper/internal/SourceFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/SourceFieldMapper.java
@@ -254,15 +254,15 @@ public class SourceFieldMapper extends AbstractFieldMapper<byte[]> implements In
     }
 
     @Override
-    protected void parseCreateField(ParseContext context, List<Field> fields) throws IOException {
+    protected ValueAndBoost parseCreateField(ParseContext context, List<Field> fields) throws IOException {
         if (!enabled) {
-            return;
+            return null;
         }
         if (!fieldType.stored()) {
-            return;
+            return null;
         }
         if (context.flyweight()) {
-            return;
+            return null;
         }
         BytesReference source = context.source();
 
@@ -341,6 +341,7 @@ public class SourceFieldMapper extends AbstractFieldMapper<byte[]> implements In
             source = source.toBytesArray();
         }
         fields.add(new StoredField(names().indexName(), source.array(), source.arrayOffset(), source.length()));
+        return null;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/mapper/internal/SourceFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/SourceFieldMapper.java
@@ -254,7 +254,7 @@ public class SourceFieldMapper extends AbstractFieldMapper<byte[]> implements In
     }
 
     @Override
-    protected ValueAndBoost parseCreateField(ParseContext context, List<Field> fields) throws IOException {
+    protected ValueAndBoost parseField(ParseContext context) throws IOException {
         if (!enabled) {
             return null;
         }
@@ -340,10 +340,17 @@ public class SourceFieldMapper extends AbstractFieldMapper<byte[]> implements In
         if (!source.hasArray()) {
             source = source.toBytesArray();
         }
-        fields.add(new StoredField(names().indexName(), source.array(), source.arrayOffset(), source.length()));
-        return null;
+        return new ValueAndBoost(source, 1.0f);
     }
 
+    @Override
+    protected void createField(ParseContext context, List<Field> fields, ValueAndBoost valueAndBoost) throws IOException {
+        if (valueAndBoost == null) {
+            return;
+        }
+        BytesReference source = (BytesReference)valueAndBoost.value;
+        fields.add(new StoredField(names().indexName(), source.array(), source.arrayOffset(), source.length()));
+    }
     @Override
     public byte[] value(Object value) {
         if (value == null) {

--- a/src/main/java/org/elasticsearch/index/mapper/internal/TTLFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/TTLFieldMapper.java
@@ -196,7 +196,7 @@ public class TTLFieldMapper extends LongFieldMapper implements InternalMapper, R
     }
 
     @Override
-    protected void innerParseCreateField(ParseContext context, List<Field> fields) throws IOException, AlreadyExpiredException {
+    protected ValueAndBoost innerParseCreateField(ParseContext context, List<Field> fields) throws IOException, AlreadyExpiredException {
         if (enabledState.enabled && !context.sourceToParse().flyweight()) {
             long ttl = context.sourceToParse().ttl();
             if (ttl <= 0 && defaultTTL > 0) { // no ttl provided so we use the default value
@@ -215,6 +215,7 @@ public class TTLFieldMapper extends LongFieldMapper implements InternalMapper, R
                 fields.add(new CustomLongNumericField(this, expire, fieldType));
             }
         }
+        return null;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/mapper/internal/TimestampFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/TimestampFieldMapper.java
@@ -214,7 +214,7 @@ public class TimestampFieldMapper extends DateFieldMapper implements InternalMap
     }
 
     @Override
-    protected void innerParseCreateField(ParseContext context, List<Field> fields) throws IOException {
+    protected ValueAndBoost innerParseCreateField(ParseContext context, List<Field> fields) throws IOException {
         if (enabledState.enabled) {
             long timestamp = context.sourceToParse().timestamp();
             if (!fieldType.indexed() && !fieldType.stored() && !hasDocValues()) {
@@ -227,6 +227,7 @@ public class TimestampFieldMapper extends DateFieldMapper implements InternalMap
                 fields.add(new NumericDocValuesField(names.indexName(), timestamp));
             }
         }
+        return null;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/mapper/internal/TypeFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/TypeFieldMapper.java
@@ -173,14 +173,15 @@ public class TypeFieldMapper extends AbstractFieldMapper<String> implements Inte
     }
 
     @Override
-    protected void parseCreateField(ParseContext context, List<Field> fields) throws IOException {
+    protected ValueAndBoost parseCreateField(ParseContext context, List<Field> fields) throws IOException {
         if (!fieldType.indexed() && !fieldType.stored()) {
-            return;
+            return null;
         }
         fields.add(new Field(names.indexName(), context.type(), fieldType));
         if (hasDocValues()) {
             fields.add(new SortedSetDocValuesField(names.indexName(), new BytesRef(context.type())));
         }
+        return null;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/mapper/internal/UidFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/UidFieldMapper.java
@@ -170,13 +170,14 @@ public class UidFieldMapper extends AbstractFieldMapper<Uid> implements Internal
     }
 
     @Override
-    protected void parseCreateField(ParseContext context, List<Field> fields) throws IOException {
+    protected ValueAndBoost parseCreateField(ParseContext context, List<Field> fields) throws IOException {
         Field uid = new Field(NAME, Uid.createUid(context.stringBuilder(), context.type(), context.id()), Defaults.FIELD_TYPE);
         context.uid(uid);
         fields.add(uid);
         if (hasDocValues()) {
             fields.add(new BinaryDocValuesField(NAME, new BytesRef(uid.stringValue())));
         }
+        return null;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/mapper/internal/UidFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/UidFieldMapper.java
@@ -39,6 +39,7 @@ import org.elasticsearch.index.fielddata.FieldDataType;
 import org.elasticsearch.index.mapper.*;
 import org.elasticsearch.index.mapper.ParseContext.Document;
 import org.elasticsearch.index.mapper.core.AbstractFieldMapper;
+import org.elasticsearch.index.mapper.core.TypeParsers;
 
 import java.io.IOException;
 import java.util.List;
@@ -94,7 +95,7 @@ public class UidFieldMapper extends AbstractFieldMapper<Uid> implements Internal
         @Override
         public Mapper.Builder<?, ?> parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
             Builder builder = uid();
-            parseField(builder, builder.name, node, parserContext);
+            TypeParsers.parseField(builder, builder.name, node, parserContext);
             return builder;
         }
     }
@@ -170,14 +171,18 @@ public class UidFieldMapper extends AbstractFieldMapper<Uid> implements Internal
     }
 
     @Override
-    protected ValueAndBoost parseCreateField(ParseContext context, List<Field> fields) throws IOException {
-        Field uid = new Field(NAME, Uid.createUid(context.stringBuilder(), context.type(), context.id()), Defaults.FIELD_TYPE);
+    protected ValueAndBoost parseField(ParseContext context) throws IOException {
+        return new ValueAndBoost(Uid.createUid(context.stringBuilder(), context.type(), context.id()),1.0f);
+    }
+
+    @Override
+    protected void createField(ParseContext context, List<Field> fields, ValueAndBoost valueAndBoost) throws IOException {
+        Field uid = new Field(NAME, (String)valueAndBoost.value, Defaults.FIELD_TYPE);
         context.uid(uid);
         fields.add(uid);
         if (hasDocValues()) {
             fields.add(new BinaryDocValuesField(NAME, new BytesRef(uid.stringValue())));
         }
-        return null;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/mapper/internal/VersionFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/VersionFieldMapper.java
@@ -108,11 +108,12 @@ public class VersionFieldMapper extends AbstractFieldMapper<Long> implements Int
     }
 
     @Override
-    protected void parseCreateField(ParseContext context, List<Field> fields) throws IOException {
+    protected ValueAndBoost parseCreateField(ParseContext context, List<Field> fields) throws IOException {
         // see UidFieldMapper.parseCreateField
         final Field version = fieldCache.get();
         context.version(version);
         fields.add(version);
+        return null;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/mapper/internal/VersionFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/VersionFieldMapper.java
@@ -108,12 +108,18 @@ public class VersionFieldMapper extends AbstractFieldMapper<Long> implements Int
     }
 
     @Override
-    protected ValueAndBoost parseCreateField(ParseContext context, List<Field> fields) throws IOException {
-        // see UidFieldMapper.parseCreateField
+    protected ValueAndBoost parseField(ParseContext context) throws IOException {
+        // see UidFieldMapper.parse/createField
         final Field version = fieldCache.get();
         context.version(version);
-        fields.add(version);
         return null;
+    }
+
+    @Override
+    protected void createField(ParseContext context, List<Field> fields, ValueAndBoost valueAndBoost) throws IOException {
+        // see UidFieldMapper.parse/createField
+        final Field version = fieldCache.get();
+        fields.add(version);
     }
 
     @Override

--- a/src/test/java/org/elasticsearch/index/mapper/core/BaseTypeMapperTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/core/BaseTypeMapperTests.java
@@ -1,0 +1,317 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper.core;
+
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.index.mapper.MapperParsingException;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.test.ElasticsearchSingleNodeTest;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+
+public class BaseTypeMapperTests extends ElasticsearchSingleNodeTest {
+
+    public static final String INDEX = "text";
+    public static final String TYPE = "type";
+    public static final String[] BASE_TYPES = {"byte", "short", "integer", "long", "float", "double", "string"};
+
+    @Test
+    public void testNumberWithBoostAppearInAll() throws IOException {
+        String type = getRandomBaseType();
+        logger.info("TYPE is " + type);
+        XContentBuilder mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties")
+                .startObject("field")
+                .field("type", type).field("omit_norms", "false")
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject();
+        createIndex(INDEX, ImmutableSettings.EMPTY, TYPE, mapping);
+
+        XContentBuilder doc = jsonBuilder().startObject()
+                .startObject("field").field("value", "2").field("boost", 10).endObject()
+                .endObject();
+        client().prepareIndex(INDEX, TYPE, "1").setSource(doc).get();
+        doc = jsonBuilder().startObject()
+                .startObject("field").field("value", "2").field("boost", 5).endObject()
+                .endObject();
+        client().prepareIndex(INDEX, TYPE, "2").setSource(doc).get();
+        client().admin().indices().prepareRefresh(INDEX).get();
+        String termInAllField = "2" + ((type.equals("float") || type.equals("double")) ? ".0" : "");
+        SearchResponse searchResponse = client().prepareSearch(INDEX).setQuery(QueryBuilders.termQuery("_all", termInAllField)).get();
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2l));
+    }
+
+    @Test
+    public void testMultiFieldsWithArray() throws IOException {
+
+        String type = getRandomBaseType();
+        XContentBuilder mapping = XContentFactory.jsonBuilder().startObject().startObject(TYPE)
+                .startObject("properties")
+                .startObject("field")
+                .field("type", type)
+                .startObject("fields")
+                .startObject("same_base_type")
+                .field("type", type)
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject();
+        createIndex(INDEX, ImmutableSettings.EMPTY, TYPE, mapping);
+
+        XContentBuilder doc = jsonBuilder().startObject()
+                .field("field", "1", "2", "3")
+                .endObject();
+        client().prepareIndex(INDEX, TYPE, "1").setSource(doc).get();
+        client().admin().indices().prepareRefresh(INDEX).get();
+        SearchResponse searchResponse = client().prepareSearch(INDEX).setQuery(QueryBuilders.termQuery("field.same_base_type", "1")).get();
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1l));
+    }
+
+    // test that multi fields and boost works for number and String
+    @Test
+    public void testMultiFieldsWithArrayAndBoost() throws IOException {
+        String type = getRandomBaseType();
+        logger.info("TYPE is " + type);
+        XContentBuilder mapping =
+                XContentFactory.jsonBuilder().startObject().startObject("type")
+                        .startObject("properties")
+                        .startObject("field")
+                        .field("type", type).field("omit_norms", "false")
+                        .startObject("fields")
+                        .startObject("string")
+                        .field("omit_norms", "false")
+                                // boost only has an effect for string types so to check if it is transported to the multi fields
+                                // the multi field has to be a string
+                        .field("type", "string")
+                        .endObject()
+                        .endObject()
+                        .endObject()
+                        .endObject()
+                        .endObject()
+                        .endObject();
+        createIndex(INDEX, ImmutableSettings.EMPTY, TYPE, mapping);
+        XContentBuilder doc = jsonBuilder().startObject()
+                .startArray("field")
+                .startObject().field("value", "1").field("boost", 1).endObject()
+                .startObject().field("value", "2").field("boost", 3).endObject()
+                .startObject().field("value", "3").field("boost", 1).endObject()
+                .endArray()
+                .endObject();
+        client().prepareIndex(INDEX, TYPE, "1").setSource(doc).get();
+        doc = jsonBuilder().startObject()
+                .array("field", "1", "2", "3")
+                .endObject();
+        client().prepareIndex(INDEX, TYPE, "2").setSource(doc).get();
+        client().admin().indices().prepareRefresh(INDEX).get();
+        String termInField = "2" + ((type.equals("float") || type.equals("double")) ? ".0" : "");
+        SearchResponse searchResponse = client().prepareSearch(INDEX).setQuery(QueryBuilders.termQuery("field.string", termInField)).get();
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2l));
+        assertThat(searchResponse.getHits().getAt(0).getScore(), equalTo(searchResponse.getHits().getAt(1).getScore() * 3.0f));
+    }
+
+    @Test
+    public void testFieldBoostForMultiField() throws IOException {
+
+        String type = getRandomBaseType();
+        XContentBuilder mapping =
+                XContentFactory.jsonBuilder().startObject().startObject("type")
+                        .startObject("properties")
+                        .startObject("field")
+                        .field("type", type).field("omit_norms", "false")
+                        .startObject("fields")
+                        .startObject("string")
+                        .field("omit_norms", "false")
+                                // boost only has an effect for string types so to check if it is transported to the multi fields
+                                // the multi field has to be a string
+                        .field("type", "string")
+                        .endObject()
+                        .endObject()
+                        .endObject()
+                        .endObject()
+                        .endObject()
+                        .endObject();
+        createIndex(INDEX, ImmutableSettings.EMPTY, TYPE, mapping);
+        XContentBuilder doc = jsonBuilder().startObject()
+                .startObject("field")
+                .field("value", "1").field("boost", 4)
+                .endObject()
+                .endObject();
+        client().prepareIndex(INDEX, TYPE, "1").setSource(doc).get();
+        doc = jsonBuilder().startObject()
+                .startObject("field")
+                .field("value", "1").field("boost", 2)
+                .endObject()
+                .endObject();
+        logger.info("TYPE is " + type);
+        client().prepareIndex(INDEX, TYPE, "2").setSource(doc).get();
+        client().admin().indices().prepareRefresh(INDEX).get();
+        String termInField = "1" + ((type.equals("float") || type.equals("double")) ? ".0" : "");
+        SearchResponse searchResponse = client().prepareSearch(INDEX).setQuery(QueryBuilders.termQuery("field.string", termInField)).get();
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2l));
+        assertThat(searchResponse.getHits().getAt(0).getScore(), equalTo(searchResponse.getHits().getAt(1).getScore() * 2.0f));
+    }
+
+    @Test
+    public void testTokenCountWithBoost() throws IOException {
+
+        String type = getRandomBaseType();
+        XContentBuilder mapping =
+                XContentFactory.jsonBuilder().startObject().startObject("type")
+                        .startObject("properties")
+                        .startObject("field")
+                        .field("type", "string")
+                        .field("store", "yes")
+                        .startObject("fields")
+                        .startObject("token_count")
+                        .field("type", "token_count")
+                        .field("analyzer", "standard")
+                        .field("store", "yes")
+                        .endObject()
+                        .endObject()
+                        .endObject()
+                        .endObject()
+                        .endObject()
+                        .endObject();
+        createIndex(INDEX, ImmutableSettings.EMPTY, TYPE, mapping);
+        XContentBuilder doc = jsonBuilder().startObject()
+                .startObject("field")
+                .field("value", "in einen hering jung und schlank, zwo, drei, vier,...").field("boost", 4)
+                .endObject()
+                .endObject();
+        client().prepareIndex(INDEX, TYPE, "1").setSource(doc).get();
+        doc = jsonBuilder().startObject()
+                .field("field", "in einen hering jung und schlank, zwo, drei, vier,...")
+                .endObject();
+        logger.info("TYPE is " + type);
+        client().prepareIndex(INDEX, TYPE, "2").setSource(doc).get();
+        client().admin().indices().prepareRefresh(INDEX).get();
+        SearchResponse searchResponse = client().prepareSearch(INDEX).setQuery(matchAllQuery()).addField("field.token_count").addField("field").get();
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2l));
+        assertThat((int) searchResponse.getHits().getAt(0).getFields().get("field.token_count").getValue(), equalTo(9));
+        assertThat((int) searchResponse.getHits().getAt(1).getFields().get("field.token_count").getValue(), equalTo(9));
+        assertThat(searchResponse.getHits().getAt(0).getFields().get("field").getValue().toString(), equalTo("in einen hering jung und schlank, zwo, drei, vier,..."));
+        assertThat(searchResponse.getHits().getAt(1).getFields().get("field").getValue().toString(), equalTo("in einen hering jung und schlank, zwo, drei, vier,..."));
+    }
+
+    @Test
+    public void testBoostWithWrongArrayRepresentation() throws IOException {
+        String type = getRandomBaseType();
+        logger.info("TYPE is " + type);
+        XContentBuilder mapping =
+                XContentFactory.jsonBuilder().startObject().startObject("type")
+                        .startObject("properties")
+                        .startObject("field")
+                        .field("type", type).field("omit_norms", "false")
+                        .endObject()
+                        .endObject()
+                        .endObject()
+                        .endObject();
+        createIndex(INDEX, ImmutableSettings.EMPTY, TYPE, mapping);
+        boolean additionalDoc = randomBoolean();
+
+        XContentBuilder doc;
+        if (additionalDoc) {
+            doc = jsonBuilder().startObject()
+                    .array("field", "1", "2", "3")
+                    .endObject();
+            client().prepareIndex(INDEX, TYPE, "1").setSource(doc).get();
+            client().admin().indices().prepareRefresh(INDEX).get();
+        }
+
+        doc = jsonBuilder().startObject()
+                .startObject("field")
+                .array("value", "1", "2", "3").field("boost", 1)
+                .endObject()
+                .endObject();
+        try {
+            client().prepareIndex(INDEX, TYPE, "1").setSource(doc).get();
+            fail();
+        } catch (MapperParsingException e) {
+            assertThat(e.getDetailedMessage(), containsString("Boost for field in array must be given like this: {field_name: [{\"value\": value}, \"boost\": boost},{...},...]}"));
+        }
+
+        doc = jsonBuilder().startObject()
+                .array("field", "1", "2", "3")
+                .endObject();
+        client().prepareIndex(INDEX, TYPE, "2").setSource(doc).get();
+        client().admin().indices().prepareRefresh(INDEX).get();
+        String termInField = "2" + ((type.equals("float") || type.equals("double")) ? ".0" : "");
+        SearchResponse searchResponse = client().prepareSearch(INDEX).setQuery(QueryBuilders.termQuery("field", termInField)).get();
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1l + (additionalDoc ? 1l : 0l)));
+    }
+
+    @Test
+    public void testGeoPointArrayMultiField() throws IOException {
+        XContentBuilder mapping =
+                XContentFactory.jsonBuilder().startObject().startObject("type")
+                        .startObject("properties")
+                        .startObject("field")
+                        .field("type", "geo_point")
+                        .startObject("fields")
+                        .startObject("string_point")
+                        .field("type", "string")
+                        .endObject()
+                        .endObject()
+                        .endObject()
+                        .endObject()
+                        .endObject()
+                        .endObject();
+        createIndex(INDEX, ImmutableSettings.EMPTY, TYPE, mapping);
+
+        Map<String, Float> geoPoint1 = new HashMap<>();
+        geoPoint1.put("lat", 10f);
+        geoPoint1.put("lon", 20f);
+        Map<String, Float> geoPoint2 = new HashMap<>();
+        geoPoint2.put("lat", 11f);
+        geoPoint2.put("lon", 22f);
+        XContentBuilder doc = jsonBuilder().startObject()
+                .array("field", geoPoint1, geoPoint2)
+                .endObject();
+        client().prepareIndex(INDEX, TYPE, "1").setSource(doc).get();
+
+        doc = jsonBuilder().startObject()
+                .field("field", geoPoint2)
+                .endObject();
+        client().prepareIndex(INDEX, TYPE, "2").setSource(doc).get();
+        client().admin().indices().prepareRefresh(INDEX).get();
+        SearchResponse searchResponse = client().prepareSearch(INDEX).setQuery(QueryBuilders.termQuery("string_point", "11.0,22.0")).get();
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2l));
+    }
+
+
+    public String getRandomBaseType() {
+        return BASE_TYPES[randomInt(BASE_TYPES.length - 1)];
+    }
+}

--- a/src/test/java/org/elasticsearch/index/mapper/externalvalues/ExternalMapper.java
+++ b/src/test/java/org/elasticsearch/index/mapper/externalvalues/ExternalMapper.java
@@ -129,7 +129,7 @@ public class ExternalMapper extends AbstractFieldMapper<Object> {
         @Override
         public Mapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
             ExternalMapper.Builder builder = new ExternalMapper.Builder(name, generatedValue, mapperName);
-            parseField(builder, name, node, parserContext);
+            TypeParsers.parseField(builder, name, node, parserContext);
             for (Map.Entry<String, Object> entry : node.entrySet()) {
                 String propName = Strings.toUnderscoreCase(entry.getKey());
                 Object propNode = entry.getValue();
@@ -209,7 +209,7 @@ public class ExternalMapper extends AbstractFieldMapper<Object> {
     }
 
     @Override
-    protected ValueAndBoost parseCreateField(ParseContext context, List<Field> fields) throws IOException {
+    protected ValueAndBoost parseField(ParseContext context) throws IOException {
         throw new UnsupportedOperationException();
     }
 

--- a/src/test/java/org/elasticsearch/index/mapper/externalvalues/ExternalValuesMapperIntegrationTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/externalvalues/ExternalValuesMapperIntegrationTests.java
@@ -30,6 +30,7 @@ import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.junit.Test;
 
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.equalTo;
 
 /**
@@ -120,6 +121,7 @@ public class ExternalValuesMapperIntegrationTests extends ElasticsearchIntegrati
                 .setQuery(QueryBuilders.termQuery("f.f.raw", "FOO BAR"))
                 .execute().actionGet();
 
+        assertSearchResponse(response);
         assertThat(response.getHits().totalHits(), equalTo((long) 1));
     }
 }

--- a/src/test/java/org/elasticsearch/index/mapper/externalvalues/SimpleExternalMappingTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/externalvalues/SimpleExternalMappingTests.java
@@ -65,6 +65,9 @@ public class SimpleExternalMappingTests extends ElasticsearchSingleNodeLuceneTes
 
         assertThat(doc.rootDoc().getField("field.shape"), notNullValue());
 
+        assertThat(doc.rootDoc().getField("field.float"), notNullValue());
+        assertThat(doc.rootDoc().getField("field.float").numericValue().floatValue(), is(1.234f));
+
         assertThat(doc.rootDoc().getField("field.field"), notNullValue());
         assertThat(doc.rootDoc().getField("field.field").stringValue(), is("foo"));
 

--- a/src/test/java/org/elasticsearch/index/mapper/multifield/MultiFieldTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/multifield/MultiFieldTests.java
@@ -278,7 +278,7 @@ public class MultiFieldTests extends ElasticsearchSingleNodeTest {
         f = doc.getField("a.b");
         assertThat(f, notNullValue());
         assertThat(f.name(), equalTo("a.b"));
-        assertThat(f.stringValue(), equalTo("-1.0,-1.0"));
+        assertThat(f.stringValue(), equalTo("-1,-1"));
         assertThat(f.fieldType().stored(), equalTo(false));
         assertThat(f.fieldType().indexed(), equalTo(true));
 
@@ -296,34 +296,34 @@ public class MultiFieldTests extends ElasticsearchSingleNodeTest {
 
         json = jsonBuilder().startObject()
                 .field("_id", "1")
-                .field("b", "-1,-1")
+                .field("b", "-1,1")
                 .endObject().bytes();
         doc = docMapper.parse(json).rootDoc();
 
         f = doc.getField("b");
         assertThat(f, notNullValue());
         assertThat(f.name(), equalTo("b"));
-        assertThat(f.stringValue(), equalTo("-1.0,-1.0"));
+        assertThat(f.stringValue(), equalTo("-1,1"));
         assertThat(f.fieldType().stored(), equalTo(false));
         assertThat(f.fieldType().indexed(), equalTo(true));
 
         f = doc.getField("b.a");
         assertThat(f, notNullValue());
         assertThat(f.name(), equalTo("b.a"));
-        assertThat(f.stringValue(), equalTo("-1,-1"));
+        assertThat(f.stringValue(), equalTo("-1,1"));
         assertThat(f.fieldType().stored(), equalTo(false));
         assertThat(f.fieldType().indexed(), equalTo(true));
 
         json = jsonBuilder().startObject()
                 .field("_id", "1")
-                .startArray("b").startArray().value(-1).value(-1).endArray().startArray().value(-2).value(-2).endArray().endArray()
+                .startArray("b").startArray().value(-1).value(1).endArray().startArray().value(-2).value(-2).endArray().endArray()
                 .endObject().bytes();
         doc = docMapper.parse(json).rootDoc();
 
         f = doc.getFields("b")[0];
         assertThat(f, notNullValue());
         assertThat(f.name(), equalTo("b"));
-        assertThat(f.stringValue(), equalTo("-1.0,-1.0"));
+        assertThat(f.stringValue(), equalTo("1.0,-1.0"));
         assertThat(f.fieldType().stored(), equalTo(false));
         assertThat(f.fieldType().indexed(), equalTo(true));
 
@@ -337,10 +337,7 @@ public class MultiFieldTests extends ElasticsearchSingleNodeTest {
         f = doc.getField("b.a");
         assertThat(f, notNullValue());
         assertThat(f.name(), equalTo("b.a"));
-        // NOTE: "]" B/c the lat,long aren't specified as a string, we miss the actual values when parsing the multi
-        // fields. We already skipped over the coordinates values and can't get to the coordinates.
-        // This happens if coordinates are specified as array and object.
-        assertThat(f.stringValue(), equalTo("]"));
+        assertThat(f.stringValue(), equalTo("1.0,-1.0"));
         assertThat(f.fieldType().stored(), equalTo(false));
         assertThat(f.fieldType().indexed(), equalTo(true));
     }


### PR DESCRIPTION
I just make this pull request for having a better basis to discuss potential changes in the way external values are handled right now. I do not think it is ready for pulling in yet. Feel free to comment.

The external value mechanism was a workaround for not being able to set
a value while parsing a field value. It was used for example by geo point
to set the values for the lat and lon field. However, its the major
disadvantage was that it made the code hard to read.
This commit removes the external value from parse context and instead
adds a new method FieldMapper.addValue() which can be used to add fields
to a mapper that are unrelated to the currently parsed source.
In addition, this method is now used also by the multi_field handling so that
parsing is called only once and the parsed value (or any other) is passed
to multi_fields explicitely. Before, multi_fields relied on the parser
being at a particular position.
This means that now values which are objects or arrays in a json structure
can also be passed to multi_fields which was not possible before
(see BaseTypeMapperTests where all test except for testMultiFieldsWithArray
failed without this change).
