### PR TITLE
Resiliency: Add logging/safety when deleting files

### DIFF
--- a/all-signatures.txt
+++ b/all-signatures.txt
@@ -1,3 +1,5 @@
 @defaultMessage Convert to URI
 java.net.URL#getPath()
 java.net.URL#getFile()
+
+java.io.File#delete() @ use Files.delete for real exception, IOUtils.deleteFilesIgnoringExceptions if you dont care

--- a/core-signatures.txt
+++ b/core-signatures.txt
@@ -111,5 +111,3 @@ com.ning.compress.lzf.LZFOutputStream#<init>(java.io.OutputStream)
 com.ning.compress.lzf.LZFOutputStream#<init>(java.io.OutputStream, com.ning.compress.BufferRecycler)
 com.ning.compress.lzf.LZFUncompressor#<init>(com.ning.compress.DataHandler)
 com.ning.compress.lzf.LZFUncompressor#<init>(com.ning.compress.DataHandler, com.ning.compress.BufferRecycler)
-
-java.io.File#delete() @ use Files.delete for real exception, IOUtils.deleteFilesIgnoringExceptions if you dont care

--- a/core-signatures.txt
+++ b/core-signatures.txt
@@ -111,3 +111,5 @@ com.ning.compress.lzf.LZFOutputStream#<init>(java.io.OutputStream)
 com.ning.compress.lzf.LZFOutputStream#<init>(java.io.OutputStream, com.ning.compress.BufferRecycler)
 com.ning.compress.lzf.LZFUncompressor#<init>(com.ning.compress.DataHandler)
 com.ning.compress.lzf.LZFUncompressor#<init>(com.ning.compress.DataHandler, com.ning.compress.BufferRecycler)
+
+java.io.File#delete() @ use Files.delete for real exception, IOUtils.deleteFilesIgnoringExceptions if you dont care

--- a/src/main/java/org/apache/lucene/search/suggest/analyzing/XAnalyzingSuggester.java
+++ b/src/main/java/org/apache/lucene/search/suggest/analyzing/XAnalyzingSuggester.java
@@ -40,6 +40,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Files;
 import java.util.*;
 
 /**
@@ -530,7 +531,7 @@ public class XAnalyzingSuggester extends Lookup {
       new OfflineSorter(new AnalyzingComparator(hasPayloads)).sort(tempInput, tempSorted);
 
       // Free disk space:
-      tempInput.delete();
+      Files.delete(tempInput.toPath());
 
       reader = new OfflineSorter.ByteSequencesReader(tempSorted);
      
@@ -625,14 +626,13 @@ public class XAnalyzingSuggester extends Lookup {
 
       success = true;
     } finally {
+      IOUtils.closeWhileHandlingException(reader, writer);
+
       if (success) {
-        IOUtils.close(reader, writer);
+        XIOUtils.deleteFilesIfExist(tempInput, tempSorted);
       } else {
-        IOUtils.closeWhileHandlingException(reader, writer);
+        XIOUtils.deleteFilesIgnoringExceptions(tempInput, tempSorted);
       }
-      
-      tempInput.delete();
-      tempSorted.delete();
     }
   }
 

--- a/src/main/java/org/apache/lucene/util/XIOUtils.java
+++ b/src/main/java/org/apache/lucene/util/XIOUtils.java
@@ -1,0 +1,154 @@
+package org.apache.lucene.util;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** This class emulates the new Java 7 "Try-With-Resources" statement.
+ * Remove once Lucene is on Java 7.
+ * @lucene.internal */
+public final class XIOUtils {
+  
+  private XIOUtils() {} // no instance
+  
+  static {
+      assert Version.LATEST.equals(Version.LUCENE_4_10_0) : "Remove this class on upgrade to Lucene 4.11";
+  }
+  
+  /** adds a Throwable to the list of suppressed Exceptions of the first Throwable
+   * @param exception this exception should get the suppressed one added
+   * @param suppressed the suppressed exception
+   */
+  private static void addSuppressed(Throwable exception, Throwable suppressed) {
+    if (exception != null && suppressed != null) {
+      exception.addSuppressed(suppressed);
+    }
+  }
+  
+  /**
+   * Deletes all given files, suppressing all thrown IOExceptions.
+   * <p>
+   * Some of the files may be null, if so they are ignored.
+   */
+  public static void deleteFilesIgnoringExceptions(File... files) {
+    deleteFilesIgnoringExceptions(Arrays.asList(files));
+  }
+  
+  /**
+   * Deletes all given files, suppressing all thrown IOExceptions.
+   * <p>
+   * Some of the files may be null, if so they are ignored.
+   */
+  public static void deleteFilesIgnoringExceptions(Iterable<? extends File> files) {
+    for (File name : files) {
+      if (name != null) {
+        try {
+          Files.delete(name.toPath());
+        } catch (Throwable ignored) {
+          // ignore
+        }
+      }
+    }
+  }
+  
+  /**
+   * Deletes all given <tt>File</tt>s, if they exist.  Some of the
+   * <tt>File</tt>s may be null; they are
+   * ignored.  After everything is deleted, the method either
+   * throws the first exception it hit while deleting, or
+   * completes normally if there were no exceptions.
+   * 
+   * @param files files to delete
+   */
+  public static void deleteFilesIfExist(File... files) throws IOException {
+    deleteFilesIfExist(Arrays.asList(files));
+  }
+  
+  /**
+   * Deletes all given <tt>File</tt>s, if they exist.  Some of the
+   * <tt>File</tt>s may be null; they are
+   * ignored.  After everything is deleted, the method either
+   * throws the first exception it hit while deleting, or
+   * completes normally if there were no exceptions.
+   * 
+   * @param files files to delete
+   */
+  public static void deleteFilesIfExist(Iterable<? extends File> files) throws IOException {
+    Throwable th = null;
+
+    for (File file : files) {
+      try {
+        if (file != null) {
+          Files.deleteIfExists(file.toPath());
+        }
+      } catch (Throwable t) {
+        addSuppressed(th, t);
+        if (th == null) {
+          th = t;
+        }
+      }
+    }
+
+    IOUtils.reThrow(th);
+  }
+  
+  /**
+   * Deletes one or more files or directories (and everything underneath it).
+   * 
+   * @throws IOException if any of the given files (or their subhierarchy files in case
+   * of directories) cannot be removed.
+   */
+  public static void rm(File... locations) throws IOException {
+    LinkedHashMap<File,Throwable> unremoved = rm(new LinkedHashMap<File,Throwable>(), locations);
+    if (!unremoved.isEmpty()) {
+      StringBuilder b = new StringBuilder("Could not remove the following files (in the order of attempts):\n");
+      for (Map.Entry<File,Throwable> kv : unremoved.entrySet()) {
+        b.append("   ")
+         .append(kv.getKey().getAbsolutePath())
+         .append(": ")
+         .append(kv.getValue())
+         .append("\n");
+      }
+      throw new IOException(b.toString());
+    }
+  }
+
+  private static LinkedHashMap<File,Throwable> rm(LinkedHashMap<File,Throwable> unremoved, File... locations) {
+    if (locations != null) {
+      for (File location : locations) {
+        if (location != null && location.exists()) {
+          if (location.isDirectory()) {
+            rm(unremoved, location.listFiles());
+          }
+  
+          try {
+            Files.delete(location.toPath());
+          } catch (Throwable cause) {
+            unremoved.put(location, cause);
+          }
+        }
+      }
+    }
+    return unremoved;
+  }
+}

