### PR TITLE
Add explicit error when PUT mapping API is given an empty request body.

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingRequest.java
@@ -83,9 +83,13 @@ public class PutMappingRequest extends AcknowledgedRequest<PutMappingRequest> im
         ActionRequestValidationException validationException = null;
         if (type == null) {
             validationException = addValidationError("mapping type is missing", validationException);
+        }else if (type.isEmpty()) {
+            validationException = addValidationError("mapping type is empty", validationException);
         }
         if (source == null) {
             validationException = addValidationError("mapping source is missing", validationException);
+        } else if (source.isEmpty()) {
+            validationException = addValidationError("mapping source is empty", validationException);
         }
         return validationException;
     }

--- a/src/test/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingRequestTests.java
+++ b/src/test/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingRequestTests.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.admin.indices.mapping.put;
+
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.test.ElasticsearchTestCase;
+
+public class PutMappingRequestTests extends ElasticsearchTestCase {
+
+    public void testValidation() {
+        PutMappingRequest r = new PutMappingRequest("myindex");
+        ActionRequestValidationException ex = r.validate();
+        assertNotNull("type validation should fail", ex);
+        assertTrue(ex.getMessage().contains("type is missing"));
+
+        r.type("");
+        ex = r.validate();
+        assertNotNull("type validation should fail", ex);
+        assertTrue(ex.getMessage().contains("type is empty"));
+
+        r.type("mytype");
+        ex = r.validate();
+        assertNotNull("source validation should fail", ex);
+        assertTrue(ex.getMessage().contains("source is missing"));
+
+        r.source("");
+        ex = r.validate();
+        assertNotNull("source validation should fail", ex);
+        assertTrue(ex.getMessage().contains("source is empty"));
+
+        r.source("somevalidmapping");
+        ex = r.validate();
+        assertNull("validation should succeed", ex);
+    }
+}


### PR DESCRIPTION
I also added validation for an empty type, and added tests (just for validation for now).

closes #7536
