### PR TITLE
Mark transport client as such when instantiating

### DIFF
--- a/src/main/java/org/elasticsearch/client/Client.java
+++ b/src/main/java/org/elasticsearch/client/Client.java
@@ -82,6 +82,8 @@ import org.elasticsearch.common.settings.Settings;
  */
 public interface Client extends ElasticsearchClient<Client>, Releasable {
 
+    String CLIENT_TYPE_SETTING = "client.type";
+
     /**
      * The admin client that can be used to perform administrative operations.
      */

--- a/src/main/java/org/elasticsearch/client/transport/TransportClient.java
+++ b/src/main/java/org/elasticsearch/client/transport/TransportClient.java
@@ -98,19 +98,15 @@ import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilde
  */
 public class TransportClient extends AbstractClient {
 
+    private static final String CLIENT_TYPE = "transport";
+
     final Injector injector;
 
     private final Settings settings;
-
     private final Environment environment;
-
-
     private final PluginsService pluginsService;
-
     private final TransportClientNodesService nodesService;
-
     private final InternalTransportClient internalClient;
-
 
     /**
      * Constructs a new transport client with settings loaded either from the classpath or the file system (the
@@ -163,6 +159,7 @@ public class TransportClient extends AbstractClient {
         Settings settings = settingsBuilder().put(tuple.v1())
                 .put("network.server", false)
                 .put("node.client", true)
+                .put(CLIENT_TYPE_SETTING, CLIENT_TYPE)
                 .build();
         this.environment = tuple.v2();
 

--- a/src/main/java/org/elasticsearch/node/internal/InternalNode.java
+++ b/src/main/java/org/elasticsearch/node/internal/InternalNode.java
@@ -103,28 +103,29 @@ import org.elasticsearch.watcher.ResourceWatcherService;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
+import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+
 /**
  *
  */
 public final class InternalNode implements Node {
 
+    private static final String CLIENT_TYPE = "node";
+
     private final Lifecycle lifecycle = new Lifecycle();
-
     private final Injector injector;
-
     private final Settings settings;
-
     private final Environment environment;
-
     private final PluginsService pluginsService;
-
     private final Client client;
 
     public InternalNode() throws ElasticsearchException {
         this(ImmutableSettings.Builder.EMPTY_SETTINGS, true);
     }
 
-    public InternalNode(Settings pSettings, boolean loadConfigSettings) throws ElasticsearchException {
+    public InternalNode(Settings preparedSettings, boolean loadConfigSettings) throws ElasticsearchException {
+        final Settings pSettings = settingsBuilder().put(preparedSettings)
+                .put(Client.CLIENT_TYPE_SETTING, CLIENT_TYPE).build();
         Tuple<Settings, Environment> tuple = InternalSettingsPreparer.prepareSettings(pSettings, loadConfigSettings);
         tuple = new Tuple<>(TribeService.processSettings(tuple.v1()), tuple.v2());
 

--- a/src/test/java/org/elasticsearch/client/node/NodeClientTests.java
+++ b/src/test/java/org/elasticsearch/client/node/NodeClientTests.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.client.node;
+
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
+
+import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.Scope;
+import static org.hamcrest.Matchers.is;
+
+/**
+ *
+ */
+@ClusterScope(scope = Scope.SUITE)
+public class NodeClientTests extends ElasticsearchIntegrationTest {
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return settingsBuilder().put(super.nodeSettings(nodeOrdinal)).put(Client.CLIENT_TYPE_SETTING, "anything").build();
+    }
+
+    @Test
+    public void testThatClientTypeSettingCannotBeChanged() {
+        for (Settings settings : internalCluster().getInstances(Settings.class)) {
+            assertThat(settings.get(Client.CLIENT_TYPE_SETTING), is("node"));
+        }
+    }
+
+}

--- a/src/test/java/org/elasticsearch/client/transport/TransportClientTests.java
+++ b/src/test/java/org/elasticsearch/client/transport/TransportClientTests.java
@@ -20,8 +20,10 @@
 package org.elasticsearch.client.transport;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.node.NodeBuilder;
@@ -31,6 +33,8 @@ import org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
 import org.elasticsearch.transport.TransportService;
 import org.junit.Test;
 
+import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.elasticsearch.node.NodeBuilder.nodeBuilder;
 import static org.elasticsearch.test.ElasticsearchIntegrationTest.Scope;
 import static org.hamcrest.Matchers.*;
 
@@ -50,7 +54,7 @@ public class TransportClientTests extends ElasticsearchIntegrationTest {
     public void testNodeVersionIsUpdated() {
         TransportClient client = (TransportClient)  internalCluster().client();
         TransportClientNodesService nodeService = client.nodeService();
-        Node node = NodeBuilder.nodeBuilder().data(false).settings(ImmutableSettings.builder()
+        Node node = nodeBuilder().data(false).settings(ImmutableSettings.builder()
                 .put(internalCluster().getDefaultSettings())
                 .put("node.name", "testNodeVersionIsUpdated")
                 .put("http.enabled", false)
@@ -79,5 +83,19 @@ public class TransportClientTests extends ElasticsearchIntegrationTest {
         } finally {
             node.close();
         }
+    }
+
+    @Test
+    public void testThatTransportClientSettingIsSet() {
+        TransportClient client = (TransportClient)  internalCluster().client();
+        Settings settings = client.injector.getInstance(Settings.class);
+        assertThat(settings.get(Client.CLIENT_TYPE_SETTING), is("transport"));
+    }
+
+    @Test
+    public void testThatTransportClientSettingCannotBeChanged() {
+        TransportClient client = new TransportClient(settingsBuilder().put(Client.CLIENT_TYPE_SETTING, "anything"));
+        Settings settings = client.injector.getInstance(Settings.class);
+        assertThat(settings.get(Client.CLIENT_TYPE_SETTING), is("transport"));
     }
 }


### PR DESCRIPTION
This allows plugins to load/inject specific classes, when the client started
is a transport client (compared to being a node client).
