### PR TITLE
Add ActionRunnable support to ThreadPool to simplify async operation on bounded threadpools

### DIFF
--- a/src/main/java/org/elasticsearch/action/ActionRunnable.java
+++ b/src/main/java/org/elasticsearch/action/ActionRunnable.java
@@ -19,11 +19,13 @@
 
 package org.elasticsearch.action;
 
+import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+
 /**
  * Base class for {@link Runnable}s that need to call {@link ActionListener#onFailure(Throwable)} in case an uncaught
  * exception or error is thrown while the actual action is run.
  */
-public abstract class ActionRunnable<Response> implements Runnable {
+public abstract class ActionRunnable<Response> extends AbstractRunnable {
     
     protected final ActionListener<Response> listener;
 
@@ -31,13 +33,11 @@ public abstract class ActionRunnable<Response> implements Runnable {
         this.listener = listener;
     }
 
-    public final void run() {
-        try {
-            doRun();
-        } catch (Throwable t) {
-            listener.onFailure(t);
-        }
+    /**
+     * Calls the action listeners {@link ActionListener#onFailure(Throwable)} method with the given exception.
+     * This method is invoked for all exception thrown by {@link #doRun()}
+     */
+    public void onFailure(Throwable t) {
+        listener.onFailure(t);
     }
-
-    protected abstract void doRun();
 }

--- a/src/main/java/org/elasticsearch/action/search/type/TransportSearchDfsQueryAndFetchAction.java
+++ b/src/main/java/org/elasticsearch/action/search/type/TransportSearchDfsQueryAndFetchAction.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.action.search.type;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.search.ReduceSearchPhaseException;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
@@ -41,6 +42,7 @@ import org.elasticsearch.search.internal.ShardSearchRequest;
 import org.elasticsearch.search.query.QuerySearchRequest;
 import org.elasticsearch.threadpool.ThreadPool;
 
+import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -121,31 +123,28 @@ public class TransportSearchDfsQueryAndFetchAction extends TransportSearchTypeAc
         }
 
         private void finishHim() {
-            try {
-                threadPool.executor(ThreadPool.Names.SEARCH).execute(new Runnable() {
-                    @Override
-                    public void run() {
-                        try {
-                            boolean useScroll = !useSlowScroll && request.scroll() != null;
-                            sortedShardList = searchPhaseController.sortDocs(useScroll, queryFetchResults);
-                            final InternalSearchResponse internalResponse = searchPhaseController.merge(sortedShardList, queryFetchResults, queryFetchResults);
-                            String scrollId = null;
-                            if (request.scroll() != null) {
-                                scrollId = TransportSearchHelper.buildScrollId(request.searchType(), firstResults, null);
-                            }
-                            listener.onResponse(new SearchResponse(internalResponse, scrollId, expectedSuccessfulOps, successfulOps.get(), buildTookInMillis(), buildShardFailures()));
-                        } catch (Throwable e) {
-                            ReduceSearchPhaseException failure = new ReduceSearchPhaseException("query_fetch", "", e, buildShardFailures());
-                            if (logger.isDebugEnabled()) {
-                                logger.debug("failed to reduce search", failure);
-                            }
-                            listener.onFailure(failure);
-                        }
+            threadPool.executor(ThreadPool.Names.SEARCH).execute(new ActionRunnable(listener) {
+                @Override
+                public void doRun() throws IOException {
+                    boolean useScroll = !useSlowScroll && request.scroll() != null;
+                    sortedShardList = searchPhaseController.sortDocs(useScroll, queryFetchResults);
+                    final InternalSearchResponse internalResponse = searchPhaseController.merge(sortedShardList, queryFetchResults, queryFetchResults);
+                    String scrollId = null;
+                    if (request.scroll() != null) {
+                        scrollId = TransportSearchHelper.buildScrollId(request.searchType(), firstResults, null);
                     }
-                });
-            } catch (EsRejectedExecutionException ex) {
-                listener.onFailure(ex);
-            }
+                    listener.onResponse(new SearchResponse(internalResponse, scrollId, expectedSuccessfulOps, successfulOps.get(), buildTookInMillis(), buildShardFailures()));
+                }
+
+                @Override
+                public void onFailure(Throwable t) {
+                    ReduceSearchPhaseException failure = new ReduceSearchPhaseException("query_fetch", "", t, buildShardFailures());
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("failed to reduce search", failure);
+                    }
+                    super.onFailure(t);
+                }
+            });
 
         }
     }

--- a/src/main/java/org/elasticsearch/action/search/type/TransportSearchDfsQueryThenFetchAction.java
+++ b/src/main/java/org/elasticsearch/action/search/type/TransportSearchDfsQueryThenFetchAction.java
@@ -22,6 +22,7 @@ package org.elasticsearch.action.search.type;
 import com.carrotsearch.hppc.IntArrayList;
 import org.apache.lucene.search.ScoreDoc;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.search.ReduceSearchPhaseException;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.SearchRequest;
