### PR TITLE
Support for custom analyzers in term vectors and MLT query

### DIFF
--- a/docs/reference/docs/termvectors.asciidoc
+++ b/docs/reference/docs/termvectors.asciidoc
@@ -249,7 +249,7 @@ curl -XGET 'http://localhost:9200/twitter/tweet/1/_termvector?pretty=true' -d '{
 [float]
 === Example 3
 
-Additionally, term vectors can also be generated for artificial documents,
+Term vectors can also be generated for artificial documents,
 that is for documents not present in the index. The syntax is similar to the
 <<search-percolate,percolator>> API. For example, the following request would
 return the same results as in example 1. The mapping used is determined by the
@@ -271,3 +271,59 @@ curl -XGET 'http://localhost:9200/twitter/tweet/_termvector' -d '{
 }'
 --------------------------------------------------
 
+[float]
+[[docs-termvectors-per-field-analyzer]]
+=== Example 4 coming[1.5.0]
+
+Additionally, a different analyzer than the one at the field may be provided
+by using the `per_field_analyzer` parameter. This is useful in order to
+generate term vectors in any fashion, especially when using artificial
+documents. When providing an analyzer for a field that already stores term
+vectors, the term vectors will be re-generated.
+
+[source,js]
+--------------------------------------------------
+curl -XGET 'http://localhost:9200/twitter/tweet/_termvector' -d '{
+  "doc" : {
+    "fullname" : "John Doe",
+    "text" : "twitter test test test"
+  },
+  "fields": ["fullname"],
+  "per_field_analyzer" : {
+    "fullname": "keyword"
+  }
+}'
+--------------------------------------------------
+
+Response:
+
+[source,js]
+--------------------------------------------------
+{
+  "_index": "twitter",
+  "_type": "tweet",
+  "_version": 0,
+  "found": true,
+  "term_vectors": {
+    "fullname": {
+       "field_statistics": {
+          "sum_doc_freq": 1,
+          "doc_count": 1,
+          "sum_ttf": 1
+       },
+       "terms": {
+          "John Doe": {
+             "term_freq": 1,
+             "tokens": [
+                {
+                   "position": 0,
+                   "start_offset": 0,
+                   "end_offset": 8
+                }
+             ]
+          }
+       }
+    }
+  }
+}
+--------------------------------------------------

--- a/docs/reference/query-dsl/queries/mlt-query.asciidoc
+++ b/docs/reference/query-dsl/queries/mlt-query.asciidoc
@@ -19,7 +19,7 @@ running it against one or more fields.
 More Like This can find documents that are "like" a set of
 chosen documents. The syntax to specify one or more documents is similar to
 the <<docs-multi-get,Multi GET API>>, and supports the `ids` or `docs` array.
-If only one document is specified, the query behaves the same as the 
+If only one document is specified, the query behaves the same as the
 <<search-more-like-this,More Like This API>>.
 
 [source,js]
@@ -115,9 +115,11 @@ for `ids` or `docs`.
 |`like_text` |The text to find documents like it, *required* if `ids` or `docs` are
 not specified.
 
-|`ids` or `docs` |A list of documents following the same syntax as the 
+|`ids` or `docs` |A list of documents following the same syntax as the
 <<docs-multi-get,Multi GET API>> or <<docs-multi-termvectors,Multi Term Vectors API>>.
 The text is fetched from `fields` unless specified otherwise in each `doc`.
+The text is analyzed by the default analyzer at the field, unless specified by the
+`per_field_analyzer` parameter of the <<docs-termvectors-per-field-analyzer,Term Vectors API>>.
 
 |`include` |When using `ids` or `docs`, specifies whether the documents should be
 included from the search. Defaults to `false`.

--- a/src/main/java/org/elasticsearch/action/termvector/TermVectorRequest.java
+++ b/src/main/java/org/elasticsearch/action/termvector/TermVectorRequest.java
@@ -394,13 +394,10 @@ public class TermVectorRequest extends SingleShardOperationRequest<TermVectorReq
             }
         }
         if (in.getVersion().onOrAfter(Version.V_1_5_0)) {
-            this.realtime = in.readBoolean();
-        }
-
-        if (in.getVersion().onOrAfter(Version.V_1_4_0_Beta1)) {
             if (in.readBoolean()) {
                 perFieldAnalyzer = readPerFieldAnalyzer(in.readMap());
             }
+            this.realtime = in.readBoolean();
         }
     }
 
