### PR TITLE
Aggregations: More consistent response format for scripted metrics aggregation

### DIFF
--- a/docs/reference/search/aggregations/metrics/scripted-metric-aggregation.asciidoc
+++ b/docs/reference/search/aggregations/metrics/scripted-metric-aggregation.asciidoc
@@ -46,7 +46,7 @@ The response for the above aggregation:
 
     "aggregations": {
         "profit": {
-            "aggregation": 170
+            "value": 170
         }
    }
 }
@@ -207,7 +207,7 @@ produce the response:
 
     "aggregations": {
         "profit": {
-            "aggregation": 170
+            "value": 170
         }
    }
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/scripted/InternalScriptedMetric.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/scripted/InternalScriptedMetric.java
@@ -134,7 +134,7 @@ public class InternalScriptedMetric extends InternalMetricsAggregation implement
 
     @Override
     public XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
-        return builder.field("aggregation", aggregation);
+        return builder.field("value", aggregation);
     }
 
 }


### PR DESCRIPTION
Changes the name of the field in the scripted metrics aggregation from 'aggregation' to 'value' to be more in line with the other metrics aggregations like 'avg'
