### PR TITLE
[Tests] add different node name prefix for the different cluster type

### DIFF
--- a/src/test/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/src/test/java/org/elasticsearch/test/InternalTestCluster.java
@@ -139,11 +139,6 @@ public final class InternalTestCluster extends TestCluster {
      */
     public static final String SETTING_CLUSTER_NODE_SEED = "test.cluster.node.seed";
 
-    /**
-     * All nodes started by the cluster will have their name set to NODE_PREFIX followed by a positive number
-     */
-    public static final String NODE_PREFIX = "node_";
-
     private static final boolean ENABLE_MOCK_MODULES = systemPropertyAsBoolean(TESTS_ENABLE_MOCK_MODULES, true);
 
     static final int DEFAULT_MIN_NUM_DATA_NODES = 2;
@@ -187,11 +182,21 @@ public final class InternalTestCluster extends TestCluster {
 
     private final boolean hasFilterCache;
 
-    public InternalTestCluster(long clusterSeed, int minNumDataNodes, int maxNumDataNodes, String clusterName, int numClientNodes, boolean enableRandomBenchNodes, int jvmOrdinal) {
-        this(clusterSeed, minNumDataNodes, maxNumDataNodes, clusterName, DEFAULT_SETTINGS_SOURCE, numClientNodes, enableRandomBenchNodes, jvmOrdinal);
+    /**
+     * All nodes started by the cluster will have their name set to nodePrefix followed by a positive number
+     */
+    private final String nodePrefix;
+
+
+    public InternalTestCluster(long clusterSeed, int minNumDataNodes, int maxNumDataNodes, String clusterName, int numClientNodes, boolean enableRandomBenchNodes,
+                               int jvmOrdinal, String nodePrefix) {
+        this(clusterSeed, minNumDataNodes, maxNumDataNodes, clusterName, DEFAULT_SETTINGS_SOURCE, numClientNodes, enableRandomBenchNodes, jvmOrdinal, nodePrefix);
     }
 
-    public InternalTestCluster(long clusterSeed, int minNumDataNodes, int maxNumDataNodes, String clusterName, SettingsSource settingsSource, int numClientNodes, boolean enableRandomBenchNodes, int jvmOrdinal) {
+    public InternalTestCluster(long clusterSeed,
+                               int minNumDataNodes, int maxNumDataNodes, String clusterName, SettingsSource settingsSource, int numClientNodes,
+                               boolean enableRandomBenchNodes,
+                               int jvmOrdinal, String nodePrefix) {
         this.clusterName = clusterName;
 
         if (minNumDataNodes < 0 || maxNumDataNodes < 0) {
@@ -220,6 +225,10 @@ public final class InternalTestCluster extends TestCluster {
         assert this.numSharedClientNodes >=0;
 
         this.enableRandomBenchNodes = enableRandomBenchNodes;
+
+        this.nodePrefix = nodePrefix;
+
+        assert nodePrefix != null;
 
         /*
          *  TODO
@@ -522,14 +531,14 @@ public final class InternalTestCluster extends TestCluster {
     }
 
     private String buildNodeName(int id) {
-        return NODE_PREFIX + id;
+        return nodePrefix + id;
     }
 
     /**
      * Returns the common node name prefix for this test cluster.
      */
     public String nodePrefix() {
-        return NODE_PREFIX;
+        return nodePrefix;
     }
 
     @Override

--- a/src/test/java/org/elasticsearch/threadpool/SimpleThreadPoolTests.java
+++ b/src/test/java/org/elasticsearch/threadpool/SimpleThreadPoolTests.java
@@ -38,6 +38,7 @@ import org.elasticsearch.test.ElasticsearchSingleNodeTest;
 import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.test.hamcrest.RegexMatcher;
 import org.elasticsearch.threadpool.ThreadPool.Names;
+import org.elasticsearch.tribe.TribeTests;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -116,7 +117,11 @@ public class SimpleThreadPoolTests extends ElasticsearchIntegrationTest {
                     || threadName.contains("Keep-Alive-Timer")) {
                 continue;
             }
-            String nodePrefix = "(" + Pattern.quote(InternalTestCluster.TRANSPORT_CLIENT_PREFIX) + ")?" + Pattern.quote(InternalTestCluster.NODE_PREFIX);
+            String nodePrefix = "(" + Pattern.quote(InternalTestCluster.TRANSPORT_CLIENT_PREFIX) + ")?(" +
+                    Pattern.quote(ElasticsearchIntegrationTest.GLOBAL_CLUSTER_NODE_PREFIX) + "|" +
+                    Pattern.quote(ElasticsearchIntegrationTest.SUITE_CLUSTER_NODE_PREFIX) + "|" +
+                    Pattern.quote(ElasticsearchIntegrationTest.TEST_CLUSTER_NODE_PREFIX) + "|" +
+                    Pattern.quote(TribeTests.SECOND_CLUSTER_NODE_PREFIX) + ")";
             assertThat(threadName, RegexMatcher.matches("\\[" + nodePrefix + "\\d+\\]"));
         }
     }

--- a/src/test/java/org/elasticsearch/tribe/TribeTests.java
+++ b/src/test/java/org/elasticsearch/tribe/TribeTests.java
@@ -53,6 +53,8 @@ import static org.hamcrest.Matchers.notNullValue;
  */
 public class TribeTests extends ElasticsearchIntegrationTest {
 
+    public static final String SECOND_CLUSTER_NODE_PREFIX = "node_tribe2";
+
     private static InternalTestCluster cluster2;
 
     private Node tribeNode;
@@ -62,7 +64,7 @@ public class TribeTests extends ElasticsearchIntegrationTest {
     public static void setupSecondCluster() throws Exception {
         ElasticsearchIntegrationTest.beforeClass();
         // create another cluster
-        cluster2 = new InternalTestCluster(randomLong(), 2, 2, Strings.randomBase64UUID(getRandom()), 0, false, CHILD_JVM_ID);
+        cluster2 = new InternalTestCluster(randomLong(), 2, 2, Strings.randomBase64UUID(getRandom()), 0, false, CHILD_JVM_ID, SECOND_CLUSTER_NODE_PREFIX);
         cluster2.beforeTest(getRandom(), 0.1);
         cluster2.ensureAtLeastNumDataNodes(2);
     }


### PR DESCRIPTION
During a test run we have a global shared cluster and potentially a suite level or even a test level cluster running. All of those share the same node name pattern (node_#). This can be confusing if you're debugging discovery related tests where those nodes from the different clusters potentially interact (and reject each other). This commit gives each cluster type a unique prefix to make tracing and log filtering simpler.
