### PR TITLE
Discovery: back port #7558 to 1.x and add bwc protections of the new ping on master gone introduced in #7493

### DIFF
--- a/src/main/java/org/elasticsearch/Version.java
+++ b/src/main/java/org/elasticsearch/Version.java
@@ -403,6 +403,13 @@ public class Version implements Serializable {
     }
 
     /**
+     * Returns the largest version between the 2.
+     */
+    public static Version largest(Version version1, Version version2) {
+        return version1.id > version2.id ? version1 : version2;
+    }
+
+    /**
      * Returns the version given its string representation, current version if the argument is null or empty
      */
     public static Version fromString(String version) {
@@ -434,7 +441,7 @@ public class Version implements Serializable {
 
             return fromId(major + minor + revision + build);
 
-        } catch(NumberFormatException e) {
+        } catch (NumberFormatException e) {
             throw new IllegalArgumentException("unable to parse version " + version, e);
         }
     }

--- a/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -1006,7 +1006,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
             activeNodes.add(pingResponse.node());
             minimumPingVersion = Version.smallest(pingResponse.node().version(), minimumPingVersion);
             if (pingResponse.hasJoinedOnce() != null && pingResponse.hasJoinedOnce()) {
-                assert minimumPingVersion.onOrAfter(Version.V_1_4_0);
+                assert pingResponse.node().getVersion().onOrAfter(Version.V_1_4_0) : "ping version [" + pingResponse.node().version() + "]< 1.4.0 while having hasJoinedOnce == true";
                 joinedOnceActiveNodes.add(pingResponse.node());
             }
         }

--- a/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -624,7 +624,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
                 if (!rejoinOnMasterGone) {
                     logger.debug("not rejoining cluster due to rejoinOnMasterGone [{}]", rejoinOnMasterGone);
                     rejoin = false;
-                } else if (discoveryNodes.smallestNonClientNodeVersion().before(Version.V_1_4_0)) {
+                } else if (discoveryNodes.smallestNonClientNodeVersion().before(Version.V_1_4_0_Beta)) {
                     logger.debug("not rejoining cluster due a minimum node version of [{}]", discoveryNodes.smallestNonClientNodeVersion());
                     rejoin = false;
                 }
@@ -1006,12 +1006,12 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
             activeNodes.add(pingResponse.node());
             minimumPingVersion = Version.smallest(pingResponse.node().version(), minimumPingVersion);
             if (pingResponse.hasJoinedOnce() != null && pingResponse.hasJoinedOnce()) {
-                assert pingResponse.node().getVersion().onOrAfter(Version.V_1_4_0) : "ping version [" + pingResponse.node().version() + "]< 1.4.0 while having hasJoinedOnce == true";
+                assert pingResponse.node().getVersion().onOrAfter(Version.V_1_4_0_Beta) : "ping version [" + pingResponse.node().version() + "]< 1.4.0 while having hasJoinedOnce == true";
                 joinedOnceActiveNodes.add(pingResponse.node());
             }
         }
 
