### PR TITLE
[API] Fix minor issues with indices.get definition and tests

### DIFF
--- a/rest-api-spec/api/indices.get.json
+++ b/rest-api-spec/api/indices.get.json
@@ -8,6 +8,7 @@
       "parts":{
         "index":{
           "type":"list",
+          "required" : true,
           "description":"A comma-separated list of index names"
         },
         "feature":{

--- a/rest-api-spec/test/indices.get/10_basic.yaml
+++ b/rest-api-spec/test/indices.get/10_basic.yaml
@@ -131,7 +131,7 @@ setup:
         index: test_not_found
         ignore_unavailable: true
 
-  - match: { $body: "{}" }
+  - match: { $body: {} }
 
 ---
 "Should return empty object if allow_no_indices":
@@ -140,7 +140,7 @@ setup:
       indices.get:
         index: test_not*
 
-  - match: { $body: "{}" }
+  - match: { $body: {} }
 
 ---
 "Should throw error if allow_no_indices=false":

--- a/rest-api-spec/test/indices.get_mapping/50_wildcard_expansion.yaml
+++ b/rest-api-spec/test/indices.get_mapping/50_wildcard_expansion.yaml
@@ -100,7 +100,7 @@ setup:
         index: test-x*
         expand_wildcards: none
 
- - match: { $body: "{}" }
+ - match: { $body: {} }
 
 ---
 "Get test-* with wildcard_expansion=open,closed":


### PR DESCRIPTION
mark index param as required
make body match json, not string containing json
