### PR TITLE
add support for resetting dynamic cluster settings

### DIFF
--- a/docs/reference/cluster/update-settings.asciidoc
+++ b/docs/reference/cluster/update-settings.asciidoc
@@ -38,6 +38,31 @@ last example will be:
 }' 
 --------------------------------------------------
 
+Resetting persistent or transient settings can be done by assigning a
+`null` value. If a transient setting is reset, the persistent setting
+is applied if available. Otherwise Elasticsearch will fallback to the setting
+defined at the configuration file or, if not existent, to the default
+value. Here is an example:
+
+[source,js]
+--------------------------------------------------
+curl -XPUT localhost:9200/_cluster/settings -d '{
+    "transient" : {
+        "discovery.zen.minimum_master_nodes" : null
+    }
+}'
+--------------------------------------------------
+
+Reset settings will not be included in the cluster response. So
+the response for the last example will be:
+
+[source,js]
+--------------------------------------------------
+{
+    "persistent" : {},
+    "transient" : {}
+}
+
 Cluster wide settings can be returned using:
 
 [source,js]

--- a/rest-api-spec/test/cluster.put_settings/11_reset.yaml
+++ b/rest-api-spec/test/cluster.put_settings/11_reset.yaml
@@ -1,31 +1,31 @@
 ---
-"Test put settings":
+"Test reset cluster settings":
   - do:
       cluster.put_settings:
         body:
-          transient:
+          persistent:
             cluster.routing.allocation.disk.threshold_enabled: false
         flat_settings: true
 
-  - match: {transient: {cluster.routing.allocation.disk.threshold_enabled: "false"}}
+  - match: {persistent: {cluster.routing.allocation.disk.threshold_enabled: "false"}}
 
   - do:
       cluster.get_settings:
         flat_settings: true
 
-  - match: {transient: {cluster.routing.allocation.disk.threshold_enabled: "false"}}
+  - match: {persistent: {cluster.routing.allocation.disk.threshold_enabled: "false"}}
 
   - do:
       cluster.put_settings:
         body:
-          transient:
+          persistent:
             cluster.routing.allocation.disk.threshold_enabled: null
         flat_settings: true
 
-  - match: {transient: {}}
+  - match: {persistent: {}}
 
   - do:
       cluster.get_settings:
         flat_settings: true
 
-  - match: {transient: {}}
+  - match: {persistent: {}}

--- a/src/main/java/org/elasticsearch/action/admin/cluster/settings/ClusterUpdateSettingsRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/settings/ClusterUpdateSettingsRequestBuilder.java
@@ -25,6 +25,7 @@ import org.elasticsearch.client.ClusterAdminClient;
 import org.elasticsearch.common.settings.Settings;
 
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Builder for a cluster update settings request
@@ -98,6 +99,22 @@ public class ClusterUpdateSettingsRequestBuilder extends AcknowledgedRequestBuil
         request.persistentSettings(settings);
         return this;
     }
+    /**
+     * Sets a set of transient setting names which should be removed
+     */
+    public ClusterUpdateSettingsRequestBuilder setTransientSettingsToRemove(Set<String> transientSettingsToRemove) {
+        request.transientSettingsToRemove(transientSettingsToRemove);
+        return this;
+    }
+
+    /**
+     * Sets a set of persistent setting names which should be removed
+     */
+    public ClusterUpdateSettingsRequestBuilder setPersistentSettingsToRemove(Set persistentSettingsToRemove) {
+        request.persistentSettingsToRemove(persistentSettingsToRemove);
+        return this;
+    }
+
 
     @Override
     protected void doExecute(ActionListener<ClusterUpdateSettingsResponse> listener) {

--- a/src/main/java/org/elasticsearch/action/admin/cluster/settings/TransportClusterUpdateSettingsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/settings/TransportClusterUpdateSettingsAction.java
@@ -217,6 +217,24 @@ public class TransportClusterUpdateSettingsAction extends TransportMasterNodeOpe
                     }
                 }
 
+                for (String settingName : request.transientSettingsToRemove()) {
+                    if (dynamicSettings.hasDynamicSetting(settingName)) {
+                        transientSettings.remove(settingName);
+                        changed = true;
+                    } else {
+                        logger.warn("ignoring transient setting [{}], not dynamically updateable", settingName);
+                    }
+                }
+
+                for (String settingName : request.persistentSettingsToRemove()) {
+                    if (dynamicSettings.hasDynamicSetting(settingName)) {
+                        persistentSettings.remove(settingName);
+                        changed = true;
+                    } else {
+                        logger.warn("ignoring persistent setting [{}], not dynamically updateable", settingName);
+                    }
+                }
+
                 if (!changed) {
                     return currentState;
                 }