@@ -436,14 +433,11 @@ public class TermVectorRequest extends SingleShardOperationRequest<TermVectorReq
             out.writeVInt(0);
         }
         if (out.getVersion().onOrAfter(Version.V_1_5_0)) {
-            out.writeBoolean(realtime());
-        }
-
-        if (out.getVersion().onOrAfter(Version.V_1_4_0_Beta1)) {
             out.writeBoolean(perFieldAnalyzer != null);
             if (perFieldAnalyzer != null) {
                 out.writeGenericValue(perFieldAnalyzer);
             }
+            out.writeBoolean(realtime());
         }
     }
 

--- a/src/main/java/org/elasticsearch/action/termvector/TermVectorRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/termvector/TermVectorRequestBuilder.java
@@ -24,6 +24,8 @@ import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
+import java.util.Map;
+
 /**
  */
 public class TermVectorRequestBuilder extends ActionRequestBuilder<TermVectorRequest, TermVectorResponse, TermVectorRequestBuilder, Client> {
@@ -128,6 +130,11 @@ public class TermVectorRequestBuilder extends ActionRequestBuilder<TermVectorReq
 
     public TermVectorRequestBuilder setRealtime(Boolean realtime) {
         request.realtime(realtime);
+        return this;
+    }
+
+    public TermVectorRequestBuilder setPerFieldAnalyzer(Map<String, Object> perFieldAnalyzer) {
+        request.perFieldAnalyzer(perFieldAnalyzer);
         return this;
     }
 

--- a/src/main/java/org/elasticsearch/action/termvector/TermVectorRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/termvector/TermVectorRequestBuilder.java
@@ -133,7 +133,7 @@ public class TermVectorRequestBuilder extends ActionRequestBuilder<TermVectorReq
         return this;
     }
 
