### PR TITLE
Internal: MulticastChannel should wait on receiver thread to stop during shutdown

### DIFF
--- a/src/main/java/org/elasticsearch/common/network/MulticastChannel.java
+++ b/src/main/java/org/elasticsearch/common/network/MulticastChannel.java
@@ -21,7 +21,6 @@ package org.elasticsearch.common.network;
 
 import com.google.common.collect.Maps;
 import org.apache.lucene.util.IOUtils;
-
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.logging.ESLogger;
@@ -315,6 +314,11 @@ public abstract class MulticastChannel implements Closeable {
             if (multicastSocket != null) {
                 IOUtils.closeWhileHandlingException(multicastSocket);
                 multicastSocket = null;
+            }
+            try {
+                receiverThread.join(10000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
             }
         }
 


### PR DESCRIPTION
This was signaled by our tests which shutdown class and check for thread leakage.
