### PR TITLE
GeoJSON is lon,lat not lat,lon

### DIFF
--- a/docs/reference/query-dsl/filters/geo-distance-filter.asciidoc
+++ b/docs/reference/query-dsl/filters/geo-distance-filter.asciidoc
@@ -84,7 +84,7 @@ conform with http://geojson.org/[GeoJSON].
         "filter" : {
             "geo_distance" : {
                 "distance" : "12km",
-                "pin.location" : [40, -70]
+                "pin.location" : [-70, 40]
             }
         }
     }


### PR DESCRIPTION
Although emphasized in the text, the example was backwards.
