### PR TITLE
Refactor copy headers mechanism in REST API

### DIFF
--- a/src/main/java/org/elasticsearch/rest/BaseRestHandler.java
+++ b/src/main/java/org/elasticsearch/rest/BaseRestHandler.java
@@ -19,151 +19,31 @@
 
 package org.elasticsearch.rest;
 
-import com.google.common.collect.Sets;
-import org.elasticsearch.action.*;
 import org.elasticsearch.client.Client;
-import org.elasticsearch.client.ClusterAdminClient;
-import org.elasticsearch.client.FilterClient;
-import org.elasticsearch.client.IndicesAdminClient;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.settings.Settings;
-
-import java.util.Collections;
-import java.util.Set;
 
 /**
  * Base handler for REST requests.
  *
  * This handler makes sure that the headers & context of the handled {@link RestRequest requests} are copied over to
  * the transport requests executed by the associated client. While the context is fully copied over, not all the headers
- * are copied, but a selected few. It is possible to control what header are copied over by registering them using
- * {@link #addUsefulHeaders(String...)}
+ * are copied, but a selected few. It is possible to control what headers are copied over by registering them using
+ * {@link org.elasticsearch.rest.ClientFactory#addUsefulHeaders(String...)}
  */
 public abstract class BaseRestHandler extends AbstractComponent implements RestHandler {
 
-    private static Set<String> usefulHeaders = Sets.newCopyOnWriteArraySet();
+    private final ClientFactory clientFactory;
 
-    /**
-     * Controls which REST headers get copied over from a {@link org.elasticsearch.rest.RestRequest} to
-     * its corresponding {@link org.elasticsearch.transport.TransportRequest}(s).
-     *
-     * By default no headers get copied but it is possible to extend this behaviour via plugins by calling this method.
-     */
-    public static void addUsefulHeaders(String... headers) {
-        Collections.addAll(usefulHeaders, headers);
-    }
-
-    static Set<String> usefulHeaders() {
-        return usefulHeaders;
-    }
-
-    private final Client client;
-
-    protected BaseRestHandler(Settings settings, Client client) {
+    protected BaseRestHandler(Settings settings, ClientFactory clientFactory) {
         super(settings);
-        this.client = client;
+        this.clientFactory = clientFactory;
     }
 
     @Override
     public final void handleRequest(RestRequest request, RestChannel channel) throws Exception {
-        handleRequest(request, channel, new HeadersAndContextCopyClient(client, request, usefulHeaders));
+        handleRequest(request, channel, clientFactory.client(request));
     }
 
     protected abstract void handleRequest(RestRequest request, RestChannel channel, Client client) throws Exception;
-
-    static final class HeadersAndContextCopyClient extends FilterClient {
-
-        private final RestRequest restRequest;
-        private final IndicesAdmin indicesAdmin;
-        private final ClusterAdmin clusterAdmin;
-        private final Set<String> headers;
-
-        HeadersAndContextCopyClient(Client in, RestRequest restRequest, Set<String> headers) {
-            super(in);
-            this.restRequest = restRequest;
-            this.indicesAdmin = new IndicesAdmin(in.admin().indices(), restRequest, headers);
-            this.clusterAdmin = new ClusterAdmin(in.admin().cluster(), restRequest, headers);
-            this.headers = headers;
-        }
-
-        private static void copyHeadersAndContext(ActionRequest actionRequest, RestRequest restRequest, Set<String> headers) {
-            for (String usefulHeader : headers) {
-                String headerValue = restRequest.header(usefulHeader);
-                if (headerValue != null) {
-                    actionRequest.putHeader(usefulHeader, headerValue);
-                }
-            }
-            actionRequest.copyContextFrom(restRequest);
-        }
-
-        @Override
-        public <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder, Client>> ActionFuture<Response> execute(Action<Request, Response, RequestBuilder, Client> action, Request request) {
-            copyHeadersAndContext(request, restRequest, headers);
-            return super.execute(action, request);
-        }
-
-        @Override
-        public <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder, Client>> void execute(Action<Request, Response, RequestBuilder, Client> action, Request request, ActionListener<Response> listener) {
-            copyHeadersAndContext(request, restRequest, headers);
-            super.execute(action, request, listener);
-        }
-
-        @Override
-        public ClusterAdminClient cluster() {
-            return clusterAdmin;
-        }
-
-        @Override
-        public IndicesAdminClient indices() {
-            return indicesAdmin;
-        }
-
-        private static final class ClusterAdmin extends FilterClient.ClusterAdmin {
-
-            private final RestRequest restRequest;
-            private final Set<String> headers;
-
-            private ClusterAdmin(ClusterAdminClient in, RestRequest restRequest, Set<String> headers) {
-                super(in);
-                this.restRequest = restRequest;
-                this.headers = headers;
-            }
-
-            @Override
-            public <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder, ClusterAdminClient>> ActionFuture<Response> execute(Action<Request, Response, RequestBuilder, ClusterAdminClient> action, Request request) {
-                copyHeadersAndContext(request, restRequest, headers);
-                return super.execute(action, request);
-            }
-
-            @Override
-            public <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder, ClusterAdminClient>> void execute(Action<Request, Response, RequestBuilder, ClusterAdminClient> action, Request request, ActionListener<Response> listener) {
-                copyHeadersAndContext(request, restRequest, headers);
-                super.execute(action, request, listener);
-            }
-        }
-
-        private final class IndicesAdmin extends FilterClient.IndicesAdmin {
-
-            private final RestRequest restRequest;
-            private final Set<String> headers;
-
-            private IndicesAdmin(IndicesAdminClient in, RestRequest restRequest, Set<String> headers) {
-                super(in);
-                this.restRequest = restRequest;
-                this.headers = headers;
-            }
-
-            @Override
-            public <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder, IndicesAdminClient>> ActionFuture<Response> execute(Action<Request, Response, RequestBuilder, IndicesAdminClient> action, Request request) {
-                copyHeadersAndContext(request, restRequest, headers);
-                return super.execute(action, request);
-            }
-
-            @Override
-            public <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder, IndicesAdminClient>> void execute(Action<Request, Response, RequestBuilder, IndicesAdminClient> action, Request request, ActionListener<Response> listener) {
-                copyHeadersAndContext(request, restRequest, headers);
-                super.execute(action, request, listener);
-            }
-        }
-    }
 }

--- a/src/main/java/org/elasticsearch/rest/BaseRestHandler.java
+++ b/src/main/java/org/elasticsearch/rest/BaseRestHandler.java
@@ -29,20 +29,20 @@ import org.elasticsearch.common.settings.Settings;
  * This handler makes sure that the headers & context of the handled {@link RestRequest requests} are copied over to
  * the transport requests executed by the associated client. While the context is fully copied over, not all the headers
  * are copied, but a selected few. It is possible to control what headers are copied over by registering them using
- * {@link org.elasticsearch.rest.ClientFactory#addUsefulHeaders(String...)}
+ * {@link RestClientFactory#addRelevantHeaders(String...)}
  */
 public abstract class BaseRestHandler extends AbstractComponent implements RestHandler {
 
-    private final ClientFactory clientFactory;
+    private final RestClientFactory restClientFactory;
 
-    protected BaseRestHandler(Settings settings, ClientFactory clientFactory) {
+    protected BaseRestHandler(Settings settings, RestClientFactory restClientFactory) {
         super(settings);
-        this.clientFactory = clientFactory;
+        this.restClientFactory = restClientFactory;
     }
 
     @Override
     public final void handleRequest(RestRequest request, RestChannel channel) throws Exception {
-        handleRequest(request, channel, clientFactory.client(request));
+        handleRequest(request, channel, restClientFactory.client(request));
     }
 
     protected abstract void handleRequest(RestRequest request, RestChannel channel, Client client) throws Exception;

--- a/src/main/java/org/elasticsearch/rest/ClientFactory.java
+++ b/src/main/java/org/elasticsearch/rest/ClientFactory.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.rest;
+
+import com.google.common.collect.Sets;
+import org.elasticsearch.action.*;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.client.ClusterAdminClient;
+import org.elasticsearch.client.FilterClient;
+import org.elasticsearch.client.IndicesAdminClient;
+import org.elasticsearch.common.inject.Inject;
+
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * Client factory that returns a proper {@link Client} given a {@link org.elasticsearch.rest.RestRequest}.
+ * Makes it possible to register useful headers that will be copied over from REST requests
+ * to corresponding transport requests at execution time.
+ */
+public final class ClientFactory {
+
+    private Set<String> usefulHeaders = Sets.newCopyOnWriteArraySet();
+    private final Client client;
+
+    @Inject
+    public ClientFactory(Client client) {
+        this.client = client;
+    }
+
+    /**
+     * Returns a proper {@link Client client} given the provided {@link org.elasticsearch.rest.RestRequest}
+     */
+    public Client client(RestRequest restRequest) {
+        return usefulHeaders.size() == 0 ? client : new HeadersAndContextCopyClient(client, restRequest, usefulHeaders);
+    }
+
+    /**
+     * Controls which REST headers get copied over from a {@link org.elasticsearch.rest.RestRequest} to
+     * its corresponding {@link org.elasticsearch.transport.TransportRequest}(s).
+     *
+     * By default no headers get copied but it is possible to extend this behaviour via plugins by calling this method.
+     */
+    public void addUsefulHeaders(String... headers) {
+        Collections.addAll(usefulHeaders, headers);
+    }
+
+    Set<String> usefulHeaders() {
+        return usefulHeaders;
+    }
+
+    static final class HeadersAndContextCopyClient extends FilterClient {
+
+        private final RestRequest restRequest;
+        private final IndicesAdmin indicesAdmin;
+        private final ClusterAdmin clusterAdmin;
+        private final Set<String> headers;
+
+        HeadersAndContextCopyClient(Client in, RestRequest restRequest, Set<String> headers) {
+            super(in);
+            this.restRequest = restRequest;
+            this.indicesAdmin = new IndicesAdmin(in.admin().indices(), restRequest, headers);
+            this.clusterAdmin = new ClusterAdmin(in.admin().cluster(), restRequest, headers);
+            this.headers = headers;
+        }
+
+        private static void copyHeadersAndContext(ActionRequest actionRequest, RestRequest restRequest, Set<String> headers) {
+            for (String usefulHeader : headers) {
+                String headerValue = restRequest.header(usefulHeader);
+                if (headerValue != null) {
+                    actionRequest.putHeader(usefulHeader, headerValue);
+                }
+            }
+            actionRequest.copyContextFrom(restRequest);
+        }
+
+        @Override
+        public <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder, Client>> ActionFuture<Response> execute(Action<Request, Response, RequestBuilder, Client> action, Request request) {
+            copyHeadersAndContext(request, restRequest, headers);
+            return super.execute(action, request);
+        }
+
+        @Override
+        public <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder, Client>> void execute(Action<Request, Response, RequestBuilder, Client> action, Request request, ActionListener<Response> listener) {
+            copyHeadersAndContext(request, restRequest, headers);
+            super.execute(action, request, listener);
+        }
+
+        @Override
+        public ClusterAdminClient cluster() {
+            return clusterAdmin;
+        }
+
+        @Override
+        public IndicesAdminClient indices() {
+            return indicesAdmin;
+        }
+
+        private static final class ClusterAdmin extends FilterClient.ClusterAdmin {
+
+            private final RestRequest restRequest;
+            private final Set<String> headers;
+
+            private ClusterAdmin(ClusterAdminClient in, RestRequest restRequest, Set<String> headers) {
+                super(in);
+                this.restRequest = restRequest;
+                this.headers = headers;
+            }
+
+            @Override
+            public <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder, ClusterAdminClient>> ActionFuture<Response> execute(Action<Request, Response, RequestBuilder, ClusterAdminClient> action, Request request) {
+                copyHeadersAndContext(request, restRequest, headers);
+                return super.execute(action, request);
+            }
+
+            @Override
+            public <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder, ClusterAdminClient>> void execute(Action<Request, Response, RequestBuilder, ClusterAdminClient> action, Request request, ActionListener<Response> listener) {
+                copyHeadersAndContext(request, restRequest, headers);
+                super.execute(action, request, listener);
+            }
+        }
+
+        private final class IndicesAdmin extends FilterClient.IndicesAdmin {
+
+            private final RestRequest restRequest;
+            private final Set<String> headers;
+
+            private IndicesAdmin(IndicesAdminClient in, RestRequest restRequest, Set<String> headers) {
+                super(in);
+                this.restRequest = restRequest;
+                this.headers = headers;
+            }
+
+            @Override
+            public <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder, IndicesAdminClient>> ActionFuture<Response> execute(Action<Request, Response, RequestBuilder, IndicesAdminClient> action, Request request) {
+                copyHeadersAndContext(request, restRequest, headers);
+                return super.execute(action, request);
+            }
+
+            @Override
+            public <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder, IndicesAdminClient>> void execute(Action<Request, Response, RequestBuilder, IndicesAdminClient> action, Request request, ActionListener<Response> listener) {
+                copyHeadersAndContext(request, restRequest, headers);
+                super.execute(action, request, listener);
+            }
+        }
+    }
+}

--- a/src/main/java/org/elasticsearch/rest/RestClientFactory.java
+++ b/src/main/java/org/elasticsearch/rest/RestClientFactory.java
@@ -35,13 +35,13 @@ import java.util.Set;
  * Makes it possible to register useful headers that will be copied over from REST requests
  * to corresponding transport requests at execution time.
  */
-public final class ClientFactory {
+public final class RestClientFactory {
 
-    private Set<String> usefulHeaders = Sets.newCopyOnWriteArraySet();
+    private Set<String> relevantHeaders = Sets.newCopyOnWriteArraySet();
     private final Client client;
 
     @Inject
-    public ClientFactory(Client client) {
+    public RestClientFactory(Client client) {
         this.client = client;
     }
 
@@ -49,7 +49,7 @@ public final class ClientFactory {
      * Returns a proper {@link Client client} given the provided {@link org.elasticsearch.rest.RestRequest}
      */
     public Client client(RestRequest restRequest) {
-        return usefulHeaders.size() == 0 ? client : new HeadersAndContextCopyClient(client, restRequest, usefulHeaders);
+        return relevantHeaders.size() == 0 ? client : new HeadersAndContextCopyClient(client, restRequest, relevantHeaders);
     }
 
     /**
@@ -58,12 +58,12 @@ public final class ClientFactory {
      *
      * By default no headers get copied but it is possible to extend this behaviour via plugins by calling this method.
      */
-    public void addUsefulHeaders(String... headers) {
-        Collections.addAll(usefulHeaders, headers);
+    public void addRelevantHeaders(String... headers) {
+        Collections.addAll(relevantHeaders, headers);
     }
 
-    Set<String> usefulHeaders() {
-        return usefulHeaders;
+    Set<String> relevantHeaders() {
+        return relevantHeaders;
     }
 
     static final class HeadersAndContextCopyClient extends FilterClient {

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/health/RestClusterHealthAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/health/RestClusterHealthAction.java
@@ -26,10 +26,7 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.rest.BaseRestHandler;
-import org.elasticsearch.rest.RestChannel;
-import org.elasticsearch.rest.RestController;
-import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.RestToXContentListener;
 
 import java.util.Locale;
@@ -42,8 +39,8 @@ import static org.elasticsearch.client.Requests.clusterHealthRequest;
 public class RestClusterHealthAction extends BaseRestHandler {
 
     @Inject
-    public RestClusterHealthAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestClusterHealthAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
 
         controller.registerHandler(RestRequest.Method.GET, "/_cluster/health", this);
         controller.registerHandler(RestRequest.Method.GET, "/_cluster/health/{index}", this);

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/health/RestClusterHealthAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/health/RestClusterHealthAction.java
@@ -39,8 +39,8 @@ import static org.elasticsearch.client.Requests.clusterHealthRequest;
 public class RestClusterHealthAction extends BaseRestHandler {
 
     @Inject
-    public RestClusterHealthAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestClusterHealthAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
 
         controller.registerHandler(RestRequest.Method.GET, "/_cluster/health", this);
         controller.registerHandler(RestRequest.Method.GET, "/_cluster/health/{index}", this);

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/hotthreads/RestNodesHotThreadsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/hotthreads/RestNodesHotThreadsAction.java
@@ -36,8 +36,8 @@ import org.elasticsearch.rest.action.support.RestResponseListener;
 public class RestNodesHotThreadsAction extends BaseRestHandler {
 
     @Inject
-    public RestNodesHotThreadsAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestNodesHotThreadsAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(RestRequest.Method.GET, "/_cluster/nodes/hotthreads", this);
         controller.registerHandler(RestRequest.Method.GET, "/_cluster/nodes/hot_threads", this);
         controller.registerHandler(RestRequest.Method.GET, "/_cluster/nodes/{nodeId}/hotthreads", this);

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/hotthreads/RestNodesHotThreadsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/hotthreads/RestNodesHotThreadsAction.java
@@ -36,8 +36,8 @@ import org.elasticsearch.rest.action.support.RestResponseListener;
 public class RestNodesHotThreadsAction extends BaseRestHandler {
 
     @Inject
-    public RestNodesHotThreadsAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestNodesHotThreadsAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(RestRequest.Method.GET, "/_cluster/nodes/hotthreads", this);
         controller.registerHandler(RestRequest.Method.GET, "/_cluster/nodes/hot_threads", this);
         controller.registerHandler(RestRequest.Method.GET, "/_cluster/nodes/{nodeId}/hotthreads", this);

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/info/RestNodesInfoAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/info/RestNodesInfoAction.java
@@ -45,9 +45,9 @@ public class RestNodesInfoAction extends BaseRestHandler {
     private final static Set<String> ALLOWED_METRICS = Sets.newHashSet("http", "jvm", "network", "os", "plugins", "process", "settings", "thread_pool", "transport");
 
     @Inject
-    public RestNodesInfoAction(Settings settings, Client client, RestController controller,
-                               SettingsFilter settingsFilter) {
-        super(settings, client);
+    public RestNodesInfoAction(Settings settings, RestController controller,
+                               SettingsFilter settingsFilter, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(GET, "/_nodes", this);
         // this endpoint is used for metrics, not for nodeIds, like /_nodes/fs
         controller.registerHandler(GET, "/_nodes/{nodeId}", this);

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/info/RestNodesInfoAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/info/RestNodesInfoAction.java
@@ -46,8 +46,8 @@ public class RestNodesInfoAction extends BaseRestHandler {
 
     @Inject
     public RestNodesInfoAction(Settings settings, RestController controller,
-                               SettingsFilter settingsFilter, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+                               SettingsFilter settingsFilter, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(GET, "/_nodes", this);
         // this endpoint is used for metrics, not for nodeIds, like /_nodes/fs
         controller.registerHandler(GET, "/_nodes/{nodeId}", this);

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/restart/RestNodesRestartAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/restart/RestNodesRestartAction.java
@@ -35,8 +35,8 @@ import org.elasticsearch.rest.action.support.RestBuilderListener;
 public class RestNodesRestartAction extends BaseRestHandler {
 
     @Inject
-    public RestNodesRestartAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestNodesRestartAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
 
         controller.registerHandler(RestRequest.Method.POST, "/_cluster/nodes/_restart", this);
         controller.registerHandler(RestRequest.Method.POST, "/_cluster/nodes/{nodeId}/_restart", this);

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/restart/RestNodesRestartAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/restart/RestNodesRestartAction.java
@@ -35,8 +35,8 @@ import org.elasticsearch.rest.action.support.RestBuilderListener;
 public class RestNodesRestartAction extends BaseRestHandler {
 
     @Inject
-    public RestNodesRestartAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestNodesRestartAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
 
         controller.registerHandler(RestRequest.Method.POST, "/_cluster/nodes/_restart", this);
         controller.registerHandler(RestRequest.Method.POST, "/_cluster/nodes/{nodeId}/_restart", this);

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/shutdown/RestNodesShutdownAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/shutdown/RestNodesShutdownAction.java
@@ -36,8 +36,8 @@ import org.elasticsearch.rest.action.support.RestBuilderListener;
 public class RestNodesShutdownAction extends BaseRestHandler {
 
     @Inject
-    public RestNodesShutdownAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestNodesShutdownAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
 
         controller.registerHandler(RestRequest.Method.POST, "/_shutdown", this);
         controller.registerHandler(RestRequest.Method.POST, "/_cluster/nodes/_shutdown", this);

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/shutdown/RestNodesShutdownAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/shutdown/RestNodesShutdownAction.java
@@ -36,8 +36,8 @@ import org.elasticsearch.rest.action.support.RestBuilderListener;
 public class RestNodesShutdownAction extends BaseRestHandler {
 
     @Inject
-    public RestNodesShutdownAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestNodesShutdownAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
 
         controller.registerHandler(RestRequest.Method.POST, "/_shutdown", this);
         controller.registerHandler(RestRequest.Method.POST, "/_cluster/nodes/_shutdown", this);

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/stats/RestNodesStatsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/stats/RestNodesStatsAction.java
@@ -41,8 +41,8 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 public class RestNodesStatsAction extends BaseRestHandler {
 
     @Inject
-    public RestNodesStatsAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestNodesStatsAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(GET, "/_nodes/stats", this);
         controller.registerHandler(GET, "/_nodes/{nodeId}/stats", this);
 

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/stats/RestNodesStatsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/stats/RestNodesStatsAction.java
@@ -27,10 +27,7 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.rest.BaseRestHandler;
-import org.elasticsearch.rest.RestChannel;
-import org.elasticsearch.rest.RestController;
-import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.RestToXContentListener;
 
 import java.util.Set;
@@ -44,8 +41,8 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 public class RestNodesStatsAction extends BaseRestHandler {
 
     @Inject
-    public RestNodesStatsAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestNodesStatsAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(GET, "/_nodes/stats", this);
         controller.registerHandler(GET, "/_nodes/{nodeId}/stats", this);
 

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/repositories/delete/RestDeleteRepositoryAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/repositories/delete/RestDeleteRepositoryAction.java
@@ -36,8 +36,8 @@ import static org.elasticsearch.rest.RestRequest.Method.DELETE;
 public class RestDeleteRepositoryAction extends BaseRestHandler {
 
     @Inject
-    public RestDeleteRepositoryAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestDeleteRepositoryAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(DELETE, "/_snapshot/{repository}", this);
     }
 

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/repositories/delete/RestDeleteRepositoryAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/repositories/delete/RestDeleteRepositoryAction.java
@@ -36,8 +36,8 @@ import static org.elasticsearch.rest.RestRequest.Method.DELETE;
 public class RestDeleteRepositoryAction extends BaseRestHandler {
 
     @Inject
-    public RestDeleteRepositoryAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestDeleteRepositoryAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(DELETE, "/_snapshot/{repository}", this);
     }
 

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/repositories/get/RestGetRepositoriesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/repositories/get/RestGetRepositoriesAction.java
@@ -41,8 +41,8 @@ import static org.elasticsearch.rest.RestStatus.OK;
 public class RestGetRepositoriesAction extends BaseRestHandler {
 
     @Inject
-    public RestGetRepositoriesAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestGetRepositoriesAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(GET, "/_snapshot", this);
         controller.registerHandler(GET, "/_snapshot/{repository}", this);
     }

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/repositories/get/RestGetRepositoriesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/repositories/get/RestGetRepositoriesAction.java
@@ -41,8 +41,8 @@ import static org.elasticsearch.rest.RestStatus.OK;
 public class RestGetRepositoriesAction extends BaseRestHandler {
 
     @Inject
-    public RestGetRepositoriesAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestGetRepositoriesAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(GET, "/_snapshot", this);
         controller.registerHandler(GET, "/_snapshot/{repository}", this);
     }

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/repositories/put/RestPutRepositoryAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/repositories/put/RestPutRepositoryAction.java
@@ -37,8 +37,8 @@ import static org.elasticsearch.rest.RestRequest.Method.PUT;
 public class RestPutRepositoryAction extends BaseRestHandler {
 
     @Inject
-    public RestPutRepositoryAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestPutRepositoryAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(PUT, "/_snapshot/{repository}", this);
         controller.registerHandler(POST, "/_snapshot/{repository}", this);
     }

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/repositories/put/RestPutRepositoryAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/repositories/put/RestPutRepositoryAction.java
@@ -37,8 +37,8 @@ import static org.elasticsearch.rest.RestRequest.Method.PUT;
 public class RestPutRepositoryAction extends BaseRestHandler {
 
     @Inject
-    public RestPutRepositoryAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestPutRepositoryAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(PUT, "/_snapshot/{repository}", this);
         controller.registerHandler(POST, "/_snapshot/{repository}", this);
     }

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/reroute/RestClusterRerouteAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/reroute/RestClusterRerouteAction.java
@@ -40,9 +40,9 @@ public class RestClusterRerouteAction extends BaseRestHandler {
     private final SettingsFilter settingsFilter;
 
     @Inject
-    public RestClusterRerouteAction(Settings settings, Client client, RestController controller,
-                                    SettingsFilter settingsFilter) {
-        super(settings, client);
+    public RestClusterRerouteAction(Settings settings, RestController controller,
+                                    SettingsFilter settingsFilter, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         this.settingsFilter = settingsFilter;
         controller.registerHandler(RestRequest.Method.POST, "/_cluster/reroute", this);
     }

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/reroute/RestClusterRerouteAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/reroute/RestClusterRerouteAction.java
@@ -41,8 +41,8 @@ public class RestClusterRerouteAction extends BaseRestHandler {
 
     @Inject
     public RestClusterRerouteAction(Settings settings, RestController controller,
-                                    SettingsFilter settingsFilter, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+                                    SettingsFilter settingsFilter, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         this.settingsFilter = settingsFilter;
         controller.registerHandler(RestRequest.Method.POST, "/_cluster/reroute", this);
     }

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/settings/RestClusterGetSettingsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/settings/RestClusterGetSettingsAction.java
@@ -34,8 +34,8 @@ import org.elasticsearch.rest.action.support.RestBuilderListener;
 public class RestClusterGetSettingsAction extends BaseRestHandler {
 
     @Inject
-    public RestClusterGetSettingsAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestClusterGetSettingsAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(RestRequest.Method.GET, "/_cluster/settings", this);
     }
 

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/settings/RestClusterGetSettingsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/settings/RestClusterGetSettingsAction.java
@@ -34,8 +34,8 @@ import org.elasticsearch.rest.action.support.RestBuilderListener;
 public class RestClusterGetSettingsAction extends BaseRestHandler {
 
     @Inject
-    public RestClusterGetSettingsAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestClusterGetSettingsAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(RestRequest.Method.GET, "/_cluster/settings", this);
     }
 

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/settings/RestClusterUpdateSettingsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/settings/RestClusterUpdateSettingsAction.java
@@ -38,8 +38,8 @@ import java.util.Map;
 public class RestClusterUpdateSettingsAction extends BaseRestHandler {
 
     @Inject
-    public RestClusterUpdateSettingsAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestClusterUpdateSettingsAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(RestRequest.Method.PUT, "/_cluster/settings", this);
     }
 

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/settings/RestClusterUpdateSettingsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/settings/RestClusterUpdateSettingsAction.java
@@ -38,8 +38,8 @@ import java.util.Map;
 public class RestClusterUpdateSettingsAction extends BaseRestHandler {
 
     @Inject
-    public RestClusterUpdateSettingsAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestClusterUpdateSettingsAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(RestRequest.Method.PUT, "/_cluster/settings", this);
     }
 

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/shards/RestClusterSearchShardsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/shards/RestClusterSearchShardsAction.java
@@ -27,10 +27,7 @@ import org.elasticsearch.client.Requests;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.rest.BaseRestHandler;
-import org.elasticsearch.rest.RestChannel;
-import org.elasticsearch.rest.RestController;
-import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.RestToXContentListener;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
@@ -41,8 +38,8 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
 public class RestClusterSearchShardsAction extends BaseRestHandler {
 
     @Inject
-    public RestClusterSearchShardsAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestClusterSearchShardsAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(GET, "/_search_shards", this);
         controller.registerHandler(POST, "/_search_shards", this);
         controller.registerHandler(GET, "/{index}/_search_shards", this);

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/shards/RestClusterSearchShardsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/shards/RestClusterSearchShardsAction.java
@@ -38,8 +38,8 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
 public class RestClusterSearchShardsAction extends BaseRestHandler {
 
     @Inject
-    public RestClusterSearchShardsAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestClusterSearchShardsAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(GET, "/_search_shards", this);
         controller.registerHandler(POST, "/_search_shards", this);
         controller.registerHandler(GET, "/{index}/_search_shards", this);

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/snapshots/create/RestCreateSnapshotAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/snapshots/create/RestCreateSnapshotAction.java
@@ -24,10 +24,7 @@ import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotRes
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.rest.BaseRestHandler;
-import org.elasticsearch.rest.RestChannel;
-import org.elasticsearch.rest.RestController;
-import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.RestToXContentListener;
 
 import static org.elasticsearch.client.Requests.createSnapshotRequest;
@@ -40,8 +37,8 @@ import static org.elasticsearch.rest.RestRequest.Method.PUT;
 public class RestCreateSnapshotAction extends BaseRestHandler {
 
     @Inject
-    public RestCreateSnapshotAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestCreateSnapshotAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(PUT, "/_snapshot/{repository}/{snapshot}", this);
         controller.registerHandler(POST, "/_snapshot/{repository}/{snapshot}/_create", this);
     }

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/snapshots/create/RestCreateSnapshotAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/snapshots/create/RestCreateSnapshotAction.java
@@ -37,8 +37,8 @@ import static org.elasticsearch.rest.RestRequest.Method.PUT;
 public class RestCreateSnapshotAction extends BaseRestHandler {
 
     @Inject
-    public RestCreateSnapshotAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestCreateSnapshotAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(PUT, "/_snapshot/{repository}/{snapshot}", this);
         controller.registerHandler(POST, "/_snapshot/{repository}/{snapshot}/_create", this);
     }

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/snapshots/delete/RestDeleteSnapshotAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/snapshots/delete/RestDeleteSnapshotAction.java
@@ -36,8 +36,8 @@ import static org.elasticsearch.rest.RestRequest.Method.DELETE;
 public class RestDeleteSnapshotAction extends BaseRestHandler {
 
     @Inject
-    public RestDeleteSnapshotAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestDeleteSnapshotAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(DELETE, "/_snapshot/{repository}/{snapshot}", this);
     }
 

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/snapshots/delete/RestDeleteSnapshotAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/snapshots/delete/RestDeleteSnapshotAction.java
@@ -36,8 +36,8 @@ import static org.elasticsearch.rest.RestRequest.Method.DELETE;
 public class RestDeleteSnapshotAction extends BaseRestHandler {
 
     @Inject
-    public RestDeleteSnapshotAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestDeleteSnapshotAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(DELETE, "/_snapshot/{repository}/{snapshot}", this);
     }
 

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/snapshots/get/RestGetSnapshotsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/snapshots/get/RestGetSnapshotsAction.java
@@ -37,8 +37,8 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 public class RestGetSnapshotsAction extends BaseRestHandler {
 
     @Inject
-    public RestGetSnapshotsAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestGetSnapshotsAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(GET, "/_snapshot/{repository}/{snapshot}", this);
     }
 

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/snapshots/get/RestGetSnapshotsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/snapshots/get/RestGetSnapshotsAction.java
@@ -25,10 +25,7 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.rest.BaseRestHandler;
-import org.elasticsearch.rest.RestChannel;
-import org.elasticsearch.rest.RestController;
-import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.RestToXContentListener;
 
 import static org.elasticsearch.client.Requests.getSnapshotsRequest;
@@ -40,8 +37,8 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 public class RestGetSnapshotsAction extends BaseRestHandler {
 
     @Inject
-    public RestGetSnapshotsAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestGetSnapshotsAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(GET, "/_snapshot/{repository}/{snapshot}", this);
     }
 

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/snapshots/restore/RestRestoreSnapshotAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/snapshots/restore/RestRestoreSnapshotAction.java
@@ -36,8 +36,8 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
 public class RestRestoreSnapshotAction extends BaseRestHandler {
 
     @Inject
-    public RestRestoreSnapshotAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestRestoreSnapshotAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(POST, "/_snapshot/{repository}/{snapshot}/_restore", this);
     }
 

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/snapshots/restore/RestRestoreSnapshotAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/snapshots/restore/RestRestoreSnapshotAction.java
@@ -24,10 +24,7 @@ import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotR
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.rest.BaseRestHandler;
-import org.elasticsearch.rest.RestChannel;
-import org.elasticsearch.rest.RestController;
-import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.RestToXContentListener;
 
 import static org.elasticsearch.client.Requests.restoreSnapshotRequest;
@@ -39,8 +36,8 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
 public class RestRestoreSnapshotAction extends BaseRestHandler {
 
     @Inject
-    public RestRestoreSnapshotAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestRestoreSnapshotAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(POST, "/_snapshot/{repository}/{snapshot}/_restore", this);
     }
 

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/snapshots/status/RestSnapshotsStatusAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/snapshots/status/RestSnapshotsStatusAction.java
@@ -25,10 +25,7 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.rest.BaseRestHandler;
-import org.elasticsearch.rest.RestChannel;
-import org.elasticsearch.rest.RestController;
-import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.RestToXContentListener;
 
 import static org.elasticsearch.client.Requests.snapshotsStatusRequest;
@@ -40,8 +37,8 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 public class RestSnapshotsStatusAction extends BaseRestHandler {
 
     @Inject
-    public RestSnapshotsStatusAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestSnapshotsStatusAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(GET, "/_snapshot/{repository}/{snapshot}/_status", this);
         controller.registerHandler(GET, "/_snapshot/{repository}/_status", this);
         controller.registerHandler(GET, "/_snapshot/_status", this);

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/snapshots/status/RestSnapshotsStatusAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/snapshots/status/RestSnapshotsStatusAction.java
@@ -37,8 +37,8 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 public class RestSnapshotsStatusAction extends BaseRestHandler {
 
     @Inject
-    public RestSnapshotsStatusAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestSnapshotsStatusAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(GET, "/_snapshot/{repository}/{snapshot}/_status", this);
         controller.registerHandler(GET, "/_snapshot/{repository}/_status", this);
         controller.registerHandler(GET, "/_snapshot/_status", this);

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/state/RestClusterStateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/state/RestClusterStateAction.java
@@ -43,9 +43,9 @@ public class RestClusterStateAction extends BaseRestHandler {
     private final SettingsFilter settingsFilter;
 
     @Inject
-    public RestClusterStateAction(Settings settings, Client client, RestController controller,
-                                  SettingsFilter settingsFilter) {
-        super(settings, client);
+    public RestClusterStateAction(Settings settings, RestController controller,
+                                  SettingsFilter settingsFilter, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(RestRequest.Method.GET, "/_cluster/state", this);
         controller.registerHandler(RestRequest.Method.GET, "/_cluster/state/{metric}", this);
         controller.registerHandler(RestRequest.Method.GET, "/_cluster/state/{metric}/{indices}", this);

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/state/RestClusterStateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/state/RestClusterStateAction.java
@@ -44,8 +44,8 @@ public class RestClusterStateAction extends BaseRestHandler {
 
     @Inject
     public RestClusterStateAction(Settings settings, RestController controller,
-                                  SettingsFilter settingsFilter, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+                                  SettingsFilter settingsFilter, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(RestRequest.Method.GET, "/_cluster/state", this);
         controller.registerHandler(RestRequest.Method.GET, "/_cluster/state/{metric}", this);
         controller.registerHandler(RestRequest.Method.GET, "/_cluster/state/{metric}/{indices}", this);

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/stats/RestClusterStatsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/stats/RestClusterStatsAction.java
@@ -24,10 +24,7 @@ import org.elasticsearch.action.admin.cluster.stats.ClusterStatsResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.rest.BaseRestHandler;
-import org.elasticsearch.rest.RestChannel;
-import org.elasticsearch.rest.RestController;
-import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.RestToXContentListener;
 
 
@@ -37,8 +34,8 @@ import org.elasticsearch.rest.action.support.RestToXContentListener;
 public class RestClusterStatsAction extends BaseRestHandler {
 
     @Inject
-    public RestClusterStatsAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestClusterStatsAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(RestRequest.Method.GET, "/_cluster/stats", this);
         controller.registerHandler(RestRequest.Method.GET, "/_cluster/stats/nodes/{nodeId}", this);
     }

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/stats/RestClusterStatsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/stats/RestClusterStatsAction.java
@@ -34,8 +34,8 @@ import org.elasticsearch.rest.action.support.RestToXContentListener;
 public class RestClusterStatsAction extends BaseRestHandler {
 
     @Inject
-    public RestClusterStatsAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestClusterStatsAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(RestRequest.Method.GET, "/_cluster/stats", this);
         controller.registerHandler(RestRequest.Method.GET, "/_cluster/stats/nodes/{nodeId}", this);
     }

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/tasks/RestPendingClusterTasksAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/tasks/RestPendingClusterTasksAction.java
@@ -24,10 +24,7 @@ import org.elasticsearch.action.admin.cluster.tasks.PendingClusterTasksResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.rest.BaseRestHandler;
-import org.elasticsearch.rest.RestChannel;
-import org.elasticsearch.rest.RestController;
-import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.RestToXContentListener;
 
 /**
@@ -35,8 +32,8 @@ import org.elasticsearch.rest.action.support.RestToXContentListener;
 public class RestPendingClusterTasksAction extends BaseRestHandler {
 
     @Inject
-    public RestPendingClusterTasksAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestPendingClusterTasksAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(RestRequest.Method.GET, "/_cluster/pending_tasks", this);
     }
 

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/tasks/RestPendingClusterTasksAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/tasks/RestPendingClusterTasksAction.java
@@ -32,8 +32,8 @@ import org.elasticsearch.rest.action.support.RestToXContentListener;
 public class RestPendingClusterTasksAction extends BaseRestHandler {
 
     @Inject
-    public RestPendingClusterTasksAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestPendingClusterTasksAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(RestRequest.Method.GET, "/_cluster/pending_tasks", this);
     }
 

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/RestIndicesAliasesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/RestIndicesAliasesAction.java
@@ -42,8 +42,8 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
 public class RestIndicesAliasesAction extends BaseRestHandler {
 
     @Inject
-    public RestIndicesAliasesAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestIndicesAliasesAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(POST, "/_aliases", this);
     }
 

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/RestIndicesAliasesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/RestIndicesAliasesAction.java
@@ -42,8 +42,8 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
 public class RestIndicesAliasesAction extends BaseRestHandler {
 
     @Inject
-    public RestIndicesAliasesAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestIndicesAliasesAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(POST, "/_aliases", this);
     }
 

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/delete/RestIndexDeleteAliasesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/delete/RestIndexDeleteAliasesAction.java
@@ -34,8 +34,8 @@ import static org.elasticsearch.rest.RestRequest.Method.DELETE;
 public class RestIndexDeleteAliasesAction extends BaseRestHandler {
 
     @Inject
-    public RestIndexDeleteAliasesAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestIndexDeleteAliasesAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(DELETE, "/{index}/_alias/{name}", this);
         controller.registerHandler(DELETE, "/{index}/_aliases/{name}", this);
     }

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/delete/RestIndexDeleteAliasesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/delete/RestIndexDeleteAliasesAction.java
@@ -34,8 +34,8 @@ import static org.elasticsearch.rest.RestRequest.Method.DELETE;
 public class RestIndexDeleteAliasesAction extends BaseRestHandler {
 
     @Inject
-    public RestIndexDeleteAliasesAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestIndexDeleteAliasesAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(DELETE, "/{index}/_alias/{name}", this);
         controller.registerHandler(DELETE, "/{index}/_aliases/{name}", this);
     }

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/get/RestGetAliasesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/get/RestGetAliasesAction.java
@@ -45,8 +45,8 @@ import static org.elasticsearch.rest.RestStatus.OK;
 public class RestGetAliasesAction extends BaseRestHandler {
 
     @Inject
-    public RestGetAliasesAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestGetAliasesAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(GET, "/_alias/", this);
         controller.registerHandler(GET, "/_alias/{name}", this);
         controller.registerHandler(GET, "/{index}/_alias/{name}", this);

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/get/RestGetAliasesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/get/RestGetAliasesAction.java
@@ -45,8 +45,8 @@ import static org.elasticsearch.rest.RestStatus.OK;
 public class RestGetAliasesAction extends BaseRestHandler {
 
     @Inject
-    public RestGetAliasesAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestGetAliasesAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(GET, "/_alias/", this);
         controller.registerHandler(GET, "/_alias/{name}", this);
         controller.registerHandler(GET, "/{index}/_alias/{name}", this);

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/get/RestGetIndicesAliasesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/get/RestGetIndicesAliasesAction.java
@@ -45,8 +45,8 @@ import static org.elasticsearch.rest.RestStatus.OK;
 public class RestGetIndicesAliasesAction extends BaseRestHandler {
 
     @Inject
-    public RestGetIndicesAliasesAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestGetIndicesAliasesAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(GET, "/_aliases", this);
         controller.registerHandler(GET, "/{index}/_aliases", this);
         controller.registerHandler(GET, "/{index}/_aliases/{name}", this);

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/get/RestGetIndicesAliasesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/get/RestGetIndicesAliasesAction.java
@@ -45,8 +45,8 @@ import static org.elasticsearch.rest.RestStatus.OK;
 public class RestGetIndicesAliasesAction extends BaseRestHandler {
 
     @Inject
-    public RestGetIndicesAliasesAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestGetIndicesAliasesAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(GET, "/_aliases", this);
         controller.registerHandler(GET, "/{index}/_aliases", this);
         controller.registerHandler(GET, "/{index}/_aliases/{name}", this);

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/head/RestAliasesExistAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/head/RestAliasesExistAction.java
@@ -39,8 +39,8 @@ import static org.elasticsearch.rest.RestStatus.OK;
 public class RestAliasesExistAction extends BaseRestHandler {
 
     @Inject
-    public RestAliasesExistAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestAliasesExistAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(HEAD, "/_alias/{name}", this);
         controller.registerHandler(HEAD, "/{index}/_alias/{name}", this);
         controller.registerHandler(HEAD, "/{index}/_alias", this);

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/head/RestAliasesExistAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/head/RestAliasesExistAction.java
@@ -39,8 +39,8 @@ import static org.elasticsearch.rest.RestStatus.OK;
 public class RestAliasesExistAction extends BaseRestHandler {
 
     @Inject
-    public RestAliasesExistAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestAliasesExistAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(HEAD, "/_alias/{name}", this);
         controller.registerHandler(HEAD, "/{index}/_alias/{name}", this);
         controller.registerHandler(HEAD, "/{index}/_alias", this);

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/put/RestIndexPutAliasAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/put/RestIndexPutAliasAction.java
@@ -42,8 +42,8 @@ import static org.elasticsearch.rest.RestRequest.Method.PUT;
 public class RestIndexPutAliasAction extends BaseRestHandler {
 
     @Inject
-    public RestIndexPutAliasAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestIndexPutAliasAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(PUT, "/{index}/_alias/{name}", this);
         controller.registerHandler(PUT, "/_alias/{name}", this);
         controller.registerHandler(PUT, "/{index}/_aliases/{name}", this);

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/put/RestIndexPutAliasAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/put/RestIndexPutAliasAction.java
@@ -42,8 +42,8 @@ import static org.elasticsearch.rest.RestRequest.Method.PUT;
 public class RestIndexPutAliasAction extends BaseRestHandler {
 
     @Inject
-    public RestIndexPutAliasAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestIndexPutAliasAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(PUT, "/{index}/_alias/{name}", this);
         controller.registerHandler(PUT, "/_alias/{name}", this);
         controller.registerHandler(PUT, "/{index}/_aliases/{name}", this);

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/analyze/RestAnalyzeAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/analyze/RestAnalyzeAction.java
@@ -36,8 +36,8 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
 public class RestAnalyzeAction extends BaseRestHandler {
 
     @Inject
-    public RestAnalyzeAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestAnalyzeAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(GET, "/_analyze", this);
         controller.registerHandler(GET, "/{index}/_analyze", this);
         controller.registerHandler(POST, "/_analyze", this);

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/analyze/RestAnalyzeAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/analyze/RestAnalyzeAction.java
@@ -24,10 +24,7 @@ import org.elasticsearch.action.admin.indices.analyze.AnalyzeResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.rest.BaseRestHandler;
-import org.elasticsearch.rest.RestChannel;
-import org.elasticsearch.rest.RestController;
-import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.RestToXContentListener;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
@@ -39,8 +36,8 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
 public class RestAnalyzeAction extends BaseRestHandler {
 
     @Inject
-    public RestAnalyzeAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestAnalyzeAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(GET, "/_analyze", this);
         controller.registerHandler(GET, "/{index}/_analyze", this);
         controller.registerHandler(POST, "/_analyze", this);

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/cache/clear/RestClearIndicesCacheAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/cache/clear/RestClearIndicesCacheAction.java
@@ -44,8 +44,8 @@ import static org.elasticsearch.rest.action.support.RestActions.buildBroadcastSh
 public class RestClearIndicesCacheAction extends BaseRestHandler {
 
     @Inject
-    public RestClearIndicesCacheAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestClearIndicesCacheAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(POST, "/_cache/clear", this);
         controller.registerHandler(POST, "/{index}/_cache/clear", this);
 

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/cache/clear/RestClearIndicesCacheAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/cache/clear/RestClearIndicesCacheAction.java
@@ -44,8 +44,8 @@ import static org.elasticsearch.rest.action.support.RestActions.buildBroadcastSh
 public class RestClearIndicesCacheAction extends BaseRestHandler {
 
     @Inject
-    public RestClearIndicesCacheAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestClearIndicesCacheAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(POST, "/_cache/clear", this);
         controller.registerHandler(POST, "/{index}/_cache/clear", this);
 

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/close/RestCloseIndexAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/close/RestCloseIndexAction.java
@@ -35,8 +35,8 @@ import org.elasticsearch.rest.action.support.AcknowledgedRestListener;
 public class RestCloseIndexAction extends BaseRestHandler {
 
     @Inject
-    public RestCloseIndexAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestCloseIndexAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(RestRequest.Method.POST, "/_close", this);
         controller.registerHandler(RestRequest.Method.POST, "/{index}/_close", this);
     }

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/close/RestCloseIndexAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/close/RestCloseIndexAction.java
@@ -35,8 +35,8 @@ import org.elasticsearch.rest.action.support.AcknowledgedRestListener;
 public class RestCloseIndexAction extends BaseRestHandler {
 
     @Inject
-    public RestCloseIndexAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestCloseIndexAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(RestRequest.Method.POST, "/_close", this);
         controller.registerHandler(RestRequest.Method.POST, "/{index}/_close", this);
     }

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/create/RestCreateIndexAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/create/RestCreateIndexAction.java
@@ -33,8 +33,8 @@ import org.elasticsearch.rest.action.support.AcknowledgedRestListener;
 public class RestCreateIndexAction extends BaseRestHandler {
 
     @Inject
-    public RestCreateIndexAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestCreateIndexAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(RestRequest.Method.PUT, "/{index}", this);
         controller.registerHandler(RestRequest.Method.POST, "/{index}", this);
     }

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/create/RestCreateIndexAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/create/RestCreateIndexAction.java
@@ -24,10 +24,7 @@ import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.rest.BaseRestHandler;
-import org.elasticsearch.rest.RestChannel;
-import org.elasticsearch.rest.RestController;
-import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.AcknowledgedRestListener;
 
 /**
@@ -36,8 +33,8 @@ import org.elasticsearch.rest.action.support.AcknowledgedRestListener;
 public class RestCreateIndexAction extends BaseRestHandler {
 
     @Inject
-    public RestCreateIndexAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestCreateIndexAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(RestRequest.Method.PUT, "/{index}", this);
         controller.registerHandler(RestRequest.Method.POST, "/{index}", this);
     }

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/delete/RestDeleteIndexAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/delete/RestDeleteIndexAction.java
@@ -35,8 +35,8 @@ import org.elasticsearch.rest.action.support.AcknowledgedRestListener;
 public class RestDeleteIndexAction extends BaseRestHandler {
 
     @Inject
-    public RestDeleteIndexAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestDeleteIndexAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(RestRequest.Method.DELETE, "/", this);
         controller.registerHandler(RestRequest.Method.DELETE, "/{index}", this);
     }

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/delete/RestDeleteIndexAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/delete/RestDeleteIndexAction.java
@@ -35,8 +35,8 @@ import org.elasticsearch.rest.action.support.AcknowledgedRestListener;
 public class RestDeleteIndexAction extends BaseRestHandler {
 
     @Inject
-    public RestDeleteIndexAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestDeleteIndexAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(RestRequest.Method.DELETE, "/", this);
         controller.registerHandler(RestRequest.Method.DELETE, "/{index}", this);
     }

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/exists/indices/RestIndicesExistsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/exists/indices/RestIndicesExistsAction.java
@@ -42,9 +42,9 @@ public class RestIndicesExistsAction extends BaseRestHandler {
     private final SettingsFilter settingsFilter;
 
     @Inject
-    public RestIndicesExistsAction(Settings settings, Client client, RestController controller,
-                                   SettingsFilter settingsFilter) {
-        super(settings, client);
+    public RestIndicesExistsAction(Settings settings, RestController controller,
+                                   SettingsFilter settingsFilter, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(HEAD, "/{index}", this);
 
         this.settingsFilter = settingsFilter;

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/exists/indices/RestIndicesExistsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/exists/indices/RestIndicesExistsAction.java
@@ -43,8 +43,8 @@ public class RestIndicesExistsAction extends BaseRestHandler {
 
     @Inject
     public RestIndicesExistsAction(Settings settings, RestController controller,
-                                   SettingsFilter settingsFilter, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+                                   SettingsFilter settingsFilter, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(HEAD, "/{index}", this);
 
         this.settingsFilter = settingsFilter;

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/exists/types/RestTypesExistsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/exists/types/RestTypesExistsAction.java
@@ -38,8 +38,8 @@ import static org.elasticsearch.rest.RestStatus.OK;
 public class RestTypesExistsAction extends BaseRestHandler {
 
     @Inject
-    public RestTypesExistsAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestTypesExistsAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(HEAD, "/{index}/{type}", this);
     }
 

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/exists/types/RestTypesExistsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/exists/types/RestTypesExistsAction.java
@@ -38,8 +38,8 @@ import static org.elasticsearch.rest.RestStatus.OK;
 public class RestTypesExistsAction extends BaseRestHandler {
 
     @Inject
-    public RestTypesExistsAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestTypesExistsAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(HEAD, "/{index}/{type}", this);
     }
 

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/flush/RestFlushAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/flush/RestFlushAction.java
@@ -41,8 +41,8 @@ import static org.elasticsearch.rest.action.support.RestActions.buildBroadcastSh
 public class RestFlushAction extends BaseRestHandler {
 
     @Inject
-    public RestFlushAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestFlushAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(POST, "/_flush", this);
         controller.registerHandler(POST, "/{index}/_flush", this);
 

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/flush/RestFlushAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/flush/RestFlushAction.java
@@ -41,8 +41,8 @@ import static org.elasticsearch.rest.action.support.RestActions.buildBroadcastSh
 public class RestFlushAction extends BaseRestHandler {
 
     @Inject
-    public RestFlushAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestFlushAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(POST, "/_flush", this);
         controller.registerHandler(POST, "/{index}/_flush", this);
 

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/delete/RestDeleteMappingAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/delete/RestDeleteMappingAction.java
@@ -38,8 +38,8 @@ import static org.elasticsearch.rest.RestRequest.Method.DELETE;
 public class RestDeleteMappingAction extends BaseRestHandler {
 
     @Inject
-    public RestDeleteMappingAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestDeleteMappingAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(DELETE, "/{index}/{type}/_mapping", this);
         controller.registerHandler(DELETE, "/{index}/{type}", this);
         controller.registerHandler(DELETE, "/{index}/_mapping/{type}", this);

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/delete/RestDeleteMappingAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/delete/RestDeleteMappingAction.java
@@ -38,8 +38,8 @@ import static org.elasticsearch.rest.RestRequest.Method.DELETE;
 public class RestDeleteMappingAction extends BaseRestHandler {
 
     @Inject
-    public RestDeleteMappingAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestDeleteMappingAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(DELETE, "/{index}/{type}/_mapping", this);
         controller.registerHandler(DELETE, "/{index}/{type}", this);
         controller.registerHandler(DELETE, "/{index}/_mapping/{type}", this);

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/get/RestGetFieldMappingAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/get/RestGetFieldMappingAction.java
@@ -46,8 +46,8 @@ import static org.elasticsearch.rest.RestStatus.OK;
 public class RestGetFieldMappingAction extends BaseRestHandler {
 
     @Inject
-    public RestGetFieldMappingAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestGetFieldMappingAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(GET, "/_mapping/field/{fields}", this);
         controller.registerHandler(GET, "/_mapping/{type}/field/{fields}", this);
         controller.registerHandler(GET, "/{index}/_mapping/field/{fields}", this);

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/get/RestGetFieldMappingAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/get/RestGetFieldMappingAction.java
@@ -46,8 +46,8 @@ import static org.elasticsearch.rest.RestStatus.OK;
 public class RestGetFieldMappingAction extends BaseRestHandler {
 
     @Inject
-    public RestGetFieldMappingAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestGetFieldMappingAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(GET, "/_mapping/field/{fields}", this);
         controller.registerHandler(GET, "/_mapping/{type}/field/{fields}", this);
         controller.registerHandler(GET, "/{index}/_mapping/field/{fields}", this);

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/get/RestGetMappingAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/get/RestGetMappingAction.java
@@ -46,8 +46,8 @@ import static org.elasticsearch.rest.RestStatus.OK;
 public class RestGetMappingAction extends BaseRestHandler {
 
     @Inject
-    public RestGetMappingAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestGetMappingAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(GET, "/_mapping", this);
         controller.registerHandler(GET, "/{index}/_mapping", this);
         controller.registerHandler(GET, "/{index}/{type}/_mapping", this);

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/get/RestGetMappingAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/get/RestGetMappingAction.java
@@ -46,8 +46,8 @@ import static org.elasticsearch.rest.RestStatus.OK;
 public class RestGetMappingAction extends BaseRestHandler {
 
     @Inject
-    public RestGetMappingAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestGetMappingAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(GET, "/_mapping", this);
         controller.registerHandler(GET, "/{index}/_mapping", this);
         controller.registerHandler(GET, "/{index}/{type}/_mapping", this);

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/put/RestPutMappingAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/put/RestPutMappingAction.java
@@ -40,8 +40,8 @@ public class RestPutMappingAction extends BaseRestHandler {
 
 
     @Inject
-    public RestPutMappingAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestPutMappingAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(PUT, "/{index}/_mapping/", this);
         controller.registerHandler(PUT, "/{index}/{type}/_mapping", this);
         controller.registerHandler(PUT, "/{index}/_mapping/{type}", this);

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/put/RestPutMappingAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/put/RestPutMappingAction.java
@@ -40,8 +40,8 @@ public class RestPutMappingAction extends BaseRestHandler {
 
 
     @Inject
-    public RestPutMappingAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestPutMappingAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(PUT, "/{index}/_mapping/", this);
         controller.registerHandler(PUT, "/{index}/{type}/_mapping", this);
         controller.registerHandler(PUT, "/{index}/_mapping/{type}", this);

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/open/RestOpenIndexAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/open/RestOpenIndexAction.java
@@ -35,8 +35,8 @@ import org.elasticsearch.rest.action.support.AcknowledgedRestListener;
 public class RestOpenIndexAction extends BaseRestHandler {
 
     @Inject
-    public RestOpenIndexAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestOpenIndexAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(RestRequest.Method.POST, "/_open", this);
         controller.registerHandler(RestRequest.Method.POST, "/{index}/_open", this);
     }

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/open/RestOpenIndexAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/open/RestOpenIndexAction.java
@@ -35,8 +35,8 @@ import org.elasticsearch.rest.action.support.AcknowledgedRestListener;
 public class RestOpenIndexAction extends BaseRestHandler {
 
     @Inject
-    public RestOpenIndexAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestOpenIndexAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(RestRequest.Method.POST, "/_open", this);
         controller.registerHandler(RestRequest.Method.POST, "/{index}/_open", this);
     }

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/optimize/RestOptimizeAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/optimize/RestOptimizeAction.java
@@ -41,8 +41,8 @@ import static org.elasticsearch.rest.action.support.RestActions.buildBroadcastSh
 public class RestOptimizeAction extends BaseRestHandler {
 
     @Inject
-    public RestOptimizeAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestOptimizeAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(POST, "/_optimize", this);
         controller.registerHandler(POST, "/{index}/_optimize", this);
 

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/optimize/RestOptimizeAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/optimize/RestOptimizeAction.java
@@ -41,8 +41,8 @@ import static org.elasticsearch.rest.action.support.RestActions.buildBroadcastSh
 public class RestOptimizeAction extends BaseRestHandler {
 
     @Inject
-    public RestOptimizeAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestOptimizeAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(POST, "/_optimize", this);
         controller.registerHandler(POST, "/{index}/_optimize", this);
 

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/recovery/RestRecoveryAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/recovery/RestRecoveryAction.java
@@ -39,8 +39,8 @@ import static org.elasticsearch.rest.RestStatus.OK;
 public class RestRecoveryAction extends BaseRestHandler {
 
     @Inject
-    public RestRecoveryAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestRecoveryAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(GET, "/_recovery", this);
         controller.registerHandler(GET, "/{index}/_recovery", this);
     }

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/recovery/RestRecoveryAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/recovery/RestRecoveryAction.java
@@ -39,8 +39,8 @@ import static org.elasticsearch.rest.RestStatus.OK;
 public class RestRecoveryAction extends BaseRestHandler {
 
     @Inject
-    public RestRecoveryAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestRecoveryAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(GET, "/_recovery", this);
         controller.registerHandler(GET, "/{index}/_recovery", this);
     }

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/refresh/RestRefreshAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/refresh/RestRefreshAction.java
@@ -41,8 +41,8 @@ import static org.elasticsearch.rest.action.support.RestActions.buildBroadcastSh
 public class RestRefreshAction extends BaseRestHandler {
 
     @Inject
-    public RestRefreshAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestRefreshAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(POST, "/_refresh", this);
         controller.registerHandler(POST, "/{index}/_refresh", this);
 

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/refresh/RestRefreshAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/refresh/RestRefreshAction.java
@@ -41,8 +41,8 @@ import static org.elasticsearch.rest.action.support.RestActions.buildBroadcastSh
 public class RestRefreshAction extends BaseRestHandler {
 
     @Inject
-    public RestRefreshAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestRefreshAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(POST, "/_refresh", this);
         controller.registerHandler(POST, "/{index}/_refresh", this);
 

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/segments/RestIndicesSegmentsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/segments/RestIndicesSegmentsAction.java
@@ -39,8 +39,8 @@ import static org.elasticsearch.rest.action.support.RestActions.buildBroadcastSh
 public class RestIndicesSegmentsAction extends BaseRestHandler {
 
     @Inject
-    public RestIndicesSegmentsAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestIndicesSegmentsAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(GET, "/_segments", this);
         controller.registerHandler(GET, "/{index}/_segments", this);
     }

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/segments/RestIndicesSegmentsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/segments/RestIndicesSegmentsAction.java
@@ -39,8 +39,8 @@ import static org.elasticsearch.rest.action.support.RestActions.buildBroadcastSh
 public class RestIndicesSegmentsAction extends BaseRestHandler {
 
     @Inject
-    public RestIndicesSegmentsAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestIndicesSegmentsAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(GET, "/_segments", this);
         controller.registerHandler(GET, "/{index}/_segments", this);
     }

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/settings/RestGetSettingsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/settings/RestGetSettingsAction.java
@@ -38,8 +38,8 @@ import static org.elasticsearch.rest.RestStatus.OK;
 public class RestGetSettingsAction extends BaseRestHandler {
 
     @Inject
-    public RestGetSettingsAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestGetSettingsAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(GET, "/_settings", this);
         controller.registerHandler(GET, "/{index}/_settings", this);
         controller.registerHandler(GET, "/{index}/_settings/{name}", this);

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/settings/RestGetSettingsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/settings/RestGetSettingsAction.java
@@ -38,8 +38,8 @@ import static org.elasticsearch.rest.RestStatus.OK;
 public class RestGetSettingsAction extends BaseRestHandler {
 
     @Inject
-    public RestGetSettingsAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestGetSettingsAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(GET, "/_settings", this);
         controller.registerHandler(GET, "/{index}/_settings", this);
         controller.registerHandler(GET, "/{index}/_settings/{name}", this);

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/settings/RestUpdateSettingsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/settings/RestUpdateSettingsAction.java
@@ -40,8 +40,8 @@ import static org.elasticsearch.client.Requests.updateSettingsRequest;
 public class RestUpdateSettingsAction extends BaseRestHandler {
 
     @Inject
-    public RestUpdateSettingsAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestUpdateSettingsAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(RestRequest.Method.PUT, "/{index}/_settings", this);
         controller.registerHandler(RestRequest.Method.PUT, "/_settings", this);
     }

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/settings/RestUpdateSettingsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/settings/RestUpdateSettingsAction.java
@@ -40,8 +40,8 @@ import static org.elasticsearch.client.Requests.updateSettingsRequest;
 public class RestUpdateSettingsAction extends BaseRestHandler {
 
     @Inject
-    public RestUpdateSettingsAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestUpdateSettingsAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(RestRequest.Method.PUT, "/{index}/_settings", this);
         controller.registerHandler(RestRequest.Method.PUT, "/_settings", this);
     }

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/stats/RestIndicesStatsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/stats/RestIndicesStatsAction.java
@@ -41,8 +41,8 @@ import static org.elasticsearch.rest.action.support.RestActions.buildBroadcastSh
 public class RestIndicesStatsAction extends BaseRestHandler {
 
     @Inject
-    public RestIndicesStatsAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestIndicesStatsAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(GET, "/_stats", this);
         controller.registerHandler(GET, "/_stats/{metric}", this);
         controller.registerHandler(GET, "/_stats/{metric}/{indexMetric}", this);

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/stats/RestIndicesStatsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/stats/RestIndicesStatsAction.java
@@ -41,8 +41,8 @@ import static org.elasticsearch.rest.action.support.RestActions.buildBroadcastSh
 public class RestIndicesStatsAction extends BaseRestHandler {
 
     @Inject
-    public RestIndicesStatsAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestIndicesStatsAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(GET, "/_stats", this);
         controller.registerHandler(GET, "/_stats/{metric}", this);
         controller.registerHandler(GET, "/_stats/{metric}/{indexMetric}", this);

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/template/delete/RestDeleteIndexTemplateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/template/delete/RestDeleteIndexTemplateAction.java
@@ -32,8 +32,8 @@ import org.elasticsearch.rest.action.support.AcknowledgedRestListener;
 public class RestDeleteIndexTemplateAction extends BaseRestHandler {
 
     @Inject
-    public RestDeleteIndexTemplateAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestDeleteIndexTemplateAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(RestRequest.Method.DELETE, "/_template/{name}", this);
     }
 

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/template/delete/RestDeleteIndexTemplateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/template/delete/RestDeleteIndexTemplateAction.java
@@ -32,8 +32,8 @@ import org.elasticsearch.rest.action.support.AcknowledgedRestListener;
 public class RestDeleteIndexTemplateAction extends BaseRestHandler {
 
     @Inject
-    public RestDeleteIndexTemplateAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestDeleteIndexTemplateAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(RestRequest.Method.DELETE, "/_template/{name}", this);
     }
 

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/template/get/RestGetIndexTemplateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/template/get/RestGetIndexTemplateAction.java
@@ -43,8 +43,8 @@ import static org.elasticsearch.rest.RestStatus.OK;
 public class RestGetIndexTemplateAction extends BaseRestHandler {
 
     @Inject
-    public RestGetIndexTemplateAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestGetIndexTemplateAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
 
         controller.registerHandler(GET, "/_template", this);
         controller.registerHandler(GET, "/_template/{name}", this);

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/template/get/RestGetIndexTemplateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/template/get/RestGetIndexTemplateAction.java
@@ -43,8 +43,8 @@ import static org.elasticsearch.rest.RestStatus.OK;
 public class RestGetIndexTemplateAction extends BaseRestHandler {
 
     @Inject
-    public RestGetIndexTemplateAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestGetIndexTemplateAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
 
         controller.registerHandler(GET, "/_template", this);
         controller.registerHandler(GET, "/_template/{name}", this);

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/template/head/RestHeadIndexTemplateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/template/head/RestHeadIndexTemplateAction.java
@@ -36,8 +36,8 @@ import static org.elasticsearch.rest.RestStatus.OK;
 public class RestHeadIndexTemplateAction extends BaseRestHandler {
 
     @Inject
-    public RestHeadIndexTemplateAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestHeadIndexTemplateAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
 
         controller.registerHandler(HEAD, "/_template/{name}", this);
     }

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/template/head/RestHeadIndexTemplateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/template/head/RestHeadIndexTemplateAction.java
@@ -36,8 +36,8 @@ import static org.elasticsearch.rest.RestStatus.OK;
 public class RestHeadIndexTemplateAction extends BaseRestHandler {
 
     @Inject
-    public RestHeadIndexTemplateAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestHeadIndexTemplateAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
 
         controller.registerHandler(HEAD, "/_template/{name}", this);
     }

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/template/put/RestPutIndexTemplateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/template/put/RestPutIndexTemplateAction.java
@@ -32,8 +32,8 @@ import org.elasticsearch.rest.action.support.AcknowledgedRestListener;
 public class RestPutIndexTemplateAction extends BaseRestHandler {
 
     @Inject
-    public RestPutIndexTemplateAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestPutIndexTemplateAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(RestRequest.Method.PUT, "/_template/{name}", this);
         controller.registerHandler(RestRequest.Method.POST, "/_template/{name}", this);
     }

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/template/put/RestPutIndexTemplateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/template/put/RestPutIndexTemplateAction.java
@@ -32,8 +32,8 @@ import org.elasticsearch.rest.action.support.AcknowledgedRestListener;
 public class RestPutIndexTemplateAction extends BaseRestHandler {
 
     @Inject
-    public RestPutIndexTemplateAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestPutIndexTemplateAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(RestRequest.Method.PUT, "/_template/{name}", this);
         controller.registerHandler(RestRequest.Method.POST, "/_template/{name}", this);
     }

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/validate/query/RestValidateQueryAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/validate/query/RestValidateQueryAction.java
@@ -44,8 +44,8 @@ import static org.elasticsearch.rest.action.support.RestActions.buildBroadcastSh
 public class RestValidateQueryAction extends BaseRestHandler {
 
     @Inject
-    public RestValidateQueryAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestValidateQueryAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(GET, "/_validate/query", this);
         controller.registerHandler(POST, "/_validate/query", this);
         controller.registerHandler(GET, "/{index}/_validate/query", this);

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/validate/query/RestValidateQueryAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/validate/query/RestValidateQueryAction.java
@@ -44,8 +44,8 @@ import static org.elasticsearch.rest.action.support.RestActions.buildBroadcastSh
 public class RestValidateQueryAction extends BaseRestHandler {
 
     @Inject
-    public RestValidateQueryAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestValidateQueryAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(GET, "/_validate/query", this);
         controller.registerHandler(POST, "/_validate/query", this);
         controller.registerHandler(GET, "/{index}/_validate/query", this);

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/warmer/delete/RestDeleteWarmerAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/warmer/delete/RestDeleteWarmerAction.java
@@ -25,10 +25,7 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.rest.BaseRestHandler;
-import org.elasticsearch.rest.RestChannel;
-import org.elasticsearch.rest.RestController;
-import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.AcknowledgedRestListener;
 
 import static org.elasticsearch.rest.RestRequest.Method.DELETE;
@@ -38,8 +35,8 @@ import static org.elasticsearch.rest.RestRequest.Method.DELETE;
 public class RestDeleteWarmerAction extends BaseRestHandler {
 
     @Inject
-    public RestDeleteWarmerAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestDeleteWarmerAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(DELETE, "/{index}/_warmer", this);
         controller.registerHandler(DELETE, "/{index}/_warmer/{name}", this);
         controller.registerHandler(DELETE, "/{index}/_warmers", this);

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/warmer/delete/RestDeleteWarmerAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/warmer/delete/RestDeleteWarmerAction.java
@@ -35,8 +35,8 @@ import static org.elasticsearch.rest.RestRequest.Method.DELETE;
 public class RestDeleteWarmerAction extends BaseRestHandler {
 
     @Inject
-    public RestDeleteWarmerAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestDeleteWarmerAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(DELETE, "/{index}/_warmer", this);
         controller.registerHandler(DELETE, "/{index}/_warmer/{name}", this);
         controller.registerHandler(DELETE, "/{index}/_warmers", this);

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/warmer/get/RestGetWarmerAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/warmer/get/RestGetWarmerAction.java
@@ -41,8 +41,8 @@ import static org.elasticsearch.rest.RestStatus.OK;
 public class RestGetWarmerAction extends BaseRestHandler {
 
     @Inject
-    public RestGetWarmerAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestGetWarmerAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(GET, "/_warmer", this);
         controller.registerHandler(GET, "/_warmer/{name}", this);
         controller.registerHandler(GET, "/{index}/_warmer", this);

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/warmer/get/RestGetWarmerAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/warmer/get/RestGetWarmerAction.java
@@ -41,8 +41,8 @@ import static org.elasticsearch.rest.RestStatus.OK;
 public class RestGetWarmerAction extends BaseRestHandler {
 
     @Inject
-    public RestGetWarmerAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestGetWarmerAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(GET, "/_warmer", this);
         controller.registerHandler(GET, "/_warmer/{name}", this);
         controller.registerHandler(GET, "/{index}/_warmer", this);

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/warmer/put/RestPutWarmerAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/warmer/put/RestPutWarmerAction.java
@@ -37,8 +37,8 @@ import static org.elasticsearch.rest.RestRequest.Method.PUT;
 public class RestPutWarmerAction extends BaseRestHandler {
 
     @Inject
-    public RestPutWarmerAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestPutWarmerAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(PUT, "/_warmer/{name}", this);
         controller.registerHandler(PUT, "/{index}/_warmer/{name}", this);
         controller.registerHandler(PUT, "/{index}/{type}/_warmer/{name}", this);

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/warmer/put/RestPutWarmerAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/warmer/put/RestPutWarmerAction.java
@@ -26,10 +26,7 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.rest.BaseRestHandler;
-import org.elasticsearch.rest.RestChannel;
-import org.elasticsearch.rest.RestController;
-import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.AcknowledgedRestListener;
 
 import static org.elasticsearch.rest.RestRequest.Method.POST;
@@ -40,8 +37,8 @@ import static org.elasticsearch.rest.RestRequest.Method.PUT;
 public class RestPutWarmerAction extends BaseRestHandler {
 
     @Inject
-    public RestPutWarmerAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestPutWarmerAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(PUT, "/_warmer/{name}", this);
         controller.registerHandler(PUT, "/{index}/_warmer/{name}", this);
         controller.registerHandler(PUT, "/{index}/{type}/_warmer/{name}", this);

--- a/src/main/java/org/elasticsearch/rest/action/bench/RestBenchAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/bench/RestBenchAction.java
@@ -52,8 +52,8 @@ import static org.elasticsearch.rest.RestStatus.*;
 public class RestBenchAction extends BaseRestHandler {
 
     @Inject
-    public RestBenchAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestBenchAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
 
         // List active benchmarks
         controller.registerHandler(GET, "/_bench", this);

--- a/src/main/java/org/elasticsearch/rest/action/bench/RestBenchAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/bench/RestBenchAction.java
@@ -52,8 +52,8 @@ import static org.elasticsearch.rest.RestStatus.*;
 public class RestBenchAction extends BaseRestHandler {
 
     @Inject
-    public RestBenchAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestBenchAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
 
         // List active benchmarks
         controller.registerHandler(GET, "/_bench", this);

--- a/src/main/java/org/elasticsearch/rest/action/bulk/RestBulkAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/bulk/RestBulkAction.java
@@ -55,8 +55,8 @@ public class RestBulkAction extends BaseRestHandler {
     private final boolean allowExplicitIndex;
 
     @Inject
-    public RestBulkAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestBulkAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
 
         controller.registerHandler(POST, "/_bulk", this);
         controller.registerHandler(PUT, "/_bulk", this);

--- a/src/main/java/org/elasticsearch/rest/action/bulk/RestBulkAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/bulk/RestBulkAction.java
@@ -55,8 +55,8 @@ public class RestBulkAction extends BaseRestHandler {
     private final boolean allowExplicitIndex;
 
     @Inject
-    public RestBulkAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestBulkAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
 
         controller.registerHandler(POST, "/_bulk", this);
         controller.registerHandler(PUT, "/_bulk", this);

--- a/src/main/java/org/elasticsearch/rest/action/cat/AbstractCatAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/AbstractCatAction.java
@@ -33,8 +33,8 @@ import static org.elasticsearch.rest.action.support.RestTable.pad;
  */
 public abstract class AbstractCatAction extends BaseRestHandler {
 
-    public AbstractCatAction(Settings settings, Client client) {
-        super(settings, client);
+    public AbstractCatAction(Settings settings, ClientFactory clientFactory) {
+        super(settings, clientFactory);
     }
 
     abstract void doRequest(final RestRequest request, final RestChannel channel, final Client client);

--- a/src/main/java/org/elasticsearch/rest/action/cat/AbstractCatAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/AbstractCatAction.java
@@ -33,8 +33,8 @@ import static org.elasticsearch.rest.action.support.RestTable.pad;
  */
 public abstract class AbstractCatAction extends BaseRestHandler {
 
-    public AbstractCatAction(Settings settings, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public AbstractCatAction(Settings settings, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
     }
 
     abstract void doRequest(final RestRequest request, final RestChannel channel, final Client client);

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestAliasAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestAliasAction.java
@@ -27,10 +27,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.Table;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.rest.RestChannel;
-import org.elasticsearch.rest.RestController;
-import org.elasticsearch.rest.RestRequest;
-import org.elasticsearch.rest.RestResponse;
+import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.RestResponseListener;
 import org.elasticsearch.rest.action.support.RestTable;
 
@@ -44,8 +41,8 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 public class RestAliasAction extends AbstractCatAction {
 
     @Inject
-    public RestAliasAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestAliasAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(GET, "/_cat/aliases", this);
         controller.registerHandler(GET, "/_cat/aliases/{alias}", this);
     }

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestAliasAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestAliasAction.java
@@ -41,8 +41,8 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 public class RestAliasAction extends AbstractCatAction {
 
     @Inject
-    public RestAliasAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestAliasAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(GET, "/_cat/aliases", this);
         controller.registerHandler(GET, "/_cat/aliases/{alias}", this);
     }

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestAllocationAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestAllocationAction.java
@@ -44,8 +44,8 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 public class RestAllocationAction extends AbstractCatAction {
 
     @Inject
-    public RestAllocationAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestAllocationAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(GET, "/_cat/allocation", this);
         controller.registerHandler(GET, "/_cat/allocation/{nodes}", this);
     }

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestAllocationAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestAllocationAction.java
@@ -33,10 +33,7 @@ import org.elasticsearch.common.Table;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
-import org.elasticsearch.rest.RestChannel;
-import org.elasticsearch.rest.RestController;
-import org.elasticsearch.rest.RestRequest;
-import org.elasticsearch.rest.RestResponse;
+import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.RestActionListener;
 import org.elasticsearch.rest.action.support.RestResponseListener;
 import org.elasticsearch.rest.action.support.RestTable;
@@ -47,8 +44,8 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 public class RestAllocationAction extends AbstractCatAction {
 
     @Inject
-    public RestAllocationAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestAllocationAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(GET, "/_cat/allocation", this);
         controller.registerHandler(GET, "/_cat/allocation/{nodes}", this);
     }

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestCatAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestCatAction.java
@@ -35,8 +35,8 @@ public class RestCatAction extends BaseRestHandler {
     private final String HELP;
 
     @Inject
-    public RestCatAction(Settings settings, RestController controller, Set<AbstractCatAction> catActions, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestCatAction(Settings settings, RestController controller, Set<AbstractCatAction> catActions, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(GET, "/_cat", this);
         StringBuilder sb = new StringBuilder();
         sb.append(CAT_NL);

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestCatAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestCatAction.java
@@ -35,8 +35,8 @@ public class RestCatAction extends BaseRestHandler {
     private final String HELP;
 
     @Inject
-    public RestCatAction(Settings settings, Client client, RestController controller, Set<AbstractCatAction> catActions) {
-        super(settings, client);
+    public RestCatAction(Settings settings, RestController controller, Set<AbstractCatAction> catActions, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(GET, "/_cat", this);
         StringBuilder sb = new StringBuilder();
         sb.append(CAT_NL);

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestCountAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestCountAction.java
@@ -27,10 +27,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.Table;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.rest.RestChannel;
-import org.elasticsearch.rest.RestController;
-import org.elasticsearch.rest.RestRequest;
-import org.elasticsearch.rest.RestResponse;
+import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.RestActions;
 import org.elasticsearch.rest.action.support.RestResponseListener;
 import org.elasticsearch.rest.action.support.RestTable;
@@ -44,8 +41,8 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 public class RestCountAction extends AbstractCatAction {
 
     @Inject
-    protected RestCountAction(Settings settings, Client client, RestController restController) {
-        super(settings, client);
+    protected RestCountAction(Settings settings, RestController restController, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         restController.registerHandler(GET, "/_cat/count", this);
         restController.registerHandler(GET, "/_cat/count/{index}", this);
     }

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestCountAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestCountAction.java
@@ -41,8 +41,8 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 public class RestCountAction extends AbstractCatAction {
 
     @Inject
-    protected RestCountAction(Settings settings, RestController restController, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    protected RestCountAction(Settings settings, RestController restController, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         restController.registerHandler(GET, "/_cat/count", this);
         restController.registerHandler(GET, "/_cat/count/{index}", this);
     }

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestFielddataAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestFielddataAction.java
@@ -46,8 +46,8 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 public class RestFielddataAction extends AbstractCatAction {
 
     @Inject
-    public RestFielddataAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestFielddataAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(GET, "/_cat/fielddata", this);
         controller.registerHandler(GET, "/_cat/fielddata/{fields}", this);
     }

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestFielddataAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestFielddataAction.java
@@ -29,10 +29,7 @@ import org.elasticsearch.common.Table;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
-import org.elasticsearch.rest.RestChannel;
-import org.elasticsearch.rest.RestController;
-import org.elasticsearch.rest.RestRequest;
-import org.elasticsearch.rest.RestResponse;
+import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.RestResponseListener;
 import org.elasticsearch.rest.action.support.RestTable;
 
@@ -49,8 +46,8 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 public class RestFielddataAction extends AbstractCatAction {
 
     @Inject
-    public RestFielddataAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestFielddataAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(GET, "/_cat/fielddata", this);
         controller.registerHandler(GET, "/_cat/fielddata/{fields}", this);
     }

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestHealthAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestHealthAction.java
@@ -39,8 +39,8 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 public class RestHealthAction extends AbstractCatAction {
 
     @Inject
-    public RestHealthAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestHealthAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(GET, "/_cat/health", this);
     }
 

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestHealthAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestHealthAction.java
@@ -25,10 +25,7 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Table;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.rest.RestChannel;
-import org.elasticsearch.rest.RestController;
-import org.elasticsearch.rest.RestRequest;
-import org.elasticsearch.rest.RestResponse;
+import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.RestResponseListener;
 import org.elasticsearch.rest.action.support.RestTable;
 import org.joda.time.format.DateTimeFormat;
@@ -42,8 +39,8 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 public class RestHealthAction extends AbstractCatAction {
 
     @Inject
-    public RestHealthAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestHealthAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(GET, "/_cat/health", this);
     }
 

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
@@ -46,8 +46,8 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 public class RestIndicesAction extends AbstractCatAction {
 
     @Inject
-    public RestIndicesAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestIndicesAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(GET, "/_cat/indices", this);
         controller.registerHandler(GET, "/_cat/indices/{index}", this);
     }

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
@@ -34,10 +34,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.Table;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.rest.RestChannel;
-import org.elasticsearch.rest.RestController;
-import org.elasticsearch.rest.RestRequest;
-import org.elasticsearch.rest.RestResponse;
+import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.RestActionListener;
 import org.elasticsearch.rest.action.support.RestResponseListener;
 import org.elasticsearch.rest.action.support.RestTable;
@@ -49,8 +46,8 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 public class RestIndicesAction extends AbstractCatAction {
 
     @Inject
-    public RestIndicesAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestIndicesAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(GET, "/_cat/indices", this);
         controller.registerHandler(GET, "/_cat/indices/{index}", this);
     }

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestMasterAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestMasterAction.java
@@ -36,8 +36,8 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 public class RestMasterAction extends AbstractCatAction {
 
     @Inject
-    public RestMasterAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestMasterAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(GET, "/_cat/master", this);
     }
 

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestMasterAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestMasterAction.java
@@ -27,10 +27,7 @@ import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.Table;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.rest.RestChannel;
-import org.elasticsearch.rest.RestController;
-import org.elasticsearch.rest.RestRequest;
-import org.elasticsearch.rest.RestResponse;
+import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.RestResponseListener;
 import org.elasticsearch.rest.action.support.RestTable;
 
@@ -39,8 +36,8 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 public class RestMasterAction extends AbstractCatAction {
 
     @Inject
-    public RestMasterAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestMasterAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(GET, "/_cat/master", this);
     }
 

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
@@ -35,10 +35,7 @@ import org.elasticsearch.common.Table;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
-import org.elasticsearch.rest.RestChannel;
-import org.elasticsearch.rest.RestController;
-import org.elasticsearch.rest.RestRequest;
-import org.elasticsearch.rest.RestResponse;
+import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.RestActionListener;
 import org.elasticsearch.rest.action.support.RestResponseListener;
 import org.elasticsearch.rest.action.support.RestTable;
@@ -50,8 +47,8 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 public class RestNodesAction extends AbstractCatAction {
 
     @Inject
-    public RestNodesAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestNodesAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(GET, "/_cat/nodes", this);
     }
 

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
@@ -47,8 +47,8 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 public class RestNodesAction extends AbstractCatAction {
 
     @Inject
-    public RestNodesAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestNodesAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(GET, "/_cat/nodes", this);
     }
 

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestPendingClusterTasksAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestPendingClusterTasksAction.java
@@ -34,8 +34,8 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 
 public class RestPendingClusterTasksAction extends AbstractCatAction {
     @Inject
-    public RestPendingClusterTasksAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestPendingClusterTasksAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(GET, "/_cat/pending_tasks", this);
     }
 

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestPendingClusterTasksAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestPendingClusterTasksAction.java
@@ -26,10 +26,7 @@ import org.elasticsearch.cluster.service.PendingClusterTask;
 import org.elasticsearch.common.Table;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.rest.RestChannel;
-import org.elasticsearch.rest.RestController;
-import org.elasticsearch.rest.RestRequest;
-import org.elasticsearch.rest.RestResponse;
+import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.RestResponseListener;
 import org.elasticsearch.rest.action.support.RestTable;
 
@@ -37,8 +34,8 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 
 public class RestPendingClusterTasksAction extends AbstractCatAction {
     @Inject
-    public RestPendingClusterTasksAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestPendingClusterTasksAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(GET, "/_cat/pending_tasks", this);
     }
 

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestPluginsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestPluginsAction.java
@@ -31,10 +31,7 @@ import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.Table;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.rest.RestChannel;
-import org.elasticsearch.rest.RestController;
-import org.elasticsearch.rest.RestRequest;
-import org.elasticsearch.rest.RestResponse;
+import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.RestActionListener;
 import org.elasticsearch.rest.action.support.RestResponseListener;
 import org.elasticsearch.rest.action.support.RestTable;
@@ -44,8 +41,8 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 public class RestPluginsAction extends AbstractCatAction {
 
     @Inject
-    public RestPluginsAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestPluginsAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(GET, "/_cat/plugins", this);
     }
 

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestPluginsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestPluginsAction.java
@@ -41,8 +41,8 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 public class RestPluginsAction extends AbstractCatAction {
 
     @Inject
-    public RestPluginsAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestPluginsAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(GET, "/_cat/plugins", this);
     }
 

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestRecoveryAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestRecoveryAction.java
@@ -48,8 +48,8 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 public class RestRecoveryAction extends AbstractCatAction {
 
     @Inject
-    protected RestRecoveryAction(Settings settings, RestController restController, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    protected RestRecoveryAction(Settings settings, RestController restController, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         restController.registerHandler(GET, "/_cat/recovery", this);
         restController.registerHandler(GET, "/_cat/recovery/{index}", this);
     }

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestRecoveryAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestRecoveryAction.java
@@ -30,10 +30,7 @@ import org.elasticsearch.common.Table;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.indices.recovery.RecoveryState;
-import org.elasticsearch.rest.RestChannel;
-import org.elasticsearch.rest.RestController;
-import org.elasticsearch.rest.RestRequest;
-import org.elasticsearch.rest.RestResponse;
+import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.RestResponseListener;
 import org.elasticsearch.rest.action.support.RestTable;
 
@@ -51,8 +48,8 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 public class RestRecoveryAction extends AbstractCatAction {
 
     @Inject
-    protected RestRecoveryAction(Settings settings, Client client, RestController restController) {
-        super(settings, client);
+    protected RestRecoveryAction(Settings settings, RestController restController, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         restController.registerHandler(GET, "/_cat/recovery", this);
         restController.registerHandler(GET, "/_cat/recovery/{index}", this);
     }

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestSegmentsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestSegmentsAction.java
@@ -42,8 +42,8 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 public class RestSegmentsAction extends AbstractCatAction {
 
     @Inject
-    public RestSegmentsAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestSegmentsAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(GET, "/_cat/segments", this);
         controller.registerHandler(GET, "/_cat/segments/{index}", this);
     }

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestSegmentsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestSegmentsAction.java
@@ -42,8 +42,8 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 public class RestSegmentsAction extends AbstractCatAction {
 
     @Inject
-    public RestSegmentsAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestSegmentsAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(GET, "/_cat/segments", this);
         controller.registerHandler(GET, "/_cat/segments/{index}", this);
     }

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestShardsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestShardsAction.java
@@ -40,8 +40,8 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 public class RestShardsAction extends AbstractCatAction {
 
     @Inject
-    public RestShardsAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestShardsAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(GET, "/_cat/shards", this);
         controller.registerHandler(GET, "/_cat/shards/{index}", this);
     }

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestShardsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestShardsAction.java
@@ -30,10 +30,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.Table;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.rest.RestChannel;
-import org.elasticsearch.rest.RestController;
-import org.elasticsearch.rest.RestRequest;
-import org.elasticsearch.rest.RestResponse;
+import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.RestActionListener;
 import org.elasticsearch.rest.action.support.RestResponseListener;
 import org.elasticsearch.rest.action.support.RestTable;
@@ -43,8 +40,8 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 public class RestShardsAction extends AbstractCatAction {
 
     @Inject
-    public RestShardsAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestShardsAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(GET, "/_cat/shards", this);
         controller.registerHandler(GET, "/_cat/shards/{index}", this);
     }

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestThreadPoolAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestThreadPoolAction.java
@@ -105,8 +105,8 @@ public class RestThreadPoolAction extends AbstractCatAction {
     }
 
     @Inject
-    public RestThreadPoolAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestThreadPoolAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(GET, "/_cat/thread_pool", this);
     }
 

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestThreadPoolAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestThreadPoolAction.java
@@ -36,10 +36,7 @@ import org.elasticsearch.common.Table;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
-import org.elasticsearch.rest.RestChannel;
-import org.elasticsearch.rest.RestController;
-import org.elasticsearch.rest.RestRequest;
-import org.elasticsearch.rest.RestResponse;
+import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.RestActionListener;
 import org.elasticsearch.rest.action.support.RestResponseListener;
 import org.elasticsearch.rest.action.support.RestTable;
@@ -108,8 +105,8 @@ public class RestThreadPoolAction extends AbstractCatAction {
     }
 
     @Inject
-    public RestThreadPoolAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestThreadPoolAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(GET, "/_cat/thread_pool", this);
     }
 

--- a/src/main/java/org/elasticsearch/rest/action/count/RestCountAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/count/RestCountAction.java
@@ -45,8 +45,8 @@ import static org.elasticsearch.rest.action.support.RestActions.buildBroadcastSh
 public class RestCountAction extends BaseRestHandler {
 
     @Inject
-    public RestCountAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestCountAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(POST, "/_count", this);
         controller.registerHandler(GET, "/_count", this);
         controller.registerHandler(POST, "/{index}/_count", this);

--- a/src/main/java/org/elasticsearch/rest/action/count/RestCountAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/count/RestCountAction.java
@@ -45,8 +45,8 @@ import static org.elasticsearch.rest.action.support.RestActions.buildBroadcastSh
 public class RestCountAction extends BaseRestHandler {
 
     @Inject
-    public RestCountAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestCountAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(POST, "/_count", this);
         controller.registerHandler(GET, "/_count", this);
         controller.registerHandler(POST, "/{index}/_count", this);

--- a/src/main/java/org/elasticsearch/rest/action/delete/RestDeleteAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/delete/RestDeleteAction.java
@@ -43,8 +43,8 @@ import static org.elasticsearch.rest.RestStatus.OK;
 public class RestDeleteAction extends BaseRestHandler {
 
     @Inject
-    public RestDeleteAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestDeleteAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(DELETE, "/{index}/{type}/{id}", this);
     }
 

--- a/src/main/java/org/elasticsearch/rest/action/delete/RestDeleteAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/delete/RestDeleteAction.java
@@ -43,8 +43,8 @@ import static org.elasticsearch.rest.RestStatus.OK;
 public class RestDeleteAction extends BaseRestHandler {
 
     @Inject
-    public RestDeleteAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestDeleteAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(DELETE, "/{index}/{type}/{id}", this);
     }
 

--- a/src/main/java/org/elasticsearch/rest/action/deletebyquery/RestDeleteByQueryAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/deletebyquery/RestDeleteByQueryAction.java
@@ -46,8 +46,8 @@ import static org.elasticsearch.rest.RestRequest.Method.DELETE;
 public class RestDeleteByQueryAction extends BaseRestHandler {
 
     @Inject
-    public RestDeleteByQueryAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestDeleteByQueryAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(DELETE, "/{index}/_query", this);
         controller.registerHandler(DELETE, "/{index}/{type}/_query", this);
     }

--- a/src/main/java/org/elasticsearch/rest/action/deletebyquery/RestDeleteByQueryAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/deletebyquery/RestDeleteByQueryAction.java
@@ -46,8 +46,8 @@ import static org.elasticsearch.rest.RestRequest.Method.DELETE;
 public class RestDeleteByQueryAction extends BaseRestHandler {
 
     @Inject
-    public RestDeleteByQueryAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestDeleteByQueryAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(DELETE, "/{index}/_query", this);
         controller.registerHandler(DELETE, "/{index}/{type}/_query", this);
     }

--- a/src/main/java/org/elasticsearch/rest/action/exists/RestExistsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/exists/RestExistsAction.java
@@ -40,8 +40,8 @@ import static org.elasticsearch.rest.RestStatus.OK;
  */
 public class RestExistsAction extends BaseRestHandler {
 
-    public RestExistsAction(Settings settings, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestExistsAction(Settings settings, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/rest/action/exists/RestExistsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/exists/RestExistsAction.java
@@ -40,8 +40,8 @@ import static org.elasticsearch.rest.RestStatus.OK;
  */
 public class RestExistsAction extends BaseRestHandler {
 
-    public RestExistsAction(Settings settings, Client client) {
-        super(settings, client);
+    public RestExistsAction(Settings settings, ClientFactory clientFactory) {
+        super(settings, clientFactory);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/rest/action/explain/RestExplainAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/explain/RestExplainAction.java
@@ -51,8 +51,8 @@ import static org.elasticsearch.rest.RestStatus.OK;
 public class RestExplainAction extends BaseRestHandler {
 
     @Inject
-    public RestExplainAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestExplainAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(GET, "/{index}/{type}/{id}/_explain", this);
         controller.registerHandler(POST, "/{index}/{type}/{id}/_explain", this);
     }

--- a/src/main/java/org/elasticsearch/rest/action/explain/RestExplainAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/explain/RestExplainAction.java
@@ -51,8 +51,8 @@ import static org.elasticsearch.rest.RestStatus.OK;
 public class RestExplainAction extends BaseRestHandler {
 
     @Inject
-    public RestExplainAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestExplainAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(GET, "/{index}/{type}/{id}/_explain", this);
         controller.registerHandler(POST, "/{index}/{type}/{id}/_explain", this);
     }

--- a/src/main/java/org/elasticsearch/rest/action/get/RestGetAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/get/RestGetAction.java
@@ -42,8 +42,8 @@ import static org.elasticsearch.rest.RestStatus.OK;
 public class RestGetAction extends BaseRestHandler {
 
     @Inject
-    public RestGetAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestGetAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(GET, "/{index}/{type}/{id}", this);
     }
 

--- a/src/main/java/org/elasticsearch/rest/action/get/RestGetAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/get/RestGetAction.java
@@ -42,8 +42,8 @@ import static org.elasticsearch.rest.RestStatus.OK;
 public class RestGetAction extends BaseRestHandler {
 
     @Inject
-    public RestGetAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestGetAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(GET, "/{index}/{type}/{id}", this);
     }
 

--- a/src/main/java/org/elasticsearch/rest/action/get/RestGetSourceAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/get/RestGetSourceAction.java
@@ -43,8 +43,8 @@ import static org.elasticsearch.rest.RestStatus.OK;
 public class RestGetSourceAction extends BaseRestHandler {
 
     @Inject
-    public RestGetSourceAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestGetSourceAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(GET, "/{index}/{type}/{id}/_source", this);
     }
 

--- a/src/main/java/org/elasticsearch/rest/action/get/RestGetSourceAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/get/RestGetSourceAction.java
@@ -43,8 +43,8 @@ import static org.elasticsearch.rest.RestStatus.OK;
 public class RestGetSourceAction extends BaseRestHandler {
 
     @Inject
-    public RestGetSourceAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestGetSourceAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(GET, "/{index}/{type}/{id}/_source", this);
     }
 

--- a/src/main/java/org/elasticsearch/rest/action/get/RestHeadAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/get/RestHeadAction.java
@@ -38,8 +38,8 @@ import static org.elasticsearch.rest.RestStatus.OK;
 public class RestHeadAction extends BaseRestHandler {
 
     @Inject
-    public RestHeadAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestHeadAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(HEAD, "/{index}/{type}/{id}", this);
         controller.registerHandler(HEAD, "/{index}/{type}/{id}/_source", this);
     }

--- a/src/main/java/org/elasticsearch/rest/action/get/RestHeadAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/get/RestHeadAction.java
@@ -38,8 +38,8 @@ import static org.elasticsearch.rest.RestStatus.OK;
 public class RestHeadAction extends BaseRestHandler {
 
     @Inject
-    public RestHeadAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestHeadAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(HEAD, "/{index}/{type}/{id}", this);
         controller.registerHandler(HEAD, "/{index}/{type}/{id}/_source", this);
     }

--- a/src/main/java/org/elasticsearch/rest/action/get/RestMultiGetAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/get/RestMultiGetAction.java
@@ -38,8 +38,8 @@ public class RestMultiGetAction extends BaseRestHandler {
     private final boolean allowExplicitIndex;
 
     @Inject
-    public RestMultiGetAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestMultiGetAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(GET, "/_mget", this);
         controller.registerHandler(POST, "/_mget", this);
         controller.registerHandler(GET, "/{index}/_mget", this);

--- a/src/main/java/org/elasticsearch/rest/action/get/RestMultiGetAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/get/RestMultiGetAction.java
@@ -38,8 +38,8 @@ public class RestMultiGetAction extends BaseRestHandler {
     private final boolean allowExplicitIndex;
 
     @Inject
-    public RestMultiGetAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestMultiGetAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(GET, "/_mget", this);
         controller.registerHandler(POST, "/_mget", this);
         controller.registerHandler(GET, "/{index}/_mget", this);

--- a/src/main/java/org/elasticsearch/rest/action/index/RestIndexAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/index/RestIndexAction.java
@@ -46,19 +46,19 @@ import static org.elasticsearch.rest.RestStatus.*;
 public class RestIndexAction extends BaseRestHandler {
 
     @Inject
-    public RestIndexAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestIndexAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(POST, "/{index}/{type}", this); // auto id creation
         controller.registerHandler(PUT, "/{index}/{type}/{id}", this);
         controller.registerHandler(POST, "/{index}/{type}/{id}", this);
-        CreateHandler createHandler = new CreateHandler(settings, client);
+        CreateHandler createHandler = new CreateHandler(settings, clientFactory);
         controller.registerHandler(PUT, "/{index}/{type}/{id}/_create", createHandler);
         controller.registerHandler(POST, "/{index}/{type}/{id}/_create", createHandler);
     }
 
     final class CreateHandler extends BaseRestHandler {
-        protected CreateHandler(Settings settings, final Client client) {
-            super(settings, client);
+        protected CreateHandler(Settings settings, ClientFactory clientFactory) {
+            super(settings, clientFactory);
         }
 
         @Override

--- a/src/main/java/org/elasticsearch/rest/action/index/RestIndexAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/index/RestIndexAction.java
@@ -46,19 +46,19 @@ import static org.elasticsearch.rest.RestStatus.*;
 public class RestIndexAction extends BaseRestHandler {
 
     @Inject
-    public RestIndexAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestIndexAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(POST, "/{index}/{type}", this); // auto id creation
         controller.registerHandler(PUT, "/{index}/{type}/{id}", this);
         controller.registerHandler(POST, "/{index}/{type}/{id}", this);
-        CreateHandler createHandler = new CreateHandler(settings, clientFactory);
+        CreateHandler createHandler = new CreateHandler(settings, restClientFactory);
         controller.registerHandler(PUT, "/{index}/{type}/{id}/_create", createHandler);
         controller.registerHandler(POST, "/{index}/{type}/{id}/_create", createHandler);
     }
 
     final class CreateHandler extends BaseRestHandler {
-        protected CreateHandler(Settings settings, ClientFactory clientFactory) {
-            super(settings, clientFactory);
+        protected CreateHandler(Settings settings, RestClientFactory restClientFactory) {
+            super(settings, restClientFactory);
         }
 
         @Override

--- a/src/main/java/org/elasticsearch/rest/action/main/RestMainAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/main/RestMainAction.java
@@ -45,8 +45,8 @@ public class RestMainAction extends BaseRestHandler {
     private final ClusterName clusterName;
 
     @Inject
-    public RestMainAction(Settings settings, Version version, RestController controller, ClusterName clusterName, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestMainAction(Settings settings, Version version, RestController controller, ClusterName clusterName, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         this.version = version;
         this.clusterName = clusterName;
         controller.registerHandler(GET, "/", this);

--- a/src/main/java/org/elasticsearch/rest/action/main/RestMainAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/main/RestMainAction.java
@@ -45,8 +45,8 @@ public class RestMainAction extends BaseRestHandler {
     private final ClusterName clusterName;
 
     @Inject
-    public RestMainAction(Settings settings, Version version, Client client, RestController controller, ClusterName clusterName) {
-        super(settings, client);
+    public RestMainAction(Settings settings, Version version, RestController controller, ClusterName clusterName, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         this.version = version;
         this.clusterName = clusterName;
         controller.registerHandler(GET, "/", this);

--- a/src/main/java/org/elasticsearch/rest/action/mlt/RestMoreLikeThisAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/mlt/RestMoreLikeThisAction.java
@@ -40,8 +40,8 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
 public class RestMoreLikeThisAction extends BaseRestHandler {
 
     @Inject
-    public RestMoreLikeThisAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestMoreLikeThisAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(GET, "/{index}/{type}/{id}/_mlt", this);
         controller.registerHandler(POST, "/{index}/{type}/{id}/_mlt", this);
     }

--- a/src/main/java/org/elasticsearch/rest/action/mlt/RestMoreLikeThisAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/mlt/RestMoreLikeThisAction.java
@@ -40,8 +40,8 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
 public class RestMoreLikeThisAction extends BaseRestHandler {
 
     @Inject
-    public RestMoreLikeThisAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestMoreLikeThisAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(GET, "/{index}/{type}/{id}/_mlt", this);
         controller.registerHandler(POST, "/{index}/{type}/{id}/_mlt", this);
     }

--- a/src/main/java/org/elasticsearch/rest/action/percolate/RestMultiPercolateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/percolate/RestMultiPercolateAction.java
@@ -40,8 +40,8 @@ public class RestMultiPercolateAction extends BaseRestHandler {
     private final boolean allowExplicitIndex;
 
     @Inject
-    public RestMultiPercolateAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestMultiPercolateAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(POST, "/_mpercolate", this);
         controller.registerHandler(POST, "/{index}/_mpercolate", this);
         controller.registerHandler(POST, "/{index}/{type}/_mpercolate", this);

--- a/src/main/java/org/elasticsearch/rest/action/percolate/RestMultiPercolateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/percolate/RestMultiPercolateAction.java
@@ -40,8 +40,8 @@ public class RestMultiPercolateAction extends BaseRestHandler {
     private final boolean allowExplicitIndex;
 
     @Inject
-    public RestMultiPercolateAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestMultiPercolateAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(POST, "/_mpercolate", this);
         controller.registerHandler(POST, "/{index}/_mpercolate", this);
         controller.registerHandler(POST, "/{index}/{type}/_mpercolate", this);

--- a/src/main/java/org/elasticsearch/rest/action/percolate/RestPercolateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/percolate/RestPercolateAction.java
@@ -40,20 +40,20 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
 public class RestPercolateAction extends BaseRestHandler {
 
     @Inject
-    public RestPercolateAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestPercolateAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(GET, "/{index}/{type}/_percolate", this);
         controller.registerHandler(POST, "/{index}/{type}/_percolate", this);
 
-        RestPercolateExistingDocHandler existingDocHandler = new RestPercolateExistingDocHandler(settings, client);
+        RestPercolateExistingDocHandler existingDocHandler = new RestPercolateExistingDocHandler(settings, clientFactory);
         controller.registerHandler(GET, "/{index}/{type}/{id}/_percolate", existingDocHandler);
         controller.registerHandler(POST, "/{index}/{type}/{id}/_percolate", existingDocHandler);
 
-        RestCountPercolateDocHandler countHandler = new RestCountPercolateDocHandler(settings, client);
+        RestCountPercolateDocHandler countHandler = new RestCountPercolateDocHandler(settings, clientFactory);
         controller.registerHandler(GET, "/{index}/{type}/_percolate/count", countHandler);
         controller.registerHandler(POST, "/{index}/{type}/_percolate/count", countHandler);
 
-        RestCountPercolateExistingDocHandler countExistingDocHandler = new RestCountPercolateExistingDocHandler(settings, client);
+        RestCountPercolateExistingDocHandler countExistingDocHandler = new RestCountPercolateExistingDocHandler(settings, clientFactory);
         controller.registerHandler(GET, "/{index}/{type}/{id}/_percolate/count", countExistingDocHandler);
         controller.registerHandler(POST, "/{index}/{type}/{id}/_percolate/count", countExistingDocHandler);
     }
@@ -107,8 +107,8 @@ public class RestPercolateAction extends BaseRestHandler {
 
     final class RestCountPercolateDocHandler extends BaseRestHandler {
 
-        private RestCountPercolateDocHandler(Settings settings, final Client client) {
-            super(settings, client);
+        private RestCountPercolateDocHandler(Settings settings, final ClientFactory clientFactory) {
+            super(settings, clientFactory);
         }
 
         @Override
@@ -121,8 +121,8 @@ public class RestPercolateAction extends BaseRestHandler {
 
     final class RestPercolateExistingDocHandler extends BaseRestHandler {
 
-        protected RestPercolateExistingDocHandler(Settings settings, final Client client) {
-            super(settings, client);
+        protected RestPercolateExistingDocHandler(Settings settings, final ClientFactory clientFactory) {
+            super(settings, clientFactory);
         }
 
         @Override
@@ -134,8 +134,8 @@ public class RestPercolateAction extends BaseRestHandler {
 
     final class RestCountPercolateExistingDocHandler extends BaseRestHandler {
 
-        protected RestCountPercolateExistingDocHandler(Settings settings, final Client client) {
-            super(settings, client);
+        protected RestCountPercolateExistingDocHandler(Settings settings, final ClientFactory clientFactory) {
+            super(settings, clientFactory);
         }
 
         @Override

--- a/src/main/java/org/elasticsearch/rest/action/percolate/RestPercolateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/percolate/RestPercolateAction.java
@@ -40,20 +40,20 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
 public class RestPercolateAction extends BaseRestHandler {
 
     @Inject
-    public RestPercolateAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestPercolateAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(GET, "/{index}/{type}/_percolate", this);
         controller.registerHandler(POST, "/{index}/{type}/_percolate", this);
 
-        RestPercolateExistingDocHandler existingDocHandler = new RestPercolateExistingDocHandler(settings, clientFactory);
+        RestPercolateExistingDocHandler existingDocHandler = new RestPercolateExistingDocHandler(settings, restClientFactory);
         controller.registerHandler(GET, "/{index}/{type}/{id}/_percolate", existingDocHandler);
         controller.registerHandler(POST, "/{index}/{type}/{id}/_percolate", existingDocHandler);
 
-        RestCountPercolateDocHandler countHandler = new RestCountPercolateDocHandler(settings, clientFactory);
+        RestCountPercolateDocHandler countHandler = new RestCountPercolateDocHandler(settings, restClientFactory);
         controller.registerHandler(GET, "/{index}/{type}/_percolate/count", countHandler);
         controller.registerHandler(POST, "/{index}/{type}/_percolate/count", countHandler);
 
-        RestCountPercolateExistingDocHandler countExistingDocHandler = new RestCountPercolateExistingDocHandler(settings, clientFactory);
+        RestCountPercolateExistingDocHandler countExistingDocHandler = new RestCountPercolateExistingDocHandler(settings, restClientFactory);
         controller.registerHandler(GET, "/{index}/{type}/{id}/_percolate/count", countExistingDocHandler);
         controller.registerHandler(POST, "/{index}/{type}/{id}/_percolate/count", countExistingDocHandler);
     }
@@ -107,8 +107,8 @@ public class RestPercolateAction extends BaseRestHandler {
 
     final class RestCountPercolateDocHandler extends BaseRestHandler {
 
-        private RestCountPercolateDocHandler(Settings settings, final ClientFactory clientFactory) {
-            super(settings, clientFactory);
+        private RestCountPercolateDocHandler(Settings settings, final RestClientFactory restClientFactory) {
+            super(settings, restClientFactory);
         }
 
         @Override
@@ -121,8 +121,8 @@ public class RestPercolateAction extends BaseRestHandler {
 
     final class RestPercolateExistingDocHandler extends BaseRestHandler {
 
-        protected RestPercolateExistingDocHandler(Settings settings, final ClientFactory clientFactory) {
-            super(settings, clientFactory);
+        protected RestPercolateExistingDocHandler(Settings settings, final RestClientFactory restClientFactory) {
+            super(settings, restClientFactory);
         }
 
         @Override
@@ -134,8 +134,8 @@ public class RestPercolateAction extends BaseRestHandler {
 
     final class RestCountPercolateExistingDocHandler extends BaseRestHandler {
 
-        protected RestCountPercolateExistingDocHandler(Settings settings, final ClientFactory clientFactory) {
-            super(settings, clientFactory);
+        protected RestCountPercolateExistingDocHandler(Settings settings, final RestClientFactory restClientFactory) {
+            super(settings, restClientFactory);
         }
 
         @Override

--- a/src/main/java/org/elasticsearch/rest/action/script/RestDeleteIndexedScriptAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/script/RestDeleteIndexedScriptAction.java
@@ -36,13 +36,13 @@ import static org.elasticsearch.rest.RestStatus.OK;
 public class RestDeleteIndexedScriptAction extends BaseRestHandler {
 
     @Inject
-    public RestDeleteIndexedScriptAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestDeleteIndexedScriptAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(DELETE, "/_scripts/{lang}/{id}", this);
     }
 
-    protected RestDeleteIndexedScriptAction(Settings settings, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    protected RestDeleteIndexedScriptAction(Settings settings, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
     }
 
     protected String getScriptLang(RestRequest request) {

--- a/src/main/java/org/elasticsearch/rest/action/script/RestDeleteIndexedScriptAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/script/RestDeleteIndexedScriptAction.java
@@ -36,13 +36,13 @@ import static org.elasticsearch.rest.RestStatus.OK;
 public class RestDeleteIndexedScriptAction extends BaseRestHandler {
 
     @Inject
-    public RestDeleteIndexedScriptAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestDeleteIndexedScriptAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(DELETE, "/_scripts/{lang}/{id}", this);
     }
 
-    protected RestDeleteIndexedScriptAction(Settings settings, Client client) {
-        super(settings, client);
+    protected RestDeleteIndexedScriptAction(Settings settings, ClientFactory clientFactory) {
+        super(settings, clientFactory);
     }
 
     protected String getScriptLang(RestRequest request) {

--- a/src/main/java/org/elasticsearch/rest/action/script/RestGetIndexedScriptAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/script/RestGetIndexedScriptAction.java
@@ -43,13 +43,13 @@ import static org.elasticsearch.rest.RestStatus.OK;
 public class RestGetIndexedScriptAction extends BaseRestHandler {
 
     @Inject
-    public RestGetIndexedScriptAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestGetIndexedScriptAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(GET, "/_scripts/{lang}/{id}", this);
     }
 
-    protected RestGetIndexedScriptAction(Settings settings, Client client) {
-        super(settings, client);
+    protected RestGetIndexedScriptAction(Settings settings, ClientFactory clientFactory) {
+        super(settings, clientFactory);
     }
 
     protected String getScriptLang(RestRequest request) {

--- a/src/main/java/org/elasticsearch/rest/action/script/RestGetIndexedScriptAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/script/RestGetIndexedScriptAction.java
@@ -43,13 +43,13 @@ import static org.elasticsearch.rest.RestStatus.OK;
 public class RestGetIndexedScriptAction extends BaseRestHandler {
 
     @Inject
-    public RestGetIndexedScriptAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestGetIndexedScriptAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(GET, "/_scripts/{lang}/{id}", this);
     }
 
-    protected RestGetIndexedScriptAction(Settings settings, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    protected RestGetIndexedScriptAction(Settings settings, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
     }
 
     protected String getScriptLang(RestRequest request) {

--- a/src/main/java/org/elasticsearch/rest/action/script/RestPutIndexedScriptAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/script/RestPutIndexedScriptAction.java
@@ -43,23 +43,23 @@ import static org.elasticsearch.rest.RestStatus.*;
 public class RestPutIndexedScriptAction extends BaseRestHandler {
 
     @Inject
-    public RestPutIndexedScriptAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestPutIndexedScriptAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
 
         controller.registerHandler(POST, "/_scripts/{lang}/{id}", this);
         controller.registerHandler(PUT, "/_scripts/{lang}/{id}", this);
 
-        controller.registerHandler(PUT, "/_scripts/{lang}/{id}/_create", new CreateHandler(settings, client));
-        controller.registerHandler(POST, "/_scripts/{lang}/{id}/_create", new CreateHandler(settings, client));
+        controller.registerHandler(PUT, "/_scripts/{lang}/{id}/_create", new CreateHandler(settings, clientFactory));
+        controller.registerHandler(POST, "/_scripts/{lang}/{id}/_create", new CreateHandler(settings, clientFactory));
     }
 
-    protected RestPutIndexedScriptAction(Settings settings, Client client) {
-        super(settings, client);
+    protected RestPutIndexedScriptAction(Settings settings, ClientFactory clientFactory) {
+        super(settings, clientFactory);
     }
 
     final class CreateHandler extends BaseRestHandler {
-        protected CreateHandler(Settings settings, final Client client) {
-            super(settings, client);
+        protected CreateHandler(Settings settings, ClientFactory clientFactory) {
+            super(settings, clientFactory);
         }
 
         @Override

--- a/src/main/java/org/elasticsearch/rest/action/script/RestPutIndexedScriptAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/script/RestPutIndexedScriptAction.java
@@ -43,23 +43,23 @@ import static org.elasticsearch.rest.RestStatus.*;
 public class RestPutIndexedScriptAction extends BaseRestHandler {
 
     @Inject
-    public RestPutIndexedScriptAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestPutIndexedScriptAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
 
         controller.registerHandler(POST, "/_scripts/{lang}/{id}", this);
         controller.registerHandler(PUT, "/_scripts/{lang}/{id}", this);
 
-        controller.registerHandler(PUT, "/_scripts/{lang}/{id}/_create", new CreateHandler(settings, clientFactory));
-        controller.registerHandler(POST, "/_scripts/{lang}/{id}/_create", new CreateHandler(settings, clientFactory));
+        controller.registerHandler(PUT, "/_scripts/{lang}/{id}/_create", new CreateHandler(settings, restClientFactory));
+        controller.registerHandler(POST, "/_scripts/{lang}/{id}/_create", new CreateHandler(settings, restClientFactory));
     }
 
-    protected RestPutIndexedScriptAction(Settings settings, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    protected RestPutIndexedScriptAction(Settings settings, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
     }
 
     final class CreateHandler extends BaseRestHandler {
-        protected CreateHandler(Settings settings, ClientFactory clientFactory) {
-            super(settings, clientFactory);
+        protected CreateHandler(Settings settings, RestClientFactory restClientFactory) {
+            super(settings, restClientFactory);
         }
 
         @Override

--- a/src/main/java/org/elasticsearch/rest/action/search/RestClearScrollAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/search/RestClearScrollAction.java
@@ -25,10 +25,7 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.rest.BaseRestHandler;
-import org.elasticsearch.rest.RestChannel;
-import org.elasticsearch.rest.RestController;
-import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.RestActions;
 import org.elasticsearch.rest.action.support.RestStatusToXContentListener;
 
@@ -41,8 +38,8 @@ import static org.elasticsearch.rest.RestRequest.Method.DELETE;
 public class RestClearScrollAction extends BaseRestHandler {
 
     @Inject
-    public RestClearScrollAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestClearScrollAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
 
         controller.registerHandler(DELETE, "/_search/scroll", this);
         controller.registerHandler(DELETE, "/_search/scroll/{scroll_id}", this);

--- a/src/main/java/org/elasticsearch/rest/action/search/RestClearScrollAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/search/RestClearScrollAction.java
@@ -38,8 +38,8 @@ import static org.elasticsearch.rest.RestRequest.Method.DELETE;
 public class RestClearScrollAction extends BaseRestHandler {
 
     @Inject
-    public RestClearScrollAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestClearScrollAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
 
         controller.registerHandler(DELETE, "/_search/scroll", this);
         controller.registerHandler(DELETE, "/_search/scroll/{scroll_id}", this);

--- a/src/main/java/org/elasticsearch/rest/action/search/RestMultiSearchAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/search/RestMultiSearchAction.java
@@ -40,8 +40,8 @@ public class RestMultiSearchAction extends BaseRestHandler {
     private final boolean allowExplicitIndex;
 
     @Inject
-    public RestMultiSearchAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestMultiSearchAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
 
         controller.registerHandler(GET, "/_msearch", this);
         controller.registerHandler(POST, "/_msearch", this);

--- a/src/main/java/org/elasticsearch/rest/action/search/RestMultiSearchAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/search/RestMultiSearchAction.java
@@ -40,8 +40,8 @@ public class RestMultiSearchAction extends BaseRestHandler {
     private final boolean allowExplicitIndex;
 
     @Inject
-    public RestMultiSearchAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestMultiSearchAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
 
         controller.registerHandler(GET, "/_msearch", this);
         controller.registerHandler(POST, "/_msearch", this);

--- a/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
@@ -29,10 +29,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.QueryStringQueryBuilder;
-import org.elasticsearch.rest.BaseRestHandler;
-import org.elasticsearch.rest.RestChannel;
-import org.elasticsearch.rest.RestController;
-import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.exists.RestExistsAction;
 import org.elasticsearch.rest.action.support.RestStatusToXContentListener;
 import org.elasticsearch.search.Scroll;
@@ -52,8 +49,8 @@ import static org.elasticsearch.search.suggest.SuggestBuilders.termSuggestion;
 public class RestSearchAction extends BaseRestHandler {
 
     @Inject
-    public RestSearchAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestSearchAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(GET, "/_search", this);
         controller.registerHandler(POST, "/_search", this);
         controller.registerHandler(GET, "/{index}/_search", this);
@@ -67,7 +64,7 @@ public class RestSearchAction extends BaseRestHandler {
         controller.registerHandler(GET, "/{index}/{type}/_search/template", this);
         controller.registerHandler(POST, "/{index}/{type}/_search/template", this);
 
-        RestExistsAction restExistsAction = new RestExistsAction(settings, client);
+        RestExistsAction restExistsAction = new RestExistsAction(settings, clientFactory);
         controller.registerHandler(GET, "/_search/exists", restExistsAction);
         controller.registerHandler(POST, "/_search/exists", restExistsAction);
         controller.registerHandler(GET, "/{index}/_search/exists", restExistsAction);

--- a/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
@@ -49,8 +49,8 @@ import static org.elasticsearch.search.suggest.SuggestBuilders.termSuggestion;
 public class RestSearchAction extends BaseRestHandler {
 
     @Inject
-    public RestSearchAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestSearchAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(GET, "/_search", this);
         controller.registerHandler(POST, "/_search", this);
         controller.registerHandler(GET, "/{index}/_search", this);
@@ -64,7 +64,7 @@ public class RestSearchAction extends BaseRestHandler {
         controller.registerHandler(GET, "/{index}/{type}/_search/template", this);
         controller.registerHandler(POST, "/{index}/{type}/_search/template", this);
 
-        RestExistsAction restExistsAction = new RestExistsAction(settings, clientFactory);
+        RestExistsAction restExistsAction = new RestExistsAction(settings, restClientFactory);
         controller.registerHandler(GET, "/_search/exists", restExistsAction);
         controller.registerHandler(POST, "/_search/exists", restExistsAction);
         controller.registerHandler(GET, "/{index}/_search/exists", restExistsAction);

--- a/src/main/java/org/elasticsearch/rest/action/search/RestSearchScrollAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/search/RestSearchScrollAction.java
@@ -39,8 +39,8 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
 public class RestSearchScrollAction extends BaseRestHandler {
 
     @Inject
-    public RestSearchScrollAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestSearchScrollAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
 
         controller.registerHandler(GET, "/_search/scroll", this);
         controller.registerHandler(POST, "/_search/scroll", this);

--- a/src/main/java/org/elasticsearch/rest/action/search/RestSearchScrollAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/search/RestSearchScrollAction.java
@@ -24,10 +24,7 @@ import org.elasticsearch.action.search.SearchScrollRequest;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.rest.BaseRestHandler;
-import org.elasticsearch.rest.RestChannel;
-import org.elasticsearch.rest.RestController;
-import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.RestActions;
 import org.elasticsearch.rest.action.support.RestStatusToXContentListener;
 import org.elasticsearch.search.Scroll;
@@ -42,8 +39,8 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
 public class RestSearchScrollAction extends BaseRestHandler {
 
     @Inject
-    public RestSearchScrollAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestSearchScrollAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
 
         controller.registerHandler(GET, "/_search/scroll", this);
         controller.registerHandler(POST, "/_search/scroll", this);

--- a/src/main/java/org/elasticsearch/rest/action/suggest/RestSuggestAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/suggest/RestSuggestAction.java
@@ -43,8 +43,8 @@ import static org.elasticsearch.rest.action.support.RestActions.buildBroadcastSh
 public class RestSuggestAction extends BaseRestHandler {
 
     @Inject
-    public RestSuggestAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestSuggestAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(POST, "/_suggest", this);
         controller.registerHandler(GET, "/_suggest", this);
         controller.registerHandler(POST, "/{index}/_suggest", this);

--- a/src/main/java/org/elasticsearch/rest/action/suggest/RestSuggestAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/suggest/RestSuggestAction.java
@@ -43,8 +43,8 @@ import static org.elasticsearch.rest.action.support.RestActions.buildBroadcastSh
 public class RestSuggestAction extends BaseRestHandler {
 
     @Inject
-    public RestSuggestAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestSuggestAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(POST, "/_suggest", this);
         controller.registerHandler(GET, "/_suggest", this);
         controller.registerHandler(POST, "/{index}/_suggest", this);

--- a/src/main/java/org/elasticsearch/rest/action/template/RestDeleteSearchTemplateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/template/RestDeleteSearchTemplateAction.java
@@ -20,7 +20,7 @@ package org.elasticsearch.rest.action.template;
 
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.rest.ClientFactory;
+import org.elasticsearch.rest.RestClientFactory;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.script.RestDeleteIndexedScriptAction;
@@ -30,8 +30,8 @@ import static org.elasticsearch.rest.RestRequest.Method.DELETE;
 public class RestDeleteSearchTemplateAction extends RestDeleteIndexedScriptAction {
 
     @Inject
-    public RestDeleteSearchTemplateAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestDeleteSearchTemplateAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(DELETE, "/_search/template/{id}", this);
     }
 

--- a/src/main/java/org/elasticsearch/rest/action/template/RestDeleteSearchTemplateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/template/RestDeleteSearchTemplateAction.java
@@ -18,9 +18,9 @@
  */
 package org.elasticsearch.rest.action.template;
 
-import org.elasticsearch.client.Client;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.rest.ClientFactory;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.script.RestDeleteIndexedScriptAction;
@@ -30,8 +30,8 @@ import static org.elasticsearch.rest.RestRequest.Method.DELETE;
 public class RestDeleteSearchTemplateAction extends RestDeleteIndexedScriptAction {
 
     @Inject
-    public RestDeleteSearchTemplateAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestDeleteSearchTemplateAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(DELETE, "/_search/template/{id}", this);
     }
 

--- a/src/main/java/org/elasticsearch/rest/action/template/RestGetSearchTemplateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/template/RestGetSearchTemplateAction.java
@@ -20,7 +20,7 @@ package org.elasticsearch.rest.action.template;
 
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.rest.ClientFactory;
+import org.elasticsearch.rest.RestClientFactory;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.script.RestGetIndexedScriptAction;
@@ -33,8 +33,8 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 public class RestGetSearchTemplateAction extends RestGetIndexedScriptAction {
 
     @Inject
-    public RestGetSearchTemplateAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestGetSearchTemplateAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(GET, "/_search/template/{id}", this);
     }
 

--- a/src/main/java/org/elasticsearch/rest/action/template/RestGetSearchTemplateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/template/RestGetSearchTemplateAction.java
@@ -18,9 +18,9 @@
  */
 package org.elasticsearch.rest.action.template;
 
-import org.elasticsearch.client.Client;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.rest.ClientFactory;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.script.RestGetIndexedScriptAction;
@@ -33,8 +33,8 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 public class RestGetSearchTemplateAction extends RestGetIndexedScriptAction {
 
     @Inject
-    public RestGetSearchTemplateAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestGetSearchTemplateAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(GET, "/_search/template/{id}", this);
     }
 

--- a/src/main/java/org/elasticsearch/rest/action/template/RestPutSearchTemplateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/template/RestPutSearchTemplateAction.java
@@ -21,10 +21,7 @@ package org.elasticsearch.rest.action.template;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.rest.BaseRestHandler;
-import org.elasticsearch.rest.RestChannel;
-import org.elasticsearch.rest.RestController;
-import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.script.RestPutIndexedScriptAction;
 
 import static org.elasticsearch.rest.RestRequest.Method.POST;
@@ -36,20 +33,20 @@ import static org.elasticsearch.rest.RestRequest.Method.PUT;
 public class RestPutSearchTemplateAction extends RestPutIndexedScriptAction {
 
     @Inject
-    public RestPutSearchTemplateAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestPutSearchTemplateAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
 
         //controller.registerHandler(GET, "/template", this);
         controller.registerHandler(POST, "/_search/template/{id}", this);
         controller.registerHandler(PUT, "/_search/template/{id}", this);
 
-        controller.registerHandler(PUT, "/_search/template/{id}/_create", new CreateHandler(settings, client));
-        controller.registerHandler(POST, "/_search/template/{id}/_create", new CreateHandler(settings, client));
+        controller.registerHandler(PUT, "/_search/template/{id}/_create", new CreateHandler(settings, clientFactory));
+        controller.registerHandler(POST, "/_search/template/{id}/_create", new CreateHandler(settings, clientFactory));
     }
 
     final class CreateHandler extends BaseRestHandler {
-        protected CreateHandler(Settings settings, final Client client) {
-            super(settings, client);
+        protected CreateHandler(Settings settings, ClientFactory clientFactory) {
+            super(settings, clientFactory);
         }
 
         @Override

--- a/src/main/java/org/elasticsearch/rest/action/template/RestPutSearchTemplateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/template/RestPutSearchTemplateAction.java
@@ -33,20 +33,20 @@ import static org.elasticsearch.rest.RestRequest.Method.PUT;
 public class RestPutSearchTemplateAction extends RestPutIndexedScriptAction {
 
     @Inject
-    public RestPutSearchTemplateAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestPutSearchTemplateAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
 
         //controller.registerHandler(GET, "/template", this);
         controller.registerHandler(POST, "/_search/template/{id}", this);
         controller.registerHandler(PUT, "/_search/template/{id}", this);
 
-        controller.registerHandler(PUT, "/_search/template/{id}/_create", new CreateHandler(settings, clientFactory));
-        controller.registerHandler(POST, "/_search/template/{id}/_create", new CreateHandler(settings, clientFactory));
+        controller.registerHandler(PUT, "/_search/template/{id}/_create", new CreateHandler(settings, restClientFactory));
+        controller.registerHandler(POST, "/_search/template/{id}/_create", new CreateHandler(settings, restClientFactory));
     }
 
     final class CreateHandler extends BaseRestHandler {
-        protected CreateHandler(Settings settings, ClientFactory clientFactory) {
-            super(settings, clientFactory);
+        protected CreateHandler(Settings settings, RestClientFactory restClientFactory) {
+            super(settings, restClientFactory);
         }
 
         @Override

--- a/src/main/java/org/elasticsearch/rest/action/termvector/RestMultiTermVectorsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/termvector/RestMultiTermVectorsAction.java
@@ -36,8 +36,8 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
 public class RestMultiTermVectorsAction extends BaseRestHandler {
 
     @Inject
-    public RestMultiTermVectorsAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestMultiTermVectorsAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(GET, "/_mtermvectors", this);
         controller.registerHandler(POST, "/_mtermvectors", this);
         controller.registerHandler(GET, "/{index}/_mtermvectors", this);

--- a/src/main/java/org/elasticsearch/rest/action/termvector/RestMultiTermVectorsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/termvector/RestMultiTermVectorsAction.java
@@ -36,8 +36,8 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
 public class RestMultiTermVectorsAction extends BaseRestHandler {
 
     @Inject
-    public RestMultiTermVectorsAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestMultiTermVectorsAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(GET, "/_mtermvectors", this);
         controller.registerHandler(POST, "/_mtermvectors", this);
         controller.registerHandler(GET, "/{index}/_mtermvectors", this);

--- a/src/main/java/org/elasticsearch/rest/action/termvector/RestTermVectorAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/termvector/RestTermVectorAction.java
@@ -27,10 +27,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.rest.BaseRestHandler;
-import org.elasticsearch.rest.RestChannel;
-import org.elasticsearch.rest.RestController;
-import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.RestToXContentListener;
 
 import java.util.HashSet;
@@ -46,8 +43,8 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
 public class RestTermVectorAction extends BaseRestHandler {
 
     @Inject
-    public RestTermVectorAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestTermVectorAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(GET, "/{index}/{type}/_termvector", this);
         controller.registerHandler(POST, "/{index}/{type}/_termvector", this);
         controller.registerHandler(GET, "/{index}/{type}/{id}/_termvector", this);

--- a/src/main/java/org/elasticsearch/rest/action/termvector/RestTermVectorAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/termvector/RestTermVectorAction.java
@@ -43,8 +43,8 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
 public class RestTermVectorAction extends BaseRestHandler {
 
     @Inject
-    public RestTermVectorAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestTermVectorAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(GET, "/{index}/{type}/_termvector", this);
         controller.registerHandler(POST, "/{index}/{type}/_termvector", this);
         controller.registerHandler(GET, "/{index}/{type}/{id}/_termvector", this);

--- a/src/main/java/org/elasticsearch/rest/action/update/RestUpdateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/update/RestUpdateAction.java
@@ -47,8 +47,8 @@ import static org.elasticsearch.rest.RestStatus.OK;
 public class RestUpdateAction extends BaseRestHandler {
 
     @Inject
-    public RestUpdateAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public RestUpdateAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(POST, "/{index}/{type}/{id}/_update", this);
     }
 

--- a/src/main/java/org/elasticsearch/rest/action/update/RestUpdateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/update/RestUpdateAction.java
@@ -47,8 +47,8 @@ import static org.elasticsearch.rest.RestStatus.OK;
 public class RestUpdateAction extends BaseRestHandler {
 
     @Inject
-    public RestUpdateAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public RestUpdateAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(POST, "/{index}/{type}/{id}/_update", this);
     }
 

--- a/src/test/java/org/elasticsearch/plugins/responseheader/TestResponseHeaderRestAction.java
+++ b/src/test/java/org/elasticsearch/plugins/responseheader/TestResponseHeaderRestAction.java
@@ -26,8 +26,8 @@ import org.elasticsearch.rest.*;
 public class TestResponseHeaderRestAction extends BaseRestHandler {
 
     @Inject
-    public TestResponseHeaderRestAction(Settings settings, Client client, RestController controller) {
-        super(settings, client);
+    public TestResponseHeaderRestAction(Settings settings, RestController controller, ClientFactory clientFactory) {
+        super(settings, clientFactory);
         controller.registerHandler(RestRequest.Method.GET, "/_protected", this);
     }
 

--- a/src/test/java/org/elasticsearch/plugins/responseheader/TestResponseHeaderRestAction.java
+++ b/src/test/java/org/elasticsearch/plugins/responseheader/TestResponseHeaderRestAction.java
@@ -26,8 +26,8 @@ import org.elasticsearch.rest.*;
 public class TestResponseHeaderRestAction extends BaseRestHandler {
 
     @Inject
-    public TestResponseHeaderRestAction(Settings settings, RestController controller, ClientFactory clientFactory) {
-        super(settings, clientFactory);
+    public TestResponseHeaderRestAction(Settings settings, RestController controller, RestClientFactory restClientFactory) {
+        super(settings, restClientFactory);
         controller.registerHandler(RestRequest.Method.GET, "/_protected", this);
     }
 

--- a/src/test/java/org/elasticsearch/rest/HeadersAndContextCopyClientTests.java
+++ b/src/test/java/org/elasticsearch/rest/HeadersAndContextCopyClientTests.java
@@ -55,7 +55,7 @@ public class HeadersAndContextCopyClientTests extends ElasticsearchTestCase {
     @Test
     public void testAddUsefulHeaders() throws InterruptedException {
 
-        final ClientFactory clientFactory = new ClientFactory(null);
+        final RestClientFactory restClientFactory = new RestClientFactory(null);
         int iterations = randomIntBetween(1, 5);
 
         Set<String> headers = new HashSet<>();
@@ -72,14 +72,14 @@ public class HeadersAndContextCopyClientTests extends ElasticsearchTestCase {
             executorService.submit(new Runnable() {
                 @Override
                 public void run() {
-                    clientFactory.addUsefulHeaders(newHeaders.toArray(new String[newHeaders.size()]));
+                    restClientFactory.addRelevantHeaders(newHeaders.toArray(new String[newHeaders.size()]));
                 }
             });
         }
 
         executorService.shutdown();
         assertThat(executorService.awaitTermination(1, TimeUnit.SECONDS), equalTo(true));
-        String[] usefulHeaders = clientFactory.usefulHeaders().toArray(new String[clientFactory.usefulHeaders().size()]);
+        String[] usefulHeaders = restClientFactory.relevantHeaders().toArray(new String[restClientFactory.relevantHeaders().size()]);
         assertThat(usefulHeaders.length, equalTo(headers.size()));
 
         Arrays.sort(usefulHeaders);
@@ -375,7 +375,7 @@ public class HeadersAndContextCopyClientTests extends ElasticsearchTestCase {
     }
 
     private static Client client(Client noOpClient, RestRequest restRequest, Set<String> usefulRestHeaders) {
-        return new ClientFactory.HeadersAndContextCopyClient(noOpClient, restRequest, usefulRestHeaders);
+        return new RestClientFactory.HeadersAndContextCopyClient(noOpClient, restRequest, usefulRestHeaders);
     }
 
     private static void putHeaders(ActionRequest<?> request, Map<String, String> headers) {


### PR DESCRIPTION
The functionality of copying headers in the REST layer (from REST requests to transport requests) remains the same. Made it a bit nicer by introducing a ClientFactory component that is a singleton and allows to register useful headers without requiring static methods.

Plugins just have to inject the ClientFactory now, and call its `addUsefulHeaders` method that is not static anymore.

Relates to #6513
