### PR TITLE
Add the cluster name to the "/" endpoint

### DIFF
--- a/rest-api-spec/test/info/10_info.yaml
+++ b/rest-api-spec/test/info/10_info.yaml
@@ -3,6 +3,7 @@
     - do:         {info: {}}
     - match:      {status: 200}
     - is_true:    name
+    - is_true:    cluster_name
     - is_true:    tagline
     - is_true:    version
     - is_true:    version.number

--- a/src/main/java/org/elasticsearch/rest/action/main/RestMainAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/main/RestMainAction.java
@@ -25,6 +25,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
@@ -41,13 +42,15 @@ import static org.elasticsearch.rest.RestRequest.Method.HEAD;
 public class RestMainAction extends BaseRestHandler {
 
     private final Version version;
+    private final ClusterName clusterName;
 
     @Inject
-    public RestMainAction(Settings settings, Version version, Client client, RestController controller) {
+    public RestMainAction(Settings settings, Version version, Client client, RestController controller, ClusterName clusterName) {
         super(settings, client);
         this.version = version;
         controller.registerHandler(GET, "/", this);
         controller.registerHandler(HEAD, "/", this);
+        this.clusterName = clusterName;
     }
 
     @Override
@@ -80,6 +83,7 @@ public class RestMainAction extends BaseRestHandler {
                 if (settings.get("name") != null) {
                     builder.field("name", settings.get("name"));
                 }
+                builder.field("cluster_name", clusterName.value());
                 builder.startObject("version")
                         .field("number", version.number())
                         .field("build_hash", Build.CURRENT.hash())

--- a/src/main/java/org/elasticsearch/rest/action/main/RestMainAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/main/RestMainAction.java
@@ -48,9 +48,9 @@ public class RestMainAction extends BaseRestHandler {
     public RestMainAction(Settings settings, Version version, Client client, RestController controller, ClusterName clusterName) {
         super(settings, client);
         this.version = version;
+        this.clusterName = clusterName;
         controller.registerHandler(GET, "/", this);
         controller.registerHandler(HEAD, "/", this);
-        this.clusterName = clusterName;
     }
 
     @Override


### PR DESCRIPTION
The root endpoint returns basic information about this node, like it's name and ES version etc. The cluster name is an important information that belongs in that list.
