### PR TITLE
[TEST] Make it possible to customize whether the REST tests are run by d...

### DIFF
--- a/src/test/java/org/elasticsearch/test/rest/ElasticsearchRestTests.java
+++ b/src/test/java/org/elasticsearch/test/rest/ElasticsearchRestTests.java
@@ -61,6 +61,7 @@ public class ElasticsearchRestTests extends ElasticsearchIntegrationTest {
      * Property that allows to control whether the REST tests need to be run (default) or not (false)
      */
     public static final String REST_TESTS = "tests.rest";
+    public static boolean REST_TESTS_ENABLED_BY_DEFAULT = true;
     /**
      * Property that allows to control which REST tests get run. Supports comma separated list of tests
      * or directories that contain tests e.g. -Dtests.rest.suite=index,get,create/10_with_id
@@ -161,7 +162,7 @@ public class ElasticsearchRestTests extends ElasticsearchIntegrationTest {
     @BeforeClass
     public static void initExecutionContext() throws IOException, RestException {
         //skip REST tests if disabled through -Dtests.rest=false
-        assumeTrue(systemPropertyAsBoolean(REST_TESTS, true));
+        assumeTrue(systemPropertyAsBoolean(REST_TESTS, REST_TESTS_ENABLED_BY_DEFAULT));
 
         String[] specPaths = resolvePathsProperty(REST_TESTS_SPEC, DEFAULT_SPEC_PATH);
         RestSpec restSpec = RestSpec.parseFrom(DEFAULT_SPEC_PATH, specPaths);


### PR DESCRIPTION
We currently run REST tests by default. There might be third parties that use our test infra and don't want to run REST tests by default, especially since they need some additional configuration for spec and tests that are not shipped with the tests jar file. In those cases we might want to customize the value for the property that controls whether REST tests are run by default or not.

This change makes it possible to change the default value from a static block like the following:

```
static {
    ElasticsearchRestTests.REST_TESTS_ENABLED_BY_DEFAULT = false;
}
```
