### PR TITLE
Removing useless methods and method parameters from ObjectMapper.java and TypeParsers.java

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/core/CompletionFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/CompletionFieldMapper.java
@@ -170,7 +170,7 @@ public class CompletionFieldMapper extends AbstractFieldMapper<String> {
                 } else if (Fields.MAX_INPUT_LENGTH.match(fieldName)) {
                     builder.maxInputLength(Integer.parseInt(fieldNode.toString()));
                 } else if ("fields".equals(fieldName) || "path".equals(fieldName)) {
-                    parseMultiField(builder, name, node, parserContext, fieldName, fieldNode);
+                    parseMultiField(builder, name, parserContext, fieldName, fieldNode);
                 } else if (fieldName.equals(Fields.CONTEXT)) {
                     builder.contextMapping(ContextBuilder.loadMappings(fieldNode));
                 } else {

--- a/src/main/java/org/elasticsearch/index/mapper/core/DateFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/DateFieldMapper.java
@@ -153,7 +153,7 @@ public class DateFieldMapper extends NumberFieldMapper<Long> {
                 if (propName.equals("null_value")) {
                     builder.nullValue(propNode.toString());
                 } else if (propName.equals("format")) {
-                    builder.dateTimeFormatter(parseDateTimeFormatter(propName, propNode));
+                    builder.dateTimeFormatter(parseDateTimeFormatter(propNode));
                 } else if (propName.equals("numeric_resolution")) {
                     builder.timeUnit(TimeUnit.valueOf(propNode.toString().toUpperCase(Locale.ROOT)));
                 } else if (propName.equals("locale")) {

--- a/src/main/java/org/elasticsearch/index/mapper/core/StringFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/StringFieldMapper.java
@@ -178,7 +178,7 @@ public class StringFieldMapper extends AbstractFieldMapper<String> implements Al
                 } else if (propName.equals("ignore_above")) {
                     builder.ignoreAbove(XContentMapValues.nodeIntegerValue(propNode, -1));
                 } else {
-                    parseMultiField(builder, name, node, parserContext, propName, propNode);
+                    parseMultiField(builder, name, parserContext, propName, propNode);
                 }
             }
             return builder;

--- a/src/main/java/org/elasticsearch/index/mapper/core/TypeParsers.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/TypeParsers.java
@@ -154,7 +154,7 @@ public class TypeParsers {
             } else if (propName.equals("similarity")) {
                 builder.similarity(parserContext.similarityLookupService().similarity(propNode.toString()));
             } else {
-                parseMultiField(builder, name, numberNode, parserContext, propName, propNode);
+                parseMultiField(builder, name, parserContext, propName, propNode);
             }
         }
     }
@@ -245,7 +245,7 @@ public class TypeParsers {
         }
     }
 
-    public static void parseMultiField(AbstractFieldMapper.Builder builder, String name, Map<String, Object> node, Mapper.TypeParser.ParserContext parserContext, String propName, Object propNode) {
+    public static void parseMultiField(AbstractFieldMapper.Builder builder, String name, Mapper.TypeParser.ParserContext parserContext, String propName, Object propNode) {
         if (propName.equals("path")) {
             builder.multiFieldPathType(parsePathType(name, propNode.toString()));
         } else if (propName.equals("fields")) {
@@ -291,7 +291,7 @@ public class TypeParsers {
         }
     }
 
-    public static FormatDateTimeFormatter parseDateTimeFormatter(String fieldName, Object node) {
+    public static FormatDateTimeFormatter parseDateTimeFormatter(Object node) {
         return Joda.forPattern(node.toString());
     }
 
@@ -332,16 +332,6 @@ public class TypeParsers {
             builder.tokenized(true);
         } else {
             throw new MapperParsingException("Wrong value for index [" + index + "] for field [" + fieldName + "]");
-        }
-    }
-
-    public static boolean parseDocValues(String docValues) {
-        if ("no".equals(docValues)) {
-            return false;
-        } else if ("yes".equals(docValues)) {
-            return true;
-        } else {
-            return nodeBooleanValue(docValues);
         }
     }
 

--- a/src/main/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapper.java
@@ -245,7 +245,7 @@ public class GeoPointFieldMapper extends AbstractFieldMapper<GeoPoint> implement
                 } else if (fieldName.equals("normalize_lon")) {
                     builder.normalizeLon = XContentMapValues.nodeBooleanValue(fieldNode);
                 } else {
-                    parseMultiField(builder, name, node, parserContext, fieldName, fieldNode);
+                    parseMultiField(builder, name, parserContext, fieldName, fieldNode);
                 }
             }
             return builder;

