### PR TITLE
Improved Suggest Client API

### DIFF
--- a/src/main/java/org/elasticsearch/action/suggest/SuggestRequest.java
+++ b/src/main/java/org/elasticsearch/action/suggest/SuggestRequest.java
@@ -32,18 +32,21 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentHelper;
-import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.search.suggest.SuggestBuilder;
 
 /**
  * A request to get suggestions for corrections of phrases. Best created with
  * {@link org.elasticsearch.client.Requests#suggestRequest(String...)}.
  * <p/>
- * <p>The request requires the suggest query source to be set either using {@link #suggest(org.elasticsearch.common.bytes.BytesReference)},
- * or {@link #suggest(org.elasticsearch.common.bytes.BytesReference, boolean)}.
+ * <p>The request requires the suggest query source to be set either using
+ * {@link #suggest(org.elasticsearch.common.bytes.BytesReference)} / {@link #suggest(org.elasticsearch.common.bytes.BytesReference, boolean)}
+ * or by using {@link #suggest(org.elasticsearch.search.suggest.SuggestBuilder)}
+ * (Best created using the {link @org.elasticsearch.search.suggest.SuggestBuilders)}).
  *
  * @see SuggestResponse
  * @see org.elasticsearch.client.Client#suggest(SuggestRequest)
  * @see org.elasticsearch.client.Requests#suggestRequest(String...)
+ * @see org.elasticsearch.search.suggest.SuggestBuilders
  */
 public final class SuggestRequest extends BroadcastOperationRequest<SuggestRequest> {
 
@@ -92,6 +95,22 @@ public final class SuggestRequest extends BroadcastOperationRequest<SuggestReque
      */
     public SuggestRequest suggest(BytesReference suggestSource) {
         return suggest(suggestSource, false);
+    }
+
+    /**
+     * set a new source using a {@link org.elasticsearch.search.suggest.SuggestBuilder}
+     * for phrase and term suggestion lookup
+     */
+    public SuggestRequest suggest(SuggestBuilder suggestBuilder) {
+        return suggest(suggestBuilder.buildAsBytes(Requests.CONTENT_TYPE));
+    }
+
+    /**
+     * set a new source using a {@link org.elasticsearch.search.suggest.SuggestBuilder.SuggestionBuilder}
+     * for completion suggestion lookup
+     */
+    public SuggestRequest suggest(SuggestBuilder.SuggestionBuilder suggestionBuilder) {
+        return suggest(suggestionBuilder.buildAsBytes(Requests.CONTENT_TYPE));
     }
     
     /**

--- a/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
@@ -44,7 +44,7 @@ import org.elasticsearch.search.sort.SortOrder;
 import static org.elasticsearch.common.unit.TimeValue.parseTimeValue;
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
-import static org.elasticsearch.search.suggest.SuggestBuilder.termSuggestion;
+import static org.elasticsearch.search.suggest.SuggestBuilders.termSuggestion;
 
 /**
  *

--- a/src/main/java/org/elasticsearch/search/suggest/SuggestBuilderException.java
+++ b/src/main/java/org/elasticsearch/search/suggest/SuggestBuilderException.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.suggest;
+
+import org.elasticsearch.ElasticsearchException;
+
+/**
+ * Exception thrown when errors are encountered in building Suggest lookup queries
+ * via {@link org.elasticsearch.search.suggest.SuggestBuilder}
+ */
+public class SuggestBuilderException extends ElasticsearchException {
+
+    public SuggestBuilderException(String msg) {
+        super(msg);
+    }
+
+    public SuggestBuilderException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+}

--- a/src/main/java/org/elasticsearch/search/suggest/SuggestBuilders.java
+++ b/src/main/java/org/elasticsearch/search/suggest/SuggestBuilders.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.suggest;
+
+import org.elasticsearch.search.suggest.completion.CompletionSuggestionBuilder;
+import org.elasticsearch.search.suggest.completion.CompletionSuggestionFuzzyBuilder;
+import org.elasticsearch.search.suggest.phrase.PhraseSuggestionBuilder;
+import org.elasticsearch.search.suggest.term.TermSuggestionBuilder;
+
+/**
+ * A static factory for building suggester lookup queries
+ */
+public abstract class SuggestBuilders {
+
+    /**
+     * Creates a term suggestion lookup query with the provided <code>name</code>
+     *
+     * @param name The suggestion name
+     * @return a {@link org.elasticsearch.search.suggest.term.TermSuggestionBuilder}
+     * instance
+     */
+    public static TermSuggestionBuilder termSuggestion(String name) {
+        return new TermSuggestionBuilder(name);
+    }
+
+    /**
+     * Creates a phrase suggestion lookup query with the provided <code>name</code>
+     *
+     * @param name The suggestion name
+     * @return a {@link org.elasticsearch.search.suggest.phrase.PhraseSuggestionBuilder}
+     * instance
+     */
+    public static PhraseSuggestionBuilder phraseSuggestion(String name) {
+        return new PhraseSuggestionBuilder(name);
+    }
+
+    /**
+     * Creates a completion suggestion lookup query with the provided <code>name</code>
+     *
+     * @param name The suggestion name
+     * @return a {@link org.elasticsearch.search.suggest.completion.CompletionSuggestionBuilder}
+     * instance
+     */
+    public static CompletionSuggestionBuilder completionSuggestion(String name) {
+        return new CompletionSuggestionBuilder(name);
+    }
+
+    /**
+     * Creates a fuzzy completion suggestion lookup query with the provided <code>name</code>
+     *
+     * @param name The suggestion name
+     * @return a {@link org.elasticsearch.search.suggest.completion.CompletionSuggestionFuzzyBuilder}
+     * instance
+     */
+    public static CompletionSuggestionFuzzyBuilder fuzzyCompletionSuggestion(String name) {
+        return new CompletionSuggestionFuzzyBuilder(name);
+    }
+}

--- a/src/test/java/org/elasticsearch/benchmark/search/SuggestSearchBenchMark.java
+++ b/src/test/java/org/elasticsearch/benchmark/search/SuggestSearchBenchMark.java
@@ -32,7 +32,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.search.suggest.Suggest.Suggestion.Entry.Option;
-import org.elasticsearch.search.suggest.SuggestBuilder;
+import org.elasticsearch.search.suggest.SuggestBuilders;
 
 import java.io.IOException;
 import java.util.List;
@@ -118,7 +118,7 @@ public class SuggestSearchBenchMark {
             String term = "prefix" + startChar;
             SearchResponse response = client.prepareSearch()
                     .setQuery(prefixQuery("field", term))
-                    .addSuggestion(SuggestBuilder.termSuggestion("field").field("field").text(term).suggestMode("always"))
+                    .addSuggestion(SuggestBuilders.termSuggestion("field").field("field").text(term).suggestMode("always"))
                     .execute().actionGet();
             if (response.getHits().totalHits() == 0) {
                 System.err.println("No hits");
@@ -135,7 +135,7 @@ public class SuggestSearchBenchMark {
             String term = "prefix" + startChar;
             SearchResponse response = client.prepareSearch()
                     .setQuery(matchQuery("field", term))
-                    .addSuggestion(SuggestBuilder.termSuggestion("field").text(term).field("field").suggestMode("always"))
+                    .addSuggestion(SuggestBuilders.termSuggestion("field").text(term).field("field").suggestMode("always"))
                     .execute().actionGet();
             timeTaken += response.getTookInMillis();
             if (response.getSuggest() == null) {

--- a/src/test/java/org/elasticsearch/indices/IndicesOptionsIntegrationTests.java
+++ b/src/test/java/org/elasticsearch/indices/IndicesOptionsIntegrationTests.java
@@ -53,7 +53,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.index.query.QueryBuilders;
-import org.elasticsearch.search.suggest.SuggestBuilder;
+import org.elasticsearch.search.suggest.SuggestBuilders;
 import org.elasticsearch.search.warmer.IndexWarmersMetaData;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.junit.Test;
@@ -800,7 +800,7 @@ public class IndicesOptionsIntegrationTests extends ElasticsearchIntegrationTest
     }
 
     private static SuggestRequestBuilder suggest(String... indices) {
-        return client().prepareSuggest(indices).addSuggestion(SuggestBuilder.termSuggestion("name").field("a"));
+        return client().prepareSuggest(indices).addSuggestion(SuggestBuilders.termSuggestion("name").field("a"));
     }
 
     private static GetAliasesRequestBuilder getAliases(String... indices) {

--- a/src/test/java/org/elasticsearch/search/suggest/CompletionSuggestSearchTests.java
+++ b/src/test/java/org/elasticsearch/search/suggest/CompletionSuggestSearchTests.java
@@ -458,7 +458,7 @@ public class CompletionSuggestSearchTests extends ElasticsearchIntegrationTest {
         ensureGreen(INDEX);
 
         SuggestResponse afterReindexingResponse = client().prepareSuggest(INDEX).addSuggestion(
-                new CompletionSuggestionBuilder("suggs").field("suggest").text("f").size(10)
+                SuggestBuilders.completionSuggestion("suggs").field("suggest").text("f").size(10)
         ).execute().actionGet();
         assertSuggestions(afterReindexingResponse, "suggs", "Foo Fighters");
     }
@@ -495,7 +495,7 @@ public class CompletionSuggestSearchTests extends ElasticsearchIntegrationTest {
         assertThat(putMappingResponse.isAcknowledged(), is(true));
 
         SuggestResponse suggestResponse = client().prepareSuggest(INDEX).addSuggestion(
-                new CompletionSuggestionBuilder("suggs").field("suggest").text("f").size(10)
+                SuggestBuilders.completionSuggestion("suggs").field("suggest").text("f").size(10)
         ).execute().actionGet();
         assertSuggestions(suggestResponse, "suggs");
 
@@ -503,7 +503,7 @@ public class CompletionSuggestSearchTests extends ElasticsearchIntegrationTest {
         ensureGreen(INDEX);
 
         SuggestResponse afterReindexingResponse = client().prepareSuggest(INDEX).addSuggestion(
-                new CompletionSuggestionBuilder("suggs").field("suggest").text("f").size(10)
+                SuggestBuilders.completionSuggestion("suggs").field("suggest").text("f").size(10)
         ).execute().actionGet();
         assertSuggestions(afterReindexingResponse, "suggs", "Foo Fighters");
     }
@@ -521,12 +521,12 @@ public class CompletionSuggestSearchTests extends ElasticsearchIntegrationTest {
         refresh();
 
         SuggestResponse suggestResponse = client().prepareSuggest(INDEX).addSuggestion(
-                new CompletionSuggestionFuzzyBuilder("foo").field(FIELD).text("Nirv").size(10)
+                SuggestBuilders.fuzzyCompletionSuggestion("foo").field(FIELD).text("Nirv").size(10)
         ).execute().actionGet();
         assertSuggestions(suggestResponse, false, "foo", "Nirvana");
 
         suggestResponse = client().prepareSuggest(INDEX).addSuggestion(
-                new CompletionSuggestionFuzzyBuilder("foo").field(FIELD).text("Nirw").size(10)
+                SuggestBuilders.fuzzyCompletionSuggestion("foo").field(FIELD).text("Nirw").size(10)
         ).execute().actionGet();
         assertSuggestions(suggestResponse, false, "foo", "Nirvana");
     }
@@ -545,13 +545,13 @@ public class CompletionSuggestSearchTests extends ElasticsearchIntegrationTest {
 
         // edit distance 1
         SuggestResponse suggestResponse = client().prepareSuggest(INDEX).addSuggestion(
-                new CompletionSuggestionFuzzyBuilder("foo").field(FIELD).text("Norw").size(10)
+                SuggestBuilders.fuzzyCompletionSuggestion("foo").field(FIELD).text("Norw").size(10)
         ).execute().actionGet();
         assertSuggestions(suggestResponse, false, "foo");
 
         // edit distance 2
         suggestResponse = client().prepareSuggest(INDEX).addSuggestion(
-                new CompletionSuggestionFuzzyBuilder("foo").field(FIELD).text("Norw").size(10).setFuzziness(Fuzziness.TWO)
+                SuggestBuilders.fuzzyCompletionSuggestion("foo").field(FIELD).text("Norw").size(10).setFuzziness(Fuzziness.TWO)
         ).execute().actionGet();
         assertSuggestions(suggestResponse, false, "foo", "Nirvana");
     }
@@ -569,12 +569,12 @@ public class CompletionSuggestSearchTests extends ElasticsearchIntegrationTest {
         refresh();
 
         SuggestResponse suggestResponse = client().prepareSuggest(INDEX).addSuggestion(
-                new CompletionSuggestionFuzzyBuilder("foo").field(FIELD).text("Nriv").size(10).setFuzzyTranspositions(false).setFuzziness(Fuzziness.ONE)
+                SuggestBuilders.fuzzyCompletionSuggestion("foo").field(FIELD).text("Nriv").size(10).setFuzzyTranspositions(false).setFuzziness(Fuzziness.ONE)
         ).execute().actionGet();
         assertSuggestions(suggestResponse, false, "foo");
 
         suggestResponse = client().prepareSuggest(INDEX).addSuggestion(
-                new CompletionSuggestionFuzzyBuilder("foo").field(FIELD).text("Nriv").size(10).setFuzzyTranspositions(true).setFuzziness(Fuzziness.ONE)
+                SuggestBuilders.fuzzyCompletionSuggestion("foo").field(FIELD).text("Nriv").size(10).setFuzzyTranspositions(true).setFuzziness(Fuzziness.ONE)
         ).execute().actionGet();
         assertSuggestions(suggestResponse, false, "foo", "Nirvana");
     }
@@ -592,12 +592,12 @@ public class CompletionSuggestSearchTests extends ElasticsearchIntegrationTest {
         refresh();
 
         SuggestResponse suggestResponse = client().prepareSuggest(INDEX).addSuggestion(
-                new CompletionSuggestionFuzzyBuilder("foo").field(FIELD).text("Nriva").size(10).setFuzzyMinLength(6)
+                SuggestBuilders.fuzzyCompletionSuggestion("foo").field(FIELD).text("Nriva").size(10).setFuzzyMinLength(6)
         ).execute().actionGet();
         assertSuggestions(suggestResponse, false, "foo");
 
         suggestResponse = client().prepareSuggest(INDEX).addSuggestion(
-                new CompletionSuggestionFuzzyBuilder("foo").field(FIELD).text("Nrivan").size(10).setFuzzyMinLength(6)
+                SuggestBuilders.fuzzyCompletionSuggestion("foo").field(FIELD).text("Nrivan").size(10).setFuzzyMinLength(6)
         ).execute().actionGet();
         assertSuggestions(suggestResponse, false, "foo", "Nirvana");
     }
@@ -615,12 +615,12 @@ public class CompletionSuggestSearchTests extends ElasticsearchIntegrationTest {
         refresh();
 
         SuggestResponse suggestResponse = client().prepareSuggest(INDEX).addSuggestion(
-                new CompletionSuggestionFuzzyBuilder("foo").field(FIELD).text("Nirw").size(10).setFuzzyPrefixLength(4)
+                SuggestBuilders.fuzzyCompletionSuggestion("foo").field(FIELD).text("Nirw").size(10).setFuzzyPrefixLength(4)
         ).execute().actionGet();
         assertSuggestions(suggestResponse, false, "foo");
 
         suggestResponse = client().prepareSuggest(INDEX).addSuggestion(
-                new CompletionSuggestionFuzzyBuilder("foo").field(FIELD).text("Nirvo").size(10).setFuzzyPrefixLength(4)
+                SuggestBuilders.fuzzyCompletionSuggestion("foo").field(FIELD).text("Nirvo").size(10).setFuzzyPrefixLength(4)
         ).execute().actionGet();
         assertSuggestions(suggestResponse, false, "foo", "Nirvana");
     }
@@ -639,7 +639,7 @@ public class CompletionSuggestSearchTests extends ElasticsearchIntegrationTest {
 
         // suggestion with a character, which needs unicode awareness
         CompletionSuggestionFuzzyBuilder completionSuggestionBuilder =
-                new CompletionSuggestionFuzzyBuilder("foo").field(FIELD).text("öööи").size(10).setUnicodeAware(true);
+                SuggestBuilders.fuzzyCompletionSuggestion("foo").field(FIELD).text("öööи").size(10).setUnicodeAware(true);
 
         SuggestResponse suggestResponse = client().prepareSuggest(INDEX).addSuggestion(completionSuggestionBuilder).execute().actionGet();
         assertSuggestions(suggestResponse, false, "foo", "ööööö");
@@ -773,7 +773,7 @@ public class CompletionSuggestSearchTests extends ElasticsearchIntegrationTest {
     public void assertSuggestions(String suggestion, String... suggestions) {
         String suggestionName = RandomStrings.randomAsciiOfLength(new Random(), 10);
         SuggestResponse suggestResponse = client().prepareSuggest(INDEX).addSuggestion(
-                new CompletionSuggestionBuilder(suggestionName).field(FIELD).text(suggestion).size(10)
+                SuggestBuilders.completionSuggestion(suggestionName).field(FIELD).text(suggestion).size(10)
         ).execute().actionGet();
 
         assertSuggestions(suggestResponse, suggestionName, suggestions);
@@ -782,7 +782,7 @@ public class CompletionSuggestSearchTests extends ElasticsearchIntegrationTest {
     public void assertSuggestionsNotInOrder(String suggestString, String... suggestions) {
         String suggestionName = RandomStrings.randomAsciiOfLength(new Random(), 10);
         SuggestResponse suggestResponse = client().prepareSuggest(INDEX).addSuggestion(
-                new CompletionSuggestionBuilder(suggestionName).field(FIELD).text(suggestString).size(10)
+                SuggestBuilders.completionSuggestion(suggestionName).field(FIELD).text(suggestString).size(10)
         ).execute().actionGet();
 
         assertSuggestions(suggestResponse, false, suggestionName, suggestions);

--- a/src/test/java/org/elasticsearch/search/suggest/ContextSuggestSearchTests.java
+++ b/src/test/java/org/elasticsearch/search/suggest/ContextSuggestSearchTests.java
@@ -102,7 +102,7 @@ public class ContextSuggestSearchTests extends ElasticsearchIntegrationTest {
         client().admin().indices().prepareRefresh(INDEX).get();
         
         String suggestionName = randomAsciiOfLength(10);
-        CompletionSuggestionBuilder context = new CompletionSuggestionBuilder(suggestionName).field(FIELD).text("h").size(10)
+        CompletionSuggestionBuilder context = SuggestBuilders.completionSuggestion(suggestionName).field(FIELD).text("h").size(10)
                 .addGeoLocation("st", 52.52, 13.4);
         
         SuggestRequestBuilder suggestionRequest = client().prepareSuggest(INDEX).addSuggestion(context);
@@ -207,7 +207,7 @@ public class ContextSuggestSearchTests extends ElasticsearchIntegrationTest {
         refresh();
         
         String suggestionName = randomAsciiOfLength(10);
-        CompletionSuggestionBuilder context = new CompletionSuggestionBuilder(suggestionName).field(FIELD).text("h").size(10)
+        CompletionSuggestionBuilder context = SuggestBuilders.completionSuggestion(suggestionName).field(FIELD).text("h").size(10)
                 .addGeoLocation("st", 52.52, 13.4);
         SuggestRequestBuilder suggestionRequest = client().prepareSuggest(INDEX).addSuggestion(context);
         SuggestResponse suggestResponse = suggestionRequest.execute().actionGet();
@@ -335,7 +335,7 @@ public class ContextSuggestSearchTests extends ElasticsearchIntegrationTest {
 
     private void getBackpackSuggestionAndCompare(String contextValue, String... expectedText) {
         Set<String> expected = Sets.newHashSet(expectedText);
-        CompletionSuggestionBuilder context = new CompletionSuggestionBuilder("suggestion").field("suggest_field").text("back").size(10).addContextField("color", contextValue);
+        CompletionSuggestionBuilder context = SuggestBuilders.completionSuggestion("suggestion").field("suggest_field").text("back").size(10).addContextField("color", contextValue);
         SuggestRequestBuilder suggestionRequest = client().prepareSuggest(INDEX).addSuggestion(context);
         SuggestResponse suggestResponse = suggestionRequest.execute().actionGet();
         Suggest suggest = suggestResponse.getSuggest();
@@ -535,7 +535,7 @@ public class ContextSuggestSearchTests extends ElasticsearchIntegrationTest {
         index(INDEX, "poi", "1", jsonBuilder().startObject().startObject("suggest").field("input", "Berlin Alexanderplatz").endObject().endObject());
         refresh();
 
-        CompletionSuggestionBuilder suggestionBuilder = new CompletionSuggestionBuilder("suggestion").field("suggest").text("b").size(10).addGeoLocation("location", berlinAlexanderplatz.lat(), berlinAlexanderplatz.lon());
+        CompletionSuggestionBuilder suggestionBuilder = SuggestBuilders.completionSuggestion("suggestion").field("suggest").text("b").size(10).addGeoLocation("location", berlinAlexanderplatz.lat(), berlinAlexanderplatz.lon());
         SuggestResponse suggestResponse = client().prepareSuggest(INDEX).addSuggestion(suggestionBuilder).get();
         assertSuggestion(suggestResponse.getSuggest(), 0, "suggestion", "Berlin Alexanderplatz");
     }
@@ -616,7 +616,7 @@ public class ContextSuggestSearchTests extends ElasticsearchIntegrationTest {
         index(INDEX, "item", "2", jsonBuilder().startObject().startObject("suggest").field("input", "Hoodie blue").startObject("context").field("color", "blue").endObject().endObject().endObject());
         refresh();
 
-        CompletionSuggestionBuilder suggestionBuilder = new CompletionSuggestionBuilder("suggestion").field("suggest").text("h").size(10).addContextField("color", "red");
+        CompletionSuggestionBuilder suggestionBuilder = SuggestBuilders.completionSuggestion("suggestion").field("suggest").text("h").size(10).addContextField("color", "red");
         SuggestResponse suggestResponse = client().prepareSuggest(INDEX).addSuggestion(suggestionBuilder).get();
         assertSuggestion(suggestResponse.getSuggest(), 0, "suggestion", "Hoodie red");
     }
@@ -641,7 +641,7 @@ public class ContextSuggestSearchTests extends ElasticsearchIntegrationTest {
         index(INDEX, "item", "2", jsonBuilder().startObject().startObject("suggest").field("input", "Hoodie blue").endObject().field("color", "blue").endObject());
         refresh();
 
-        CompletionSuggestionBuilder suggestionBuilder = new CompletionSuggestionBuilder("suggestion").field("suggest").text("h").size(10).addContextField("color", "red");
+        CompletionSuggestionBuilder suggestionBuilder = SuggestBuilders.completionSuggestion("suggestion").field("suggest").text("h").size(10).addContextField("color", "red");
         SuggestResponse suggestResponse = client().prepareSuggest(INDEX).addSuggestion(suggestionBuilder).get();
         assertSuggestion(suggestResponse.getSuggest(), 0, "suggestion", "Hoodie red");
     }
@@ -674,7 +674,7 @@ public class ContextSuggestSearchTests extends ElasticsearchIntegrationTest {
         index(INDEX, "item", "4", jsonBuilder().startObject().startObject("suggest").field("input", "Berlin Dahlem").field("weight", 1).startObject("context").startObject("location").field("lat", dahlem.lat()).field("lon", dahlem.lon()).endObject().endObject().endObject().endObject());
         refresh();
 
-        CompletionSuggestionBuilder suggestionBuilder = new CompletionSuggestionBuilder("suggestion").field("suggest").text("b").size(10).addGeoLocation("location", alexanderplatz.lat(), alexanderplatz.lon());
+        CompletionSuggestionBuilder suggestionBuilder = SuggestBuilders.completionSuggestion("suggestion").field("suggest").text("b").size(10).addGeoLocation("location", alexanderplatz.lat(), alexanderplatz.lon());
         SuggestResponse suggestResponse = client().prepareSuggest(INDEX).addSuggestion(suggestionBuilder).get();
         assertSuggestion(suggestResponse.getSuggest(), 0, "suggestion", "Berlin Alexanderplatz", "Berlin Poelchaustr.", "Berlin Dahlem");
     }
@@ -704,7 +704,7 @@ public class ContextSuggestSearchTests extends ElasticsearchIntegrationTest {
         index(INDEX, "item", "2", jsonBuilder().startObject().startObject("suggest").field("input", "Berlin Hackescher Markt").field("weight", 2).startObject("context").startObject("location").field("lat", cellNeighbourOfAlexanderplatz.lat()).field("lon", cellNeighbourOfAlexanderplatz.lon()).endObject().endObject().endObject().endObject());
         refresh();
 
-        CompletionSuggestionBuilder suggestionBuilder = new CompletionSuggestionBuilder("suggestion").field("suggest").text("b").size(10).addGeoLocation("location", alexanderplatz.lat(), alexanderplatz.lon());
+        CompletionSuggestionBuilder suggestionBuilder = SuggestBuilders.completionSuggestion("suggestion").field("suggest").text("b").size(10).addGeoLocation("location", alexanderplatz.lat(), alexanderplatz.lon());
         SuggestResponse suggestResponse = client().prepareSuggest(INDEX).addSuggestion(suggestionBuilder).get();
         assertSuggestion(suggestResponse.getSuggest(), 0, "suggestion", "Berlin Alexanderplatz");
     }
@@ -729,7 +729,7 @@ public class ContextSuggestSearchTests extends ElasticsearchIntegrationTest {
         index(INDEX, "item", "1", jsonBuilder().startObject().startObject("suggest").field("input", "Berlin Alexanderplatz").endObject().startObject("loc").field("lat", alexanderplatz.lat()).field("lon", alexanderplatz.lon()).endObject().endObject());
         refresh();
 
-        CompletionSuggestionBuilder suggestionBuilder = new CompletionSuggestionBuilder("suggestion").field("suggest").text("b").size(10).addGeoLocation("location", alexanderplatz.lat(), alexanderplatz.lon());
+        CompletionSuggestionBuilder suggestionBuilder = SuggestBuilders.completionSuggestion("suggestion").field("suggest").text("b").size(10).addGeoLocation("location", alexanderplatz.lat(), alexanderplatz.lon());
         SuggestResponse suggestResponse = client().prepareSuggest(INDEX).addSuggestion(suggestionBuilder).get();
         assertSuggestion(suggestResponse.getSuggest(), 0, "suggestion", "Berlin Alexanderplatz");
     }
@@ -787,7 +787,7 @@ public class ContextSuggestSearchTests extends ElasticsearchIntegrationTest {
 
     public void assertGeoSuggestionsInRange(String location, String suggest, double precision) throws IOException {
         String suggestionName = randomAsciiOfLength(10);
-        CompletionSuggestionBuilder context = new CompletionSuggestionBuilder(suggestionName).field(FIELD).text(suggest).size(10)
+        CompletionSuggestionBuilder context = SuggestBuilders.completionSuggestion(suggestionName).field(FIELD).text(suggest).size(10)
                 .addGeoLocation("st", location);
         SuggestRequestBuilder suggestionRequest = client().prepareSuggest(INDEX).addSuggestion(context);
         SuggestResponse suggestResponse = suggestionRequest.execute().actionGet();
@@ -810,7 +810,7 @@ public class ContextSuggestSearchTests extends ElasticsearchIntegrationTest {
 
     public void assertPrefixSuggestions(long prefix, String suggest, String... hits) throws IOException {
         String suggestionName = randomAsciiOfLength(10);
-        CompletionSuggestionBuilder context = new CompletionSuggestionBuilder(suggestionName).field(FIELD).text(suggest)
+        CompletionSuggestionBuilder context = SuggestBuilders.completionSuggestion(suggestionName).field(FIELD).text(suggest)
                 .size(hits.length + 1).addCategory("st", Long.toString(prefix));
         SuggestRequestBuilder suggestionRequest = client().prepareSuggest(INDEX).addSuggestion(context);
         SuggestResponse suggestResponse = suggestionRequest.execute().actionGet();
@@ -835,7 +835,7 @@ public class ContextSuggestSearchTests extends ElasticsearchIntegrationTest {
 
     public void assertContextWithFuzzySuggestions(String[] prefix1, String[] prefix2, String suggest, String... hits) throws IOException {
         String suggestionName = randomAsciiOfLength(10);
-        CompletionSuggestionFuzzyBuilder context = new CompletionSuggestionFuzzyBuilder(suggestionName).field(FIELD).text(suggest)
+        CompletionSuggestionFuzzyBuilder context = SuggestBuilders.fuzzyCompletionSuggestion(suggestionName).field(FIELD).text(suggest)
                 .size(hits.length + 10).addContextField("st", prefix1).addContextField("nd", prefix2).setFuzziness(Fuzziness.TWO);
         SuggestRequestBuilder suggestionRequest = client().prepareSuggest(INDEX).addSuggestion(context);
         SuggestResponse suggestResponse = suggestionRequest.execute().actionGet();
@@ -863,7 +863,7 @@ public class ContextSuggestSearchTests extends ElasticsearchIntegrationTest {
 
     public void assertFieldSuggestions(String value, String suggest, String... hits) throws IOException {
         String suggestionName = randomAsciiOfLength(10);
-        CompletionSuggestionBuilder context = new CompletionSuggestionBuilder(suggestionName).field(FIELD).text(suggest).size(10)
+        CompletionSuggestionBuilder context = SuggestBuilders.completionSuggestion(suggestionName).field(FIELD).text(suggest).size(10)
                 .addContextField("st", value);
         SuggestRequestBuilder suggestionRequest = client().prepareSuggest(INDEX).addSuggestion(context);
         SuggestResponse suggestResponse = suggestionRequest.execute().actionGet();
@@ -888,7 +888,7 @@ public class ContextSuggestSearchTests extends ElasticsearchIntegrationTest {
 
     public void assertDoubleFieldSuggestions(String field1, String field2, String suggest, String... hits) throws IOException {
         String suggestionName = randomAsciiOfLength(10);
-        CompletionSuggestionBuilder context = new CompletionSuggestionBuilder(suggestionName).field(FIELD).text(suggest).size(10)
+        CompletionSuggestionBuilder context = SuggestBuilders.completionSuggestion(suggestionName).field(FIELD).text(suggest).size(10)
                 .addContextField("st", field1).addContextField("nd", field2);
         SuggestRequestBuilder suggestionRequest = client().prepareSuggest(INDEX).addSuggestion(context);
         SuggestResponse suggestResponse = suggestionRequest.execute().actionGet();
@@ -912,7 +912,7 @@ public class ContextSuggestSearchTests extends ElasticsearchIntegrationTest {
 
     public void assertMultiContextSuggestions(String value1, String value2, String suggest, String... hits) throws IOException {
         String suggestionName = randomAsciiOfLength(10);
-        CompletionSuggestionBuilder context = new CompletionSuggestionBuilder(suggestionName).field(FIELD).text(suggest).size(10)
+        CompletionSuggestionBuilder context = SuggestBuilders.completionSuggestion(suggestionName).field(FIELD).text(suggest).size(10)
                 .addContextField("st", value1).addContextField("nd", value2);
 
         SuggestRequestBuilder suggestionRequest = client().prepareSuggest(INDEX).addSuggestion(context);

--- a/src/test/java/org/elasticsearch/search/suggest/SuggestSearchTests.java
+++ b/src/test/java/org/elasticsearch/search/suggest/SuggestSearchTests.java
@@ -49,8 +49,8 @@ import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
-import static org.elasticsearch.search.suggest.SuggestBuilder.phraseSuggestion;
-import static org.elasticsearch.search.suggest.SuggestBuilder.termSuggestion;
+import static org.elasticsearch.search.suggest.SuggestBuilders.phraseSuggestion;
+import static org.elasticsearch.search.suggest.SuggestBuilders.termSuggestion;
 import static org.elasticsearch.search.suggest.phrase.PhraseSuggestionBuilder.candidateGenerator;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.*;
 import static org.hamcrest.Matchers.*;


### PR DESCRIPTION
- Added `SuggestBuilders` (analogous to `QueryBuilders`)
  - supporting `term`, `phrase`, `completion` and `fuzzyCompletion` suggestion builders
- Added `suggest(SuggestionBuilder)` to `SuggestRequest`
  - previously only `suggest(BytesReference)` was supported
- Use new `SuggestBuilders` methods in tests, instead of directly instantiating specific suggestion builder.

closes #7435
