### PR TITLE
Add file descriptor details to cat/nodes

### DIFF
--- a/docs/reference/cat/nodes.asciidoc
+++ b/docs/reference/cat/nodes.asciidoc
@@ -90,10 +90,18 @@ k0zy 192.168.56.10 9300 {version} m
 |`build` |`b` |No |Elasticsearch Build hash |5c03844
 |`jdk` |`j` |No |Running Java version |1.8.0
 |`disk.avail` |`d`, `disk`, `diskAvail` |No |Available disk space |1.8gb
-|`heap.percent` |`hp`, `heapPercent` |No |Used heap percentage |7
+|`heap.current` |`hc`, `heapCurrent` |No |Used heap |311.2mb
+|`heap.percent` |`hp`, `heapPercent` |Yes |Used heap percentage |7
 |`heap.max` |`hm`, `heapMax` |No |Maximum configured heap |1015.6mb
-|`ram.percent` |`rp`, `ramPercent` |No |Used total memory percentage |47
+|`ram.current` |`rc`, `ramCurrent` |No |Used total memory |513.4mb
+|`ram.percent` |`rp`, `ramPercent` |Yes |Used total memory percentage |47
 |`ram.max` |`rm`, `ramMax` |No |Total memory |2.9gb
+|`file_desc.current` |`fdc`, `fileDescriptorCurrent` |No |Used file
+descriptors |123
+|`file_desc.percent` |`fdp`, `fileDescriptorPercent` |Yes |Used file
+descriptors percentage |1
+|`file_desc.max` |`fdm`, `fileDescriptorMax` |No |Maximum number of file
+descriptors |1024
 |`load` |`l` |No |Most recent load average |0.22
 |`uptime` |`u` |No |Node uptime |17.3m
 |`node.role` |`r`, `role`, `dc`, `nodeRole` |Yes |Data node (d); Client

--- a/rest-api-spec/test/cat.nodes/10_basic.yaml
+++ b/rest-api-spec/test/cat.nodes/10_basic.yaml
@@ -1,0 +1,39 @@
+---
+"Test cat nodes output":
+
+  - do:
+      cat.nodes: {}
+
+  - match:
+      $body: |
+               /  #host       ip                          heap.percent        ram.percent      load        node.role        master         name
+               ^  (\S+   \s+  (\d{1,3}\.){3}\d{1,3}  \s+  \d+            \s+  \d*         \s+  \d*    \s+  [-dc]       \s+  [-*mx]    \s+   \S+   \s+  \n)+  $/
+
+  - do:
+      cat.nodes:
+          v: true
+
+  - match:
+      $body: |
+               /^  host  \s+  ip                     \s+  heap\.percent   \s+  ram\.percent \s+  load   \s+  node\.role   \s+  master   \s+   name   \s+  \n
+                  (\S+   \s+  (\d{1,3}\.){3}\d{1,3}  \s+  \d+             \s+  \d*          \s+  \d*    \s+  [-dc]        \s+  [-*mx]    \s+   \S+   \s+  \n)+  $/
+
+  - do:
+      cat.nodes:
+          h: heap.current,heap.percent,heap.max
+          v: true
+
+  - match:
+      $body: |
+               /^      heap\.current          \s+  heap\.percent  \s+  heap\.max             \s+ \n
+                  (\s+ \d+(\.\d+)?[ptgmk]?b   \s+  \d+            \s+  \d+(\.\d+)?[ptgmk]?b  \s+ \n)+  $/
+
+  - do:
+      cat.nodes:
+          h: file_desc.current,file_desc.percent,file_desc.max
+          v: true
+
+  - match:
+      $body: |
+               /^      file_desc\.current  \s+  file_desc\.percent  \s+  file_desc\.max  \s+ \n
+                  (\s+ \d+                 \s+  \d+                 \s+  \d+             \s+ \n)+  $/


### PR DESCRIPTION
cat/nodes currently does not report any details related to file descriptors. This adds the current number in use, the maximum number available as well as their ratio (percentage) to cat/nodes as hidden-by-default metrics. In addition, this also adds current heap usage (as a non-percentage of ts max) and ram usage (as a non-percerntage of its max) to allow tools to provide more granularity.

While adding a test for the default headers, I noticed that heap.percent and ram.percent were actually displayed by default, so I updated their documentation.

Closes #7652
