### PR TITLE
Fixes node client section name on Java API Doc

### DIFF
--- a/docs/java-api/client.asciidoc
+++ b/docs/java-api/client.asciidoc
@@ -13,7 +13,7 @@ You can use the *Java client* in multiple ways:
 Obtaining an elasticsearch `Client` is simple. The most common way to
 get a client is by:
 
-1.  Creating an embedded link:#nodeclient[`Node`] that acts as a node
+1.  Creating an embedded link:#node-client[`Node`] that acts as a node
 within a cluster.
 2.  Requesting a `Client` from your embedded `Node`.
 
@@ -154,7 +154,7 @@ Client client =    new TransportClient(settings);
 //Add transport addresses and do something with the client...
 --------------------------------------------------
 
-Or using `elasticsearch.yml` file as shown in the link:#nodeclient[Node
+Or using `elasticsearch.yml` file as shown in the link:#node-client[Node
 Client section]
 
 The client allows to sniff the rest of the cluster, and add those into

--- a/docs/java-api/client.asciidoc
+++ b/docs/java-api/client.asciidoc
@@ -13,11 +13,11 @@ You can use the *Java client* in multiple ways:
 Obtaining an elasticsearch `Client` is simple. The most common way to
 get a client is by:
 
-1.  Creating an embedded link:#node-client[`Node`] that acts as a node
+1.  Creating an embedded <<node-client,`Node`>> that acts as a node
 within a cluster.
 2.  Requesting a `Client` from your embedded `Node`.
 
-Another manner is by creating a link:#transport-client[`TransportClient`]
+Another manner is by creating a <<transport-client,`TransportClient`>>
 that connects to a cluster.
 
 *Important:*
@@ -154,8 +154,7 @@ Client client =    new TransportClient(settings);
 //Add transport addresses and do something with the client...
 --------------------------------------------------
 
-Or using `elasticsearch.yml` file as shown in the link:#node-client[Node
-Client section]
+Or using `elasticsearch.yml` file as shown in the <<node-client,`Node Client section`>>
 
 The client allows to sniff the rest of the cluster, and add those into
 its list of machines to use. In this case, note that the IP addresses


### PR DESCRIPTION
The links to the "node client" section on the [client java-api doc](http://www.elasticsearch.org/guide/en/elasticsearch/client/java-api/master/client.html) don't work due to a minor typo in the references.