@@ -47,6 +48,7 @@ import org.elasticsearch.search.query.QuerySearchRequest;
 import org.elasticsearch.search.query.QuerySearchResult;
 import org.elasticsearch.threadpool.ThreadPool;
 
+import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -193,36 +195,32 @@ public class TransportSearchDfsQueryThenFetchAction extends TransportSearchTypeA
         }
 
         private void finishHim() {
-            try {
-                threadPool.executor(ThreadPool.Names.SEARCH).execute(new Runnable() {
-                    @Override
-                    public void run() {
-                        try {
-                            final InternalSearchResponse internalResponse = searchPhaseController.merge(sortedShardList, queryResults, fetchResults);
-                            String scrollId = null;
-                            if (request.scroll() != null) {
-                                scrollId = TransportSearchHelper.buildScrollId(request.searchType(), firstResults, null);
-                            }
-                            listener.onResponse(new SearchResponse(internalResponse, scrollId, expectedSuccessfulOps, successfulOps.get(), buildTookInMillis(), buildShardFailures()));
-                        } catch (Throwable e) {
-                            ReduceSearchPhaseException failure = new ReduceSearchPhaseException("merge", "", e, buildShardFailures());
-                            if (logger.isDebugEnabled()) {
-                                logger.debug("failed to reduce search", failure);
-                            }
-                            listener.onFailure(failure);
-                        } finally {
-                            releaseIrrelevantSearchContexts(queryResults, docIdsToLoad);
-                        }
+            threadPool.executor(ThreadPool.Names.SEARCH).execute(new ActionRunnable<SearchResponse>(listener) {
+                @Override
+                public void doRun() throws IOException {
+                    final InternalSearchResponse internalResponse = searchPhaseController.merge(sortedShardList, queryResults, fetchResults);
+                    String scrollId = null;
+                    if (request.scroll() != null) {
+                        scrollId = TransportSearchHelper.buildScrollId(request.searchType(), firstResults, null);
                     }
-                });
-            } catch (EsRejectedExecutionException ex) {
-                try {
+                    listener.onResponse(new SearchResponse(internalResponse, scrollId, expectedSuccessfulOps, successfulOps.get(), buildTookInMillis(), buildShardFailures()));
                     releaseIrrelevantSearchContexts(queryResults, docIdsToLoad);
-                } finally {
-                    listener.onFailure(ex);
                 }
-            }
 
+                @Override
+                public void onFailure(Throwable t) {
+                    try {
+                        ReduceSearchPhaseException failure = new ReduceSearchPhaseException("merge", "", t, buildShardFailures());
+                        if (logger.isDebugEnabled()) {
+                            logger.debug("failed to reduce search", failure);
+                        }
+                        super.onFailure(failure);
+                    } finally {
+                        releaseIrrelevantSearchContexts(queryResults, docIdsToLoad);
+                    }
+                }
+            });
+
+            }
         }
-    }
 }

