### PR TITLE
[TESTS]: create directory for heapdumps if not exists

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <tests.bwc.path>${project.basedir}/backwards</tests.bwc.path>
         <es.logger.level>INFO</es.logger.level>
         <tests.heap.size>512m</tests.heap.size>
-        <tests.heapdump.path>${basedir}/logs</tests.heapdump.path>
+        <tests.heapdump.path>${basedir}/logs/</tests.heapdump.path>
         <tests.topn>5</tests.topn>
         <execution.hint.file>.local-${project.version}-execution-hints.log</execution.hint.file>
     </properties>
@@ -575,6 +575,19 @@
                                 </fail>
                             </target>
                         </configuration>
+                    </execution>
+                    <execution>
+                        <phase>create-heapdump-directory</phase>
+                        <id>create-heapdump-directory</id>
+                        <configuration>
+                            <tasks>
+                                <echo message="Creating heapdump directory"/>
+                                <mkdir dir="${tests.heapdump.path}"/>
+                            </tasks>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
                     </execution>
                     <execution>
                         <id>tests</id>

--- a/pom.xml
+++ b/pom.xml
@@ -577,7 +577,7 @@
                         </configuration>
                     </execution>
                     <execution>
-                        <phase>create-heapdump-directory</phase>
+                        <phase>generate-test-resources</phase>
                         <id>create-heapdump-directory</id>
                         <configuration>
                             <tasks>


### PR DESCRIPTION
Before the heapdump was either written in a file with the
directory name if the heapdump path ended without / or
not written at all if the path ended with /