--- a/src/main/java/org/elasticsearch/index/mapper/internal/TimestampFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/TimestampFieldMapper.java
@@ -130,7 +130,7 @@ public class TimestampFieldMapper extends DateFieldMapper implements InternalMap
                 } else if (fieldName.equals("path")) {
                     builder.path(fieldNode.toString());
                 } else if (fieldName.equals("format")) {
-                    builder.dateTimeFormatter(parseDateTimeFormatter(builder.name(), fieldNode.toString()));
+                    builder.dateTimeFormatter(parseDateTimeFormatter(fieldNode.toString()));
                 } else if (fieldName.equals("default")) {
                     builder.defaultTimestamp(fieldNode == null ? null : fieldNode.toString());
                 }

--- a/src/main/java/org/elasticsearch/index/mapper/object/ObjectMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/object/ObjectMapper.java
@@ -415,10 +415,6 @@ public class ObjectMapper implements Mapper, AllFieldMapper.IncludeInAll {
         return this.fullPath;
     }
 
-    public BytesRef nestedTypePathAsBytes() {
-        return nestedTypePathAsBytes;
-    }
-
     public String nestedTypePathAsString() {
         return nestedTypePathAsString;
     }
@@ -791,21 +787,6 @@ public class ObjectMapper implements Mapper, AllFieldMapper.IncludeInAll {
                             }
                         }
                     }
-                    // DON'T do automatic ip detection logic, since it messes up with docs that have hosts and ips
-                    // check if its an ip
-//                if (!resolved && text.indexOf('.') != -1) {
-//                    try {
-//                        IpFieldMapper.ipToLong(text);
-//                        XContentMapper.Builder builder = context.root().findTemplateBuilder(context, currentFieldName, "ip");
-//                        if (builder == null) {
-//                            builder = ipField(currentFieldName);
-//                        }
-//                        mapper = builder.build(builderContext);
-//                        resolved = true;
-//                    } catch (Exception e) {
-//                        // failure to parse, not ip...
-//                    }
-//                }
                     if (!resolved) {
                         Mapper.Builder builder = context.root().findTemplateBuilder(context, currentFieldName, "string");
                         if (builder == null) {

--- a/src/main/java/org/elasticsearch/index/mapper/object/RootObjectMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/object/RootObjectMapper.java
@@ -146,12 +146,12 @@ public class RootObjectMapper extends ObjectMapper {
                 List<FormatDateTimeFormatter> dateTimeFormatters = newArrayList();
                 if (fieldNode instanceof List) {
                     for (Object node1 : (List) fieldNode) {
-                        dateTimeFormatters.add(parseDateTimeFormatter(fieldName, node1));
+                        dateTimeFormatters.add(parseDateTimeFormatter(node1));
                     }
                 } else if ("none".equals(fieldNode.toString())) {
                     dateTimeFormatters = null;
                 } else {
-                    dateTimeFormatters.add(parseDateTimeFormatter(fieldName, fieldNode));
+                    dateTimeFormatters.add(parseDateTimeFormatter(fieldNode));
                 }
                 if (dateTimeFormatters == null) {
                     ((Builder) builder).noDynamicDateTimeFormatter();

--- a/src/test/java/org/elasticsearch/index/mapper/externalvalues/ExternalMapper.java
+++ b/src/test/java/org/elasticsearch/index/mapper/externalvalues/ExternalMapper.java
@@ -131,7 +131,7 @@ public class ExternalMapper extends AbstractFieldMapper<Object> {
                 String propName = Strings.toUnderscoreCase(entry.getKey());
                 Object propNode = entry.getValue();
 
-                parseMultiField(builder, name, node, parserContext, propName, propNode);
+                parseMultiField(builder, name, parserContext, propName, propNode);
             }
 
             return builder;


### PR DESCRIPTION
While working on #7271 I found some methods that were not being used (I searched for the names too, to see if I could find any reflective calls) and some method parameters too.

To make it easier to merge #7271 I am submitting this as a side Pull request.

I've ran all tests and they OK!

Thanks
