### PR TITLE
field name lookup: return List instead of Set for names matching a patte...

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/DocumentFieldMappers.java
+++ b/src/main/java/org/elasticsearch/index/mapper/DocumentFieldMappers.java
@@ -101,11 +101,11 @@ public class DocumentFieldMappers implements Iterable<FieldMapper> {
         return fieldMappers.fullName(fullName);
     }
 
-    public Set<String> simpleMatchToIndexNames(String pattern) {
+    public List<String> simpleMatchToIndexNames(String pattern) {
         return fieldMappers.simpleMatchToIndexNames(pattern);
     }
 
-    public Set<String> simpleMatchToFullName(String pattern) {
+    public List<String> simpleMatchToFullName(String pattern) {
         return fieldMappers.simpleMatchToFullName(pattern);
     }
 

--- a/src/main/java/org/elasticsearch/index/mapper/FieldMappersLookup.java
+++ b/src/main/java/org/elasticsearch/index/mapper/FieldMappersLookup.java
@@ -189,10 +189,10 @@ public class FieldMappersLookup implements Iterable<FieldMapper> {
     }
 
     /**
-     * Returns a set of the index names of a simple match regex like pattern against full name, name and index name.
+     * Returns a list of the index names of a simple match regex like pattern against full name, name and index name.
      */
-    public Set<String> simpleMatchToIndexNames(String pattern) {
-        Set<String> fields = Sets.newHashSet();
+    public List<String> simpleMatchToIndexNames(String pattern) {
+        List<String> fields = Lists.newArrayList();
         for (FieldMapper fieldMapper : mappers) {
             if (Regex.simpleMatch(pattern, fieldMapper.names().fullName())) {
                 fields.add(fieldMapper.names().indexName());
@@ -206,10 +206,10 @@ public class FieldMappersLookup implements Iterable<FieldMapper> {
     }
 
     /**
-     * Returns a set of the full names of a simple match regex like pattern against full name, name and index name.
+     * Returns a list of the full names of a simple match regex like pattern against full name, name and index name.
      */
-    public Set<String> simpleMatchToFullName(String pattern) {
-        Set<String> fields = Sets.newHashSet();
+    public List<String> simpleMatchToFullName(String pattern) {
+        List<String> fields = Lists.newArrayList();
         for (FieldMapper fieldMapper : mappers) {
             if (Regex.simpleMatch(pattern, fieldMapper.names().fullName())) {
                 fields.add(fieldMapper.names().fullName());

--- a/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -612,7 +612,7 @@ public class MapperService extends AbstractIndexComponent  {
      * Returns all the fields that match the given pattern, with an optional narrowing
      * based on a list of types.
      */
-    public Set<String> simpleMatchToIndexNames(String pattern, @Nullable String[] types) {
+    public List<String> simpleMatchToIndexNames(String pattern, @Nullable String[] types) {
         if (types == null || types.length == 0) {
             return simpleMatchToIndexNames(pattern);
         }
@@ -620,9 +620,9 @@ public class MapperService extends AbstractIndexComponent  {
             return simpleMatchToIndexNames(pattern);
         }
         if (!Regex.isSimpleMatchPattern(pattern)) {
-            return ImmutableSet.of(pattern);
+            return ImmutableList.of(pattern);
         }
-        Set<String> fields = Sets.newHashSet();
+        List<String> fields = Lists.newArrayList();
         for (String type : types) {
             DocumentMapper possibleDocMapper = mappers.get(type);
             if (possibleDocMapper != null) {
@@ -638,16 +638,16 @@ public class MapperService extends AbstractIndexComponent  {
      * Returns all the fields that match the given pattern. If the pattern is prefixed with a type
      * then the fields will be returned with a type prefix.
      */
-    public Set<String> simpleMatchToIndexNames(String pattern) {
+    public List<String> simpleMatchToIndexNames(String pattern) {
         if (!Regex.isSimpleMatchPattern(pattern)) {
-            return ImmutableSet.of(pattern);
+            return ImmutableList.of(pattern);
         }
         int dotIndex = pattern.indexOf('.');
         if (dotIndex != -1) {
             String possibleType = pattern.substring(0, dotIndex);
             DocumentMapper possibleDocMapper = mappers.get(possibleType);
             if (possibleDocMapper != null) {
-                Set<String> typedFields = Sets.newHashSet();
+                List<String> typedFields = Lists.newArrayList();
                 for (String indexName : possibleDocMapper.mappers().simpleMatchToIndexNames(pattern)) {
                     typedFields.add(possibleType + "." + indexName);
                 }

--- a/src/main/java/org/elasticsearch/index/query/ExistsFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/ExistsFilterParser.java
@@ -32,6 +32,7 @@ import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.internal.FieldNamesFieldMapper;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Set;
 
 import static org.elasticsearch.index.query.support.QueryParsers.wrapSmartNameFilter;
@@ -91,7 +92,7 @@ public class ExistsFilterParser implements FilterParser {
             fieldPattern = fieldPattern + ".*";
         }
 
-        Set<String> fields = parseContext.simpleMatchToIndexNames(fieldPattern);
+        List<String> fields = parseContext.simpleMatchToIndexNames(fieldPattern);
         if (fields.isEmpty()) {
             // no fields exists, so we should not match anything
             return Queries.MATCH_NO_FILTER;

--- a/src/main/java/org/elasticsearch/index/query/MissingFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MissingFilterParser.java
@@ -33,6 +33,7 @@ import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.internal.FieldNamesFieldMapper;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Set;
 
 import static org.elasticsearch.index.query.support.QueryParsers.wrapSmartNameFilter;
@@ -103,7 +104,7 @@ public class MissingFilterParser implements FilterParser {
             fieldPattern = fieldPattern + ".*";
         }
 
-        Set<String> fields = parseContext.simpleMatchToIndexNames(fieldPattern);
+        List<String> fields = parseContext.simpleMatchToIndexNames(fieldPattern);
         if (fields.isEmpty()) {
             if (existence) {
                 // if we ask for existence of fields, and we found none, then we should match on all

--- a/src/main/java/org/elasticsearch/index/query/QueryParseContext.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryParseContext.java
@@ -315,7 +315,7 @@ public class QueryParseContext {
         return smartMapper.names().indexName();
     }
 
-    public Set<String> simpleMatchToIndexNames(String pattern) {
+    public List<String> simpleMatchToIndexNames(String pattern) {
         return indexQueryParser.mapperService.simpleMatchToIndexNames(pattern, getTypes());
     }
 

--- a/src/main/java/org/elasticsearch/search/highlight/HighlightPhase.java
+++ b/src/main/java/org/elasticsearch/search/highlight/HighlightPhase.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.search.highlight;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.apache.lucene.index.FieldInfo;
@@ -37,6 +38,7 @@ import org.elasticsearch.search.fetch.FetchSubPhase;
 import org.elasticsearch.search.internal.InternalSearchHit;
 import org.elasticsearch.search.internal.SearchContext;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -78,12 +80,12 @@ public class HighlightPhase extends AbstractComponent implements FetchSubPhase {
     public void hitExecute(SearchContext context, HitContext hitContext) throws ElasticsearchException {
         Map<String, HighlightField> highlightFields = newHashMap();
         for (SearchContextHighlight.Field field : context.highlight().fields()) {
-            Set<String> fieldNamesToHighlight;
+            List<String> fieldNamesToHighlight;
             if (Regex.isSimpleMatchPattern(field.field())) {
                 DocumentMapper documentMapper = context.mapperService().documentMapper(hitContext.hit().type());
                 fieldNamesToHighlight = documentMapper.mappers().simpleMatchToFullName(field.field());
             } else {
-                fieldNamesToHighlight = ImmutableSet.of(field.field());
+                fieldNamesToHighlight = ImmutableList.of(field.field());
             }
 
             if (context.highlight().forceSource(field)) {

--- a/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
@@ -850,7 +850,7 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
                     DocumentMapper documentMapper = indexService.mapperService().documentMapper(type);
                     assertThat("document mapper doesn't exists on " + node, documentMapper, notNullValue());
                     for (String fieldName : fieldNames) {
-                        Set<String> matches = documentMapper.mappers().simpleMatchToFullName(fieldName);
+                        List<String> matches = documentMapper.mappers().simpleMatchToFullName(fieldName);
                         assertThat("field " + fieldName + " doesn't exists on " + node, matches, Matchers.not(emptyIterable()));
                     }
                 }


### PR DESCRIPTION
...rn

The returned sets are only used for iterating. Therefore we might
as well return a list since this guaratees order.

This is the same effect as in
https://github.com/elasticsearch/elasticsearch/pull/7698
The test SimpleIndexQueryParserTests#testQueryStringFieldsMatch
failed on openjdk 1.7.0_65 with
<jdk.map.althashing.threshold>0</jdk.map.althashing.threshold>

Unsure if this is the best solution - we might as well just change the test SimpleIndexQueryParserTests#testQueryStringFieldsMatch 
