### PR TITLE
Update action returns before updating stats for `NONE` operations

### DIFF
--- a/src/main/java/org/elasticsearch/action/update/TransportUpdateAction.java
+++ b/src/main/java/org/elasticsearch/action/update/TransportUpdateAction.java
@@ -270,7 +270,6 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
                 break;
             case NONE:
                 UpdateResponse update = result.action();
-                listener.onResponse(update);
                 IndexService indexServiceOrNull = indicesService.indexService(request.concreteIndex());
                 if (indexServiceOrNull !=  null) {
                     IndexShard shard = indexService.shard(request.request().shardId());
@@ -278,6 +277,7 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
                         shard.indexingService().noopUpdate(request.request().type());
                     }
                 }
+                listener.onResponse(update);
                 break;
             default:
                 throw new ElasticsearchIllegalStateException("Illegal operation " + result.operation());


### PR DESCRIPTION
We keep around a noop stats indicating how many update operations ended up not updating the document (typically because it didn't change). However, the TransportUpdateAction update that counter only after returning the result. This can throw off stats check which are done immediately after, potentially causing test failures.
