### PR TITLE
In thread pools, use DirectExecutor instead of deprecated API

### DIFF
--- a/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
+++ b/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
@@ -286,7 +286,7 @@ public class ThreadPool extends AbstractComponent {
             } else {
                 logger.debug("creating thread_pool [{}], type [{}]", name, type);
             }
-            return new ExecutorHolder(MoreExecutors.sameThreadExecutor(), new Info(name, type));
+            return new ExecutorHolder(MoreExecutors.directExecutor(), new Info(name, type));
         } else if ("cached".equals(type)) {
             TimeValue defaultKeepAlive = defaultSettings.getAsTime("keep_alive", timeValueMinutes(5));
             if (previousExecutorHolder != null) {

--- a/src/test/java/org/elasticsearch/threadpool/UpdateThreadPoolSettingsTests.java
+++ b/src/test/java/org/elasticsearch/threadpool/UpdateThreadPoolSettingsTests.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.threadpool;
 
 import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.util.concurrent.EsThreadPoolExecutor;
 import org.elasticsearch.test.ElasticsearchTestCase;
@@ -61,7 +62,7 @@ public class UpdateThreadPoolSettingsTests extends ElasticsearchTestCase {
         // Replace with different type
         threadPool.updateSettings(settingsBuilder().put("threadpool.search.type", "same").build());
         assertThat(info(threadPool, Names.SEARCH).getType(), equalTo("same"));
-        assertThat(threadPool.executor(Names.SEARCH), instanceOf(ListeningExecutorService.class));
+        assertThat(threadPool.executor(Names.SEARCH), instanceOf(MoreExecutors.directExecutor().getClass()));
 
         // Replace with different type again
         threadPool.updateSettings(settingsBuilder()


### PR DESCRIPTION
Guava deprecated MoreExecutors#sameThreadExecutor in favour of
a more efficient implementation. We should move over to the new impl.
