### PR TITLE
Restore preference to latest unicast pings describing the same node

### DIFF
--- a/src/main/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPing.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPing.java
@@ -394,7 +394,8 @@ public class UnicastZenPing extends AbstractLifecycleComponent<ZenPing> implemen
                                 // try and merge the best ping response for it, i.e. if the new one
                                 // doesn't have the master node set, and the existing one does, then
                                 // the existing one is better, so we keep it
-                                if (pingResponse.master() != null) {
+                                // if both have a master or both have none, we prefer the latest ping
+                                if (existingResponse.master() == null || pingResponse.master() != null) {
                                     responses.put(pingResponse.node(), pingResponse);
                                 }
                             }

--- a/src/test/java/org/elasticsearch/indices/IndicesLifecycleListenerTests.java
+++ b/src/test/java/org/elasticsearch/indices/IndicesLifecycleListenerTests.java
@@ -20,7 +20,6 @@ package org.elasticsearch.indices;
 
 import com.google.common.base.Predicate;
 import com.google.common.collect.Maps;
-import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.index.shard.IndexShardState;
@@ -45,7 +44,6 @@ import static org.elasticsearch.test.ElasticsearchIntegrationTest.Scope;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 
 @ClusterScope(scope = Scope.TEST, numDataNodes = 0)
-@LuceneTestCase.AwaitsFix(bugUrl = "fails due to old ping responses confusing master elections, bleskes investigating")
 public class IndicesLifecycleListenerTests extends ElasticsearchIntegrationTest {
 
     @Test


### PR DESCRIPTION
#5413 introduced a change where we prefer ping responses containing a master over those who don't. The same change changes the preference of acceptance if both pings have a master indication or if neither do.

 #7558 added new flag to the PingResponse which changes after a node has joined the cluster for the very first time. Giving preference to older pings cause the wrong value of this flag to be used.   This commit restores the preference to the original one.
