### PR TITLE
Cleanup StoreFileMetadata.java

### DIFF
--- a/src/main/java/org/elasticsearch/gateway/local/LocalGatewayAllocator.java
+++ b/src/main/java/org/elasticsearch/gateway/local/LocalGatewayAllocator.java
@@ -323,7 +323,7 @@ public class LocalGatewayAllocator extends AbstractComponent implements GatewayA
                                 long sizeMatched = 0;
 
                                 for (StoreFileMetaData storeFileMetaData : storeFilesMetaData) {
-                                    if (primaryNodeStore.fileExists(storeFileMetaData.name()) && primaryNodeStore.file(storeFileMetaData.name()).isSame(storeFileMetaData)) {
+                                    if (primaryNodeStore.fileExists(storeFileMetaData.name()) && primaryNodeStore.file(storeFileMetaData.name()).equals(storeFileMetaData)) {
                                         sizeMatched += storeFileMetaData.length();
                                     }
                                 }

--- a/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardRepository.java
+++ b/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardRepository.java
@@ -768,7 +768,7 @@ public class BlobStoreIndexShardRepository extends AbstractComponent implements 
                         maybeRecalculateMetadataHash(blobContainer, fileInfo, recoveryTargetMetadata);
                     }  catch (Throwable e) {
                         // if the index is broken we might not be able to read it
-                        logger.warn("{} Can't calculate hash from blog for file [{}] [{}]", e, shardId, fileInfo.physicalName(), fileInfo.metadata());
+                        logger.warn("{} Can't calculate hash from blog for file [{}] [{}]", e, shardId, fileInfo.name(), fileInfo.metadata());
                     }
                     snapshotMetaData.put(fileInfo.metadata().name(), fileInfo.metadata());
                     fileInfos.put(fileInfo.metadata().name(), fileInfo);

