### PR TITLE
Update regexp-syntax.asciidoc

### DIFF
--- a/docs/reference/query-dsl/queries/regexp-syntax.asciidoc
+++ b/docs/reference/query-dsl/queries/regexp-syntax.asciidoc
@@ -78,7 +78,7 @@ once or more times. For string `"aaabbb"`:
     a+b+        # match
     aa+bb+      # match
     a+.+        # match
-    aa+bbb+     # match
+    aa+bbb+     # no match as "+" atleast once
 
 --
 


### PR DESCRIPTION
The plus sign "+" can be used to repeat the preceding shortest pattern once or more time.

at-least once therefor, For string "aaabbb":

aa+bbb+  #  no match
