### PR TITLE
Fix `percent_terms_to_match`

### DIFF
--- a/docs/reference/query-dsl/queries/mlt-query.asciidoc
+++ b/docs/reference/query-dsl/queries/mlt-query.asciidoc
@@ -87,8 +87,8 @@ unless specified otherwise in each `doc`.
 |`include` |When using `ids` or `docs`, specifies whether the documents should be
 included from the search. Defaults to `false`.
 
-|`percent_terms_to_match` |The percentage of terms to match on (float
-value). Defaults to `0.3` (30 percent).
+|`percent_terms_to_match` |From the generated query, the percentage of terms
+that must match (float value between 0 and 1). Defaults to `0.3` (30 percent).
 
 |`min_term_freq` |The frequency below which terms will be ignored in the
 source doc. The default frequency is `2`.

--- a/src/main/java/org/elasticsearch/common/lucene/search/MoreLikeThisQuery.java
+++ b/src/main/java/org/elasticsearch/common/lucene/search/MoreLikeThisQuery.java
@@ -152,7 +152,9 @@ public class MoreLikeThisQuery extends Query {
 
         BooleanQuery bq = new BooleanQuery();
         if (this.likeFields != null) {
-            bq.add((BooleanQuery) mlt.like(this.likeFields), BooleanClause.Occur.SHOULD);
+            Query mltQuery = mlt.like(this.likeFields);
+            setMinimumShouldMatch((BooleanQuery) mltQuery, percentTermsToMatch);
+            bq.add(mltQuery, BooleanClause.Occur.SHOULD);
         }
         if (this.likeText != null) {
             Reader[] readers = new Reader[likeText.length];
@@ -160,11 +162,10 @@ public class MoreLikeThisQuery extends Query {
                 readers[i] = new FastStringReader(likeText[i]);
             }
             //LUCENE 4 UPGRADE this mapps the 3.6 behavior (only use the first field)
-            bq.add((BooleanQuery) mlt.like(moreLikeFields[0], readers), BooleanClause.Occur.SHOULD);
+            Query mltQuery = mlt.like(moreLikeFields[0], readers);
+            setMinimumShouldMatch((BooleanQuery) mltQuery, percentTermsToMatch);
+            bq.add(mltQuery, BooleanClause.Occur.SHOULD);
         }
-
-        BooleanClause[] clauses = bq.getClauses();
-        bq.setMinimumNumberShouldMatch((int) (clauses.length * percentTermsToMatch));
 
         bq.setBoost(getBoost());
         return bq;
@@ -308,5 +309,10 @@ public class MoreLikeThisQuery extends Query {
 
     public void setBoostTermsFactor(float boostTermsFactor) {
         this.boostTermsFactor = boostTermsFactor;
+    }
+
+    private static void setMinimumShouldMatch(BooleanQuery bq, float percentTermsToMatch) {
+        BooleanClause[] clauses = bq.getClauses();
+        bq.setMinimumNumberShouldMatch((int) (clauses.length * percentTermsToMatch));
     }
 }


### PR DESCRIPTION
The parameter `percent_terms_to_match` (number of terms that must match in the
generated query) was wrongly set to the top level boolean query. This would
lead to zero or all results type of situations. This commit ensures that the
parameter is indeed applied to the query of generated terms.
