### PR TITLE
Resolves #7812 : adding elasticsearch-dsl to list of python clients

### DIFF
--- a/docs/community/clients.asciidoc
+++ b/docs/community/clients.asciidoc
@@ -12,6 +12,9 @@ See the {client}/perl-api/current/index.html[official Elasticsearch Perl client]
 
 See the {client}/python-api/current/index.html[official Elasticsearch Python client].
 
+* http://github.com/elasticsearch/elasticsearch-dsl-py[elasticsearch-dsl]
+  chainable query and filter construction built on top of offical client.
+
 * http://github.com/rhec/pyelasticsearch[pyelasticsearch]:
   Python client.
 

--- a/docs/community/clients.asciidoc
+++ b/docs/community/clients.asciidoc
@@ -12,7 +12,7 @@ See the {client}/perl-api/current/index.html[official Elasticsearch Perl client]
 
 See the {client}/python-api/current/index.html[official Elasticsearch Python client].
 
-* http://github.com/elasticsearch/elasticsearch-dsl-py[elasticsearch-dsl]
+* http://github.com/elasticsearch/elasticsearch-dsl-py[elasticsearch-dsl-py]
   chainable query and filter construction built on top of offical client.
 
 * http://github.com/rhec/pyelasticsearch[pyelasticsearch]:


### PR DESCRIPTION
adding [elasticsearch-dsl](https://github.com/elasticsearch/elasticsearch-dsl-py) to list of python clients.

This resolve Documentation Issue #7812
