### PR TITLE
Fix `.script` index template.

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
@@ -66,6 +66,7 @@ import org.elasticsearch.indices.IndexAlreadyExistsException;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.indices.InvalidIndexNameException;
 import org.elasticsearch.river.RiverIndexName;
+import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import java.io.File;
@@ -328,19 +329,28 @@ public class MetaDataCreateIndexService extends AbstractComponent {
                     }
                     // now, put the request settings, so they override templates
                     indexSettingsBuilder.put(request.settings());
-
-                    if (indexSettingsBuilder.get(SETTING_NUMBER_OF_SHARDS) == null) {
-                        if (request.index().equals(riverIndexName)) {
-                            indexSettingsBuilder.put(SETTING_NUMBER_OF_SHARDS, settings.getAsInt(SETTING_NUMBER_OF_SHARDS, 1));
-                        } else {
-                            indexSettingsBuilder.put(SETTING_NUMBER_OF_SHARDS, settings.getAsInt(SETTING_NUMBER_OF_SHARDS, 5));
+                    if (request.index().equals(ScriptService.SCRIPT_INDEX)) {
+                        indexSettingsBuilder.put(SETTING_NUMBER_OF_SHARDS, settings.getAsInt(SETTING_NUMBER_OF_SHARDS, 1));
+                    } else {
+                        if (indexSettingsBuilder.get(SETTING_NUMBER_OF_SHARDS) == null) {
+                            if (request.index().equals(riverIndexName)) {
+                                indexSettingsBuilder.put(SETTING_NUMBER_OF_SHARDS, settings.getAsInt(SETTING_NUMBER_OF_SHARDS, 1));
+                            } else {
+                                indexSettingsBuilder.put(SETTING_NUMBER_OF_SHARDS, settings.getAsInt(SETTING_NUMBER_OF_SHARDS, 5));
+                            }
                         }
                     }
-                    if (indexSettingsBuilder.get(SETTING_NUMBER_OF_REPLICAS) == null) {
-                        if (request.index().equals(riverIndexName)) {
-                            indexSettingsBuilder.put(SETTING_NUMBER_OF_REPLICAS, settings.getAsInt(SETTING_NUMBER_OF_REPLICAS, 1));
-                        } else {
-                            indexSettingsBuilder.put(SETTING_NUMBER_OF_REPLICAS, settings.getAsInt(SETTING_NUMBER_OF_REPLICAS, 1));
+                    if (request.index().equals(ScriptService.SCRIPT_INDEX)) {
+                        indexSettingsBuilder.put(SETTING_NUMBER_OF_REPLICAS, settings.getAsInt(SETTING_NUMBER_OF_REPLICAS, 0));
+                        indexSettingsBuilder.put(SETTING_AUTO_EXPAND_REPLICAS, "1-all");
+                    }
+                    else {
+                        if (indexSettingsBuilder.get(SETTING_NUMBER_OF_REPLICAS) == null) {
+                            if (request.index().equals(riverIndexName)) {
+                                indexSettingsBuilder.put(SETTING_NUMBER_OF_REPLICAS, settings.getAsInt(SETTING_NUMBER_OF_REPLICAS, 1));
+                            } else {
+                                indexSettingsBuilder.put(SETTING_NUMBER_OF_REPLICAS, settings.getAsInt(SETTING_NUMBER_OF_REPLICAS, 1));
+                            }
                         }
                     }
 

--- a/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -145,7 +145,7 @@ public class MapperService extends AbstractIndexComponent  {
         String defaultMappingLocation = componentSettings.get("default_mapping_location");
         final URL defaultMappingUrl;
         if (index.getName().equals(ScriptService.SCRIPT_INDEX)){
-            defaultMappingUrl = getMappingUrl(indexSettings, environment, defaultMappingLocation,"script-index-defaults.json","org/elasticsearch/index/mapper/script-index-defaults.json");
+            defaultMappingUrl = getMappingUrl(indexSettings, environment, defaultMappingLocation,"script-mapping.json","org/elasticsearch/index/mapper/script-mapping.json");
         } else {
             defaultMappingUrl = getMappingUrl(indexSettings, environment, defaultMappingLocation,"default-mapping.json","org/elasticsearch/index/mapper/default-mapping.json");
         }

--- a/src/main/java/org/elasticsearch/index/mapper/script-mapping.json
+++ b/src/main/java/org/elasticsearch/index/mapper/script-mapping.json
@@ -1,16 +1,9 @@
 {
-    "settings" : {
-        "number_of_shards" : 1,
-        "number_of_replicas" : "0-all"
-    }
-
-    "mappings": {
      "_default_": {
+
        "properties": {
          "script": { "enabled": false },
          "template": { "enabled": false }
        }
      }
-    }
-
 }

--- a/src/test/java/org/elasticsearch/script/ScriptIndexSettingsTest.java
+++ b/src/test/java/org/elasticsearch/script/ScriptIndexSettingsTest.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.script;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.admin.indices.delete.DeleteIndexResponse;
+import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsRequest;
+import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsResponse;
+import org.elasticsearch.action.admin.indices.settings.get.GetSettingsRequest;
+import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
+import org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesResponse;
+import org.elasticsearch.action.delete.DeleteResponse;
+import org.elasticsearch.action.exists.ExistsRequest;
+import org.elasticsearch.action.indexedscripts.delete.DeleteIndexedScriptAction;
+import org.elasticsearch.action.indexedscripts.get.GetIndexedScriptResponse;
+import org.elasticsearch.action.indexedscripts.put.PutIndexedScriptResponse;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.cluster.metadata.IndexTemplateMetaData;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.indices.IndexMissingException;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
+
+import java.util.Map;
+import java.util.Set;
+
+@ElasticsearchIntegrationTest.ClusterScope(scope = ElasticsearchIntegrationTest.Scope.TEST)
+public class ScriptIndexSettingsTest extends ElasticsearchIntegrationTest{
+
+
+    @Test
+    public void testScriptIndexSettings() {
+        PutIndexedScriptResponse putIndexedScriptResponse =
+                client().preparePutIndexedScript().setId("foobar").setScriptLang("groovy").setSource("{ \"script\": 1 }")
+                        .get();
+        assertTrue(putIndexedScriptResponse.isCreated());
+        ensureGreen();
+
+        IndicesExistsRequest existsRequest = new IndicesExistsRequest();
+        String[] index = new String[1];
+        index[0] = ScriptService.SCRIPT_INDEX;
+        existsRequest.indices(index);
+
+
+        IndicesExistsResponse existsResponse = cluster().client().admin().indices().exists(existsRequest).actionGet();
+        assertTrue(existsResponse.isExists());
+
+        GetSettingsRequest settingsRequest = new GetSettingsRequest();
+        settingsRequest.indices(ScriptService.SCRIPT_INDEX);
+        settingsRequest.indicesOptions(IndicesOptions.strictExpandOpen());
+        GetSettingsResponse settingsResponse = client()
+                .admin()
+                .indices()
+                .getSettings(settingsRequest)
+                .actionGet();
+
+        String numberOfShards = settingsResponse.getSetting(ScriptService.SCRIPT_INDEX,"index.number_of_shards");
+        String numberOfReplicas = settingsResponse.getSetting(ScriptService.SCRIPT_INDEX,"index.auto_expand_replicas");
+
+        assertEquals("Number of shards should be 1", "1", numberOfShards);
+        assertEquals("Auto expand replicas should be 1-all", "1-all", numberOfReplicas);
+    }
+
+    @Test
+    public void testDeleteScriptIndex() {
+        PutIndexedScriptResponse putIndexedScriptResponse =
+                client().preparePutIndexedScript().setId("foobar").setScriptLang("groovy").setSource("{ \"script\": 1 }")
+                        .get();
+        assertTrue(putIndexedScriptResponse.isCreated());
+        DeleteIndexResponse deleteResponse = client().admin().indices().prepareDelete(ScriptService.SCRIPT_INDEX).get();
+        assertTrue(deleteResponse.isAcknowledged());
+        ensureGreen();
+        try {
+            GetIndexedScriptResponse response = client().prepareGetIndexedScript("groovy","foobar").get();
+            assertTrue(false); //This should not happen
+        } catch (IndexMissingException ime) {
+            assertTrue(true);
+        }
+    }
+
+
+
+}


### PR DESCRIPTION
This commit makes the default number of shards for the .scripts index to `1`, it also
forces the auto_expand replicas to `1-all`. This change means that script index GET requests to load
scripts from the index should always use the local copy of the scripts index, preventing any network traffic or calls on script GET.
