### PR TITLE
[TEST] Update REST client before each test in our REST tests

### DIFF
--- a/src/test/java/org/elasticsearch/test/rest/client/RestClient.java
+++ b/src/test/java/org/elasticsearch/test/rest/client/RestClient.java
@@ -221,6 +221,10 @@ public class RestClient implements Closeable {
         return HttpClients.createDefault();
     }
 
+    public InetSocketAddress[] httpAddresses() {
+        return addresses;
+    }
+
     /**
      * Closes the REST client and the underlying http client
      */


### PR DESCRIPTION
In #7723 we removed the `updateAddresses` method from `RestClient` under the assumption that the addresses never change during the suite execution, as REST tests rely on the global cluster. Due to #6734 we restart the global cluster though before each test if there was a failure in the suite. If that happens we do need to make sure that the REST client points to the proper nodes. What was missing before was the http call to verify the es version every time the addresses change, which we do now since we effectively recreate the REST client from scratch when needed (if the http addresses have changed).