--- a/src/main/java/org/elasticsearch/action/support/replication/TransportShardReplicationOperationAction.java
+++ b/src/main/java/org/elasticsearch/action/support/replication/TransportShardReplicationOperationAction.java
@@ -733,7 +733,7 @@ public abstract class TransportShardReplicationOperationAction<Request extends S
                     try {
                         threadPool.executor(executor).execute(new AbstractRunnable() {
                             @Override
-                            public void run() {
+                            protected void doRun() {
                                 try {
                                     shardOperationOnReplica(shardRequest);
                                 } catch (Throwable e) {
@@ -749,6 +749,9 @@ public abstract class TransportShardReplicationOperationAction<Request extends S
                             public boolean isForceExecution() {
                                 return true;
                             }
+
+                            @Override
+                            public void onFailure(Throwable t) {}
                         });
                     } catch (Throwable e) {
                         failReplicaIfNeeded(shard.index(), shard.id(), e);

--- a/src/main/java/org/elasticsearch/common/util/concurrent/AbstractRunnable.java
+++ b/src/main/java/org/elasticsearch/common/util/concurrent/AbstractRunnable.java
@@ -30,4 +30,34 @@ public abstract class AbstractRunnable implements Runnable {
     public boolean isForceExecution() {
         return false;
     }
+
+    public final void run() {
+        try {
+            doRun();
+        } catch (InterruptedException ex) {
+            Thread.interrupted();
+            onFailure(ex);
+        } catch (Throwable t) {
+            onFailure(t);
+        }
+    }
+
+    /**
+     * This method is invoked for all exception thrown by {@link #doRun()}
+     */
+    public abstract void onFailure(Throwable t);
+
+    /**
+     * This should be executed if the thread-pool executing this action rejected the execution.
+     * The default implementation forwards to {@link #onFailure(Throwable)}
+     */
+    public void onRejection(Throwable t) {
+        onFailure(t);
+    }
+
+    /**
+     * This method has the same semantics as {@link Runnable#run()}
+     * @throws InterruptedException if the run method throws an InterruptedException
+     */
+    protected abstract void doRun() throws Exception;
 }

--- a/src/main/java/org/elasticsearch/transport/netty/MessageChannelHandler.java
+++ b/src/main/java/org/elasticsearch/transport/netty/MessageChannelHandler.java
@@ -270,25 +270,26 @@ public class MessageChannelHandler extends SimpleChannelUpstreamHandler {
 
         @SuppressWarnings({"unchecked"})
         @Override
-        public void run() {
-            try {
-                handler.messageReceived(request, transportChannel);
-            } catch (Throwable e) {
-                if (transport.lifecycleState() == Lifecycle.State.STARTED) {
-                    // we can only send a response transport is started....
-                    try {
-                        transportChannel.sendResponse(e);
-                    } catch (Throwable e1) {
-                        logger.warn("Failed to send error message back to client for action [" + action + "]", e1);
-                        logger.warn("Actual Exception", e);
-                    }
-                }
-            }
+        protected void doRun() throws Exception {
+            handler.messageReceived(request, transportChannel);
         }
 
         @Override
         public boolean isForceExecution() {
             return handler.isForceExecution();
+        }
+
+        @Override
+        public void onFailure(Throwable e) {
+            if (transport.lifecycleState() == Lifecycle.State.STARTED) {
+                // we can only send a response transport is started....
+                try {
+                    transportChannel.sendResponse(e);
+                } catch (Throwable e1) {
+                    logger.warn("Failed to send error message back to client for action [" + action + "]", e1);
+                    logger.warn("Actual Exception", e);
+                }
+            }
         }
     }
 }

--- a/src/test/java/org/elasticsearch/common/util/concurrent/EsExecutorsTests.java
+++ b/src/test/java/org/elasticsearch/common/util/concurrent/EsExecutorsTests.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.common.util.concurrent;
 
-import com.google.common.base.Predicate;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.junit.Test;
 
@@ -73,7 +72,7 @@ public class EsExecutorsTests extends ElasticsearchTestCase {
         final CountDownLatch exec3Wait = new CountDownLatch(1);
         executor.execute(new AbstractRunnable() {
             @Override
-            public void run() {
+            protected void doRun() {
                 executed3.set(true);
                 exec3Wait.countDown();
             }
@@ -81,6 +80,11 @@ public class EsExecutorsTests extends ElasticsearchTestCase {
             @Override
             public boolean isForceExecution() {
                 return true;
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                throw new AssertionError(t);
             }
         });
 

--- a/src/test/java/org/elasticsearch/test/transport/MockTransportService.java
+++ b/src/test/java/org/elasticsearch/test/transport/MockTransportService.java
@@ -237,12 +237,13 @@ public class MockTransportService extends TransportService {
 
                 threadPool.schedule(delay, ThreadPool.Names.GENERIC, new AbstractRunnable() {
                     @Override
-                    public void run() {
-                        try {
-                            original.sendRequest(node, requestId, action, clonedRequest, options);
-                        } catch (Throwable e) {
-                            logger.debug("failed to send delayed request", e);
-                        }
+                    public void onFailure(Throwable e) {
+                        logger.debug("failed to send delayed request", e);
+                    }
+
+                    @Override
+                    protected void doRun() throws IOException {
+                        original.sendRequest(node, requestId, action, clonedRequest, options);
                     }
                 });
             }

--- a/src/test/java/org/elasticsearch/test/transport/NettyTransportTests.java
+++ b/src/test/java/org/elasticsearch/test/transport/NettyTransportTests.java
@@ -155,26 +155,26 @@ public class NettyTransportTests extends ElasticsearchIntegrationTest {
 
                         @SuppressWarnings({"unchecked"})
                         @Override
-                        public void run() {
-                            try {
-                                handler.messageReceived(request, transportChannel);
-                            } catch (Throwable e) {
-                                if (transport.lifecycleState() == Lifecycle.State.STARTED) {
-                                    // we can only send a response transport is started....
-                                    try {
-                                        transportChannel.sendResponse(e);
-                                    } catch (Throwable e1) {
-                                        logger.warn("Failed to send error message back to client for action [" + action + "]", e1);
-                                        logger.warn("Actual Exception", e);
-                                    }
-                                }
-                            }
+                        protected void doRun() throws Exception {
+                            handler.messageReceived(request, transportChannel);
                         }
 
                         @Override
                         public boolean isForceExecution() {
                             return handler.isForceExecution();
                         }
+
+                        @Override
+                        public void onFailure(Throwable e) {
+                            if (transport.lifecycleState() == Lifecycle.State.STARTED) {
+                                // we can only send a response transport is started....
+                                try {
+                                    transportChannel.sendResponse(e);
+                                } catch (Throwable e1) {
+                                    logger.warn("Failed to send error message back to client for action [" + action + "]", e1);
+                                    logger.warn("Actual Exception", e);
+                                }
+                            }                        }
                     }
                 });
                 return pipeline;


### PR DESCRIPTION
today we have to catch rejected operation exceptions in various places
and notify an ActionListener. This pattern is error prone and adds a lot
of boilerplait code. It's also easy to miss catching this exception
which only is relevant if nodes are under high load. This commit adds
infrastructure that makes ActionListener first class citizen on async
actions.
