### PR TITLE
Add ThreadPool.terminate to streamline shutdown

### DIFF
--- a/src/main/java/org/elasticsearch/client/transport/TransportClient.java
+++ b/src/main/java/org/elasticsearch/client/transport/TransportClient.java
@@ -279,16 +279,8 @@ public class TransportClient extends AbstractClient {
         for (Class<? extends LifecycleComponent> plugin : pluginsService.services()) {
             injector.getInstance(plugin).close();
         }
-
-        injector.getInstance(ThreadPool.class).shutdown();
         try {
-            injector.getInstance(ThreadPool.class).awaitTermination(10, TimeUnit.SECONDS);
-        } catch (InterruptedException e) {
-            // ignore
-            Thread.currentThread().interrupt();
-        }
-        try {
-            injector.getInstance(ThreadPool.class).shutdownNow();
+            ThreadPool.terminate(injector.getInstance(ThreadPool.class), 10, TimeUnit.SECONDS);
         } catch (Exception e) {
             // ignore
         }

--- a/src/main/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPing.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPing.java
@@ -243,10 +243,8 @@ public class UnicastZenPing extends AbstractLifecycleComponent<ZenPing> implemen
 
         public void close() {
             closed = true;
-            if (executor != null) {
-                executor.shutdownNow();
-                executor = null;
-            }
+            ThreadPool.terminate(executor, 0, TimeUnit.SECONDS);
+            executor = null;
         }
     }
 

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoverySettings.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoverySettings.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.node.settings.NodeSettingsService;
+import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -95,13 +96,7 @@ public class RecoverySettings extends AbstractComponent {
     }
 
     public void close() {
-        concurrentStreamPool.shutdown();
-        try {
-            concurrentStreamPool.awaitTermination(1, TimeUnit.SECONDS);
-        } catch (InterruptedException e) {
-            // that's fine...
-        }
-        concurrentStreamPool.shutdownNow();
+        ThreadPool.terminate(concurrentStreamPool, 1, TimeUnit.SECONDS);
     }
 
     public ByteSizeValue fileChunkSize() {

--- a/src/main/java/org/elasticsearch/node/internal/InternalNode.java
+++ b/src/main/java/org/elasticsearch/node/internal/InternalNode.java
@@ -368,6 +368,7 @@ public final class InternalNode implements Node {
         injector.getInstance(ScriptService.class).close();
 
         stopWatch.stop().start("thread_pool");
+        // TODO this should really use ThreadPool.terminate()
         injector.getInstance(ThreadPool.class).shutdown();
         try {
             injector.getInstance(ThreadPool.class).awaitTermination(10, TimeUnit.SECONDS);

--- a/src/main/java/org/elasticsearch/transport/local/LocalTransport.java
+++ b/src/main/java/org/elasticsearch/transport/local/LocalTransport.java
@@ -117,13 +117,7 @@ public class LocalTransport extends AbstractLifecycleComponent<Transport> implem
 
     @Override
     protected void doClose() throws ElasticsearchException {
-        workers.shutdown();
-        try {
-            workers.awaitTermination(10, TimeUnit.SECONDS);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
-        workers.shutdownNow();
+        ThreadPool.terminate(workers, 10, TimeUnit.SECONDS);
     }
 
     @Override

--- a/src/test/java/org/elasticsearch/client/transport/TransportClientNodesServiceTests.java
+++ b/src/test/java/org/elasticsearch/client/transport/TransportClientNodesServiceTests.java
@@ -70,14 +70,14 @@ public class TransportClientNodesServiceTests extends ElasticsearchTestCase {
         }
 
         public void close() {
-            threadPool.shutdown();
-            try {
-                threadPool.awaitTermination(1, TimeUnit.SECONDS);
-            } catch (InterruptedException e) {
-                Thread.currentThread().isInterrupted();
-            }
+
             transportService.stop();
             transportClientNodesService.close();
+            try {
+                terminate(threadPool);
+            } catch (InterruptedException e) {
+                throw new AssertionError(e);
+            }
         }
     }
 

--- a/src/test/java/org/elasticsearch/common/util/concurrent/EsExecutorsTests.java
+++ b/src/test/java/org/elasticsearch/common/util/concurrent/EsExecutorsTests.java
@@ -153,7 +153,7 @@ public class EsExecutorsTests extends ElasticsearchTestCase {
         assertThat(executed2.get(), equalTo(true));
         assertThat(executed3.get(), equalTo(false));
 
-        executor.shutdownNow();
+        terminate(executor);
     }
 
     @Test
@@ -189,7 +189,7 @@ public class EsExecutorsTests extends ElasticsearchTestCase {
         assertThat("wrong pool size", pool.getPoolSize(), equalTo(max));
         assertThat("wrong active size", pool.getActiveCount(), equalTo(max));
         barrier.await();
-        pool.shutdown();
+        terminate(pool);
     }
 
     @Test
@@ -232,6 +232,6 @@ public class EsExecutorsTests extends ElasticsearchTestCase {
                 assertThat("idle threads didn't shrink below max. (" + pool.getPoolSize() + ")", pool.getPoolSize(), lessThan(max));
             }
         });
-        pool.shutdown();
+        terminate(pool);
     }
 }

