### PR TITLE
Test: Ensure BWC test run even if node.mode=local is set

### DIFF
--- a/src/test/java/org/elasticsearch/bwcompat/TransportClientBackwardsCompatibilityTest.java
+++ b/src/test/java/org/elasticsearch/bwcompat/TransportClientBackwardsCompatibilityTest.java
@@ -43,7 +43,7 @@ public class TransportClientBackwardsCompatibilityTest extends ElasticsearchBack
     @Test
     public void testSniffMode() throws ExecutionException, InterruptedException {
 
-        Settings settings = ImmutableSettings.builder().put("client.transport.nodes_sampler_interval", "1s")
+        Settings settings = ImmutableSettings.builder().put(requiredSettings()).put("client.transport.nodes_sampler_interval", "1s")
                 .put("name", "transport_client_sniff_mode").put(ClusterName.SETTING, cluster().getClusterName())
                 .put("client.transport.sniff", true).build();
 

--- a/src/test/java/org/elasticsearch/test/ExternalTestCluster.java
+++ b/src/test/java/org/elasticsearch/test/ExternalTestCluster.java
@@ -35,6 +35,7 @@ import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
 import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.discovery.DiscoveryModule;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.node.internal.InternalSettingsPreparer;
 
@@ -67,13 +68,9 @@ public final class ExternalTestCluster extends TestCluster {
     public ExternalTestCluster(TransportAddress... transportAddresses) {
 
         Settings clientSettings = ImmutableSettings.settingsBuilder()
+                .put("config.ignore_system_properties", true) // prevents any settings to be replaced by system properties.
                 .put("client.transport.ignore_cluster_name", true)
                 .put("node.mode", "network").build(); // we require network here!
-
-        // verify that the end node setting will have network enabled.
-        Tuple<Settings, Environment> finalSettings = InternalSettingsPreparer.prepareSettings(clientSettings, true);
-        assertFalse("testing against an external cluster must run in network mode. You probably have a system property overriding the test settings.",
-                DiscoveryNode.localNode(finalSettings.v1()));
 
         this.client = new TransportClient(clientSettings).addTransportAddresses(transportAddresses);
 


### PR DESCRIPTION
Today we throw an error if local transport is configured with BWC tests.
Yet, the BWC test need network to be enabled so test can just set the
required defaults.
