### PR TITLE
Clean up translog interface

### DIFF
--- a/src/main/java/org/elasticsearch/common/io/stream/NoopStreamOutput.java
+++ b/src/main/java/org/elasticsearch/common/io/stream/NoopStreamOutput.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.io.stream;
+
+import java.io.IOException;
+
+/**
+ * A non-threadsafe StreamOutput that doesn't actually write the bytes to any
+ * stream, it only keeps track of how many bytes have been written
+ */
+public final class NoopStreamOutput extends StreamOutput {
+
+    private int count = 0;
+
+    /** Retrieve the number of bytes that have been written */
+    public int getCount() {
+        return count;
+    }
+
+    @Override
+    public void writeByte(byte b) throws IOException {
+        count++;
+    }
+
+    @Override
+    public void writeBytes(byte[] b, int offset, int length) throws IOException {
+        count += length;
+    }
+
+    @Override
+    public void flush() throws IOException {
+        // no-op
+    }
+
+    @Override
+    public void close() throws IOException {
+        // nothing to close
+    }
+
+    @Override
+    public void reset() throws IOException {
+        count = 0;
+    }
+}

--- a/src/main/java/org/elasticsearch/index/translog/LegacyTranslogStream.java
+++ b/src/main/java/org/elasticsearch/index/translog/LegacyTranslogStream.java
@@ -19,11 +19,13 @@
 
 package org.elasticsearch.index.translog;
 
-import org.elasticsearch.common.io.stream.BytesStreamInput;
 import org.elasticsearch.common.io.stream.InputStreamStreamInput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.channels.FileChannel;
 
