### PR TITLE
Give a unique id to each ping response 

### DIFF
--- a/src/main/java/org/elasticsearch/discovery/zen/ping/ZenPing.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ping/ZenPing.java
@@ -152,8 +152,7 @@ public interface ZenPing extends LifecycleComponent<ZenPing> {
 
 
     /**
-     * a class the represent a collection of pings where only the most recent ping is stored
-     * per node
+     * a utility collection of pings where only the most recent ping is stored per node
      */
     public static class PingCollection {
 
@@ -163,19 +162,28 @@ public interface ZenPing extends LifecycleComponent<ZenPing> {
             pings = new HashMap<>();
         }
 
-        public synchronized void addPing(PingResponse ping) {
+        /**
+         * adds a ping if newer than previous pings from the same node
+         *
+         * @return true if added, false o.w.
+         */
+        public synchronized boolean addPing(PingResponse ping) {
             PingResponse existingResponse = pings.get(ping.node());
             if (existingResponse == null || existingResponse.id() < ping.id()) {
                 pings.put(ping.node(), ping);
+                return true;
             }
+            return false;
         }
 
+        /** adds multiple pings if newer than previous pings from the same node */
         public synchronized void addPings(PingResponse[] pings) {
             for (PingResponse ping : pings) {
                 addPing(ping);
             }
         }
 
+        /** serialize current pings to an array */
         public synchronized PingResponse[] toArray() {
             return pings.values().toArray(new PingResponse[pings.size()]);
         }

--- a/src/main/java/org/elasticsearch/discovery/zen/ping/ZenPing.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ping/ZenPing.java
@@ -170,7 +170,13 @@ public interface ZenPing extends LifecycleComponent<ZenPing> {
             }
         }
 
-        public synchronized PingResponse[] asArray() {
+        public synchronized void addPings(PingResponse[] pings) {
+            for (PingResponse ping : pings) {
+                addPing(ping);
+            }
+        }
+
+        public synchronized PingResponse[] toArray() {
             return pings.values().toArray(new PingResponse[pings.size()]);
         }
 

--- a/src/main/java/org/elasticsearch/discovery/zen/ping/ZenPing.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ping/ZenPing.java
@@ -30,6 +30,9 @@ import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.unit.TimeValue;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static org.elasticsearch.cluster.ClusterName.readClusterName;
 import static org.elasticsearch.cluster.node.DiscoveryNode.readNode;
@@ -52,6 +55,12 @@ public interface ZenPing extends LifecycleComponent<ZenPing> {
 
         public static final PingResponse[] EMPTY = new PingResponse[0];
 
+        private static final AtomicLong idGenerator = new AtomicLong();
+
+        // an always increasing unique identifier for this ping response.
+        // lower values means older pings.
+        private long id;
+
         private ClusterName clusterName;
 
         private DiscoveryNode node;
@@ -70,10 +79,19 @@ public interface ZenPing extends LifecycleComponent<ZenPing> {
          * @param hasJoinedOnce true if the joined has successfully joined the cluster before
          */
         public PingResponse(DiscoveryNode node, DiscoveryNode master, ClusterName clusterName, boolean hasJoinedOnce) {
+            this.id = idGenerator.incrementAndGet();
             this.node = node;
             this.master = master;
             this.clusterName = clusterName;
             this.hasJoinedOnce = hasJoinedOnce;
+        }
+
+        /**
+         * an always increasing unique identifier for this ping response.
+         * lower values means older pings.
+         */
+        public long id() {
+            return this.id;
         }
 
         public ClusterName clusterName() {
@@ -108,16 +126,8 @@ public interface ZenPing extends LifecycleComponent<ZenPing> {
             if (in.readBoolean()) {
                 master = readNode(in);
             }
-            if (in.getVersion().onOrAfter(Version.V_1_4_0_Beta1)) {
-                this.hasJoinedOnce = in.readBoolean();
-            } else {
-                // As of 1.4.0 we prefer to elect nodes which have previously successfully joined the cluster.
-                // Nodes before 1.4.0 do not take this into consideration. If pre<1.4.0 node elects it self as master
-                // based on the pings, we need to make sure we do the same. We therefore can not demote it
-                // and thus mark it as if it has previously joined.
-                this.hasJoinedOnce = true;
-            }
-
+            this.hasJoinedOnce = in.readBoolean();
+            this.id = in.readLong();
         }
 
         @Override
@@ -130,14 +140,39 @@ public interface ZenPing extends LifecycleComponent<ZenPing> {
                 out.writeBoolean(true);
                 master.writeTo(out);
             }
-            if (out.getVersion().onOrAfter(Version.V_1_4_0_Beta1)) {
-                out.writeBoolean(hasJoinedOnce);
-            }
+            out.writeBoolean(hasJoinedOnce);
+            out.writeLong(id);
         }
 
         @Override
         public String toString() {
-            return "ping_response{node [" + node + "], master [" + master + "], hasJoinedOnce [" + hasJoinedOnce + "], cluster_name[" + clusterName.value() + "]}";
+            return "ping_response{node [" + node + "], id[" + id + "], master [" + master + "], hasJoinedOnce [" + hasJoinedOnce + "], cluster_name[" + clusterName.value() + "]}";
         }
+    }
+
+
+    /**
+     * a class the represent a collection of pings where only the most recent ping is stored
+     * per node
+     */
+    public static class PingCollection {
+
+        Map<DiscoveryNode, PingResponse> pings;
+
+        public PingCollection() {
+            pings = new HashMap<>();
+        }
+
+        public synchronized void addPing(PingResponse ping) {
+            PingResponse existingResponse = pings.get(ping.node());
+            if (existingResponse == null || existingResponse.id() < ping.id()) {
+                pings.put(ping.node(), ping);
+            }
+        }
+
+        public synchronized PingResponse[] asArray() {
+            return pings.values().toArray(new PingResponse[pings.size()]);
+        }
+
     }
 }

--- a/src/main/java/org/elasticsearch/discovery/zen/ping/ZenPing.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ping/ZenPing.java
@@ -169,7 +169,9 @@ public interface ZenPing extends LifecycleComponent<ZenPing> {
          */
         public synchronized boolean addPing(PingResponse ping) {
             PingResponse existingResponse = pings.get(ping.node());
-            if (existingResponse == null || existingResponse.id() < ping.id()) {
+            // in case both existing and new ping have the same id (probably because they come
+            // from nodes from version <1.4.0) we prefer to use the last added one.
+            if (existingResponse == null || existingResponse.id() <= ping.id()) {
                 pings.put(ping.node(), ping);
                 return true;
             }

--- a/src/test/java/org/elasticsearch/discovery/zen/ZenPingTests.java
+++ b/src/test/java/org/elasticsearch/discovery/zen/ZenPingTests.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.discovery.zen;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.transport.DummyTransportAddress;
+import org.elasticsearch.discovery.zen.ping.ZenPing;
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class ZenPingTests extends ElasticsearchTestCase {
+
+    @Test
+    public void testPingCollection() {
+        DiscoveryNode[] nodes = new DiscoveryNode[randomIntBetween(1, 30)];
+        long maxIdPerNode[] = new long[nodes.length];
+        DiscoveryNode masterPerNode[] = new DiscoveryNode[nodes.length];
+        boolean hasJoinedOncePerNode[] = new boolean[nodes.length];
+        ArrayList<ZenPing.PingResponse> pings = new ArrayList<>();
+        for (int i = 0; i < nodes.length; i++) {
+            nodes[i] = new DiscoveryNode("" + i, DummyTransportAddress.INSTANCE, Version.CURRENT);
+        }
+
+        for (int pingCount = scaledRandomIntBetween(10, nodes.length * 10); pingCount > 0; pingCount--) {
+            int node = randomInt(nodes.length - 1);
+            DiscoveryNode masterNode = null;
+            if (randomBoolean()) {
+                masterNode = nodes[randomInt(nodes.length - 1)];
+            }
+            boolean hasJoinedOnce = randomBoolean();
+            ZenPing.PingResponse ping = new ZenPing.PingResponse(nodes[node], masterNode, ClusterName.DEFAULT, hasJoinedOnce);
+            if (rarely()) {
+                // ignore some pings
+                continue;
+            }
+            // update max ping info
+            maxIdPerNode[node] = ping.id();
+            masterPerNode[node] = masterNode;
+            hasJoinedOncePerNode[node] = hasJoinedOnce;
+            pings.add(ping);
+        }
+
+        // shuffle
+        Collections.shuffle(pings);
+
+        ZenPing.PingCollection collection = new ZenPing.PingCollection();
+        collection.addPings(pings.toArray(new ZenPing.PingResponse[pings.size()]));
+
+        ZenPing.PingResponse[] aggregate = collection.toArray();
+
+        for (ZenPing.PingResponse ping : aggregate) {
+            int nodeId = Integer.parseInt(ping.node().id());
+            assertThat(maxIdPerNode[nodeId], equalTo(ping.id()));
+            assertThat(masterPerNode[nodeId], equalTo(ping.master()));
+            assertThat(hasJoinedOncePerNode[nodeId], equalTo(ping.hasJoinedOnce()));
+
+            maxIdPerNode[nodeId] = -1; // mark as seen
+        }
+
+        for (int i = 0; i < maxIdPerNode.length; i++) {
+            assertTrue("node " + i + " had pings but it was not found in collection", maxIdPerNode[i] <= 0);
+        }
+
+
+    }
+}


### PR DESCRIPTION
During discovery a node gossips with other nodes to discover the current state of the cluster - what nodes are out there, what version they use and most importantly whether there is an active master out there.  During this ping process we may end up in a situation where old information is mixed with new. This is comment if a couple of master election happen in rapid succession. 

This PR adds a monotonically increasing id to each ping response. This makes it easy to always select the last ping from every node.
