### PR TITLE
Transport: Remove parsing of port ranges

### DIFF
--- a/docs/reference/modules/discovery/zen.asciidoc
+++ b/docs/reference/modules/discovery/zen.asciidoc
@@ -56,8 +56,7 @@ as gossip routers. It provides the following settings with the
 |=======================================================================
 |Setting |Description
 |`hosts` |Either an array setting or a comma delimited setting. Each
-value is either in the form of `host:port`, or in the form of
-`host[port1-port2]`.
+value is in the form of `host:port`.
 |=======================================================================
 
 The unicast discovery uses the

--- a/src/main/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPing.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPing.java
@@ -62,8 +62,6 @@ public class UnicastZenPing extends AbstractLifecycleComponent<ZenPing> implemen
 
     public static final String ACTION_NAME = "internal:discovery/zen/unicast";
 
-    public static final int LIMIT_PORTS_COUNT = 1;
-
     private final ThreadPool threadPool;
     private final TransportService transportService;
     private final ClusterName clusterName;
@@ -111,11 +109,8 @@ public class UnicastZenPing extends AbstractLifecycleComponent<ZenPing> implemen
         int idCounter = 0;
         for (String host : hosts) {
             try {
-                TransportAddress[] addresses = transportService.addressesFromString(host);
-                // we only limit to 1 addresses, makes no sense to ping 100 ports
-                for (int i = 0; (i < addresses.length && i < LIMIT_PORTS_COUNT); i++) {
-                    configuredTargetNodes.add(new DiscoveryNode("#zen_unicast_" + (++idCounter) + "#", addresses[i], version.minimumCompatibilityVersion()));
-                }
+                TransportAddress address = transportService.addressFromString(host);
+                configuredTargetNodes.add(new DiscoveryNode("#zen_unicast_" + (++idCounter) + "#", address, version.minimumCompatibilityVersion()));
             } catch (Exception e) {
                 throw new ElasticsearchIllegalArgumentException("Failed to resolve address for [" + host + "]", e);
             }

--- a/src/main/java/org/elasticsearch/transport/Transport.java
+++ b/src/main/java/org/elasticsearch/transport/Transport.java
@@ -45,7 +45,7 @@ public interface Transport extends LifecycleComponent<Transport> {
     /**
      * Returns an address from its string representation.
      */
-    TransportAddress[] addressesFromString(String address) throws Exception;
+    TransportAddress addressFromString(String address) throws Exception;
 
     /**
      * Is the address type supported.

--- a/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -225,8 +225,8 @@ public class TransportService extends AbstractLifecycleComponent<TransportServic
         return requestIds.getAndIncrement();
     }
 
-    public TransportAddress[] addressesFromString(String address) throws Exception {
-        return transport.addressesFromString(address);
+    public TransportAddress addressFromString(String address) throws Exception {
+        return transport.addressFromString(address);
     }
 
     public void registerHandler(String action, TransportRequestHandler handler) {

--- a/src/main/java/org/elasticsearch/transport/local/LocalTransport.java
+++ b/src/main/java/org/elasticsearch/transport/local/LocalTransport.java
@@ -79,8 +79,8 @@ public class LocalTransport extends AbstractLifecycleComponent<Transport> implem
     }
 
     @Override
-    public TransportAddress[] addressesFromString(String address) {
-        return new TransportAddress[]{new LocalTransportAddress(address)};
+    public TransportAddress addressFromString(String address) {
+        return new LocalTransportAddress(address);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/transport/netty/NettyTransport.java
+++ b/src/main/java/org/elasticsearch/transport/netty/NettyTransport.java
@@ -427,34 +427,12 @@ public class NettyTransport extends AbstractLifecycleComponent<Transport> implem
     }
 
     @Override
-    public TransportAddress[] addressesFromString(String address) throws Exception {
-        int index = address.indexOf('[');
-        if (index != -1) {
-            String host = address.substring(0, index);
-            Set<String> ports = Strings.commaDelimitedListToSet(address.substring(index + 1, address.indexOf(']')));
-            List<TransportAddress> addresses = Lists.newArrayList();
-            for (String port : ports) {
-                int[] iPorts = new PortsRange(port).ports();
-                for (int iPort : iPorts) {
-                    addresses.add(new InetSocketTransportAddress(host, iPort));
-                }
-            }
-            return addresses.toArray(new TransportAddress[addresses.size()]);
-        } else {
-            index = address.lastIndexOf(':');
-            if (index == -1) {
-                List<TransportAddress> addresses = Lists.newArrayList();
-                int[] iPorts = new PortsRange(this.port).ports();
-                for (int iPort : iPorts) {
-                    addresses.add(new InetSocketTransportAddress(address, iPort));
-                }
-                return addresses.toArray(new TransportAddress[addresses.size()]);
-            } else {
-                String host = address.substring(0, index);
-                int port = Integer.parseInt(address.substring(index + 1));
-                return new TransportAddress[]{new InetSocketTransportAddress(host, port)};
-            }
+    public TransportAddress addressFromString(String address) throws Exception {
+        int index = address.lastIndexOf(':');
+        if (index == -1) {
+            return new InetSocketTransportAddress(address, Integer.parseInt(this.port));
         }
+        return new InetSocketTransportAddress(address.substring(0, index), Integer.parseInt(address.substring(index + 1)));
     }
 
     @Override

--- a/src/test/java/org/elasticsearch/client/transport/FailAndRetryMockTransport.java
+++ b/src/test/java/org/elasticsearch/client/transport/FailAndRetryMockTransport.java
@@ -126,7 +126,7 @@ abstract class FailAndRetryMockTransport<Response extends TransportResponse> imp
     }
 
     @Override
-    public TransportAddress[] addressesFromString(String address) throws Exception {
+    public TransportAddress addressFromString(String address) throws Exception {
         throw new UnsupportedOperationException();
     }
 

--- a/src/test/java/org/elasticsearch/test/transport/MockTransportService.java
+++ b/src/test/java/org/elasticsearch/test/transport/MockTransportService.java
@@ -332,8 +332,8 @@ public class MockTransportService extends TransportService {
         }
 
         @Override
-        public TransportAddress[] addressesFromString(String address) throws Exception {
-            return transport.addressesFromString(address);
+        public TransportAddress addressFromString(String address) throws Exception {
+            return transport.addressFromString(address);
         }
 
         @Override


### PR DESCRIPTION
UnicastZenDiscovery allowed you to specify port ranges for hosts to connect to.
However only the first port was used at all, when specifying something like
`host[9300-9400]`. This commit only accepts `host:port` pairs and thus makes
the configuration reflect the execution as even in the old setup only a single
host:port pair was pinged at all, as this was very expensive.

Note there is a coming PR for 1.x, which deprecates this setting and emits a warning instead of removing it.