--- a/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshot.java
+++ b/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshot.java
@@ -187,7 +187,7 @@ public class BlobStoreIndexShardSnapshot {
          * @return true if file in a store this this file have the same checksum and length
          */
         public boolean isSame(StoreFileMetaData md) {
-            return metadata.isSame(md);
+            return metadata.equals(md);
         }
 
         static final class Fields {

--- a/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/src/main/java/org/elasticsearch/index/store/Store.java
@@ -674,7 +674,7 @@ public class Store extends AbstractIndexShardComponent implements CloseableIndex
                     if (storeFileMetaData == null) {
                         consistent = false;
                         missing.add(meta);
-                    } else if (storeFileMetaData.isSame(meta) == false) {
+                    } else if (storeFileMetaData.equals(meta) == false) {
                         consistent = false;
                         different.add(meta);
                     } else {

--- a/src/main/java/org/elasticsearch/index/store/StoreFileMetaData.java
+++ b/src/main/java/org/elasticsearch/index/store/StoreFileMetaData.java
@@ -49,14 +49,6 @@ public final class StoreFileMetaData implements Streamable {
     private StoreFileMetaData() {
     }
 
-    public StoreFileMetaData(String name, long length) {
-        this(name, length, null);
-    }
-
-    public StoreFileMetaData(String name, long length, String checksum) {
-        this(name, length, checksum, null, null);
-    }
-
     public StoreFileMetaData(String name, long length, String checksum, Version writtenBy) {
         this(name, length, checksum, writtenBy, null);
     }
@@ -164,6 +156,7 @@ public final class StoreFileMetaData implements Streamable {
     public int hashCode() {
         int result = name.hashCode();
         result = 31 * result + (int) (length ^ (length >>> 32));
+        result = 31 * result + (hash.length ^ (hash.length >>> 32));
         result = 31 * result + (checksum != null ? checksum.hashCode() : 0);
         result = 31 * result + (writtenBy != null ? writtenBy.hashCode() : 0);
         return result;
@@ -176,7 +169,11 @@ public final class StoreFileMetaData implements Streamable {
             if (checksum == null || other.checksum == null) {
                 return false;
             }
-            return name.equals(other.name()) && length == other.length && checksum.equals(other.checksum) && hash.equals(other.hash);
+            return name.equals(other.name())
+                    && (writtenBy == null ? other.writtenBy == null : writtenBy.equals(other.writtenBy))
+                    && length == other.length
+                    && checksum.equals(other.checksum)
+                    && hash.equals(other.hash);
         }
         return false;
     }

--- a/src/main/java/org/elasticsearch/index/store/StoreFileMetaData.java
+++ b/src/main/java/org/elasticsearch/index/store/StoreFileMetaData.java
@@ -156,6 +156,7 @@ public final class StoreFileMetaData implements Streamable {
     public int hashCode() {
         int result = name.hashCode();
         result = 31 * result + (int) (length ^ (length >>> 32));
+        // we only use hash.length here since the actual hash might be expensive
         result = 31 * result + (hash.length ^ (hash.length >>> 32));
         result = 31 * result + (checksum != null ? checksum.hashCode() : 0);
         result = 31 * result + (writtenBy != null ? writtenBy.hashCode() : 0);

--- a/src/test/java/org/elasticsearch/index/snapshots/blobstore/FileInfoTest.java
+++ b/src/test/java/org/elasticsearch/index/snapshots/blobstore/FileInfoTest.java
@@ -43,7 +43,8 @@ public class FileInfoTest extends ElasticsearchTestCase {
             for (int i = 0; i < hash.length; i++) {
                 hash.bytes[i] = randomByte();
             }
-            StoreFileMetaData meta = new StoreFileMetaData("foobar", randomInt(), randomAsciiOfLengthBetween(1, 10), TEST_VERSION_CURRENT, hash);
+            final long len = Math.max(0, Math.abs(randomLong()));
+            StoreFileMetaData meta = new StoreFileMetaData("foobar", len, randomAsciiOfLengthBetween(1, 10), TEST_VERSION_CURRENT, hash);
             ByteSizeValue size = new ByteSizeValue(Math.max(0,Math.abs(randomLong())));
             BlobStoreIndexShardSnapshot.FileInfo info = new BlobStoreIndexShardSnapshot.FileInfo("_foobar", meta, size);
             XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON).prettyPrint();

--- a/src/test/java/org/elasticsearch/index/store/StoreFileMetaDataTest.java
+++ b/src/test/java/org/elasticsearch/index/store/StoreFileMetaDataTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.index.store;
+
+import com.carrotsearch.randomizedtesting.generators.RandomPicks;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.Version;
+import org.elasticsearch.ElasticsearchIllegalArgumentException;
+import org.elasticsearch.common.io.stream.InputStreamStreamInput;
+import org.elasticsearch.common.io.stream.OutputStreamStreamOutput;
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+
+public class StoreFileMetaDataTest extends ElasticsearchTestCase {
+
+    public void testHashCodeAndEquals() throws IOException {
+        final int iters = scaledRandomIntBetween(1, 10);
+        for (int iter = 0; iter < iters; iter++) {
+            final BytesRef hash = new BytesRef(scaledRandomIntBetween(0, 1024 * 1024));
+            hash.length = hash.bytes.length;
+            for (int i = 0; i < hash.length; i++) {
+                hash.bytes[i] = randomByte();
+            }
+            final String name = randomRealisticUnicodeOfCodepointLengthBetween(1, 10);
+            final long len = Math.max(0, Math.abs(randomLong()));
+            final String checksum = randomAsciiOfLengthBetween(1, 10);
+            final Version version = RandomPicks.randomFrom(getRandom(), Version.values());
+            StoreFileMetaData meta = new StoreFileMetaData(name, len, checksum, version, BytesRef.deepCopyOf(hash));
+            assertEquals(maybeSerialize(meta), new StoreFileMetaData(name, len, checksum, version, BytesRef.deepCopyOf(hash)));
+            assertEquals(maybeSerialize(meta).hashCode(), new StoreFileMetaData(name, len, checksum, version,  BytesRef.deepCopyOf(hash)).hashCode());
+            assertThat(maybeSerialize(meta), not(equalTo(new StoreFileMetaData(name+"foobar", len, checksum, version,  BytesRef.deepCopyOf(hash)))));
+            assertThat(maybeSerialize(meta), not(equalTo(new StoreFileMetaData(name, len+1, checksum, version,  BytesRef.deepCopyOf(hash)))));
+            assertThat(maybeSerialize(meta), not(equalTo(new StoreFileMetaData(name, len, checksum+"foo", version,  BytesRef.deepCopyOf(hash)))));
+            Version otherVersion = version;
+            while(otherVersion == version) {
+                otherVersion = RandomPicks.randomFrom(getRandom(), Version.values());
+            }
+            assertThat(maybeSerialize(meta), not(equalTo(new StoreFileMetaData(name, len, checksum, otherVersion,  BytesRef.deepCopyOf(hash)))));
+            assertThat(maybeSerialize(meta), not(equalTo(new StoreFileMetaData(name, len, checksum, version, null))));
+            BytesRef otherHash = BytesRef.deepCopyOf(hash);
+            while (otherHash.equals(hash)) {
+                otherHash.copyChars(randomAsciiOfLengthBetween(1,10));
+            }
+            assertThat(maybeSerialize(meta), not(equalTo(new StoreFileMetaData(name, len, checksum, version, otherHash))));
+        }
+    }
+
+    @Test(expected = ElasticsearchIllegalArgumentException.class)
+    public void testNullName() {
+        new StoreFileMetaData(null, 1, "", TEST_VERSION_CURRENT, null);
+    }
+
+    @Test(expected = ElasticsearchIllegalArgumentException.class)
+    public void testNegativeLen() {
+        new StoreFileMetaData("", Math.min(-1, -randomInt()), "", TEST_VERSION_CURRENT, null);
+    }
+
+    public StoreFileMetaData maybeSerialize(StoreFileMetaData meta) throws IOException {
+        if (randomBoolean()) {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        meta.writeTo(new OutputStreamStreamOutput(outputStream));
+        return StoreFileMetaData.readStoreFileMetaData(new InputStreamStreamInput(new ByteArrayInputStream(outputStream.toByteArray())));
+        }
+        return meta;
+    }
+}

--- a/src/test/java/org/elasticsearch/index/store/StoreFileMetaDataTest.java
+++ b/src/test/java/org/elasticsearch/index/store/StoreFileMetaDataTest.java
@@ -50,19 +50,19 @@ public class StoreFileMetaDataTest extends ElasticsearchTestCase {
             final Version version = RandomPicks.randomFrom(getRandom(), Version.values());
             StoreFileMetaData meta = new StoreFileMetaData(name, len, checksum, version, BytesRef.deepCopyOf(hash));
             assertEquals(maybeSerialize(meta), new StoreFileMetaData(name, len, checksum, version, BytesRef.deepCopyOf(hash)));
-            assertEquals(maybeSerialize(meta).hashCode(), new StoreFileMetaData(name, len, checksum, version,  BytesRef.deepCopyOf(hash)).hashCode());
-            assertThat(maybeSerialize(meta), not(equalTo(new StoreFileMetaData(name+"foobar", len, checksum, version,  BytesRef.deepCopyOf(hash)))));
-            assertThat(maybeSerialize(meta), not(equalTo(new StoreFileMetaData(name, len+1, checksum, version,  BytesRef.deepCopyOf(hash)))));
-            assertThat(maybeSerialize(meta), not(equalTo(new StoreFileMetaData(name, len, checksum+"foo", version,  BytesRef.deepCopyOf(hash)))));
+            assertEquals(maybeSerialize(meta).hashCode(), new StoreFileMetaData(name, len, checksum, version, BytesRef.deepCopyOf(hash)).hashCode());
+            assertThat(maybeSerialize(meta), not(equalTo(new StoreFileMetaData(name + "foobar", len, checksum, version, BytesRef.deepCopyOf(hash)))));
+            assertThat(maybeSerialize(meta), not(equalTo(new StoreFileMetaData(name, len + 1, checksum, version, BytesRef.deepCopyOf(hash)))));
+            assertThat(maybeSerialize(meta), not(equalTo(new StoreFileMetaData(name, len, checksum + "foo", version, BytesRef.deepCopyOf(hash)))));
             Version otherVersion = version;
-            while(otherVersion == version) {
+            while (otherVersion == version) {
                 otherVersion = RandomPicks.randomFrom(getRandom(), Version.values());
             }
-            assertThat(maybeSerialize(meta), not(equalTo(new StoreFileMetaData(name, len, checksum, otherVersion,  BytesRef.deepCopyOf(hash)))));
+            assertThat(maybeSerialize(meta), not(equalTo(new StoreFileMetaData(name, len, checksum, otherVersion, BytesRef.deepCopyOf(hash)))));
             assertThat(maybeSerialize(meta), not(equalTo(new StoreFileMetaData(name, len, checksum, version, null))));
             BytesRef otherHash = BytesRef.deepCopyOf(hash);
             while (otherHash.equals(hash)) {
-                otherHash.copyChars(randomAsciiOfLengthBetween(1,10));
+                otherHash.copyChars(randomAsciiOfLengthBetween(1, 10));
             }
             assertThat(maybeSerialize(meta), not(equalTo(new StoreFileMetaData(name, len, checksum, version, otherHash))));
         }
@@ -80,9 +80,9 @@ public class StoreFileMetaDataTest extends ElasticsearchTestCase {
 
     public StoreFileMetaData maybeSerialize(StoreFileMetaData meta) throws IOException {
         if (randomBoolean()) {
-        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        meta.writeTo(new OutputStreamStreamOutput(outputStream));
-        return StoreFileMetaData.readStoreFileMetaData(new InputStreamStreamInput(new ByteArrayInputStream(outputStream.toByteArray())));
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            meta.writeTo(new OutputStreamStreamOutput(outputStream));
+            return StoreFileMetaData.readStoreFileMetaData(new InputStreamStreamInput(new ByteArrayInputStream(outputStream.toByteArray())));
         }
         return meta;
     }

--- a/src/test/java/org/elasticsearch/index/store/StoreTest.java
+++ b/src/test/java/org/elasticsearch/index/store/StoreTest.java
@@ -559,7 +559,6 @@ public class StoreTest extends ElasticsearchLuceneTestCase {
         return random.nextBoolean() ? new LeastUsedDistributor(service) : new RandomWeightedDistributor(service);
     }
 
-
     @Test
     public void testRecoveryDiff() throws IOException, InterruptedException {
         int numDocs = 2 + random().nextInt(100);

--- a/src/test/java/org/elasticsearch/index/store/StoreTest.java
+++ b/src/test/java/org/elasticsearch/index/store/StoreTest.java
@@ -211,7 +211,7 @@ public class StoreTest extends ElasticsearchLuceneTestCase {
         assertThat(legacyMeta.size(), equalTo(stringStoreFileMetaDataMap.size()));
         for (StoreFileMetaData meta : legacyMeta.values()) {
             assertTrue(stringStoreFileMetaDataMap.containsKey(meta.name()));
-            assertTrue(stringStoreFileMetaDataMap.get(meta.name()).isSame(meta));
+            assertTrue(stringStoreFileMetaDataMap.get(meta.name()).equals(meta));
         }
         assertDeleteContent(store, directoryService);
         IOUtils.close(store);
@@ -630,7 +630,7 @@ public class StoreTest extends ElasticsearchLuceneTestCase {
         for (StoreFileMetaData md : first) {
             assertThat(second.get(md.name()), notNullValue());
             // si files are different - containing timestamps etc
-            assertThat(second.get(md.name()).isSame(md), equalTo(md.name().endsWith(".si") == false));
+            assertThat(second.get(md.name()).equals(md), equalTo(md.name().endsWith(".si") == false));
         }
         assertThat(diff.different.size(), equalTo(first.size()-1));
         assertThat(diff.identical.size(), equalTo(1)); // commit point is identical


### PR DESCRIPTION
StoreFileMetadata.java uses a `isSame` methods which is essentially `equals` I think we should clean it up and also provide a `hashCode` implementation.
