### PR TITLE
Master election should demotes nodes which try to join the cluster for the first time

### DIFF
--- a/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -960,7 +960,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
                 sb.append(" {none}");
             } else {
                 for (ZenPing.PingResponse pingResponse : pingResponses) {
-                    sb.append("\n\t--> ").append("target [").append(pingResponse.target()).append("], master [").append(pingResponse.master()).append("]");
+                    sb.append("\n\t--> ").append(pingResponse);
                 }
             }
             logger.debug(sb.toString());
@@ -983,6 +983,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
         if (localNode.masterNode()) {
             activeNodes.add(localNode);
             if (hasJoinedClusterOnce.get()) {
+                logger.trace("adding local node to the list of active nodes who has previously joined the cluster");
                 joinedOnceActiveNodes.add(localNode);
             }
         }

--- a/src/main/java/org/elasticsearch/discovery/zen/ping/PingContextProvider.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ping/PingContextProvider.java
@@ -26,7 +26,7 @@ import org.elasticsearch.discovery.zen.DiscoveryNodesProvider;
  */
 public interface PingContextProvider extends DiscoveryNodesProvider {
 
-    /** return true if this node is joining the cluster for the first time */
-    boolean isFirstClusterJoin();
+    /** return true if this node has previously joined the cluster at least once. False if this is first join */
+    boolean nodeHasJoinedClusterOnce();
 
 }

--- a/src/main/java/org/elasticsearch/discovery/zen/ping/PingContextProvider.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ping/PingContextProvider.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.discovery.zen.ping;
+
+import org.elasticsearch.discovery.zen.DiscoveryNodesProvider;
+
+/**
+ *
+ */
+public interface PingContextProvider extends DiscoveryNodesProvider {
+
+    /** return true if this node is joining the cluster for the first time */
+    boolean isFirstClusterJoin();
+
+}

--- a/src/main/java/org/elasticsearch/discovery/zen/ping/ZenPing.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ping/ZenPing.java
@@ -28,7 +28,6 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.discovery.zen.DiscoveryNodesProvider;
 
 import java.io.IOException;
 