-        if (minimumPingVersion.before(Version.V_1_4_0)) {
+        if (minimumPingVersion.before(Version.V_1_4_0_Beta)) {
             logger.trace("ignoring joined once flags in ping responses, minimum ping version [{}]", minimumPingVersion);
             joinedOnceActiveNodes.clear();
         }

--- a/src/main/java/org/elasticsearch/discovery/zen/ping/PingContextProvider.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ping/PingContextProvider.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.discovery.zen.ping;
+
+import org.elasticsearch.discovery.zen.DiscoveryNodesProvider;
+
+/**
+ *
+ */
+public interface PingContextProvider extends DiscoveryNodesProvider {
+
+    /** return true if this node has previously joined the cluster at least once. False if this is first join */
+    boolean nodeHasJoinedClusterOnce();
+
+}

--- a/src/main/java/org/elasticsearch/discovery/zen/ping/ZenPing.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ping/ZenPing.java
@@ -23,6 +23,7 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.component.LifecycleComponent;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -58,7 +59,8 @@ public interface ZenPing extends LifecycleComponent<ZenPing> {
 
         private DiscoveryNode master;
 
-        private boolean hasJoinedOnce;
+        @Nullable
+        private Boolean hasJoinedOnce;
 
         private PingResponse() {
         }
@@ -90,8 +92,9 @@ public interface ZenPing extends LifecycleComponent<ZenPing> {
             return master;
         }
 
-        /** true if the joined has successfully joined the cluster before */
-        public boolean hasJoinedOnce() {
+        /** true if the joined has successfully joined the cluster before, null for nodes with a <1.4.0 version */
+        @Nullable
+        public Boolean hasJoinedOnce() {
             return hasJoinedOnce;
         }
 
@@ -111,11 +114,7 @@ public interface ZenPing extends LifecycleComponent<ZenPing> {
             if (in.getVersion().onOrAfter(Version.V_1_4_0)) {
                 this.hasJoinedOnce = in.readBoolean();
             } else {
-                // As of 1.4.0 we prefer to elect nodes which have previously successfully joined the cluster.
-                // Nodes before 1.4.0 do not take this into consideration. If pre<1.4.0 node elects it self as master
-                // based on the pings, we need to make sure we do the same. We therefore can not demote it
-                // and thus mark it as if it has previously joined.
-                this.hasJoinedOnce = true;
+                this.hasJoinedOnce = null;
             }
 
         }

--- a/src/main/java/org/elasticsearch/discovery/zen/ping/ZenPing.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ping/ZenPing.java
@@ -111,7 +111,7 @@ public interface ZenPing extends LifecycleComponent<ZenPing> {
             if (in.readBoolean()) {
                 master = readNode(in);
             }
-            if (in.getVersion().onOrAfter(Version.V_1_4_0)) {
+            if (in.getVersion().onOrAfter(Version.V_1_4_0_Beta)) {
                 this.hasJoinedOnce = in.readBoolean();
             } else {
                 this.hasJoinedOnce = null;
@@ -129,7 +129,7 @@ public interface ZenPing extends LifecycleComponent<ZenPing> {
                 out.writeBoolean(true);
                 master.writeTo(out);
             }
-            if (out.getVersion().onOrAfter(Version.V_1_4_0)) {
+            if (out.getVersion().onOrAfter(Version.V_1_4_0_Beta)) {
                 out.writeBoolean(hasJoinedOnce);
             }
         }

--- a/src/main/java/org/elasticsearch/discovery/zen/ping/ZenPing.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ping/ZenPing.java
@@ -92,7 +92,7 @@ public interface ZenPing extends LifecycleComponent<ZenPing> {
             return master;
         }
 
-        /** true if the joined has successfully joined the cluster before, null for nodes with a <1.4.0 version */
+        /** true if the node has successfully joined the cluster before, null for nodes with a <1.4.0 version */
         @Nullable
         public Boolean hasJoinedOnce() {
             return hasJoinedOnce;

--- a/src/main/java/org/elasticsearch/discovery/zen/ping/ZenPing.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ping/ZenPing.java
@@ -112,7 +112,9 @@ public interface ZenPing extends LifecycleComponent<ZenPing> {
                 master = readNode(in);
             }
             if (in.getVersion().onOrAfter(Version.V_1_4_0_Beta)) {
-                this.hasJoinedOnce = in.readBoolean();
+                if (in.readBoolean()) {
+                    this.hasJoinedOnce = in.readBoolean();
+                }
             } else {
                 this.hasJoinedOnce = null;
             }
@@ -130,7 +132,12 @@ public interface ZenPing extends LifecycleComponent<ZenPing> {
                 master.writeTo(out);
             }
             if (out.getVersion().onOrAfter(Version.V_1_4_0_Beta)) {
-                out.writeBoolean(hasJoinedOnce);
+                if (hasJoinedOnce != null) {
+                    out.writeBoolean(true);
+                    out.writeBoolean(hasJoinedOnce);
+                } else {
+                    out.writeBoolean(false);
+                }
             }
         }
 

--- a/src/main/java/org/elasticsearch/discovery/zen/ping/ZenPingService.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ping/ZenPingService.java
@@ -33,7 +33,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
-import org.elasticsearch.discovery.zen.DiscoveryNodesProvider;
 import org.elasticsearch.discovery.zen.elect.ElectMasterService;
 import org.elasticsearch.discovery.zen.ping.multicast.MulticastZenPing;
 import org.elasticsearch.discovery.zen.ping.unicast.UnicastHostsProvider;
@@ -92,12 +91,12 @@ public class ZenPingService extends AbstractLifecycleComponent<ZenPing> implemen
     }
 
     @Override
-    public void setNodesProvider(DiscoveryNodesProvider nodesProvider) {
+    public void setPingContextProvider(PingContextProvider contextProvider) {
         if (lifecycle.started()) {
             throw new ElasticsearchIllegalStateException("Can't set nodes provider when started");
         }
         for (ZenPing zenPing : zenPings) {
-            zenPing.setNodesProvider(nodesProvider);
+            zenPing.setPingContextProvider(contextProvider);
         }
     }
 
@@ -172,7 +171,7 @@ public class ZenPingService extends AbstractLifecycleComponent<ZenPing> implemen
         public void onPing(PingResponse[] pings) {
             if (pings != null) {
                 for (PingResponse pingResponse : pings) {
-                    responses.put(pingResponse.target(), pingResponse);
+                    responses.put(pingResponse.node(), pingResponse);
                 }
             }
             if (counter.decrementAndGet() == 0) {

--- a/src/main/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPing.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPing.java
@@ -386,7 +386,7 @@ public class UnicastZenPing extends AbstractLifecycleComponent<ZenPing> implemen
     private void sendPingRequestTo14NodeWithFallback(final int id, final TimeValue timeout, final UnicastPingRequest pingRequest, final CountDownLatch latch, final DiscoveryNode node, final DiscoveryNode nodeToSend) {
         logger.trace("[{}] sending to {}, using >=1.4.0 serialization", id, nodeToSend);
         DiscoveryNode actualNodeToSend = new DiscoveryNode(nodeToSend.name(), nodeToSend.id(), nodeToSend.getHostName(), nodeToSend.getHostAddress(),
-                nodeToSend.address(), nodeToSend.attributes(), Version.largest(nodeToSend.version(), Version.V_1_4_0));
+                nodeToSend.address(), nodeToSend.attributes(), Version.largest(nodeToSend.version(), Version.V_1_4_0_Beta));
         transportService.sendRequest(actualNodeToSend, ACTION_NAME_GTE_1_4, pingRequest, TransportRequestOptions.options().withTimeout((long) (timeout.millis() * 1.25)), new BaseTransportResponseHandler<UnicastPingResponse>() {
 
             @Override

--- a/src/main/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPing.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPing.java
@@ -21,10 +21,7 @@ package org.elasticsearch.discovery.zen.ping.unicast;
 
 import com.carrotsearch.hppc.cursors.ObjectCursor;
 import com.google.common.collect.Lists;
-import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.ElasticsearchIllegalArgumentException;
-import org.elasticsearch.ElasticsearchIllegalStateException;
-import org.elasticsearch.Version;
+import org.elasticsearch.*;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
@@ -61,6 +58,18 @@ import static org.elasticsearch.discovery.zen.ping.ZenPing.PingResponse.readPing
 public class UnicastZenPing extends AbstractLifecycleComponent<ZenPing> implements ZenPing {
 
     public static final String ACTION_NAME = "internal:discovery/zen/unicast";
+
+
+    /**
+     * when pinging the initial configured target hosts, we do not know there version. We there therefore use
+     * the lowest possible version (i.e., 1.0.0) for serializing information on the wire. As of 1.4, we needed to extend
+     * the information sent in a ping, to prefer nodes which have previously joined the cluster during master election.
+     * This information is only needed if all the cluster is on version 1.4 or up. To bypass this issue we introduce
+     * a second action name which is guaranteed to exist only nodes from version 1.4.0 and up. Using this action,
+     * we can safely use 1.4.0 as a serialization format. If this fails with a {@link ActionNotFoundTransportException}
+     * we know we speak to a node with <1.4 version, and fall back to use {@link #ACTION_NAME}.
+     */
+    public static final String ACTION_NAME_GTE_1_4 = "internal:discovery/zen/unicast_gte_1_4";
 
     public static final int LIMIT_PORTS_COUNT = 1;
 
@@ -127,7 +136,9 @@ public class UnicastZenPing extends AbstractLifecycleComponent<ZenPing> implemen
         }
         this.configuredTargetNodes = configuredTargetNodes.toArray(new DiscoveryNode[configuredTargetNodes.size()]);
 
-        transportService.registerHandler(ACTION_NAME, new UnicastPingRequestHandler());
+        UnicastPingRequestHandler unicastPingHanlder = new UnicastPingRequestHandler();
+        transportService.registerHandler(ACTION_NAME, unicastPingHanlder);
+        transportService.registerHandler(ACTION_NAME_GTE_1_4, unicastPingHanlder);
     }
 
     @Override
@@ -334,7 +345,12 @@ public class UnicastZenPing extends AbstractLifecycleComponent<ZenPing> implemen
                             logger.trace("[{}] connected to {}", sendPingsHandler.id(), node);
                             if (receivedResponses.containsKey(sendPingsHandler.id())) {
                                 // we are connected and still in progress, send the ping request
-                                sendPingRequestToNode(sendPingsHandler.id(), timeout, pingRequest, latch, node, finalNodeToSend);
+                                if (nodeFoundByAddress) {
+                                    // we're good - we know what version to use for serialization
+                                    sendPingRequestToNode(sendPingsHandler.id(), timeout, pingRequest, latch, node, finalNodeToSend);
+                                } else {
+                                    sendPingRequestTo14NodeWithFallback(sendPingsHandler.id(), timeout, pingRequest, latch, node, finalNodeToSend);
+                                }
                             } else {
                                 // connect took too long, just log it and bail
                                 latch.countDown();
@@ -366,6 +382,46 @@ public class UnicastZenPing extends AbstractLifecycleComponent<ZenPing> implemen
         }
     }
 
+    /** See {@link #ACTION_NAME_GTE_1_4} for an explaination of why this needed */
+    private void sendPingRequestTo14NodeWithFallback(final int id, final TimeValue timeout, final UnicastPingRequest pingRequest, final CountDownLatch latch, final DiscoveryNode node, final DiscoveryNode nodeToSend) {
+        logger.trace("[{}] sending to {}, using >=1.4.0 serialization", id, nodeToSend);
+        DiscoveryNode actualNodeToSend = new DiscoveryNode(nodeToSend.name(), nodeToSend.id(), nodeToSend.getHostName(), nodeToSend.getHostAddress(),
+                nodeToSend.address(), nodeToSend.attributes(), Version.largest(nodeToSend.version(), Version.V_1_4_0));
+        transportService.sendRequest(actualNodeToSend, ACTION_NAME_GTE_1_4, pingRequest, TransportRequestOptions.options().withTimeout((long) (timeout.millis() * 1.25)), new BaseTransportResponseHandler<UnicastPingResponse>() {
+
+            @Override
+            public UnicastPingResponse newInstance() {
+                return new UnicastPingResponse();
+            }
+
+            @Override
+            public String executor() {
+                return ThreadPool.Names.SAME;
+            }
+
+            @Override
+            public void handleResponse(UnicastPingResponse response) {
+                handlePingResponse(response, id, nodeToSend, latch);
+            }
+
+            @Override
+            public void handleException(TransportException exp) {
+                if (ExceptionsHelper.unwrapCause(exp) instanceof ActionNotFoundTransportException) {
+                    logger.trace("failed to ping {}, falling back to <=1.4.0 ping action", node);
+                    sendPingRequestToNode(id, timeout, pingRequest, latch, node, nodeToSend);
+                    return;
+                }
+                latch.countDown();
+                if (exp instanceof ConnectTransportException) {
+                    // ok, not connected...
+                    logger.trace("failed to connect to {}", exp, nodeToSend);
+                } else {
+                    logger.warn("failed to send ping to [{}]", exp, node);
+                }
+            }
+        });
+    }
+
     private void sendPingRequestToNode(final int id, final TimeValue timeout, final UnicastPingRequest pingRequest, final CountDownLatch latch, final DiscoveryNode node, final DiscoveryNode nodeToSend) {
         logger.trace("[{}] sending to {}", id, nodeToSend);
         transportService.sendRequest(nodeToSend, ACTION_NAME, pingRequest, TransportRequestOptions.options().withTimeout((long) (timeout.millis() * 1.25)), new BaseTransportResponseHandler<UnicastPingResponse>() {
@@ -382,40 +438,7 @@ public class UnicastZenPing extends AbstractLifecycleComponent<ZenPing> implemen
 
             @Override
             public void handleResponse(UnicastPingResponse response) {
-                logger.trace("[{}] received response from {}: {}", id, nodeToSend, Arrays.toString(response.pingResponses));
-                try {
-                    DiscoveryNodes discoveryNodes = contextProvider.nodes();
-                    for (PingResponse pingResponse : response.pingResponses) {
-                        if (pingResponse.node().id().equals(discoveryNodes.localNodeId())) {
-                            // that's us, ignore
-                            continue;
-                        }
-                        if (!pingResponse.clusterName().equals(clusterName)) {
-                            // not part of the cluster
-                            logger.debug("[{}] filtering out response from {}, not same cluster_name [{}]", id, pingResponse.node(), pingResponse.clusterName().value());
-                            continue;
-                        }
-                        ConcurrentMap<DiscoveryNode, PingResponse> responses = receivedResponses.get(response.id);
-                        if (responses == null) {
-                            logger.warn("received ping response {} with no matching id [{}]", pingResponse, response.id);
-                        } else {
-                            PingResponse existingResponse = responses.get(pingResponse.node());
-                            if (existingResponse == null) {
-                                responses.put(pingResponse.node(), pingResponse);
-                            } else {
-                                // try and merge the best ping response for it, i.e. if the new one
-                                // doesn't have the master node set, and the existing one does, then
-                                // the existing one is better, so we keep it
-                                // if both have a master or both have none, we prefer the latest ping
-                                if (existingResponse.master() == null || pingResponse.master() != null) {
-                                    responses.put(pingResponse.node(), pingResponse);
-                                }
-                            }
-                        }
-                    }
-                } finally {
-                    latch.countDown();
-                }
+                handlePingResponse(response, id, nodeToSend, latch);
             }
 
             @Override
@@ -429,6 +452,43 @@ public class UnicastZenPing extends AbstractLifecycleComponent<ZenPing> implemen
                 }
             }
         });
+    }
+
+    private void handlePingResponse(UnicastPingResponse response, int id, DiscoveryNode nodeToSend, CountDownLatch latch) {
+        logger.trace("[{}] received response from {}: {}", id, nodeToSend, Arrays.toString(response.pingResponses));
+        try {
+            DiscoveryNodes discoveryNodes = contextProvider.nodes();
+            for (PingResponse pingResponse : response.pingResponses) {
+                if (pingResponse.node().id().equals(discoveryNodes.localNodeId())) {
+                    // that's us, ignore
+                    continue;
+                }
+                if (!pingResponse.clusterName().equals(clusterName)) {
+                    // not part of the cluster
+                    logger.debug("[{}] filtering out response from {}, not same cluster_name [{}]", id, pingResponse.node(), pingResponse.clusterName().value());
+                    continue;
+                }
+                ConcurrentMap<DiscoveryNode, PingResponse> responses = receivedResponses.get(response.id);
+                if (responses == null) {
+                    logger.warn("received ping response {} with no matching id [{}]", pingResponse, response.id);
+                } else {
+                    PingResponse existingResponse = responses.get(pingResponse.node());
+                    if (existingResponse == null) {
+                        responses.put(pingResponse.node(), pingResponse);
+                    } else {
+                        // try and merge the best ping response for it, i.e. if the new one
+                        // doesn't have the master node set, and the existing one does, then
+                        // the existing one is better, so we keep it
+                        // if both have a master or both have none, we prefer the latest ping
+                        if (existingResponse.master() == null || pingResponse.master() != null) {
+                            responses.put(pingResponse.node(), pingResponse);
+                        }
+                    }
+                }
+            }
+        } finally {
+            latch.countDown();
+        }
     }
 
     private UnicastPingResponse handlePingRequest(final UnicastPingRequest request) {

--- a/src/main/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPing.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPing.java
@@ -65,7 +65,7 @@ public class UnicastZenPing extends AbstractLifecycleComponent<ZenPing> implemen
      * the lowest possible version (i.e., 1.0.0) for serializing information on the wire. As of 1.4, we needed to extend
      * the information sent in a ping, to prefer nodes which have previously joined the cluster during master election.
      * This information is only needed if all the cluster is on version 1.4 or up. To bypass this issue we introduce
-     * a second action name which is guaranteed to exist only nodes from version 1.4.0 and up. Using this action,
+     * a second action name which is guaranteed to exist only on nodes from version 1.4.0 and up. Using this action,
      * we can safely use 1.4.0 as a serialization format. If this fails with a {@link ActionNotFoundTransportException}
      * we know we speak to a node with <1.4 version, and fall back to use {@link #ACTION_NAME}.
      */

--- a/src/main/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPing.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPing.java
@@ -61,7 +61,7 @@ public class UnicastZenPing extends AbstractLifecycleComponent<ZenPing> implemen
 
 
     /**
-     * when pinging the initial configured target hosts, we do not know there version. We there therefore use
+     * when pinging the initial configured target hosts, we do not know their version. We therefore use
      * the lowest possible version (i.e., 1.0.0) for serializing information on the wire. As of 1.4, we needed to extend
      * the information sent in a ping, to prefer nodes which have previously joined the cluster during master election.
      * This information is only needed if all the cluster is on version 1.4 or up. To bypass this issue we introduce
@@ -382,7 +382,7 @@ public class UnicastZenPing extends AbstractLifecycleComponent<ZenPing> implemen
         }
     }
 
-    /** See {@link #ACTION_NAME_GTE_1_4} for an explaination of why this needed */
+    /** See {@link #ACTION_NAME_GTE_1_4} for an explanation for why this needed */
     private void sendPingRequestTo14NodeWithFallback(final int id, final TimeValue timeout, final UnicastPingRequest pingRequest, final CountDownLatch latch, final DiscoveryNode node, final DiscoveryNode nodeToSend) {
         logger.trace("[{}] sending to {}, using >=1.4.0 serialization", id, nodeToSend);
         DiscoveryNode actualNodeToSend = new DiscoveryNode(nodeToSend.name(), nodeToSend.id(), nodeToSend.getHostName(), nodeToSend.getHostAddress(),

--- a/src/test/java/org/elasticsearch/bwcompat/UnicastBackwardsCompatibilityTest.java
+++ b/src/test/java/org/elasticsearch/bwcompat/UnicastBackwardsCompatibilityTest.java
@@ -71,9 +71,8 @@ public class UnicastBackwardsCompatibilityTest extends ElasticsearchBackwardsCom
     @Test
     @TestLogging("discovery.zen:TRACE")
     public void testUnicastDiscovery() throws ExecutionException, InterruptedException, IOException {
-        // start a client node now, to make sure it grabs the first port o.w. the backwards
-        // comparability infra may start one *after* the first external node and mess up our unicast host
-        // list
+        // the backwards comparability infra will *sometimes* start one client node which will grab the first port
+        // to make sure this always happens and gives us port stability start the node here.
         backwardsCluster().internalCluster().startNode(ImmutableSettings.builder()
                 .put("node.client", "true")
                 .put(DiscoveryService.SETTING_INITIAL_STATE_TIMEOUT, "10ms")); // don't wait there is nothing out there.

--- a/src/test/java/org/elasticsearch/bwcompat/UnicastBackwardsCompatibilityTest.java
+++ b/src/test/java/org/elasticsearch/bwcompat/UnicastBackwardsCompatibilityTest.java
@@ -71,7 +71,9 @@ public class UnicastBackwardsCompatibilityTest extends ElasticsearchBackwardsCom
     @Test
     @TestLogging("discovery.zen:TRACE")
     public void testUnicastDiscovery() throws ExecutionException, InterruptedException, IOException {
-        // start a client node now, to make sure it grabs the first port
+        // start a client node now, to make sure it grabs the first port o.w. the backwards
+        // comparability infra may start one *after* the first external node and mess up our unicast host
+        // list
         backwardsCluster().internalCluster().startNode(ImmutableSettings.builder()
                 .put("node.client", "true")
                 .put(DiscoveryService.SETTING_INITIAL_STATE_TIMEOUT, "10ms")); // don't wait there is nothing out there.

--- a/src/test/java/org/elasticsearch/discovery/DiscoveryWithServiceDisruptions.java
+++ b/src/test/java/org/elasticsearch/discovery/DiscoveryWithServiceDisruptions.java
@@ -162,7 +162,7 @@ public class DiscoveryWithServiceDisruptions extends ElasticsearchIntegrationTes
         for (ZenPingService pingService : internalCluster().getInstances(ZenPingService.class)) {
             for (ZenPing zenPing : pingService.zenPings()) {
                 if (zenPing instanceof UnicastZenPing) {
-                    ((UnicastZenPing) zenPing).clearTemporalReponses();
+                    ((UnicastZenPing) zenPing).clearTemporalResponses();
                 }
             }
         }
@@ -488,7 +488,7 @@ public class DiscoveryWithServiceDisruptions extends ElasticsearchIntegrationTes
         // includes all the other nodes that have pinged it and the issue doesn't manifest
         for (ZenPingService pingService : internalCluster().getInstances(ZenPingService.class)) {
             for (ZenPing zenPing : pingService.zenPings()) {
-                ((UnicastZenPing) zenPing).clearTemporalReponses();
+                ((UnicastZenPing) zenPing).clearTemporalResponses();
             }
         }
 
@@ -527,7 +527,7 @@ public class DiscoveryWithServiceDisruptions extends ElasticsearchIntegrationTes
         // includes all the other nodes that have pinged it and the issue doesn't manifest
         for (ZenPingService pingService : internalCluster().getInstances(ZenPingService.class)) {
             for (ZenPing zenPing : pingService.zenPings()) {
-                ((UnicastZenPing) zenPing).clearTemporalReponses();
+                ((UnicastZenPing) zenPing).clearTemporalResponses();
             }
         }
 

--- a/src/test/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPingTests.java
+++ b/src/test/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPingTests.java
@@ -29,8 +29,8 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.discovery.zen.DiscoveryNodesProvider;
 import org.elasticsearch.discovery.zen.elect.ElectMasterService;
+import org.elasticsearch.discovery.zen.ping.PingContextProvider;
 import org.elasticsearch.discovery.zen.ping.ZenPing;
 import org.elasticsearch.node.service.NodeService;
 import org.elasticsearch.test.ElasticsearchTestCase;
@@ -76,7 +76,7 @@ public class UnicastZenPingTests extends ElasticsearchTestCase {
                 .build();
 
         UnicastZenPing zenPingA = new UnicastZenPing(hostsSettings, threadPool, transportServiceA, clusterName, Version.CURRENT, electMasterService, null);
-        zenPingA.setNodesProvider(new DiscoveryNodesProvider() {
+        zenPingA.setPingContextProvider(new PingContextProvider() {
             @Override
             public DiscoveryNodes nodes() {
                 return DiscoveryNodes.builder().put(nodeA).localNodeId("UZP_A").build();
@@ -86,11 +86,16 @@ public class UnicastZenPingTests extends ElasticsearchTestCase {
             public NodeService nodeService() {
                 return null;
             }
+
+            @Override
+            public boolean nodeHasJoinedClusterOnce() {
+                return false;
+            }
         });
         zenPingA.start();
 
         UnicastZenPing zenPingB = new UnicastZenPing(hostsSettings, threadPool, transportServiceB, clusterName, Version.CURRENT, electMasterService, null);
-        zenPingB.setNodesProvider(new DiscoveryNodesProvider() {
+        zenPingB.setPingContextProvider(new PingContextProvider() {
             @Override
             public DiscoveryNodes nodes() {
                 return DiscoveryNodes.builder().put(nodeB).localNodeId("UZP_B").build();
@@ -100,13 +105,28 @@ public class UnicastZenPingTests extends ElasticsearchTestCase {
             public NodeService nodeService() {
                 return null;
             }
+
+            @Override
+            public boolean nodeHasJoinedClusterOnce() {
+                return true;
+            }
         });
         zenPingB.start();
 
         try {
+            logger.info("ping from UZP_A");
             ZenPing.PingResponse[] pingResponses = zenPingA.pingAndWait(TimeValue.timeValueSeconds(1));
             assertThat(pingResponses.length, equalTo(1));
-            assertThat(pingResponses[0].target().id(), equalTo("UZP_B"));
+            assertThat(pingResponses[0].node().id(), equalTo("UZP_B"));
+            assertTrue(pingResponses[0].hasJoinedOnce());
+
+            // ping again, this time from B,
+            logger.info("ping from UZP_B");
+            pingResponses = zenPingB.pingAndWait(TimeValue.timeValueSeconds(1));
+            assertThat(pingResponses.length, equalTo(1));
+            assertThat(pingResponses[0].node().id(), equalTo("UZP_A"));
+            assertFalse(pingResponses[0].hasJoinedOnce());
+
         } finally {
             zenPingA.close();
             zenPingB.close();

--- a/src/test/java/org/elasticsearch/transport/ActionNamesBackwardsCompatibilityTest.java
+++ b/src/test/java/org/elasticsearch/transport/ActionNamesBackwardsCompatibilityTest.java
@@ -136,7 +136,7 @@ public class ActionNamesBackwardsCompatibilityTest extends ElasticsearchBackward
         actionsVersions.put(DeleteIndexedScriptAction.NAME, Version.V_1_3_0);
         actionsVersions.put(PutIndexedScriptAction.NAME, Version.V_1_3_0);
 
-        actionsVersions.put(UnicastZenPing.ACTION_NAME_GTE_1_4, Version.V_1_4_0);
+        actionsVersions.put(UnicastZenPing.ACTION_NAME_GTE_1_4, Version.V_1_4_0_Beta);
 
     }
 }

--- a/src/test/java/org/elasticsearch/transport/ActionNamesBackwardsCompatibilityTest.java
+++ b/src/test/java/org/elasticsearch/transport/ActionNamesBackwardsCompatibilityTest.java
@@ -32,6 +32,7 @@ import org.elasticsearch.action.indexedscripts.get.GetIndexedScriptAction;
 import org.elasticsearch.action.indexedscripts.put.PutIndexedScriptAction;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.discovery.zen.ping.unicast.UnicastZenPing;
 import org.elasticsearch.indices.store.IndicesStore;
 import org.elasticsearch.test.ElasticsearchBackwardsCompatIntegrationTest;
 import org.elasticsearch.test.InternalTestCluster;
@@ -134,6 +135,8 @@ public class ActionNamesBackwardsCompatibilityTest extends ElasticsearchBackward
         actionsVersions.put(GetIndexedScriptAction.NAME, Version.V_1_3_0);
         actionsVersions.put(DeleteIndexedScriptAction.NAME, Version.V_1_3_0);
         actionsVersions.put(PutIndexedScriptAction.NAME, Version.V_1_3_0);
+
+        actionsVersions.put(UnicastZenPing.ACTION_NAME_GTE_1_4, Version.V_1_4_0);
 
     }
 }

--- a/src/test/java/org/elasticsearch/transport/ActionNamesTests.java
+++ b/src/test/java/org/elasticsearch/transport/ActionNamesTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.action.bench.BenchmarkAction;
 import org.elasticsearch.action.bench.BenchmarkService;
 import org.elasticsearch.action.bench.BenchmarkStatusAction;
 import org.elasticsearch.action.exists.ExistsAction;
+import org.elasticsearch.discovery.zen.ping.unicast.UnicastZenPing;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.junit.Test;
 
@@ -133,5 +134,6 @@ public class ActionNamesTests extends ElasticsearchIntegrationTest {
         post_1_4_actions.add(ExistsAction.NAME);
         post_1_4_actions.add(ExistsAction.NAME + "[s]");
         post_1_4_actions.add(GetIndexAction.NAME);
+        post_1_4_actions.add(UnicastZenPing.ACTION_NAME_GTE_1_4);
     }
 }


### PR DESCRIPTION
The change in #7558 adds a flag to PingResponse. However, when unicast discovery is used,  this extra flag can not be serialized by the very initial pings as they do not know yet what node version they ping (i.e., they have to default to 1.0.0, which excludes changing the serialization format). This commit bypasses this problem by adding a dedicated action which only exist on nodes of version 1.4 or up. Nodes first try to ping this endpoint using 1.4.0 as a serialization version. If that fails they fall back to the pre 1.4.0 action. This is optimal if all nodes are on 1.4.0 or higher, with a small down side if the cluster has mixed versions - but this is a temporary state.

Further two bwc protections are added:
1) Disable the preference to nodes who previously joined the cluster if some of the pings are on version < 1.4.0
2) Disable the rejoin on master gone functionality if some nodes in the cluster or version < 1.4.0
