### PR TITLE
During discovery, remove any local state and use clusterService.state instead

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/service/InternalClusterService.java
+++ b/src/main/java/org/elasticsearch/cluster/service/InternalClusterService.java
@@ -61,6 +61,7 @@ import static org.elasticsearch.common.util.concurrent.EsExecutors.daemonThreadF
  */
 public class InternalClusterService extends AbstractLifecycleComponent<ClusterService> implements ClusterService {
 
+    public static final String UPDATE_THREAD_NAME = "clusterService#updateTask";
     private final ThreadPool threadPool;
 
     private final DiscoveryService discoveryService;
@@ -131,7 +132,7 @@ public class InternalClusterService extends AbstractLifecycleComponent<ClusterSe
     protected void doStart() throws ElasticsearchException {
         add(localNodeMasterListeners);
         this.clusterState = ClusterState.builder(clusterState).blocks(initialBlocks).build();
-        this.updateTasksExecutor = EsExecutors.newSinglePrioritizing(daemonThreadFactory(settings, "clusterService#updateTask"));
+        this.updateTasksExecutor = EsExecutors.newSinglePrioritizing(daemonThreadFactory(settings, UPDATE_THREAD_NAME));
         this.reconnectToNodes = threadPool.schedule(reconnectInterval, ThreadPool.Names.GENERIC, new ReconnectToNodes());
         discoveryService.addLifecycleListener(new LifecycleListener() {
             @Override

--- a/src/main/java/org/elasticsearch/cluster/service/InternalClusterService.java
+++ b/src/main/java/org/elasticsearch/cluster/service/InternalClusterService.java
@@ -21,6 +21,7 @@ package org.elasticsearch.cluster.service;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchIllegalStateException;
+import org.elasticsearch.Version;
 import org.elasticsearch.cluster.*;
 import org.elasticsearch.cluster.ClusterState.Builder;
 import org.elasticsearch.cluster.block.ClusterBlock;
@@ -28,13 +29,13 @@ import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.metadata.ProcessClusterEventTimeoutException;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeService;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.operation.OperationRouting;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
-import org.elasticsearch.common.component.LifecycleListener;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
@@ -48,10 +49,7 @@ import org.elasticsearch.node.settings.NodeSettingsService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Queue;
+import java.util.*;
 import java.util.concurrent.*;
 
 import static org.elasticsearch.common.util.concurrent.EsExecutors.daemonThreadFactory;
@@ -71,6 +69,8 @@ public class InternalClusterService extends AbstractLifecycleComponent<ClusterSe
     private final TransportService transportService;
 
     private final NodeSettingsService nodeSettingsService;
+    private final DiscoveryNodeService discoveryNodeService;
+    private final Version version;
 
     private final TimeValue reconnectInterval;
 
@@ -91,13 +91,17 @@ public class InternalClusterService extends AbstractLifecycleComponent<ClusterSe
 
     @Inject
     public InternalClusterService(Settings settings, DiscoveryService discoveryService, OperationRouting operationRouting, TransportService transportService,
-                                  NodeSettingsService nodeSettingsService, ThreadPool threadPool, ClusterName clusterName) {
+                                  NodeSettingsService nodeSettingsService, ThreadPool threadPool, ClusterName clusterName, DiscoveryNodeService discoveryNodeService, Version version) {
         super(settings);
         this.operationRouting = operationRouting;
         this.transportService = transportService;
         this.discoveryService = discoveryService;
         this.threadPool = threadPool;
         this.nodeSettingsService = nodeSettingsService;
+        this.discoveryNodeService = discoveryNodeService;
+        this.version = version;
+
+        // will be replaced on doStart.
         this.clusterState = ClusterState.builder(clusterName).build();
 
         this.nodeSettingsService.setClusterService(this);
@@ -134,24 +138,13 @@ public class InternalClusterService extends AbstractLifecycleComponent<ClusterSe
         this.clusterState = ClusterState.builder(clusterState).blocks(initialBlocks).build();
         this.updateTasksExecutor = EsExecutors.newSinglePrioritizing(daemonThreadFactory(settings, UPDATE_THREAD_NAME));
         this.reconnectToNodes = threadPool.schedule(reconnectInterval, ThreadPool.Names.GENERIC, new ReconnectToNodes());
-        discoveryService.addLifecycleListener(new LifecycleListener() {
-            @Override
-            public void afterStart() {
-                submitStateUpdateTask("update local node", Priority.IMMEDIATE, new ClusterStateNonMasterUpdateTask() {
-                    @Override
-                    public ClusterState execute(ClusterState currentState) throws Exception {
-                        return ClusterState.builder(currentState)
-                                .nodes(DiscoveryNodes.builder(currentState.nodes()).put(localNode()).localNodeId(localNode().id()))
-                                .build();
-                    }
+        Map<String, String> nodeAttributes = discoveryNodeService.buildAttributes();
+        // note, we rely on the fact that its a new id each time we start, see FD and "kill -9" handling
+        final String nodeId = DiscoveryService.generateNodeId(settings);
+        DiscoveryNode localNode = new DiscoveryNode(settings.get("name"), nodeId, transportService.boundAddress().publishAddress(), nodeAttributes, version);
+        DiscoveryNodes.Builder nodeBuilder = DiscoveryNodes.builder().put(localNode).localNodeId(localNode.id());
+        this.clusterState = ClusterState.builder(clusterState).nodes(nodeBuilder).blocks(initialBlocks).build();
 
-                    @Override
-                    public void onFailure(String source, Throwable t) {
-                        logger.warn("failed to update local node", t);
-                    }
-                });
-            }
-        });
     }
 
     @Override
@@ -176,7 +169,7 @@ public class InternalClusterService extends AbstractLifecycleComponent<ClusterSe
 
     @Override
     public DiscoveryNode localNode() {
-        return discoveryService.localNode();
+        return clusterState.getNodes().localNode();
     }
 
     @Override
@@ -457,7 +450,7 @@ public class InternalClusterService extends AbstractLifecycleComponent<ClusterSe
                 //manual ack only from the master at the end of the publish
                 if (newClusterState.nodes().localNodeMaster()) {
                     try {
-                        ackListener.onNodeAck(localNode(), null);
+                        ackListener.onNodeAck(newClusterState.nodes().localNode(), null);
                     } catch (Throwable t) {
                         logger.debug("error while processing ack for master node [{}]", t, newClusterState.nodes().localNode());
                     }

--- a/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -315,7 +315,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
         if (!clusterState.getNodes().localNodeMaster()) {
             throw new ElasticsearchIllegalStateException("Shouldn't publish state when not master");
         }
-        nodesFD.updateNodes(clusterState);
+        nodesFD.updateNodesAndPing(clusterState);
         publishClusterState.publish(clusterState, ackListener);
     }
 
@@ -377,7 +377,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
                     if (newState.nodes().localNodeMaster()) {
                         // we only starts nodesFD if we are master (it may be that we received a cluster state while pinging)
                         joinThreadControl.markThreadAsDone(currentThread);
-                        nodesFD.start(newState); // start the nodes FD
+                        nodesFD.updateNodesAndPing(newState); // start the nodes FD
                     } else {
                         // if we're not a master it means another node published a cluster state while we were pinging
                         // make sure we go through another pinging round and actively join it
@@ -645,7 +645,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
                     masterFD.stop("got elected as new master since master left (reason = " + reason + ")");
                     discoveryNodes = DiscoveryNodes.builder(discoveryNodes).masterNodeId(localNode.id()).build();
                     ClusterState newState = ClusterState.builder(currentState).nodes(discoveryNodes).build();
-                    nodesFD.start(newState);
+                    nodesFD.updateNodesAndPing(newState);
                     return newState;
 
                 } else {

--- a/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -1048,7 +1048,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
         // clean the nodes, we are now not connected to anybody, since we try and reform the cluster
         DiscoveryNodes discoveryNodes = new DiscoveryNodes.Builder(clusterState.nodes()).masterNodeId(null).build();
 
-        // nocommit: do we want to force a new thread if we actively removed the master? this is to give a full pinging cycle
+        // TODO: do we want to force a new thread if we actively removed the master? this is to give a full pinging cycle
         // before a decision is made.
         joinThreadControl.startNewThreadIfNotRunning();
 

--- a/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -393,7 +393,9 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
                 @Override
                 public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
                     joinThreadControl.markThreadAsDone(currentThread);
-                    nodesFD.start(); // start the nodes FD
+                    if (newState.nodes().localNodeMaster()) {
+                        nodesFD.start(); // start the nodes FD
+                    }
                     sendInitialStateEventIfNeeded();
                     long count = clusterJoinsCounter.incrementAndGet();
                     logger.trace("cluster joins counter set to [{}] (elected as master)", count);

--- a/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -237,7 +237,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
         initialStateSent.set(false);
         DiscoveryNodes nodes = nodes();
         if (sendLeaveRequest) {
-            if (nodes().masterNode() == null) {
+            if (nodes.masterNode() == null) {
                 // if we don't know who the master is, nothing to do here
             } else if (!nodes.localNodeMaster()) {
                 try {
@@ -504,7 +504,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
                     logger.error("unexpected failure during [{}]", t, source);
                 }
             });
-        } else {
+        } else if (node.equals(nodes().masterNode())) {
             handleMasterGone(node, "shut_down");
         }
     }

--- a/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -208,8 +208,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
     @Override
     protected void doStart() throws ElasticsearchException {
 
-        // we update the nodes to know the local node, but not start it.
-        nodesFD.updateNodes(clusterService.state());
+        nodesFD.setLocalNode(clusterService.localNode());
         pingService.start();
 
         // start the join thread from a cluster state update. See {@link JoinThreadControl} for details.

--- a/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -725,7 +725,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
                 logger.warn("received a cluster state from [{}] and not part of the cluster, should not happen", newClusterState.nodes().masterNode());
                 newStateProcessed.onNewClusterStateFailed(new ElasticsearchIllegalStateException("received state from a node that is not part of the cluster"));
             } else {
-                if (currentJoinThread != null) {
+                if (currentJoinThread.get() != null) {
                     logger.trace("got a new state from master node while joining the cluster, this is a valid state during the last phase of the join process");
                 }
 

--- a/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -208,7 +208,8 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
     @Override
     protected void doStart() throws ElasticsearchException {
 
-        nodesFD.updateNodes(nodes(), ClusterState.UNKNOWN_VERSION);
+        // we update the nodes to know the local node, but not start it.
+        nodesFD.updateNodes(clusterService.state());
         pingService.start();
 
         // start the join thread from a cluster state update. See {@link JoinThreadControl} for details.
@@ -312,7 +313,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
         if (!clusterState.getNodes().localNodeMaster()) {
             throw new ElasticsearchIllegalStateException("Shouldn't publish state when not master");
         }
-        nodesFD.updateNodes(clusterState.nodes(), clusterState.version());
+        nodesFD.updateNodes(clusterState);
         publishClusterState.publish(clusterState, ackListener);
     }
 

--- a/src/main/java/org/elasticsearch/discovery/zen/fd/NodesFaultDetection.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/fd/NodesFaultDetection.java
@@ -24,7 +24,6 @@ import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
-import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
@@ -36,7 +35,6 @@ import java.io.IOException;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-import static org.elasticsearch.cluster.node.DiscoveryNodes.EMPTY_NODES;
 import static org.elasticsearch.common.util.concurrent.ConcurrentCollections.newConcurrentMap;
 import static org.elasticsearch.transport.TransportRequestOptions.options;
 
@@ -59,13 +57,9 @@ public class NodesFaultDetection extends FaultDetection {
 
     private final ConcurrentMap<DiscoveryNode, NodeFD> nodesFD = newConcurrentMap();
 
-    private volatile DiscoveryNodes latestNodes = EMPTY_NODES;
-
-    private volatile DiscoveryNode localNode;
-
     private volatile long clusterStateVersion = ClusterState.UNKNOWN_VERSION;
 
-    private volatile boolean running = false;
+    private volatile DiscoveryNode localNode;
 
     public NodesFaultDetection(Settings settings, ThreadPool threadPool, TransportService transportService, ClusterName clusterName) {
         super(settings, threadPool, transportService, clusterName);
@@ -87,41 +81,37 @@ public class NodesFaultDetection extends FaultDetection {
         listeners.remove(listener);
     }
 
-    public void updateNodes(ClusterState clusterState) {
-        if (!running) {
-            return;
+    /**
+     * make sure that nodes in clusterState are pinged. Any pinging to nodes which are not
+     * part of the cluster will be stopped
+     */
+    public void updateNodesAndPing(ClusterState clusterState) {
+        // remove any nodes we don't need, this will cause their FD to stop
+        for (DiscoveryNode monitoredNode : nodesFD.keySet()) {
+            if (!clusterState.nodes().nodeExists(monitoredNode.id())) {
+                nodesFD.remove(monitoredNode);
+            }
         }
-        DiscoveryNodes prevNodes = latestNodes;
-        this.latestNodes = clusterState.nodes();
-        this.clusterStateVersion = clusterState.version();
-        DiscoveryNodes.Delta delta = this.latestNodes.delta(prevNodes);
-        for (DiscoveryNode newNode : delta.addedNodes()) {
-            if (newNode.id().equals(this.localNode.id())) {
+        // add any missing nodes
+
+        for (DiscoveryNode node : clusterState.nodes()) {
+            if (node.equals(localNode)) {
                 // no need to monitor the local node
                 continue;
             }
-            if (!nodesFD.containsKey(newNode)) {
-                nodesFD.put(newNode, new NodeFD());
+            if (!nodesFD.containsKey(node)) {
+                NodeFD fd = new NodeFD(node);
+                // it's OK to overwrite an existing nodeFD - it will just stop and the new one will pick things up.
+                nodesFD.put(node, fd);
                 // we use schedule with a 0 time value to run the pinger on the pool as it will run on later
-                threadPool.schedule(TimeValue.timeValueMillis(0), ThreadPool.Names.SAME, new SendPingRequest(newNode));
+                threadPool.schedule(TimeValue.timeValueMillis(0), ThreadPool.Names.SAME, fd);
             }
         }
-        for (DiscoveryNode removedNode : delta.removedNodes()) {
-            nodesFD.remove(removedNode);
-        }
     }
 
-    public NodesFaultDetection start(ClusterState clusterState) {
-        running = true;
-        updateNodes(clusterState);
-        return this;
-    }
-
+    /** stops all pinging **/
     public NodesFaultDetection stop() {
-        if (!running) {
-            return this;
-        }
-        running = false;
+        nodesFD.clear();
         return this;
     }
 
@@ -133,25 +123,21 @@ public class NodesFaultDetection extends FaultDetection {
 
     @Override
     protected void handleTransportDisconnect(DiscoveryNode node) {
-        if (!latestNodes.nodeExists(node.id())) {
-            return;
-        }
         NodeFD nodeFD = nodesFD.remove(node);
         if (nodeFD == null) {
             return;
         }
-        if (!running) {
-            return;
-        }
-        nodeFD.running = false;
         if (connectOnNetworkDisconnect) {
+            NodeFD fd = new NodeFD(node);
             try {
                 transportService.connectToNode(node);
-                nodesFD.put(node, new NodeFD());
+                nodesFD.put(node, fd);
                 // we use schedule with a 0 time value to run the pinger on the pool as it will run on later
-                threadPool.schedule(TimeValue.timeValueMillis(0), ThreadPool.Names.SAME, new SendPingRequest(node));
+                threadPool.schedule(TimeValue.timeValueMillis(0), ThreadPool.Names.SAME, fd);
             } catch (Exception e) {
                 logger.trace("[node  ] [{}] transport disconnected (with verified connect)", node);
+                // clean up if needed, just to be safe..
+                nodesFD.remove(node, fd);
                 notifyNodeFailure(node, "transport disconnected (with verified connect)");
             }
         } else {
@@ -184,17 +170,23 @@ public class NodesFaultDetection extends FaultDetection {
         });
     }
 
-    private class SendPingRequest implements Runnable {
+
+    private class NodeFD implements Runnable {
+        volatile int retryCount;
 
         private final DiscoveryNode node;
 
-        private SendPingRequest(DiscoveryNode node) {
+        private NodeFD(DiscoveryNode node) {
             this.node = node;
+        }
+
+        private boolean running() {
+            return NodeFD.this.equals(nodesFD.get(node));
         }
 
         @Override
         public void run() {
-            if (!running) {
+            if (!running()) {
                 return;
             }
             final PingRequest pingRequest = new PingRequest(node.id(), clusterName, localNode, clusterStateVersion);
@@ -207,47 +199,34 @@ public class NodesFaultDetection extends FaultDetection {
 
                         @Override
                         public void handleResponse(PingResponse response) {
-                            if (!running) {
+                            if (!running()) {
                                 return;
                             }
-                            NodeFD nodeFD = nodesFD.get(node);
-                            if (nodeFD != null) {
-                                if (!nodeFD.running) {
-                                    return;
-                                }
-                                nodeFD.retryCount = 0;
-                                threadPool.schedule(pingInterval, ThreadPool.Names.SAME, SendPingRequest.this);
-                            }
+                            retryCount = 0;
+                            threadPool.schedule(pingInterval, ThreadPool.Names.SAME, NodeFD.this);
                         }
 
                         @Override
                         public void handleException(TransportException exp) {
-                            // check if the master node did not get switched on us...
-                            if (!running) {
+                            if (!running()) {
                                 return;
                             }
-                            NodeFD nodeFD = nodesFD.get(node);
-                            if (nodeFD != null) {
-                                if (!nodeFD.running) {
-                                    return;
-                                }
-                                if (exp instanceof ConnectTransportException || exp.getCause() instanceof ConnectTransportException) {
-                                    handleTransportDisconnect(node);
-                                    return;
-                                }
+                            if (exp instanceof ConnectTransportException || exp.getCause() instanceof ConnectTransportException) {
+                                handleTransportDisconnect(node);
+                                return;
+                            }
 
-                                int retryCount = ++nodeFD.retryCount;
-                                logger.trace("[node  ] failed to ping [{}], retry [{}] out of [{}]", exp, node, retryCount, pingRetryCount);
-                                if (retryCount >= pingRetryCount) {
-                                    logger.debug("[node  ] failed to ping [{}], tried [{}] times, each with  maximum [{}] timeout", node, pingRetryCount, pingRetryTimeout);
-                                    // not good, failure
-                                    if (nodesFD.remove(node) != null) {
-                                        notifyNodeFailure(node, "failed to ping, tried [" + pingRetryCount + "] times, each with maximum [" + pingRetryTimeout + "] timeout");
-                                    }
-                                } else {
-                                    // resend the request, not reschedule, rely on send timeout
-                                    transportService.sendRequest(node, PING_ACTION_NAME, pingRequest, options, this);
+                            retryCount++;
+                            logger.trace("[node  ] failed to ping [{}], retry [{}] out of [{}]", exp, node, retryCount, pingRetryCount);
+                            if (retryCount >= pingRetryCount) {
+                                logger.debug("[node  ] failed to ping [{}], tried [{}] times, each with  maximum [{}] timeout", node, pingRetryCount, pingRetryTimeout);
+                                // not good, failure
+                                if (nodesFD.remove(node, NodeFD.this)) {
+                                    notifyNodeFailure(node, "failed to ping, tried [" + pingRetryCount + "] times, each with maximum [" + pingRetryTimeout + "] timeout");
                                 }
+                            } else {
+                                // resend the request, not reschedule, rely on send timeout
+                                transportService.sendRequest(node, PING_ACTION_NAME, pingRequest, options, this);
                             }
                         }
 
@@ -258,11 +237,6 @@ public class NodesFaultDetection extends FaultDetection {
                     }
             );
         }
-    }
-
-    static class NodeFD {
-        volatile int retryCount;
-        volatile boolean running = true;
     }
 
     class PingRequestHandler extends BaseTransportRequestHandler<PingRequest> {

--- a/src/main/java/org/elasticsearch/discovery/zen/fd/NodesFaultDetection.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/fd/NodesFaultDetection.java
@@ -81,16 +81,16 @@ public class NodesFaultDetection extends FaultDetection {
         listeners.remove(listener);
     }
 
-    public void updateNodes(DiscoveryNodes nodes, long clusterStateVersion) {
+    public void updateNodes(ClusterState clusterState) {
         DiscoveryNodes prevNodes = latestNodes;
-        this.latestNodes = nodes;
-        this.clusterStateVersion = clusterStateVersion;
+        this.latestNodes = clusterState.nodes();
+        this.clusterStateVersion = clusterState.version();
         if (!running) {
             return;
         }
-        DiscoveryNodes.Delta delta = nodes.delta(prevNodes);
+        DiscoveryNodes.Delta delta = this.latestNodes.delta(prevNodes);
         for (DiscoveryNode newNode : delta.addedNodes()) {
-            if (newNode.id().equals(nodes.localNodeId())) {
+            if (newNode.id().equals(this.latestNodes.localNodeId())) {
                 // no need to monitor the local node
                 continue;
             }
@@ -107,7 +107,7 @@ public class NodesFaultDetection extends FaultDetection {
 
     public NodesFaultDetection start(ClusterState clusterState) {
         running = true;
-        updateNodes(clusterState.nodes(), clusterState.version());
+        updateNodes(clusterState);
         return this;
     }
 

--- a/src/main/java/org/elasticsearch/discovery/zen/fd/NodesFaultDetection.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/fd/NodesFaultDetection.java
@@ -61,6 +61,8 @@ public class NodesFaultDetection extends FaultDetection {
 
     private volatile DiscoveryNodes latestNodes = EMPTY_NODES;
 
+    private volatile DiscoveryNode localNode;
+
     private volatile long clusterStateVersion = ClusterState.UNKNOWN_VERSION;
 
     private volatile boolean running = false;
@@ -73,6 +75,10 @@ public class NodesFaultDetection extends FaultDetection {
         transportService.registerHandler(PING_ACTION_NAME, new PingRequestHandler());
     }
 
+    public void setLocalNode(DiscoveryNode localNode) {
+        this.localNode = localNode;
+    }
+
     public void addListener(Listener listener) {
         listeners.add(listener);
     }
@@ -82,15 +88,15 @@ public class NodesFaultDetection extends FaultDetection {
     }
 
     public void updateNodes(ClusterState clusterState) {
-        DiscoveryNodes prevNodes = latestNodes;
-        this.latestNodes = clusterState.nodes();
-        this.clusterStateVersion = clusterState.version();
         if (!running) {
             return;
         }
+        DiscoveryNodes prevNodes = latestNodes;
+        this.latestNodes = clusterState.nodes();
+        this.clusterStateVersion = clusterState.version();
         DiscoveryNodes.Delta delta = this.latestNodes.delta(prevNodes);
         for (DiscoveryNode newNode : delta.addedNodes()) {
-            if (newNode.id().equals(this.latestNodes.localNodeId())) {
+            if (newNode.id().equals(this.localNode.id())) {
                 // no need to monitor the local node
                 continue;
             }
@@ -191,7 +197,7 @@ public class NodesFaultDetection extends FaultDetection {
             if (!running) {
                 return;
             }
-            final PingRequest pingRequest = new PingRequest(node.id(), clusterName, latestNodes.localNode(), clusterStateVersion);
+            final PingRequest pingRequest = new PingRequest(node.id(), clusterName, localNode, clusterStateVersion);
             final TransportRequestOptions options = options().withType(TransportRequestOptions.Type.PING).withTimeout(pingRetryTimeout);
             transportService.sendRequest(node, PING_ACTION_NAME, pingRequest, options, new BaseTransportResponseHandler<PingResponse>() {
                         @Override
@@ -270,8 +276,8 @@ public class NodesFaultDetection extends FaultDetection {
         public void messageReceived(PingRequest request, TransportChannel channel) throws Exception {
             // if we are not the node we are supposed to be pinged, send an exception
             // this can happen when a kill -9 is sent, and another node is started using the same port
-            if (!latestNodes.localNodeId().equals(request.nodeId)) {
-                throw new ElasticsearchIllegalStateException("Got pinged as node [" + request.nodeId + "], but I am node [" + latestNodes.localNodeId() + "]");
+            if (!localNode.id().equals(request.nodeId)) {
+                throw new ElasticsearchIllegalStateException("Got pinged as node [" + request.nodeId + "], but I am node [" + localNode.id() + "]");
             }
 
             // PingRequest will have clusterName set to null if it came from a node of version <1.4.0

--- a/src/main/java/org/elasticsearch/discovery/zen/fd/NodesFaultDetection.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/fd/NodesFaultDetection.java
@@ -105,11 +105,9 @@ public class NodesFaultDetection extends FaultDetection {
         }
     }
 
-    public NodesFaultDetection start() {
-        if (running) {
-            return this;
-        }
+    public NodesFaultDetection start(ClusterState clusterState) {
         running = true;
+        updateNodes(clusterState.nodes(), clusterState.version());
         return this;
     }
 

--- a/src/main/java/org/elasticsearch/node/internal/InternalNode.java
+++ b/src/main/java/org/elasticsearch/node/internal/InternalNode.java
@@ -241,12 +241,12 @@ public final class InternalNode implements Node {
         injector.getInstance(IndicesTTLService.class).start();
         injector.getInstance(RiversManager.class).start();
         injector.getInstance(SnapshotsService.class).start();
+        injector.getInstance(TransportService.class).start();
         injector.getInstance(ClusterService.class).start();
         injector.getInstance(RoutingService.class).start();
         injector.getInstance(SearchService.class).start();
         injector.getInstance(MonitorService.class).start();
         injector.getInstance(RestController.class).start();
-        injector.getInstance(TransportService.class).start();
         DiscoveryService discoService = injector.getInstance(DiscoveryService.class).start();
         discoService.waitForInitialState();
 

--- a/src/test/java/org/elasticsearch/discovery/DiscoveryWithServiceDisruptions.java
+++ b/src/test/java/org/elasticsearch/discovery/DiscoveryWithServiceDisruptions.java
@@ -215,6 +215,33 @@ public class DiscoveryWithServiceDisruptions extends ElasticsearchIntegrationTes
         assertMaster(masterNode, nodes);
     }
 
+
+    /** Verify that nodes fault detection works after master (re) election */
+    @Test
+    @TestLogging(value = "cluster.service:TRACE,indices.recovery:TRACE")
+    public void testNodesFDAfterMasterReelection() throws Exception {
+        startCluster(3);
+
+        logger.info("stopping current master");
+        internalCluster().stopCurrentMasterNode();
+
+        ensureStableCluster(2);
+
+        String master = internalCluster().getMasterName();
+        String nonMaster = null;
+        for (String node : internalCluster().getNodeNames()) {
+            if (!node.equals(master)) {
+                nonMaster = node;
+            }
+        }
+
+        logger.info("--> isolating [{}]", nonMaster);
+        addRandomIsolation(nonMaster).startDisrupting();
+
+        logger.info("--> waiting for master to remove it");
+        ensureStableCluster(1, master);
+    }
+
     /**
      * Verify that the proper block is applied when nodes loose their master
      */

--- a/src/test/java/org/elasticsearch/discovery/ZenFaultDetectionTests.java
+++ b/src/test/java/org/elasticsearch/discovery/ZenFaultDetectionTests.java
@@ -138,7 +138,7 @@ public class ZenFaultDetectionTests extends ElasticsearchTestCase {
         ClusterState clusterState = ClusterState.builder(new ClusterName("test")).nodes(buildNodesForA(true)).build();
         NodesFaultDetection nodesFD = new NodesFaultDetection(settings.build(), threadPool, serviceA, clusterState.getClusterName());
         nodesFD.setLocalNode(clusterState.nodes().localNode());
-        nodesFD.start(clusterState);
+        nodesFD.updateNodesAndPing(clusterState);
         final String[] failureReason = new String[1];
         final DiscoveryNode[] failureNode = new DiscoveryNode[1];
         final CountDownLatch notified = new CountDownLatch(1);

--- a/src/test/java/org/elasticsearch/discovery/ZenFaultDetectionTests.java
+++ b/src/test/java/org/elasticsearch/discovery/ZenFaultDetectionTests.java
@@ -200,7 +200,7 @@ public class ZenFaultDetectionTests extends ElasticsearchTestCase {
             }
 
             @Override
-            public void onDisconnectedFromMaster() {
+            public void notListedOnMaster() {
 
             }
         });

--- a/src/test/java/org/elasticsearch/discovery/ZenFaultDetectionTests.java
+++ b/src/test/java/org/elasticsearch/discovery/ZenFaultDetectionTests.java
@@ -22,6 +22,7 @@ package org.elasticsearch.discovery;
 import com.google.common.collect.ImmutableMap;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.settings.ImmutableSettings;
@@ -134,9 +135,9 @@ public class ZenFaultDetectionTests extends ElasticsearchTestCase {
         // make sure we don't ping
         settings.put(FaultDetection.SETTING_CONNECT_ON_NETWORK_DISCONNECT, shouldRetry)
                 .put(FaultDetection.SETTING_PING_INTERVAL, "5m");
-        NodesFaultDetection nodesFD = new NodesFaultDetection(settings.build(), threadPool, serviceA, new ClusterName("test"));
-        nodesFD.start();
-        nodesFD.updateNodes(buildNodesForA(true), -1);
+        ClusterName clusterName = new ClusterName("test");
+        NodesFaultDetection nodesFD = new NodesFaultDetection(settings.build(), threadPool, serviceA, clusterName);
+        nodesFD.start(ClusterState.builder(clusterName).nodes(buildNodesForA(true)).build());
         final String[] failureReason = new String[1];
         final DiscoveryNode[] failureNode = new DiscoveryNode[1];
         final CountDownLatch notified = new CountDownLatch(1);

--- a/src/test/java/org/elasticsearch/discovery/ZenFaultDetectionTests.java
+++ b/src/test/java/org/elasticsearch/discovery/ZenFaultDetectionTests.java
@@ -135,9 +135,10 @@ public class ZenFaultDetectionTests extends ElasticsearchTestCase {
         // make sure we don't ping
         settings.put(FaultDetection.SETTING_CONNECT_ON_NETWORK_DISCONNECT, shouldRetry)
                 .put(FaultDetection.SETTING_PING_INTERVAL, "5m");
-        ClusterName clusterName = new ClusterName("test");
-        NodesFaultDetection nodesFD = new NodesFaultDetection(settings.build(), threadPool, serviceA, clusterName);
-        nodesFD.start(ClusterState.builder(clusterName).nodes(buildNodesForA(true)).build());
+        ClusterState clusterState = ClusterState.builder(new ClusterName("test")).nodes(buildNodesForA(true)).build();
+        NodesFaultDetection nodesFD = new NodesFaultDetection(settings.build(), threadPool, serviceA, clusterState.getClusterName());
+        nodesFD.setLocalNode(clusterState.nodes().localNode());
+        nodesFD.start(clusterState);
         final String[] failureReason = new String[1];
         final DiscoveryNode[] failureNode = new DiscoveryNode[1];
         final CountDownLatch notified = new CountDownLatch(1);


### PR DESCRIPTION
At the moment, ZenDiscovery contains a local copy of the disco nodes plus a flag that indicates whether the local node is master or not. This is redundant as the same information is stored in the cluster state. Have duplicate copy can lead to unneeded concurrency issues. This PR removes the duplication.

The PR introduces a tighter control of the background joining thread to make sure it is started and stopped together with any cluster state changes. This solves potentially concurrency bugs where a joining thread may fail to start.

Last we add a couple of safety checks to make sure that if a nodes receives a cluster state from a new master while actively trying to join another one (or electing itself) we go back to pinging to actively join it.

Note - this is PR is against the 1.x branch.
