### PR TITLE
Indexed Scripts : Add timeout

### DIFF
--- a/src/main/java/org/elasticsearch/action/indexedscripts/get/GetIndexedScriptRequest.java
+++ b/src/main/java/org/elasticsearch/action/indexedscripts/get/GetIndexedScriptRequest.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.lucene.uid.Versions;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.fetch.source.FetchSourceContext;
@@ -55,6 +56,7 @@ public class GetIndexedScriptRequest extends SingleShardOperationRequest<GetInde
 
     private VersionType versionType = VersionType.INTERNAL;
     private long version = Versions.MATCH_ANY;
+    private TimeValue timeout = new TimeValue(5000);
 
 
 
@@ -106,6 +108,20 @@ public class GetIndexedScriptRequest extends SingleShardOperationRequest<GetInde
     public GetIndexedScriptRequest scriptLang(@Nullable String type) {
         this.scriptLang = type;
         return this;
+    }
+
+    /**
+     * Sets the timeout for the request
+     * @param timeout
+     * @return
+     */
+    public GetIndexedScriptRequest timeout(TimeValue timeout) {
+        this.timeout = timeout;
+        return this;
+    }
+
+    public TimeValue timeout() {
+        return this.timeout;
     }
 
     /**

--- a/src/main/java/org/elasticsearch/action/indexedscripts/get/TransportGetIndexedScriptAction.java
+++ b/src/main/java/org/elasticsearch/action/indexedscripts/get/TransportGetIndexedScriptAction.java
@@ -55,7 +55,7 @@ public class TransportGetIndexedScriptAction extends HandledTransportAction<GetI
     @Override
     public void doExecute(GetIndexedScriptRequest request, ActionListener<GetIndexedScriptResponse> listener){
         try {
-            GetResponse scriptResponse = scriptService.queryScriptIndex(client, request.scriptLang(), request.id(), request.version(), request.versionType());
+            GetResponse scriptResponse = scriptService.queryScriptIndex(client, request.scriptLang(), request.id(), request.version(), request.versionType(), request.timeout());
             listener.onResponse(new GetIndexedScriptResponse(scriptResponse));
         } catch(Throwable e){
             listener.onFailure(e);

--- a/src/test/java/org/elasticsearch/script/IndexedScriptTests.java
+++ b/src/test/java/org/elasticsearch/script/IndexedScriptTests.java
@@ -20,6 +20,7 @@
 
 package org.elasticsearch.script;
 
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.unit.TimeValue;

--- a/src/test/java/org/elasticsearch/script/MissingIndexIndexedScriptTests.java
+++ b/src/test/java/org/elasticsearch/script/MissingIndexIndexedScriptTests.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.script;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.indexedscripts.get.GetIndexedScriptResponse;
+import org.elasticsearch.indices.IndexMissingException;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
+
+@ElasticsearchIntegrationTest.ClusterScope(scope = ElasticsearchIntegrationTest.Scope.SUITE)
+public class MissingIndexIndexedScriptTests extends ElasticsearchIntegrationTest{
+
+    @Test(expected = IndexMissingException.class)
+    public void testMissingScriptIndexScriptGet() {
+        GetIndexedScriptResponse gisr = client().prepareGetIndexedScript().setId("foobar").setScriptLang("groovy").get();
+        assertFalse(gisr.isExists());
+    }
+}


### PR DESCRIPTION
This commit adds a timeout that defaults to 5 seconds to the indexed script get operation.
It also adds a test that attempts a script get before the .scripts index is created.
