### PR TITLE
dynamic scripting update is disabled by default so reflect it to "getting started" doc.

### DIFF
--- a/docs/reference/getting-started.asciidoc
+++ b/docs/reference/getting-started.asciidoc
@@ -447,18 +447,6 @@ curl -XPOST 'localhost:9200/customer/external/1/_update?pretty' -d '
 }'
 --------------------------------------------------
 
-Updates can also be performed by using simple scripts. This example uses a script to increment the age by 5:
-
-[source,sh]
---------------------------------------------------
-curl -XPOST 'localhost:9200/customer/external/1/_update?pretty' -d '
-{
-  "script" : "ctx._source.age += 5"
-}'
---------------------------------------------------
-
-In the above example, `ctx._source` refers to the current source document that is about to be updated.
-
 Note that as of this writing, updates can only be performed on a single document at a time. In the future, Elasticsearch will provide the ability to update multiple documents given a query condition (like an `SQL UPDATE-WHERE` statement).
 
 === Deleting Documents


### PR DESCRIPTION
Since dynamic scripting update is disabled by default as of 1.3.0, reference documentation should reflect it. Updated relevant section by removing few lines which explains update by dynamic scripting.
