### PR TITLE
Add indices setter to IndicesRequest interface

### DIFF
--- a/src/main/java/org/elasticsearch/action/IndicesRequest.java
+++ b/src/main/java/org/elasticsearch/action/IndicesRequest.java
@@ -39,4 +39,11 @@ public interface IndicesRequest {
      * accepted, whether an empty array will be converted to _all, and how wildcards will be expanded if needed.
      */
     IndicesOptions indicesOptions();
+
+    static interface Replaceable extends IndicesRequest {
+        /*
+         * Sets the array of indices that the action relates to
+         */
+        IndicesRequest indices(String[] indices);
+    }
 }

--- a/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthRequest.java
@@ -37,7 +37,7 @@ import static org.elasticsearch.common.unit.TimeValue.readTimeValue;
 /**
  *
  */
-public class ClusterHealthRequest extends MasterNodeReadOperationRequest<ClusterHealthRequest> implements IndicesRequest {
+public class ClusterHealthRequest extends MasterNodeReadOperationRequest<ClusterHealthRequest> implements IndicesRequest.Replaceable {
 
     private String[] indices;
     private TimeValue timeout = new TimeValue(30, TimeUnit.SECONDS);
@@ -59,6 +59,7 @@ public class ClusterHealthRequest extends MasterNodeReadOperationRequest<Cluster
         return indices;
     }
 
+    @Override
     public ClusterHealthRequest indices(String[] indices) {
         this.indices = indices;
         return this;

--- a/src/main/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsRequest.java
@@ -33,7 +33,7 @@ import java.io.IOException;
 
 /**
  */
-public class ClusterSearchShardsRequest extends MasterNodeReadOperationRequest<ClusterSearchShardsRequest> implements IndicesRequest {
+public class ClusterSearchShardsRequest extends MasterNodeReadOperationRequest<ClusterSearchShardsRequest> implements IndicesRequest.Replaceable {
     private String[] indices;
     @Nullable
     private String routing;
@@ -58,6 +58,7 @@ public class ClusterSearchShardsRequest extends MasterNodeReadOperationRequest<C
     /**
      * Sets the indices the search will be executed on.
      */
+    @Override
     public ClusterSearchShardsRequest indices(String... indices) {
         if (indices == null) {
             throw new ElasticsearchIllegalArgumentException("indices must not be null");

--- a/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotRequest.java
@@ -62,7 +62,7 @@ import static org.elasticsearch.common.xcontent.support.XContentMapValues.nodeBo
  * <li>must not contain invalid file name characters {@link org.elasticsearch.common.Strings#INVALID_FILENAME_CHARS} </li>
  * </ul>
  */
-public class CreateSnapshotRequest extends MasterNodeOperationRequest<CreateSnapshotRequest> implements IndicesRequest {
+public class CreateSnapshotRequest extends MasterNodeOperationRequest<CreateSnapshotRequest> implements IndicesRequest.Replaceable {
 
     private String snapshot;
 
@@ -171,6 +171,7 @@ public class CreateSnapshotRequest extends MasterNodeOperationRequest<CreateSnap
      * @param indices
      * @return this request
      */
+    @Override
     public CreateSnapshotRequest indices(String... indices) {
         this.indices = indices;
         return this;

--- a/src/main/java/org/elasticsearch/action/admin/cluster/state/ClusterStateRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/state/ClusterStateRequest.java
@@ -33,7 +33,7 @@ import java.io.IOException;
 /**
  *
  */
-public class ClusterStateRequest extends MasterNodeReadOperationRequest<ClusterStateRequest> implements IndicesRequest {
+public class ClusterStateRequest extends MasterNodeReadOperationRequest<ClusterStateRequest> implements IndicesRequest.Replaceable {
 
     private boolean routingTable = true;
     private boolean nodes = true;
@@ -108,6 +108,7 @@ public class ClusterStateRequest extends MasterNodeReadOperationRequest<ClusterS
         return indices;
     }
 
+    @Override
     public ClusterStateRequest indices(String... indices) {
         this.indices = indices;
         return this;

--- a/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesRequest.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 
 /**
  */
-public class GetAliasesRequest extends MasterNodeReadOperationRequest<GetAliasesRequest> implements IndicesRequest {
+public class GetAliasesRequest extends MasterNodeReadOperationRequest<GetAliasesRequest> implements IndicesRequest.Replaceable {
 
     private String[] indices = Strings.EMPTY_ARRAY;
     private String[] aliases = Strings.EMPTY_ARRAY;
@@ -49,6 +49,7 @@ public class GetAliasesRequest extends MasterNodeReadOperationRequest<GetAliases
     public GetAliasesRequest() {
     }
 
+    @Override
     public GetAliasesRequest indices(String... indices) {
         this.indices = indices;
         return this;

--- a/src/main/java/org/elasticsearch/action/admin/indices/close/CloseIndexRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/close/CloseIndexRequest.java
@@ -34,7 +34,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 /**
  * A request to close an index.
  */
-public class CloseIndexRequest extends AcknowledgedRequest<CloseIndexRequest> implements IndicesRequest {
+public class CloseIndexRequest extends AcknowledgedRequest<CloseIndexRequest> implements IndicesRequest.Replaceable {
 
     private String[] indices;
     private IndicesOptions indicesOptions = IndicesOptions.fromOptions(false, false, true, false);
@@ -72,6 +72,7 @@ public class CloseIndexRequest extends AcknowledgedRequest<CloseIndexRequest> im
      * @param indices the indices to be closed
      * @return the request itself
      */
+    @Override
     public CloseIndexRequest indices(String... indices) {
         this.indices = indices;
         return this;

--- a/src/main/java/org/elasticsearch/action/admin/indices/delete/DeleteIndexRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/delete/DeleteIndexRequest.java
@@ -37,7 +37,7 @@ import static org.elasticsearch.common.unit.TimeValue.readTimeValue;
 /**
  * A request to delete an index. Best created with {@link org.elasticsearch.client.Requests#deleteIndexRequest(String)}.
  */
-public class DeleteIndexRequest extends MasterNodeOperationRequest<DeleteIndexRequest> implements IndicesRequest {
+public class DeleteIndexRequest extends MasterNodeOperationRequest<DeleteIndexRequest> implements IndicesRequest.Replaceable {
 
     private String[] indices;
     // Delete index should work by default on both open and closed indices.
@@ -84,6 +84,7 @@ public class DeleteIndexRequest extends MasterNodeOperationRequest<DeleteIndexRe
         return validationException;
     }
 
+    @Override
     public DeleteIndexRequest indices(String... indices) {
         this.indices = indices;
         return this;

--- a/src/main/java/org/elasticsearch/action/admin/indices/exists/indices/IndicesExistsRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/exists/indices/IndicesExistsRequest.java
@@ -32,7 +32,7 @@ import java.io.IOException;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
-public class IndicesExistsRequest extends MasterNodeReadOperationRequest<IndicesExistsRequest> implements IndicesRequest {
+public class IndicesExistsRequest extends MasterNodeReadOperationRequest<IndicesExistsRequest> implements IndicesRequest.Replaceable {
 
     private String[] indices = Strings.EMPTY_ARRAY;
     private IndicesOptions indicesOptions = IndicesOptions.fromOptions(false, false, true, true);
@@ -46,6 +46,7 @@ public class IndicesExistsRequest extends MasterNodeReadOperationRequest<Indices
         return indices;
     }
 
+    @Override
     public IndicesExistsRequest indices(String[] indices) {
         this.indices = indices;
         return this;

--- a/src/main/java/org/elasticsearch/action/admin/indices/exists/types/TypesExistsRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/exists/types/TypesExistsRequest.java
@@ -32,7 +32,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 
 /**
  */
-public class TypesExistsRequest extends MasterNodeReadOperationRequest<TypesExistsRequest> implements IndicesRequest {
+public class TypesExistsRequest extends MasterNodeReadOperationRequest<TypesExistsRequest> implements IndicesRequest.Replaceable {
 
     private String[] indices;
     private String[] types;
@@ -52,8 +52,10 @@ public class TypesExistsRequest extends MasterNodeReadOperationRequest<TypesExis
         return indices;
     }
 
-    public void indices(String[] indices) {
+    @Override
+    public TypesExistsRequest indices(String[] indices) {
         this.indices = indices;
+        return this;
     }
 
     public String[] types() {

--- a/src/main/java/org/elasticsearch/action/admin/indices/mapping/delete/DeleteMappingRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/mapping/delete/DeleteMappingRequest.java
@@ -35,7 +35,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 /**
  * Represents a request to delete a mapping
  */
-public class DeleteMappingRequest extends AcknowledgedRequest<DeleteMappingRequest> implements IndicesRequest {
+public class DeleteMappingRequest extends AcknowledgedRequest<DeleteMappingRequest> implements IndicesRequest.Replaceable {
 
     private String[] indices;
     private IndicesOptions indicesOptions = IndicesOptions.fromOptions(false, false, true, false);
@@ -85,6 +85,7 @@ public class DeleteMappingRequest extends AcknowledgedRequest<DeleteMappingReque
     /**
      * Sets the indices this delete mapping operation will execute on.
      */
+    @Override
     public DeleteMappingRequest indices(String[] indices) {
         this.indices = indices;
         return this;

--- a/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetFieldMappingsRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetFieldMappingsRequest.java
@@ -32,7 +32,7 @@ import org.elasticsearch.common.unit.TimeValue;
 import java.io.IOException;
 
 /** Request the mappings of specific fields */
-public class GetFieldMappingsRequest extends ActionRequest<GetFieldMappingsRequest> implements IndicesRequest {
+public class GetFieldMappingsRequest extends ActionRequest<GetFieldMappingsRequest> implements IndicesRequest.Replaceable {
 
     protected boolean local = false;
 
@@ -71,6 +71,7 @@ public class GetFieldMappingsRequest extends ActionRequest<GetFieldMappingsReque
         return local;
     }
 
+    @Override
     public GetFieldMappingsRequest indices(String... indices) {
         this.indices = indices;
         return this;

--- a/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingRequest.java
@@ -50,7 +50,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
  * @see org.elasticsearch.client.IndicesAdminClient#putMapping(PutMappingRequest)
  * @see PutMappingResponse
  */
-public class PutMappingRequest extends AcknowledgedRequest<PutMappingRequest> implements IndicesRequest {
+public class PutMappingRequest extends AcknowledgedRequest<PutMappingRequest> implements IndicesRequest.Replaceable {
 
     private static ObjectOpenHashSet<String> RESERVED_FIELDS = ObjectOpenHashSet.from(
             "_uid", "_id", "_type", "_source",  "_all", "_analyzer", "_boost", "_parent", "_routing", "_index",
@@ -97,6 +97,7 @@ public class PutMappingRequest extends AcknowledgedRequest<PutMappingRequest> im
     /**
      * Sets the indices this put mapping operation will execute on.
      */
+    @Override
     public PutMappingRequest indices(String[] indices) {
         this.indices = indices;
         return this;

--- a/src/main/java/org/elasticsearch/action/admin/indices/open/OpenIndexRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/open/OpenIndexRequest.java
@@ -34,7 +34,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 /**
  * A request to open an index.
  */
-public class OpenIndexRequest extends AcknowledgedRequest<OpenIndexRequest> implements IndicesRequest {
+public class OpenIndexRequest extends AcknowledgedRequest<OpenIndexRequest> implements IndicesRequest.Replaceable {
 
     private String[] indices;
     private IndicesOptions indicesOptions = IndicesOptions.fromOptions(false, false, false, true);
@@ -72,6 +72,7 @@ public class OpenIndexRequest extends AcknowledgedRequest<OpenIndexRequest> impl
      * @param indices the indices to be opened
      * @return the request itself
      */
+    @Override
     public OpenIndexRequest indices(String... indices) {
         this.indices = indices;
         return this;

--- a/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsRequest.java
@@ -33,12 +33,13 @@ import java.io.IOException;
 
 /**
  */
-public class GetSettingsRequest extends MasterNodeReadOperationRequest<GetSettingsRequest> implements IndicesRequest {
+public class GetSettingsRequest extends MasterNodeReadOperationRequest<GetSettingsRequest> implements IndicesRequest.Replaceable {
 
     private String[] indices = Strings.EMPTY_ARRAY;
     private IndicesOptions indicesOptions = IndicesOptions.fromOptions(false, true, true, true);
     private String[] names = Strings.EMPTY_ARRAY;
 
+    @Override
     public GetSettingsRequest indices(String... indices) {
         this.indices = indices;
         return this;

--- a/src/main/java/org/elasticsearch/action/admin/indices/settings/put/UpdateSettingsRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/settings/put/UpdateSettingsRequest.java
@@ -43,7 +43,7 @@ import static org.elasticsearch.common.settings.ImmutableSettings.writeSettingsT
 /**
  * Request for an update index settings action
  */
-public class UpdateSettingsRequest extends AcknowledgedRequest<UpdateSettingsRequest> implements IndicesRequest {
+public class UpdateSettingsRequest extends AcknowledgedRequest<UpdateSettingsRequest> implements IndicesRequest.Replaceable {
 
     private String[] indices;
     private IndicesOptions indicesOptions = IndicesOptions.fromOptions(false, false, true, true);
@@ -88,6 +88,7 @@ public class UpdateSettingsRequest extends AcknowledgedRequest<UpdateSettingsReq
     /**
      * Sets the indices to apply to settings update to
      */
+    @Override
     public UpdateSettingsRequest indices(String... indices) {
         this.indices = indices;
         return this;

--- a/src/main/java/org/elasticsearch/action/admin/indices/warmer/delete/DeleteWarmerRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/warmer/delete/DeleteWarmerRequest.java
@@ -36,7 +36,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
  * A request that deletes a index warmer (name, {@link org.elasticsearch.action.search.SearchRequest})
  * tuple from the clusters metadata.
  */
-public class DeleteWarmerRequest extends AcknowledgedRequest<DeleteWarmerRequest> implements IndicesRequest {
+public class DeleteWarmerRequest extends AcknowledgedRequest<DeleteWarmerRequest> implements IndicesRequest.Replaceable {
 
     private String[] names = Strings.EMPTY_ARRAY;
     private IndicesOptions indicesOptions = IndicesOptions.fromOptions(false, false, true, false);
@@ -103,6 +103,7 @@ public class DeleteWarmerRequest extends AcknowledgedRequest<DeleteWarmerRequest
     /**
      * Sets the indices this put mapping operation will execute on.
      */
+    @Override
     public DeleteWarmerRequest indices(String... indices) {
         this.indices = indices;
         return this;

--- a/src/main/java/org/elasticsearch/action/admin/indices/warmer/put/PutWarmerRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/warmer/put/PutWarmerRequest.java
@@ -38,7 +38,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
  *
  * Note: neither the search request nor the name must be <code>null</code>
  */
-public class PutWarmerRequest extends AcknowledgedRequest<PutWarmerRequest> implements IndicesRequest {
+public class PutWarmerRequest extends AcknowledgedRequest<PutWarmerRequest> implements IndicesRequest.Replaceable {
 
     private String name;
 
@@ -108,6 +108,15 @@ public class PutWarmerRequest extends AcknowledgedRequest<PutWarmerRequest> impl
             throw new IllegalStateException("unable to retrieve indices, search request is null");
         }
         return searchRequest.indices();
+    }
+
+    @Override
+    public IndicesRequest indices(String[] indices) {
+        if (searchRequest == null) {
+            throw new IllegalStateException("unable to set indices, search request is null");
+        }
+        searchRequest.indices(indices);
+        return this;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/indexedscripts/get/GetIndexedScriptRequest.java
+++ b/src/main/java/org/elasticsearch/action/indexedscripts/get/GetIndexedScriptRequest.java
@@ -96,7 +96,6 @@ public class GetIndexedScriptRequest extends ActionRequest<GetIndexedScriptReque
         return new String[]{ScriptService.SCRIPT_INDEX};
     }
 
-
     @Override
     public IndicesOptions indicesOptions() {
         return IndicesOptions.strictSingleIndexNoExpandForbidClosed();

--- a/src/main/java/org/elasticsearch/action/mlt/MoreLikeThisRequest.java
+++ b/src/main/java/org/elasticsearch/action/mlt/MoreLikeThisRequest.java
@@ -136,13 +136,19 @@ public class MoreLikeThisRequest extends ActionRequest<MoreLikeThisRequest> impl
                 return MoreLikeThisRequest.this.indicesOptions();
             }
         });
-        requests.add(new IndicesRequest() {
+        requests.add(new IndicesRequest.Replaceable() {
             @Override
             public String[] indices() {
                 if (searchIndices != null) {
                     return searchIndices;
                 }
                 return new String[]{index};
+            }
+
+            @Override
+            public IndicesRequest indices(String[] indices) {
+                searchIndices = indices;
+                return this;
             }
 
             @Override

--- a/src/main/java/org/elasticsearch/action/search/SearchRequest.java
+++ b/src/main/java/org/elasticsearch/action/search/SearchRequest.java
@@ -59,7 +59,7 @@ import static org.elasticsearch.search.Scroll.readScroll;
  * @see org.elasticsearch.client.Client#search(SearchRequest)
  * @see SearchResponse
  */
-public class SearchRequest extends ActionRequest<SearchRequest> implements IndicesRequest {
+public class SearchRequest extends ActionRequest<SearchRequest> implements IndicesRequest.Replaceable {
 
     private SearchType searchType = SearchType.DEFAULT;
 
@@ -173,6 +173,7 @@ public class SearchRequest extends ActionRequest<SearchRequest> implements Indic
     /**
      * Sets the indices the search will be executed on.
      */
+    @Override
     public SearchRequest indices(String... indices) {
         if (indices == null) {
             throw new ElasticsearchIllegalArgumentException("indices must not be null");

--- a/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastOperationRequest.java
+++ b/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastOperationRequest.java
@@ -32,7 +32,7 @@ import java.io.IOException;
 /**
  *
  */
-public abstract class BroadcastOperationRequest<T extends BroadcastOperationRequest> extends ActionRequest<T> implements IndicesRequest {
+public abstract class BroadcastOperationRequest<T extends BroadcastOperationRequest> extends ActionRequest<T> implements IndicesRequest.Replaceable {
 
     protected String[] indices;
     private IndicesOptions indicesOptions = IndicesOptions.strictExpandOpenAndForbidClosed();
@@ -55,6 +55,7 @@ public abstract class BroadcastOperationRequest<T extends BroadcastOperationRequ
     }
 
     @SuppressWarnings("unchecked")
+    @Override
     public final T indices(String... indices) {
         this.indices = indices;
         return (T) this;

--- a/src/main/java/org/elasticsearch/action/support/master/info/ClusterInfoRequest.java
+++ b/src/main/java/org/elasticsearch/action/support/master/info/ClusterInfoRequest.java
@@ -30,7 +30,7 @@ import java.io.IOException;
 
 /**
  */
-public abstract class ClusterInfoRequest<T extends ClusterInfoRequest> extends MasterNodeReadOperationRequest<T> implements IndicesRequest {
+public abstract class ClusterInfoRequest<T extends ClusterInfoRequest> extends MasterNodeReadOperationRequest<T> implements IndicesRequest.Replaceable {
 
     private String[] indices = Strings.EMPTY_ARRAY;
     private String[] types = Strings.EMPTY_ARRAY;
@@ -38,6 +38,7 @@ public abstract class ClusterInfoRequest<T extends ClusterInfoRequest> extends M
     private IndicesOptions indicesOptions = IndicesOptions.strictExpandOpen();
 
     @SuppressWarnings("unchecked")
+    @Override
     public T indices(String... indices) {
         this.indices = indices;
         return (T) this;

--- a/src/main/java/org/elasticsearch/action/support/replication/IndicesReplicationOperationRequest.java
+++ b/src/main/java/org/elasticsearch/action/support/replication/IndicesReplicationOperationRequest.java
@@ -33,7 +33,7 @@ import java.io.IOException;
 /**
  *
  */
-public abstract class IndicesReplicationOperationRequest<T extends IndicesReplicationOperationRequest> extends ActionRequest<T> implements IndicesRequest {
+public abstract class IndicesReplicationOperationRequest<T extends IndicesReplicationOperationRequest> extends ActionRequest<T> implements IndicesRequest.Replaceable {
 
     protected TimeValue timeout = ShardReplicationOperationRequest.DEFAULT_TIMEOUT;
     protected String[] indices;
@@ -94,6 +94,7 @@ public abstract class IndicesReplicationOperationRequest<T extends IndicesReplic
      * The indices the request will execute against.
      */
     @SuppressWarnings("unchecked")
+    @Override
     public final T indices(String[] indices) {
         this.indices = indices;
         return (T) this;


### PR DESCRIPTION
We currently expose generic getters for `indices` and `indicesOptions` on the `IndicesRequest` interface. This commit adds a generic setter as well, which can be used to set the indices to a request. The setter impl throws `UnsupportedOperationException` if called on internal requests, since it makes sense to eventually replace the indices on external requests only. Also throws exception when the set operation doesn't make sense.
