### PR TITLE
bad text wrapping

### DIFF
--- a/docs/reference/analysis/tokenfilters/synonym-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/synonym-tokenfilter.asciidoc
@@ -63,9 +63,11 @@ ipod, i-pod, i pod
 foozball , foosball
 universe , cosmos
 
-# If expand==true, "ipod, i-pod, i pod" is equivalent to the explicit mapping:
+# If expand==true, "ipod, i-pod, i pod" is equivalent
+# to the explicit mapping:
 ipod, i-pod, i pod => ipod, i-pod, i pod
-# If expand==false, "ipod, i-pod, i pod" is equivalent to the explicit mapping:
+# If expand==false, "ipod, i-pod, i pod" is equivalent
+# to the explicit mapping:
 ipod, i-pod, i pod => ipod
 
 #multiple synonym mapping entries are merged.


### PR DESCRIPTION
On the page http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/analysis-synonym-tokenfilter.html

even on a huge monitor the text is being wrapped the next way

```
# If expand==true, "ipod, i-pod, i pod" is equivalent to the explicit
mapping:
ipod, i-pod, i pod => ipod, i-pod, i pod
# If expand==false, "ipod, i-pod, i pod" is equivalent to the explicit
mapping:
ipod, i-pod, i pod => ipod
```

So one can think that "mapping:" is not in comment and is a part of syntax. But the lines are less than 80 chars, so perhaps the problem is in the page layout and there may be some other pages in the reference where the text is also being wrapped in an undesirable way.