--- a/src/main/java/org/elasticsearch/common/blobstore/fs/AbstractFsBlobContainer.java
+++ b/src/main/java/org/elasticsearch/common/blobstore/fs/AbstractFsBlobContainer.java
@@ -29,8 +29,8 @@ import org.elasticsearch.common.collect.MapBuilder;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.Files;
 
 /**
  *
@@ -67,7 +67,13 @@ public abstract class AbstractFsBlobContainer extends AbstractBlobContainer {
     }
 
     public boolean deleteBlob(String blobName) throws IOException {
-        return new File(path, blobName).delete();
+        // TODO: change this API to return void and just throw exception if it cannot delete?
+        try {
+            Files.delete(new File(path, blobName).toPath());
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobStore.java
+++ b/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobStore.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.common.blobstore.fs;
 
+import org.apache.lucene.util.XIOUtils;
 import org.elasticsearch.common.blobstore.BlobPath;
 import org.elasticsearch.common.blobstore.BlobStore;
 import org.elasticsearch.common.blobstore.BlobStoreException;
@@ -84,7 +85,11 @@ public class FsBlobStore extends AbstractComponent implements BlobStore {
 
     @Override
     public void delete(BlobPath path) {
-        FileSystemUtils.deleteRecursively(buildPath(path));
+        try {
+            XIOUtils.rm(buildPath(path));
+        } catch (Exception e) {
+            logger.debug("failed to delete files", e);
+        }
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/common/blobstore/fs/FsImmutableBlobContainer.java
+++ b/src/main/java/org/elasticsearch/common/blobstore/fs/FsImmutableBlobContainer.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.common.blobstore.fs;
 
+import org.apache.lucene.util.XIOUtils;
 import org.elasticsearch.ElasticsearchIllegalStateException;
 import org.elasticsearch.common.blobstore.BlobPath;
 import org.elasticsearch.common.blobstore.ImmutableBlobContainer;
@@ -71,7 +72,7 @@ public class FsImmutableBlobContainer extends AbstractFsBlobContainer implements
                 } catch (Throwable e) {
                     listener.onFailure(e);
                     // just on the safe size, try and delete it on failure
-                    FileSystemUtils.tryDeleteFile(file);
+                    XIOUtils.deleteFilesIgnoringExceptions(file);
                 } finally {
                    if (success) {
                        listener.onCompleted();

--- a/src/main/java/org/elasticsearch/common/io/FileSystemUtils.java
+++ b/src/main/java/org/elasticsearch/common/io/FileSystemUtils.java
@@ -23,7 +23,6 @@ import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.common.logging.ESLogger;
 
 import java.io.File;
-import java.io.FileFilter;
 import java.io.IOException;
 
 /**
@@ -66,76 +65,6 @@ public class FileSystemUtils {
     public static boolean exists(File... files) {
         for (File file : files) {
             if (file.exists()) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Deletes the given files recursively. if <tt>deleteRoots</tt> is set to <code>true</code>
-     * the given root files will be deleted as well. Otherwise only their content is deleted.
-     */
-    public static boolean deleteRecursively(File[] roots, boolean deleteRoots) {
-
-        boolean deleted = true;
-        for (File root : roots) {
-            deleted &= deleteRecursively(root, deleteRoots);
-        }
-        return deleted;
-    }
-
-    /**
-     * Deletes all subdirectories of the given roots recursively.
-     */
-    public static boolean deleteSubDirectories(File[] roots) {
-
-        boolean deleted = true;
-        for (File root : roots) {
-            if (root.isDirectory()) {
-                File[] files = root.listFiles(new FileFilter() {
-                    @Override
-                    public boolean accept(File pathname) {
-                        return pathname.isDirectory();
-                    }
-                });
-                deleted &= deleteRecursively(files, true);
-            }
-
-        }
-        return deleted;
-    }
-
-    /**
-     * Deletes the given files recursively including the given roots.
-     */
-    public static boolean deleteRecursively(File... roots) {
-       return deleteRecursively(roots, true);
-    }
-
-    /**
-     * Delete the supplied {@link java.io.File} - for directories,
-     * recursively delete any nested directories or files as well.
-     *
-     * @param root       the root <code>File</code> to delete
-     * @param deleteRoot whether or not to delete the root itself or just the content of the root.
-     * @return <code>true</code> if the <code>File</code> was deleted,
-     *         otherwise <code>false</code>
-     */
-    public static boolean deleteRecursively(File root, boolean deleteRoot) {
-        if (root != null && root.exists()) {
-            if (root.isDirectory()) {
-                File[] children = root.listFiles();
-                if (children != null) {
-                    for (File aChildren : children) {
-                        deleteRecursively(aChildren, true);
-                    }
-                }
-            }
-
-            if (deleteRoot) {
-                return root.delete();
-            } else {
                 return true;
             }
         }

--- a/src/main/java/org/elasticsearch/common/io/FileSystemUtils.java
+++ b/src/main/java/org/elasticsearch/common/io/FileSystemUtils.java
@@ -104,12 +104,4 @@ public class FileSystemUtils {
     }
 
     private FileSystemUtils() {}
-
-    public static void tryDeleteFile(File file) {
-        try {
-            file.delete();
-        } catch (SecurityException e1) {
-            // ignore
-        }
-    }
 }

