### PR TITLE
Update java source example

### DIFF
--- a/docs/java-api/count.asciidoc
+++ b/docs/java-api/count.asciidoc
@@ -8,8 +8,8 @@ and across one or more types. The query can be provided using the
 
 [source,java]
 --------------------------------------------------
-import static org.elasticsearch.index.query.xcontent.FilterBuilders.*;
-import static org.elasticsearch.index.query.xcontent.QueryBuilders.*;
+import static org.elasticsearch.index.query.FilterBuilders.*;
+import static org.elasticsearch.index.query.QueryBuilders.*;
 
 CountResponse response = client.prepareCount("test")
         .setQuery(termQuery("_type", "type1"))


### PR DESCRIPTION
From the version 1.0 FilterBuilders and QueryBuilders are not part from org.elasticsearch.index.query.xcontent package no more.