@@ -32,18 +34,7 @@ import java.nio.channels.FileChannel;
  */
 public class LegacyTranslogStream implements TranslogStream {
 
-    private final InputStreamStreamInput in;
-    private final boolean fileExists;
-
-    LegacyTranslogStream(InputStreamStreamInput in, boolean fileExists) {
-        this.in = in;
-        this.fileExists = fileExists;
-    }
-
-    public Translog.Operation read() throws IOException {
-        assert this.fileExists : "cannot read from a stream for a file that does not exist";
-        in.readInt(); // ignored operation size
-        return this.read(in);
+    LegacyTranslogStream() {
     }
 
     @Override
@@ -52,15 +43,6 @@ public class LegacyTranslogStream implements TranslogStream {
         Translog.Operation operation = TranslogStreams.newOperationFromType(type);
         operation.readFrom(in);
         return operation;
-    }
-
-    @Override
-    public Translog.Source readSource(byte[] data) throws IOException {
-        BytesStreamInput in = new BytesStreamInput(data, false);
-        in.readInt(); // the size header
-        Translog.Operation.Type type = Translog.Operation.Type.fromId(in.readByte());
-        Translog.Operation operation = TranslogStreams.newOperationFromType(type);
-        return operation.readSource(in);
     }
 
     @Override
@@ -76,7 +58,9 @@ public class LegacyTranslogStream implements TranslogStream {
     }
 
     @Override
-    public void close() throws IOException {
-        this.in.close();
+    public StreamInput openInput(File translogFile) throws FileNotFoundException {
+        // nothing to do, legacy translogs have no header
+        return new InputStreamStreamInput(new FileInputStream(translogFile));
     }
+
 }

--- a/src/main/java/org/elasticsearch/index/translog/Translog.java
+++ b/src/main/java/org/elasticsearch/index/translog/Translog.java
@@ -238,7 +238,7 @@ public interface Translog extends IndexShardComponent, CloseableIndexComponent, 
 
         long estimateSize();
 
-        Source readSource(StreamInput in) throws IOException;
+        Source getSource();
     }
 
     static class Source {
@@ -338,8 +338,7 @@ public interface Translog extends IndexShardComponent, CloseableIndexComponent, 
         }
 
         @Override
-        public Source readSource(StreamInput in) throws IOException {
-            readFrom(in);
+        public Source getSource() {
             return new Source(source, routing, parent, timestamp, ttl);
         }
 
@@ -481,8 +480,7 @@ public interface Translog extends IndexShardComponent, CloseableIndexComponent, 
         }
 
         @Override
-        public Source readSource(StreamInput in) throws IOException {
-            readFrom(in);
+        public Source getSource() {
             return new Source(source, routing, parent, timestamp, ttl);
         }
 
@@ -596,7 +594,7 @@ public interface Translog extends IndexShardComponent, CloseableIndexComponent, 
         }
 
         @Override
-        public Source readSource(StreamInput in) throws IOException {
+        public Source getSource(){
             throw new ElasticsearchIllegalStateException("trying to read doc source from delete operation");
         }
 
@@ -668,7 +666,7 @@ public interface Translog extends IndexShardComponent, CloseableIndexComponent, 
         }
 
         @Override
-        public Source readSource(StreamInput in) throws IOException {
+        public Source getSource() {
             throw new ElasticsearchIllegalStateException("trying to read doc source from delete_by_query operation");
         }
 

--- a/src/main/java/org/elasticsearch/index/translog/TranslogStream.java
+++ b/src/main/java/org/elasticsearch/index/translog/TranslogStream.java
@@ -22,7 +22,7 @@ package org.elasticsearch.index.translog;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
-import java.io.Closeable;
+import java.io.File;
 import java.io.IOException;
 import java.nio.channels.FileChannel;
 
@@ -30,24 +30,12 @@ import java.nio.channels.FileChannel;
  * A translog stream that will read and write operations in the
  * version-specific format
  */
-public interface TranslogStream extends Closeable {
-
-    /**
-     * Read the next operation from the translog file, the stream <b>must</b>
-     * have been created through {@link TranslogStreams#translogStreamFor(java.io.File)}
-     */
-    public Translog.Operation read() throws IOException;
+public interface TranslogStream {
 
     /**
      * Read the next translog operation from the input stream
      */
     public Translog.Operation read(StreamInput in) throws IOException;
-
-    /**
-     * Read a translog operation from the given byte array, returning the
-     * {@link Translog.Source} object from the Operation
-     */
-    public Translog.Source readSource(byte[] data) throws IOException;
 
     /**
      * Write the given translog operation to the output stream
@@ -61,7 +49,8 @@ public interface TranslogStream extends Closeable {
     public int writeHeader(FileChannel channel) throws IOException;
 
     /**
-     * Close the stream opened with {@link TranslogStreams#translogStreamFor(java.io.File)}
+     * Seek past the header, if any header is present
      */
-    public void close() throws IOException;
+    public StreamInput openInput(File translogFile) throws IOException;
+
 }

--- a/src/main/java/org/elasticsearch/index/translog/TruncatedTranslogException.java
+++ b/src/main/java/org/elasticsearch/index/translog/TruncatedTranslogException.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.translog;
+
+import java.io.IOException;
+
+public class TruncatedTranslogException extends IOException {
+    public TruncatedTranslogException(String msg) {
+        super(msg);
+    }
+
+    public TruncatedTranslogException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+}

--- a/src/main/java/org/elasticsearch/index/translog/fs/BufferingFsTranslogFile.java
+++ b/src/main/java/org/elasticsearch/index/translog/fs/BufferingFsTranslogFile.java
@@ -197,7 +197,6 @@ public class BufferingFsTranslogFile implements FsTranslogFile {
             if (!delete) {
                 try {
                     sync();
-                    translogStream.close();
                 } catch (Exception e) {
                     throw new TranslogException(shardId, "failed to sync on close", e);
                 }

--- a/src/main/java/org/elasticsearch/index/translog/fs/FsChannelSnapshot.java
+++ b/src/main/java/org/elasticsearch/index/translog/fs/FsChannelSnapshot.java
@@ -110,12 +110,11 @@ public class FsChannelSnapshot implements Translog.Snapshot {
             }
             assert bytesRead == 4;
             cacheBuffer.flip();
-            int opSize = cacheBuffer.getInt();
-            position += 4;
+            // Add an extra 4 to account for the operation size integer itself
+            int opSize = cacheBuffer.getInt() + 4;
             if ((position + opSize) > length) {
                 // the snapshot is acquired under a write lock. we should never
                 // read beyond the EOF, must be an abrupt EOF
-                position -= 4;
                 throw new EOFException("opSize of [" + opSize + "] pointed beyond EOF. position [" + position + "] length [" + length + "]");
             }
             if (cacheBuffer.capacity() < opSize) {

--- a/src/main/java/org/elasticsearch/index/translog/fs/SimpleFsTranslogFile.java
+++ b/src/main/java/org/elasticsearch/index/translog/fs/SimpleFsTranslogFile.java
@@ -105,7 +105,6 @@ public class SimpleFsTranslogFile implements FsTranslogFile {
             if (!delete) {
                 try {
                     sync();
-                    translogStream.close();
                 } catch (Exception e) {
                     throw new TranslogException(shardId, "failed to sync on close", e);
                 }

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoveryTranslogOperationsRequest.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoveryTranslogOperationsRequest.java
@@ -70,9 +70,9 @@ class RecoveryTranslogOperationsRequest extends TransportRequest {
         operations = Lists.newArrayListWithExpectedSize(size);
         for (int i = 0; i < size; i++) {
             if (in.getVersion().onOrAfter(Version.V_1_4_0)) {
-                operations.add(TranslogStreams.V1.read(in));
+                operations.add(TranslogStreams.CHECKSUMMED_TRANSLOG_STREAM.read(in));
             } else {
-                operations.add(TranslogStreams.V0.read(in));
+                operations.add(TranslogStreams.LEGACY_TRANSLOG_STREAM.read(in));
             }
 
         }
@@ -86,9 +86,9 @@ class RecoveryTranslogOperationsRequest extends TransportRequest {
         out.writeVInt(operations.size());
         for (Translog.Operation operation : operations) {
             if (out.getVersion().onOrAfter(Version.V_1_4_0)) {
-                TranslogStreams.V1.write(out, operation);
+                TranslogStreams.CHECKSUMMED_TRANSLOG_STREAM.write(out, operation);
             } else {
-                TranslogStreams.V0.write(out, operation);
+                TranslogStreams.LEGACY_TRANSLOG_STREAM.write(out, operation);
             }
         }
     }


### PR DESCRIPTION
This has two major parts:
- Simplifying the translog interface

Get rid of readSource() entirely, it sucked, Operations should be able
to provide the source themselves.

No more TranslogStream headers, you are now required to pass an
StreamInput or StreamOutput for all operations, which means no extra
state is needed and no need to construct new versions when detecting the
version.

The interface now exists of 2 main methods, and one helper:

``` java
// read
Translog.Operation read(StreamInput in)
// write
void write(StreamOutput out, Translog.Operation op)
// when reading a file, need to be able to read and consume the header
void seekPastHeader(StreamInput in)
```

---
- Read and write translog op sizes in TranslogStreams

Previously we handled these integers outside of the translog stream
itself, which was very unclean because other code had to know about
reading the size, or about writing the correct header sometimes.

There is some additional code in LocalIndexShardGateway to handle the
legacy case for older translogs, because we need to read and discard the
size in order to maintain the compatibility for the streaming
operations (they did not read or write the size for 1.3.x and earlier).

Additionally, we need to handle a case where the header is truncated
when recovering from disk, so added code for that.

---

I'm hoping this makes working with the translog easier and less error-prone. On top of this (in a separate PR) we can add the size-reading safety to prevent rare OOMEs on corrupted translogs.