--- a/src/main/java/org/elasticsearch/gateway/local/LocalGateway.java
+++ b/src/main/java/org/elasticsearch/gateway/local/LocalGateway.java
@@ -22,6 +22,7 @@ package org.elasticsearch.gateway.local;
 import com.carrotsearch.hppc.ObjectFloatOpenHashMap;
 import com.carrotsearch.hppc.ObjectOpenHashSet;
 import com.carrotsearch.hppc.cursors.ObjectCursor;
+import org.apache.lucene.util.XIOUtils;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.cluster.*;
@@ -30,7 +31,6 @@ import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Module;
-import org.elasticsearch.common.io.FileSystemUtils;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.gateway.Gateway;
@@ -197,7 +197,11 @@ public class LocalGateway extends AbstractLifecycleComponent<Gateway> implements
 
     @Override
     public void reset() throws Exception {
-        FileSystemUtils.deleteRecursively(nodeEnv.nodeDataLocations());
+        try {
+            XIOUtils.rm(nodeEnv.nodeDataLocations());
+        } catch (Exception e) {
+            logger.debug("failed to delete files", e);
+        }
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/gateway/local/state/meta/LocalGatewayMetaState.java
+++ b/src/main/java/org/elasticsearch/gateway/local/state/meta/LocalGatewayMetaState.java
@@ -51,6 +51,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -401,7 +402,11 @@ public class LocalGatewayMetaState extends AbstractComponent implements ClusterS
                     if (file.getName().equals(stateFileName)) {
                         continue;
                     }
-                    file.delete();
+                    try {
+                        Files.delete(file.toPath());
+                    } catch (Exception e) {
+                        logger.debug("failed to delete files", e);
+                    }
                 }
             }
         }