--- a/src/main/java/org/elasticsearch/action/support/DestructiveOperations.java
+++ b/src/main/java/org/elasticsearch/action/support/DestructiveOperations.java
@@ -34,7 +34,10 @@ public final class DestructiveOperations implements NodeSettingsService.Listener
      */
     public static final String REQUIRES_NAME = "action.destructive_requires_name";
 
+    private static final boolean DEFAULT_REQUIRES_NAME = false;
+
     private final ESLogger logger;
+    private final Settings settings;
     private volatile boolean destructiveRequiresName;
 
     // TODO: Turn into a component that can be reused and wired up into all the transport actions where
@@ -42,7 +45,9 @@ public final class DestructiveOperations implements NodeSettingsService.Listener
     // statement is printed several times, this can removed once this becomes a component.
     public DestructiveOperations(ESLogger logger, Settings settings, NodeSettingsService nodeSettingsService) {
         this.logger = logger;
-        destructiveRequiresName = settings.getAsBoolean(DestructiveOperations.REQUIRES_NAME, false);
+        this.settings = settings;
+        destructiveRequiresName = settings.getAsBoolean(DestructiveOperations.REQUIRES_NAME,
+                DEFAULT_REQUIRES_NAME);
         nodeSettingsService.addListener(this);
     }
 
