### PR TITLE
Clarify when a shard search request gets created to be only used locally

### DIFF
--- a/src/main/java/org/elasticsearch/action/OriginalIndices.java
+++ b/src/main/java/org/elasticsearch/action/OriginalIndices.java
@@ -42,12 +42,12 @@ public class OriginalIndices implements IndicesRequest {
     }
 
     public OriginalIndices(IndicesRequest indicesRequest) {
-        this.indices = indicesRequest.indices();
-        this.indicesOptions = indicesRequest.indicesOptions();
+        this(indicesRequest.indices(), indicesRequest.indicesOptions());
     }
 
     public OriginalIndices(String[] indices, IndicesOptions indicesOptions) {
         this.indices = indices;
+        assert indicesOptions != null;
         this.indicesOptions = indicesOptions;
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/validate/query/TransportValidateQueryAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/validate/query/TransportValidateQueryAction.java
@@ -45,7 +45,7 @@ import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.internal.DefaultSearchContext;
 import org.elasticsearch.search.internal.SearchContext;
-import org.elasticsearch.search.internal.ShardSearchRequest;
+import org.elasticsearch.search.internal.ShardSearchLocalRequest;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
@@ -179,8 +179,7 @@ public class TransportValidateQueryAction extends TransportBroadcastOperationAct
         String error = null;
 
         DefaultSearchContext searchContext = new DefaultSearchContext(0,
-                new ShardSearchRequest(request).types(request.types()).nowInMillis(request.nowInMillis())
-                        .filteringAliases(request.filteringAliases()),
+                new ShardSearchLocalRequest(request.types(), request.nowInMillis(), request.filteringAliases()),
                 null, indexShard.acquireSearcher("validate_query"), indexService, indexShard,
                 scriptService, cacheRecycler, pageCacheRecycler, bigArrays, threadPool.estimatedTimeInMillisCounter()
         );

--- a/src/main/java/org/elasticsearch/action/count/TransportCountAction.java
+++ b/src/main/java/org/elasticsearch/action/count/TransportCountAction.java
@@ -47,7 +47,7 @@ import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.search.internal.DefaultSearchContext;
 import org.elasticsearch.search.internal.SearchContext;
-import org.elasticsearch.search.internal.ShardSearchRequest;
+import org.elasticsearch.search.internal.ShardSearchLocalRequest;
 import org.elasticsearch.search.query.QueryPhaseExecutionException;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -170,9 +170,7 @@ public class TransportCountAction extends TransportBroadcastOperationAction<Coun
 
         SearchShardTarget shardTarget = new SearchShardTarget(clusterService.localNode().id(), request.shardId().getIndex(), request.shardId().id());
         SearchContext context = new DefaultSearchContext(0,
-                new ShardSearchRequest(request).types(request.types())
-                        .filteringAliases(request.filteringAliases())
-                        .nowInMillis(request.nowInMillis()),
+                new ShardSearchLocalRequest(request.types(), request.nowInMillis(), request.filteringAliases()),
                 shardTarget, indexShard.acquireSearcher("count"), indexService, indexShard,
                 scriptService, cacheRecycler, pageCacheRecycler, bigArrays, threadPool.estimatedTimeInMillisCounter());
         SearchContext.setCurrent(context);

--- a/src/main/java/org/elasticsearch/action/deletebyquery/TransportShardDeleteByQueryAction.java
+++ b/src/main/java/org/elasticsearch/action/deletebyquery/TransportShardDeleteByQueryAction.java
@@ -42,7 +42,7 @@ import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.internal.DefaultSearchContext;
 import org.elasticsearch.search.internal.SearchContext;
-import org.elasticsearch.search.internal.ShardSearchRequest;
+import org.elasticsearch.search.internal.ShardSearchLocalRequest;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
@@ -108,7 +108,7 @@ public class TransportShardDeleteByQueryAction extends TransportShardReplication
         IndexService indexService = indicesService.indexServiceSafe(shardRequest.shardId.getIndex());
         IndexShard indexShard = indexService.shardSafe(shardRequest.shardId.id());
 
-        SearchContext.setCurrent(new DefaultSearchContext(0, new ShardSearchRequest(shardRequest.request).types(request.types()).nowInMillis(request.nowInMillis()), null,
+        SearchContext.setCurrent(new DefaultSearchContext(0, new ShardSearchLocalRequest(request.types(), request.nowInMillis()), null,
                 indexShard.acquireSearcher(DELETE_BY_QUERY_API), indexService, indexShard, scriptService, cacheRecycler,
                 pageCacheRecycler, bigArrays, threadPool.estimatedTimeInMillisCounter()));
         try {
@@ -130,7 +130,7 @@ public class TransportShardDeleteByQueryAction extends TransportShardReplication
         IndexService indexService = indicesService.indexServiceSafe(shardRequest.shardId.getIndex());
         IndexShard indexShard = indexService.shardSafe(shardRequest.shardId.id());
 
-        SearchContext.setCurrent(new DefaultSearchContext(0, new ShardSearchRequest(shardRequest).types(request.types()).nowInMillis(request.nowInMillis()), null,
+        SearchContext.setCurrent(new DefaultSearchContext(0, new ShardSearchLocalRequest(request.types(), request.nowInMillis()), null,
                 indexShard.acquireSearcher(DELETE_BY_QUERY_API, IndexShard.Mode.WRITE), indexService, indexShard, scriptService,
                 cacheRecycler, pageCacheRecycler, bigArrays, threadPool.estimatedTimeInMillisCounter()));
         try {

--- a/src/main/java/org/elasticsearch/action/exists/TransportExistsAction.java
+++ b/src/main/java/org/elasticsearch/action/exists/TransportExistsAction.java
@@ -49,7 +49,7 @@ import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.search.internal.DefaultSearchContext;
 import org.elasticsearch.search.internal.SearchContext;
-import org.elasticsearch.search.internal.ShardSearchRequest;
+import org.elasticsearch.search.internal.ShardSearchLocalRequest;
 import org.elasticsearch.search.query.QueryPhaseExecutionException;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -171,9 +171,7 @@ public class TransportExistsAction extends TransportBroadcastOperationAction<Exi
 
         SearchShardTarget shardTarget = new SearchShardTarget(clusterService.localNode().id(), request.shardId().getIndex(), request.shardId().id());
         SearchContext context = new DefaultSearchContext(0,
-                new ShardSearchRequest(request).types(request.types())
-                        .filteringAliases(request.filteringAliases())
-                        .nowInMillis(request.nowInMillis()),
+                new ShardSearchLocalRequest(request.types(), request.nowInMillis(), request.filteringAliases()),
                 shardTarget, indexShard.acquireSearcher("exists"), indexService, indexShard,
                 scriptService, cacheRecycler, pageCacheRecycler, bigArrays, threadPool.estimatedTimeInMillisCounter());
         SearchContext.setCurrent(context);

--- a/src/main/java/org/elasticsearch/action/explain/TransportExplainAction.java
+++ b/src/main/java/org/elasticsearch/action/explain/TransportExplainAction.java
@@ -45,7 +45,7 @@ import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.internal.DefaultSearchContext;
 import org.elasticsearch.search.internal.SearchContext;
-import org.elasticsearch.search.internal.ShardSearchRequest;
+import org.elasticsearch.search.internal.ShardSearchLocalRequest;
 import org.elasticsearch.search.rescore.RescoreSearchContext;
 import org.elasticsearch.search.rescore.Rescorer;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -117,10 +117,7 @@ public class TransportExplainAction extends TransportShardSingleOperationAction<
         }
 
         SearchContext context = new DefaultSearchContext(
-                0,
-                new ShardSearchRequest(request).types(new String[]{request.type()})
-                        .filteringAliases(request.filteringAlias())
-                        .nowInMillis(request.nowInMillis),
+                0, new ShardSearchLocalRequest(new String[]{request.type()}, request.nowInMillis, request.filteringAlias()),
                 null, result.searcher(), indexService, indexShard,
                 scriptService, cacheRecycler, pageCacheRecycler,
                 bigArrays, threadPool.estimatedTimeInMillisCounter()

--- a/src/main/java/org/elasticsearch/action/search/type/TransportSearchCountAction.java
+++ b/src/main/java/org/elasticsearch/action/search/type/TransportSearchCountAction.java
@@ -33,8 +33,7 @@ import org.elasticsearch.search.action.SearchServiceTransportAction;
 import org.elasticsearch.search.controller.SearchPhaseController;
 import org.elasticsearch.search.fetch.FetchSearchResultProvider;
 import org.elasticsearch.search.internal.InternalSearchResponse;
-import org.elasticsearch.search.internal.ShardSearchRequest;
-import org.elasticsearch.search.query.QuerySearchResult;
+import org.elasticsearch.search.internal.ShardSearchTransportRequest;
 import org.elasticsearch.search.query.QuerySearchResultProvider;
 import org.elasticsearch.threadpool.ThreadPool;
 
@@ -68,7 +67,7 @@ public class TransportSearchCountAction extends TransportSearchTypeAction {
         }
 
         @Override
-        protected void sendExecuteFirstPhase(DiscoveryNode node, ShardSearchRequest request, SearchServiceListener<QuerySearchResultProvider> listener) {
+        protected void sendExecuteFirstPhase(DiscoveryNode node, ShardSearchTransportRequest request, SearchServiceListener<QuerySearchResultProvider> listener) {
             searchService.sendExecuteQuery(node, request, listener);
         }
 

--- a/src/main/java/org/elasticsearch/action/search/type/TransportSearchDfsQueryAndFetchAction.java
+++ b/src/main/java/org/elasticsearch/action/search/type/TransportSearchDfsQueryAndFetchAction.java
@@ -30,7 +30,6 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.AtomicArray;
-import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.search.action.SearchServiceListener;
 import org.elasticsearch.search.action.SearchServiceTransportAction;
 import org.elasticsearch.search.controller.SearchPhaseController;
@@ -38,7 +37,7 @@ import org.elasticsearch.search.dfs.AggregatedDfs;
 import org.elasticsearch.search.dfs.DfsSearchResult;
 import org.elasticsearch.search.fetch.QueryFetchSearchResult;
 import org.elasticsearch.search.internal.InternalSearchResponse;
-import org.elasticsearch.search.internal.ShardSearchRequest;
+import org.elasticsearch.search.internal.ShardSearchTransportRequest;
 import org.elasticsearch.search.query.QuerySearchRequest;
 import org.elasticsearch.threadpool.ThreadPool;
 
@@ -76,7 +75,7 @@ public class TransportSearchDfsQueryAndFetchAction extends TransportSearchTypeAc
         }
 
         @Override
-        protected void sendExecuteFirstPhase(DiscoveryNode node, ShardSearchRequest request, SearchServiceListener<DfsSearchResult> listener) {
+        protected void sendExecuteFirstPhase(DiscoveryNode node, ShardSearchTransportRequest request, SearchServiceListener<DfsSearchResult> listener) {
             searchService.sendExecuteDfs(node, request, listener);
         }
 

--- a/src/main/java/org/elasticsearch/action/search/type/TransportSearchDfsQueryThenFetchAction.java
+++ b/src/main/java/org/elasticsearch/action/search/type/TransportSearchDfsQueryThenFetchAction.java
@@ -42,7 +42,7 @@ import org.elasticsearch.search.dfs.DfsSearchResult;
 import org.elasticsearch.search.fetch.ShardFetchSearchRequest;
 import org.elasticsearch.search.fetch.FetchSearchResult;
 import org.elasticsearch.search.internal.InternalSearchResponse;
-import org.elasticsearch.search.internal.ShardSearchRequest;
+import org.elasticsearch.search.internal.ShardSearchTransportRequest;
 import org.elasticsearch.search.query.QuerySearchRequest;
 import org.elasticsearch.search.query.QuerySearchResult;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -85,7 +85,7 @@ public class TransportSearchDfsQueryThenFetchAction extends TransportSearchTypeA
         }
 
         @Override
-        protected void sendExecuteFirstPhase(DiscoveryNode node, ShardSearchRequest request, SearchServiceListener<DfsSearchResult> listener) {
+        protected void sendExecuteFirstPhase(DiscoveryNode node, ShardSearchTransportRequest request, SearchServiceListener<DfsSearchResult> listener) {
             searchService.sendExecuteDfs(node, request, listener);
         }
 

--- a/src/main/java/org/elasticsearch/action/search/type/TransportSearchHelper.java
+++ b/src/main/java/org/elasticsearch/action/search/type/TransportSearchHelper.java
@@ -36,7 +36,7 @@ import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.util.concurrent.AtomicArray;
 import org.elasticsearch.search.SearchPhaseResult;
 import org.elasticsearch.search.internal.InternalScrollSearchRequest;
-import org.elasticsearch.search.internal.ShardSearchRequest;
+import org.elasticsearch.search.internal.ShardSearchTransportRequest;
 
 import java.io.IOException;
 import java.util.Map;
@@ -46,11 +46,8 @@ import java.util.Map;
  */
 public abstract class TransportSearchHelper {
 
-    public static ShardSearchRequest internalSearchRequest(ShardRouting shardRouting, int numberOfShards, SearchRequest request, String[] filteringAliases, long nowInMillis, boolean useSlowScroll) {
-        ShardSearchRequest shardRequest = new ShardSearchRequest(request, shardRouting, numberOfShards, useSlowScroll);
-        shardRequest.filteringAliases(filteringAliases);
-        shardRequest.nowInMillis(nowInMillis);
-        return shardRequest;
+    public static ShardSearchTransportRequest internalSearchRequest(ShardRouting shardRouting, int numberOfShards, SearchRequest request, String[] filteringAliases, long nowInMillis, boolean useSlowScroll) {
+        return new ShardSearchTransportRequest(request, shardRouting, numberOfShards, useSlowScroll, filteringAliases, nowInMillis);
     }
 
     public static InternalScrollSearchRequest internalScrollSearchRequest(long id, SearchScrollRequest request) {

--- a/src/main/java/org/elasticsearch/action/search/type/TransportSearchQueryAndFetchAction.java
+++ b/src/main/java/org/elasticsearch/action/search/type/TransportSearchQueryAndFetchAction.java
@@ -29,13 +29,12 @@ import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.search.action.SearchServiceListener;
 import org.elasticsearch.search.action.SearchServiceTransportAction;
 import org.elasticsearch.search.controller.SearchPhaseController;
 import org.elasticsearch.search.fetch.QueryFetchSearchResult;
 import org.elasticsearch.search.internal.InternalSearchResponse;
-import org.elasticsearch.search.internal.ShardSearchRequest;
+import org.elasticsearch.search.internal.ShardSearchTransportRequest;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import java.io.IOException;
@@ -70,7 +69,7 @@ public class TransportSearchQueryAndFetchAction extends TransportSearchTypeActio
         }
 
         @Override
-        protected void sendExecuteFirstPhase(DiscoveryNode node, ShardSearchRequest request, SearchServiceListener<QueryFetchSearchResult> listener) {
+        protected void sendExecuteFirstPhase(DiscoveryNode node, ShardSearchTransportRequest request, SearchServiceListener<QueryFetchSearchResult> listener) {
             searchService.sendExecuteFetch(node, request, listener);
         }
 

--- a/src/main/java/org/elasticsearch/action/search/type/TransportSearchQueryThenFetchAction.java
+++ b/src/main/java/org/elasticsearch/action/search/type/TransportSearchQueryThenFetchAction.java
@@ -39,7 +39,7 @@ import org.elasticsearch.search.controller.SearchPhaseController;
 import org.elasticsearch.search.fetch.ShardFetchSearchRequest;
 import org.elasticsearch.search.fetch.FetchSearchResult;
 import org.elasticsearch.search.internal.InternalSearchResponse;
-import org.elasticsearch.search.internal.ShardSearchRequest;
+import org.elasticsearch.search.internal.ShardSearchTransportRequest;
 import org.elasticsearch.search.query.QuerySearchResultProvider;
 import org.elasticsearch.threadpool.ThreadPool;
 
@@ -79,7 +79,7 @@ public class TransportSearchQueryThenFetchAction extends TransportSearchTypeActi
         }
 
         @Override
-        protected void sendExecuteFirstPhase(DiscoveryNode node, ShardSearchRequest request, SearchServiceListener<QuerySearchResultProvider> listener) {
+        protected void sendExecuteFirstPhase(DiscoveryNode node, ShardSearchTransportRequest request, SearchServiceListener<QuerySearchResultProvider> listener) {
             searchService.sendExecuteQuery(node, request, listener);
         }
 

--- a/src/main/java/org/elasticsearch/action/search/type/TransportSearchScanAction.java
+++ b/src/main/java/org/elasticsearch/action/search/type/TransportSearchScanAction.java
@@ -34,7 +34,7 @@ import org.elasticsearch.search.action.SearchServiceTransportAction;
 import org.elasticsearch.search.controller.SearchPhaseController;
 import org.elasticsearch.search.fetch.FetchSearchResultProvider;
 import org.elasticsearch.search.internal.InternalSearchResponse;
-import org.elasticsearch.search.internal.ShardSearchRequest;
+import org.elasticsearch.search.internal.ShardSearchTransportRequest;
 import org.elasticsearch.search.query.QuerySearchResult;
 import org.elasticsearch.threadpool.ThreadPool;
 
@@ -65,7 +65,7 @@ public class TransportSearchScanAction extends TransportSearchTypeAction {
         }
 
         @Override
-        protected void sendExecuteFirstPhase(DiscoveryNode node, ShardSearchRequest request, SearchServiceListener<QuerySearchResult> listener) {
+        protected void sendExecuteFirstPhase(DiscoveryNode node, ShardSearchTransportRequest request, SearchServiceListener<QuerySearchResult> listener) {
             searchService.sendExecuteScan(node, request, listener);
         }
 

--- a/src/main/java/org/elasticsearch/action/search/type/TransportSearchScrollQueryAndFetchAction.java
+++ b/src/main/java/org/elasticsearch/action/search/type/TransportSearchScrollQueryAndFetchAction.java
@@ -149,7 +149,6 @@ public class TransportSearchScrollQueryAndFetchAction extends AbstractComponent 
                     if (counter.decrementAndGet() == 0) {
                         finishHim();
                     }
-                } else {
                 }
             }
         }

--- a/src/main/java/org/elasticsearch/action/search/type/TransportSearchTypeAction.java
+++ b/src/main/java/org/elasticsearch/action/search/type/TransportSearchTypeAction.java
@@ -46,7 +46,7 @@ import org.elasticsearch.search.action.SearchServiceTransportAction;
 import org.elasticsearch.search.controller.SearchPhaseController;
 import org.elasticsearch.search.fetch.ShardFetchSearchRequest;
 import org.elasticsearch.search.internal.InternalSearchResponse;
-import org.elasticsearch.search.internal.ShardSearchRequest;
+import org.elasticsearch.search.internal.ShardSearchTransportRequest;
 import org.elasticsearch.search.query.QuerySearchResult;
 import org.elasticsearch.search.query.QuerySearchResultProvider;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -357,7 +357,7 @@ public abstract class TransportSearchTypeAction extends TransportAction<SearchRe
             }
         }
 
-        protected abstract void sendExecuteFirstPhase(DiscoveryNode node, ShardSearchRequest request, SearchServiceListener<FirstResult> listener);
+        protected abstract void sendExecuteFirstPhase(DiscoveryNode node, ShardSearchTransportRequest request, SearchServiceListener<FirstResult> listener);
 
         protected final void processFirstPhaseResult(int shardIndex, ShardRouting shard, FirstResult result) {
             firstResults.set(shardIndex, result);

--- a/src/main/java/org/elasticsearch/indices/cache/query/IndicesQueryCache.java
+++ b/src/main/java/org/elasticsearch/indices/cache/query/IndicesQueryCache.java
@@ -415,13 +415,9 @@ public class IndicesQueryCache extends AbstractComponent implements RemovalListe
     private static Key buildKey(ShardSearchRequest request, SearchContext context) throws Exception {
         // TODO: for now, this will create different keys for different JSON order
         // TODO: tricky to get around this, need to parse and order all, which can be expensive
-        BytesStreamOutput out = new BytesStreamOutput();
-        request.writeTo(out, true);
-        // copy it over, most requests are small, we might as well copy to make sure we are not sliced...
-        // we could potentially keep it without copying, but then pay the price of extra unused bytes up to a page
         return new Key(context.indexShard(),
                 ((DirectoryReader) context.searcher().getIndexReader()).getVersion(),
-                out.bytes().copyBytesArray());
+                request.cacheKey());
     }
 
     /**

--- a/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/src/main/java/org/elasticsearch/search/SearchService.java
@@ -947,11 +947,8 @@ public class SearchService extends AbstractLifecycleComponent<SearchService> {
                         SearchContext context = null;
                         try {
                             long now = System.nanoTime();
-                            ShardSearchRequest request = new ShardSearchRequest(indexShard.shardId().index().name(), indexShard.shardId().id(), indexMetaData.numberOfShards(),
-                                    SearchType.QUERY_THEN_FETCH)
-                                    .source(entry.source())
-                                    .types(entry.types())
-                                    .queryCache(entry.queryCache());
+                            ShardSearchRequest request = new ShardSearchLocalRequest(indexShard.shardId(), indexMetaData.numberOfShards(),
+                                    SearchType.QUERY_THEN_FETCH, entry.source(), entry.types(), entry.queryCache());
                             context = createContext(request, warmerContext.searcher());
                             // if we use sort, we need to do query to sort on it and load relevant field data
                             // if not, we might as well use COUNT (and cache if needed)

--- a/src/main/java/org/elasticsearch/search/action/SearchServiceTransportAction.java
+++ b/src/main/java/org/elasticsearch/search/action/SearchServiceTransportAction.java
@@ -37,7 +37,7 @@ import org.elasticsearch.search.SearchService;
 import org.elasticsearch.search.dfs.DfsSearchResult;
 import org.elasticsearch.search.fetch.*;
 import org.elasticsearch.search.internal.InternalScrollSearchRequest;
-import org.elasticsearch.search.internal.ShardSearchRequest;
+import org.elasticsearch.search.internal.ShardSearchTransportRequest;
 import org.elasticsearch.search.query.QuerySearchRequest;
 import org.elasticsearch.search.query.QuerySearchResult;
 import org.elasticsearch.search.query.QuerySearchResultProvider;
@@ -189,7 +189,7 @@ public class SearchServiceTransportAction extends AbstractComponent {
         }
     }
 
-    public void sendExecuteDfs(DiscoveryNode node, final ShardSearchRequest request, final SearchServiceListener<DfsSearchResult> listener) {
+    public void sendExecuteDfs(DiscoveryNode node, final ShardSearchTransportRequest request, final SearchServiceListener<DfsSearchResult> listener) {
         if (clusterService.state().nodes().localNodeId().equals(node.id())) {
             execute(new Callable<DfsSearchResult>() {
                 @Override
@@ -223,7 +223,7 @@ public class SearchServiceTransportAction extends AbstractComponent {
         }
     }
 
-    public void sendExecuteQuery(DiscoveryNode node, final ShardSearchRequest request, final SearchServiceListener<QuerySearchResultProvider> listener) {
+    public void sendExecuteQuery(DiscoveryNode node, final ShardSearchTransportRequest request, final SearchServiceListener<QuerySearchResultProvider> listener) {
         if (clusterService.state().nodes().localNodeId().equals(node.id())) {
             execute(new Callable<QuerySearchResultProvider>() {
                 @Override
@@ -325,7 +325,7 @@ public class SearchServiceTransportAction extends AbstractComponent {
         }
     }
 
-    public void sendExecuteFetch(DiscoveryNode node, final ShardSearchRequest request, final SearchServiceListener<QueryFetchSearchResult> listener) {
+    public void sendExecuteFetch(DiscoveryNode node, final ShardSearchTransportRequest request, final SearchServiceListener<QueryFetchSearchResult> listener) {
         if (clusterService.state().nodes().localNodeId().equals(node.id())) {
             execute(new Callable<QueryFetchSearchResult>() {
                 @Override
@@ -478,7 +478,7 @@ public class SearchServiceTransportAction extends AbstractComponent {
         }
     }
 
-    public void sendExecuteScan(DiscoveryNode node, final ShardSearchRequest request, final SearchServiceListener<QuerySearchResult> listener) {
+    public void sendExecuteScan(DiscoveryNode node, final ShardSearchTransportRequest request, final SearchServiceListener<QuerySearchResult> listener) {
         if (clusterService.state().nodes().localNodeId().equals(node.id())) {
             execute(new Callable<QuerySearchResult>() {
                 @Override
@@ -745,15 +745,15 @@ public class SearchServiceTransportAction extends AbstractComponent {
         }
     }
 
-    private class SearchDfsTransportHandler extends BaseTransportRequestHandler<ShardSearchRequest> {
+    private class SearchDfsTransportHandler extends BaseTransportRequestHandler<ShardSearchTransportRequest> {
 
         @Override
-        public ShardSearchRequest newInstance() {
-            return new ShardSearchRequest();
+        public ShardSearchTransportRequest newInstance() {
+            return new ShardSearchTransportRequest();
         }
 
         @Override
-        public void messageReceived(ShardSearchRequest request, TransportChannel channel) throws Exception {
+        public void messageReceived(ShardSearchTransportRequest request, TransportChannel channel) throws Exception {
             DfsSearchResult result = searchService.executeDfsPhase(request);
             channel.sendResponse(result);
         }
@@ -764,15 +764,15 @@ public class SearchServiceTransportAction extends AbstractComponent {
         }
     }
 
-    private class SearchQueryTransportHandler extends BaseTransportRequestHandler<ShardSearchRequest> {
+    private class SearchQueryTransportHandler extends BaseTransportRequestHandler<ShardSearchTransportRequest> {
 
         @Override
-        public ShardSearchRequest newInstance() {
-            return new ShardSearchRequest();
+        public ShardSearchTransportRequest newInstance() {
+            return new ShardSearchTransportRequest();
         }
 
         @Override
-        public void messageReceived(ShardSearchRequest request, TransportChannel channel) throws Exception {
+        public void messageReceived(ShardSearchTransportRequest request, TransportChannel channel) throws Exception {
             QuerySearchResultProvider result = searchService.executeQueryPhase(request);
             channel.sendResponse(result);
         }
@@ -821,15 +821,15 @@ public class SearchServiceTransportAction extends AbstractComponent {
         }
     }
 
-    private class SearchQueryFetchTransportHandler extends BaseTransportRequestHandler<ShardSearchRequest> {
+    private class SearchQueryFetchTransportHandler extends BaseTransportRequestHandler<ShardSearchTransportRequest> {
 
         @Override
-        public ShardSearchRequest newInstance() {
-            return new ShardSearchRequest();
+        public ShardSearchTransportRequest newInstance() {
+            return new ShardSearchTransportRequest();
         }
 
         @Override
-        public void messageReceived(ShardSearchRequest request, TransportChannel channel) throws Exception {
+        public void messageReceived(ShardSearchTransportRequest request, TransportChannel channel) throws Exception {
             QueryFetchSearchResult result = searchService.executeFetchPhase(request);
             channel.sendResponse(result);
         }
@@ -908,15 +908,15 @@ public class SearchServiceTransportAction extends AbstractComponent {
         }
     }
 
-    private class SearchScanTransportHandler extends BaseTransportRequestHandler<ShardSearchRequest> {
+    private class SearchScanTransportHandler extends BaseTransportRequestHandler<ShardSearchTransportRequest> {
 
         @Override
-        public ShardSearchRequest newInstance() {
-            return new ShardSearchRequest();
+        public ShardSearchTransportRequest newInstance() {
+            return new ShardSearchTransportRequest();
         }
 
         @Override
-        public void messageReceived(ShardSearchRequest request, TransportChannel channel) throws Exception {
+        public void messageReceived(ShardSearchTransportRequest request, TransportChannel channel) throws Exception {
             QuerySearchResult result = searchService.executeScan(request);
             channel.sendResponse(result);
         }

--- a/src/main/java/org/elasticsearch/search/internal/InternalScrollSearchRequest.java
+++ b/src/main/java/org/elasticsearch/search/internal/InternalScrollSearchRequest.java
@@ -47,10 +47,6 @@ public class InternalScrollSearchRequest extends TransportRequest {
         this.scroll = request.scroll();
     }
 
-    public InternalScrollSearchRequest(long id) {
-        this.id = id;
-    }
-
     public long id() {
         return id;
     }

--- a/src/main/java/org/elasticsearch/search/internal/ShardSearchLocalRequest.java
+++ b/src/main/java/org/elasticsearch/search/internal/ShardSearchLocalRequest.java
@@ -1,0 +1,304 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.internal;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchType;
+import org.elasticsearch.action.search.type.ParsedScrollId;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.search.Scroll;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.elasticsearch.search.Scroll.readScroll;
+
+/**
+ * Shard level search request that gets created and consumed on the local node.
+ * Used by warmers and by api that need to create a search context within their execution.
+ *
+ * Source structure:
+ * <p/>
+ * <pre>
+ * {
+ *  from : 0, size : 20, (optional, can be set on the request)
+ *  sort : { "name.first" : {}, "name.last" : { reverse : true } }
+ *  fields : [ "name.first", "name.last" ]
+ *  query : { ... }
+ *  facets : {
+ *      "facet1" : {
+ *          query : { ... }
+ *      }
+ *  }
+ * }
+ * </pre>
+ */
+public class ShardSearchLocalRequest implements ShardSearchRequest {
+
+    private String index;
+
+    private int shardId;
+
+    private int numberOfShards;
+
+    private SearchType searchType;
+
+    private Scroll scroll;
+
+    private String[] types = Strings.EMPTY_ARRAY;
+
+    private String[] filteringAliases;
+
+    private BytesReference source;
+    private BytesReference extraSource;
+    private BytesReference templateSource;
+    private String templateName;
+    private ScriptService.ScriptType templateType;
+    private Map<String, String> templateParams;
+    private Boolean queryCache;
+
+    private long nowInMillis;
+
+    private boolean useSlowScroll;
+
+    ShardSearchLocalRequest() {
+    }
+
+    ShardSearchLocalRequest(SearchRequest searchRequest, ShardRouting shardRouting, int numberOfShards,
+                            boolean useSlowScroll, String[] filteringAliases, long nowInMillis) {
+        this(shardRouting.shardId(), numberOfShards, searchRequest.searchType(),
+                searchRequest.source(), searchRequest.types(), searchRequest.queryCache());
+
+        this.extraSource = searchRequest.extraSource();
+        this.templateSource = searchRequest.templateSource();
+        this.templateName = searchRequest.templateName();
+        this.templateType = searchRequest.templateType();
+        this.templateParams = searchRequest.templateParams();
+        this.scroll = searchRequest.scroll();
+        this.useSlowScroll = useSlowScroll;
+        this.filteringAliases = filteringAliases;
+        this.nowInMillis = nowInMillis;
+    }
+
+    public ShardSearchLocalRequest(String[] types, long nowInMillis) {
+        this.types = types;
+        this.nowInMillis = nowInMillis;
+    }
+
+    public ShardSearchLocalRequest(String[] types, long nowInMillis, String[] filteringAliases) {
+        this(types, nowInMillis);
+        this.filteringAliases = filteringAliases;
+    }
+
+    public ShardSearchLocalRequest(ShardId shardId, int numberOfShards, SearchType searchType,
+                                   BytesReference source, String[] types, Boolean queryCache) {
+        this.index = shardId.getIndex();
+        this.shardId = shardId.id();
+        this.numberOfShards = numberOfShards;
+        this.searchType = searchType;
+        this.source = source;
+        this.types = types;
+        this.queryCache = queryCache;
+    }
+
+    @Override
+    public String index() {
+        return index;
+    }
+
+    @Override
+    public int shardId() {
+        return shardId;
+    }
+
+    @Override
+    public String[] types() {
+        return types;
+    }
+
+    @Override
+    public BytesReference source() {
+        return source;
+    }
+
+    @Override
+    public void source(BytesReference source) {
+        this.source = source;
+    }
+
+    @Override
+    public BytesReference extraSource() {
+        return extraSource;
+    }
+
+    @Override
+    public int numberOfShards() {
+        return numberOfShards;
+    }
+
+    @Override
+    public SearchType searchType() {
+        return searchType;
+    }
+
+    @Override
+    public String[] filteringAliases() {
+        return filteringAliases;
+    }
+
+    @Override
+    public long nowInMillis() {
+        return nowInMillis;
+    }
+
+    @Override
+    public String templateName() {
+        return templateName;
+    }
+
+    @Override
+    public ScriptService.ScriptType templateType() {
+        return templateType;
+    }
+
+    @Override
+    public Map<String, String> templateParams() {
+        return templateParams;
+    }
+
+    @Override
+    public BytesReference templateSource() {
+        return templateSource;
+    }
+
+    @Override
+    public Boolean queryCache() {
+        return queryCache;
+    }
+
+    @Override
+    public Scroll scroll() {
+        return scroll;
+    }
+
+    @Override
+    public boolean useSlowScroll() {
+        return useSlowScroll;
+    }
+
+    @SuppressWarnings("unchecked")
+    protected void innerReadFrom(StreamInput in) throws IOException {
+        index = in.readString();
+        shardId = in.readVInt();
+        searchType = SearchType.fromId(in.readByte());
+        numberOfShards = in.readVInt();
+        if (in.readBoolean()) {
+            scroll = readScroll(in);
+        }
+
+        source = in.readBytesReference();
+        extraSource = in.readBytesReference();
+
+        types = in.readStringArray();
+        filteringAliases = in.readStringArray();
+        nowInMillis = in.readVLong();
+
+        if (in.getVersion().onOrAfter(Version.V_1_1_0)) {
+            templateSource = in.readBytesReference();
+            templateName = in.readOptionalString();
+            if (in.getVersion().onOrAfter(Version.V_1_3_0)) {
+                templateType = ScriptService.ScriptType.readFrom(in);
+            }
+            if (in.readBoolean()) {
+                templateParams = (Map<String, String>) in.readGenericValue();
+            }
+        }
+        if (in.getVersion().onOrAfter(ParsedScrollId.SCROLL_SEARCH_AFTER_MINIMUM_VERSION)) {
+            useSlowScroll = in.readBoolean();
+        } else {
+            // This means that this request was send from a 1.0.x or 1.1.x node and we need to fallback to slow scroll.
+            useSlowScroll = in.getVersion().before(ParsedScrollId.SCROLL_SEARCH_AFTER_MINIMUM_VERSION);
+        }
+
+        if (in.getVersion().onOrAfter(Version.V_1_4_0_Beta1)) {
+            queryCache = in.readOptionalBoolean();
+        }
+    }
+
+    protected void innerWriteTo(StreamOutput out, boolean asKey) throws IOException {
+        out.writeString(index);
+        out.writeVInt(shardId);
+        out.writeByte(searchType.id());
+        if (!asKey) {
+            out.writeVInt(numberOfShards);
+        }
+        if (scroll == null) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            scroll.writeTo(out);
+        }
+        out.writeBytesReference(source);
+        out.writeBytesReference(extraSource);
+        out.writeStringArray(types);
+        out.writeStringArrayNullable(filteringAliases);
+        if (!asKey) {
+            out.writeVLong(nowInMillis);
+        }
+
+        if (out.getVersion().onOrAfter(Version.V_1_1_0)) {
+            out.writeBytesReference(templateSource);
+            out.writeOptionalString(templateName);
+            if (out.getVersion().onOrAfter(Version.V_1_3_0)) {
+                ScriptService.ScriptType.writeTo(templateType, out);
+            }
+            boolean existTemplateParams = templateParams != null;
+            out.writeBoolean(existTemplateParams);
+            if (existTemplateParams) {
+                out.writeGenericValue(templateParams);
+            }
+        }
+        if (out.getVersion().onOrAfter(ParsedScrollId.SCROLL_SEARCH_AFTER_MINIMUM_VERSION)) {
+            out.writeBoolean(useSlowScroll);
+        }
+
+        if (out.getVersion().onOrAfter(Version.V_1_4_0_Beta1)) {
+            out.writeOptionalBoolean(queryCache);
+        }
+    }
+
+    @Override
+    public BytesReference cacheKey() throws IOException {
+        BytesStreamOutput out = new BytesStreamOutput();
+        this.innerWriteTo(out, true);
+        // copy it over, most requests are small, we might as well copy to make sure we are not sliced...
+        // we could potentially keep it without copying, but then pay the price of extra unused bytes up to a page
+        return out.bytes().copyBytesArray();
+    }
+}
+

--- a/src/main/java/org/elasticsearch/search/internal/ShardSearchRequest.java
+++ b/src/main/java/org/elasticsearch/search/internal/ShardSearchRequest.java
@@ -19,204 +19,52 @@
 
 package org.elasticsearch.search.internal;
 
-import org.elasticsearch.Version;
-import org.elasticsearch.action.IndicesRequest;
-import org.elasticsearch.action.OriginalIndices;
-import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchType;
-import org.elasticsearch.action.search.type.ParsedScrollId;
-import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.cluster.routing.ShardRouting;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.Scroll;
-import org.elasticsearch.transport.TransportRequest;
 
 import java.io.IOException;
 import java.util.Map;
 
-import static org.elasticsearch.search.Scroll.readScroll;
-
 /**
- * Source structure:
- * <p/>
- * <pre>
- * {
- *  from : 0, size : 20, (optional, can be set on the request)
- *  sort : { "name.first" : {}, "name.last" : { reverse : true } }
- *  fields : [ "name.first", "name.last" ]
- *  query : { ... }
- *  facets : {
- *      "facet1" : {
- *          query : { ... }
- *      }
- *  }
- * }
- * </pre>
+ * Shard level request that represents a search.
+ * It provides all the methods that the {@link org.elasticsearch.search.internal.SearchContext} needs.
+ * Provides a cache key based on its content that can be used to cache shard level response.
  */
-public class ShardSearchRequest extends TransportRequest implements IndicesRequest {
+public interface ShardSearchRequest {
 
-    private String index;
+    String index();
 
-    private int shardId;
+    int shardId();
 
-    private int numberOfShards;
+    String[] types();
 
-    private SearchType searchType;
+    BytesReference source();
 
-    private Scroll scroll;
+    void source(BytesReference source);
 
-    private String[] types = Strings.EMPTY_ARRAY;
+    BytesReference extraSource();
 
-    private String[] filteringAliases;
+    int numberOfShards();
 
-    private BytesReference source;
-    private BytesReference extraSource;
-    private BytesReference templateSource;
-    private String templateName;
-    private ScriptService.ScriptType templateType;
-    private Map<String, String> templateParams;
-    private Boolean queryCache;
+    SearchType searchType();
 
-    private long nowInMillis;
+    String[] filteringAliases();
 
-    private boolean useSlowScroll;
+    long nowInMillis();
 
-    private OriginalIndices originalIndices;
+    String templateName();
 
-    public ShardSearchRequest() {
+    ScriptService.ScriptType templateType();
 
-    }
+    Map<String, String> templateParams();
 
-    public ShardSearchRequest(TransportRequest request) {
-        super(request);
-    }
+    BytesReference templateSource();
 
-    public ShardSearchRequest(SearchRequest searchRequest, ShardRouting shardRouting, int numberOfShards, boolean useSlowScroll) {
-        super(searchRequest);
-        this.index = shardRouting.index();
-        this.shardId = shardRouting.id();
-        this.numberOfShards = numberOfShards;
-        this.searchType = searchRequest.searchType();
-        this.source = searchRequest.source();
-        this.extraSource = searchRequest.extraSource();
-        this.templateSource = searchRequest.templateSource();
-        this.templateName = searchRequest.templateName();
-        this.templateType = searchRequest.templateType();
-        this.templateParams = searchRequest.templateParams();
-        this.scroll = searchRequest.scroll();
-        this.types = searchRequest.types();
-        this.useSlowScroll = useSlowScroll;
-        this.queryCache = searchRequest.queryCache();
-        this.originalIndices = new OriginalIndices(searchRequest);
-    }
+    Boolean queryCache();
 
-    public ShardSearchRequest(String index, int shardId, int numberOfShards, SearchType searchType) {
-        this.index = index;
-        this.shardId = shardId;
-        this.numberOfShards = numberOfShards;
-        this.searchType = searchType;
-        this.originalIndices = OriginalIndices.EMPTY;
-    }
-
-    public String index() {
-        return index;
-    }
-
-    @Override
-    public String[] indices() {
-        return originalIndices.indices();
-    }
-
-    @Override
-    public IndicesOptions indicesOptions() {
-        return originalIndices.indicesOptions();
-    }
-
-    public int shardId() {
-        return shardId;
-    }
-
-    public SearchType searchType() {
-        return this.searchType;
-    }
-
-    public int numberOfShards() {
-        return numberOfShards;
-    }
-
-    public BytesReference source() {
-        return this.source;
-    }
-
-    public BytesReference extraSource() {
-        return this.extraSource;
-    }
-
-    public ShardSearchRequest source(BytesReference source) {
-        this.source = source;
-        return this;
-    }
-
-    public ShardSearchRequest extraSource(BytesReference extraSource) {
-        this.extraSource = extraSource;
-        return this;
-    }
-
-    public BytesReference templateSource() {
-        return this.templateSource;
-    }
-
-    public String templateName() {
-        return templateName;
-    }
-
-    public ScriptService.ScriptType templateType() {
-        return templateType;
-    }
-
-    public Map<String, String> templateParams() {
-        return templateParams;
-    }
-
-    public ShardSearchRequest nowInMillis(long nowInMillis) {
-        this.nowInMillis = nowInMillis;
-        return this;
-    }
-
-    public long nowInMillis() {
-        return this.nowInMillis;
-    }
-
-    public Scroll scroll() {
-        return scroll;
-    }
-
-    public ShardSearchRequest scroll(Scroll scroll) {
-        this.scroll = scroll;
-        return this;
-    }
-
-    public String[] filteringAliases() {
-        return filteringAliases;
-    }
-
-    public ShardSearchRequest filteringAliases(String[] filteringAliases) {
-        this.filteringAliases = filteringAliases;
-        return this;
-    }
-
-    public String[] types() {
-        return types;
-    }
-
-    public ShardSearchRequest types(String[] types) {
-        this.types = types;
-        return this;
-    }
+    Scroll scroll();
 
     /**
      * This setting is internal and will be enabled when at least one node is on versions 1.0.x and 1.1.x to enable
@@ -225,106 +73,10 @@ public class ShardSearchRequest extends TransportRequest implements IndicesReque
      * @return Whether the scrolling should use regular search and incrementing the from on each round, which can
      * bring down nodes due to the big priority queues being generated to accommodate from + size hits for sorting.
      */
-    public boolean useSlowScroll() {
-        return useSlowScroll;
-    }
+    boolean useSlowScroll();
 
-    public Boolean queryCache() {
-        return this.queryCache;
-    }
-
-    public ShardSearchRequest queryCache(Boolean queryCache) {
-        this.queryCache = queryCache;
-        return this;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        index = in.readString();
-        shardId = in.readVInt();
-        searchType = SearchType.fromId(in.readByte());
-        numberOfShards = in.readVInt();
-        if (in.readBoolean()) {
-            scroll = readScroll(in);
-        }
-
-        source = in.readBytesReference();
-        extraSource = in.readBytesReference();
-
-        types = in.readStringArray();
-        filteringAliases = in.readStringArray();
-        nowInMillis = in.readVLong();
-
-        if (in.getVersion().onOrAfter(Version.V_1_1_0)) {
-            templateSource = in.readBytesReference();
-            templateName = in.readOptionalString();
-            if (in.getVersion().onOrAfter(Version.V_1_3_0)) {
-                templateType = ScriptService.ScriptType.readFrom(in);
-            }
-            if (in.readBoolean()) {
-                templateParams = (Map<String, String>) in.readGenericValue();
-            }
-        }
-        if (in.getVersion().onOrAfter(ParsedScrollId.SCROLL_SEARCH_AFTER_MINIMUM_VERSION)) {
-            useSlowScroll = in.readBoolean();
-        } else {
-            // This means that this request was send from a 1.0.x or 1.1.x node and we need to fallback to slow scroll.
-            useSlowScroll = in.getVersion().before(ParsedScrollId.SCROLL_SEARCH_AFTER_MINIMUM_VERSION);
-        }
-
-        if (in.getVersion().onOrAfter(Version.V_1_4_0_Beta1)) {
-            queryCache = in.readOptionalBoolean();
-        }
-        originalIndices = OriginalIndices.readOptionalOriginalIndices(in);
-    }
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        writeTo(out, false);
-    }
-
-    public void writeTo(StreamOutput out, boolean asKey) throws IOException {
-        super.writeTo(out);
-        out.writeString(index);
-        out.writeVInt(shardId);
-        out.writeByte(searchType.id());
-        if (!asKey) {
-            out.writeVInt(numberOfShards);
-        }
-        if (scroll == null) {
-            out.writeBoolean(false);
-        } else {
-            out.writeBoolean(true);
-            scroll.writeTo(out);
-        }
-        out.writeBytesReference(source);
-        out.writeBytesReference(extraSource);
-        out.writeStringArray(types);
-        out.writeStringArrayNullable(filteringAliases);
-        if (!asKey) {
-            out.writeVLong(nowInMillis);
-        }
-
-        if (out.getVersion().onOrAfter(Version.V_1_1_0)) {
-            out.writeBytesReference(templateSource);
-            out.writeOptionalString(templateName);
-            if (out.getVersion().onOrAfter(Version.V_1_3_0)) {
-                ScriptService.ScriptType.writeTo(templateType, out);
-            }
-            boolean existTemplateParams = templateParams != null;
-            out.writeBoolean(existTemplateParams);
-            if (existTemplateParams) {
-                out.writeGenericValue(templateParams);
-            }
-        }
-        if (out.getVersion().onOrAfter(ParsedScrollId.SCROLL_SEARCH_AFTER_MINIMUM_VERSION)) {
-            out.writeBoolean(useSlowScroll);
-        }
-
-        if (out.getVersion().onOrAfter(Version.V_1_4_0_Beta1)) {
-            out.writeOptionalBoolean(queryCache);
-        }
-        OriginalIndices.writeOptionalOriginalIndices(originalIndices, out);
-    }
+    /**
+     * Returns the cache key for this shard search request, based on its content
+     */
+    BytesReference cacheKey() throws IOException;
 }

--- a/src/main/java/org/elasticsearch/search/internal/ShardSearchTransportRequest.java
+++ b/src/main/java/org/elasticsearch/search/internal/ShardSearchTransportRequest.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.internal;
+
+import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.OriginalIndices;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchType;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.search.Scroll;
+import org.elasticsearch.transport.TransportRequest;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Shard level search request that represents an actual search sent from the coordinating node to the nodes holding
+ * the shards where the query needs to be executed. Holds the same info as {@link org.elasticsearch.search.internal.ShardSearchLocalRequest}
+ * but gets sent over the transport and holds also the indices coming from the original request that generated it, plus its headers and context.
+ */
+public class ShardSearchTransportRequest extends TransportRequest implements ShardSearchRequest, IndicesRequest {
+
+    private OriginalIndices originalIndices;
+
+    private ShardSearchLocalRequest shardSearchLocalRequest;
+
+    public ShardSearchTransportRequest(){
+    }
+
+    public ShardSearchTransportRequest(SearchRequest searchRequest, ShardRouting shardRouting, int numberOfShards,
+                                       boolean useSlowScroll, String[] filteringAliases, long nowInMillis) {
+        super(searchRequest);
+        this.shardSearchLocalRequest = new ShardSearchLocalRequest(searchRequest, shardRouting, numberOfShards,
+                useSlowScroll, filteringAliases, nowInMillis);
+        this.originalIndices = new OriginalIndices(searchRequest);
+    }
+
+    @Override
+    public String[] indices() {
+        if (originalIndices == null) {
+            return null;
+        }
+        return originalIndices.indices();
+    }
+
+    @Override
+    public IndicesOptions indicesOptions() {
+        if (originalIndices == null) {
+            return null;
+        }
+        return originalIndices.indicesOptions();
+    }
+
+    @Override
+    public String index() {
+        return shardSearchLocalRequest.index();
+    }
+
+    @Override
+    public int shardId() {
+        return shardSearchLocalRequest.shardId();
+    }
+
+    @Override
+    public String[] types() {
+        return shardSearchLocalRequest.types();
+    }
+
+    @Override
+    public BytesReference source() {
+        return shardSearchLocalRequest.source();
+    }
+
+    @Override
+    public void source(BytesReference source) {
+        shardSearchLocalRequest.source(source);
+    }
+
+    @Override
+    public BytesReference extraSource() {
+        return shardSearchLocalRequest.extraSource();
+    }
+
+    @Override
+    public int numberOfShards() {
+        return shardSearchLocalRequest.numberOfShards();
+    }
+
+    @Override
+    public SearchType searchType() {
+        return shardSearchLocalRequest.searchType();
+    }
+
+    @Override
+    public String[] filteringAliases() {
+        return shardSearchLocalRequest.filteringAliases();
+    }
+
+    @Override
+    public long nowInMillis() {
+        return shardSearchLocalRequest.nowInMillis();
+    }
+
+    @Override
+    public String templateName() {
+        return shardSearchLocalRequest.templateName();
+    }
+
+    @Override
+    public ScriptService.ScriptType templateType() {
+        return shardSearchLocalRequest.templateType();
+    }
+
+    @Override
+    public Map<String, String> templateParams() {
+        return shardSearchLocalRequest.templateParams();
+    }
+
+    @Override
+    public BytesReference templateSource() {
+        return shardSearchLocalRequest.templateSource();
+    }
+
+    @Override
+    public Boolean queryCache() {
+        return shardSearchLocalRequest.queryCache();
+    }
+
+    @Override
+    public Scroll scroll() {
+        return shardSearchLocalRequest.scroll();
+    }
+
+    @Override
+    public boolean useSlowScroll() {
+        return shardSearchLocalRequest.useSlowScroll();
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+        shardSearchLocalRequest = new ShardSearchLocalRequest();
+        shardSearchLocalRequest.innerReadFrom(in);
+        originalIndices = OriginalIndices.readOriginalIndices(in);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        shardSearchLocalRequest.innerWriteTo(out, false);
+        OriginalIndices.writeOriginalIndices(originalIndices, out);
+    }
+
+    @Override
+    public BytesReference cacheKey() throws IOException {
+        return shardSearchLocalRequest.cacheKey();
+    }
+}


### PR DESCRIPTION
In some cases a shard search request gets created on a node to be only used there and never sent over the transport. This commit clarifies that and creates a new base class called `ShardSearchLocalRequest` that can and will be only used locally. `ShardSearchTransportRequest` on the other hand delegates to the local version but extends `TransportRequest` and is `Streamable`, which means that it is supposed to be sent over the transport.

This way we can make the `OriginalIndices` only required (and mandatory now) in the transport variant.

Took the chance to remove an unused InternalScrollSearchRequest constructor and an empty else branch in `TransportSearchScrollQueryAndFetchAction`.
