### PR TITLE
Make sure headers are handed over to internal requests and streamline versioning support

### DIFF
--- a/rest-api-spec/api/delete_script.json
+++ b/rest-api-spec/api/delete_script.json
@@ -16,6 +16,17 @@
           "description" : "Script language",
           "required" : true
         }
+      },
+      "params" : {
+        "version": {
+          "type": "number",
+          "description": "Explicit version number for concurrency control"
+        },
+        "version_type": {
+          "type": "enum",
+          "options": ["internal", "external", "external_gte", "force"],
+          "description": "Specific version type"
+        }
       }
     },
     "body": null

--- a/rest-api-spec/api/delete_template.json
+++ b/rest-api-spec/api/delete_template.json
@@ -12,6 +12,17 @@
         }
       }
     },
+    "params" : {
+      "version": {
+        "type": "number",
+        "description": "Explicit version number for concurrency control"
+      },
+      "version_type": {
+        "type": "enum",
+        "options": ["internal", "external", "external_gte", "force"],
+        "description": "Specific version type"
+      }
+    },
     "body": null
   }
 }

--- a/rest-api-spec/api/get_script.json
+++ b/rest-api-spec/api/get_script.json
@@ -16,6 +16,17 @@
           "description" : "Script language",
           "required" : true
         }
+      },
+      "params" : {
+        "version": {
+          "type": "number",
+            "description": "Explicit version number for concurrency control"
+          },
+        "version_type": {
+          "type": "enum",
+          "options": ["internal", "external", "external_gte", "force"],
+          "description": "Specific version type"
+        }
       }
     },
     "body": null

--- a/rest-api-spec/api/get_template.json
+++ b/rest-api-spec/api/get_template.json
@@ -11,11 +11,19 @@
           "description" : "Template ID",
           "required" : true
         }
+      },
+      "params" : {
+        "version": {
+          "type": "number",
+          "description": "Explicit version number for concurrency control"
+        },
+        "version_type": {
+          "type": "enum",
+          "options": ["internal", "external", "external_gte", "force"],
+          "description": "Specific version type"
+        }
       }
     },
-    "body": {
-      "description" : "The document",
-      "required" : false
-    }
+    "body": null
   }
 }

--- a/rest-api-spec/api/put_script.json
+++ b/rest-api-spec/api/put_script.json
@@ -16,6 +16,23 @@
           "description" : "Script language",
           "required" : true
         }
+      },
+      "params" : {
+        "op_type": {
+          "type" : "enum",
+          "options" : ["index", "create"],
+          "default" : "index",
+          "description" : "Explicit operation type"
+        },
+        "version": {
+          "type": "number",
+          "description": "Explicit version number for concurrency control"
+        },
+        "version_type": {
+          "type": "enum",
+          "options": ["internal", "external", "external_gte", "force"],
+          "description": "Specific version type"
+        }
       }
     },
     "body": {

--- a/rest-api-spec/api/put_template.json
+++ b/rest-api-spec/api/put_template.json
@@ -13,6 +13,23 @@
         }
       }
     },
