### PR TITLE
Make sure that internally generated percolate request re-uses the original headers and request context

### DIFF
--- a/src/main/java/org/elasticsearch/action/percolate/PercolateRequest.java
+++ b/src/main/java/org/elasticsearch/action/percolate/PercolateRequest.java
@@ -69,7 +69,8 @@ public class PercolateRequest extends BroadcastOperationRequest<PercolateRequest
     }
 
     PercolateRequest(PercolateRequest request, BytesReference docSource) {
-        super(request.indices());
+        super(request);
+        this.indices = request.indices();
         this.documentType = request.documentType();
         this.routing = request.routing();
         this.preference = request.preference();

--- a/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastOperationRequest.java
+++ b/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastOperationRequest.java
@@ -41,6 +41,10 @@ public abstract class BroadcastOperationRequest<T extends BroadcastOperationRequ
 
     }
 
+    protected BroadcastOperationRequest(ActionRequest originalRequest) {
+        super(originalRequest);
+    }
+
     protected BroadcastOperationRequest(String[] indices) {
         this.indices = indices;
     }


### PR DESCRIPTION
When percolating an existing document we internally recreate a new `PercolateRequest` that we go execute. We need to make sure that original headers and request context are preserved though when doing that.
