### PR TITLE
A `has_child` or other p/c query wrapped in a query filter may emit wrong results

### DIFF
--- a/src/main/java/org/elasticsearch/common/lucene/search/Queries.java
+++ b/src/main/java/org/elasticsearch/common/lucene/search/Queries.java
@@ -21,6 +21,7 @@ package org.elasticsearch.common.lucene.search;
 
 import org.apache.lucene.search.*;
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.index.query.QueryParseContext;
 import org.elasticsearch.index.search.child.CustomQueryWrappingFilter;
 
 import java.util.List;
@@ -141,8 +142,14 @@ public class Queries {
 
     }
 
-    public static Filter wrap(Query query) {
-        return FACTORY.wrap(query);
+    /**
+     * Wraps a query in a filter.
+     *
+     * If a filter has an anti per segment execution / caching nature then @{@link CustomQueryWrappingFilter} is returned
+     * otherwise the standard {@link org.apache.lucene.search.QueryWrapperFilter} is returned.
+     */
+    public static Filter wrap(Query query, QueryParseContext context) {
+        return FACTORY.wrap(query, context);
     }
 
     private static final QueryWrapperFilterFactory FACTORY = new QueryWrapperFilterFactory();
@@ -151,8 +158,8 @@ public class Queries {
     // and potentially miss a forbidden API usage!
     private static final class QueryWrapperFilterFactory {
 
-        public Filter wrap(Query query) {
-            if (CustomQueryWrappingFilter.shouldUseCustomQueryWrappingFilter(query)) {
+        public Filter wrap(Query query, QueryParseContext context) {
+            if (context.requireCustomQueryWrappingFilter() || CustomQueryWrappingFilter.shouldUseCustomQueryWrappingFilter(query)) {
                 return new CustomQueryWrappingFilter(query);
             } else {
                 return new QueryWrapperFilter(query);

--- a/src/main/java/org/elasticsearch/index/query/FQueryFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/FQueryFilterParser.java
@@ -25,7 +25,6 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.cache.filter.support.CacheKeyFilter;
-import org.elasticsearch.index.search.child.CustomQueryWrappingFilter;
 
 import java.io.IOException;
 
@@ -86,7 +85,7 @@ public class FQueryFilterParser implements FilterParser {
         if (query == null) {
             return null;
         }
-        Filter filter = Queries.wrap(query);
+        Filter filter = Queries.wrap(query, parseContext);
         if (cache) {
             filter = parseContext.cacheFilter(filter, cacheKey);
         }

--- a/src/main/java/org/elasticsearch/index/query/NestedFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/NestedFilterParser.java
@@ -148,7 +148,7 @@ public class NestedFilterParser implements FilterParser {
             // expects FixedBitSet instances
             parentFilter = parseContext.fixedBitSetFilter(parentFilter);
 
-            Filter nestedFilter = Queries.wrap(new ToParentBlockJoinQuery(query, parentFilter, ScoreMode.None));
+            Filter nestedFilter = Queries.wrap(new ToParentBlockJoinQuery(query, parentFilter, ScoreMode.None), parseContext);
 
             if (cache) {
                 nestedFilter = parseContext.cacheFilter(nestedFilter, cacheKey);

--- a/src/main/java/org/elasticsearch/index/query/QueryFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryFilterParser.java
@@ -48,6 +48,6 @@ public class QueryFilterParser implements FilterParser {
         if (query == null) {
             return null;
         }
-        return Queries.wrap(query);
+        return Queries.wrap(query, parseContext);
     }
 }


### PR DESCRIPTION
If a `has_child`, `has_parent` or `top_children` is indirectly wrapped in a `query` filter (for example via a `bool` query) then the results are incorrect. This bug manifests in all places in the dsl where `query` filter can be used.

This PR lets the `query` filter use the `CustomQueryWrappingFilter` class if the query being wrapped in a `query` filter indirectly uses a p/c query. (the case when p/c query was directly being wrapped was already covered). 

Also if a `query` filter is wrapping a p/c query (either directly or indirectly) any filter wrapping it if forcefully never cached. Caching this would also lead to wrong results, since the p/c queries can't be cached per segment, while regular filter can.
