### PR TITLE
Support for artificial documents

### DIFF
--- a/docs/reference/docs/multi-termvectors.asciidoc
+++ b/docs/reference/docs/multi-termvectors.asciidoc
@@ -1,7 +1,10 @@
 [[docs-multi-termvectors]]
 == Multi termvectors API
 
-Multi termvectors API allows to get multiple termvectors based on an index, type and id. The response includes a `docs`
+Multi termvectors API allows to get multiple termvectors at once. The
+documents from which to retrieve the term vectors are specified by an index,
+type and id. But the documents could also be artificially provided coming[1.4.0].
+The response includes a `docs`
 array with all the fetched termvectors, each element having the structure
 provided by the <<docs-termvectors,termvectors>>
 API. Here is an example:
@@ -89,4 +92,32 @@ curl 'localhost:9200/testidx/test/_mtermvectors' -d '{
 }'
 --------------------------------------------------
 
-Parameters can also be set by passing them as uri parameters (see <<docs-termvectors,termvectors>>). uri parameters are the default parameters and are overwritten by any parameter setting defined in the body.
+Additionally coming[1.4.0], just like for the <<docs-termvectors,termvectors>>
+API, term vectors could be generated for user provided documents. The syntax
+is similar to the <<search-percolate,percolator>> API. The mapping used is
+determined by `_index` and `_type`. Term statistics are disallowed as they
+depend on the shard processing the request.
+
+[source,js]
+--------------------------------------------------
+curl 'localhost:9200/_mtermvectors' -d '{
+   "docs": [
+      {
+         "_index": "testidx",
+         "_type": "test",
+         "doc" : {
+            "fullname" : "John Doe",
+            "text" : "twitter test test test"
+         }
+      },
+      {
+         "_index": "testidx",
+         "_type": "test",
+         "doc" : {
+           "fullname" : "Jane Doe",
+           "text" : "Another twitter test ..."
+         }
+      }
+   ]
+}'
+--------------------------------------------------

--- a/docs/reference/docs/multi-termvectors.asciidoc
+++ b/docs/reference/docs/multi-termvectors.asciidoc
@@ -95,8 +95,7 @@ curl 'localhost:9200/testidx/test/_mtermvectors' -d '{
 Additionally coming[1.4.0], just like for the <<docs-termvectors,termvectors>>
 API, term vectors could be generated for user provided documents. The syntax
 is similar to the <<search-percolate,percolator>> API. The mapping used is
-determined by `_index` and `_type`. Term statistics are disallowed as they
-depend on the shard processing the request.
+determined by `_index` and `_type`.
 
 [source,js]
 --------------------------------------------------

--- a/docs/reference/docs/termvectors.asciidoc
+++ b/docs/reference/docs/termvectors.asciidoc
@@ -259,6 +259,12 @@ that is for documents not present in the index. The syntax is similar to the
 return the same results as in example 1. The mapping used is determined by the
 `index` and `type`.
 
+[WARNING]
+======
+If dynamic mapping is turned on (default), the document fields not in the original
+mapping will be dynamically created.
+======
+
 [source,js]
 --------------------------------------------------
 curl -XGET 'http://localhost:9200/twitter/tweet/_termvector' -d '{

--- a/docs/reference/docs/termvectors.asciidoc
+++ b/docs/reference/docs/termvectors.asciidoc
@@ -87,8 +87,9 @@ The term and field statistics are not accurate. Deleted documents
 are not taken into account. The information is only retrieved for the
 shard the requested document resides in. The term and field statistics
 are therefore only useful as relative measures whereas the absolute
-numbers have no meaning in this context. The term statistics are disabled
-when using artificial documents.
+numbers have no meaning in this context. By default, when requesting
+term vectors of artificial documents, a shard to get the statistics from
+is randomly selected. Use `routing` only to hit a particular shard.
 
 [float]
 === Example 1
@@ -256,8 +257,7 @@ Additionally, term vectors can also be generated for artificial documents,
 that is for documents not present in the index. The syntax is similar to the
 <<search-percolate,percolator>> API. For example, the following request would
 return the same results as in example 1. The mapping used is determined by the
-`index` and `type`. Term statistics are disallowed as they depend on the shard
-processing the request.
+`index` and `type`.
 
 [source,js]
 --------------------------------------------------

--- a/docs/reference/docs/termvectors.asciidoc
+++ b/docs/reference/docs/termvectors.asciidoc
@@ -3,10 +3,11 @@
 
 added[1.0.0.Beta1]
 
-Returns information and statistics on terms in the fields of a
-particular document as stored in the index. Note that this is a
-near realtime API as the term vectors are not available until the
-next refresh.
+Returns information and statistics on terms in the fields of a particular
+document. The document could be stored in the index or artificially provided
+by the user coming[1.4.0]. Note that for documents stored in the index, this
+is a near realtime API as the term vectors are not available until the next
+refresh.
 
 [source,js]
 --------------------------------------------------
