### PR TITLE
Clarify s3 snapshot compress behavior

### DIFF
--- a/docs/reference/modules/snapshots.asciidoc
+++ b/docs/reference/modules/snapshots.asciidoc
@@ -66,7 +66,7 @@ on all data and master nodes. The following settings are supported:
 
 [horizontal]
 `location`:: Location of the snapshots. Mandatory.
-`compress`:: Turns on compression of the snapshot files. Defaults to `true`.
+`compress`:: Turns on compression of the snapshot files. Compression is applied only to metadata files (index mapping and settings). Data files are not compressed. Defaults to `true`.
 `chunk_size`:: Big files can be broken down into chunks during snapshotting if needed. The chunk size can be specified in bytes or by
  using size value notation, i.e. 1g, 10m, 5k. Defaults to `null` (unlimited chunk size).
 


### PR DESCRIPTION
Clarify s3 snapshot compress behavior only applies to metadata and no index files.
