### PR TITLE
Fix `index` setting in `_boost` field

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/internal/BoostFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/BoostFieldMapper.java
@@ -297,7 +297,7 @@ public class BoostFieldMapper extends NumberFieldMapper<Float> implements Intern
             builder.field("null_value", nullValue);
         }
         if (includeDefaults || fieldType.indexed() != Defaults.FIELD_TYPE.indexed()) {
-            builder.field("index", fieldType.indexed());
+            builder.field("index", indexTokenizeOptionToString(fieldType.indexed(), fieldType.tokenized()));
         }
         if (includeDefaults || fieldType.stored() != Defaults.FIELD_TYPE.stored()) {
             builder.field("store", fieldType.stored());

--- a/src/test/java/org/elasticsearch/index/mapper/boost/BoostMappingIntegrationTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/boost/BoostMappingIntegrationTests.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper.boost;
+
+import org.elasticsearch.action.admin.indices.mapping.get.GetFieldMappingsResponse;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.index.mapper.DocumentMapper;
+import org.elasticsearch.index.service.IndexService;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.ElasticsearchSingleNodeTest;
+import org.junit.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.hamcrest.Matchers.equalTo;
+
+
+public class BoostMappingIntegrationTests extends ElasticsearchIntegrationTest {
+
+    @Test
+    public void testSetValues() throws Exception {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("_boost")
+                .field("store", "yes").field("index", "not_analyzed")
+                .endObject()
+                .endObject().endObject().string();
+        assertAcked(prepareCreate("test").addMapping("type", mapping));
+        ensureYellow();
+        GetFieldMappingsResponse response = client().admin().indices().prepareGetFieldMappings().addIndices("test").addTypes("type").setFields("_boost").get();
+        assertTrue(response.mappings().containsKey("test"));
+        assertNotNull(response.fieldMappings("test", "type", "_boost"));
+        Map<String, Object> boostSource = response.fieldMappings("test", "type", "_boost").sourceAsMap();
+        assertThat((Boolean)((LinkedHashMap)(boostSource.get("_boost"))).get("store"), equalTo(true));
+        assertThat((String)((LinkedHashMap)(boostSource.get("_boost"))).get("index"), equalTo("not_analyzed"));
+    }
+}

--- a/src/test/java/org/elasticsearch/index/mapper/boost/BoostMappingTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/boost/BoostMappingTests.java
@@ -20,10 +20,13 @@
 package org.elasticsearch.index.mapper.boost;
 
 import org.apache.lucene.index.IndexableField;
+import org.elasticsearch.common.compress.CompressedString;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.index.mapper.internal.BoostFieldMapper;
+import org.elasticsearch.index.service.IndexService;
+import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.test.ElasticsearchSingleNodeTest;
 import org.junit.Test;
 
@@ -87,7 +90,12 @@ public class BoostMappingTests extends ElasticsearchSingleNodeTest {
                 .field("store", "yes").field("index", "not_analyzed")
                 .endObject()
                 .endObject().endObject().string();
-        DocumentMapper docMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
+        IndexService indexServices = createIndex("test");
+        DocumentMapper docMapper = indexServices.mapperService().documentMapperParser().parse("type", mapping);
+        assertThat(docMapper.boostFieldMapper().fieldType().stored(), equalTo(true));
+        assertThat(docMapper.boostFieldMapper().fieldType().indexed(), equalTo(true));
+        docMapper.refreshSource();
+        docMapper = indexServices.mapperService().documentMapperParser().parse("type", docMapper.mappingSource().string());
         assertThat(docMapper.boostFieldMapper().fieldType().stored(), equalTo(true));
         assertThat(docMapper.boostFieldMapper().fieldType().indexed(), equalTo(true));
     }


### PR DESCRIPTION
Serialization if "index" setting for boost did not work since
the serialization was just true/false instead of valid options
"no"/"not_analyzed"/"analyzed".
