### PR TITLE
[TEST] Improve HTTP support in TestClusters

### DIFF
--- a/src/main/java/org/elasticsearch/node/internal/InternalNode.java
+++ b/src/main/java/org/elasticsearch/node/internal/InternalNode.java
@@ -113,6 +113,8 @@ import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilde
 public final class InternalNode implements Node {
 
     private static final String CLIENT_TYPE = "node";
+    public static final String HTTP_ENABLED = "http.enabled";
+
 
     private final Lifecycle lifecycle = new Lifecycle();
     private final Injector injector;
@@ -176,7 +178,7 @@ public final class InternalNode implements Node {
             modules.add(new ClusterModule(settings));
             modules.add(new RestModule(settings));
             modules.add(new TransportModule(settings));
-            if (settings.getAsBoolean("http.enabled", true)) {
+            if (settings.getAsBoolean(HTTP_ENABLED, true)) {
                 modules.add(new HttpServerModule(settings));
             }
             modules.add(new RiversModule(settings));

--- a/src/main/java/org/elasticsearch/rest/RestController.java
+++ b/src/main/java/org/elasticsearch/rest/RestController.java
@@ -44,7 +44,6 @@ import static org.elasticsearch.rest.RestStatus.*;
 public class RestController extends AbstractLifecycleComponent<RestController> {
 
     public static final String HTTP_JSON_ENABLE = "http.jsonp.enable";
-
     private ImmutableSet<String> relevantHeaders = ImmutableSet.of();
 
     private final PathTrie<RestHandler> getHandlers = new PathTrie<>(RestUtils.REST_DECODER);

--- a/src/test/java/org/elasticsearch/options/jsonp/JsonpOptionDisabledTest.java
+++ b/src/test/java/org/elasticsearch/options/jsonp/JsonpOptionDisabledTest.java
@@ -23,6 +23,7 @@ import org.apache.http.impl.client.HttpClients;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.http.HttpServerTransport;
+import org.elasticsearch.node.internal.InternalNode;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
@@ -48,6 +49,7 @@ public class JsonpOptionDisabledTest extends ElasticsearchIntegrationTest {
         }
         return ImmutableSettings.settingsBuilder()
                 .put(super.nodeSettings(nodeOrdinal))
+                .put(InternalNode.HTTP_ENABLED, true)
                 .put(RestController.HTTP_JSON_ENABLE, false)
                 .build();
     }

--- a/src/test/java/org/elasticsearch/options/jsonp/JsonpOptionEnabledTest.java
+++ b/src/test/java/org/elasticsearch/options/jsonp/JsonpOptionEnabledTest.java
@@ -23,6 +23,7 @@ import org.apache.http.impl.client.HttpClients;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.http.HttpServerTransport;
+import org.elasticsearch.node.internal.InternalNode;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
@@ -44,6 +45,7 @@ public class JsonpOptionEnabledTest extends ElasticsearchIntegrationTest {
         return ImmutableSettings.settingsBuilder()
                 .put(super.nodeSettings(nodeOrdinal))
                 .put(RestController.HTTP_JSON_ENABLE, true)
+                .put(InternalNode.HTTP_ENABLED, true)
                 .build();
     }
 

--- a/src/test/java/org/elasticsearch/rest/CorsRegexTests.java
+++ b/src/test/java/org/elasticsearch/rest/CorsRegexTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
 import org.elasticsearch.http.HttpServerTransport;
+import org.elasticsearch.node.internal.InternalNode;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.elasticsearch.test.rest.client.http.HttpRequestBuilder;
 import org.elasticsearch.test.rest.client.http.HttpResponse;
@@ -55,6 +56,7 @@ public class CorsRegexTests extends ElasticsearchIntegrationTest {
                 .put(SETTING_CORS_ALLOW_ORIGIN, "/https?:\\/\\/localhost(:[0-9]+)?/")
                 .put(SETTING_CORS_ALLOW_CREDENTIALS, true)
                 .put(SETTING_CORS_ENABLED, true)
+                .put(InternalNode.HTTP_ENABLED, true)
                 .build();
     }
 

--- a/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
@@ -94,6 +94,8 @@ import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.indices.cache.query.IndicesQueryCache;
 import org.elasticsearch.indices.recovery.RecoverySettings;
 import org.elasticsearch.indices.store.IndicesStore;
+import org.elasticsearch.node.internal.InternalNode;
+import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.SearchService;
@@ -1582,7 +1584,8 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
         SettingsSource settingsSource = new SettingsSource() {
             @Override
             public Settings node(int nodeOrdinal) {
-                return nodeSettings(nodeOrdinal);
+                return ImmutableSettings.builder().put(InternalNode.HTTP_ENABLED, false).
+                        put(nodeSettings(nodeOrdinal)).build();
             }
 
             @Override
@@ -1614,7 +1617,6 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
             default:
                 throw new ElasticsearchException("Scope not supported: " + scope);
         }
-
         return new InternalTestCluster(currentClusterSeed, minNumDataNodes, maxNumDataNodes,
                 clusterName(scope.name(), Integer.toString(CHILD_JVM_ID), currentClusterSeed), settingsSource, numClientNodes,
                 enableRandomBenchNodes, CHILD_JVM_ID, nodePrefix);

--- a/src/test/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/src/test/java/org/elasticsearch/test/InternalTestCluster.java
@@ -260,7 +260,8 @@ public final class InternalTestCluster extends TestCluster {
             }
         }
         final int basePort = 9300 + (100 * (jvmOrdinal+1));
-        builder.put("transport.tcp.port", basePort + "-" + (basePort+199));
+        builder.put("transport.tcp.port", basePort + "-" + (basePort+100));
+        builder.put("http.port", basePort+101 + "-" + (basePort+200));
         builder.put("config.ignore_system_properties", true);
         builder.put("node.mode", NODE_MODE);
         builder.put("script.disable_dynamic", false);


### PR DESCRIPTION
This commit disalbes HTTP for all the suite and test scope tests
since it's an unused / unneeded module which takes time to startup.
This also uses a JVM private port range for HTTP ports to ensure
there are no cross JVM conflicts.
