### PR TITLE
Core: Do not cache term filters by default.

### DIFF
--- a/docs/reference/query-dsl/filters/term-filter.asciidoc
+++ b/docs/reference/query-dsl/filters/term-filter.asciidoc
@@ -20,8 +20,10 @@ accept a filter, for example:
 [float]
 ==== Caching
 
-The result of the filter is automatically cached by default. The
-`_cache` can be set to `false` to turn it off. Here is an example:
+coming[1.4.0,Before 1.4.0 caching was on by default]
+
+Term filters are not cached by default. The `_cache` can be set to `true` to
+turn it on. Here is an example:
 
 [source,js]
 --------------------------------------------------
@@ -30,7 +32,7 @@ The result of the filter is automatically cached by default. The
         "filter" : {
             "term" : { 
                 "user" : "kimchy",
-                "_cache" : false
+                "_cache" : true
             }
         }
     }

--- a/src/main/java/org/elasticsearch/index/query/TermFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TermFilterParser.java
@@ -52,7 +52,7 @@ public class TermFilterParser implements FilterParser {
     public Filter parse(QueryParseContext parseContext) throws IOException, QueryParsingException {
         XContentParser parser = parseContext.parser();
 
-        boolean cache = true; // since usually term filter is on repeating terms, cache it by default
+        boolean cache = false; // term filters are already very fast, don't cache by default
         CacheKeyFilter.Key cacheKey = null;
         String fieldName = null;
         Object value = null;

--- a/src/test/java/org/elasticsearch/index/aliases/IndexAliasesServiceTests.java
+++ b/src/test/java/org/elasticsearch/index/aliases/IndexAliasesServiceTests.java
@@ -66,8 +66,8 @@ public class IndexAliasesServiceTests extends ElasticsearchSingleNodeTest {
         assertThat(indexAliasesService.hasAlias("dogs"), equalTo(true));
         assertThat(indexAliasesService.hasAlias("turtles"), equalTo(false));
 
-        assertThat(indexAliasesService.aliasFilter("cats").toString(), equalTo("cache(animal:cat)"));
-        assertThat(indexAliasesService.aliasFilter("cats", "dogs").toString(), equalTo("BooleanFilter(cache(animal:cat) cache(animal:dog))"));
+        assertThat(indexAliasesService.aliasFilter("cats").toString(), equalTo("animal:cat"));
+        assertThat(indexAliasesService.aliasFilter("cats", "dogs").toString(), equalTo("BooleanFilter(animal:cat animal:dog)"));
 
         // Non-filtering alias should turn off all filters because filters are ORed
         assertThat(indexAliasesService.aliasFilter("all"), nullValue());
@@ -76,7 +76,7 @@ public class IndexAliasesServiceTests extends ElasticsearchSingleNodeTest {
 
         indexAliasesService.add("cats", filter(termFilter("animal", "feline")));
         indexAliasesService.add("dogs", filter(termFilter("animal", "canine")));
-        assertThat(indexAliasesService.aliasFilter("dogs", "cats").toString(), equalTo("BooleanFilter(cache(animal:canine) cache(animal:feline))"));
+        assertThat(indexAliasesService.aliasFilter("dogs", "cats").toString(), equalTo("BooleanFilter(animal:canine animal:feline)"));
     }
 
     @Test
@@ -86,13 +86,13 @@ public class IndexAliasesServiceTests extends ElasticsearchSingleNodeTest {
         indexAliasesService.add("dogs", filter(termFilter("animal", "dog")));
 
         assertThat(indexAliasesService.aliasFilter(), nullValue());
-        assertThat(indexAliasesService.aliasFilter("dogs").toString(), equalTo("cache(animal:dog)"));
-        assertThat(indexAliasesService.aliasFilter("dogs", "cats").toString(), equalTo("BooleanFilter(cache(animal:dog) cache(animal:cat))"));
+        assertThat(indexAliasesService.aliasFilter("dogs").toString(), equalTo("animal:dog"));
+        assertThat(indexAliasesService.aliasFilter("dogs", "cats").toString(), equalTo("BooleanFilter(animal:dog animal:cat)"));
 
         indexAliasesService.add("cats", filter(termFilter("animal", "feline")));
         indexAliasesService.add("dogs", filter(termFilter("animal", "canine")));
 
-        assertThat(indexAliasesService.aliasFilter("dogs", "cats").toString(), equalTo("BooleanFilter(cache(animal:canine) cache(animal:feline))"));
+        assertThat(indexAliasesService.aliasFilter("dogs", "cats").toString(), equalTo("BooleanFilter(animal:canine animal:feline)"));
     }
 
     @Test(expected = InvalidAliasNameException.class)

--- a/src/test/java/org/elasticsearch/validate/SimpleValidateQueryTests.java
+++ b/src/test/java/org/elasticsearch/validate/SimpleValidateQueryTests.java
@@ -132,14 +132,14 @@ public class SimpleValidateQueryTests extends ElasticsearchIntegrationTest {
                         FilterBuilders.termFilter("bar", "2"),
                         FilterBuilders.termFilter("baz", "3")
                 )
-        ), equalTo("filtered(filtered(foo:1)->" + filter("bar:[2 TO 2]") + " " + filter("baz:3") + ")->" + typeFilter));
+        ), equalTo("filtered(filtered(foo:1)->bar:[2 TO 2] baz:3)->" + typeFilter));
 
         assertExplanation(QueryBuilders.filteredQuery(
                 QueryBuilders.termQuery("foo", "1"),
                 FilterBuilders.orFilter(
                         FilterBuilders.termFilter("bar", "2")
                 )
-        ), equalTo("filtered(filtered(foo:1)->" + filter("bar:[2 TO 2]") + ")->" + typeFilter));
+        ), equalTo("filtered(filtered(foo:1)->bar:[2 TO 2])->" + typeFilter));
 
         assertExplanation(QueryBuilders.filteredQuery(
                 QueryBuilders.matchAllQuery(),
@@ -177,13 +177,13 @@ public class SimpleValidateQueryTests extends ElasticsearchIntegrationTest {
                         FilterBuilders.termFilter("bar", "2"),
                         FilterBuilders.termFilter("baz", "3")
                 )
-        ), equalTo("filtered(filtered(foo:1)->+" + filter("bar:[2 TO 2]") + " +" + filter("baz:3") + ")->" + typeFilter));
+        ), equalTo("filtered(filtered(foo:1)->+bar:[2 TO 2] +baz:3)->" + typeFilter));
 
         assertExplanation(QueryBuilders.constantScoreQuery(FilterBuilders.termsFilter("foo", "1", "2", "3")),
                 equalTo("filtered(ConstantScore(" + filter("foo:1 foo:2 foo:3") + "))->" + typeFilter));
 
         assertExplanation(QueryBuilders.constantScoreQuery(FilterBuilders.notFilter(FilterBuilders.termFilter("foo", "bar"))),
-                equalTo("filtered(ConstantScore(NotFilter(" + filter("foo:bar") + ")))->" + typeFilter));
+                equalTo("filtered(ConstantScore(NotFilter(foo:bar)))->" + typeFilter));
 
         assertExplanation(QueryBuilders.filteredQuery(
                 QueryBuilders.termQuery("foo", "1"),


### PR DESCRIPTION
These filters are directly based on postings lists and can already
iterate/advance quickly. It is still possible to opt-in for caching.