@@ -40,7 +39,7 @@ import static org.elasticsearch.cluster.node.DiscoveryNode.readNode;
  */
 public interface ZenPing extends LifecycleComponent<ZenPing> {
 
-    void setNodesProvider(DiscoveryNodesProvider nodesProvider);
+    void setPingContextProvider(PingContextProvider contextProvider);
 
     void ping(PingListener listener, TimeValue timeout) throws ElasticsearchException;
 
@@ -50,7 +49,7 @@ public interface ZenPing extends LifecycleComponent<ZenPing> {
     }
 
     public static class PingResponse implements Streamable {
-        
+
         public static final PingResponse[] EMPTY = new PingResponse[0];
 
         private ClusterName clusterName;

--- a/src/main/java/org/elasticsearch/discovery/zen/ping/ZenPing.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ping/ZenPing.java
@@ -103,7 +103,7 @@ public interface ZenPing extends LifecycleComponent<ZenPing> {
             if (in.getVersion().onOrAfter(Version.V_1_4_0)) {
                 this.initialJoin = in.readBoolean();
             } else {
-                // we prefer to elect nodes who do not ping due to the first time they join the cluster
+                // we prefer to elect nodes which are not in the process of joining the cluster for the first time.
                 // false is the safe choice here.
                 this.initialJoin = false;
             }

--- a/src/main/java/org/elasticsearch/discovery/zen/ping/ZenPingService.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ping/ZenPingService.java
@@ -23,7 +23,7 @@ import com.google.common.collect.ImmutableList;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchIllegalStateException;
 import org.elasticsearch.Version;
-import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
@@ -55,21 +55,21 @@ public class ZenPingService extends AbstractLifecycleComponent<ZenPing> implemen
     private volatile ImmutableList<? extends ZenPing> zenPings = ImmutableList.of();
 
     // here for backward comp. with discovery plugins
-    public ZenPingService(Settings settings, ThreadPool threadPool, TransportService transportService, ClusterName clusterName, NetworkService networkService,
+    public ZenPingService(Settings settings, ThreadPool threadPool, TransportService transportService, ClusterService clusterService, NetworkService networkService,
                           ElectMasterService electMasterService, @Nullable Set<UnicastHostsProvider> unicastHostsProviders) {
-        this(settings, threadPool, transportService, clusterName, networkService, Version.CURRENT, electMasterService, unicastHostsProviders);
+        this(settings, threadPool, transportService, clusterService, networkService, Version.CURRENT, electMasterService, unicastHostsProviders);
     }
 
     @Inject
-    public ZenPingService(Settings settings, ThreadPool threadPool, TransportService transportService, ClusterName clusterName, NetworkService networkService,
+    public ZenPingService(Settings settings, ThreadPool threadPool, TransportService transportService, ClusterService clusterService, NetworkService networkService,
                           Version version, ElectMasterService electMasterService, @Nullable Set<UnicastHostsProvider> unicastHostsProviders) {
         super(settings);
         ImmutableList.Builder<ZenPing> zenPingsBuilder = ImmutableList.builder();
         if (componentSettings.getAsBoolean("multicast.enabled", true)) {
-            zenPingsBuilder.add(new MulticastZenPing(settings, threadPool, transportService, clusterName, networkService, version));
+            zenPingsBuilder.add(new MulticastZenPing(settings, threadPool, transportService, clusterService, networkService, version));
         }
         // always add the unicast hosts, so it will be able to receive unicast requests even when working in multicast
-        zenPingsBuilder.add(new UnicastZenPing(settings, threadPool, transportService, clusterName, version, electMasterService, unicastHostsProviders));
+        zenPingsBuilder.add(new UnicastZenPing(settings, threadPool, transportService, clusterService, version, electMasterService, unicastHostsProviders));
 
         this.zenPings = zenPingsBuilder.build();
     }

--- a/src/main/java/org/elasticsearch/discovery/zen/ping/ZenPingService.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ping/ZenPingService.java
@@ -171,7 +171,7 @@ public class ZenPingService extends AbstractLifecycleComponent<ZenPing> implemen
         public void onPing(PingResponse[] pings) {
             if (pings != null) {
                 for (PingResponse pingResponse : pings) {
-                    responses.put(pingResponse.target(), pingResponse);
+                    responses.put(pingResponse.node(), pingResponse);
                 }
             }
             if (counter.decrementAndGet() == 0) {

--- a/src/main/java/org/elasticsearch/discovery/zen/ping/multicast/MulticastZenPing.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ping/multicast/MulticastZenPing.java
@@ -213,6 +213,7 @@ public class MulticastZenPing extends AbstractLifecycleComponent<ZenPing> implem
             BytesStreamOutput bStream = new BytesStreamOutput();
             StreamOutput out = new HandlesStreamOutput(bStream);
             out.writeBytes(INTERNAL_HEADER);
+            // TODO: change to min_required version!
             Version.writeVersion(version, out);
             out.writeInt(id);
             clusterName.writeTo(out);
@@ -250,7 +251,7 @@ public class MulticastZenPing extends AbstractLifecycleComponent<ZenPing> implem
             if (responses == null) {
                 logger.warn("received ping response {} with no matching id [{}]", request.pingResponse, request.id);
             } else {
-                responses.put(request.pingResponse.target(), request.pingResponse);
+                responses.put(request.pingResponse.node(), request.pingResponse);
             }
             channel.sendResponse(TransportResponse.Empty.INSTANCE);
         }
@@ -433,7 +434,7 @@ public class MulticastZenPing extends AbstractLifecycleComponent<ZenPing> implem
             }
             final MulticastPingResponse multicastPingResponse = new MulticastPingResponse();
             multicastPingResponse.id = id;
-            multicastPingResponse.pingResponse = new PingResponse(discoveryNodes.localNode(), discoveryNodes.masterNode(), clusterName, contextProvider.isFirstClusterJoin());
+            multicastPingResponse.pingResponse = new PingResponse(discoveryNodes.localNode(), discoveryNodes.masterNode(), clusterName, contextProvider.nodeHasJoinedClusterOnce());
 
             if (logger.isTraceEnabled()) {
                 logger.trace("[{}] received ping_request from [{}], sending {}", id, requestingNode, multicastPingResponse.pingResponse);

--- a/src/main/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPing.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPing.java
@@ -258,7 +258,7 @@ public class UnicastZenPing extends AbstractLifecycleComponent<ZenPing> implemen
         for (PingResponse temporalResponse : temporalResponses) {
             // Only send pings to nodes that have the same cluster name.
             if (clusterName.equals(temporalResponse.clusterName())) {
-                nodesToPingSet.add(temporalResponse.target());
+                nodesToPingSet.add(temporalResponse.node());
             }
         }
 
@@ -374,28 +374,28 @@ public class UnicastZenPing extends AbstractLifecycleComponent<ZenPing> implemen
                 try {
                     DiscoveryNodes discoveryNodes = contextProvider.nodes();
                     for (PingResponse pingResponse : response.pingResponses) {
-                        if (pingResponse.target().id().equals(discoveryNodes.localNodeId())) {
+                        if (pingResponse.node().id().equals(discoveryNodes.localNodeId())) {
                             // that's us, ignore
                             continue;
                         }
                         if (!pingResponse.clusterName().equals(clusterName)) {
                             // not part of the cluster
-                            logger.debug("[{}] filtering out response from {}, not same cluster_name [{}]", id, pingResponse.target(), pingResponse.clusterName().value());
+                            logger.debug("[{}] filtering out response from {}, not same cluster_name [{}]", id, pingResponse.node(), pingResponse.clusterName().value());
                             continue;
                         }
                         ConcurrentMap<DiscoveryNode, PingResponse> responses = receivedResponses.get(response.id);
                         if (responses == null) {
                             logger.warn("received ping response {} with no matching id [{}]", pingResponse, response.id);
                         } else {
-                            PingResponse existingResponse = responses.get(pingResponse.target());
+                            PingResponse existingResponse = responses.get(pingResponse.node());
                             if (existingResponse == null) {
-                                responses.put(pingResponse.target(), pingResponse);
+                                responses.put(pingResponse.node(), pingResponse);
                             } else {
                                 // try and merge the best ping response for it, i.e. if the new one
                                 // doesn't have the master node set, and the existing one does, then
                                 // the existing one is better, so we keep it
                                 if (pingResponse.master() != null) {
-                                    responses.put(pingResponse.target(), pingResponse);
+                                    responses.put(pingResponse.node(), pingResponse);
                                 }
                             }
                         }
@@ -488,7 +488,7 @@ public class UnicastZenPing extends AbstractLifecycleComponent<ZenPing> implemen
     }
 
     private PingResponse createPingResponse(DiscoveryNodes discoNodes) {
-        return new PingResponse(discoNodes.localNode(), discoNodes.masterNode(), clusterName, contextProvider.isFirstClusterJoin());
+        return new PingResponse(discoNodes.localNode(), discoNodes.masterNode(), clusterName, contextProvider.nodeHasJoinedClusterOnce());
     }
 
     static class UnicastPingResponse extends TransportResponse {

--- a/src/test/java/org/elasticsearch/cluster/MinimumMasterNodesTests.java
+++ b/src/test/java/org/elasticsearch/cluster/MinimumMasterNodesTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Priority;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.discovery.DiscoverySettings;
 import org.elasticsearch.discovery.zen.elect.ElectMasterService;
@@ -39,7 +40,7 @@ import java.util.concurrent.TimeUnit;
 import static org.elasticsearch.client.Requests.clusterHealthRequest;
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 import static org.elasticsearch.test.ElasticsearchIntegrationTest.Scope;
-import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.*;
 
 @ClusterScope(scope = Scope.TEST, numDataNodes =0)
 public class MinimumMasterNodesTests extends ElasticsearchIntegrationTest {
@@ -234,8 +235,7 @@ public class MinimumMasterNodesTests extends ElasticsearchIntegrationTest {
         assertNoMasterBlockOnAllNodes();
 
         logger.info("--> start back the 2 nodes ");
-        internalCluster().startNode(settings);
-        internalCluster().startNode(settings);
+        String[] newNodes = internalCluster().startNodesAsync(2, settings).get().toArray(Strings.EMPTY_ARRAY);
 
         clusterHealthResponse = client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForNodes("4").execute().actionGet();
         assertThat(clusterHealthResponse.isTimedOut(), equalTo(false));
@@ -248,6 +248,8 @@ public class MinimumMasterNodesTests extends ElasticsearchIntegrationTest {
 
         state = client().admin().cluster().prepareState().execute().actionGet().getState();
         assertThat(state.nodes().size(), equalTo(4));
+        // we prefer to elect up and running nodes
+        assertThat(state.nodes().masterNodeId(), not(isOneOf(newNodes)));
 
         logger.info("--> verify we the data back");
         for (int i = 0; i < 10; i++) {

--- a/src/test/java/org/elasticsearch/cluster/MinimumMasterNodesTests.java
+++ b/src/test/java/org/elasticsearch/cluster/MinimumMasterNodesTests.java
@@ -201,8 +201,7 @@ public class MinimumMasterNodesTests extends ElasticsearchIntegrationTest {
         assertThat(state.blocks().hasGlobalBlock(DiscoverySettings.NO_MASTER_BLOCK_ID), equalTo(true));
 
         logger.info("--> start two more nodes");
-        internalCluster().startNode(settings);
-        internalCluster().startNode(settings);
+        internalCluster().startNodesAsync(2, settings).get();
 
         ClusterHealthResponse clusterHealthResponse = client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForNodes("4").execute().actionGet();
         assertThat(clusterHealthResponse.isTimedOut(), equalTo(false));

--- a/src/test/java/org/elasticsearch/discovery/DiscoveryWithServiceDisruptions.java
+++ b/src/test/java/org/elasticsearch/discovery/DiscoveryWithServiceDisruptions.java
@@ -167,7 +167,7 @@ public class DiscoveryWithServiceDisruptions extends ElasticsearchIntegrationTes
         for (ZenPingService pingService : internalCluster().getInstances(ZenPingService.class)) {
             for (ZenPing zenPing : pingService.zenPings()) {
                 if (zenPing instanceof UnicastZenPing) {
-                    ((UnicastZenPing) zenPing).clearTemporalReponses();
+                    ((UnicastZenPing) zenPing).clearTemporalResponses();
                 }
             }
         }
@@ -629,7 +629,7 @@ public class DiscoveryWithServiceDisruptions extends ElasticsearchIntegrationTes
         // includes all the other nodes that have pinged it and the issue doesn't manifest
         for (ZenPingService pingService : internalCluster().getInstances(ZenPingService.class)) {
             for (ZenPing zenPing : pingService.zenPings()) {
-                ((UnicastZenPing) zenPing).clearTemporalReponses();
+                ((UnicastZenPing) zenPing).clearTemporalResponses();
             }
         }
 
@@ -668,7 +668,7 @@ public class DiscoveryWithServiceDisruptions extends ElasticsearchIntegrationTes
         // includes all the other nodes that have pinged it and the issue doesn't manifest
         for (ZenPingService pingService : internalCluster().getInstances(ZenPingService.class)) {
             for (ZenPing zenPing : pingService.zenPings()) {
-                ((UnicastZenPing) zenPing).clearTemporalReponses();
+                ((UnicastZenPing) zenPing).clearTemporalResponses();
             }
         }
 

--- a/src/test/java/org/elasticsearch/discovery/zen/ping/multicast/MulticastZenPingTests.java
+++ b/src/test/java/org/elasticsearch/discovery/zen/ping/multicast/MulticastZenPingTests.java
@@ -85,8 +85,8 @@ public class MulticastZenPingTests extends ElasticsearchTestCase {
             }
 
             @Override
-            public boolean isFirstClusterJoin() {
-                return true;
+            public boolean nodeHasJoinedClusterOnce() {
+                return false;
             }
         });
         zenPingA.start();
@@ -104,8 +104,8 @@ public class MulticastZenPingTests extends ElasticsearchTestCase {
             }
 
             @Override
-            public boolean isFirstClusterJoin() {
-                return false;
+            public boolean nodeHasJoinedClusterOnce() {
+                return true;
             }
         });
         zenPingB.start();
@@ -114,14 +114,14 @@ public class MulticastZenPingTests extends ElasticsearchTestCase {
             logger.info("ping from A");
             ZenPing.PingResponse[] pingResponses = zenPingA.pingAndWait(TimeValue.timeValueSeconds(1));
             assertThat(pingResponses.length, equalTo(1));
-            assertThat(pingResponses[0].target().id(), equalTo("B"));
-            assertFalse(pingResponses[0].initialJoin());
+            assertThat(pingResponses[0].node().id(), equalTo("B"));
+            assertTrue(pingResponses[0].hasJoinedOnce());
 
             logger.info("ping from B");
             pingResponses = zenPingB.pingAndWait(TimeValue.timeValueSeconds(1));
             assertThat(pingResponses.length, equalTo(1));
-            assertThat(pingResponses[0].target().id(), equalTo("A"));
-            assertTrue(pingResponses[0].initialJoin());
+            assertThat(pingResponses[0].node().id(), equalTo("A"));
+            assertFalse(pingResponses[0].hasJoinedOnce());
 
         } finally {
             zenPingA.close();
@@ -155,7 +155,7 @@ public class MulticastZenPingTests extends ElasticsearchTestCase {
             }
 
             @Override
-            public boolean isFirstClusterJoin() {
+            public boolean nodeHasJoinedClusterOnce() {
                 return false;
             }
         });

--- a/src/test/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPingTests.java
+++ b/src/test/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPingTests.java
@@ -88,8 +88,8 @@ public class UnicastZenPingTests extends ElasticsearchTestCase {
             }
 
             @Override
-            public boolean isFirstClusterJoin() {
-                return true;
+            public boolean nodeHasJoinedClusterOnce() {
+                return false;
             }
         });
         zenPingA.start();
@@ -107,8 +107,8 @@ public class UnicastZenPingTests extends ElasticsearchTestCase {
             }
 
             @Override
-            public boolean isFirstClusterJoin() {
-                return false;
+            public boolean nodeHasJoinedClusterOnce() {
+                return true;
             }
         });
         zenPingB.start();
@@ -117,15 +117,15 @@ public class UnicastZenPingTests extends ElasticsearchTestCase {
             logger.info("ping from UZP_A");
             ZenPing.PingResponse[] pingResponses = zenPingA.pingAndWait(TimeValue.timeValueSeconds(1));
             assertThat(pingResponses.length, equalTo(1));
-            assertThat(pingResponses[0].target().id(), equalTo("UZP_B"));
-            assertFalse(pingResponses[0].initialJoin());
+            assertThat(pingResponses[0].node().id(), equalTo("UZP_B"));
+            assertTrue(pingResponses[0].hasJoinedOnce());
 
             // ping again, this time from B,
             logger.info("ping from UZP_B");
             pingResponses = zenPingB.pingAndWait(TimeValue.timeValueSeconds(1));
             assertThat(pingResponses.length, equalTo(1));
-            assertThat(pingResponses[0].target().id(), equalTo("UZP_A"));
-            assertTrue(pingResponses[0].initialJoin());
+            assertThat(pingResponses[0].node().id(), equalTo("UZP_A"));
+            assertFalse(pingResponses[0].hasJoinedOnce());
 
         } finally {
             zenPingA.close();

--- a/src/test/java/org/elasticsearch/test/cluster/NoopClusterService.java
+++ b/src/test/java/org/elasticsearch/test/cluster/NoopClusterService.java
@@ -34,8 +34,6 @@ import java.util.List;
 
 public class NoopClusterService implements ClusterService {
 
-    ClusterState state = null;
-
     @Override
     public DiscoveryNode localNode() {
         return null;
@@ -43,12 +41,7 @@ public class NoopClusterService implements ClusterService {
 
     @Override
     public ClusterState state() {
-        return state;
-    }
-
-    public NoopClusterService state(ClusterState state) {
-        this.state = state;
-        return this;
+        return null;
     }
 
     @Override

--- a/src/test/java/org/elasticsearch/test/cluster/NoopClusterService.java
+++ b/src/test/java/org/elasticsearch/test/cluster/NoopClusterService.java
@@ -34,6 +34,8 @@ import java.util.List;
 
 public class NoopClusterService implements ClusterService {
 
+    ClusterState state = null;
+
     @Override
     public DiscoveryNode localNode() {
         return null;
@@ -41,7 +43,12 @@ public class NoopClusterService implements ClusterService {
 
     @Override
     public ClusterState state() {
-        return null;
+        return state;
+    }
+
+    public NoopClusterService state(ClusterState state) {
+        this.state = state;
+        return this;
     }
 
     @Override


### PR DESCRIPTION
With the change in #7493 ,  we introduced a pinging round when a master nodes goes down. That pinging round helps validating the current state of the cluster and takes, by default, 3 seconds. It may be that during that window, a new node tries to join the cluster and starts pinging (this is typical when you quickly restart the current master).  If this node gets elected as the new master it will force recovery from the gateway (it has no in memory cluster state), which in turn will cause a full cluster shard synchronisation. While this is not a problem on it's own, it's a shame. This commit demotes "new" nodes during master election so the will only be elected if really needed.
