### PR TITLE
Remove comma in JSON

### DIFF
--- a/docs/reference/analysis/charfilters/mapping-charfilter.asciidoc
+++ b/docs/reference/analysis/charfilters/mapping-charfilter.asciidoc
@@ -21,7 +21,7 @@ Here is a sample configuration:
                 "custom_with_char_filter" : {
                     "tokenizer" : "standard",
                     "char_filter" : ["my_mapping"]
-                },
+                }
             }
         }
     }


### PR DESCRIPTION
There was a comma too many in the documentation for the mapping char filter.
