### PR TITLE
Add LZF safe encoder in LZFCompressor

### DIFF
--- a/src/main/java/org/elasticsearch/common/compress/lzf/LZFCompressedStreamOutput.java
+++ b/src/main/java/org/elasticsearch/common/compress/lzf/LZFCompressedStreamOutput.java
@@ -22,7 +22,6 @@ package org.elasticsearch.common.compress.lzf;
 import com.ning.compress.BufferRecycler;
 import com.ning.compress.lzf.ChunkEncoder;
 import com.ning.compress.lzf.LZFChunk;
-import com.ning.compress.lzf.util.ChunkEncoderFactory;
 import org.elasticsearch.common.compress.CompressedStreamOutput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -35,12 +34,12 @@ public class LZFCompressedStreamOutput extends CompressedStreamOutput<LZFCompres
     private final BufferRecycler recycler;
     private final ChunkEncoder encoder;
 
-    public LZFCompressedStreamOutput(StreamOutput out) throws IOException {
+    public LZFCompressedStreamOutput(StreamOutput out, ChunkEncoder encoder) throws IOException {
         super(out, LZFCompressorContext.INSTANCE);
         this.recycler = BufferRecycler.instance();
         this.uncompressed = this.recycler.allocOutputBuffer(LZFChunk.MAX_CHUNK_LEN);
         this.uncompressedLength = LZFChunk.MAX_CHUNK_LEN;
-        this.encoder = ChunkEncoderFactory.safeInstance();
+        this.encoder = encoder;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/common/compress/lzf/LZFCompressor.java
+++ b/src/main/java/org/elasticsearch/common/compress/lzf/LZFCompressor.java
@@ -20,9 +20,11 @@
 package org.elasticsearch.common.compress.lzf;
 
 import com.ning.compress.lzf.ChunkDecoder;
+import com.ning.compress.lzf.ChunkEncoder;
 import com.ning.compress.lzf.LZFChunk;
 import com.ning.compress.lzf.LZFEncoder;
 import com.ning.compress.lzf.util.ChunkDecoderFactory;
+import com.ning.compress.lzf.util.ChunkEncoderFactory;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.util.Constants;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -46,11 +48,16 @@ public class LZFCompressor implements Compressor {
 
     public static final String TYPE = "lzf";
 
+    private ChunkEncoder encoder;
+
     private ChunkDecoder decoder;
 
     public LZFCompressor() {
+        this.encoder = ChunkEncoderFactory.safeInstance();
         this.decoder = ChunkDecoderFactory.safeInstance();
-        Loggers.getLogger(LZFCompressor.class).debug("using [{}] decoder", this.decoder.getClass().getSimpleName());
+        Loggers.getLogger(LZFCompressor.class).debug("using encoder [{}] and decoder[{}] ",
+                this.encoder.getClass().getSimpleName(),
+                this.decoder.getClass().getSimpleName());
     }
 
     @Override
@@ -110,7 +117,7 @@ public class LZFCompressor implements Compressor {
 
     @Override
     public byte[] compress(byte[] data, int offset, int length) throws IOException {
-        return LZFEncoder.encode(data, offset, length);
+        return LZFEncoder.encode(encoder, data, offset, length);
     }
 
     @Override
@@ -120,7 +127,7 @@ public class LZFCompressor implements Compressor {
 
     @Override
     public CompressedStreamOutput streamOutput(StreamOutput out) throws IOException {
-        return new LZFCompressedStreamOutput(out);
+        return new LZFCompressedStreamOutput(out, encoder);
     }
 
     @Override


### PR DESCRIPTION
Selecting the safe encoder fixes a 64bit JVM crash on big-endian architectures with
LZF UnsafeChunkEncoderBE.

Example of such a big-endian architecture is Solaris SPARC 64bit (another one is POWER).

Without safe encoder, LZF uses the unsafe encoder, and crashes when
for example this command is executed

```
    PUT /_template/logstash
    {
            "template" : "logstash-*",
            "settings" : {
                    "index.refresh_interval" : "5s"
            },
            "mappings" : {
                    "_default_" : {
                            "_all" : { "enabled" : true },
                            "dynamic_templates" : [ {
                                    "string_fields" : {
                                            "match" : "*",
                                            "match_mapping_type" : "string",
                                            "mapping" : {
                                                    "type" : "string",
                                                    "index" : "analyzed",
                                                    "omit_norms" : true,
                                                    "fields" : {
                                                            "raw" : {
                                                                    "type": "string",
                                                                    "index" : "not_analyzed",
                                                                    "ignore_above" : 256
                                                            }
                                                    }
                                            }
                                    }
                            } ],
                            "properties" : {
                                    "@version": { "type": "string", "index": "not_analyzed" },
                                    "geoip"  : {
                                            "type" : "object",
                                            "dynamic": true,
                                            "path": "full",
                                            "properties" : {
                                                    "location" : { "type" : "geo_point" }
                                            }
                                    }
                            }
                    }
            }
    }
```

A crash file is available at https://gist.github.com/jprante/79f4b4c0b9fd83eb1c9b
