### PR TITLE
Do not use a background thread to disconnect node which are removed from the ClusterState

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/service/InternalClusterService.java
+++ b/src/main/java/org/elasticsearch/cluster/service/InternalClusterService.java
@@ -444,7 +444,11 @@ public class InternalClusterService extends AbstractLifecycleComponent<ClusterSe
                 }
 
                 for (DiscoveryNode node : nodesDelta.removedNodes()) {
-                    transportService.disconnectFromNode(node);
+                    try {
+                        transportService.disconnectFromNode(node);
+                    } catch (Throwable e) {
+                        logger.warn("failed to disconnect to node [" + node + "]", e);
+                    }
                 }
 
                 newClusterState.status(ClusterState.ClusterStateStatus.APPLIED);

--- a/src/main/java/org/elasticsearch/cluster/service/InternalClusterService.java
+++ b/src/main/java/org/elasticsearch/cluster/service/InternalClusterService.java
@@ -448,7 +448,12 @@ public class InternalClusterService extends AbstractLifecycleComponent<ClusterSe
                         @Override
                         public void run() {
                             for (DiscoveryNode node : nodesDelta.removedNodes()) {
-                                transportService.disconnectFromNode(node);
+                                // verify the node is no longer in state - things may have changed by the time this runs
+                                if (state().nodes().nodeExists(node.id())) {
+                                    logger.trace("not disconnecting from {} as it is back in the cluster state", node);
+                                } else {
+                                    transportService.disconnectFromNode(node);
+                                }
                             }
                         }
                     });

--- a/src/main/java/org/elasticsearch/cluster/service/InternalClusterService.java
+++ b/src/main/java/org/elasticsearch/cluster/service/InternalClusterService.java
@@ -443,20 +443,8 @@ public class InternalClusterService extends AbstractLifecycleComponent<ClusterSe
                     listener.clusterChanged(clusterChangedEvent);
                 }
 
-                if (!nodesDelta.removedNodes().isEmpty()) {
-                    threadPool.generic().execute(new Runnable() {
-                        @Override
-                        public void run() {
-                            for (DiscoveryNode node : nodesDelta.removedNodes()) {
-                                // verify the node is no longer in state - things may have changed by the time this runs
-                                if (state().nodes().nodeExists(node.id())) {
-                                    logger.trace("not disconnecting from {} as it is back in the cluster state", node);
-                                } else {
-                                    transportService.disconnectFromNode(node);
-                                }
-                            }
-                        }
-                    });
+                for (DiscoveryNode node : nodesDelta.removedNodes()) {
+                    transportService.disconnectFromNode(node);
                 }
 
                 newClusterState.status(ClusterState.ClusterStateStatus.APPLIED);


### PR DESCRIPTION
After a node fails to respond to a ping correctly (master or node fault detection), they are removed from the cluster state through an UpdateTask. When a node is removed, a background task is scheduled using the generic threadpool to actually disconnect the node. However, in the case of temporary node failures (for example) it may be that the node was re-added by the time the task get executed, causing an untimely disconnect call. Disconnect is cheep and should be done during the UpdateTask.
