### PR TITLE
Refactor the Translog.read(Location) method

### DIFF
--- a/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
+++ b/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
@@ -358,13 +358,9 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
                     if (!get.loadSource()) {
                         return new GetResult(true, versionValue.version(), null);
                     }
-                    try {
-                        Translog.Source source = translog.readSource(versionValue.translogLocation());
-                        if (source != null) {
-                            return new GetResult(true, versionValue.version(), source);
-                        }
-                    } catch (IOException e) {
-                        // switched on us, read it from the reader
+                    Translog.Operation op = translog.read(versionValue.translogLocation());
+                    if (op != null) {
+                        return new GetResult(true, versionValue.version(), op.getSource());
                     }
                 }
             }

--- a/src/main/java/org/elasticsearch/index/translog/Translog.java
+++ b/src/main/java/org/elasticsearch/index/translog/Translog.java
@@ -103,9 +103,7 @@ public interface Translog extends IndexShardComponent, CloseableIndexComponent, 
      */
     Location add(Operation operation) throws TranslogException;
 
-    byte[] read(Location location);
-
-    Translog.Source readSource(Location location) throws IOException;
+    Translog.Operation read(Location location);
 
     /**
      * Snapshots the current transaction log allowing to safely iterate over the snapshot.
@@ -153,6 +151,11 @@ public interface Translog extends IndexShardComponent, CloseableIndexComponent, 
         @Override
         public long ramBytesUsed() {
             return RamUsageEstimator.NUM_BYTES_OBJECT_HEADER + 2*RamUsageEstimator.NUM_BYTES_LONG + RamUsageEstimator.NUM_BYTES_INT;
+        }
+
+        @Override
+        public String toString() {
+            return "[id: " + translogId + ", location: " + translogLocation + ", size: " + size + "]";
         }
     }
 


### PR DESCRIPTION
It was only used by `readSource`, it has been changed to return a
Translog.Operation, which can have .getSource() called on it to return
the source. `readSource` has been removed.

This also removes the checked IOException, any exception thrown is
unexpected and should throw a runtime exception.

Moves the ReleasableBytesStreamOutput allocation into the body of the
try-catch block so the lock can be released in the event of an exception
during allocation.
