### PR TITLE
RestAPI: Change validation exceptions to respond with 400 status instead of 500

### DIFF
--- a/src/main/java/org/elasticsearch/action/ActionRequestValidationException.java
+++ b/src/main/java/org/elasticsearch/action/ActionRequestValidationException.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.action;
 
-import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.ElasticsearchIllegalArgumentException;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -27,7 +27,7 @@ import java.util.List;
 /**
  *
  */
-public class ActionRequestValidationException extends ElasticsearchException {
+public class ActionRequestValidationException extends ElasticsearchIllegalArgumentException {
 
     private final List<String> validationErrors = new ArrayList<>();
 


### PR DESCRIPTION
Validation errors are clearly in the realm of client errors (a program with the request).  Thus they should return a 4xx response code.
