### PR TITLE
Make .zip and .tar.gz release artifacts contain same files

### DIFF
--- a/src/main/assemblies/common-bin.xml
+++ b/src/main/assemblies/common-bin.xml
@@ -28,6 +28,46 @@
                 <include>*</include>
             </includes>
         </fileSet>
+        <fileSet>
+            <filtered>true</filtered>
+            <directory>bin</directory>
+            <outputDirectory>bin</outputDirectory>
+            <lineEnding>dos</lineEnding>
+            <includes>
+                <include>elasticsearch.bat</include>
+                <include>plugin.bat</include>
+                <include>service.bat</include>
+            </includes>
+        </fileSet>
+        <fileSet>
+            <filtered>false</filtered>
+            <directory>bin</directory>
+            <outputDirectory>bin</outputDirectory>
+            <includes>
+                <include>*.exe</include>
+            </includes>
+        </fileSet>
+        <fileSet>
+            <filtered>true</filtered>
+            <directory>bin</directory>
+            <outputDirectory>bin</outputDirectory>
+            <fileMode>0755</fileMode>
+            <directoryMode>0755</directoryMode>
+            <lineEnding>unix</lineEnding>
+            <includes>
+                <include>elasticsearch.in.sh</include>
+                <include>elasticsearch</include>
+                <include>plugin</include>
+            </includes>
+        </fileSet>
+
+        <fileSet>
+            <directory>lib/sigar</directory>
+            <outputDirectory>lib/sigar</outputDirectory>
+            <includes>
+                <include>*</include>
+            </includes>
+        </fileSet>
     </fileSets>
     <files>
         <file>

--- a/src/main/assemblies/targz-bin.xml
+++ b/src/main/assemblies/targz-bin.xml
@@ -7,31 +7,6 @@
 
     <includeBaseDirectory>true</includeBaseDirectory>
 
-    <fileSets>
-        <fileSet>
-            <directory>bin</directory>
-            <outputDirectory>bin</outputDirectory>
-            <fileMode>0755</fileMode>
-            <directoryMode>0755</directoryMode>
-            <lineEnding>unix</lineEnding>
-            <filtered>true</filtered>
-            <includes>
-                <include>elasticsearch.in.sh</include>
-                <include>elasticsearch</include>
-                <include>plugin</include>
-            </includes>
-        </fileSet>
-
-        <fileSet>
-            <directory>lib/sigar</directory>
-            <outputDirectory>lib/sigar</outputDirectory>
-            <excludes>
-                <exclude>*.dll</exclude>
-                <exclude>**winnt**</exclude>
-            </excludes>
-        </fileSet>
-    </fileSets>
-
     <componentDescriptors>
         <componentDescriptor>src/main/assemblies/common-bin.xml</componentDescriptor>
     </componentDescriptors>

--- a/src/main/assemblies/zip-bin.xml
+++ b/src/main/assemblies/zip-bin.xml
@@ -7,49 +7,6 @@
 
     <includeBaseDirectory>true</includeBaseDirectory>
 
-    <fileSets>
-        <fileSet>
-            <filtered>true</filtered>
-            <directory>bin</directory>
-            <outputDirectory>bin</outputDirectory>
-            <lineEnding>dos</lineEnding>
-            <includes>
-                <include>elasticsearch.bat</include>
-                <include>plugin.bat</include>
-                <include>service.bat</include>
-            </includes>
-        </fileSet>
-        <fileSet>
-            <filtered>false</filtered>
-            <directory>bin</directory>
-            <outputDirectory>bin</outputDirectory>
-            <includes>
-                <include>*.exe</include>
-            </includes>
-        </fileSet>
-        <fileSet>
-            <filtered>true</filtered>
-            <directory>bin</directory>
-            <outputDirectory>bin</outputDirectory>
-            <fileMode>0755</fileMode>
-            <directoryMode>0755</directoryMode>
-            <lineEnding>unix</lineEnding>
-            <includes>
-                <include>elasticsearch.in.sh</include>
-                <include>elasticsearch</include>
-                <include>plugin</include>
-            </includes>
-        </fileSet>
-
-        <fileSet>
-            <directory>lib/sigar</directory>
-            <outputDirectory>lib/sigar</outputDirectory>
-            <includes>
-                <include>*</include>
-            </includes>
-        </fileSet>
-    </fileSets>
-
     <componentDescriptors>
         <componentDescriptor>src/main/assemblies/common-bin.xml</componentDescriptor>
     </componentDescriptors>


### PR DESCRIPTION
This commit changes the build to include .exe and sigar/.dll files in
both the zip and tar artifacts.

Closes #2793
