### PR TITLE
Add support for realtime term vectors

### DIFF
--- a/docs/reference/docs/termvectors.asciidoc
+++ b/docs/reference/docs/termvectors.asciidoc
@@ -5,9 +5,9 @@ added[1.0.0.Beta1]
 
 Returns information and statistics on terms in the fields of a particular
 document. The document could be stored in the index or artificially provided
-by the user coming[1.4.0]. Note that for documents stored in the index, this
-is a near realtime API as the term vectors are not available until the next
-refresh.
+by the user coming[1.4.0]. Term vectors are now <<realtime,realtime>>, as opposed to
+previously near realtime coming[1.5.0]. The functionality is disabled by setting
+`realtime` parameter to `false`.
 
 [source,js]
 --------------------------------------------------

--- a/rest-api-spec/api/mtermvectors.json
+++ b/rest-api-spec/api/mtermvectors.json
@@ -74,6 +74,11 @@
           "type" : "string",
           "description" : "Parent id of documents. Applies to all returned documents unless otherwise specified in body \"params\" or \"docs\".",
           "required" : false
+        },
+        "realtime": {
+           "type" : "boolean",
+           "description" : "Specifies if requests are real-time as opposed to near-real-time (default: true).",
+           "required" : false
         }
       }
     },

--- a/rest-api-spec/api/termvector.json
+++ b/rest-api-spec/api/termvector.json
@@ -72,6 +72,11 @@
           "type" : "string",
           "description" : "Parent id of documents.",
           "required" : false
+        },
+        "realtime": {
+          "type" : "boolean",
+          "description" : "Specifies if request is real-time as opposed to near-real-time (default: true).",
+          "required" : false
         }
       }
     },

--- a/rest-api-spec/test/termvector/30_realtime.yaml
+++ b/rest-api-spec/test/termvector/30_realtime.yaml
@@ -1,0 +1,40 @@
+---
+"Realtime Term Vectors":
+
+ - do:
+      indices.create:
+        index:    test_1
+        body:
+          settings:
+            index:
+              refresh_interval: -1
+              number_of_replicas: 0
+
+ - do:
+      cluster.health:
+          wait_for_status: green
+
+ - do:
+      index:
+          index:   test_1
+          type:    test
+          id:      1
+          body:    { foo: bar }
+
+ - do:
+      termvector:
+          index:    test_1
+          type:     test
+          id:       1
+          realtime: 0
+
+ - is_false: found
+
+ - do:
+      termvector:
+          index:    test_1
+          type:     test
+          id:       1
+          realtime: 1
+
+ - is_true: found

--- a/src/main/java/org/elasticsearch/action/termvector/TermVectorRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/termvector/TermVectorRequestBuilder.java
@@ -126,6 +126,11 @@ public class TermVectorRequestBuilder extends ActionRequestBuilder<TermVectorReq
         return this;
     }
 
+    public TermVectorRequestBuilder setRealtime(Boolean realtime) {
+        request.realtime(realtime);
+        return this;
+    }
+
     @Override
     protected void doExecute(ActionListener<TermVectorResponse> listener) {
         client.termVector(request, listener);

--- a/src/main/java/org/elasticsearch/rest/action/termvector/RestTermVectorAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/termvector/RestTermVectorAction.java
@@ -77,6 +77,7 @@ public class RestTermVectorAction extends BaseRestHandler {
         termVectorRequest.positions(request.paramAsBoolean("positions", termVectorRequest.positions()));
         termVectorRequest.payloads(request.paramAsBoolean("payloads", termVectorRequest.payloads()));
         termVectorRequest.routing(request.param("routing"));
+        termVectorRequest.realtime(request.paramAsBoolean("realtime", null));
         termVectorRequest.parent(request.param("parent"));
         termVectorRequest.preference(request.param("preference"));
         termVectorRequest.termStatistics(request.paramAsBoolean("termStatistics", termVectorRequest.termStatistics()));

--- a/src/test/java/org/elasticsearch/action/termvector/GetTermVectorTests.java
+++ b/src/test/java/org/elasticsearch/action/termvector/GetTermVectorTests.java
@@ -32,8 +32,6 @@ import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.mapper.core.AbstractFieldMapper;
-import org.elasticsearch.index.service.IndexService;
-import org.elasticsearch.indices.IndicesService;
 import org.junit.Test;
 
 import java.io.IOException;


### PR DESCRIPTION
By default term vectors are now realtime, as opposed to previously near
realtime. If they are not found in the index, they will be generated on the
fly. The document is fetched from the transaction log and treated as an
artificial document. One can set `realtime` parameter to `false` in order to
disable this functionality. This consequently makes the MLT query realtime in
fetching documents, as it previsouly used to be before switching from using
the multi get API to the mtv API.
