### PR TITLE
Significant terms: add scriptable significance heuristic

### DIFF
--- a/docs/reference/search/aggregations/bucket/significantterms-aggregation.asciidoc
+++ b/docs/reference/search/aggregations/bucket/significantterms-aggregation.asciidoc
@@ -326,7 +326,7 @@ Roughly, `mutual_information` prefers high frequent terms even if they occur als
 
 It is hard to say which one of the different heuristics will be the best choice as it depends on what the significant terms are used for (see for example [Yang and Pedersen, "A Comparative Study on Feature Selection in Text Categorization", 1997](http://courses.ischool.berkeley.edu/i256/f06/papers/yang97comparative.pdf) for a study on using significant terms for feature selection for text classification).
 
-If none of the above measures suites your usecase than another option is to implement a custom significance measure:
+If none of the above measures suits your usecase than another option is to implement a custom significance measure:
 
 ===== scripted
 coming[1.5.0]
@@ -342,7 +342,7 @@ Customized scores can be implemented via a script:
 --------------------------------------------------
 
 Scripts can be inline (as in above example), indexed or stored on disk. For details on the options, see <<modules-scripting, script documentation>>. 
-Paramters need to be set as follows:
+Parameters need to be set as follows:
 
 [horizontal]
 `script`:: Inline script, name of script file or name of indexed script. Mandatory.

--- a/docs/reference/search/aggregations/bucket/significantterms-aggregation.asciidoc
+++ b/docs/reference/search/aggregations/bucket/significantterms-aggregation.asciidoc
@@ -149,7 +149,6 @@ Now we have anomaly detection for each of the police forces using a single reque
 We can use other forms of top-level aggregations to segment our data, for example segmenting by geographic
 area to identify unusual hot-spots of a particular crime type:
 
-
 [source,js]
 --------------------------------------------------
 {
@@ -327,9 +326,38 @@ Roughly, `mutual_information` prefers high frequent terms even if they occur als
 
 It is hard to say which one of the different heuristics will be the best choice as it depends on what the significant terms are used for (see for example [Yang and Pedersen, "A Comparative Study on Feature Selection in Text Categorization", 1997](http://courses.ischool.berkeley.edu/i256/f06/papers/yang97comparative.pdf) for a study on using significant terms for feature selection for text classification).
 
+If none of the above measures suites your usecase than another option is to implement a custom significance measure:
 
+===== scripted
+coming[1.5.0]
 
+Customized scores can be implemented via a script:
 	
+[source,js]
+--------------------------------------------------
+
+	    "script_heuristic": {
+              "script": "_subset_freq/(_superset_freq - _subset_freq + 1)"
+            }
+--------------------------------------------------
+
+Scripts can be inline (as in above example), indexed or stored on disk. For details on the options, see <<modules-scripting, script documentation>>. 
+Paramters need to be set as follows:
+
+[horizontal]
+`script`:: Inline script, name of script file or name of indexed script. Mandatory.
+`script_type`:: One of "inline" (default), "indexed" or "file".
+`lang`:: Script language (default "groovy")
+`params`:: Script parameters (default empty).
+
+Available parameters in the script are
+
+[horizontal]
+`_subset_freq`:: Number of documents the term appears in in the subset.
+`_superset_freq`:: Number of documents the term appears in in the superset.
+`_subset_size`:: Number of documents in the subset.
+`_superset_size`:: Number of documents in the superset.
+
 ===== Size & Shard Size
 
 The `size` parameter can be set to define how many term buckets should be returned out of the overall terms list. By

--- a/src/main/java/org/elasticsearch/script/ScriptService.java
+++ b/src/main/java/org/elasticsearch/script/ScriptService.java
@@ -139,13 +139,33 @@ public class ScriptService extends AbstractComponent {
 
     public static enum ScriptType {
 
-        INLINE,
-        INDEXED,
-        FILE;
+        INLINE("inline"),
+        INDEXED("indexed"),
+        FILE("file");
 
         private static final int INLINE_VAL = 0;
         private static final int INDEXED_VAL = 1;
         private static final int FILE_VAL = 2;
+        private final String typeName;
+
+        ScriptType(String name) {
+            this.typeName = name;
+        }
+
+        public String getTypeName() {
+            return typeName;
+        }
+
+        public static ScriptType fromString(String type) throws ElasticsearchIllegalArgumentException {
+            if (INLINE.getTypeName().equalsIgnoreCase(type)) {
+                return INLINE;
+            } else if (INDEXED.getTypeName().equalsIgnoreCase(type)) {
+                return INDEXED;
+            } else if (FILE.getTypeName().equalsIgnoreCase(type)) {
+                return FILE;
+            }
+            throw new ElasticsearchIllegalArgumentException("string type [" + type + "] not valid, can be one of [inline|indexed|file]");
+        }
 
         public static ScriptType readFrom(StreamInput in) throws IOException {
             int scriptTypeVal = in.readVInt();

--- a/src/main/java/org/elasticsearch/script/ScriptService.java
+++ b/src/main/java/org/elasticsearch/script/ScriptService.java
@@ -139,33 +139,13 @@ public class ScriptService extends AbstractComponent {
 
     public static enum ScriptType {
 
-        INLINE("inline"),
-        INDEXED("indexed"),
-        FILE("file");
+        INLINE,
+        INDEXED,
+        FILE;
 
         private static final int INLINE_VAL = 0;
         private static final int INDEXED_VAL = 1;
         private static final int FILE_VAL = 2;
-        private final String typeName;
-
-        ScriptType(String name) {
-            this.typeName = name;
-        }
-
-        public String getTypeName() {
-            return typeName;
-        }
-
-        public static ScriptType fromString(String type) throws ElasticsearchIllegalArgumentException {
-            if (INLINE.getTypeName().equalsIgnoreCase(type)) {
-                return INLINE;
-            } else if (INDEXED.getTypeName().equalsIgnoreCase(type)) {
-                return INDEXED;
-            } else if (FILE.getTypeName().equalsIgnoreCase(type)) {
-                return FILE;
-            }
-            throw new ElasticsearchIllegalArgumentException("string type [" + type + "] not valid, can be one of [inline|indexed|file]");
-        }
 
         public static ScriptType readFrom(StreamInput in) throws IOException {
             int scriptTypeVal = in.readVInt();

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/InternalSignificantTerms.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/InternalSignificantTerms.java
@@ -183,6 +183,7 @@ public abstract class InternalSignificantTerms extends InternalMultiBucketAggreg
             }
         }
 
+        significanceHeuristic.initialize(reduceContext);
         final int size = Math.min(requiredSize, buckets.size());
         BucketSignificancePriorityQueue ordered = new BucketSignificancePriorityQueue(size);
         for (Map.Entry<String, List<Bucket>> entry : buckets.entrySet()) {

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantLongTerms.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantLongTerms.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.search.aggregations.bucket.significant;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantStringTerms.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantStringTerms.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.search.aggregations.bucket.significant;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/ScriptHeuristic.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/ScriptHeuristic.java
@@ -1,0 +1,220 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.elasticsearch.search.aggregations.bucket.significant.heuristics;
+
+
+import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.logging.ESLoggerFactory;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.query.QueryParsingException;
+import org.elasticsearch.script.ExecutableScript;
+import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ScriptHeuristic extends SignificanceHeuristic {
+
+    protected static final ParseField NAMES_FIELD = new ParseField("script_heuristic");
+    ExecutableScript script = null;
+    String scriptLang;
+    String scriptString;
+    ScriptService.ScriptType scriptType;
+    Map<String, Object> params;
+
+    private ScriptHeuristic() {
+    }
+
+    public static final SignificanceHeuristicStreams.Stream STREAM = new SignificanceHeuristicStreams.Stream() {
+        @Override
+        public SignificanceHeuristic readResult(StreamInput in) throws IOException {
+            return new ScriptHeuristic(null, in.readString(), in.readString(), ScriptService.ScriptType.readFrom(in), in.readMap());
+        }
+
+        @Override
+        public String getName() {
+            return NAMES_FIELD.getPreferredName();
+        }
+    };
+
+    public ScriptHeuristic(ExecutableScript searchScript, String scriptLang, String scriptString, ScriptService.ScriptType scriptType, Map<String, Object> params) {
+        this.script = searchScript;
+        this.scriptLang = scriptLang;
+        this.scriptString = scriptString;
+        this.scriptType = scriptType;
+        this.params = params;
+    }
+
+    public void initialize(InternalAggregation.ReduceContext context) {
+        script = context.scriptService().executable(scriptLang, scriptString, scriptType, params);
+    }
+
+    /**
+     * Calculates score with a script
+     *
+     * @param subsetFreq   The frequency of the term in the selected sample
+     * @param subsetSize   The size of the selected sample (typically number of docs)
+     * @param supersetFreq The frequency of the term in the superset from which the sample was taken
+     * @param supersetSize The size of the superset from which the sample was taken  (typically number of docs)
+     * @return a "significance" score
+     */
+    @Override
+    public double getScore(long subsetFreq, long subsetSize, long supersetFreq, long supersetSize) {
+        if (script == null) {
+            ESLoggerFactory.getLogger("script heuristic").warn("cannot compute score - script has not been initialized yet. If this warning appears within an integration test test you can ignore it. If it appeared while running es or within a bwc test then there is a problem.");
+            return 0;
+        }
+        script.setNextVar("_subset_freq", subsetFreq);
+        script.setNextVar("_subset_size", subsetSize);
+        script.setNextVar("_superset_freq", supersetFreq);
+        script.setNextVar("_superset_size", supersetSize);
+        return ((Number) script.run()).doubleValue();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(STREAM.getName());
+        out.writeString(scriptLang);
+        out.writeString(scriptString);
+        ScriptService.ScriptType.writeTo(scriptType, out);
+        out.writeMap(params);
+    }
+
+    public static class ScriptHeuristicParser implements SignificanceHeuristicParser {
+        private final ScriptService scriptService;
+        private final ParseField scriptTypeField = new ParseField("script_type");
+        @Inject
+        public ScriptHeuristicParser(ScriptService scriptService) {
+            this.scriptService = scriptService;
+        }
+
+        @Override
+        public SignificanceHeuristic parse(XContentParser parser) throws IOException, QueryParsingException {
+            NAMES_FIELD.match(parser.currentName(), ParseField.EMPTY_FLAGS);
+            String script = null;
+            String scriptLang = ScriptService.DEFAULT_LANG;
+            XContentParser.Token token;
+            Map<String, Object> params = new HashMap<>();
+            String currentFieldName = null;
+            ScriptService.ScriptType scriptType = ScriptService.ScriptType.INLINE;
+
+            while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+                if (token.equals(XContentParser.Token.FIELD_NAME)) {
+                    currentFieldName = parser.currentName();
+                } else if (token == XContentParser.Token.START_OBJECT) {
+                    if ("params".equals(currentFieldName)) {
+                        params = parser.map();
+                    } else {
+                        throw new ElasticsearchParseException("unknown object " + currentFieldName + " in script_heuristic");
+                    }
+                } else if (token.isValue()) {
+                    if ("script".equals(currentFieldName)) {
+                        script = parser.text();
+                    } else if (scriptTypeField.match(currentFieldName)) {
+                        scriptType = ScriptService.ScriptType.fromString(parser.text());
+                    } else if ("lang".equals(currentFieldName)) {
+                        scriptLang = parser.text();
+                    } else {
+                        throw new ElasticsearchParseException("unknown field " + currentFieldName + " in script_heuristic");
+                    }
+                }
+            }
+
+            if (script == null) {
+                throw new ElasticsearchParseException("No script found in script_heuristic");
+            }
+
+            ExecutableScript searchScript;
+            try {
+                searchScript = scriptService.executable(scriptLang, script, scriptType, params);
+            } catch (Exception e) {
+                throw new ElasticsearchParseException("The script [" + script + "] could not be loaded");
+            }
+            return new ScriptHeuristic(searchScript, scriptLang, script, scriptType, params);
+        }
+
+        @Override
+        public String[] getNames() {
+            return NAMES_FIELD.getAllNamesIncludedDeprecated();
+        }
+    }
+
+    public static class ScriptHeuristicBuilder implements SignificanceHeuristicBuilder {
+
+        public ScriptHeuristicBuilder() {
+        }
+
+        private String script = null;
+        private String lang = null;
+        private Map<String, Object> params = null;
+        private ScriptService.ScriptType scriptType;
+        public ScriptHeuristicBuilder setScript(String script) {
+            this.script = script;
+            return this;
+        }
+
+        public ScriptHeuristicBuilder setLang(String lang) {
+            this.lang = lang;
+            return this;
+        }
+
+        public ScriptHeuristicBuilder setParams(Map<String, Object> params) {
+            this.params = params;
+            return this;
+        }
+
+        public ScriptHeuristicBuilder setType(String scriptType) {
+            this.scriptType = ScriptService.ScriptType.fromString(scriptType);
+            return this;
+        }
+
+        @Override
+        public void toXContent(XContentBuilder builder) throws IOException {
+            builder.startObject(STREAM.getName());
+            if (script != null) {
+                builder.field("script", script);
+            }
+            if (lang != null) {
+                builder.field("lang", lang);
+            }
+            if (params != null) {
+                builder.field("params", params);
+            }
+            if (scriptType != null) {
+                builder.field("script_type", scriptType.getTypeName());
+            }
+            builder.endObject();
+        }
+
+        public ScriptHeuristicBuilder setType(ScriptService.ScriptType scriptType) {
+            this.scriptType = scriptType;
+            return this;
+        }
+    }
+}
+

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/ScriptHeuristic.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/ScriptHeuristic.java
@@ -166,9 +166,6 @@ public class ScriptHeuristic extends SignificanceHeuristic {
 
     public static class ScriptHeuristicBuilder implements SignificanceHeuristicBuilder {
 
-        public ScriptHeuristicBuilder() {
-        }
-
         private String script = null;
         private String lang = null;
         private Map<String, Object> params = null;

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/ScriptHeuristic.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/ScriptHeuristic.java
@@ -21,7 +21,6 @@
 package org.elasticsearch.search.aggregations.bucket.significant.heuristics;
 
 
-import org.elasticsearch.ElasticsearchIllegalStateException;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.inject.Inject;
@@ -105,7 +104,8 @@ public class ScriptHeuristic extends SignificanceHeuristic {
     @Override
     public double getScore(long subsetFreq, long subsetSize, long supersetFreq, long supersetSize) {
         if (script == null) {
-            throw new ElasticsearchIllegalStateException("Script in script_heuristic has not been initialized yet!");
+            ESLoggerFactory.getLogger("script heuristic").warn("cannot compute score - script has not been initialized yet. If this warning appears within an integration test test you can ignore it. If it appeared while running es or within a bwc test then there is a problem.");
+            return 0;
         }
         subsetSizeHolder.value = subsetSize;
         supersetSizeHolder.value = supersetSize;

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/ScriptHeuristic.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/ScriptHeuristic.java
@@ -21,6 +21,7 @@
 package org.elasticsearch.search.aggregations.bucket.significant.heuristics;
 
 
+import org.elasticsearch.ElasticsearchIllegalStateException;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.inject.Inject;
@@ -104,8 +105,7 @@ public class ScriptHeuristic extends SignificanceHeuristic {
     @Override
     public double getScore(long subsetFreq, long subsetSize, long supersetFreq, long supersetSize) {
         if (script == null) {
-            ESLoggerFactory.getLogger("script heuristic").warn("cannot compute score - script has not been initialized yet. If this warning appears within an integration test test you can ignore it. If it appeared while running es or within a bwc test then there is a problem.");
-            return 0;
+            throw new ElasticsearchIllegalStateException("Script in script_heuristic has not been initialized yet!");
         }
         subsetSizeHolder.value = subsetSize;
         supersetSizeHolder.value = supersetSize;

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/ScriptHeuristic.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/ScriptHeuristic.java
@@ -172,7 +172,7 @@ public class ScriptHeuristic extends SignificanceHeuristic {
             try {
                 searchScript = scriptService.executable(scriptLang, script, scriptType, params);
             } catch (Exception e) {
-                throw new ElasticsearchParseException("The script [" + script + "] could not be loaded");
+                throw new ElasticsearchParseException("The script [" + script + "] could not be loaded", e);
             }
             return new ScriptHeuristic(searchScript, scriptLang, script, scriptType, params);
         }
@@ -246,6 +246,11 @@ public class ScriptHeuristic extends SignificanceHeuristic {
         @Override
         public double doubleValue() {
             return (double)value;
+        }
+
+        @Override
+        public String toString() {
+            return Long.toString(value);
         }
     }
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/ScriptHeuristic.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/ScriptHeuristic.java
@@ -104,7 +104,11 @@ public class ScriptHeuristic extends SignificanceHeuristic {
     @Override
     public double getScore(long subsetFreq, long subsetSize, long supersetFreq, long supersetSize) {
         if (script == null) {
-            ESLoggerFactory.getLogger("script heuristic").warn("cannot compute score - script has not been initialized yet. If this warning appears within an integration test test you can ignore it. If it appeared while running es or within a bwc test then there is a problem.");
+            //In tests, wehn calling assertSearchResponse(..) the response is streamed one additional time with an arbitrary version, see assertVersionSerializable(..).
+            // Now, for version before 1.5.0 the score is computed after streaming the response but for scripts the script does not exists yet.
+            // assertSearchResponse() might therefore fail although there is no problem.
+            // This should be replaced by an exception in 2.0.
+            ESLoggerFactory.getLogger("script heuristic").warn("cannot compute score - script has not been initialized yet.");
             return 0;
         }
         subsetSizeHolder.value = subsetSize;

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/SignificanceHeuristic.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/SignificanceHeuristic.java
@@ -22,6 +22,7 @@ package org.elasticsearch.search.aggregations.bucket.significant.heuristics;
 
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.search.aggregations.InternalAggregation;
 
 import java.io.IOException;
 
@@ -47,5 +48,9 @@ public abstract class SignificanceHeuristic {
         if (supersetFreq > supersetSize) {
             throw new ElasticsearchIllegalArgumentException("supersetFreq > supersetSize, in JLHScore.score(..)");
         }
+    }
+
+    public void initialize(InternalAggregation.ReduceContext reduceContext) {
+
     }
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/SignificantTermsHeuristicModule.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/SignificantTermsHeuristicModule.java
@@ -32,10 +32,12 @@ public class SignificantTermsHeuristicModule extends AbstractModule {
     private List<Class<? extends SignificanceHeuristicParser>> parsers = Lists.newArrayList();
 
     public SignificantTermsHeuristicModule() {
+
         registerParser(JLHScore.JLHScoreParser.class);
         registerParser(MutualInformation.MutualInformationParser.class);
         registerParser(GND.GNDParser.class);
         registerParser(ChiSquare.ChiSquareParser.class);
+        registerParser(ScriptHeuristic.ScriptHeuristicParser.class);
     }
 
     public void registerParser(Class<? extends SignificanceHeuristicParser> parser) {

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/TransportSignificantTermsHeuristicModule.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/TransportSignificantTermsHeuristicModule.java
@@ -35,6 +35,7 @@ public class TransportSignificantTermsHeuristicModule extends AbstractModule {
         registerStream(MutualInformation.STREAM);
         registerStream(GND.STREAM);
         registerStream(ChiSquare.STREAM);
+        registerStream(ScriptHeuristic.STREAM);
     }
 
     public void registerStream(SignificanceHeuristicStreams.Stream stream) {

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/SignificantTermsSignificanceScoreTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/SignificantTermsSignificanceScoreTests.java
@@ -505,7 +505,7 @@ public class SignificantTermsSignificanceScoreTests extends ElasticsearchIntegra
         Map<String, Object> params = null;
         String script = null;
         String lang = null;
-        ScriptService.ScriptType scriptType = null;
+        String scriptId = null;
         if (randomBoolean()) {
             params = new HashMap<>();
             params.put("param", randomIntBetween(1, 100));
@@ -521,9 +521,6 @@ public class SignificantTermsSignificanceScoreTests extends ElasticsearchIntegra
                 } else {
                     script = "return param*(_subset_freq + _subset_size + _superset_freq + _superset_size)/param";
                 }
-                if (randomBoolean()) {
-                    scriptType = ScriptService.ScriptType.INLINE;
-                }
                 break;
             }
             case 1: {
@@ -537,8 +534,8 @@ public class SignificantTermsSignificanceScoreTests extends ElasticsearchIntegra
                                 .field("script", script)
                                 .endObject()).get();
                 refresh();
-                script = "my_script";
-                scriptType = ScriptService.ScriptType.INDEXED;
+                scriptId = "my_script";
+                script = null;
                 break;
             }
             case 2: {
@@ -547,7 +544,6 @@ public class SignificantTermsSignificanceScoreTests extends ElasticsearchIntegra
                 } else {
                     script = "significance_script_with_params";
                 }
-                scriptType = ScriptService.ScriptType.FILE;
                 break;
             }
             case 3: {
@@ -559,19 +555,12 @@ public class SignificantTermsSignificanceScoreTests extends ElasticsearchIntegra
                 }
                 lang = "native";
                 if (randomBoolean()) {
-                    scriptType = ScriptService.ScriptType.INLINE;
                 }
                 break;
             }
         }
-        ScriptHeuristic.ScriptHeuristicBuilder builder = new ScriptHeuristic.ScriptHeuristicBuilder().setScript(script).setLang(lang).setParams(params);
-        if (scriptType != null) {
-            if (randomBoolean()) {
-                builder.setType(scriptType);
-            } else {
-                builder.setType(scriptType.getTypeName());
-            }
-        }
+        ScriptHeuristic.ScriptHeuristicBuilder builder = new ScriptHeuristic.ScriptHeuristicBuilder().setScript(script).setLang(lang).setParams(params).setScriptId(scriptId);
+
         return builder;
     }
 

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/SignificantTermsSignificanceScoreTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/SignificantTermsSignificanceScoreTests.java
@@ -59,7 +59,6 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSear
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
 /**
@@ -482,9 +481,7 @@ public class SignificantTermsSignificanceScoreTests extends ElasticsearchIntegra
                         .minDocCount(1).shardSize(2).size(2)))
                 .execute()
                 .actionGet();
-        assertThat("Unexpected ShardFailures: " + Arrays.toString(response.getShardFailures()),
-                response.getShardFailures().length, equalTo(0));
-        assertThat("One or more shards were not successful but didn't trigger a failure", response.getSuccessfulShards(), equalTo(response.getTotalShards()));
+        assertSearchResponse(response);
         for (Terms.Bucket classBucket : ((Terms) response.getAggregations().get("class")).getBuckets()) {
             for (SignificantTerms.Bucket bucket : ((SignificantTerms) classBucket.getAggregations().get("mySignificantTerms")).getBuckets()) {
                 assertThat(bucket.getSignificanceScore(), is((double) bucket.getSubsetDf() + bucket.getSubsetSize() + bucket.getSupersetDf() + bucket.getSupersetSize()));

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/SignificantTermsSignificanceScoreTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/SignificantTermsSignificanceScoreTests.java
@@ -551,6 +551,7 @@ public class SignificantTermsSignificanceScoreTests extends ElasticsearchIntegra
                 break;
             }
             case 3: {
+                logger.info("NATIVE SCRIPT");
                 if (params == null) {
                     script = "native_significance_score_script_no_params";
                 } else {

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/script/NativeSignificanceScoreScriptNoParams.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/script/NativeSignificanceScoreScriptNoParams.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.bucket.script;
+
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.script.ExecutableScript;
+import org.elasticsearch.script.NativeScriptFactory;
+
+import java.util.Map;
+
+public class NativeSignificanceScoreScriptNoParams implements ExecutableScript {
+
+    public static final String NATIVE_SIGNIFICANCE_SCORE_SCRIPT_NO_PARAMS = "native_significance_score_script_no_params";
+    double _subset_freq = 0;
+    double _subset_size = 0;
+    double _superset_freq = 0;
+    double _superset_size = 0;
+
+    public static class Factory implements NativeScriptFactory {
+
+        @Override
+        public ExecutableScript newScript(@Nullable Map<String, Object> params) {
+            return new NativeSignificanceScoreScriptNoParams(params);
+        }
+    }
+
+    private NativeSignificanceScoreScriptNoParams(Map<String, Object> params) {
+    }
+
+    @Override
+    public void setNextVar(String name, Object value) {
+        if (name.equals("_subset_freq")) {
+            _subset_freq = unwrap(value);
+        }
+        if (name.equals("_subset_size")) {
+            _subset_size = unwrap(value);
+        }
+        if (name.equals("_superset_freq")) {
+            _superset_freq = unwrap(value);
+        }
+        if (name.equals("_superset_size")) {
+            _superset_size = unwrap(value);
+        }
+    }
+
+    @Override
+    public Object run() {
+        return _subset_freq + _subset_size + _superset_freq + _superset_size;
+    }
+
+    @Override
+    public Double unwrap(Object value) {
+        return ((Number) value).doubleValue();
+    }
+
+}

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/script/NativeSignificanceScoreScriptNoParams.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/script/NativeSignificanceScoreScriptNoParams.java
@@ -25,49 +25,23 @@ import org.elasticsearch.script.NativeScriptFactory;
 
 import java.util.Map;
 
-public class NativeSignificanceScoreScriptNoParams implements ExecutableScript {
+public class NativeSignificanceScoreScriptNoParams extends TestScript {
 
     public static final String NATIVE_SIGNIFICANCE_SCORE_SCRIPT_NO_PARAMS = "native_significance_score_script_no_params";
-    double _subset_freq = 0;
-    double _subset_size = 0;
-    double _superset_freq = 0;
-    double _superset_size = 0;
 
     public static class Factory implements NativeScriptFactory {
 
         @Override
         public ExecutableScript newScript(@Nullable Map<String, Object> params) {
-            return new NativeSignificanceScoreScriptNoParams(params);
+            return new NativeSignificanceScoreScriptNoParams();
         }
     }
 
-    private NativeSignificanceScoreScriptNoParams(Map<String, Object> params) {
-    }
-
-    @Override
-    public void setNextVar(String name, Object value) {
-        if (name.equals("_subset_freq")) {
-            _subset_freq = unwrap(value);
-        }
-        if (name.equals("_subset_size")) {
-            _subset_size = unwrap(value);
-        }
-        if (name.equals("_superset_freq")) {
-            _superset_freq = unwrap(value);
-        }
-        if (name.equals("_superset_size")) {
-            _superset_size = unwrap(value);
-        }
+    private NativeSignificanceScoreScriptNoParams() {
     }
 
     @Override
     public Object run() {
-        return _subset_freq + _subset_size + _superset_freq + _superset_size;
+        return _subset_freq.longValue() + _subset_size.longValue() + _superset_freq.longValue() + _superset_size.longValue();
     }
-
-    @Override
-    public Double unwrap(Object value) {
-        return ((Number) value).doubleValue();
-    }
-
 }

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/script/NativeSignificanceScoreScriptWithParams.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/script/NativeSignificanceScoreScriptWithParams.java
@@ -25,14 +25,10 @@ import org.elasticsearch.script.NativeScriptFactory;
 
 import java.util.Map;
 
-public class NativeSignificanceScoreScriptWithParams implements ExecutableScript {
+public class NativeSignificanceScoreScriptWithParams extends TestScript {
 
     public static final String NATIVE_SIGNIFICANCE_SCORE_SCRIPT_WITH_PARAMS = "native_significance_score_script_with_params";
     double factor = 0.0;
-    double _subset_freq = 0;
-    double _subset_size = 0;
-    double _superset_freq = 0;
-    double _superset_size = 0;
 
     public static class Factory implements NativeScriptFactory {
 
@@ -47,29 +43,8 @@ public class NativeSignificanceScoreScriptWithParams implements ExecutableScript
     }
 
     @Override
-    public void setNextVar(String name, Object value) {
-        if (name.equals("_subset_freq")) {
-            _subset_freq = unwrap(value);
-        }
-        if (name.equals("_subset_size")) {
-            _subset_size = unwrap(value);
-        }
-        if (name.equals("_superset_freq")) {
-            _superset_freq = unwrap(value);
-        }
-        if (name.equals("_superset_size")) {
-            _superset_size = unwrap(value);
-        }
-    }
-
-    @Override
     public Object run() {
-        return factor * (_subset_freq + _subset_size + _superset_freq + _superset_size) / factor;
-    }
-
-    @Override
-    public Double unwrap(Object value) {
-        return ((Number) value).doubleValue();
+        return factor * (_subset_freq.longValue() + _subset_size.longValue() + _superset_freq.longValue() + _superset_size.longValue()) / factor;
     }
 
 }

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/script/NativeSignificanceScoreScriptWithParams.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/script/NativeSignificanceScoreScriptWithParams.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.bucket.script;
+
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.script.ExecutableScript;
+import org.elasticsearch.script.NativeScriptFactory;
+
+import java.util.Map;
+
+public class NativeSignificanceScoreScriptWithParams implements ExecutableScript {
+
+    public static final String NATIVE_SIGNIFICANCE_SCORE_SCRIPT_WITH_PARAMS = "native_significance_score_script_with_params";
+    double factor = 0.0;
+    double _subset_freq = 0;
+    double _subset_size = 0;
+    double _superset_freq = 0;
+    double _superset_size = 0;
+
+    public static class Factory implements NativeScriptFactory {
+
+        @Override
+        public ExecutableScript newScript(@Nullable Map<String, Object> params) {
+            return new NativeSignificanceScoreScriptWithParams(params);
+        }
+    }
+
+    private NativeSignificanceScoreScriptWithParams(Map<String, Object> params) {
+        factor = ((Number) params.get("param")).doubleValue();
+    }
+
+    @Override
+    public void setNextVar(String name, Object value) {
+        if (name.equals("_subset_freq")) {
+            _subset_freq = unwrap(value);
+        }
+        if (name.equals("_subset_size")) {
+            _subset_size = unwrap(value);
+        }
+        if (name.equals("_superset_freq")) {
+            _superset_freq = unwrap(value);
+        }
+        if (name.equals("_superset_size")) {
+            _superset_size = unwrap(value);
+        }
+    }
+
+    @Override
+    public Object run() {
+        return factor * (_subset_freq + _subset_size + _superset_freq + _superset_size) / factor;
+    }
+
+    @Override
+    public Double unwrap(Object value) {
+        return ((Number) value).doubleValue();
+    }
+
+}

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/script/TestScript.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/script/TestScript.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.bucket.script;
+
+import org.elasticsearch.script.ExecutableScript;
+import org.elasticsearch.search.aggregations.bucket.significant.heuristics.ScriptHeuristic;
+
+public abstract class TestScript implements ExecutableScript{
+
+    ScriptHeuristic.LongAccessor _subset_freq;
+    ScriptHeuristic.LongAccessor _subset_size;
+    ScriptHeuristic.LongAccessor _superset_freq;
+    ScriptHeuristic.LongAccessor _superset_size;
+
+    protected TestScript() {
+    }
+
+    @Override
+    public void setNextVar(String name, Object value) {
+        if (name.equals("_subset_freq")) {
+            _subset_freq = (ScriptHeuristic.LongAccessor)value;
+        }
+        if (name.equals("_subset_size")) {
+            _subset_size = (ScriptHeuristic.LongAccessor)value;
+        }
+        if (name.equals("_superset_freq")) {
+            _superset_freq = (ScriptHeuristic.LongAccessor)value;
+        }
+        if (name.equals("_superset_size")) {
+            _superset_size = (ScriptHeuristic.LongAccessor)value;
+        }
+    }
+
+    @Override
+    public Double unwrap(Object value) {
+        return ((Number) value).doubleValue();
+    }
+}

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/significant/SignificanceHeuristicTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/significant/SignificanceHeuristicTests.java
@@ -70,6 +70,7 @@ public class SignificanceHeuristicTests extends ElasticsearchTestCase {
         SignificanceHeuristicStreams.registerStream(JLHScore.STREAM, JLHScore.STREAM.getName());
         SignificanceHeuristicStreams.registerStream(GND.STREAM, GND.STREAM.getName());
         SignificanceHeuristicStreams.registerStream(ChiSquare.STREAM, ChiSquare.STREAM.getName());
+        SignificanceHeuristicStreams.registerStream(ScriptHeuristic.STREAM, ScriptHeuristic.STREAM.getName());
         Version version = ElasticsearchIntegrationTest.randomVersion();
         InternalSignificantTerms[] sigTerms = getRandomSignificantTerms(getRandomSignificanceheuristic());
 

--- a/src/test/resources/org/elasticsearch/search/aggregations/bucket/config/scripts/significance_script_no_params.groovy
+++ b/src/test/resources/org/elasticsearch/search/aggregations/bucket/config/scripts/significance_script_no_params.groovy
@@ -1,0 +1,1 @@
+return _subset_freq + _subset_size + _superset_freq + _superset_size

--- a/src/test/resources/org/elasticsearch/search/aggregations/bucket/config/scripts/significance_script_with_params.groovy
+++ b/src/test/resources/org/elasticsearch/search/aggregations/bucket/config/scripts/significance_script_with_params.groovy
@@ -1,0 +1,1 @@
+return param*(_subset_freq + _subset_size + _superset_freq + _superset_size)/param


### PR DESCRIPTION
This commit adds scripting capability to significant_terms.
Custom heuristics can be implemented with a script that provides
parameters subset_freq, superset_freq,subset_size, superset_size.

Script heuristic and results have to be serialized. When deserializing the ScriptService is not available and the new score cannot be computed immediately after reading the result.
Therefore, instead of re-computing the score the score is serialized with each bucket. 
For the reduce phase the script is initialized before buckets are reduced (https://github.com/brwe/elasticsearch/compare/elasticsearch:master...brwe:significant-terms-scripting?expand=1#diff-ba5a615f489137f2b16d37bc54dd3f8dR174) which seems a little clumsy to me. Happy for any suggestion.