--- a/src/test/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPingTests.java
+++ b/src/test/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPingTests.java
@@ -47,7 +47,7 @@ import static org.hamcrest.Matchers.equalTo;
 public class UnicastZenPingTests extends ElasticsearchTestCase {
 
     @Test
-    public void testSimplePings() {
+    public void testSimplePings() throws InterruptedException {
         Settings settings = ImmutableSettings.EMPTY;
         int startPort = 11000 + randomIntBetween(0, 1000);
         int endPort = startPort + 10;
@@ -132,7 +132,7 @@ public class UnicastZenPingTests extends ElasticsearchTestCase {
             zenPingB.close();
             transportServiceA.close();
             transportServiceB.close();
-            threadPool.shutdown();
+            terminate(threadPool);
         }
     }
 }

--- a/src/test/java/org/elasticsearch/test/ElasticsearchTestCase.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchTestCase.java
@@ -67,6 +67,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAllS
  */
 @ThreadLeakFilters(defaultFilters = true, filters = {ElasticsearchThreadFilter.class})
 @ThreadLeakScope(Scope.SUITE)
+@ThreadLeakLingering(linger = 5000) // 5 sec lingering
 @TimeoutSuite(millis = 20 * TimeUnits.MINUTE) // timeout the suite after 20min and fail the test.
 @Listeners(LoggingListener.class)
 public abstract class ElasticsearchTestCase extends AbstractRandomizedTest {

--- a/src/test/java/org/elasticsearch/test/ElasticsearchTestCase.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchTestCase.java
@@ -530,20 +530,13 @@ public abstract class ElasticsearchTestCase extends AbstractRandomizedTest {
         boolean terminated = true;
         for (ExecutorService service : services) {
             if (service != null) {
-                service.shutdown();
-                service.shutdownNow();
-                terminated &= service.awaitTermination(10, TimeUnit.SECONDS);
+                terminated &= ThreadPool.terminate(service, 10, TimeUnit.SECONDS);
             }
         }
         return terminated;
     }
 
     public static boolean terminate(ThreadPool service) throws InterruptedException {
-        if (service != null) {
-            service.shutdown();
-            service.shutdownNow();
-            return service.awaitTermination(10, TimeUnit.SECONDS);
-        }
-        return true;
+        return ThreadPool.terminate(service, 10, TimeUnit.SECONDS);
     }
 }

--- a/src/test/java/org/elasticsearch/test/ElasticsearchThreadFilter.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchThreadFilter.java
@@ -52,6 +52,6 @@ public final class ElasticsearchThreadFilter implements ThreadFilter {
                 || threadName.contains("Keep-Alive-Timer")) {
             return true;
         }
-        return nodePrefix.matcher(t.getName()).find() || true; // TODO disabled for now
+        return nodePrefix.matcher(t.getName()).find();
     }
 }


### PR DESCRIPTION
Shutting down threadpools and executor services is done in very similar
fashion across the codebase. This commit streamlines the process by
adding a terminate method to ThreadPool.

This PR also re-enables the threadleak filtering including a 5 second linger period since threadpools don't join their threads.
