### PR TITLE
Fix to accept empty arrays on Highlight queries

### DIFF
--- a/src/main/java/org/elasticsearch/search/highlight/HighlighterParseElement.java
+++ b/src/main/java/org/elasticsearch/search/highlight/HighlighterParseElement.java
@@ -172,6 +172,10 @@ public class HighlighterParseElement implements SearchParseElement {
                         } else if (token == XContentParser.Token.START_OBJECT) {
                             fieldsOptions.add(Tuple.tuple(highlightFieldName, parseFields(parser, queryParserService)));
                         }
+                        else if (token == XContentParser.Token.START_ARRAY && parser.nextToken() == XContentParser.Token.END_ARRAY){
+                            final SearchContextHighlight.FieldOptions.Builder fieldOptionsBuilder = new SearchContextHighlight.FieldOptions.Builder();
+                            fieldsOptions.add(Tuple.tuple(highlightFieldName, fieldOptionsBuilder));
+                        }
                     }
                 } else if ("highlight_query".equals(topLevelFieldName) || "highlightQuery".equals(topLevelFieldName)) {
                     globalOptionsBuilder.highlightQuery(queryParserService.parse(parser).query());


### PR DESCRIPTION
Here is a fix for #2974 specific case.

Tested it with this REST command

<code>
{
   "highlight": {
      "fields": {
         "about": []
      }
   },
   "query": {
      "match": {
        "about": "rock"
      }
   }
}
<code>

and now it's returning the highlighted section as it does with <code>about": {}</code>. In case this could break some other use case please advise.

All tests passed (mvn test -Dtests.filter="@nightly and not(@slow or @backwards)")

Thanks
