### PR TITLE
Change the default cache filter impl from FixedBitSet to WAH8DocIdSet

### DIFF
--- a/docs/reference/index-modules/cache.asciidoc
+++ b/docs/reference/index-modules/cache.asciidoc
@@ -24,10 +24,10 @@ when a cache becomes full, the least recently used data is evicted to
 make way for new data.
 
 The setting that allows one to control the memory size for the filter
-cache is `indices.cache.filter.size`, which defaults to `10%`. *Note*,
+cache is `indices.cache.filter.size`, which defaults to `5%`. *Note*,
 this is *not* an index level setting but a node level setting (can be
 configured in the node configuration).
 
 `indices.cache.filter.size` can accept either a percentage value, like
-`30%`, or an exact value, like `512mb`.
+`10%`, or an exact value, like `512mb`.
 

--- a/src/main/java/org/elasticsearch/common/lucene/docset/AndDocIdSet.java
+++ b/src/main/java/org/elasticsearch/common/lucene/docset/AndDocIdSet.java
@@ -77,7 +77,7 @@ public class AndDocIdSet extends DocIdSet {
         List<DocIdSet> iterators = new ArrayList<>(sets.length);
         List<Bits> bits = new ArrayList<>(sets.length);
         for (DocIdSet set : sets) {
-            if (DocIdSets.isFastIterator(set)) {
+            if (DocIdSets.hasFasterIteratorThanRandomAccess(set)) {
                 iterators.add(set);
             } else {
                 Bits bit = set.bits();

--- a/src/main/java/org/elasticsearch/common/lucene/search/ApplyAcceptedDocsFilter.java
+++ b/src/main/java/org/elasticsearch/common/lucene/search/ApplyAcceptedDocsFilter.java
@@ -107,7 +107,7 @@ public class ApplyAcceptedDocsFilter extends Filter {
 
         @Override
         public DocIdSetIterator iterator() throws IOException {
-            if (!DocIdSets.isFastIterator(innerSet) && liveDocs instanceof FixedBitSet) {
+            if (!DocIdSets.hasFasterIteratorThanRandomAccess(innerSet) && liveDocs instanceof FixedBitSet) {
                 // might as well iterate over the live docs..., since the iterator is not fast enough
                 // but we can only do that if we have Bits..., in short, we reverse the order...
                 Bits bits = innerSet.bits();

--- a/src/main/java/org/elasticsearch/common/lucene/search/XBooleanFilter.java
+++ b/src/main/java/org/elasticsearch/common/lucene/search/XBooleanFilter.java
@@ -101,7 +101,7 @@ public class XBooleanFilter extends Filter implements Iterable<FilterClause> {
                 }
             }
             Bits bits = null;
-            if (!DocIdSets.isFastIterator(set)) {
+            if (!DocIdSets.hasFasterIteratorThanRandomAccess(set)) {
                 bits = set.bits();
             }
             results.add(new ResultClause(set, bits, clause));

--- a/src/main/java/org/elasticsearch/common/lucene/search/XFilteredQuery.java
+++ b/src/main/java/org/elasticsearch/common/lucene/search/XFilteredQuery.java
@@ -225,7 +225,7 @@ public final class XFilteredQuery extends Query {
             // CHANGE: handle "default" value
             if (threshold == -1) {
                 // default  value, don't iterate on only apply filter after query if its not a "fast" docIdSet
-                if (!DocIdSets.isFastIterator(ApplyAcceptedDocsFilter.unwrap(docIdSet))) {
+                if (!DocIdSets.hasFasterIteratorThanRandomAccess(ApplyAcceptedDocsFilter.unwrap(docIdSet))) {
                     return FilteredQuery.QUERY_FIRST_FILTER_STRATEGY.filteredScorer(context, weight, docIdSet);
                 }
             }

--- a/src/main/java/org/elasticsearch/index/cache/filter/FilterCache.java
+++ b/src/main/java/org/elasticsearch/index/cache/filter/FilterCache.java
@@ -42,8 +42,6 @@ public interface FilterCache extends IndexComponent, CloseableComponent {
     // we need to "inject" the index service to not create cyclic dep
     void setIndexService(IndexService indexService);
 
-    String type();
-
     Filter cache(Filter filterToCache);
 
     void clear(Object reader);

--- a/src/main/java/org/elasticsearch/index/cache/filter/none/NoneFilterCache.java
+++ b/src/main/java/org/elasticsearch/index/cache/filter/none/NoneFilterCache.java
@@ -45,11 +45,6 @@ public class NoneFilterCache extends AbstractIndexComponent implements FilterCac
     }
 
     @Override
-    public String type() {
-        return "none";
-    }
-
-    @Override
     public void close() {
         // nothing to do here
     }

--- a/src/main/java/org/elasticsearch/indices/cache/filter/IndicesFilterCache.java
+++ b/src/main/java/org/elasticsearch/indices/cache/filter/IndicesFilterCache.java
@@ -91,7 +91,7 @@ public class IndicesFilterCache extends AbstractComponent implements RemovalList
     public IndicesFilterCache(Settings settings, ThreadPool threadPool, NodeSettingsService nodeSettingsService) {
         super(settings);
         this.threadPool = threadPool;
-        this.size = componentSettings.get("size", "10%");
+        this.size = componentSettings.get("size", "5%");
         this.expire = componentSettings.getAsTime("expire", null);
         this.cleanInterval = componentSettings.getAsTime("clean_interval", TimeValue.timeValueSeconds(60));
         computeSizeInBytes();


### PR DESCRIPTION
A few months ago, Lucene switched from FixedBitSet to WAH8DocIdSet in order
to cache filters. WAH8DocIdSet is especially better when dealing with sparse
sets: iteration is faster, memory usage is lower and there is an index that
helps keep advance fast.

This doesn't break existing code since #6280 already made sure that there was no
abusive cast from DocIdSet to Bits or FixedBitSet and #7037 moved consumers of
the filter cache that absolutely need to get fixed bitsets to their own cache.

Since cached filters will be more memory-efficient, the filter cache size has
been decreased from 10 to 5%. Although smaller, this might still allow to cache
more filters.
