### PR TITLE
Mapping: Return `_boost` and `_analyzer` in the GET field mapping API

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/internal/AnalyzerMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/AnalyzerMapper.java
@@ -19,13 +19,10 @@
 
 package org.elasticsearch.index.mapper.internal;
 
-import com.google.common.base.Predicates;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.StringField;
-import org.apache.lucene.index.FieldInfo;
-import org.apache.lucene.index.IndexableField;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.lucene.Lucene;
@@ -36,7 +33,6 @@ import org.elasticsearch.index.codec.postingsformat.PostingsFormatProvider;
 import org.elasticsearch.index.fielddata.FieldDataType;
 import org.elasticsearch.index.mapper.*;
 import org.elasticsearch.index.mapper.core.AbstractFieldMapper;
-import org.elasticsearch.index.mapper.core.StringFieldMapper;
 import org.elasticsearch.search.highlight.HighlighterContext;
 
 import java.io.IOException;

--- a/src/main/java/org/elasticsearch/index/mapper/internal/BoostFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/BoostFieldMapper.java
@@ -19,11 +19,8 @@
 
 package org.elasticsearch.index.mapper.internal;
 
-import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
-import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.search.Filter;
 import org.apache.lucene.search.NumericRangeFilter;
 import org.apache.lucene.search.NumericRangeQuery;
@@ -46,8 +43,6 @@ import org.elasticsearch.index.fielddata.IndexNumericFieldData;
 import org.elasticsearch.index.mapper.*;
 import org.elasticsearch.index.mapper.core.FloatFieldMapper;
 import org.elasticsearch.index.mapper.core.NumberFieldMapper;
-import org.elasticsearch.index.mapper.core.StringFieldMapper;
-import org.elasticsearch.index.query.GeoShapeFilterParser;
 import org.elasticsearch.index.query.QueryParseContext;
 import org.elasticsearch.index.search.NumericRangeFieldDataFilter;
 
@@ -118,8 +113,6 @@ public class BoostFieldMapper extends NumberFieldMapper<Float> implements Intern
 
     private final Float nullValue;
 
-    private String name;
-
     public BoostFieldMapper() {
         this(Defaults.NAME, Defaults.PRECISION_STEP_32_BIT, Defaults.BOOST, new FieldType(Defaults.FIELD_TYPE), null,
                 Defaults.NULL_VALUE, null, null, null, ImmutableSettings.EMPTY);
@@ -130,7 +123,6 @@ public class BoostFieldMapper extends NumberFieldMapper<Float> implements Intern
         super(new Names(name, name, Defaults.NAME, Defaults.NAME), precisionStep, boost, fieldType, docValues, Defaults.IGNORE_MALFORMED, Defaults.COERCE,
                 NumericFloatAnalyzer.buildNamedAnalyzer(precisionStep), NumericFloatAnalyzer.buildNamedAnalyzer(Integer.MAX_VALUE),
                 postingsProvider, docValuesProvider, null, null, fieldDataSettings, indexSettings, MultiFields.empty(), null);
-        this.name = name;
         this.nullValue = nullValue;
     }
 

--- a/src/main/java/org/elasticsearch/index/mapper/internal/BoostFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/BoostFieldMapper.java
@@ -237,26 +237,6 @@ public class BoostFieldMapper extends NumberFieldMapper<Float> implements Intern
 
     @Override
     public void postParse(ParseContext context) throws IOException {
-        Float value = null;
-        List<IndexableField> fields = context.doc().getFields();
-        for (int i = 0, fieldsSize = fields.size(); i < fieldsSize; i++) {
-            IndexableField field = fields.get(i);
-            if (field.name().equals(name)) {
-                value = field.numericValue().floatValue();
-                break;
-            }
-        }
-        if (value == null) {
-            String previouslyIgnoredValue = context.ignoredValue(name);
-            if (previouslyIgnoredValue != null) {
-                value = Float.parseFloat(context.ignoredValue(name));
-            }
-        }
-        if (value != null) {
-            if (!Float.isNaN(value)) {
-                context.docBoost(value);
-            }
-        }
     }
 
     @Override
