### PR TITLE
Support for artificial documents in MLT query

### DIFF
--- a/docs/reference/query-dsl/queries/mlt-query.asciidoc
+++ b/docs/reference/query-dsl/queries/mlt-query.asciidoc
@@ -62,10 +62,10 @@ this case should be preferred over only using `like_text`.
             "_type" : "type",
             "doc" : {
                 "name": {
-                    "first": "John",
-                    "last": "Doe"
+                    "first": "Ben",
+                    "last": "Grimm"
                 },
-                "tweet": "twitter test test test"
+                "tweet": "You got no idea what I'd... what I'd give to be invisible."
               }
             }
         },

--- a/docs/reference/query-dsl/queries/mlt-query.asciidoc
+++ b/docs/reference/query-dsl/queries/mlt-query.asciidoc
@@ -16,7 +16,7 @@ running it against one or more fields.
 }
 --------------------------------------------------
 
-Additionally, More Like This can find documents that are "like" a set of
+More Like This can find documents that are "like" a set of
 chosen documents. The syntax to specify one or more documents is similar to
 the <<docs-multi-get,Multi GET API>>, and supports the `ids` or `docs` array.
 If only one document is specified, the query behaves the same as the 
@@ -40,6 +40,37 @@ If only one document is specified, the query behaves the same as the
         }
         ],
         "ids" : ["3", "4"],
