### PR TITLE
Fix ordering of Regex.simpleMatch() parameters

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/settings/DynamicSettings.java
+++ b/src/main/java/org/elasticsearch/cluster/settings/DynamicSettings.java
@@ -42,7 +42,7 @@ public class DynamicSettings {
 
     public String validateDynamicSetting(String dynamicSetting, String value) {
         for (Map.Entry<String, Validator> setting : dynamicSettings.entrySet()) {
-            if (Regex.simpleMatch(dynamicSetting, setting.getKey())) {
+            if (Regex.simpleMatch(setting.getKey(), dynamicSetting)) {
                 return setting.getValue().validate(dynamicSetting, value);
             }
         }

--- a/src/test/java/org/elasticsearch/cluster/settings/SettingsValidatorTests.java
+++ b/src/test/java/org/elasticsearch/cluster/settings/SettingsValidatorTests.java
@@ -22,7 +22,7 @@ package org.elasticsearch.cluster.settings;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.junit.Test;
 
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -83,5 +83,13 @@ public class SettingsValidatorTests extends ElasticsearchTestCase {
         assertThat(Validator.POSITIVE_INTEGER.validate("", "0"), notNullValue());
         assertThat(Validator.POSITIVE_INTEGER.validate("", "-1"), notNullValue());
         assertThat(Validator.POSITIVE_INTEGER.validate("", "10.2"), notNullValue());
+    }
+
+    @Test
+    public void testDynamicValidators() throws Exception {
+        DynamicSettings ds = new DynamicSettings();
+        ds.addDynamicSetting("my.test.*", Validator.POSITIVE_INTEGER);
+        String valid = ds.validateDynamicSetting("my.test.setting", "-1");
+        assertThat(valid, equalTo("the value of the setting my.test.setting must be a positive integer"));
     }
 }


### PR DESCRIPTION
Previously we incorrectly sent them in the wrong order, which can cause
validators not to be run for dynamic settings that have been added
matching a particular wildcard.

Also adds a small unit test that makes sure we fixed this behavior.

Fixes #7651
