### PR TITLE
Transport: Deprecate parsing of port ranges

### DIFF
--- a/docs/reference/modules/discovery/zen.asciidoc
+++ b/docs/reference/modules/discovery/zen.asciidoc
@@ -56,8 +56,7 @@ as gossip routers. It provides the following settings with the
 |=======================================================================
 |Setting |Description
 |`hosts` |Either an array setting or a comma delimited setting. Each
-value is either in the form of `host:port`, or in the form of
-`host[port1-port2]`.
+value is in the form of `host:port`.
 |=======================================================================
 
 The unicast discovery uses the

--- a/src/main/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPing.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPing.java
@@ -113,6 +113,9 @@ public class UnicastZenPing extends AbstractLifecycleComponent<ZenPing> implemen
             try {
                 TransportAddress[] addresses = transportService.addressesFromString(host);
                 // we only limit to 1 addresses, makes no sense to ping 100 ports
+                if (addresses.length > LIMIT_PORTS_COUNT) {
+                    logger.warn("Using deprecated port range syntax for [{}], please specify concrete host:port pairs", host);
+                }
                 for (int i = 0; (i < addresses.length && i < LIMIT_PORTS_COUNT); i++) {
                     configuredTargetNodes.add(new DiscoveryNode("#zen_unicast_" + (++idCounter) + "#", addresses[i], version.minimumCompatibilityVersion()));
                 }


### PR DESCRIPTION
UnicastZenDiscovery allowed you to specify port ranges for hosts to connect to.
However only the first port was used at all, when specifying something like
`host[9300-9400]`. Updated also the documentation to remove this syntax.

This is the accompanying PR for 1.x, where the removal is done in #7561
