### PR TITLE
[TEST] Expose ability to provide http headers when sending requests in our REST tests

### DIFF
--- a/src/main/java/org/elasticsearch/client/support/Headers.java
+++ b/src/main/java/org/elasticsearch/client/support/Headers.java
@@ -53,9 +53,12 @@ public class Headers {
         return message;
     }
 
+    public Settings headers() {
+        return headers;
+    }
+
     static Settings resolveHeaders(Settings settings) {
         Settings headers = settings.getAsSettings(PREFIX);
         return headers != null ? headers : ImmutableSettings.EMPTY;
     }
-
 }

--- a/src/test/java/org/elasticsearch/test/rest/ElasticsearchRestTests.java
+++ b/src/test/java/org/elasticsearch/test/rest/ElasticsearchRestTests.java
@@ -24,6 +24,8 @@ import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import com.google.common.collect.Lists;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
 import org.elasticsearch.test.rest.client.RestException;
@@ -173,6 +175,13 @@ public class ElasticsearchRestTests extends ElasticsearchIntegrationTest {
         restTestExecutionContext = null;
     }
 
+    /**
+     * Used to obtain settings for the REST client that is used to send REST requests.
+     */
+    protected Settings restClientSettings() {
+        return ImmutableSettings.EMPTY;
+    }
+
     @Before
     public void reset() throws IOException, RestException {
         //skip test if it matches one of the blacklist globs
@@ -183,7 +192,7 @@ public class ElasticsearchRestTests extends ElasticsearchIntegrationTest {
             assumeFalse("[" + testCandidate.getTestPath() + "] skipped, reason: blacklisted", blacklistedPathMatcher.matches(Paths.get(testPath)));
         }
 
-        restTestExecutionContext.resetClient(cluster().httpAddresses());
+        restTestExecutionContext.resetClient(cluster().httpAddresses(), restClientSettings());
         restTestExecutionContext.clear();
 
         //skip test if the whole suite (yaml file) is disabled

--- a/src/test/java/org/elasticsearch/test/rest/RestTestExecutionContext.java
+++ b/src/test/java/org/elasticsearch/test/rest/RestTestExecutionContext.java
@@ -21,6 +21,7 @@ package org.elasticsearch.test.rest;
 import com.google.common.collect.Maps;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.test.rest.client.RestClient;
 import org.elasticsearch.test.rest.client.RestException;
@@ -117,9 +118,9 @@ public class RestTestExecutionContext implements Closeable {
     /**
      * Recreates the embedded REST client which will point to the given addresses
      */
-    public void resetClient(InetSocketAddress[] addresses) throws IOException, RestException {
+    public void resetClient(InetSocketAddress[] addresses, Settings settings) throws IOException, RestException {
         if (restClient == null) {
-            restClient = new RestClient(addresses, restSpec);
+            restClient = new RestClient(restSpec, addresses, settings);
         } else {
             restClient.updateAddresses(addresses);
         }

--- a/src/test/java/org/elasticsearch/test/rest/client/RestClient.java
+++ b/src/test/java/org/elasticsearch/test/rest/client/RestClient.java
@@ -23,9 +23,11 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
+import org.elasticsearch.client.support.Headers;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.rest.client.http.HttpRequestBuilder;
 import org.elasticsearch.test.rest.client.http.HttpResponse;
 import org.elasticsearch.test.rest.spec.RestApi;
@@ -47,14 +49,16 @@ public class RestClient implements Closeable {
 
     private final RestSpec restSpec;
     private final CloseableHttpClient httpClient;
+    private final Headers headers;
 
     private InetSocketAddress[] addresses;
 
     private final String esVersion;
 
-    public RestClient(InetSocketAddress[] addresses, RestSpec restSpec) throws IOException, RestException {
+    public RestClient(RestSpec restSpec, InetSocketAddress[] addresses, Settings settings) throws IOException, RestException {
         assert addresses.length > 0;
         this.restSpec = restSpec;
+        this.headers = new Headers(settings);
         this.httpClient = createHttpClient();
         this.addresses = addresses;
         this.esVersion = readAndCheckVersion();
@@ -70,7 +74,7 @@ public class RestClient implements Closeable {
 
         String version = null;
         for (InetSocketAddress address : addresses) {
-            RestResponse restResponse = new RestResponse(new HttpRequestBuilder(httpClient)
+            RestResponse restResponse = new RestResponse(new HttpRequestBuilder(httpClient).addHeaders(headers)
                     .host(address.getHostName()).port(address.getPort())
                     .path(restApi.getPaths().get(0))
                     .method(restApi.getMethods().get(0)).execute());
@@ -219,7 +223,7 @@ public class RestClient implements Closeable {
     protected HttpRequestBuilder httpRequestBuilder() {
         //the address used is randomized between the available ones
         InetSocketAddress address = RandomizedTest.randomFrom(addresses);
-        return new HttpRequestBuilder(httpClient).host(address.getHostName()).port(address.getPort());
+        return new HttpRequestBuilder(httpClient).addHeaders(headers).host(address.getHostName()).port(address.getPort());
     }
 
     protected CloseableHttpClient createHttpClient() {

--- a/src/test/java/org/elasticsearch/test/rest/client/http/HttpRequestBuilder.java
+++ b/src/test/java/org/elasticsearch/test/rest/client/http/HttpRequestBuilder.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Maps;
 import org.apache.http.client.methods.*;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
+import org.elasticsearch.client.support.Headers;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
@@ -89,6 +90,13 @@ public class HttpRequestBuilder {
 
     public HttpRequestBuilder addParam(String name, String value) {
         this.params.put(name, value);
+        return this;
+    }
+
+    public HttpRequestBuilder addHeaders(Headers headers) {
+        for (String header : headers.headers().names()) {
+            this.headers.put(header, headers.headers().get(header));
+        }
         return this;
     }
 


### PR DESCRIPTION
`ElasticsearchRestTests` has now a `restClientSettings` method that can be overriden to provide headers as settings (similarly to what we do with transport client). Those headers will be sent together with every REST requests within the tests.
