### PR TITLE
Update delete-by-query.asciidoc

### DIFF
--- a/docs/reference/docs/delete-by-query.asciidoc
+++ b/docs/reference/docs/delete-by-query.asciidoc
@@ -22,6 +22,8 @@ $ curl -XDELETE 'http://localhost:9200/twitter/tweet/_query' -d '{
 NOTE: The query being sent in the body must be nested in a `query` key, same as
 the <<search-search,search api>> works added[1.0.0.RC1,The query was previously the top-level object].
 
+NOTE: Delete by query doesn't support `has_parent` and `has_child` queries / filters.
+
 Both above examples end up doing the same thing, which is delete all
 tweets from the twitter index for a certain user. The result of the
 commands is:


### PR DESCRIPTION
Undocumented limitation. Support for both has_parent & has_child has been dropped by commit:
https://github.com/elasticsearch/elasticsearch/commit/17a5575757317962dab4c295bbfacbdb136cc61e
