### PR TITLE
Test: Allow SingleNodeTest to reset the node if really needed after test.

### DIFF
--- a/src/test/java/org/elasticsearch/test/ElasticsearchSingleNodeLuceneTestCase.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchSingleNodeLuceneTestCase.java
@@ -34,7 +34,16 @@ public abstract class ElasticsearchSingleNodeLuceneTestCase extends Elasticsearc
 
     @After
     public void cleanup() {
-        ElasticsearchSingleNodeTest.cleanup();
+        ElasticsearchSingleNodeTest.cleanup(resetNodeAfterTest());
+    }
+
+    /**
+     * This method returns <code>true</code> if the node that is used in the background should be reset
+     * after each test. This is useful if the test changes the cluster state metadata etc. The default is
+     * <code>false</code>.
+     */
+    protected boolean resetNodeAfterTest() {
+        return false;
     }
 
     /**

--- a/src/test/java/org/elasticsearch/test/ElasticsearchSingleNodeTest.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchSingleNodeTest.java
@@ -58,11 +58,20 @@ public abstract class ElasticsearchSingleNodeTest extends ElasticsearchTestCase 
 
     private static class Holder {
         // lazy init on first access
-        private static final Node NODE = newNode();
+        private static Node NODE = newNode();
+
+        private static void reset() {
+            assert NODE != null;
+            node().stop();
+            Holder.NODE = newNode();
+        }
     }
 
-    static void cleanup() {
+    static void cleanup(boolean resetNode) {
         assertAcked(client().admin().indices().prepareDelete("*").get());
+        if (resetNode) {
+            Holder.reset();
+        }
         MetaData metaData = client().admin().cluster().prepareState().get().getState().getMetaData();
         assertThat("test leaves persistent cluster metadata behind: " + metaData.persistentSettings().getAsMap(),
                 metaData.persistentSettings().getAsMap().size(), equalTo(0));
@@ -72,7 +81,16 @@ public abstract class ElasticsearchSingleNodeTest extends ElasticsearchTestCase 
 
     @After
     public void after() {
-        cleanup();
+        cleanup(resetNodeAfterTest());
+    }
+
+    /**
+     * This method returns <code>true</code> if the node that is used in the background should be reset
+     * after each test. This is useful if the test changes the cluster state metadata etc. The default is
+     * <code>false</code>.
+     */
+    protected boolean resetNodeAfterTest() {
+        return false;
     }
 
     private static Node newNode() {


### PR DESCRIPTION
This relates to #7550 I think we should at some point merge / refactor the annotations in the test cases ie. this is just a simple workaround...
