### PR TITLE
Add a listener thread pool

### DIFF
--- a/docs/reference/modules/threadpool.asciidoc
+++ b/docs/reference/modules/threadpool.asciidoc
@@ -49,6 +49,10 @@ pools, but the important ones include:
     For refresh operations, defaults to `scaling`
     with a `5m` keep-alive.
 
+`listener`::
+    Mainly for java client executing of action when listener threaded is set to true
+    size `(# of available processors)/2` max at 10.
+
 Changing a specific thread pool can be done by setting its type and
 specific type parameters, for example, changing the `index` thread pool
 to have more threads:

--- a/src/main/java/org/elasticsearch/action/ListenableActionFuture.java
+++ b/src/main/java/org/elasticsearch/action/ListenableActionFuture.java
@@ -30,9 +30,4 @@ public interface ListenableActionFuture<T> extends ActionFuture<T> {
      * Add an action listener to be invoked when a response has received.
      */
     void addListener(final ActionListener<T> listener);
-
-    /**
-     * Add an action listener (runnable) to be invoked when a response has received.
-     */
-    void addListener(final Runnable listener);
 }

--- a/src/main/java/org/elasticsearch/action/TransportActionNodeProxy.java
+++ b/src/main/java/org/elasticsearch/action/TransportActionNodeProxy.java
@@ -63,7 +63,7 @@ public class TransportActionNodeProxy<Request extends ActionRequest, Response ex
             @Override
             public String executor() {
                 if (request.listenerThreaded()) {
-                    return ThreadPool.Names.GENERIC;
+                    return ThreadPool.Names.LISTENER;
                 }
                 return ThreadPool.Names.SAME;
             }

--- a/src/main/java/org/elasticsearch/action/support/TransportAction.java
+++ b/src/main/java/org/elasticsearch/action/support/TransportAction.java
@@ -106,7 +106,7 @@ public abstract class TransportAction<Request extends ActionRequest, Response ex
         @Override
         public void onResponse(final Response response) {
             try {
-                threadPool.generic().execute(new Runnable() {
+                threadPool.executor(ThreadPool.Names.LISTENER).execute(new Runnable() {
                     @Override
                     public void run() {
                         try {
@@ -131,15 +131,15 @@ public abstract class TransportAction<Request extends ActionRequest, Response ex
         @Override
         public void onFailure(final Throwable e) {
             try {
-                threadPool.generic().execute(new Runnable() {
+                threadPool.executor(ThreadPool.Names.LISTENER).execute(new Runnable() {
                     @Override
                     public void run() {
                         listener.onFailure(e);
                     }
                 });
             } catch (EsRejectedExecutionException ex) {
-                logger.debug("Can not run threaded action, exectuion rejected for listener [{}] running on current thread", listener);
-                /* we don't care if that takes long since we are shutting down. But if we not respond somebody could wait
+                logger.debug("Can not run threaded action, execution rejected for listener [{}] running on current thread", listener);
+                /* we don't care if that takes long since we are shutting down (or queue capacity). But if we not respond somebody could wait
                  * for the response on the listener side which could be a remote machine so make sure we push it out there.*/
                 listener.onFailure(e);
             }

--- a/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
+++ b/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
@@ -64,6 +64,7 @@ public class ThreadPool extends AbstractComponent {
     public static class Names {
         public static final String SAME = "same";
         public static final String GENERIC = "generic";
+        public static final String LISTENER = "listener";
         public static final String GET = "get";
         public static final String INDEX = "index";
         public static final String BULK = "bulk";
@@ -117,6 +118,9 @@ public class ThreadPool extends AbstractComponent {
                 .put(Names.SUGGEST, settingsBuilder().put("type", "fixed").put("size", availableProcessors).put("queue_size", 1000).build())
                 .put(Names.PERCOLATE, settingsBuilder().put("type", "fixed").put("size", availableProcessors).put("queue_size", 1000).build())
                 .put(Names.MANAGEMENT, settingsBuilder().put("type", "fixed").put("size", halfProcMaxAt5).put("queue_size", 100).build())
+                // no queue as this means clients will need to handle rejections on listener queue even if the operation succeeded
+                // the assumption here is that the listeners should be very lightweight on the listeners side
+                .put(Names.LISTENER, settingsBuilder().put("type", "fixed").put("size", halfProcMaxAt10).build())
                 .put(Names.FLUSH, settingsBuilder().put("type", "scaling").put("keep_alive", "5m").put("size", halfProcMaxAt5).build())
                 .put(Names.MERGE, settingsBuilder().put("type", "scaling").put("keep_alive", "5m").put("size", halfProcMaxAt5).build())
                 .put(Names.REFRESH, settingsBuilder().put("type", "scaling").put("keep_alive", "5m").put("size", halfProcMaxAt10).build())


### PR DESCRIPTION
Today, when executing an action (mainly when using the Java API), a listener threaded flag can be set to true in order to execute the listener on a different thread pool. Today, this thread pool is the generic thread pool, which is cached. This can create problems for Java clients (mainly) around potential thread explosion.
Introduce a new thread pool called listener, that is fixed sized and defaults to the half the cores maxed at 10, and use it where listeners are executed.