@@ -456,7 +461,11 @@ public class LocalGatewayMetaState extends AbstractComponent implements ClusterS
                 if (file.getName().equals(globalFileName)) {
                     continue;
                 }
-                file.delete();
+                try {
+                    Files.delete(file.toPath());
+                } catch (Exception e) {
+                    logger.debug("failed to delete files", e);
+                }
             }
         }
     }
@@ -666,7 +675,11 @@ public class LocalGatewayMetaState extends AbstractComponent implements ClusterS
                 if (!name.startsWith("metadata-")) {
                     continue;
                 }
-                stateFile.delete();
+                try {
+                    Files.delete(stateFile.toPath());
+                } catch (Exception e) {
+                    logger.debug("failed to delete files", e);
+                }
             }
         }
 

--- a/src/main/java/org/elasticsearch/gateway/local/state/shards/LocalGatewayShardsState.java
+++ b/src/main/java/org/elasticsearch/gateway/local/state/shards/LocalGatewayShardsState.java
@@ -315,17 +315,6 @@ public class LocalGatewayShardsState extends AbstractComponent implements Cluste
         }
     }
 
-    private void deleteShardState(ShardId shardId) {
-        logger.trace("[{}][{}] delete shard state", shardId.index().name(), shardId.id());
-        File[] shardLocations = nodeEnv.shardLocations(shardId);
-        for (File shardLocation : shardLocations) {
-            if (!shardLocation.exists()) {
-                continue;
-            }
-            FileSystemUtils.deleteRecursively(new File(shardLocation, "_state"));
-        }
-    }
-
     private void pre019Upgrade() throws Exception {
         long index = -1;
         File latest = null;

--- a/src/main/java/org/elasticsearch/gateway/local/state/shards/LocalGatewayShardsState.java
+++ b/src/main/java/org/elasticsearch/gateway/local/state/shards/LocalGatewayShardsState.java
@@ -43,6 +43,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
@@ -310,7 +311,11 @@ public class LocalGatewayShardsState extends AbstractComponent implements Cluste
         if (previousStateInfo != null && previousStateInfo.version != shardStateInfo.version) {
             for (File shardLocation : nodeEnv.shardLocations(shardId)) {
                 File stateFile = new File(new File(shardLocation, "_state"), "state-" + previousStateInfo.version);
-                stateFile.delete();
+                try {
+                    Files.delete(stateFile.toPath());
+                } catch (Exception e) {
+                    logger.debug("failed to delete files", e);
+                }
             }
         }
     }
@@ -384,7 +389,11 @@ public class LocalGatewayShardsState extends AbstractComponent implements Cluste
                 if (!name.startsWith("shards-")) {
                     continue;
                 }
-                stateFile.delete();
+                try {
+                    Files.delete(stateFile.toPath());
+                } catch (Exception e) {
+                    logger.debug("failed to delete files", e);
+                }
             }
         }
 

--- a/src/main/java/org/elasticsearch/index/gateway/local/LocalIndexShardGateway.java
+++ b/src/main/java/org/elasticsearch/index/gateway/local/LocalIndexShardGateway.java
@@ -52,6 +52,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import java.io.EOFException;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
@@ -276,7 +277,11 @@ public class LocalIndexShardGateway extends AbstractIndexShardComponent implemen
             }
             indexShard.performRecoveryFinalization(true);
 
-            recoveringTranslogFile.delete();
+            try {
+                Files.delete(recoveringTranslogFile.toPath());
+            } catch (Exception e) {
+                logger.trace("failed to delete files", e);
+            }
 
             for (final String type : typesToUpdate) {
                 final CountDownLatch latch = new CountDownLatch(1);

--- a/src/main/java/org/elasticsearch/index/store/fs/FsIndexStore.java
+++ b/src/main/java/org/elasticsearch/index/store/fs/FsIndexStore.java
@@ -19,8 +19,8 @@
 
 package org.elasticsearch.index.store.fs;
 
+import org.apache.lucene.util.XIOUtils;
 import org.elasticsearch.ElasticsearchIllegalStateException;
-import org.elasticsearch.common.io.FileSystemUtils;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.index.Index;
@@ -81,7 +81,11 @@ public abstract class FsIndexStore extends AbstractIndexStore {
         if (indexService.hasShard(shardId.id())) {
             throw new ElasticsearchIllegalStateException(shardId + " allocated, can't be deleted");
         }
-        FileSystemUtils.deleteRecursively(shardLocations(shardId));
+        try {
+            XIOUtils.rm(shardLocations(shardId));
+        } catch (Exception e) {
+            logger.debug("failed to delete files", e);
+        }
     }
 
     public File[] shardLocations(ShardId shardId) {

--- a/src/main/java/org/elasticsearch/index/translog/fs/FsTranslog.java
+++ b/src/main/java/org/elasticsearch/index/translog/fs/FsTranslog.java
@@ -34,11 +34,15 @@ import org.elasticsearch.index.settings.IndexSettings;
 import org.elasticsearch.index.settings.IndexSettingsService;
 import org.elasticsearch.index.shard.AbstractIndexShardComponent;
 import org.elasticsearch.index.shard.ShardId;
-import org.elasticsearch.index.translog.*;
+import org.elasticsearch.index.translog.Translog;
+import org.elasticsearch.index.translog.TranslogException;
+import org.elasticsearch.index.translog.TranslogStats;
+import org.elasticsearch.index.translog.TranslogStreams;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.channels.ClosedChannelException;
+import java.nio.file.Files;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -207,9 +211,10 @@ public class FsTranslog extends AbstractIndexShardComponent implements Translog 
                             continue;
                         }
                         try {
-                            file.delete();
+                            Files.delete(file.toPath());
                         } catch (Exception e) {
                             // ignore
+                            logger.trace("failed to delete files", e);
                         }
                     }
                 }

