### PR TITLE
Only return aggregations on the first page with scroll and forbidden with scan

### DIFF
--- a/docs/reference/search/request/scroll.asciidoc
+++ b/docs/reference/search/request/scroll.asciidoc
@@ -115,6 +115,9 @@ A scanning scroll request differs from a standard scroll request in three
 ways:
 
 * Sorting is disabled. Results are returned in the order they appear in the index.
+
+* Aggregations are not supported.
+
 * The response of the initial `search` request will not contain any results in
   the `hits` array. The first results will be returned by the first `scroll`
   request.

--- a/docs/reference/search/request/scroll.asciidoc
+++ b/docs/reference/search/request/scroll.asciidoc
@@ -73,6 +73,9 @@ IMPORTANT: The initial search request and each subsequent scroll request
 returns a new `scroll_id` -- only the most recent `scroll_id` should be
 used.
 
+NOTE: If the request specifies aggregations, only the initial search response
+will contain the aggregations results.
+
 [[scroll-scan]]
 ==== Efficient scrolling with Scroll-Scan
 

--- a/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/src/main/java/org/elasticsearch/search/SearchService.java
@@ -27,6 +27,7 @@ import org.apache.lucene.index.AtomicReaderContext;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.search.TopDocs;
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.search.SearchType;
@@ -69,11 +70,8 @@ import org.elasticsearch.search.dfs.CachedDfSource;
 import org.elasticsearch.search.dfs.DfsPhase;
 import org.elasticsearch.search.dfs.DfsSearchResult;
 import org.elasticsearch.search.fetch.*;
-import org.elasticsearch.search.internal.DefaultSearchContext;
-import org.elasticsearch.search.internal.InternalScrollSearchRequest;
-import org.elasticsearch.search.internal.SearchContext;
+import org.elasticsearch.search.internal.*;
 import org.elasticsearch.search.internal.SearchContext.Lifetime;
-import org.elasticsearch.search.internal.ShardSearchRequest;
 import org.elasticsearch.search.query.*;
 import org.elasticsearch.search.warmer.IndexWarmersMetaData;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -206,10 +204,14 @@ public class SearchService extends AbstractLifecycleComponent<SearchService> {
 
     public QuerySearchResult executeScan(ShardSearchRequest request) throws ElasticsearchException {
         SearchContext context = createAndPutContext(request);
-        assert context.searchType() == SearchType.SCAN;
-        context.searchType(SearchType.COUNT); // move to COUNT, and then, when scrolling, move to SCAN
-        assert context.searchType() == SearchType.COUNT;
         try {
+            if (context.aggregations() != null) {
+                throw new ElasticsearchIllegalArgumentException("aggregations are not supported with search_type=scan");
+            }
+            assert context.searchType() == SearchType.SCAN;
+            context.searchType(SearchType.COUNT); // move to COUNT, and then, when scrolling, move to SCAN
+            assert context.searchType() == SearchType.COUNT;
+
             if (context.scroll() == null) {
                 throw new ElasticsearchException("Scroll must be provided when scanning...");
             }

--- a/src/main/java/org/elasticsearch/search/aggregations/AggregationPhase.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/AggregationPhase.java
@@ -96,6 +96,7 @@ public class AggregationPhase implements SearchPhase {
     @Override
     public void execute(SearchContext context) throws ElasticsearchException {
         if (context.aggregations() == null) {
+            context.queryResult().aggregations(null);
             return;
         }
 
@@ -133,6 +134,9 @@ public class AggregationPhase implements SearchPhase {
             aggregations.add(aggregator.buildAggregation(0));
         }
         context.queryResult().aggregations(new InternalAggregations(aggregations));
+
+        // disable aggregations so that they don't run on next pages in case of scrolling
+        context.aggregations(null);
     }
 
 

--- a/src/test/java/org/elasticsearch/search/aggregations/AggregationsIntegrationTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/AggregationsIntegrationTests.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations;
+
+import com.google.common.collect.Lists;
+import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.search.aggregations.bucket.terms.Terms;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+
+import java.util.List;
+
+import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
+
+
+@ElasticsearchIntegrationTest.SuiteScopeTest
+public class AggregationsIntegrationTests extends ElasticsearchIntegrationTest {
+
+    static int numDocs;
+
+    @Override
+    public void setupSuiteScopeCluster() throws Exception {
+        assertAcked(prepareCreate("index").addMapping("type", "f", "type=string").get());
+        ensureYellow("index");
+        numDocs = randomIntBetween(1, 20);
+        List<IndexRequestBuilder> docs = Lists.newArrayList();
+        for (int i = 0; i < numDocs; ++i) {
+            docs.add(client().prepareIndex("index", "type").setSource("f", Integer.toString(i / 3)));
+        }
+        indexRandom(true, docs);
+    }
+
+    public void testScroll() {
+        final int size = randomIntBetween(1, 4);
+        SearchResponse response = client().prepareSearch("index")
+                .setSize(size).setScroll(new TimeValue(500))
+                .addAggregation(terms("f").field("f")).get();
+        assertSearchResponse(response);
+        Aggregations aggregations = response.getAggregations();
+        assertNotNull(aggregations);
+        Terms terms = aggregations.get("f");
+        assertEquals(Math.min(numDocs, 3L), terms.getBucketByKey("0").getDocCount());
+
+        int total = response.getHits().getHits().length;
+        while (response.getHits().hits().length > 0) {
+            response = client().prepareSearchScroll(response.getScrollId())
+                    .setScroll(new TimeValue(500))
+                    .execute().actionGet();
+            assertNull(response.getAggregations());
+            total += response.getHits().hits().length;
+        }
+        clearScroll(response.getScrollId());
+        assertEquals(numDocs, total);
+    }
+
+}

--- a/src/test/java/org/elasticsearch/search/aggregations/AggregationsIntegrationTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/AggregationsIntegrationTests.java
@@ -21,7 +21,9 @@ package org.elasticsearch.search.aggregations;
 
 import com.google.common.collect.Lists;
 import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
@@ -48,6 +50,15 @@ public class AggregationsIntegrationTests extends ElasticsearchIntegrationTest {
             docs.add(client().prepareIndex("index", "type").setSource("f", Integer.toString(i / 3)));
         }
         indexRandom(true, docs);
+    }
+
+    public void testScan() {
+        try {
+            client().prepareSearch("index").setSearchType(SearchType.SCAN).setScroll(new TimeValue(500)).addAggregation(terms("f").field("f")).get();
+            fail();
+        } catch (SearchPhaseExecutionException e) {
+            assertTrue(e.getMessage(), e.getMessage().contains("aggregations are not supported with search_type=scan"));
+        }
     }
 
     public void testScroll() {


### PR DESCRIPTION
Aggregations are collection-wide statistics over one or several indices so:
- `scan` should not be allowed to use aggregations since it never collects all documents at once,
- `scroll` should only return aggregations on the first page (see #1642)
