### PR TITLE
Change LZFCompressedStreamOutput to use buffer recycler when allocating encoder

### DIFF
--- a/src/main/java/org/elasticsearch/common/compress/lzf/LZFCompressedStreamOutput.java
+++ b/src/main/java/org/elasticsearch/common/compress/lzf/LZFCompressedStreamOutput.java
@@ -28,8 +28,6 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
 
-/**
- */
 public class LZFCompressedStreamOutput extends CompressedStreamOutput<LZFCompressorContext> {
 
     private final BufferRecycler recycler;
@@ -40,7 +38,7 @@ public class LZFCompressedStreamOutput extends CompressedStreamOutput<LZFCompres
         this.recycler = BufferRecycler.instance();
         this.uncompressed = this.recycler.allocOutputBuffer(LZFChunk.MAX_CHUNK_LEN);
         this.uncompressedLength = LZFChunk.MAX_CHUNK_LEN;
-        this.encoder = ChunkEncoderFactory.safeInstance();
+        this.encoder = ChunkEncoderFactory.safeInstance(recycler);
     }
 
     @Override


### PR DESCRIPTION
It should be the same instance (thread local), but better to be safe.