--- a/src/main/java/org/elasticsearch/index/translog/fs/RafReference.java
+++ b/src/main/java/org/elasticsearch/index/translog/fs/RafReference.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.index.translog.fs;
 
+import org.apache.lucene.util.XIOUtils;
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -70,11 +72,12 @@ public class RafReference {
         if (refCount.decrementAndGet() <= 0) {
             try {
                 raf.close();
-                if (delete) {
-                    file.delete();
-                }
             } catch (IOException e) {
                 // ignore
+            } finally {
+                if (delete) {
+                    XIOUtils.deleteFilesIgnoringExceptions(file);
+                }
             }
         }
     }

--- a/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
+++ b/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.indices.store;
 
 import org.apache.lucene.store.StoreRateLimiting;
+import org.apache.lucene.util.XIOUtils;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.*;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -322,7 +323,11 @@ public class IndicesStore extends AbstractComponent implements ClusterStateListe
                             File[] shardLocations = nodeEnv.shardLocations(shardId);
                             if (FileSystemUtils.exists(shardLocations)) {
                                 logger.debug("{} deleting shard that is no longer used", shardId);
-                                FileSystemUtils.deleteRecursively(shardLocations);
+                                try {
+                                    XIOUtils.rm(shardLocations);
+                                } catch (Exception e) {
+                                    logger.debug("failed to delete files", e);
+                                }
                             }
                         }
                     } else {

--- a/src/test/java/org/elasticsearch/benchmark/fs/FsAppendBenchmark.java
+++ b/src/test/java/org/elasticsearch/benchmark/fs/FsAppendBenchmark.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
+import java.nio.file.Files;
 import java.util.Random;
 
 /**
@@ -33,7 +34,7 @@ import java.util.Random;
 public class FsAppendBenchmark {
 
     public static void main(String[] args) throws Exception {
-        new File("work/test.log").delete();
+        Files.deleteIfExists(new File("work/test.log").toPath());
         RandomAccessFile raf = new RandomAccessFile("work/test.log", "rw");
         raf.setLength(0);
 

--- a/src/test/java/org/elasticsearch/cluster/allocation/ClusterRerouteTests.java
+++ b/src/test/java/org/elasticsearch/cluster/allocation/ClusterRerouteTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.cluster.allocation;
 
+import org.apache.lucene.util.XIOUtils;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.action.admin.cluster.reroute.ClusterRerouteResponse;
@@ -40,6 +41,7 @@ import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
+import org.elasticsearch.test.ElasticsearchIntegrationTest.Scope;
 import org.junit.Test;
 
 import java.io.File;
@@ -47,7 +49,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
-import static org.elasticsearch.test.ElasticsearchIntegrationTest.*;
 import static org.hamcrest.Matchers.equalTo;
 
 /**
@@ -196,7 +197,7 @@ public class ClusterRerouteTests extends ElasticsearchIntegrationTest {
 
         logger.info("--> deleting the shard data [{}] ", Arrays.toString(shardLocation));
         assertThat(FileSystemUtils.exists(shardLocation), equalTo(true)); // verify again after cluster was shut down
-        assertThat(FileSystemUtils.deleteRecursively(shardLocation), equalTo(true));
+        XIOUtils.rm(shardLocation);
 
         logger.info("--> starting nodes back, will not allocate the shard since it has no data, but the index will be there");
         node_1 = internalCluster().startNode(commonSettings);

--- a/src/test/java/org/elasticsearch/index/mapper/FileBasedMappingsTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/FileBasedMappingsTests.java
@@ -21,10 +21,10 @@ package org.elasticsearch.index.mapper;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.Files;
+import org.apache.lucene.util.XIOUtils;
 import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsResponse;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
-import org.elasticsearch.common.io.FileSystemUtils;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -98,7 +98,11 @@ public class FileBasedMappingsTests extends ElasticsearchTestCase {
                 assertEquals(ImmutableSet.of("f", "g", "h"), properties.keySet());
             }
         } finally {
-            FileSystemUtils.deleteRecursively(configDir);
+            try {
+                XIOUtils.rm(configDir);
+            } catch (Exception e) {
+                logger.debug("failed to delete files", e);
+            }
         }
     }
 

--- a/src/test/java/org/elasticsearch/index/translog/fs/FsBufferedTranslogTests.java
+++ b/src/test/java/org/elasticsearch/index/translog/fs/FsBufferedTranslogTests.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.index.translog.fs;
 
-import org.elasticsearch.common.io.FileSystemUtils;
+import org.apache.lucene.util.XIOUtils;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.index.translog.AbstractSimpleTranslogTests;
 import org.elasticsearch.index.translog.Translog;
@@ -50,6 +50,11 @@ public class FsBufferedTranslogTests extends AbstractSimpleTranslogTests {
 
     @AfterClass
     public static void cleanup() {
-        FileSystemUtils.deleteRecursively(new File("data/fs-buf-translog"), true);
+        try {
+            XIOUtils.rm(new File("data/fs-buf-translog"));
+        } catch (Exception e) {
+            System.err.println("failed to delete files");
+            e.printStackTrace(System.err);
+        }
     }
 }

--- a/src/test/java/org/elasticsearch/index/translog/fs/FsSimpleTranslogTests.java
+++ b/src/test/java/org/elasticsearch/index/translog/fs/FsSimpleTranslogTests.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.index.translog.fs;
 
-import org.elasticsearch.common.io.FileSystemUtils;
+import org.apache.lucene.util.XIOUtils;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.index.translog.AbstractSimpleTranslogTests;
 import org.elasticsearch.index.translog.Translog;
@@ -46,6 +46,11 @@ public class FsSimpleTranslogTests extends AbstractSimpleTranslogTests {
 
     @AfterClass
     public static void cleanup() {
-        FileSystemUtils.deleteRecursively(new File("data/fs-simple-translog"), true);
+        try {
+            XIOUtils.rm(new File("data/fs-simple-translog"));
+        } catch (Exception e) {
+            System.err.println("failed to delete files");
+            e.printStackTrace(System.err);
+        }
     }
 }

--- a/src/test/java/org/elasticsearch/plugins/PluginManagerTests.java
+++ b/src/test/java/org/elasticsearch/plugins/PluginManagerTests.java
@@ -20,6 +20,7 @@ package org.elasticsearch.plugins;
 
 import com.google.common.base.Predicate;
 import org.apache.http.impl.client.HttpClients;
+import org.apache.lucene.util.XIOUtils;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.ElasticsearchTimeoutException;
@@ -36,6 +37,7 @@ import org.elasticsearch.node.internal.InternalSettingsPreparer;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
+import org.elasticsearch.test.ElasticsearchIntegrationTest.Scope;
 import org.elasticsearch.test.junit.annotations.Network;
 import org.elasticsearch.test.rest.client.http.HttpRequestBuilder;
 import org.elasticsearch.test.rest.client.http.HttpResponse;
@@ -48,7 +50,6 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.concurrent.TimeUnit;
 
-import static org.elasticsearch.test.ElasticsearchIntegrationTest.Scope;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.equalTo;
@@ -121,8 +122,11 @@ public class PluginManagerTests extends ElasticsearchIntegrationTest {
             assertThat(toolFile.canExecute(), is(true));
         } finally {
             // we need to clean up the copied dirs
-            FileSystemUtils.deleteRecursively(pluginBinDir);
-            FileSystemUtils.deleteRecursively(pluginConfigDir);
+            try {
+                XIOUtils.rm(pluginBinDir, pluginConfigDir);
+            } catch (Exception e) {
+                logger.debug("failed to delete files", e);
+            }
         }
     }
 
@@ -146,7 +150,11 @@ public class PluginManagerTests extends ElasticsearchIntegrationTest {
             assertTrue(pluginBinDir.exists());
         } finally {
             // we need to clean up the copied dirs
-            FileSystemUtils.deleteRecursively(pluginBinDir);
+            try {
+                XIOUtils.rm(pluginBinDir);
+            } catch (Exception e) {
+                logger.debug("failed to delete files", e);
+            }
         }
     }
 
@@ -379,7 +387,12 @@ public class PluginManagerTests extends ElasticsearchIntegrationTest {
     }
 
     private void deletePluginsFolder() {
-        FileSystemUtils.deleteRecursively(new File(PLUGIN_DIR));
+        // TODO: if this fails, won't it cause false test fails?
+        try {
+            XIOUtils.rm(new File(PLUGIN_DIR));
+        } catch (Exception e) {
+            logger.debug("failed to delete files", e);
+        }
     }
 
     @Test

--- a/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreTests.java
+++ b/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreTests.java
@@ -22,8 +22,8 @@ package org.elasticsearch.snapshots;
 import com.carrotsearch.randomizedtesting.LifecycleScope;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
-import org.apache.lucene.util.LuceneTestCase;
 import org.apache.lucene.util.LuceneTestCase.Slow;
+import org.apache.lucene.util.XIOUtils;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ListenableActionFuture;
 import org.elasticsearch.action.admin.cluster.repositories.put.PutRepositoryResponse;
@@ -41,6 +41,7 @@ import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.metadata.IndexMetaData.State;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
 import org.elasticsearch.cluster.metadata.SnapshotMetaData;
 import org.elasticsearch.cluster.routing.allocation.decider.FilterAllocationDecider;
@@ -62,7 +63,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import static com.google.common.collect.Lists.newArrayList;
-import static org.elasticsearch.cluster.metadata.IndexMetaData.*;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_REPLICAS;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.*;
 import static org.hamcrest.Matchers.*;
 
@@ -731,8 +733,7 @@ public class SharedClusterSnapshotRestoreTests extends AbstractSnapshotTests {
         File testIndex1 = new File(indices, "test-idx-1");
         File testIndex2 = new File(indices, "test-idx-2");
         File testIndex2Shard0 = new File(testIndex2, "0");
-        new File(testIndex1, "snapshot-test-snap-1").delete();
-        new File(testIndex2Shard0, "snapshot-test-snap-1").delete();
+        XIOUtils.deleteFilesIfExist(new File(testIndex1, "snapshot-test-snap-1"), new File(testIndex2Shard0, "snapshot-test-snap-1"));
 
         logger.info("--> delete snapshot");
         client.admin().cluster().prepareDeleteSnapshot("test-repo", "test-snap-1").get();

--- a/src/test/java/org/elasticsearch/stresstest/fullrestart/FullRestartStressTest.java
+++ b/src/test/java/org/elasticsearch/stresstest/fullrestart/FullRestartStressTest.java
@@ -19,13 +19,13 @@
 
 package org.elasticsearch.stresstest.fullrestart;
 
+import org.apache.lucene.util.XIOUtils;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.count.CountResponse;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.Requests;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.io.FileSystemUtils;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.ImmutableSettings;
@@ -200,7 +200,11 @@ public class FullRestartStressTest {
                 File[] nodeDatas = ((InternalNode) node).injector().getInstance(NodeEnvironment.class).nodeDataLocations();
                 node.close();
                 if (clearNodeWork && !settings.get("gateway.type").equals("local")) {
-                    FileSystemUtils.deleteRecursively(nodeDatas);
+                    try {
+                        XIOUtils.rm(nodeDatas);
+                    } catch (Exception e) {
+                        logger.debug("failed to delete files", e);
+                    }
                 }
             }
 

--- a/src/test/java/org/elasticsearch/stresstest/rollingrestart/RollingRestartStressTest.java
+++ b/src/test/java/org/elasticsearch/stresstest/rollingrestart/RollingRestartStressTest.java
@@ -19,13 +19,13 @@
 
 package org.elasticsearch.stresstest.rollingrestart;
 
+import org.apache.lucene.util.XIOUtils;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.count.CountResponse;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.io.FileSystemUtils;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.ImmutableSettings;
@@ -170,7 +170,11 @@ public class RollingRestartStressTest {
             File[] nodeData = ((InternalNode) nodes[nodeIndex]).injector().getInstance(NodeEnvironment.class).nodeDataLocations();
             nodes[nodeIndex].close();
             if (clearNodeData) {
-                FileSystemUtils.deleteRecursively(nodeData);
+                try {
+                    XIOUtils.rm(nodeData);
+                } catch (Exception e) {
+                    logger.debug("failed to delete files", e);
+                }
             }
 
             try {

--- a/src/test/java/org/elasticsearch/watcher/FileWatcherTest.java
+++ b/src/test/java/org/elasticsearch/watcher/FileWatcherTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
 import java.util.List;
 
 import static com.google.common.collect.Lists.newArrayList;
@@ -115,7 +116,7 @@ public class FileWatcherTest extends ElasticsearchTestCase {
         fileWatcher.checkAndNotify();
         assertThat(changes.notifications(), hasSize(0));
 
-        testFile.delete();
+        Files.delete(testFile.toPath());
         fileWatcher.checkAndNotify();
         assertThat(changes.notifications(), contains(equalTo("onFileDeleted: test.txt")));
 
@@ -161,8 +162,8 @@ public class FileWatcherTest extends ElasticsearchTestCase {
         fileWatcher.checkAndNotify();
         assertThat(changes.notifications(), hasSize(0));
 
-        new File(testDir, "test1.txt").delete();
-        new File(testDir, "test2.txt").delete();
+        Files.delete(new File(testDir, "test1.txt").toPath());
+        Files.delete(new File(testDir, "test2.txt").toPath());
 
         fileWatcher.checkAndNotify();
         assertThat(changes.notifications(), contains(
@@ -174,7 +175,7 @@ public class FileWatcherTest extends ElasticsearchTestCase {
         fileWatcher.checkAndNotify();
         assertThat(changes.notifications(), hasSize(0));
 
-        new File(testDir, "test0.txt").delete();
+        Files.delete(new File(testDir, "test0.txt").toPath());
         touch(new File(testDir, "test2.txt"));
         touch(new File(testDir, "test4.txt"));
         fileWatcher.checkAndNotify();
@@ -188,8 +189,8 @@ public class FileWatcherTest extends ElasticsearchTestCase {
 
         changes.notifications().clear();
 
-        new File(testDir, "test3.txt").delete();
-        new File(testDir, "test4.txt").delete();
+        Files.delete(new File(testDir, "test3.txt").toPath());
+        Files.delete(new File(testDir, "test4.txt").toPath());
         fileWatcher.checkAndNotify();
         assertThat(changes.notifications(), contains(
                 equalTo("onFileDeleted: test-dir/test3.txt"),
@@ -319,7 +320,7 @@ public class FileWatcherTest extends ElasticsearchTestCase {
 
         changes.notifications().clear();
 
-        subDir.delete();
+        Files.delete(subDir.toPath());
         subDir.mkdir();
 
         fileWatcher.checkAndNotify();
@@ -343,8 +344,8 @@ public class FileWatcherTest extends ElasticsearchTestCase {
         fileWatcher.init();
         changes.notifications().clear();
 
-        new File(testDir, "test0.txt").delete();
-        new File(testDir, "test1.txt").delete();
+        Files.delete(new File(testDir, "test0.txt").toPath());
+        Files.delete(new File(testDir, "test1.txt").toPath());
         fileWatcher.checkAndNotify();
         assertThat(changes.notifications(), contains(
                 equalTo("onFileDeleted: test-dir/test0.txt"),

--- a/src/test/java/org/elasticsearch/watcher/FileWatcherTest.java
+++ b/src/test/java/org/elasticsearch/watcher/FileWatcherTest.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.watcher;
 
 import com.carrotsearch.randomizedtesting.LifecycleScope;
+import org.apache.lucene.util.XIOUtils;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.junit.Test;
 
@@ -28,8 +29,8 @@ import java.nio.charset.Charset;
 import java.util.List;
 
 import static com.google.common.collect.Lists.newArrayList;
-import static com.google.common.io.Files.*;
-import static org.elasticsearch.common.io.FileSystemUtils.deleteRecursively;
+import static com.google.common.io.Files.append;
+import static com.google.common.io.Files.touch;
 import static org.hamcrest.Matchers.*;
 
 /**
@@ -197,7 +198,11 @@ public class FileWatcherTest extends ElasticsearchTestCase {
 
 
         changes.notifications().clear();
-        deleteRecursively(testDir);
+        try {
+            XIOUtils.rm(testDir);
+        } catch (Exception e) {
+            logger.debug("failed to delete files", e);
+        }
         fileWatcher.checkAndNotify();
 
         assertThat(changes.notifications(), contains(
@@ -261,7 +266,11 @@ public class FileWatcherTest extends ElasticsearchTestCase {
         assertThat(changes.notifications(), hasSize(0));
 
         // Delete a directory, check notifications for
-        deleteRecursively(new File(testDir, "first-level"));
+        try {
+            XIOUtils.rm(new File(testDir, "first-level"));
+        } catch (Exception e) {
+            logger.debug("failed to delete files", e);
+        }
         fileWatcher.checkAndNotify();
         assertThat(changes.notifications(), contains(
                 equalTo("onFileDeleted: test-dir/first-level/file1.txt"),
@@ -294,7 +303,11 @@ public class FileWatcherTest extends ElasticsearchTestCase {
 
         changes.notifications().clear();
 
-        deleteRecursively(subDir);
+        try {
+            XIOUtils.rm(subDir);
+        } catch (Exception e) {
+            logger.debug("failed to delete files", e);
+        }
         touch(subDir);
         fileWatcher.checkAndNotify();
         assertThat(changes.notifications(), contains(


### PR DESCRIPTION
File.delete() is not great as it just returns a boolean if it succeeds or fails.

Instead we can use Files.delete/Files.deleteIfExists, which throws a real exception when it fails (e.g. DirectoryNotEmptyException, Access Denied, etc)

Brings in helpers from lucene (temporarily as XIOUtils):
- deleteFilesIfExist(File...): removes all the files, throwing the first exception with suppressions for other exceptions, but always attempts to remove all files
- deleteFilesIgnoringExceptions(File...): removes all files, suppressing all exceptions. good for when handling other exceptions
- rm(File...): recursive removal of all files, on any failure throws exception that contains each file name and the exception it hit.

Bans File.delete() with forbidden APIs.

This is also an opportunity to review all places in the codebase where we delete files, since they are all touched in this PR.