@@ -41,10 +42,10 @@ statistics are returned for all fields but no term statistics.
  * term payloads (`payloads` : true), as base64 encoded bytes
 
 If the requested information wasn't stored in the index, it will be
-computed on the fly if possible. See <<mapping-types,type mapping>>
-for how to configure your index to store term vectors.
+computed on the fly if possible. Additionally, term vectors could be computed
+for documents not even existing in the index, but instead provided by the user.
 
-coming[1.4.0,The ability to computed term vectors on the fly is only available from 1.4.0 onwards (see below)]
+coming[1.4.0,The ability to computed term vectors on the fly as well as support for artificial documents is only available from 1.4.0 onwards (see below example 2 and 3 respectively)]
 
 [WARNING]
 ======
@@ -86,7 +87,8 @@ The term and field statistics are not accurate. Deleted documents
 are not taken into account. The information is only retrieved for the
 shard the requested document resides in. The term and field statistics
 are therefore only useful as relative measures whereas the absolute
-numbers have no meaning in this context.
+numbers have no meaning in this context. The term statistics are disabled
+when using artificial documents.
 
 [float]
 === Example 1
@@ -231,7 +233,7 @@ Response:
 [float]
 === Example 2 coming[1.4.0]
 
-Additionally, term vectors which are not explicitly stored in the index are automatically
+Term vectors which are not explicitly stored in the index are automatically
 computed on the fly. The following request returns all information and statistics for the
 fields in document `1`, even though the terms haven't been explicitly stored in the index.
 Note that for the field `text`, the terms are not re-generated.
@@ -246,3 +248,24 @@ curl -XGET 'http://localhost:9200/twitter/tweet/1/_termvector?pretty=true' -d '{
   "field_statistics" : true
 }'
 --------------------------------------------------
+
+[float]
+=== Example 3 coming[1.4.0]
+
+Additionally, term vectors can also be generated for artificial documents,
+that is for documents not present in the index. The syntax is similar to the
+<<search-percolate,percolator>> API. For example, the following request would
+return the same results as in example 1. The mapping used is determined by the
+`index` and `type`. Term statistics are disallowed as they depend on the shard
+processing the request.
+
+[source,js]
+--------------------------------------------------
+curl -XGET 'http://localhost:9200/twitter/tweet/_termvector' -d '{
+  "doc" : {
+    "fullname" : "John Doe",
+    "text" : "twitter test test test"
+  }
+}'
+--------------------------------------------------
+

