### PR TITLE
test: write heap dump to log folder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -476,6 +476,7 @@
                                 <param>-XX:MaxDirectMemorySize=512m</param>
                                 <param>-Des.logger.prefix=</param>
                                 <param>-XX:+HeapDumpOnOutOfMemoryError</param>
+                                <param>-XX:HeapDumpPath=${basedir}/logs/</param>
                             </jvmArgs>
                             <shuffleOnSlave>${tests.shuffle}</shuffleOnSlave>
                             <sysouts>${tests.verbose}</sysouts>

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
         <tests.bwc.path>${project.basedir}/backwards</tests.bwc.path>
         <es.logger.level>INFO</es.logger.level>
         <tests.heap.size>512m</tests.heap.size>
+        <tests.heap.dumplocation>${basedir}/logs</tests.heap.dumplocation>
         <tests.topn>5</tests.topn>
         <execution.hint.file>.local-${project.version}-execution-hints.log</execution.hint.file>
     </properties>
@@ -476,7 +477,7 @@
                                 <param>-XX:MaxDirectMemorySize=512m</param>
                                 <param>-Des.logger.prefix=</param>
                                 <param>-XX:+HeapDumpOnOutOfMemoryError</param>
-                                <param>-XX:HeapDumpPath=${basedir}/logs/</param>
+                                <param>-XX:HeapDumpPath=${tests.heap.dumplocation}</param>
                             </jvmArgs>
                             <shuffleOnSlave>${tests.shuffle}</shuffleOnSlave>
                             <sysouts>${tests.verbose}</sysouts>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <tests.bwc.path>${project.basedir}/backwards</tests.bwc.path>
         <es.logger.level>INFO</es.logger.level>
         <tests.heap.size>512m</tests.heap.size>
-        <tests.heap.dumplocation>${basedir}/logs</tests.heap.dumplocation>
+        <tests.heapdump.path>${basedir}/logs</tests.heapdump.path>
         <tests.topn>5</tests.topn>
         <execution.hint.file>.local-${project.version}-execution-hints.log</execution.hint.file>
     </properties>
@@ -477,7 +477,7 @@
                                 <param>-XX:MaxDirectMemorySize=512m</param>
                                 <param>-Des.logger.prefix=</param>
                                 <param>-XX:+HeapDumpOnOutOfMemoryError</param>
-                                <param>-XX:HeapDumpPath=${tests.heap.dumplocation}</param>
+                                <param>-XX:HeapDumpPath=${tests.heapdump.path}</param>
                             </jvmArgs>
                             <shuffleOnSlave>${tests.shuffle}</shuffleOnSlave>
                             <sysouts>${tests.verbose}</sysouts>


### PR DESCRIPTION
Follow up to #7370
Per default the heap dump is written to target/JX/pidXYZ.hprof
In order to keep them when a new test is is started, they
should be written to log folder which is not cleared in a new
test run.