+    "params" : {
+      "op_type": {
+        "type" : "enum",
+        "options" : ["index", "create"],
+        "default" : "index",
+        "description" : "Explicit operation type"
+      },
+      "version": {
+        "type": "number",
+        "description": "Explicit version number for concurrency control"
+      },
+      "version_type": {
+        "type": "enum",
+        "options": ["internal", "external", "external_gte", "force"],
+        "description": "Specific version type"
+      }
+    },
     "body": {
       "description" : "The document",
       "required" : true

--- a/rest-api-spec/test/script/20_versions.yaml
+++ b/rest-api-spec/test/script/20_versions.yaml
@@ -1,0 +1,112 @@
+---
+"External version":
+
+ - do:
+      put_script:
+          lang:           groovy
+          id:             1
+          body: { "script":  "_score * doc[\"myParent.weight\"].value" }
+          version_type:   external
+          version:        0
+
+ - match:   { _version: 0 }
+
+ - do:
+      put_script:
+          lang:           groovy
+          id:             1
+          body: { "script":  "_score * doc[\"myParent.weight\"].value" }
+          version_type:   external
+          version:        5
+
+ - match:   { _version: 5 }
+
+ - do:
+      catch:      conflict
+      get_script:
+          lang:   groovy
+          id:     1
+          version: 3
+
+ - do:
+      catch:      conflict
+      delete_script:
+          lang:   groovy
+          id:     1
+          version: 3
+
+ - do:
+      get_script:
+          lang:   groovy
+          id:     1
+          version: 5
+          version_type: external
+ - is_true: script
+
+ - do:
+      get_script:
+          lang:   groovy
+          id:     1
+          version: 5
+          version_type: external_gte
+ - is_true: script
+
+ - do:
+      catch:      conflict
+      get_script:
+          lang:   groovy
+          id:     1
+          version: 10
+          version_type: external_gte
+
+ - do:
+      catch:      conflict
+      delete_script:
+          lang:   groovy
+          id:     1
+          version: 3
+          version_type: external
+
+ - do:
+      get_script:
+          lang:   groovy
+          id:     1
+          version: 5
+          version_type: force
+ - is_true: script
+
+ - do:
+      get_script:
+          lang:   groovy
+          id:     1
+          version: 10
+          version_type: force
+ - is_true: script
+
+ - do:
+      catch:             conflict
+      put_script:
+          lang:           groovy
+          id:             1
+          body: { "script":  "_score * doc[\"myParent.weight\"].value" }
+          version_type:   external
+          version:        5
+
+ - do:
+      catch:             conflict
+      put_script:
+          lang:           groovy
+          id:             1
+          body: { "script":  "_score * doc[\"myParent.weight\"].value" }
+          version_type:   external
+          version:        0
+
+ - do:
+      put_script:
+          lang:           groovy
+          id:             1
+          body: { "script":  "_score * doc[\"myParent.weight\"].value" }
+          version_type:   external
+          version:        6
+
+ - match:   { _version: 6}

--- a/src/main/java/org/elasticsearch/action/delete/DeleteRequest.java
+++ b/src/main/java/org/elasticsearch/action/delete/DeleteRequest.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.action.delete;
 
+import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.replication.ShardReplicationOperationRequest;
 import org.elasticsearch.common.Nullable;
@@ -84,6 +85,14 @@ public class DeleteRequest extends ShardReplicationOperationRequest<DeleteReques
     }
 
     public DeleteRequest() {
+    }
+
+    /**
+     * Creates a delete request caused by some other request, which is provided as an
+     * argument so that its headers and context can be copied to the new request
+     */
+    public DeleteRequest(ActionRequest request) {
+        super(request);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/index/IndexRequest.java
+++ b/src/main/java/org/elasticsearch/action/index/IndexRequest.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.index;
 
 import com.google.common.base.Charsets;
 import org.elasticsearch.*;
+import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.RoutingMissingException;
 import org.elasticsearch.action.TimestampParsingException;
@@ -149,6 +150,14 @@ public class IndexRequest extends ShardReplicationOperationRequest<IndexRequest>
     private XContentType contentType = Requests.INDEX_CONTENT_TYPE;
 
     public IndexRequest() {
+    }
+
+    /**
+     * Creates an index request caused by some other request, which is provided as an
+     * argument so that its headers and context can be copied to the new request
+     */
+    public IndexRequest(ActionRequest request) {
+        super(request);
     }
 
     /**

--- a/src/main/java/org/elasticsearch/action/indexedscripts/delete/TransportDeleteIndexedScriptAction.java
+++ b/src/main/java/org/elasticsearch/action/indexedscripts/delete/TransportDeleteIndexedScriptAction.java
@@ -20,11 +20,10 @@
 package org.elasticsearch.action.indexedscripts.delete;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.DelegatingActionListener;
-import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.support.HandledTransportAction;
-import org.elasticsearch.client.Client;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.script.ScriptService;
@@ -37,14 +36,12 @@ import org.elasticsearch.transport.TransportService;
 public class TransportDeleteIndexedScriptAction extends HandledTransportAction<DeleteIndexedScriptRequest,  DeleteIndexedScriptResponse> {
 
     private final ScriptService scriptService;
-    private final Client client;
 
     @Inject
     public TransportDeleteIndexedScriptAction(Settings settings, ThreadPool threadPool, ScriptService scriptService,
-                                              Client client, TransportService transportService, ActionFilters actionFilters) {
+                                              TransportService transportService, ActionFilters actionFilters) {
         super(settings, DeleteIndexedScriptAction.NAME, threadPool, transportService, actionFilters);
         this.scriptService = scriptService;
-        this.client = client;
     }
 
     @Override
@@ -54,10 +51,10 @@ public class TransportDeleteIndexedScriptAction extends HandledTransportAction<D
 
     @Override
     protected void doExecute(final DeleteIndexedScriptRequest request, final ActionListener<DeleteIndexedScriptResponse> listener) {
-        scriptService.deleteScriptFromIndex(client, request.scriptLang(), request.id(), request.version(), new DelegatingActionListener<DeleteResponse, DeleteIndexedScriptResponse>(listener) {
+        scriptService.deleteScriptFromIndex(request, new DelegatingActionListener<DeleteResponse, DeleteIndexedScriptResponse>(listener) {
             @Override
             public DeleteIndexedScriptResponse getDelegatedFromInstigator(DeleteResponse deleteResponse){
-                return new DeleteIndexedScriptResponse(deleteResponse.getIndex(),deleteResponse.getType(),deleteResponse.getType(),deleteResponse.getVersion(), deleteResponse.isFound());
+                return new DeleteIndexedScriptResponse(deleteResponse.getIndex(), deleteResponse.getType(), deleteResponse.getId(), deleteResponse.getVersion(), deleteResponse.isFound());
             }
         });
     }

--- a/src/main/java/org/elasticsearch/action/indexedscripts/get/TransportGetIndexedScriptAction.java
+++ b/src/main/java/org/elasticsearch/action/indexedscripts/get/TransportGetIndexedScriptAction.java
@@ -23,7 +23,6 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
-import org.elasticsearch.client.Client;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.script.ScriptService;
@@ -36,14 +35,12 @@ import org.elasticsearch.transport.TransportService;
 public class TransportGetIndexedScriptAction extends HandledTransportAction<GetIndexedScriptRequest, GetIndexedScriptResponse> {
 
     private final ScriptService scriptService;
-    private final Client client;
 
     @Inject
     public TransportGetIndexedScriptAction(Settings settings, ThreadPool threadPool, ScriptService scriptService,
-                                           TransportService transportService, Client client, ActionFilters actionFilters) {
+                                           TransportService transportService, ActionFilters actionFilters) {
         super(settings, GetIndexedScriptAction.NAME, threadPool,transportService,  actionFilters);
         this.scriptService = scriptService;
-        this.client = client;
     }
 
     @Override
@@ -53,7 +50,7 @@ public class TransportGetIndexedScriptAction extends HandledTransportAction<GetI
 
     @Override
     public void doExecute(GetIndexedScriptRequest request, ActionListener<GetIndexedScriptResponse> listener){
-        GetResponse scriptResponse = scriptService.queryScriptIndex(client, request.scriptLang(), request.id(), request.version(), request.versionType());
+        GetResponse scriptResponse = scriptService.queryScriptIndex(request);
         listener.onResponse(new GetIndexedScriptResponse(scriptResponse));
     }
 }

--- a/src/main/java/org/elasticsearch/action/indexedscripts/put/TransportPutIndexedScriptAction.java
+++ b/src/main/java/org/elasticsearch/action/indexedscripts/put/TransportPutIndexedScriptAction.java
@@ -24,7 +24,6 @@ import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.DelegatingActionListener;
 import org.elasticsearch.action.support.HandledTransportAction;
-import org.elasticsearch.client.Client;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.script.ScriptService;
@@ -37,14 +36,11 @@ import org.elasticsearch.transport.TransportService;
 public class TransportPutIndexedScriptAction extends HandledTransportAction<PutIndexedScriptRequest, PutIndexedScriptResponse> {
 
     private final ScriptService scriptService;
-    private final Client client;
 
     @Inject
     public TransportPutIndexedScriptAction(Settings settings, ThreadPool threadPool,
-                                           ScriptService scriptService, Client client,
-                                           TransportService transportService, ActionFilters actionFilters) {
+                                           ScriptService scriptService, TransportService transportService, ActionFilters actionFilters) {
         super(settings, PutIndexedScriptAction.NAME, threadPool, transportService, actionFilters);
-        this.client = client;
         this.scriptService = scriptService;
     }
 
@@ -55,12 +51,11 @@ public class TransportPutIndexedScriptAction extends HandledTransportAction<PutI
 
     @Override
     protected void doExecute(final PutIndexedScriptRequest request, final ActionListener<PutIndexedScriptResponse> listener) {
-        scriptService.putScriptToIndex(client, request.safeSource(), request.scriptLang(), request.id(), null, request.opType().toString(), request.version(), request.versionType(), new DelegatingActionListener<IndexResponse,PutIndexedScriptResponse>(listener) {
+        scriptService.putScriptToIndex(request, new DelegatingActionListener<IndexResponse,PutIndexedScriptResponse>(listener) {
             @Override
             public PutIndexedScriptResponse getDelegatedFromInstigator(IndexResponse indexResponse){
                 return new PutIndexedScriptResponse(indexResponse.getType(),indexResponse.getId(),indexResponse.getVersion(),indexResponse.isCreated());
             }
         });
     }
-
 }

--- a/src/main/java/org/elasticsearch/rest/action/script/RestDeleteIndexedScriptAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/script/RestDeleteIndexedScriptAction.java
@@ -18,17 +18,16 @@
  */
 package org.elasticsearch.rest.action.script;
 
-import org.elasticsearch.action.delete.DeleteRequest;
-import org.elasticsearch.action.delete.DeleteResponse;
+import org.elasticsearch.action.indexedscripts.delete.DeleteIndexedScriptRequest;
+import org.elasticsearch.action.indexedscripts.delete.DeleteIndexedScriptResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.lucene.uid.Versions;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentBuilderString;
+import org.elasticsearch.index.VersionType;
 import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.RestBuilderListener;
-import org.elasticsearch.script.ScriptService;
 
 import static org.elasticsearch.rest.RestRequest.Method.DELETE;
 import static org.elasticsearch.rest.RestStatus.NOT_FOUND;
@@ -36,24 +35,28 @@ import static org.elasticsearch.rest.RestStatus.OK;
 
 public class RestDeleteIndexedScriptAction extends BaseRestHandler {
 
-    private ScriptService scriptService;
-
     @Inject
-    public RestDeleteIndexedScriptAction(Settings settings, Client client,
-                                         ScriptService scriptService, RestController controller) {
+    public RestDeleteIndexedScriptAction(Settings settings, Client client, RestController controller) {
         super(settings, client);
         controller.registerHandler(DELETE, "/_scripts/{lang}/{id}", this);
-        this.scriptService = scriptService;
+    }
+
+    protected RestDeleteIndexedScriptAction(Settings settings, Client client) {
+        super(settings, client);
+    }
+
+    protected String getScriptLang(RestRequest request) {
+        return request.param("lang");
     }
 
     @Override
     public void handleRequest(final RestRequest request, final RestChannel channel, Client client) {
-
-        final String id = request.param("id");
-        final long version = request.paramAsLong("version", Versions.MATCH_ANY);
-        scriptService.deleteScriptFromIndex(client,request.param("lang"), id, version, new RestBuilderListener<DeleteResponse>(channel) {
+        DeleteIndexedScriptRequest deleteIndexedScriptRequest = new DeleteIndexedScriptRequest(getScriptLang(request), request.param("id"));
+        deleteIndexedScriptRequest.version(request.paramAsLong("version", deleteIndexedScriptRequest.version()));
+        deleteIndexedScriptRequest.versionType(VersionType.fromString(request.param("version_type"), deleteIndexedScriptRequest.versionType()));
+        client.deleteIndexedScript(deleteIndexedScriptRequest, new RestBuilderListener<DeleteIndexedScriptResponse>(channel) {
             @Override
-            public RestResponse buildResponse(DeleteResponse result, XContentBuilder builder) throws Exception {
+            public RestResponse buildResponse(DeleteIndexedScriptResponse result, XContentBuilder builder) throws Exception {
                 builder.startObject()
                         .field(Fields.FOUND, result.isFound())
                         .field(Fields._INDEX, result.getIndex())
@@ -77,6 +80,4 @@ public class RestDeleteIndexedScriptAction extends BaseRestHandler {
         static final XContentBuilderString _ID = new XContentBuilderString("_id");
         static final XContentBuilderString _VERSION = new XContentBuilderString("_version");
     }
-
-
 }

--- a/src/main/java/org/elasticsearch/rest/action/template/RestDeleteSearchTemplateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/template/RestDeleteSearchTemplateAction.java
@@ -18,63 +18,25 @@
  */
 package org.elasticsearch.rest.action.template;
 
-import org.elasticsearch.action.delete.DeleteRequest;
-import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.lucene.uid.Versions;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentBuilderString;
-import org.elasticsearch.rest.*;
-import org.elasticsearch.rest.action.support.RestBuilderListener;
-import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.script.RestDeleteIndexedScriptAction;
 
 import static org.elasticsearch.rest.RestRequest.Method.DELETE;
-import static org.elasticsearch.rest.RestStatus.OK;
-import static org.elasticsearch.rest.RestStatus.NOT_FOUND;
 
-public class RestDeleteSearchTemplateAction extends BaseRestHandler {
-
-    private ScriptService scriptService;
+public class RestDeleteSearchTemplateAction extends RestDeleteIndexedScriptAction {
 
     @Inject
-    public RestDeleteSearchTemplateAction(Settings settings, Client client, RestController controller, ScriptService scriptService) {
+    public RestDeleteSearchTemplateAction(Settings settings, Client client, RestController controller) {
         super(settings, client);
         controller.registerHandler(DELETE, "/_search/template/{id}", this);
-        this.scriptService = scriptService;
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel, Client client) {
-        final String id = request.param("id");
-        final long version = request.paramAsLong("version", Versions.MATCH_ANY);
-        scriptService.deleteScriptFromIndex(client,"mustache", id, version, new RestBuilderListener<DeleteResponse>(channel) {
-            @Override
-            public RestResponse buildResponse(DeleteResponse result, XContentBuilder builder) throws Exception {
-                builder.startObject()
-                        .field(Fields.FOUND, result.isFound())
-                        .field(Fields._INDEX, result.getIndex())
-                        .field(Fields._TYPE, result.getType())
-                        .field(Fields._ID, result.getId())
-                        .field(Fields._VERSION, result.getVersion())
-                        .endObject();
-                RestStatus status = OK;
-                if (!result.isFound()) {
-                    status = NOT_FOUND;
-                }
-                return new BytesRestResponse(status, builder);
-            }
-        });
+    protected String getScriptLang(RestRequest request) {
+        return "mustache";
     }
-
-    static final class Fields {
-        static final XContentBuilderString FOUND = new XContentBuilderString("found");
-        static final XContentBuilderString _INDEX = new XContentBuilderString("_index");
-        static final XContentBuilderString _TYPE = new XContentBuilderString("_type");
-        static final XContentBuilderString _ID = new XContentBuilderString("_id");
-        static final XContentBuilderString _VERSION = new XContentBuilderString("_version");
-    }
-
-
 }

--- a/src/main/java/org/elasticsearch/rest/action/template/RestGetSearchTemplateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/template/RestGetSearchTemplateAction.java
@@ -18,28 +18,19 @@
  */
 package org.elasticsearch.rest.action.template;
 
-import org.elasticsearch.ElasticsearchIllegalStateException;
-import org.elasticsearch.action.indexedscripts.get.GetIndexedScriptRequest;
-import org.elasticsearch.action.indexedscripts.get.GetIndexedScriptResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentFactory;
-import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.rest.*;
-import org.elasticsearch.rest.action.support.RestResponseListener;
-
-import java.io.IOException;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.script.RestGetIndexedScriptAction;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
-import static org.elasticsearch.rest.RestStatus.NOT_FOUND;
-import static org.elasticsearch.rest.RestStatus.OK;
 
 /**
  *
  */
-public class RestGetSearchTemplateAction extends BaseRestHandler {
+public class RestGetSearchTemplateAction extends RestGetIndexedScriptAction {
 
     @Inject
     public RestGetSearchTemplateAction(Settings settings, Client client, RestController controller) {
@@ -48,27 +39,12 @@ public class RestGetSearchTemplateAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel, Client client) {
-        final GetIndexedScriptRequest getRequest = new GetIndexedScriptRequest("mustache", request.param("id"));
-        RestResponseListener<GetIndexedScriptResponse> responseListener = new RestResponseListener<GetIndexedScriptResponse>(channel) {
-            @Override
-            public RestResponse buildResponse(GetIndexedScriptResponse response) throws Exception {
-                XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
-                if (!response.isExists()) {
-                    return new BytesRestResponse(NOT_FOUND, builder);
-                } else {
-                    try{
-                        String templateString = response.getScript();
-                        builder.startObject();
-                        builder.field("template",templateString);
-                        builder.endObject();
-                        return new BytesRestResponse(OK, builder);
-                    } catch( IOException|ClassCastException e ){
-                        throw new ElasticsearchIllegalStateException("Unable to parse "  + response.getScript() + " as json",e);
-                    }
-                }
-            }
-        };
-        client.getIndexedScript(getRequest, responseListener);
+    protected String getScriptLang(RestRequest request) {
+        return "mustache";
+    }
+
+    @Override
+    protected String getScriptFieldName() {
+        return "template";
     }
 }


### PR DESCRIPTION
The get, put and delete indexed script apis map to get, index and delete api and internally create those corresponding requests. We need to make sure that the original headers are handed over to the new request by passing the original request in the constructor when creating the new one.

Also streamlined the support for version and version_type in the REST layer since the parameters were not consistently parsed and set to the internal java API requests. Unified the Rest actions code to make sure that the same parameters are supported in both scripts and templates actions.

Modified the REST delete template and delete script actions to make use of a client instead of using the `ScriptService` directly.

Removed injected client from transport actions as script service has already its own, no need to pass another one in.
