### PR TITLE
[TEST] Only reset test cluster if a test actually failed

### DIFF
--- a/src/test/java/org/apache/lucene/util/AbstractRandomizedTest.java
+++ b/src/test/java/org/apache/lucene/util/AbstractRandomizedTest.java
@@ -31,6 +31,7 @@ import org.apache.lucene.util.LuceneTestCase.SuppressCodecs;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.test.CurrentTestFailedMarker;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.elasticsearch.test.junit.listeners.ReproduceInfoPrinter;
@@ -56,7 +57,8 @@ import java.util.logging.Logger;
 })
 @Listeners({
         ReproduceInfoPrinter.class,
-        FailureMarker.class
+        FailureMarker.class,
+        CurrentTestFailedMarker.class
 })
 @RunWith(value = com.carrotsearch.randomizedtesting.RandomizedRunner.class)
 @SuppressCodecs(value = "Lucene3x")

--- a/src/test/java/org/elasticsearch/test/CurrentTestFailedMarker.java
+++ b/src/test/java/org/elasticsearch/test/CurrentTestFailedMarker.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.test;
+
+import org.junit.runner.Description;
+import org.junit.runner.notification.Failure;
+import org.junit.runner.notification.RunListener;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * A {@link RunListener} that detects  test failures. We need it because we need
+ * to reset the global / suite level cluster if a test fails but don't wanna reset it
+ * for every subsequent test.
+ */
+public class CurrentTestFailedMarker extends RunListener {
+
+    private static final AtomicBoolean failed = new AtomicBoolean(false);
+
+    @Override
+    public void testFailure(Failure failure) throws Exception {
+        failed.set(true);
+    }
+
+    @Override
+    public void testRunStarted(Description description) throws Exception {
+        failed.set(false);
+    }
+
+    /**
+     * Returns <code>true</code> iff the previously executed test failed. Otherwise <code>false</code>
+     */
+    public static boolean testFailed() {
+        return failed.get();
+    }
+}

--- a/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
@@ -94,7 +94,6 @@ import org.elasticsearch.indices.cache.query.IndicesQueryCache;
 import org.elasticsearch.indices.recovery.RecoverySettings;
 import org.elasticsearch.indices.store.IndicesStore;
 import org.elasticsearch.node.internal.InternalNode;
-import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.SearchService;
@@ -610,7 +609,7 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
             }
             throw e;
         } finally {
-            if (!success || suiteFailureMarker.hadFailures()) {
+            if (!success || CurrentTestFailedMarker.testFailed()) {
                 // if we failed that means that something broke horribly so we should
                 // clear all clusters and if the current cluster is the global we shut that one
                 // down as well to prevent subsequent tests from failing due to the same problem.


### PR DESCRIPTION
Previously we resetted the test cluster for all subsequent tests
even though they didn't fail. This make suites like REST tests faster
and prevents crazy timeouts.
