### PR TITLE
Update ZenDiscovery fields via the cluster service update task.

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/service/InternalClusterService.java
+++ b/src/main/java/org/elasticsearch/cluster/service/InternalClusterService.java
@@ -61,6 +61,8 @@ import static org.elasticsearch.common.util.concurrent.EsExecutors.daemonThreadF
  */
 public class InternalClusterService extends AbstractLifecycleComponent<ClusterService> implements ClusterService {
 
+    public final static String UPDATE_THREAD_NAME = "clusterService#updateTask";
+
     private final ThreadPool threadPool;
 
     private final DiscoveryService discoveryService;
@@ -131,7 +133,7 @@ public class InternalClusterService extends AbstractLifecycleComponent<ClusterSe
     protected void doStart() throws ElasticsearchException {
         add(localNodeMasterListeners);
         this.clusterState = ClusterState.builder(clusterState).blocks(initialBlocks).build();
-        this.updateTasksExecutor = EsExecutors.newSinglePrioritizing(daemonThreadFactory(settings, "clusterService#updateTask"));
+        this.updateTasksExecutor = EsExecutors.newSinglePrioritizing(daemonThreadFactory(settings, UPDATE_THREAD_NAME));
         this.reconnectToNodes = threadPool.schedule(reconnectInterval, ThreadPool.Names.GENERIC, new ReconnectToNodes());
         discoveryService.addLifecycleListener(new LifecycleListener() {
             @Override


### PR DESCRIPTION
On join, update the latestDiscoNodes, master flag and fault detection via a cluster state update task.

This should prevent rare concurrency issues, where during a join the cluster state master node can't be seen from the join thread.
