### PR TITLE
Test: Unify the randomization logic for number of shards and replicas

### DIFF
--- a/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
@@ -335,9 +335,8 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
                             .put(SETTING_INDEX_SEED, getRandom().nextLong());
 
             if (randomizeNumberOfShardsAndReplicas()) {
-                randomSettingsBuilder.put(SETTING_NUMBER_OF_SHARDS, between(DEFAULT_MIN_NUM_SHARDS, DEFAULT_MAX_NUM_SHARDS))
-                        //use either 0 or 1 replica, yet a higher amount when possible, but only rarely
-                        .put(SETTING_NUMBER_OF_REPLICAS, between(0, getRandom().nextInt(10) > 0 ? 1 : cluster().numDataNodes() - 1));
+                randomSettingsBuilder.put(SETTING_NUMBER_OF_SHARDS, numberOfShards())
+                        .put(SETTING_NUMBER_OF_REPLICAS, numberOfReplicas());
             }
             XContentBuilder mappings = null;
             if (frequently() && randomDynamicTemplates()) {
@@ -685,7 +684,9 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
     }
 
     protected int maximumNumberOfReplicas() {
-        return Math.max(0, cluster().numDataNodes() - 1);
+        //use either 0 or 1 replica, yet a higher amount when possible, but only rarely
+        int maxNumReplicas = Math.max(0, cluster().numDataNodes() - 1);
+        return frequently() ? Math.min(1, maxNumReplicas) : maxNumReplicas;
     }
 
     protected int numberOfReplicas() {


### PR DESCRIPTION
We currently have two ways to randomize the number of shards and replicas: random index template, that stays the same for all indices created under the same scope, and the overridable `indexSettings` method, called by `createIndex` and `prepareCreate` which uses a different value for each new index.

Now that the `randomIndexTemplate` method is not static anymore, we can easily apply the same logic in both cases. Especially for number of replicas, we used to have slightly different behaviours, where more than one replicas were only rarely used through random index template, which gets now applied to the `indexSettings` method too (might speed up the tests a bit).

Side note: `randomIndexTemplate` had its own logic which didn't depend on `numberOfReplicas` or `maximumNumberOfReplicas`, which was causing bw comp tests failures since in some cases too many copies of the data are requested, which cannot be allocated to older nodes, and the write consistency quorum cannot be met, thus indexing times out.