+        "min_term_freq" : 1,
+        "max_query_terms" : 12
+    }
+}
+--------------------------------------------------
+
+Additionally coming[1.5.0], the `doc` syntax of the
+<<docs-multi-termvectors,Multi Term Vectors API>> is also supported. This is useful in
+order to specify one or more documents not present in the index, and in
+this case should be preferred over only using `like_text`.
+
+[source,js]
+--------------------------------------------------
+{
+    "more_like_this" : {
+        "fields" : ["name.first", "name.last"],
+        "docs" : [
+        {
+            "_index" : "test",
+            "_type" : "type",
+            "doc" : {
+                "fullname" : "John Doe",
+                "text" : "twitter test test test"
+            }
+        },
+        {
+            "_index" : "test",
+            "_type" : "type",
+            "_id" : "2"
+        }
+        ],
         "min_term_freq" : 1,
         "max_query_terms" : 12
     }
@@ -81,8 +112,8 @@ for `ids` or `docs`.
 not specified.
 
 |`ids` or `docs` |A list of documents following the same syntax as the 
-<<docs-multi-get,Multi GET API>>. The text is fetched from `fields`
-unless specified otherwise in each `doc`.
+<<docs-multi-get,Multi GET API>> or <<docs-multi-termvectors,Multi Term Vectors API>>.
+The text is fetched from `fields` unless specified otherwise in each `doc`.
 
 |`include` |When using `ids` or `docs`, specifies whether the documents should be
 included from the search. Defaults to `false`.

--- a/docs/reference/query-dsl/queries/mlt-query.asciidoc
+++ b/docs/reference/query-dsl/queries/mlt-query.asciidoc
@@ -61,8 +61,12 @@ this case should be preferred over only using `like_text`.
             "_index" : "test",
             "_type" : "type",
             "doc" : {
-                "fullname" : "John Doe",
-                "text" : "twitter test test test"
+                "name": {
+                    "first": "John",
+                    "last": "Doe"
+                },
+                "tweet": "twitter test test test"
+              }
             }
         },
         {

--- a/rest-api-spec/test/mlt/20_docs.yaml
+++ b/rest-api-spec/test/mlt/20_docs.yaml
@@ -1,0 +1,54 @@
+---
+"Basic mlt query with docs":
+  - do:
+      index:
+          index:  test_1
+          type:   test
+          id:     1
+          body:   { foo: bar }
+
+  - do:
+      index:
+          index:  test_1
+          type:   test
+          id:     2
+          body:   { foo: baz }
+
+  - do:
+      index:
+          index:  test_1
+          type:   test
+          id:     3
+          body:   { foo: foo }
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      cluster.health:
+           wait_for_status: green
+
+  - do:
+      search:
+          index:   test_1
+          type:    test
+          body:
+            query:
+              more_like_this:
+                docs:
+                  -
+                    _index: test_1
+                    _type: test
+                    doc:
+                      foo: bar
+                  -
+                    _index: test_1
+                    _type: test
+                    _id: 2
+                ids:
+                  - 3
+                include: true
+                min_doc_freq: 0
+                min_term_freq: 0
+
+  - match: { hits.total: 3 }

--- a/src/main/java/org/elasticsearch/action/termvector/MultiTermVectorsRequest.java
+++ b/src/main/java/org/elasticsearch/action/termvector/MultiTermVectorsRequest.java
@@ -19,10 +19,10 @@
 
 package org.elasticsearch.action.termvector;
 
+import com.google.common.collect.Iterators;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.action.*;
-import org.elasticsearch.action.get.MultiGetRequest;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -31,12 +31,9 @@ import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
-public class MultiTermVectorsRequest extends ActionRequest<MultiTermVectorsRequest> implements CompositeIndicesRequest {
+public class MultiTermVectorsRequest extends ActionRequest<MultiTermVectorsRequest> implements Iterable<TermVectorRequest>, CompositeIndicesRequest {
 
     String preference;
     List<TermVectorRequest> requests = new ArrayList<>();
@@ -50,11 +47,6 @@ public class MultiTermVectorsRequest extends ActionRequest<MultiTermVectorsReque
 
     public MultiTermVectorsRequest add(String index, @Nullable String type, String id) {
         requests.add(new TermVectorRequest(index, type, id));
-        return this;
-    }
-
-    public MultiTermVectorsRequest add(MultiGetRequest.Item item) {
-        requests.add(new TermVectorRequest(item));
         return this;
     }
 
@@ -78,6 +70,19 @@ public class MultiTermVectorsRequest extends ActionRequest<MultiTermVectorsReque
 
     @Override
     public List<? extends IndicesRequest> subRequests() {
+        return requests;
+    }
+
+    @Override
+    public Iterator<TermVectorRequest> iterator() {
+        return Iterators.unmodifiableIterator(requests.iterator());
+    }
+
+    public boolean isEmpty() {
+        return requests.isEmpty() && ids.isEmpty();
+    }
+
+    public List<TermVectorRequest> getRequests() {
         return requests;
     }
 

--- a/src/main/java/org/elasticsearch/action/termvector/TermVectorRequest.java
+++ b/src/main/java/org/elasticsearch/action/termvector/TermVectorRequest.java
@@ -287,7 +287,7 @@ public class TermVectorRequest extends SingleShardOperationRequest<TermVectorReq
      * Return only term vectors for special selected fields. Returns the term
      * vectors for all fields if selectedFields == null
      */
-    public TermVectorRequest selectedFields(String[] fields) {
+    public TermVectorRequest selectedFields(String... fields) {
         selectedFields = fields != null && fields.length != 0 ? Sets.newHashSet(fields) : null;
         return this;
     }

--- a/src/main/java/org/elasticsearch/action/termvector/TermVectorRequest.java
+++ b/src/main/java/org/elasticsearch/action/termvector/TermVectorRequest.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Sets;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.DocumentRequest;
 import org.elasticsearch.action.ValidateActions;
 import org.elasticsearch.action.get.MultiGetRequest;
 import org.elasticsearch.action.support.single.shard.SingleShardOperationRequest;
@@ -45,7 +46,7 @@ import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
  * Note, the {@link #index()}, {@link #type(String)} and {@link #id(String)} are
  * required.
  */
-public class TermVectorRequest extends SingleShardOperationRequest<TermVectorRequest> {
+public class TermVectorRequest extends SingleShardOperationRequest<TermVectorRequest> implements DocumentRequest<TermVectorRequest> {
 
     private String type;
 

--- a/src/main/java/org/elasticsearch/index/mapper/Uid.java
+++ b/src/main/java/org/elasticsearch/index/mapper/Uid.java
@@ -21,6 +21,7 @@ package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
+import org.elasticsearch.action.DocumentRequest;
 import org.elasticsearch.action.termvector.TermVectorRequest;
 import org.elasticsearch.common.lucene.BytesRefs;
 
@@ -95,10 +96,10 @@ public final class Uid {
         return new Uid(uid.substring(0, delimiterIndex), uid.substring(delimiterIndex + 1));
     }
 
-    public static BytesRef[] createUids(List<TermVectorRequest> requests) {
+    public static BytesRef[] createUids(List<? extends DocumentRequest> requests) {
         BytesRef[] uids = new BytesRef[requests.size()];
         int idx = 0;
-        for (TermVectorRequest item : requests) {
+        for (DocumentRequest item : requests) {
             uids[idx++] = createUidAsBytes(item.type(), item.id());
         }
         return uids;

--- a/src/main/java/org/elasticsearch/index/mapper/Uid.java
+++ b/src/main/java/org/elasticsearch/index/mapper/Uid.java
@@ -21,7 +21,7 @@ package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
-import org.elasticsearch.action.get.MultiGetRequest;
+import org.elasticsearch.action.termvector.TermVectorRequest;
 import org.elasticsearch.common.lucene.BytesRefs;
 
 import java.util.Collection;
@@ -95,11 +95,11 @@ public final class Uid {
         return new Uid(uid.substring(0, delimiterIndex), uid.substring(delimiterIndex + 1));
     }
 
-    public static BytesRef[] createUids(List<MultiGetRequest.Item> items) {
-        BytesRef[] uids = new BytesRef[items.size()];
+    public static BytesRef[] createUids(List<TermVectorRequest> requests) {
+        BytesRef[] uids = new BytesRef[requests.size()];
         int idx = 0;
-        for (MultiGetRequest.Item item : items) {
-            uids[idx++] = createUidAsBytes(item);
+        for (TermVectorRequest item : requests) {
+            uids[idx++] = createUidAsBytes(item.type(), item.id());
         }
         return uids;
     }
@@ -110,10 +110,6 @@ public final class Uid {
 
     public static BytesRef createUidAsBytes(String type, BytesRef id) {
         return createUidAsBytes(new BytesRef(type), id);
-    }
-
-    public static BytesRef createUidAsBytes(MultiGetRequest.Item item) {
-        return createUidAsBytes(item.type(), item.id());
     }
 
     public static BytesRef createUidAsBytes(BytesRef type, BytesRef id) {

--- a/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryParser.java
@@ -28,7 +28,6 @@ import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
-import org.elasticsearch.action.get.MultiGetRequest;
 import org.elasticsearch.action.termvector.MultiTermVectorsRequest;
 import org.elasticsearch.action.termvector.TermVectorRequest;
 import org.elasticsearch.common.Nullable;
@@ -43,7 +42,6 @@ import org.elasticsearch.index.mapper.internal.UidFieldMapper;
 import org.elasticsearch.index.search.morelikethis.MoreLikeThisFetchService;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;

--- a/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryParser.java
@@ -29,6 +29,8 @@ import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.action.get.MultiGetRequest;
+import org.elasticsearch.action.termvector.MultiTermVectorsRequest;
+import org.elasticsearch.action.termvector.TermVectorRequest;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
@@ -99,7 +101,7 @@ public class MoreLikeThisQueryParser implements QueryParser {
 
         XContentParser.Token token;
         String currentFieldName = null;
-        List<MultiGetRequest.Item> items = new ArrayList<MultiGetRequest.Item>();
+        MultiTermVectorsRequest items = new MultiTermVectorsRequest();
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
@@ -152,9 +154,21 @@ public class MoreLikeThisQueryParser implements QueryParser {
                         moreLikeFields.add(parseContext.indexName(parser.text()));
                     }
                 } else if (Fields.DOCUMENT_IDS.match(currentFieldName, parseContext.parseFlags())) {
-                    MultiGetRequest.parseIds(parser, items);
+                    while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
+                        if (!token.isValue()) {
+                            throw new ElasticsearchIllegalArgumentException("ids array element should only contain ids");
+                        }
+                        items.add(new TermVectorRequest().id(parser.text()));
+                    }
                 } else if (Fields.DOCUMENTS.match(currentFieldName, parseContext.parseFlags())) {
-                    MultiGetRequest.parseDocuments(parser, items);
+                    while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
+                        if (token != XContentParser.Token.START_OBJECT) {
+                            throw new ElasticsearchIllegalArgumentException("docs array element should include an object");
+                        }
+                        TermVectorRequest termVectorRequest = new TermVectorRequest();
+                        TermVectorRequest.parseRequest(termVectorRequest, parser);
+                        items.add(termVectorRequest);
+                    }
                 } else {
                     throw new QueryParsingException(parseContext.index(), "[mlt] query does not support [" + currentFieldName + "]");
                 }
@@ -194,7 +208,7 @@ public class MoreLikeThisQueryParser implements QueryParser {
         // handle items
         if (!items.isEmpty()) {
             // set default index, type and fields if not specified
-            for (MultiGetRequest.Item item : items) {
+            for (TermVectorRequest item : items) {
                 if (item.index() == null) {
                     item.index(parseContext.index().name());
                 }
@@ -206,11 +220,12 @@ public class MoreLikeThisQueryParser implements QueryParser {
                         item.type(parseContext.queryTypes().iterator().next());
                     }
                 }
-                if (item.fields() == null && item.fetchSourceContext() == null) {
+                // default fields if not present but don't override for artificial docs
+                if (item.selectedFields() == null && item.doc() == null) {
                     if (useDefaultField) {
-                        item.fields("*");
+                        item.selectedFields("*");
                     } else {
-                        item.fields(moreLikeFields.toArray(new String[moreLikeFields.size()]));
+                        item.selectedFields(moreLikeFields.toArray(new String[moreLikeFields.size()]));
                     }
                 }
             }
@@ -221,7 +236,7 @@ public class MoreLikeThisQueryParser implements QueryParser {
             boolQuery.add(mltQuery, BooleanClause.Occur.SHOULD);
             // exclude the items from the search
             if (!include) {
-                TermsFilter filter = new TermsFilter(UidFieldMapper.NAME, Uid.createUids(items));
+                TermsFilter filter = new TermsFilter(UidFieldMapper.NAME, Uid.createUids(items.getRequests()));
                 ConstantScoreQuery query = new ConstantScoreQuery(filter);
                 boolQuery.add(query, BooleanClause.Occur.MUST_NOT);
             }

--- a/src/main/java/org/elasticsearch/index/search/morelikethis/MoreLikeThisFetchService.java
+++ b/src/main/java/org/elasticsearch/index/search/morelikethis/MoreLikeThisFetchService.java
@@ -47,11 +47,7 @@ public class MoreLikeThisFetchService extends AbstractComponent {
         this.client = client;
     }
 
-    public Fields[] fetch(List<MultiGetRequest.Item> items) throws IOException {
-        MultiTermVectorsRequest request = new MultiTermVectorsRequest();
-        for (MultiGetRequest.Item item : items) {
-            request.add(item);
-        }
+    public Fields[] fetch(MultiTermVectorsRequest request) throws IOException {
         List<Fields> likeFields = new ArrayList<>();
         MultiTermVectorsResponse responses = client.multiTermVectors(request).actionGet();
         for (MultiTermVectorsItemResponse response : responses) {

--- a/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
+++ b/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
@@ -35,7 +35,9 @@ import org.apache.lucene.util.CharsRefBuilder;
 import org.apache.lucene.util.NumericUtils;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
-import org.elasticsearch.action.get.MultiGetRequest;
+import org.elasticsearch.action.termvector.MultiTermVectorsRequest;
+import org.elasticsearch.action.termvector.TermVectorRequest;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.compress.CompressedString;
 import org.elasticsearch.common.lucene.Lucene;
@@ -1666,10 +1668,11 @@ public class SimpleIndexQueryParserTests extends ElasticsearchSingleNodeTest {
             super(null, ImmutableSettings.Builder.EMPTY_SETTINGS);
         }
 
-        public Fields[] fetch(List<MultiGetRequest.Item> items) throws IOException {
+        @Override
+        public Fields[] fetch(MultiTermVectorsRequest items) throws IOException {
             List<Fields> likeTexts = new ArrayList<>();
-            for (MultiGetRequest.Item item : items) {
-                likeTexts.add(generateFields(item.fields(), item.id()));
+            for (TermVectorRequest item : items) {
+                likeTexts.add(generateFields(item.selectedFields().toArray(Strings.EMPTY_ARRAY), item.id()));
             }
             return likeTexts.toArray(Fields.EMPTY_ARRAY);
         }


### PR DESCRIPTION
Previously, the only way to specify a document not present in the index was to
use `like_text`. This would usually lead to complex queries made of multiple
MLT queries per document field. This commit adds the ability to the MLT query
to directly specify documents not present in the index (artificial documents).
The syntax is similar to the Percolator API or to the Multi Term Vector API.
