### PR TITLE
Add total index memory in `_cat/indices`

### DIFF
--- a/docs/reference/cat/indices.asciidoc
+++ b/docs/reference/cat/indices.asciidoc
@@ -55,3 +55,14 @@ How many merge operations have the shards for the `wiki` completed?
 health index docs.count mt pri.mt
 green  wiki        9646 16     16
 --------------------------------------------------
+
+How much memory is used per index?
+
+[source,shell]
+--------------------------------------------------
+% curl 'localhost:9200/_cat/indices?v&h=i,tm'
+i     tm
+wiki  8.1gb
+test  30.5kb
+user  1.9mb
+--------------------------------------------------

--- a/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStats.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStats.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.cache.filter.FilterCacheStats;
@@ -484,6 +485,33 @@ public class CommonStats implements Streamable, ToXContent {
         CommonStats stats = new CommonStats();
         stats.readFrom(in);
         return stats;
+    }
+
+    /**
+     * Utility method which computes total memory by adding
+     * FieldData, IdCache, Percolate, Segments (memory, index writer, version map)
+     */
+    public ByteSizeValue getTotalMemory() {
+        long size = 0;
+        if (this.getFieldData() != null) {
+            size += this.getFieldData().getMemorySizeInBytes();
+        }
+        if (this.getFilterCache() != null) {
+            size += this.getFilterCache().getMemorySizeInBytes();
+        }
+        if (this.getIdCache() != null) {
+            size += this.getIdCache().getMemorySizeInBytes();
+        }
+        if (this.getPercolate() != null) {
+            size += this.getPercolate().getMemorySizeInBytes();
+        }
+        if (this.getSegments() != null) {
+            size += this.getSegments().getMemoryInBytes() +
+                    this.getSegments().getIndexWriterMemoryInBytes() +
+                    this.getSegments().getVersionMapMemoryInBytes();
+        }
+
+        return new ByteSizeValue(size);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
@@ -283,6 +283,8 @@ public class RestIndicesAction extends AbstractCatAction {
         table.addCell("suggest.total", "sibling:pri;alias:suto,suggestTotal;default:false;text-align:right;desc:number of suggest ops");
         table.addCell("pri.suggest.total", "default:false;text-align:right;desc:number of suggest ops");
 
+        table.addCell("memory.total", "sibling:pri;alias:tm,memoryTotal;default:false;text-align:right;desc:total used memory");
+        table.addCell("pri.memory.total", "default:false;text-align:right;desc:total user memory");
 
         table.endHeaders();
         return table;
@@ -482,6 +484,9 @@ public class RestIndicesAction extends AbstractCatAction {
 
             table.addCell(indexStats == null ? null : indexStats.getTotal().getSuggest().getCount());
             table.addCell(indexStats == null ? null : indexStats.getPrimaries().getSuggest().getCount());
+
+            table.addCell(indexStats == null ? null : indexStats.getTotal().getTotalMemory());
+            table.addCell(indexStats == null ? null : indexStats.getPrimaries().getTotalMemory());
 
             table.endRow();
         }


### PR DESCRIPTION
This patch adds to `_cat/indices` information about memory usage per index by adding memory used by FieldData, IdCache, Percolate, Segments (memory, index writer, version map).

```
% curl 'localhost:9200/_cat/indices?v&h=i,tm'
i     tm
wiki  8.1gb
test  30.5kb
user  1.9mb
```

Closes #7008
