### PR TITLE
Adding `min` score mode to parent-child queries

### DIFF
--- a/docs/reference/query-dsl/queries/has-child-query.asciidoc
+++ b/docs/reference/query-dsl/queries/has-child-query.asciidoc
@@ -31,7 +31,7 @@ query the `total_hits` is always correct.
 ==== Scoring capabilities
 
 The `has_child` also has scoring support. The
-supported score types are `max`, `sum`, `avg` or `none`. The default is
+supported score types are `min`, `max`, `sum`, `avg` or `none`. The default is
 `none` and yields the same behaviour as in previous versions. If the
 score type is set to another value than `none`, the scores of all the
 matching child documents are aggregated into the associated parent
@@ -84,9 +84,9 @@ the `score_mode` parameter.
 [float]
 ==== Memory Considerations
 
-In order to support parent-child joins, all of the (string) parent IDs 
-must be resident in memory (in the <<index-modules-fielddata,field data cache>>. 
-Additionaly, every child document is mapped to its parent using a long 
+In order to support parent-child joins, all of the (string) parent IDs
+must be resident in memory (in the <<index-modules-fielddata,field data cache>>.
+Additionaly, every child document is mapped to its parent using a long
 value (approximately). It is advisable to keep the string parent ID short
 in order to reduce memory usage.
 
@@ -98,5 +98,3 @@ APIS, eg:
 --------------------------------------------------
 curl -XGET "http://localhost:9200/_stats/id_cache?pretty&human"
 --------------------------------------------------
-
-

--- a/src/main/java/org/elasticsearch/index/search/child/ChildrenQuery.java
+++ b/src/main/java/org/elasticsearch/index/search/child/ChildrenQuery.java
@@ -176,6 +176,9 @@ public class ChildrenQuery extends Query {
         try {
             if (minChildren == 0 && maxChildren == 0 && scoreType != ScoreType.NONE) {
                 switch (scoreType) {
+                case MIN:
+                    collector = new MinCollector(globalIfd, sc, parentType);
+                    break;
                 case MAX:
                     collector = new MaxCollector(globalIfd, sc, parentType);
                     break;
@@ -186,6 +189,9 @@ public class ChildrenQuery extends Query {
             }
             if (collector == null) {
                 switch (scoreType) {
+                case MIN:
+                    collector = new MinCountCollector(globalIfd, sc, parentType);
+                    break;
                 case MAX:
                     collector = new MaxCountCollector(globalIfd, sc, parentType);
                     break;
@@ -468,6 +474,21 @@ public class ChildrenQuery extends Query {
         }
     }
 
+    private final static class MinCollector extends ParentScoreCollector {
+
+        private MinCollector(IndexParentChildFieldData globalIfd, SearchContext searchContext, String parentType) {
+            super(globalIfd, searchContext, parentType);
+        }
+
+        @Override
+        protected void existingParent(long parentIdx) throws IOException {
+            float currentScore = scorer.score();
+            if (currentScore < scores.get(parentIdx)) {
+                scores.set(parentIdx, currentScore);
+            }
+        }
+    }
+
     private final static class MaxCountCollector extends ParentScoreCountCollector {
 
         private MaxCountCollector(IndexParentChildFieldData globalIfd, SearchContext searchContext, String parentType) {
@@ -478,6 +499,22 @@ public class ChildrenQuery extends Query {
         protected void existingParent(long parentIdx) throws IOException {
             float currentScore = scorer.score();
             if (currentScore > scores.get(parentIdx)) {
+                scores.set(parentIdx, currentScore);
+            }
+            occurrences.increment(parentIdx, 1);
+        }
+    }
+
+    private final static class MinCountCollector extends ParentScoreCountCollector {
+
+        private MinCountCollector(IndexParentChildFieldData globalIfd, SearchContext searchContext, String parentType) {
+            super(globalIfd, searchContext, parentType);
+        }
+
+        @Override
+        protected void existingParent(long parentIdx) throws IOException {
+            float currentScore = scorer.score();
+            if (currentScore < scores.get(parentIdx)) {
                 scores.set(parentIdx, currentScore);
             }
             occurrences.increment(parentIdx, 1);

--- a/src/main/java/org/elasticsearch/index/search/child/ScoreType.java
+++ b/src/main/java/org/elasticsearch/index/search/child/ScoreType.java
@@ -25,6 +25,11 @@ import org.elasticsearch.ElasticsearchIllegalArgumentException;
  */
 public enum ScoreType {
     /**
+     * Only the lowest score of all matching child documents is mapped into the
+     * parent.
+     */
+    MIN,
+    /**
      * Only the highest score of all matching child documents is mapped into the
      * parent.
      */
@@ -50,6 +55,8 @@ public enum ScoreType {
     public static ScoreType fromString(String type) {
         if ("none".equals(type)) {
             return NONE;
+        } else if ("min".equals(type)) {
+            return MIN;
         } else if ("max".equals(type)) {
             return MAX;
         } else if ("avg".equals(type)) {

--- a/src/test/java/org/elasticsearch/index/search/child/AbstractChildTests.java
+++ b/src/test/java/org/elasticsearch/index/search/child/AbstractChildTests.java
@@ -42,10 +42,17 @@ import static org.hamcrest.Matchers.equalTo;
 @LuceneTestCase.SuppressCodecs(value = {"Lucene40", "Lucene3x"})
 public abstract class AbstractChildTests extends ElasticsearchSingleNodeLuceneTestCase {
 
+    /**
+     * The name of the field within the child type that stores a score to use in test queries.
+     * <p />
+     * Its type is {@code double}.
+     */
+    protected static String CHILD_SCORE_NAME = "childScore";
+
     static SearchContext createSearchContext(String indexName, String parentType, String childType) throws IOException {
         IndexService indexService = createIndex(indexName);
         MapperService mapperService = indexService.mapperService();
-        mapperService.merge(childType, new CompressedString(PutMappingRequest.buildFromSimplifiedDef(childType, "_parent", "type=" + parentType).string()), true);
+        mapperService.merge(childType, new CompressedString(PutMappingRequest.buildFromSimplifiedDef(childType, "_parent", "type=" + parentType, CHILD_SCORE_NAME, "type=double").string()), true);
         return createSearchContext(indexService);
     }
 

--- a/src/test/java/org/elasticsearch/index/search/child/MockScorer.java
+++ b/src/test/java/org/elasticsearch/index/search/child/MockScorer.java
@@ -39,23 +39,35 @@ class MockScorer extends Scorer {
             return 1.0f;
         }
         float aggregateScore = 0;
-        for (int i = 0; i < scores.elementsCount; i++) {
-            float score = scores.buffer[i];
-            switch (scoreType) {
-                case MAX:
-                    if (aggregateScore < score) {
-                        aggregateScore = score;
-                    }
-                    break;
-                case SUM:
-                case AVG:
-                    aggregateScore += score;
-                    break;
-            }
-        }
 
-        if (scoreType == ScoreType.AVG) {
-            aggregateScore /= scores.elementsCount;
+        // in the case of a min value, it can't start at 0 (the lowest score); in all cases, it doesn't hurt to use the
+        //  first score, so we can safely use the first value by skipping it in the loop
+        if (scores.elementsCount != 0) {
+            aggregateScore = scores.buffer[0];
+
+            for (int i = 1; i < scores.elementsCount; i++) {
+                float score = scores.buffer[i];
+                switch (scoreType) {
+                    case MIN:
+                        if (aggregateScore > score) {
+                            aggregateScore = score;
+                        }
+                        break;
+                    case MAX:
+                        if (aggregateScore < score) {
+                            aggregateScore = score;
+                        }
+                        break;
+                    case SUM:
+                    case AVG:
+                        aggregateScore += score;
+                        break;
+                }
+            }
+
+            if (scoreType == ScoreType.AVG) {
+                aggregateScore /= scores.elementsCount;
+            }
         }
 
         return aggregateScore;

--- a/src/test/java/org/elasticsearch/index/search/child/ScoreTypeTests.java
+++ b/src/test/java/org/elasticsearch/index/search/child/ScoreTypeTests.java
@@ -1,0 +1,55 @@
+package org.elasticsearch.index.search.child;
+
+import org.elasticsearch.ElasticsearchIllegalArgumentException;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Tests {@link ScoreType} to ensure backward compatibility of any changes.
+ */
+public class ScoreTypeTests {
+    @Test
+    public void minFromString() {
+        assertThat("fromString(min) != MIN", ScoreType.MIN, equalTo(ScoreType.fromString("min")));
+    }
+
+    @Test
+    public void maxFromString() {
+        assertThat("fromString(max) != MAX", ScoreType.MAX, equalTo(ScoreType.fromString("max")));
+    }
+
+    @Test
+    public void avgFromString() {
+        assertThat("fromString(avg) != AVG", ScoreType.AVG, equalTo(ScoreType.fromString("avg")));
+    }
+
+    @Test
+    public void sumFromString() {
+        assertThat("fromString(sum) != SUM", ScoreType.SUM, equalTo(ScoreType.fromString("sum")));
+        // allowed for consistency with ScoreMode.Total:
+        assertThat("fromString(total) != SUM", ScoreType.SUM, equalTo(ScoreType.fromString("total")));
+    }
+
+    @Test
+    public void noneFromString() {
+        assertThat("fromString(none) != NONE", ScoreType.NONE, equalTo(ScoreType.fromString("none")));
+    }
+
+    /**
+     * Should throw {@link ElasticsearchIllegalArgumentException} instead of NPE.
+     */
+    @Test(expected = ElasticsearchIllegalArgumentException.class)
+    public void nullFromString_throwsException() {
+        ScoreType.fromString(null);
+    }
+
+    /**
+     * Failure should not change (and the value should never match anything...).
+     */
+    @Test(expected = ElasticsearchIllegalArgumentException.class)
+    public void unrecognizedFromString_throwsException() {
+        ScoreType.fromString("unrecognized value");
+    }
+}


### PR DESCRIPTION
Support for "max", "sum", and "avg" already existed.

Closes #7603 
