### PR TITLE
[TEST] Minor  REST tests infra cleanup

### DIFF
--- a/src/test/java/org/elasticsearch/test/rest/ElasticsearchRestTests.java
+++ b/src/test/java/org/elasticsearch/test/rest/ElasticsearchRestTests.java
@@ -165,7 +165,6 @@ public class ElasticsearchRestTests extends ElasticsearchIntegrationTest {
 
         String[] specPaths = resolvePathsProperty(REST_TESTS_SPEC, DEFAULT_SPEC_PATH);
         RestSpec restSpec = RestSpec.parseFrom(DEFAULT_SPEC_PATH, specPaths);
-        assert restTestExecutionContext == null;
         restTestExecutionContext = new RestTestExecutionContext(restSpec);
     }
 
@@ -191,7 +190,7 @@ public class ElasticsearchRestTests extends ElasticsearchIntegrationTest {
             String testPath = testCandidate.getSuitePath() + "/" + testSection;
             assumeFalse("[" + testCandidate.getTestPath() + "] skipped, reason: blacklisted", blacklistedPathMatcher.matches(Paths.get(testPath)));
         }
-
+        //The client needs non static info to get initialized, therefore it can't be initialized in the before class
         restTestExecutionContext.resetClient(cluster().httpAddresses(), restClientSettings());
         restTestExecutionContext.clear();
 

--- a/src/test/java/org/elasticsearch/test/rest/RestTestExecutionContext.java
+++ b/src/test/java/org/elasticsearch/test/rest/RestTestExecutionContext.java
@@ -53,7 +53,7 @@ public class RestTestExecutionContext implements Closeable {
 
     private RestResponse response;
 
-    public RestTestExecutionContext(RestSpec restSpec) throws RestException, IOException {
+    public RestTestExecutionContext(RestSpec restSpec) {
         this.restSpec = restSpec;
     }
 
@@ -116,13 +116,11 @@ public class RestTestExecutionContext implements Closeable {
     }
 
     /**
-     * Resets (or creates) the embedded REST client which will point to the given addresses
+     * Creates the embedded REST client when needed
      */
     public void resetClient(InetSocketAddress[] addresses, Settings settings) throws IOException, RestException {
         if (restClient == null) {
-            restClient = new RestClient(restSpec, settings, addresses);
-        } else {
-            restClient.updateAddresses(addresses);
+            this.restClient = new RestClient(restSpec, settings, addresses);
         }
     }
 

--- a/src/test/java/org/elasticsearch/test/rest/client/RestClient.java
+++ b/src/test/java/org/elasticsearch/test/rest/client/RestClient.java
@@ -50,9 +50,7 @@ public class RestClient implements Closeable {
     private final RestSpec restSpec;
     private final CloseableHttpClient httpClient;
     private final Headers headers;
-
-    private InetSocketAddress[] addresses;
-
+    private final InetSocketAddress[] addresses;
     private final String esVersion;
 
     public RestClient(RestSpec restSpec, Settings settings, InetSocketAddress[] addresses) throws IOException, RestException {
@@ -97,13 +95,6 @@ public class RestClient implements Closeable {
 
     public String getEsVersion() {
         return esVersion;
-    }
-
-    /**
-     * Allows to update the addresses the client needs to connect to
-     */
-    public void updateAddresses(InetSocketAddress[] addresses) {
-        this.addresses = addresses;
     }
 
     /**


### PR DESCRIPTION
Make the http addresses within the REST client final. It makes no sense to update them before each test if we don't check the version of the nodes again, which would mean adding too much overhead (an additional http call before each test) for no reason. We just reuse the same nodes for the whole suite and check the version once while initializing the client. Would be nice to make the REST client within the execution context final but its initialization still needs to happen after the `ElasticsearchIntegrationTest#beforeInternal` that assigns `GLOBAL_CLUSTER` to `currentCluster`.
