### PR TITLE
Remove unneeded waits on recovery cancellation

### DIFF
--- a/src/main/java/org/elasticsearch/indices/recovery/RecoveryStatus.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoveryStatus.java
@@ -91,8 +91,8 @@ public class RecoveryStatus {
         }
         return outputs.get(key);
     }
-    
-    public synchronized Set<Entry<String, IndexOutput>> cancleAndClearOpenIndexInputs() {
+
+    public synchronized Set<Entry<String, IndexOutput>> cancelAndClearOpenIndexInputs() {
         cancel();
         final ConcurrentMap<String, IndexOutput> outputs = openIndexOutputs;
         openIndexOutputs = null;

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
@@ -636,7 +636,6 @@ public class RecoveryTarget extends AbstractComponent {
             throw new IndexShardClosedException(shardId);
         }
         if (onGoingRecovery.indexShard.state() == IndexShardState.CLOSED) {
-            // mark sentCanceledToSource after cancel recovery, o.w. cancelRecovery will do nothing
             removeAndCleanOnGoingRecovery(onGoingRecovery);
             onGoingRecovery.sentCanceledToSource = true;
             throw new IndexShardClosedException(shardId);


### PR DESCRIPTION
When cancelling recoveries, we wait for up to 10s for the source node to be notified before continuing. This is not needed in two cases:
1) The source node has been disconnected due to node shutdown (recovery is canceled as a response to cluster state processing)
2) The current thread is the one that will be notifying the source node  (happens when when of the calls from the source nodes discoveres local index is closed)

The first one is especially important as it may delay cluster state update processing with 10s.
