### PR TITLE
Stats: Fix NPE in /_cat/nodes

### DIFF
--- a/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
@@ -230,10 +230,10 @@ public class RestNodesAction extends AbstractCatAction {
             table.addCell(stats == null ? null : stats.getIndices().getFilterCache().getMemorySize());
             table.addCell(stats == null ? null : stats.getIndices().getFilterCache().getEvictions());
 
-            table.addCell(stats == null ? null : stats.getIndices().getQueryCache().getMemorySize());
-            table.addCell(stats == null ? null : stats.getIndices().getQueryCache().getEvictions());
-            table.addCell(stats == null ? null : stats.getIndices().getQueryCache().getHitCount());
-            table.addCell(stats == null ? null : stats.getIndices().getQueryCache().getMissCount());
+            table.addCell(stats == null ? null : stats.getIndices().getQueryCache() == null ? null : stats.getIndices().getQueryCache().getMemorySize());
+            table.addCell(stats == null ? null : stats.getIndices().getQueryCache() == null ? null : stats.getIndices().getQueryCache().getEvictions());
+            table.addCell(stats == null ? null : stats.getIndices().getQueryCache() == null ? null : stats.getIndices().getQueryCache().getHitCount());
+            table.addCell(stats == null ? null : stats.getIndices().getQueryCache() == null ? null : stats.getIndices().getQueryCache().getMissCount());
 
             table.addCell(stats == null ? null : stats.getIndices().getFlush().getTotal());
             table.addCell(stats == null ? null : stats.getIndices().getFlush().getTotalTime());
@@ -287,9 +287,9 @@ public class RestNodesAction extends AbstractCatAction {
             table.addCell(stats == null ? null : stats.getIndices().getSegments().getVersionMapMemory());
             table.addCell(stats == null ? null : stats.getIndices().getSegments().getFixedBitSetMemory());
 
-            table.addCell(stats == null ? null : stats.getIndices().getSuggest().getCurrent());
-            table.addCell(stats == null ? null : stats.getIndices().getSuggest().getTime());
-            table.addCell(stats == null ? null : stats.getIndices().getSuggest().getCount());
+            table.addCell(stats == null ? null : stats.getIndices().getSuggest() == null ? null : stats.getIndices().getSuggest().getCurrent());
+            table.addCell(stats == null ? null : stats.getIndices().getSuggest() == null ? null : stats.getIndices().getSuggest().getTime());
+            table.addCell(stats == null ? null : stats.getIndices().getSuggest() == null ? null : stats.getIndices().getSuggest().getCount());
 
             table.endRow();
         }


### PR DESCRIPTION
Query Cache and Suggest stats were introduced in v1.4.0_beta1 and 1.2.0 respectively, therefore they can be null if stats are received from older nodes in the cluster.

Fixes #6297

This problem can occur only 1.x since current master isn't backward compatible with previous versions of elasticsearch anyway. So, I am opening this PR against 1.x not master. Not sure if this is right thing to do.