@@ -275,6 +255,7 @@ public class BoostFieldMapper extends NumberFieldMapper<Float> implements Intern
         } else {
             context.ignoredValue(context.parser().currentName(), context.parser().textOrNull());
         }
+        context.docBoost(value);
     }
 
     private float parseFloatValue(ParseContext context) throws IOException {

--- a/src/test/java/org/elasticsearch/index/mapper/analyzer/AnalyzerMapperIntegrationTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/analyzer/AnalyzerMapperIntegrationTests.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper.analyzer;
+
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.index.analysis.FieldNameAnalyzer;
+import org.elasticsearch.index.analysis.NamedAnalyzer;
+import org.elasticsearch.index.mapper.DocumentMapper;
+import org.elasticsearch.index.mapper.DocumentMapperParser;
+import org.elasticsearch.index.mapper.ParsedDocument;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.ElasticsearchSingleNodeTest;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+/**
+ *
+ */
+public class AnalyzerMapperIntegrationTests extends ElasticsearchIntegrationTest {
+
+    @Test
+    public void testAnalyzerMappingAppliedToDocs() throws Exception {
+
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("_analyzer").field("path", "field_analyzer").endObject()
+                .startObject("properties")
+                .startObject("text").field("type", "string").endObject()
+                .endObject()
+                .endObject().endObject().string();
+        prepareCreate("test").addMapping("type", mapping).get();
+        XContentBuilder doc = XContentFactory.jsonBuilder().startObject().field("text", "foo bar").field("field_analyzer", "keyword");
+        client().prepareIndex("test", "type").setSource(doc).get();
+        client().admin().indices().prepareRefresh("test").get();
+        SearchResponse response = client().prepareSearch("test").setQuery(QueryBuilders.termQuery("text", "foo bar")).get();
+        assertThat(response.getHits().totalHits(), equalTo(1l));
+
+        response = client().prepareSearch("test").setQuery(QueryBuilders.termQuery("field_analyzer", "keyword")).get();
+        assertThat(response.getHits().totalHits(), equalTo(1l));
+    }
+
+
+}


### PR DESCRIPTION
...so

_boost and _analyzer mapping can now be retrieved by their default name
or by given name ("path" for _analyzer, "name" for _boost)
Both still appear with their default name when just retrieving the mapping.
(see SimpleGetFieldMappingTests#testGet_boostAnd_analyzer and
     SimpleGetMappingTests#testGet_boostAnd_analyzer)

The index_name handling is removed from _boost. This never worked anyway,
see this test: https://github.com/brwe/elasticsearch/commit/36450043640f49f959d953dfd546f33606cb953a

Change in behavior:

_analyzer was never a field mapper. When defining an analyzer
in a document, the field (_analyzer or custom name) was indexed
with default string field properties. These could be overwritten by
defining an explicit mapping for this field, for example:

```
PUT testidx/doc/_mapping
{
  "_analyzer": {
    "path": "custom_analyzer"
  },
  "properties": {
    "custom_analyzer": {
      "type": "string",
      "store": true
    }
  }
}
```

Now, this explicit mapping will be ignored completely, instead
one can only set the "index" option in the definition of _analyzer
Every other option will be ignored.

Reason for this change:
The documentation says

"By default, the _analyzer field is indexed, it can be disabled by settings index to no in the mapping."

This was not true - the setting was ignored. There was a test
for the explicit definition of the mapping (AnalyzerMapperTests#testAnalyzerMappingExplicit)
but this functionallity was never documented so I assume it is not in use.

closes #7237

Things that worry me:

I made it work, but am unsure if this is too hacky. I just made use of the fact that four different names are used for mappers (name, indexName, indexNameClean and full name) and set the name at the fitting place. However, there is plans for deprecating indexName (#6677) so I am unsure how long this solution will have any worth. 

In addition the overwriting of the properties mapping relies on the fact that the order in which mappings are parsed is never changed. 

Also, I wonder if the change in behavior for _analyzer qualifies as "breaking change".
