### PR TITLE
Add that children aggregation is coming in 1.4.0

### DIFF
--- a/docs/reference/search/aggregations/bucket/children-aggregation.asciidoc
+++ b/docs/reference/search/aggregations/bucket/children-aggregation.asciidoc
@@ -1,6 +1,8 @@
 [[search-aggregations-bucket-children-aggregation]]
 === Children Aggregation
 
+coming[1.4.0]
+
 A special single bucket aggregation that enables aggregating from buckets on parent document types to buckets on child documents.
 
 This aggregation relies on the <<mapping-parent-field,_parent field>> in the mapping. This aggregation has a single option:


### PR DESCRIPTION
I had a syntax error because I tried the `children` aggregation on my deployed instance of ElasticSearch 1.3.2, and I had to look in the source repository to understand where it was coming from.

Better to avoid that hassle for other people.
