### PR TITLE
Security: Disable CORS by default

### DIFF
--- a/docs/reference/modules/http.asciidoc
+++ b/docs/reference/modules/http.asciidoc
@@ -39,7 +39,7 @@ Defaults to `6`.
 
 |`http.cors.enabled` |Enable or disable cross-origin resource sharing,
 i.e. whether a browser on another origin can do requests to
-Elasticsearch. Defaults to `true`.
+Elasticsearch. Defaults to `false`.
 
 |`http.cors.allow-origin` |Which origins to allow. Defaults to `*`,
 i.e. any origin. If you prepend and append a `/` to the value, this will

--- a/src/main/java/org/elasticsearch/http/netty/NettyHttpChannel.java
+++ b/src/main/java/org/elasticsearch/http/netty/NettyHttpChannel.java
@@ -96,7 +96,7 @@ public class NettyHttpChannel extends HttpChannel {
             resp = new DefaultHttpResponse(HttpVersion.HTTP_1_1, status);
         }
         if (RestUtils.isBrowser(nettyRequest.headers().get(USER_AGENT))) {
-            if (transport.settings().getAsBoolean(SETTING_CORS_ENABLED, true)) {
+            if (transport.settings().getAsBoolean(SETTING_CORS_ENABLED, false)) {
                 String originHeader = request.header(ORIGIN);
                 if (!Strings.isNullOrEmpty(originHeader)) {
                     if (corsPattern == null) {

--- a/src/test/java/org/elasticsearch/rest/CorsRegexDefaultTests.java
+++ b/src/test/java/org/elasticsearch/rest/CorsRegexDefaultTests.java
@@ -31,13 +31,12 @@ import static org.hamcrest.Matchers.*;
 public class CorsRegexDefaultTests extends ElasticsearchIntegrationTest {
 
     @Test
-    public void testCorsSettingDefaultBehaviour() throws Exception {
+    public void testCorsSettingDefaultBehaviourDoesNotReturnAnything() throws Exception {
         String corsValue = "http://localhost:9200";
         HttpResponse response = httpClient().method("GET").path("/").addHeader("User-Agent", "Mozilla Bar").addHeader("Origin", corsValue).execute();
 
         assertThat(response.getStatusCode(), is(200));
-        assertThat(response.getHeaders(), hasKey("Access-Control-Allow-Origin"));
-        assertThat(response.getHeaders().get("Access-Control-Allow-Origin"), is("*"));
+        assertThat(response.getHeaders(), not(hasKey("Access-Control-Allow-Origin")));
         assertThat(response.getHeaders(), not(hasKey("Access-Control-Allow-Credentials")));
     }
 

--- a/src/test/java/org/elasticsearch/rest/CorsRegexTests.java
+++ b/src/test/java/org/elasticsearch/rest/CorsRegexTests.java
@@ -34,6 +34,7 @@ import java.net.InetSocketAddress;
 
 import static org.elasticsearch.http.netty.NettyHttpServerTransport.SETTING_CORS_ALLOW_ORIGIN;
 import static org.elasticsearch.http.netty.NettyHttpServerTransport.SETTING_CORS_ALLOW_CREDENTIALS;
+import static org.elasticsearch.http.netty.NettyHttpServerTransport.SETTING_CORS_ENABLED;
 import static org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
 import static org.elasticsearch.test.ElasticsearchIntegrationTest.Scope;
 import static org.hamcrest.Matchers.*;
@@ -52,7 +53,8 @@ public class CorsRegexTests extends ElasticsearchIntegrationTest {
         return ImmutableSettings.settingsBuilder()
                 .put(super.nodeSettings(nodeOrdinal))
                 .put(SETTING_CORS_ALLOW_ORIGIN, "/https?:\\/\\/localhost(:[0-9]+)?/")
-                .put(SETTING_CORS_ALLOW_CREDENTIALS, "true")
+                .put(SETTING_CORS_ALLOW_CREDENTIALS, true)
+                .put(SETTING_CORS_ENABLED, true)
                 .build();
     }
 


### PR DESCRIPTION
In order to deliver a more secure out-of-the-box configuration this commit
disables cross-origin resource sharing by default. It is possibly to enable it and create a more finegrained configuration anytime using the existing cors configuration parameters.

Closes #7151
