### PR TITLE
Support for arrays of numeric values in include/exclude clauses

### DIFF
--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantLongTermsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantLongTermsAggregator.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.bucket.terms.LongTermsAggregator;
+import org.elasticsearch.search.aggregations.bucket.terms.support.IncludeExclude;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.format.ValueFormat;
@@ -40,9 +41,9 @@ public class SignificantLongTermsAggregator extends LongTermsAggregator {
 
     public SignificantLongTermsAggregator(String name, AggregatorFactories factories, ValuesSource.Numeric valuesSource, @Nullable ValueFormat format,
               long estimatedBucketCount, BucketCountThresholds bucketCountThresholds,
-              AggregationContext aggregationContext, Aggregator parent, SignificantTermsAggregatorFactory termsAggFactory) {
+              AggregationContext aggregationContext, Aggregator parent, SignificantTermsAggregatorFactory termsAggFactory, IncludeExclude.LongFilter includeExclude) {
 
-        super(name, factories, valuesSource, format, estimatedBucketCount, null, bucketCountThresholds, aggregationContext, parent, SubAggCollectionMode.DEPTH_FIRST, false);
+        super(name, factories, valuesSource, format, estimatedBucketCount, null, bucketCountThresholds, aggregationContext, parent, SubAggCollectionMode.DEPTH_FIRST, false, includeExclude);
         this.termsAggFactory = termsAggFactory;
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/DoubleTermsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/DoubleTermsAggregator.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.index.fielddata.FieldData;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
+import org.elasticsearch.search.aggregations.bucket.terms.support.IncludeExclude;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSource.Numeric;
@@ -37,8 +38,8 @@ import java.util.Arrays;
 public class DoubleTermsAggregator extends LongTermsAggregator {
 
     public DoubleTermsAggregator(String name, AggregatorFactories factories, ValuesSource.Numeric valuesSource, @Nullable ValueFormat format, long estimatedBucketCount,
-            Terms.Order order, BucketCountThresholds bucketCountThresholds, AggregationContext aggregationContext, Aggregator parent, SubAggCollectionMode collectionMode, boolean showTermDocCountError) {
-        super(name, factories, valuesSource, format, estimatedBucketCount, order, bucketCountThresholds, aggregationContext, parent, collectionMode, showTermDocCountError);
+            Terms.Order order, BucketCountThresholds bucketCountThresholds, AggregationContext aggregationContext, Aggregator parent, SubAggCollectionMode collectionMode, boolean showTermDocCountError, IncludeExclude.LongFilter longFilter) {
+        super(name, factories, valuesSource, format, estimatedBucketCount, order, bucketCountThresholds, aggregationContext, parent, collectionMode, showTermDocCountError, longFilter);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsBuilder.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsBuilder.java
@@ -117,12 +117,51 @@ public class TermsBuilder extends ValuesSourceAggregationBuilder<TermsBuilder> {
      */
     public TermsBuilder include(String [] terms) {
         if (includePattern != null) {
-            throw new ElasticsearchIllegalArgumentException("include clause must be an array of strings or a regex, not both");
+            throw new ElasticsearchIllegalArgumentException("include clause must be an array of exact values or a regex, not both");
         }
         this.includeTerms = terms;
         return this;
     }    
+    
+    /**
+     * Define a set of terms that should be aggregated.
+     */
+    public TermsBuilder include(long [] terms) {
+        if (includePattern != null) {
+            throw new ElasticsearchIllegalArgumentException("include clause must be an array of exact values or a regex, not both");
+        }
+        this.includeTerms = longsArrToStringArr(terms);
+        return this;
+    }     
+    
+    private String[] longsArrToStringArr(long[] terms) {
+        String[] termsAsString = new String[terms.length];
+        for (int i = 0; i < terms.length; i++) {
+            termsAsString[i] = Long.toString(terms[i]);
+        }
+        return termsAsString;
+    }      
+    
 
+    /**
+     * Define a set of terms that should be aggregated.
+     */
+    public TermsBuilder include(double [] terms) {
+        if (includePattern != null) {
+            throw new ElasticsearchIllegalArgumentException("include clause must be an array of exact values or a regex, not both");
+        }
+        this.includeTerms = doubleArrToStringArr(terms);
+        return this;
+    }
+
+    private String[] doubleArrToStringArr(double[] terms) {
+        String[] termsAsString = new String[terms.length];
+        for (int i = 0; i < terms.length; i++) {
+            termsAsString[i] = Double.toString(terms[i]);
+        }
+        return termsAsString;
+    }    
+    
     /**
      * Define a regular expression that will filter out terms that should be excluded from the aggregation. The regular
      * expression is based on the {@link java.util.regex.Pattern} class.
@@ -141,7 +180,7 @@ public class TermsBuilder extends ValuesSourceAggregationBuilder<TermsBuilder> {
      */
     public TermsBuilder exclude(String regex, int flags) {
         if (excludeTerms != null) {
-            throw new ElasticsearchIllegalArgumentException("exclude clause must be an array of strings or a regex, not both");
+            throw new ElasticsearchIllegalArgumentException("exclude clause must be an array of exact values or a regex, not both");
         }
         this.excludePattern = regex;
         this.excludeFlags = flags;
@@ -153,11 +192,35 @@ public class TermsBuilder extends ValuesSourceAggregationBuilder<TermsBuilder> {
      */
     public TermsBuilder exclude(String [] terms) {
         if (excludePattern != null) {
-            throw new ElasticsearchIllegalArgumentException("exclude clause must be an array of strings or a regex, not both");
+            throw new ElasticsearchIllegalArgumentException("exclude clause must be an array of exact values or a regex, not both");
         }
         this.excludeTerms = terms;
         return this;
     }    
+    
+    
+    /**
+     * Define a set of terms that should not be aggregated.
+     */
+    public TermsBuilder exclude(long [] terms) {
+        if (excludePattern != null) {
+            throw new ElasticsearchIllegalArgumentException("exclude clause must be an array of exact values or a regex, not both");
+        }
+        this.excludeTerms = longsArrToStringArr(terms);
+        return this;
+    }
+
+    /**
+     * Define a set of terms that should not be aggregated.
+     */
+    public TermsBuilder exclude(double [] terms) {
+        if (excludePattern != null) {
+            throw new ElasticsearchIllegalArgumentException("exclude clause must be an array of exact values or a regex, not both");
+        }
+        this.excludeTerms = doubleArrToStringArr(terms);
+        return this;
+    }    
+    
     
 
     /**


### PR DESCRIPTION
Changed terms and significant_terms aggregation to allow include/exclude values which are numerics.
Internally the IncludeExclude class now has a convertToLong/DoubleFilter method to convert the string representation of user criteria into a class with sets of primitive numerics used for fast evaluation of filters. 

Closes #7714 