-    public TermVectorRequestBuilder setPerFieldAnalyzer(Map<String, Object> perFieldAnalyzer) {
+    public TermVectorRequestBuilder setPerFieldAnalyzer(Map<String, String> perFieldAnalyzer) {
         request.perFieldAnalyzer(perFieldAnalyzer);
         return this;
     }

--- a/src/test/java/org/elasticsearch/action/termvector/GetTermVectorTests.java
+++ b/src/test/java/org/elasticsearch/action/termvector/GetTermVectorTests.java
@@ -959,7 +959,7 @@ public class GetTermVectorTests extends AbstractTermVectorTests {
         refresh();
 
         // create random per_field_analyzer and selected fields
-        Map<String, Object> perFieldAnalyzer = new HashMap<>();
+        Map<String, String> perFieldAnalyzer = new HashMap<>();
         Set<String> selectedFields = new HashSet<>();
         for (int i = 0; i < numFields; i++) {
             if (randomBoolean()) {
@@ -994,7 +994,7 @@ public class GetTermVectorTests extends AbstractTermVectorTests {
         checkAnalyzedFields(response.getFields(), selectedFields, perFieldAnalyzer);
     }
 
-    private void checkAnalyzedFields(Fields fieldsObject, Set<String> fieldNames, Map<String,Object> perFieldAnalyzer) throws IOException {
+    private void checkAnalyzedFields(Fields fieldsObject, Set<String> fieldNames, Map<String, String> perFieldAnalyzer) throws IOException {
         Set<String> validFields = new HashSet<>();
         for (String fieldName : fieldNames){
             if (fieldName.startsWith("non_existing")) {

--- a/src/test/java/org/elasticsearch/action/termvector/GetTermVectorTests.java
+++ b/src/test/java/org/elasticsearch/action/termvector/GetTermVectorTests.java
@@ -28,6 +28,7 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -35,10 +36,7 @@ import org.elasticsearch.index.mapper.core.AbstractFieldMapper;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.ExecutionException;
 
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
@@ -922,6 +920,99 @@ public class GetTermVectorTests extends AbstractTermVectorTests {
             // and return the generated term vectors
             checkBrownFoxTermVector(resp.getFields(), "non_existing", false);
         }
+    }
+
+    @Test
+    public void testPerFieldAnalyzer() throws ElasticsearchException, IOException {
+        int numFields = 25;
+
+        // setup mapping and document source
+        Set<String> withTermVectors = new HashSet<>();
+        XContentBuilder mapping = jsonBuilder().startObject().startObject("type1").startObject("properties");
+        XContentBuilder source = jsonBuilder().startObject();
+        for (int i = 0; i < numFields; i++) {
+            String fieldName = "field" + i;
+            if (randomBoolean()) {
+                withTermVectors.add(fieldName);
+            }
+            mapping.startObject(fieldName)
+                    .field("type", "string")
+                    .field("term_vector", withTermVectors.contains(fieldName) ? "yes" : "no")
+                    .endObject();
+            source.field(fieldName, "some text here");
+        }
+        source.endObject();
+        mapping.endObject().endObject().endObject();
+
+        // setup indices with mapping
+        ImmutableSettings.Builder settings = settingsBuilder()
+                .put(indexSettings())
+                .put("index.analysis.analyzer", "standard");
+        assertAcked(prepareCreate("test")
+                .addAlias(new Alias("alias"))
+                .setSettings(settings)
+                .addMapping("type1", mapping));
+        ensureGreen();
+
+        // index a single document with prepared source
+        client().prepareIndex("test", "type1", "0").setSource(source).get();
+        refresh();
+
+        // create random per_field_analyzer and selected fields
+        Map<String, Object> perFieldAnalyzer = new HashMap<>();
+        Set<String> selectedFields = new HashSet<>();
+        for (int i = 0; i < numFields; i++) {
+            if (randomBoolean()) {
+                perFieldAnalyzer.put("field" + i, "keyword");
+            }
+            if (randomBoolean()) {
+                perFieldAnalyzer.put("non_existing" + i, "keyword");
+            }
+            if (randomBoolean()) {
+                selectedFields.add("field" + i);
+            }
+            if (randomBoolean()) {
+                selectedFields.add("non_existing" + i);
+            }
+        }
+
+        // selected fields not specified
+        TermVectorResponse response = client().prepareTermVector(indexOrAlias(), "type1", "0")
+                .setPerFieldAnalyzer(perFieldAnalyzer)
+                .get();
+
+        // should return all fields that have terms vectors, some with overridden analyzer
+        checkAnalyzedFields(response.getFields(), withTermVectors, perFieldAnalyzer);
+
+        // selected fields specified including some not in the mapping
+        response = client().prepareTermVector(indexOrAlias(), "type1", "0")
+                .setSelectedFields(selectedFields.toArray(Strings.EMPTY_ARRAY))
+                .setPerFieldAnalyzer(perFieldAnalyzer)
+                .get();
+
+        // should return only the specified valid fields, with some with overridden analyzer
+        checkAnalyzedFields(response.getFields(), selectedFields, perFieldAnalyzer);
+    }
+
+    private void checkAnalyzedFields(Fields fieldsObject, Set<String> fieldNames, Map<String,Object> perFieldAnalyzer) throws IOException {
+        Set<String> validFields = new HashSet<>();
+        for (String fieldName : fieldNames){
+            if (fieldName.startsWith("non_existing")) {
+                assertThat("Non existing field\"" + fieldName + "\" should not be returned!", fieldsObject.terms(fieldName), nullValue());
+                continue;
+            }
+            Terms terms = fieldsObject.terms(fieldName);
+            assertThat("Existing field " + fieldName + "should have been returned", terms, notNullValue());
+            // check overridden by keyword analyzer ...
+            if (perFieldAnalyzer.containsKey(fieldName)) {
+                TermsEnum iterator = terms.iterator(null);
+                assertThat("Analyzer for " + fieldName + " should have been overridden!", iterator.next().utf8ToString(), equalTo("some text here"));
+                assertThat(iterator.next(), nullValue());
+            }
+            validFields.add(fieldName);
+        }
+        // ensure no other fields are returned
+        assertThat("More fields than expected are returned!", fieldsObject.size(), equalTo(validFields.size()));
     }
 
     private static String indexOrAlias() {


### PR DESCRIPTION
This adds a `per_field_analyzer` parameter to the Term Vectors API, which
allows to override the default analyzer at the field. If the field already
stores term vectors, then they will be re-generated. Since the MLT Query uses
the Term Vectors API under its hood, this commits also adds the same ability
to the MLT Query, thereby allowing users to fine grain how each field item
should be processed and analyzed.