--- a/src/main/java/org/elasticsearch/action/termvector/MultiTermVectorsRequest.java
+++ b/src/main/java/org/elasticsearch/action/termvector/MultiTermVectorsRequest.java
@@ -90,7 +90,6 @@ public class MultiTermVectorsRequest extends ActionRequest<MultiTermVectorsReque
                     if (token == XContentParser.Token.FIELD_NAME) {
                         currentFieldName = parser.currentName();
                     } else if (token == XContentParser.Token.START_ARRAY) {
-
                         if ("docs".equals(currentFieldName)) {
                             while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                                 if (token != XContentParser.Token.START_OBJECT) {

--- a/src/main/java/org/elasticsearch/action/termvector/TermVectorRequest.java
+++ b/src/main/java/org/elasticsearch/action/termvector/TermVectorRequest.java
@@ -329,8 +329,11 @@ public class TermVectorRequest extends SingleShardOperationRequest<TermVectorReq
         }
         type = in.readString();
         id = in.readString();
-        if (in.readBoolean()) {
-            doc = in.readBytesReference();
+
+        if (in.getVersion().after(Version.V_1_4_0)) {
+            if (in.readBoolean()) {
+                doc = in.readBytesReference();
+            }
         }
         routing = in.readOptionalString();
         preference = in.readOptionalString();
@@ -360,9 +363,12 @@ public class TermVectorRequest extends SingleShardOperationRequest<TermVectorReq
         }
         out.writeString(type);
         out.writeString(id);
-        out.writeBoolean(doc != null);
-        if (doc != null) {
-            out.writeBytesReference(doc);
+
+        if (out.getVersion().after(Version.V_1_4_0)) {
+            out.writeBoolean(doc != null);
+            if (doc != null) {
+                out.writeBytesReference(doc);
+            }
         }
         out.writeOptionalString(routing);
         out.writeOptionalString(preference);

--- a/src/main/java/org/elasticsearch/action/termvector/TermVectorRequest.java
+++ b/src/main/java/org/elasticsearch/action/termvector/TermVectorRequest.java
@@ -414,9 +414,6 @@ public class TermVectorRequest extends SingleShardOperationRequest<TermVectorReq
                 } else if (currentFieldName.equals("payloads")) {
                     termVectorRequest.payloads(parser.booleanValue());
                 } else if (currentFieldName.equals("term_statistics") || currentFieldName.equals("termStatistics")) {
-                    if (parser.booleanValue() && termVectorRequest.doc != null) {
-                        throw new ElasticsearchParseException("Term statistics are not supported with artificial documents.");
-                    }
                     termVectorRequest.termStatistics(parser.booleanValue());
                 } else if (currentFieldName.equals("field_statistics") || currentFieldName.equals("fieldStatistics")) {
                     termVectorRequest.fieldStatistics(parser.booleanValue());

--- a/src/main/java/org/elasticsearch/action/termvector/TermVectorRequest.java
+++ b/src/main/java/org/elasticsearch/action/termvector/TermVectorRequest.java
@@ -57,7 +57,7 @@ public class TermVectorRequest extends SingleShardOperationRequest<TermVectorReq
 
     protected String preference;
 
-    private static AtomicInteger randomInt = new AtomicInteger(0);
+    private static final AtomicInteger randomInt = new AtomicInteger(0);
 
     // TODO: change to String[]
     private Set<String> selectedFields;

--- a/src/main/java/org/elasticsearch/action/termvector/TermVectorRequest.java
+++ b/src/main/java/org/elasticsearch/action/termvector/TermVectorRequest.java
@@ -330,7 +330,7 @@ public class TermVectorRequest extends SingleShardOperationRequest<TermVectorReq
         type = in.readString();
         id = in.readString();
 
-        if (in.getVersion().after(Version.V_1_4_0)) {
+        if (in.getVersion().onOrAfter(Version.V_1_4_0)) {
             if (in.readBoolean()) {
                 doc = in.readBytesReference();
             }
@@ -364,7 +364,7 @@ public class TermVectorRequest extends SingleShardOperationRequest<TermVectorReq
         out.writeString(type);
         out.writeString(id);
 
-        if (out.getVersion().after(Version.V_1_4_0)) {
+        if (out.getVersion().onOrAfter(Version.V_1_4_0)) {
             out.writeBoolean(doc != null);
             if (doc != null) {
                 out.writeBytesReference(doc);

--- a/src/main/java/org/elasticsearch/action/termvector/TermVectorRequest.java
+++ b/src/main/java/org/elasticsearch/action/termvector/TermVectorRequest.java
@@ -26,12 +26,17 @@ import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ValidateActions;
 import org.elasticsearch.action.get.MultiGetRequest;
 import org.elasticsearch.action.support.single.shard.SingleShardOperationRequest;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 
 /**
  * Request returning the term vector (doc frequency, positions, offsets) for a
@@ -46,9 +51,13 @@ public class TermVectorRequest extends SingleShardOperationRequest<TermVectorReq
 
     private String id;
 
+    private BytesReference doc;
+
     private String routing;
 
     protected String preference;
+
+    private static AtomicInteger randomInt = new AtomicInteger(0);
 
     // TODO: change to String[]
     private Set<String> selectedFields;
@@ -126,6 +135,23 @@ public class TermVectorRequest extends SingleShardOperationRequest<TermVectorReq
      */
     public TermVectorRequest id(String id) {
         this.id = id;
+        return this;
+    }
+
+    /**
+     * Returns the artificial document from which term vectors are requested for.
+     */
+    public BytesReference doc() {
+        return doc;
+    }
+
+    /**
+     * Sets an artificial document from which term vectors are requested for.
+     */
+    public TermVectorRequest doc(XContentBuilder documentBuilder) {
+        // assign a random id to this artificial document, for routing
+        this.id(String.valueOf(randomInt.getAndAdd(1)));
+        this.doc = documentBuilder.bytes();
         return this;
     }
 
@@ -281,8 +307,8 @@ public class TermVectorRequest extends SingleShardOperationRequest<TermVectorReq
         if (type == null) {
             validationException = ValidateActions.addValidationError("type is missing", validationException);
         }
-        if (id == null) {
-            validationException = ValidateActions.addValidationError("id is missing", validationException);
+        if (id == null && doc == null) {
+            validationException = ValidateActions.addValidationError("id or doc is missing", validationException);
         }
         return validationException;
     }
@@ -303,6 +329,9 @@ public class TermVectorRequest extends SingleShardOperationRequest<TermVectorReq
         }
         type = in.readString();
         id = in.readString();
+        if (in.readBoolean()) {
+            doc = in.readBytesReference();
+        }
         routing = in.readOptionalString();
         preference = in.readOptionalString();
         long flags = in.readVLong();
@@ -331,6 +360,10 @@ public class TermVectorRequest extends SingleShardOperationRequest<TermVectorReq
         }
         out.writeString(type);
         out.writeString(id);
+        out.writeBoolean(doc != null);
+        if (doc != null) {
+            out.writeBytesReference(doc);
+        }
         out.writeOptionalString(routing);
         out.writeOptionalString(preference);
         long longFlags = 0;
@@ -381,6 +414,9 @@ public class TermVectorRequest extends SingleShardOperationRequest<TermVectorReq
                 } else if (currentFieldName.equals("payloads")) {
                     termVectorRequest.payloads(parser.booleanValue());
                 } else if (currentFieldName.equals("term_statistics") || currentFieldName.equals("termStatistics")) {
+                    if (parser.booleanValue() && termVectorRequest.doc != null) {
+                        throw new ElasticsearchParseException("Term statistics are not supported with artificial documents.");
+                    }
                     termVectorRequest.termStatistics(parser.booleanValue());
                 } else if (currentFieldName.equals("field_statistics") || currentFieldName.equals("fieldStatistics")) {
                     termVectorRequest.fieldStatistics(parser.booleanValue());
@@ -389,7 +425,15 @@ public class TermVectorRequest extends SingleShardOperationRequest<TermVectorReq
                 } else if ("_type".equals(currentFieldName)) {
                     termVectorRequest.type = parser.text();
                 } else if ("_id".equals(currentFieldName)) {
+                    if (termVectorRequest.doc != null) {
+                        throw new ElasticsearchParseException("Either \"id\" or \"doc\" can be specified, but not both!");
+                    }
                     termVectorRequest.id = parser.text();
+                } else if ("doc".equals(currentFieldName)) {
+                    if (termVectorRequest.id != null) {
+                        throw new ElasticsearchParseException("Either \"id\" or \"doc\" can be specified, but not both!");
+                    }
+                    termVectorRequest.doc(jsonBuilder().copyCurrentStructure(parser));
                 } else if ("_routing".equals(currentFieldName) || "routing".equals(currentFieldName)) {
                     termVectorRequest.routing = parser.text();
                 } else {
@@ -398,7 +442,6 @@ public class TermVectorRequest extends SingleShardOperationRequest<TermVectorReq
                 }
             }
         }
-
         if (fields.size() > 0) {
             String[] fieldsAsArray = new String[fields.size()];
             termVectorRequest.selectedFields(fields.toArray(fieldsAsArray));

--- a/src/main/java/org/elasticsearch/action/termvector/TermVectorRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/termvector/TermVectorRequestBuilder.java
@@ -22,6 +22,7 @@ package org.elasticsearch.action.termvector;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.common.xcontent.XContentBuilder;
 
 /**
  */
@@ -33,6 +34,26 @@ public class TermVectorRequestBuilder extends ActionRequestBuilder<TermVectorReq
 
     public TermVectorRequestBuilder(Client client, String index, String type, String id) {
         super(client, new TermVectorRequest(index, type, id));
+    }
+
+    public TermVectorRequestBuilder setIndex(String index) {
+        request.index(index);
+        return this;
+    }
+
+    public TermVectorRequestBuilder setId(String id) {
+        request.id(id);
+        return this;
+    }
+
+    public TermVectorRequestBuilder setType(String type) {
+        request.type(type);
+        return this;
+    }
+
+    public TermVectorRequestBuilder setDoc(XContentBuilder xContent) {
+        request.doc(xContent);
+        return this;
     }
 
     /**

--- a/src/main/java/org/elasticsearch/action/termvector/TermVectorRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/termvector/TermVectorRequestBuilder.java
@@ -36,21 +36,33 @@ public class TermVectorRequestBuilder extends ActionRequestBuilder<TermVectorReq
         super(client, new TermVectorRequest(index, type, id));
     }
 
+    /**
+     * Sets the index where the document is located.
+     */
     public TermVectorRequestBuilder setIndex(String index) {
         request.index(index);
         return this;
     }
 
-    public TermVectorRequestBuilder setId(String id) {
-        request.id(id);
-        return this;
-    }
-
+    /**
+     * Sets the type of the document.
+     */
     public TermVectorRequestBuilder setType(String type) {
         request.type(type);
         return this;
     }
 
+    /**
+     * Sets the id of the document.
+     */
+    public TermVectorRequestBuilder setId(String id) {
+        request.id(id);
+        return this;
+    }
+
+    /**
+     * Sets the artificial document from which to generate term vectors.
+     */
     public TermVectorRequestBuilder setDoc(XContentBuilder xContent) {
         request.doc(xContent);
         return this;

--- a/src/main/java/org/elasticsearch/action/termvector/TermVectorWriter.java
+++ b/src/main/java/org/elasticsearch/action/termvector/TermVectorWriter.java
@@ -59,6 +59,11 @@ final class TermVectorWriter {
             Terms fieldTermVector = termVectorsByField.terms(field);
             Terms topLevelTerms = topLevelFields.terms(field);
 
+            // if no terms found, take the retrieved term vector fields for stats
+            if (topLevelTerms == null) {
+                topLevelTerms = fieldTermVector;
+            }
+
             topLevelIterator = topLevelTerms.iterator(topLevelIterator);
             boolean positions = flags.contains(Flag.Positions) && fieldTermVector.hasPositions();
             boolean offsets = flags.contains(Flag.Offsets) && fieldTermVector.hasOffsets();

--- a/src/main/java/org/elasticsearch/action/termvector/TermVectorWriter.java
+++ b/src/main/java/org/elasticsearch/action/termvector/TermVectorWriter.java
@@ -46,7 +46,6 @@ final class TermVectorWriter {
     }
 
     void setFields(Fields termVectorsByField, Set<String> selectedFields, EnumSet<Flag> flags, Fields topLevelFields) throws IOException {
-
         int numFieldsWritten = 0;
         TermsEnum iterator = null;
         DocsAndPositionsEnum docsAndPosEnum = null;

--- a/src/main/java/org/elasticsearch/action/termvector/TermVectorWriter.java
+++ b/src/main/java/org/elasticsearch/action/termvector/TermVectorWriter.java
@@ -74,7 +74,6 @@ final class TermVectorWriter {
                 // get the doc frequency
                 BytesRef term = iterator.term();
                 boolean foundTerm = topLevelIterator.seekExact(term);
-                assert (foundTerm);
                 startTerm(term);
                 if (flags.contains(Flag.TermStatistics)) {
                     writeTermStatistics(topLevelIterator);

--- a/src/main/java/org/elasticsearch/client/Client.java
+++ b/src/main/java/org/elasticsearch/client/Client.java
@@ -533,7 +533,6 @@ public interface Client extends ElasticsearchClient<Client>, Releasable {
      */
     MoreLikeThisRequestBuilder prepareMoreLikeThis(String index, String type, String id);
 
-
     /**
      * An action that returns the term vectors for a specific document.
      *
@@ -550,6 +549,10 @@ public interface Client extends ElasticsearchClient<Client>, Releasable {
      */
     void termVector(TermVectorRequest request, ActionListener<TermVectorResponse> listener);
 
+    /**
+     * Builder for the term vector request.
+     */
+    TermVectorRequestBuilder prepareTermVector();
 
     /**
      * Builder for the term vector request.
@@ -559,7 +562,6 @@ public interface Client extends ElasticsearchClient<Client>, Releasable {
      * @param id    The id of the document
      */
     TermVectorRequestBuilder prepareTermVector(String index, String type, String id);
-
 
     /**
      * Multi get term vectors.
@@ -575,7 +577,6 @@ public interface Client extends ElasticsearchClient<Client>, Releasable {
      * Multi get term vectors.
      */
     MultiTermVectorsRequestBuilder prepareMultiTermVectors();
-
 
     /**
      * Percolates a request returning the matches documents.

--- a/src/main/java/org/elasticsearch/client/support/AbstractClient.java
+++ b/src/main/java/org/elasticsearch/client/support/AbstractClient.java
@@ -442,6 +442,11 @@ public abstract class AbstractClient implements Client {
     }
 
     @Override
+    public TermVectorRequestBuilder prepareTermVector() {
+        return new TermVectorRequestBuilder(this);
+    }
+
+    @Override
     public TermVectorRequestBuilder prepareTermVector(String index, String type, String id) {
         return new TermVectorRequestBuilder(this, index, type, id);
     }

--- a/src/main/java/org/elasticsearch/index/mapper/ParseContext.java
+++ b/src/main/java/org/elasticsearch/index/mapper/ParseContext.java
@@ -126,6 +126,32 @@ public abstract class ParseContext {
             return f.toArray(new IndexableField[f.size()]);
         }
 
+        /**
+         * Returns an array of values of the field specified as the method parameter.
+         * This method returns an empty array when there are no
+         * matching fields.  It never returns null.
+         * For {@link org.apache.lucene.document.IntField}, {@link org.apache.lucene.document.LongField}, {@link
+         * org.apache.lucene.document.FloatField} and {@link org.apache.lucene.document.DoubleField} it returns the string value of the number.
+         * If you want the actual numeric field instances back, use {@link #getFields}.
+         * @param name the name of the field
+         * @return a <code>String[]</code> of field values
+         */
+        public final String[] getValues(String name) {
+            List<String> result = new ArrayList<>();
+
+            for (IndexableField field : fields) {
+                if (field.name().equals(name) && field.stringValue() != null) {
+                    result.add(field.stringValue());
+                }
+            }
+
+            if (result.size() == 0) {
+                return new String[0];
+            }
+
+            return result.toArray(new String[result.size()]);
+        }
+
         public IndexableField getField(String name) {
             for (IndexableField field : fields) {
                 if (field.name().equals(name)) {

--- a/src/main/java/org/elasticsearch/index/mapper/ParseContext.java
+++ b/src/main/java/org/elasticsearch/index/mapper/ParseContext.java
@@ -138,17 +138,11 @@ public abstract class ParseContext {
          */
         public final String[] getValues(String name) {
             List<String> result = new ArrayList<>();
-
             for (IndexableField field : fields) {
                 if (field.name().equals(name) && field.stringValue() != null) {
                     result.add(field.stringValue());
                 }
             }
-
-            if (result.size() == 0) {
-                return new String[0];
-            }
-
             return result.toArray(new String[result.size()]);
         }
 

--- a/src/main/java/org/elasticsearch/index/termvectors/ShardTermVectorService.java
+++ b/src/main/java/org/elasticsearch/index/termvectors/ShardTermVectorService.java
@@ -190,7 +190,7 @@ public class ShardTermVectorService extends AbstractIndexShardComponent {
 
     private Fields generateTermVectorsFromDoc(TermVectorRequest request, Fields topLevelFields) throws IOException {
         DocumentMapper docMapper = indexShard.mapperService().documentMapper(request.type());
-        ParseContext.Document doc = docMapper.parse(source(request.doc()).type(request.type()).id(request.id())).rootDoc();
+        ParseContext.Document doc = docMapper.parse(source(request.doc()).type(request.type()).flyweight(true)).rootDoc();
 
         Collection<String> seenFields = new HashSet<>();
         Collection<GetField> getFields = new HashSet<>();

--- a/src/main/java/org/elasticsearch/index/termvectors/ShardTermVectorService.java
+++ b/src/main/java/org/elasticsearch/index/termvectors/ShardTermVectorService.java
@@ -32,16 +32,15 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.get.GetField;
 import org.elasticsearch.index.get.GetResult;
-import org.elasticsearch.index.mapper.DocumentMapper;
-import org.elasticsearch.index.mapper.FieldMapper;
-import org.elasticsearch.index.mapper.ParseContext;
-import org.elasticsearch.index.mapper.Uid;
+import org.elasticsearch.index.mapper.*;
 import org.elasticsearch.index.mapper.core.StringFieldMapper;
 import org.elasticsearch.index.mapper.internal.UidFieldMapper;
+import org.elasticsearch.index.service.IndexService;
 import org.elasticsearch.index.settings.IndexSettings;
 import org.elasticsearch.index.shard.AbstractIndexShardComponent;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.service.IndexShard;
+import org.elasticsearch.indices.IndicesService;
 
 import java.io.IOException;
 import java.util.*;
@@ -54,6 +53,7 @@ import static org.elasticsearch.index.mapper.SourceToParse.source;
 public class ShardTermVectorService extends AbstractIndexShardComponent {
 
     private IndexShard indexShard;
+
 
     @Inject
     public ShardTermVectorService(ShardId shardId, @IndexSettings Settings indexSettings) {
@@ -78,7 +78,7 @@ public class ShardTermVectorService extends AbstractIndexShardComponent {
 
         try {
             Fields topLevelFields = MultiFields.getFields(topLevelReader);
-            //* from an artificial document */
+            /* from an artificial document */
             if (request.doc() != null) {
                 Fields termVectorsByField = generateTermVectorsFromDoc(request, topLevelFields);
                 // if no document indexed in shard, take the queried document itself for stats

--- a/src/main/java/org/elasticsearch/rest/action/termvector/RestTermVectorAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/termvector/RestTermVectorAction.java
@@ -48,6 +48,8 @@ public class RestTermVectorAction extends BaseRestHandler {
     @Inject
     public RestTermVectorAction(Settings settings, Client client, RestController controller) {
         super(settings, client);
+        controller.registerHandler(GET, "/{index}/{type}/_termvector", this);
+        controller.registerHandler(POST, "/{index}/{type}/_termvector", this);
         controller.registerHandler(GET, "/{index}/{type}/{id}/_termvector", this);
         controller.registerHandler(POST, "/{index}/{type}/{id}/_termvector", this);
     }

--- a/src/test/java/org/elasticsearch/action/termvector/GetTermVectorTests.java
+++ b/src/test/java/org/elasticsearch/action/termvector/GetTermVectorTests.java
@@ -31,7 +31,6 @@ import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.mapper.core.AbstractFieldMapper;
 import org.junit.Test;
 
@@ -43,6 +42,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertThrows;
 import static org.hamcrest.Matchers.*;
@@ -51,7 +51,7 @@ public class GetTermVectorTests extends AbstractTermVectorTests {
 
     @Test
     public void testNoSuchDoc() throws Exception {
-        XContentBuilder mapping = XContentFactory.jsonBuilder().startObject().startObject("type1")
+        XContentBuilder mapping = jsonBuilder().startObject().startObject("type1")
                 .startObject("properties")
                         .startObject("field")
                             .field("type", "string")
@@ -72,13 +72,13 @@ public class GetTermVectorTests extends AbstractTermVectorTests {
             assertThat(actionGet.getIndex(), equalTo("test"));
             assertThat(actionGet.isExists(), equalTo(false));
             // check response is nevertheless serializable to json
-            actionGet.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS);
+            actionGet.toXContent(jsonBuilder(), ToXContent.EMPTY_PARAMS);
         }
     }
 
     @Test
     public void testExistingFieldWithNoTermVectorsNoNPE() throws Exception {
-        XContentBuilder mapping = XContentFactory.jsonBuilder().startObject().startObject("type1")
+        XContentBuilder mapping = jsonBuilder().startObject().startObject("type1")
                 .startObject("properties")
                         .startObject("existingfield")
                             .field("type", "string")
@@ -107,7 +107,7 @@ public class GetTermVectorTests extends AbstractTermVectorTests {
 
     @Test
     public void testExistingFieldButNotInDocNPE() throws Exception {
-        XContentBuilder mapping = XContentFactory.jsonBuilder().startObject().startObject("type1")
+        XContentBuilder mapping = jsonBuilder().startObject().startObject("type1")
                 .startObject("properties")
                         .startObject("existingfield")
                             .field("type", "string")
@@ -179,7 +179,7 @@ public class GetTermVectorTests extends AbstractTermVectorTests {
 
     @Test
     public void testSimpleTermVectors() throws ElasticsearchException, IOException {
-        XContentBuilder mapping = XContentFactory.jsonBuilder().startObject().startObject("type1")
+        XContentBuilder mapping = jsonBuilder().startObject().startObject("type1")
                 .startObject("properties")
                         .startObject("field")
                             .field("type", "string")
@@ -197,7 +197,7 @@ public class GetTermVectorTests extends AbstractTermVectorTests {
         ensureYellow();
         for (int i = 0; i < 10; i++) {
             client().prepareIndex("test", "type1", Integer.toString(i))
-                    .setSource(XContentFactory.jsonBuilder().startObject().field("field", "the quick brown fox jumps over the lazy dog")
+                    .setSource(jsonBuilder().startObject().field("field", "the quick brown fox jumps over the lazy dog")
                             // 0the3 4quick9 10brown15 16fox19 20jumps25 26over30
                             // 31the34 35lazy39 40dog43
                             .endObject()).execute().actionGet();
@@ -268,7 +268,7 @@ public class GetTermVectorTests extends AbstractTermVectorTests {
         ft.setStoreTermVectorPositions(storePositions);
 
         String optionString = AbstractFieldMapper.termVectorOptionsToString(ft);
-        XContentBuilder mapping = XContentFactory.jsonBuilder().startObject().startObject("type1")
+        XContentBuilder mapping = jsonBuilder().startObject().startObject("type1")
                 .startObject("properties")
                         .startObject("field")
                             .field("type", "string")
@@ -284,7 +284,7 @@ public class GetTermVectorTests extends AbstractTermVectorTests {
         ensureYellow();
         for (int i = 0; i < 10; i++) {
             client().prepareIndex("test", "type1", Integer.toString(i))
-                    .setSource(XContentFactory.jsonBuilder().startObject().field("field", "the quick brown fox jumps over the lazy dog")
+                    .setSource(jsonBuilder().startObject().field("field", "the quick brown fox jumps over the lazy dog")
                             // 0the3 4quick9 10brown15 16fox19 20jumps25 26over30
                             // 31the34 35lazy39 40dog43
                             .endObject()).execute().actionGet();
@@ -423,7 +423,7 @@ public class GetTermVectorTests extends AbstractTermVectorTests {
         String delimiter = createRandomDelimiter(tokens);
         String queryString = createString(tokens, payloads, encoding, delimiter.charAt(0));
         //create the mapping
-        XContentBuilder mapping = XContentFactory.jsonBuilder().startObject().startObject("type1").startObject("properties")
+        XContentBuilder mapping = jsonBuilder().startObject().startObject("type1").startObject("properties")
                 .startObject("field").field("type", "string").field("term_vector", "with_positions_offsets_payloads")
                 .field("analyzer", "payload_test").endObject().endObject().endObject().endObject();
         assertAcked(prepareCreate("test").addMapping("type1", mapping).setSettings(
@@ -437,7 +437,7 @@ public class GetTermVectorTests extends AbstractTermVectorTests {
         ensureYellow();
 
         client().prepareIndex("test", "type1", Integer.toString(1))
-                .setSource(XContentFactory.jsonBuilder().startObject().field("field", queryString).endObject()).execute().actionGet();
+                .setSource(jsonBuilder().startObject().field("field", queryString).endObject()).execute().actionGet();
         refresh();
         TermVectorRequestBuilder resp = client().prepareTermVector("test", "type1", Integer.toString(1)).setPayloads(true).setOffsets(true)
                 .setPositions(true).setSelectedFields();
@@ -579,8 +579,8 @@ public class GetTermVectorTests extends AbstractTermVectorTests {
             fieldNames[i] = "field" + String.valueOf(i);
         }
 
-        XContentBuilder mapping = XContentFactory.jsonBuilder().startObject().startObject("type1").startObject("properties");
-        XContentBuilder source = XContentFactory.jsonBuilder().startObject();
+        XContentBuilder mapping = jsonBuilder().startObject().startObject("type1").startObject("properties");
+        XContentBuilder source = jsonBuilder().startObject();
         for (String field : fieldNames) {
             mapping.startObject(field)
                     .field("type", "string")
@@ -764,8 +764,8 @@ public class GetTermVectorTests extends AbstractTermVectorTests {
     public void testSimpleWildCards() throws ElasticsearchException, IOException {
         int numFields = 25;
 
-        XContentBuilder mapping = XContentFactory.jsonBuilder().startObject().startObject("type1").startObject("properties");
-        XContentBuilder source = XContentFactory.jsonBuilder().startObject();
+        XContentBuilder mapping = jsonBuilder().startObject().startObject("type1").startObject("properties");
+        XContentBuilder source = jsonBuilder().startObject();
         for (int i = 0; i < numFields; i++) {
             mapping.startObject("field" + i)
                     .field("type", "string")
@@ -786,6 +786,55 @@ public class GetTermVectorTests extends AbstractTermVectorTests {
         assertThat("Doc doesn't exists but should", response.isExists(), equalTo(true));
         assertThat(response.getIndex(), equalTo("test"));
         assertThat("All term vectors should have been generated", response.getFields().size(), equalTo(numFields));
+    }
+
+    @Test
+    public void testExistingVsArtificial() throws ElasticsearchException, IOException, ExecutionException, InterruptedException {
+        // setup indices
+        ImmutableSettings.Builder settings = settingsBuilder()
+                .put(indexSettings())
+                .put("index.analysis.analyzer", "standard");
+        assertAcked(prepareCreate("test")
+                .setSettings(settings)
+                .addMapping("type1", "field1", "type=string,term_vector=with_positions_offsets"));
+        ensureGreen();
+
+        // index documents existing document
+        String text = "Generating a random permutation of a sequence (such as when shuffling cards).";
+        List<IndexRequestBuilder> indexBuilders = new ArrayList<>();
+        indexBuilders.add(client().prepareIndex()
+                .setIndex("test")
+                .setType("type1")
+                .setId("existing")
+                .setSource("field1", text));
+        indexRandom(true, indexBuilders);
+
+        // request tvs from existing document
+        TermVectorResponse respExisting = client().prepareTermVector("test", "type1", "existing")
+                .setOffsets(true)
+                .setPositions(true)
+                .setSelectedFields("field1")
+                .setFieldStatistics(false) // field statistics will be slightly different so ignore
+                .get();
+        assertThat("doc with index: test, type1 and id: existing", respExisting.isExists(), equalTo(true));
+
+        // request tvs from artificial document
+        TermVectorResponse respArtificial = client().prepareTermVector()
+                .setIndex("test")
+                .setType("type1")
+                .setDoc(jsonBuilder()
+                        .startObject()
+                        .field("field1", text)
+                        .endObject())
+                .setOffsets(true)
+                .setPositions(true)
+                .setSelectedFields("field1")
+                .setFieldStatistics(false) // field statistics will be slightly different so ignore
+                .get();
+        assertThat("doc with index: test, type1 and id: existing", respArtificial.isExists(), equalTo(true));
+
+        // compare existing tvs with artificial
+        compareTermVectors("field1", respExisting.getFields(), respArtificial.getFields());
     }
 
     private static String indexOrAlias() {


### PR DESCRIPTION
This adds the ability to the Term Vector API to generate term vectors for
artifical documents, that is for documents not present in the index. Following
a similar syntax to the Percolator API, a new 'doc' parameter is used, instead
of '_id', that specifies the document of interest. The parameters '_index' and
'_type' determine the mapping and therefore analyzers to apply to each value
field.