@@ -71,7 +76,8 @@ public final class DestructiveOperations implements NodeSettingsService.Listener
 
     @Override
     public void onRefreshSettings(Settings settings) {
-        boolean newValue = settings.getAsBoolean("action.destructive_requires_name", destructiveRequiresName);
+        boolean newValue = settings.getAsBoolean(REQUIRES_NAME,
+                DestructiveOperations.this.settings.getAsBoolean(REQUIRES_NAME, DEFAULT_REQUIRES_NAME));
         if (destructiveRequiresName != newValue) {
             logger.info("updating [action.operate_all_indices] from [{}] to [{}]", destructiveRequiresName, newValue);
             this.destructiveRequiresName = newValue;

--- a/src/main/java/org/elasticsearch/cluster/InternalClusterInfoService.java
+++ b/src/main/java/org/elasticsearch/cluster/InternalClusterInfoService.java
@@ -62,6 +62,8 @@ public class InternalClusterInfoService extends AbstractComponent implements Clu
 
     public static final String INTERNAL_CLUSTER_INFO_UPDATE_INTERVAL = "cluster.info.update.interval";
 
+    private static final TimeValue DEFAULT_UPDATE_INTERVAL = TimeValue.timeValueSeconds(30);
+
     private volatile TimeValue updateFrequency;
 
     private volatile ImmutableMap<String, DiskUsage> usages;
@@ -86,8 +88,10 @@ public class InternalClusterInfoService extends AbstractComponent implements Clu
         this.transportIndicesStatsAction = transportIndicesStatsAction;
         this.clusterService = clusterService;
         this.threadPool = threadPool;
-        this.updateFrequency = settings.getAsTime(INTERNAL_CLUSTER_INFO_UPDATE_INTERVAL, TimeValue.timeValueSeconds(30));
-        this.enabled = settings.getAsBoolean(DiskThresholdDecider.CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED, true);
+        this.updateFrequency = settings.getAsTime(INTERNAL_CLUSTER_INFO_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL);
+        this.enabled = settings.getAsBoolean(
+                DiskThresholdDecider.CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED,
+                DiskThresholdDecider.DEFAULT_THRESHOLD_ENABLED);
         nodeSettingsService.addListener(new ApplySettings());
 
         // Add InternalClusterInfoService to listen for Master changes
@@ -99,11 +103,16 @@ public class InternalClusterInfoService extends AbstractComponent implements Clu
     class ApplySettings implements NodeSettingsService.Listener {
         @Override
         public void onRefreshSettings(Settings settings) {
-            TimeValue newUpdateFrequency = settings.getAsTime(INTERNAL_CLUSTER_INFO_UPDATE_INTERVAL, null);
+            TimeValue newUpdateFrequency = settings.getAsTime(
+                    INTERNAL_CLUSTER_INFO_UPDATE_INTERVAL,
+                    InternalClusterInfoService.this.settings.getAsTime(
+                            INTERNAL_CLUSTER_INFO_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL));
             // ClusterInfoService is only enabled if the DiskThresholdDecider is enabled
-            Boolean newEnabled = settings.getAsBoolean(DiskThresholdDecider.CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED, null);
+            Boolean newEnabled = settings.getAsBoolean(
+                    DiskThresholdDecider.CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED,
+                    DiskThresholdDecider.DEFAULT_THRESHOLD_ENABLED);
 
-            if (newUpdateFrequency != null) {
+            if (newUpdateFrequency != null && !updateFrequency.equals(newUpdateFrequency)) {
                 if (newUpdateFrequency.getMillis() < TimeValue.timeValueSeconds(10).getMillis()) {
                     logger.warn("[{}] set too low [{}] (< 10s)", INTERNAL_CLUSTER_INFO_UPDATE_INTERVAL, newUpdateFrequency);
                     throw new IllegalStateException("Unable to set " + INTERNAL_CLUSTER_INFO_UPDATE_INTERVAL + " less than 10 seconds");
@@ -114,7 +123,7 @@ public class InternalClusterInfoService extends AbstractComponent implements Clu
             }
 
             // We don't log about enabling it here, because the DiskThresholdDecider will already be logging about enable/disable
-            if (newEnabled != null) {
+            if (newEnabled != InternalClusterInfoService.this.enabled) {
                 InternalClusterInfoService.this.enabled = newEnabled;
             }
         }

--- a/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
@@ -74,14 +74,22 @@ public class BalancedShardsAllocator extends AbstractComponent implements Shards
     private static final float DEFAULT_INDEX_BALANCE_FACTOR = 0.5f;
     private static final float DEFAULT_SHARD_BALANCE_FACTOR = 0.45f;
     private static final float DEFAULT_PRIMARY_BALANCE_FACTOR = 0.05f;
+    private static final float DEFAULT_THRESHOLD = 1.0f;
 
     class ApplySettings implements NodeSettingsService.Listener {
         @Override
         public void onRefreshSettings(Settings settings) {
-            final float indexBalance = settings.getAsFloat(SETTING_INDEX_BALANCE_FACTOR, weightFunction.indexBalance);
-            final float shardBalance = settings.getAsFloat(SETTING_SHARD_BALANCE_FACTOR, weightFunction.shardBalance);
-            final float primaryBalance = settings.getAsFloat(SETTING_PRIMARY_BALANCE_FACTOR, weightFunction.primaryBalance);
-            float threshold = settings.getAsFloat(SETTING_THRESHOLD, BalancedShardsAllocator.this.threshold);
+            final float indexBalance = settings.getAsFloat(SETTING_INDEX_BALANCE_FACTOR,
+                    BalancedShardsAllocator.this.settings.getAsFloat(SETTING_INDEX_BALANCE_FACTOR,
+                            DEFAULT_INDEX_BALANCE_FACTOR));
+            final float shardBalance = settings.getAsFloat(SETTING_SHARD_BALANCE_FACTOR,
+                    BalancedShardsAllocator.this.settings.getAsFloat(SETTING_SHARD_BALANCE_FACTOR,
+                            DEFAULT_SHARD_BALANCE_FACTOR));
+            final float primaryBalance = settings.getAsFloat(SETTING_PRIMARY_BALANCE_FACTOR,
+                    BalancedShardsAllocator.this.settings.getAsFloat(SETTING_PRIMARY_BALANCE_FACTOR,
+                            DEFAULT_PRIMARY_BALANCE_FACTOR));
+            float threshold = settings.getAsFloat(SETTING_THRESHOLD,
+                    BalancedShardsAllocator.this.settings.getAsFloat(SETTING_THRESHOLD, DEFAULT_THRESHOLD));
             if (threshold <= 0.0f) {
                 throw new ElasticsearchIllegalArgumentException("threshold must be greater than 0.0f but was: " + threshold);
             }
@@ -92,7 +100,7 @@ public class BalancedShardsAllocator extends AbstractComponent implements Shards
 
     private volatile WeightFunction weightFunction = new WeightFunction(DEFAULT_INDEX_BALANCE_FACTOR, DEFAULT_SHARD_BALANCE_FACTOR, DEFAULT_PRIMARY_BALANCE_FACTOR);
 
-    private volatile float threshold = 1.0f;
+    private volatile float threshold = DEFAULT_THRESHOLD;
 
 
     public BalancedShardsAllocator(Settings settings) {

--- a/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ConcurrentRebalanceAllocationDecider.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ConcurrentRebalanceAllocationDecider.java
@@ -43,10 +43,16 @@ public class ConcurrentRebalanceAllocationDecider extends AllocationDecider {
 
     public static final String CLUSTER_ROUTING_ALLOCATION_CLUSTER_CONCURRENT_REBALANCE = "cluster.routing.allocation.cluster_concurrent_rebalance";
 
+    private static final int DEFAULT_CLUSTER_ROUTING_ALLOCATION_CLUSTER_CONCURRENT_REBALANCE = 2;
+
     class ApplySettings implements NodeSettingsService.Listener {
         @Override
         public void onRefreshSettings(Settings settings) {
-            int clusterConcurrentRebalance = settings.getAsInt(CLUSTER_ROUTING_ALLOCATION_CLUSTER_CONCURRENT_REBALANCE, ConcurrentRebalanceAllocationDecider.this.clusterConcurrentRebalance);
+            int clusterConcurrentRebalance = settings.getAsInt(
+                    CLUSTER_ROUTING_ALLOCATION_CLUSTER_CONCURRENT_REBALANCE,
+                    ConcurrentRebalanceAllocationDecider.this.settings.getAsInt(
+                            CLUSTER_ROUTING_ALLOCATION_CLUSTER_CONCURRENT_REBALANCE,
+                            DEFAULT_CLUSTER_ROUTING_ALLOCATION_CLUSTER_CONCURRENT_REBALANCE));
             if (clusterConcurrentRebalance != ConcurrentRebalanceAllocationDecider.this.clusterConcurrentRebalance) {
                 logger.info("updating [cluster.routing.allocation.cluster_concurrent_rebalance] from [{}], to [{}]", ConcurrentRebalanceAllocationDecider.this.clusterConcurrentRebalance, clusterConcurrentRebalance);
                 ConcurrentRebalanceAllocationDecider.this.clusterConcurrentRebalance = clusterConcurrentRebalance;
@@ -59,7 +65,9 @@ public class ConcurrentRebalanceAllocationDecider extends AllocationDecider {
     @Inject
     public ConcurrentRebalanceAllocationDecider(Settings settings, NodeSettingsService nodeSettingsService) {
         super(settings);
-        this.clusterConcurrentRebalance = settings.getAsInt(CLUSTER_ROUTING_ALLOCATION_CLUSTER_CONCURRENT_REBALANCE, 2);
+        this.clusterConcurrentRebalance = settings.getAsInt(
+                CLUSTER_ROUTING_ALLOCATION_CLUSTER_CONCURRENT_REBALANCE,
+                DEFAULT_CLUSTER_ROUTING_ALLOCATION_CLUSTER_CONCURRENT_REBALANCE);
         logger.debug("using [cluster_concurrent_rebalance] with [{}]", clusterConcurrentRebalance);
         nodeSettingsService.addListener(new ApplySettings());
     }

--- a/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDecider.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDecider.java
@@ -82,21 +82,43 @@ public class DiskThresholdDecider extends AllocationDecider {
     public static final String CLUSTER_ROUTING_ALLOCATION_INCLUDE_RELOCATIONS = "cluster.routing.allocation.disk.include_relocations";
     public static final String CLUSTER_ROUTING_ALLOCATION_REROUTE_INTERVAL = "cluster.routing.allocation.disk.reroute_interval";
 
+    public static final boolean DEFAULT_THRESHOLD_ENABLED = true;
+    private static final String DEFAULT_LOW_DISK_WATERMARK = "85%";
+    private static final String DEFAULT_HIGH_DISK_WATERMARK = "90%";
+
     class ApplySettings implements NodeSettingsService.Listener {
         @Override
         public void onRefreshSettings(Settings settings) {
-            String newLowWatermark = settings.get(CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK, null);
-            String newHighWatermark = settings.get(CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK, null);
-            Boolean newRelocationsSetting = settings.getAsBoolean(CLUSTER_ROUTING_ALLOCATION_INCLUDE_RELOCATIONS, null);
-            Boolean newEnableSetting =  settings.getAsBoolean(CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED, null);
-            TimeValue newRerouteInterval = settings.getAsTime(CLUSTER_ROUTING_ALLOCATION_REROUTE_INTERVAL, null);
+            String newLowWatermark = settings.get(CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK,
+                    DiskThresholdDecider.this.settings.get(
+                            CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK,
+                            DEFAULT_LOW_DISK_WATERMARK));
+            String newHighWatermark = settings.get(CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK,
+                    DiskThresholdDecider.this.settings.get(
+                            CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK,
+                            DEFAULT_HIGH_DISK_WATERMARK));
+            Boolean newEnableSetting =  settings.getAsBoolean(
+                    CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED,
+                    DiskThresholdDecider.this.settings.getAsBoolean(
+                            CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED,
+                            DEFAULT_THRESHOLD_ENABLED));
+            Boolean newRelocationsSetting = settings.getAsBoolean(
+                    CLUSTER_ROUTING_ALLOCATION_INCLUDE_RELOCATIONS,
+                    DiskThresholdDecider.this.settings.getAsBoolean(
+                            CLUSTER_ROUTING_ALLOCATION_INCLUDE_RELOCATIONS,
+                            null));
+            TimeValue newRerouteInterval = settings.getAsTime(
+                    CLUSTER_ROUTING_ALLOCATION_REROUTE_INTERVAL,
+                    DiskThresholdDecider.this.settings.getAsTime(
+                            CLUSTER_ROUTING_ALLOCATION_REROUTE_INTERVAL,
+                            null));
 
-            if (newEnableSetting != null) {
+            if (newEnableSetting != null && newEnableSetting != DiskThresholdDecider.this.enabled) {
                 logger.info("updating [{}] from [{}] to [{}]", CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED,
                         DiskThresholdDecider.this.enabled, newEnableSetting);
                 DiskThresholdDecider.this.enabled = newEnableSetting;
             }
-            if (newRelocationsSetting != null) {
+            if (newRelocationsSetting != null && newRelocationsSetting != DiskThresholdDecider.this.includeRelocations) {
                 logger.info("updating [{}] from [{}] to [{}]", CLUSTER_ROUTING_ALLOCATION_INCLUDE_RELOCATIONS,
                         DiskThresholdDecider.this.includeRelocations, newRelocationsSetting);
                 DiskThresholdDecider.this.includeRelocations = newRelocationsSetting;
@@ -105,19 +127,29 @@ public class DiskThresholdDecider extends AllocationDecider {
                 if (!validWatermarkSetting(newLowWatermark)) {
                     throw new ElasticsearchParseException("Unable to parse low watermark: [" + newLowWatermark + "]");
                 }
-                logger.info("updating [{}] to [{}]", CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK, newLowWatermark);
-                DiskThresholdDecider.this.freeDiskThresholdLow = 100.0 - thresholdPercentageFromWatermark(newLowWatermark);
-                DiskThresholdDecider.this.freeBytesThresholdLow = thresholdBytesFromWatermark(newLowWatermark);
+                Double newFreeDiskThresholdLow = 100.0 - thresholdPercentageFromWatermark(newLowWatermark);
+                ByteSizeValue newFreeBytesThresholdLow = thresholdBytesFromWatermark(newLowWatermark);
+                if (!freeDiskThresholdLow.equals(newFreeDiskThresholdLow)
+                        || freeBytesThresholdLow.bytes() != newFreeBytesThresholdLow.bytes()) {
+                    logger.info("updating [{}] to [{}]", CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK, newLowWatermark);
+                    DiskThresholdDecider.this.freeDiskThresholdLow = newFreeDiskThresholdLow;
+                    DiskThresholdDecider.this.freeBytesThresholdLow = newFreeBytesThresholdLow;
+                }
             }
             if (newHighWatermark != null) {
                 if (!validWatermarkSetting(newHighWatermark)) {
                     throw new ElasticsearchParseException("Unable to parse high watermark: [" + newHighWatermark + "]");
                 }
-                logger.info("updating [{}] to [{}]", CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK, newHighWatermark);
-                DiskThresholdDecider.this.freeDiskThresholdHigh = 100.0 - thresholdPercentageFromWatermark(newHighWatermark);
-                DiskThresholdDecider.this.freeBytesThresholdHigh = thresholdBytesFromWatermark(newHighWatermark);
+                Double newFreeDiskThresholdHigh = 100.0 - thresholdPercentageFromWatermark(newHighWatermark);
+                ByteSizeValue newFreeBytesThresholdHigh = thresholdBytesFromWatermark(newHighWatermark);
+                if (!freeDiskThresholdHigh.equals(newFreeDiskThresholdHigh)
+                        || freeBytesThresholdHigh.bytes() != newFreeBytesThresholdHigh.bytes()) {
+                    logger.info("updating [{}] to [{}]", CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK, newHighWatermark);
+                    DiskThresholdDecider.this.freeDiskThresholdHigh = 100.0 - thresholdPercentageFromWatermark(newHighWatermark);
+                    DiskThresholdDecider.this.freeBytesThresholdHigh = thresholdBytesFromWatermark(newHighWatermark);
+                }
             }
-            if (newRerouteInterval != null) {
+            if (newRerouteInterval != null && !newRerouteInterval.equals(DiskThresholdDecider.this.rerouteInterval)) {
                 logger.info("updating [{}] to [{}]", CLUSTER_ROUTING_ALLOCATION_REROUTE_INTERVAL, newRerouteInterval);
                 DiskThresholdDecider.this.rerouteInterval = newRerouteInterval;
             }
@@ -197,8 +229,10 @@ public class DiskThresholdDecider extends AllocationDecider {
     @Inject
     public DiskThresholdDecider(Settings settings, NodeSettingsService nodeSettingsService, ClusterInfoService infoService, Client client) {
         super(settings);
-        String lowWatermark = settings.get(CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK, "85%");
-        String highWatermark = settings.get(CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK, "90%");
+        String lowWatermark = settings.get(CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK,
+                DEFAULT_LOW_DISK_WATERMARK);
+        String highWatermark = settings.get(CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK,
+                DEFAULT_HIGH_DISK_WATERMARK);
 
         if (!validWatermarkSetting(lowWatermark)) {
             throw new ElasticsearchParseException("Unable to parse low watermark: [" + lowWatermark + "]");
@@ -215,7 +249,8 @@ public class DiskThresholdDecider extends AllocationDecider {
         this.includeRelocations = settings.getAsBoolean(CLUSTER_ROUTING_ALLOCATION_INCLUDE_RELOCATIONS, true);
         this.rerouteInterval = settings.getAsTime(CLUSTER_ROUTING_ALLOCATION_REROUTE_INTERVAL, TimeValue.timeValueSeconds(60));
 
-        this.enabled = settings.getAsBoolean(CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED, true);
+        this.enabled = settings.getAsBoolean(CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED,
+                DEFAULT_THRESHOLD_ENABLED);
         nodeSettingsService.addListener(new ApplySettings());
         infoService.addListener(new DiskListener(client));
     }

--- a/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/EnableAllocationDecider.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/EnableAllocationDecider.java
@@ -154,13 +154,15 @@ public class EnableAllocationDecider extends AllocationDecider implements NodeSe
 
     @Override
     public void onRefreshSettings(Settings settings) {
-        final Allocation enable = Allocation.parse(settings.get(CLUSTER_ROUTING_ALLOCATION_ENABLE, this.enableAllocation.name()));
+        final Allocation enable = Allocation.parse(settings.get(CLUSTER_ROUTING_ALLOCATION_ENABLE,
+                this.settings.get(CLUSTER_ROUTING_ALLOCATION_ENABLE, Allocation.ALL.name())));
         if (enable != this.enableAllocation) {
             logger.info("updating [{}] from [{}] to [{}]", CLUSTER_ROUTING_ALLOCATION_ENABLE, this.enableAllocation, enable);
             EnableAllocationDecider.this.enableAllocation = enable;
         }
 
-        final Rebalance enableRebalance = Rebalance.parse(settings.get(CLUSTER_ROUTING_REBALANCE_ENABLE, this.enableRebalance.name()));
+        final Rebalance enableRebalance = Rebalance.parse(settings.get(CLUSTER_ROUTING_REBALANCE_ENABLE,
+                this.settings.get(CLUSTER_ROUTING_REBALANCE_ENABLE, Rebalance.ALL.name())));
         if (enableRebalance != this.enableRebalance) {
             logger.info("updating [{}] from [{}] to [{}]", CLUSTER_ROUTING_REBALANCE_ENABLE, this.enableRebalance, enableRebalance);
             EnableAllocationDecider.this.enableRebalance = enableRebalance;

--- a/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/SnapshotInProgressAllocationDecider.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/SnapshotInProgressAllocationDecider.java
@@ -44,7 +44,9 @@ public class SnapshotInProgressAllocationDecider extends AllocationDecider {
     class ApplySettings implements NodeSettingsService.Listener {
         @Override
         public void onRefreshSettings(Settings settings) {
-            boolean newEnableRelocation = settings.getAsBoolean(CLUSTER_ROUTING_ALLOCATION_SNAPSHOT_RELOCATION_ENABLED, enableRelocation);
+            boolean newEnableRelocation = settings.getAsBoolean(CLUSTER_ROUTING_ALLOCATION_SNAPSHOT_RELOCATION_ENABLED,
+                    SnapshotInProgressAllocationDecider.this.settings.getAsBoolean(
+                            CLUSTER_ROUTING_ALLOCATION_SNAPSHOT_RELOCATION_ENABLED, enableRelocation));
             if (newEnableRelocation != enableRelocation) {
                 logger.info("updating [{}] from [{}], to [{}]", CLUSTER_ROUTING_ALLOCATION_SNAPSHOT_RELOCATION_ENABLED, enableRelocation, newEnableRelocation);
                 enableRelocation = newEnableRelocation;

--- a/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ThrottlingAllocationDecider.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ThrottlingAllocationDecider.java
@@ -121,13 +121,21 @@ public class ThrottlingAllocationDecider extends AllocationDecider {
     class ApplySettings implements NodeSettingsService.Listener {
         @Override
         public void onRefreshSettings(Settings settings) {
-            int primariesInitialRecoveries = settings.getAsInt(CLUSTER_ROUTING_ALLOCATION_NODE_INITIAL_PRIMARIES_RECOVERIES, ThrottlingAllocationDecider.this.primariesInitialRecoveries);
+            int primariesInitialRecoveries = settings.getAsInt(
+                    CLUSTER_ROUTING_ALLOCATION_NODE_INITIAL_PRIMARIES_RECOVERIES,
+                    ThrottlingAllocationDecider.this.settings.getAsInt(
+                            CLUSTER_ROUTING_ALLOCATION_NODE_INITIAL_PRIMARIES_RECOVERIES,
+                            DEFAULT_CLUSTER_ROUTING_ALLOCATION_NODE_INITIAL_PRIMARIES_RECOVERIES));
             if (primariesInitialRecoveries != ThrottlingAllocationDecider.this.primariesInitialRecoveries) {
                 logger.info("updating [cluster.routing.allocation.node_initial_primaries_recoveries] from [{}] to [{}]", ThrottlingAllocationDecider.this.primariesInitialRecoveries, primariesInitialRecoveries);
                 ThrottlingAllocationDecider.this.primariesInitialRecoveries = primariesInitialRecoveries;
             }
 
-            int concurrentRecoveries = settings.getAsInt(CLUSTER_ROUTING_ALLOCATION_NODE_CONCURRENT_RECOVERIES, ThrottlingAllocationDecider.this.concurrentRecoveries);
+            int concurrentRecoveries = settings.getAsInt(
+                    CLUSTER_ROUTING_ALLOCATION_NODE_CONCURRENT_RECOVERIES,
+                    ThrottlingAllocationDecider.this.settings.getAsInt(
+                            CLUSTER_ROUTING_ALLOCATION_NODE_CONCURRENT_RECOVERIES,
+                            DEFAULT_CLUSTER_ROUTING_ALLOCATION_NODE_CONCURRENT_RECOVERIES));
             if (concurrentRecoveries != ThrottlingAllocationDecider.this.concurrentRecoveries) {
                 logger.info("updating [cluster.routing.allocation.node_concurrent_recoveries] from [{}] to [{}]", ThrottlingAllocationDecider.this.concurrentRecoveries, concurrentRecoveries);
                 ThrottlingAllocationDecider.this.concurrentRecoveries = concurrentRecoveries;

--- a/src/main/java/org/elasticsearch/discovery/DiscoverySettings.java
+++ b/src/main/java/org/elasticsearch/discovery/DiscoverySettings.java
@@ -71,7 +71,8 @@ public class DiscoverySettings extends AbstractComponent {
     private class ApplySettings implements NodeSettingsService.Listener {
         @Override
         public void onRefreshSettings(Settings settings) {
-            TimeValue newPublishTimeout = settings.getAsTime(PUBLISH_TIMEOUT, null);
+            TimeValue newPublishTimeout = settings.getAsTime(PUBLISH_TIMEOUT,
+                    DiscoverySettings.this.settings.getAsTime(PUBLISH_TIMEOUT, null));
             if (newPublishTimeout != null) {
                 if (newPublishTimeout.millis() != publishTimeout.millis()) {
                     logger.info("updating [{}] from [{}] to [{}]", PUBLISH_TIMEOUT, publishTimeout, newPublishTimeout);

--- a/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -1253,14 +1253,16 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
         @Override
         public void onRefreshSettings(Settings settings) {
             int minimumMasterNodes = settings.getAsInt(ElectMasterService.DISCOVERY_ZEN_MINIMUM_MASTER_NODES,
-                    ZenDiscovery.this.electMaster.minimumMasterNodes());
+                    ZenDiscovery.this.settings.getAsInt(ElectMasterService.DISCOVERY_ZEN_MINIMUM_MASTER_NODES,
+                            ElectMasterService.DEFAULT_DISCOVERY_ZEN_MINIMUM_MASTER_NODES));
             if (minimumMasterNodes != ZenDiscovery.this.electMaster.minimumMasterNodes()) {
                 logger.info("updating {} from [{}] to [{}]", ElectMasterService.DISCOVERY_ZEN_MINIMUM_MASTER_NODES,
                         ZenDiscovery.this.electMaster.minimumMasterNodes(), minimumMasterNodes);
                 handleMinimumMasterNodesChanged(minimumMasterNodes);
             }
 
-            boolean rejoinOnMasterGone = settings.getAsBoolean(SETTING_REJOIN_ON_MASTER_GONE, ZenDiscovery.this.rejoinOnMasterGone);
+            boolean rejoinOnMasterGone = settings.getAsBoolean(SETTING_REJOIN_ON_MASTER_GONE,
+                    ZenDiscovery.this.settings.getAsBoolean(SETTING_REJOIN_ON_MASTER_GONE, true));
             if (rejoinOnMasterGone != ZenDiscovery.this.rejoinOnMasterGone) {
                 logger.info("updating {} from [{}] to [{}]", SETTING_REJOIN_ON_MASTER_GONE, ZenDiscovery.this.rejoinOnMasterGone, rejoinOnMasterGone);
                 ZenDiscovery.this.rejoinOnMasterGone = rejoinOnMasterGone;

--- a/src/main/java/org/elasticsearch/discovery/zen/elect/ElectMasterService.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/elect/ElectMasterService.java
@@ -36,6 +36,8 @@ public class ElectMasterService extends AbstractComponent {
 
     public static final String DISCOVERY_ZEN_MINIMUM_MASTER_NODES = "discovery.zen.minimum_master_nodes";
 
+    public static final int DEFAULT_DISCOVERY_ZEN_MINIMUM_MASTER_NODES = -1;
+
     private final NodeComparator nodeComparator = new NodeComparator();
 
     private volatile int minimumMasterNodes;
@@ -43,7 +45,8 @@ public class ElectMasterService extends AbstractComponent {
     @Inject
     public ElectMasterService(Settings settings) {
         super(settings);
-        this.minimumMasterNodes = settings.getAsInt(DISCOVERY_ZEN_MINIMUM_MASTER_NODES, -1);
+        this.minimumMasterNodes = settings.getAsInt(DISCOVERY_ZEN_MINIMUM_MASTER_NODES,
+                DEFAULT_DISCOVERY_ZEN_MINIMUM_MASTER_NODES);
         logger.debug("using minimum_master_nodes [{}]", minimumMasterNodes);
     }
 

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/settings/RestClusterUpdateSettingsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/settings/RestClusterUpdateSettingsAction.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.rest.action.admin.cluster.settings;
 
+import com.google.common.collect.Sets;
 import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
 import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsResponse;
 import org.elasticsearch.client.Client;
@@ -27,11 +28,16 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
-import org.elasticsearch.rest.*;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.support.AcknowledgedRestListener;
 
 import java.io.IOException;
+import java.util.Iterator;
 import java.util.Map;
+import java.util.Set;
 
 /**
  */
@@ -51,10 +57,32 @@ public class RestClusterUpdateSettingsAction extends BaseRestHandler {
         clusterUpdateSettingsRequest.masterNodeTimeout(request.paramAsTime("master_timeout", clusterUpdateSettingsRequest.masterNodeTimeout()));
         Map<String, Object> source = XContentFactory.xContent(request.content()).createParser(request.content()).mapAndClose();
         if (source.containsKey("transient")) {
-            clusterUpdateSettingsRequest.transientSettings((Map) source.get("transient"));
+            Map<String, Object> transientSettings = (Map) source.get("transient");
+            Iterator<Map.Entry<String, Object>> iterator = transientSettings.entrySet().iterator();
+            Set<String> transientSettingsToRemove = Sets.newHashSet();
+            while (iterator.hasNext()) {
+                Map.Entry<String, Object> entry = iterator.next();
+                if (entry.getValue() == null) {
+                    transientSettingsToRemove.add(entry.getKey());
+                    iterator.remove();
+                }
+            }
+            clusterUpdateSettingsRequest.transientSettings(transientSettings);
+            clusterUpdateSettingsRequest.transientSettingsToRemove(transientSettingsToRemove);
         }
         if (source.containsKey("persistent")) {
-            clusterUpdateSettingsRequest.persistentSettings((Map) source.get("persistent"));
+            Map<String, Object> persistentSettings = (Map) source.get("persistent");
+            Iterator<Map.Entry<String, Object>> iterator = persistentSettings.entrySet().iterator();
+            Set<String> persistentSettingsToRemove = Sets.newHashSet();
+            while (iterator.hasNext()) {
+                Map.Entry<String, Object> entry = iterator.next();
+                if (entry.getValue() == null) {
+                    persistentSettingsToRemove.add(entry.getKey());
+                    iterator.remove();
+                }
+            }
+            clusterUpdateSettingsRequest.persistentSettings(persistentSettings);
+            clusterUpdateSettingsRequest.persistentSettingsToRemove(persistentSettingsToRemove);
         }
 
         client.admin().cluster().updateSettings(clusterUpdateSettingsRequest, new AcknowledgedRestListener<ClusterUpdateSettingsResponse>(channel) {


### PR DESCRIPTION
This PR implements support for resetting transient & persistent cluster settings to, either the configuration file value defined at node startup, or if it does not existed, the default value.

Resetting settings is done using the normal cluster update settings API, by just assigning a JSON `null` to the setting one want to reset. See `update-settings.asciidoc` for details.

There are maybe other/smarter ways to do that, but I think this is just straight-forward and it works ;)
This is related to https://github.com/elasticsearch/elasticsearch/issues/6732, but does only apply to cluster settings not custom analyzer.
