### PR TITLE
Fix NumberFormatException in Simple Query String Query

### DIFF
--- a/src/main/java/org/elasticsearch/common/xcontent/XContentParser.java
+++ b/src/main/java/org/elasticsearch/common/xcontent/XContentParser.java
@@ -154,6 +154,16 @@ public interface XContentParser extends Releasable {
 
     Object objectBytes() throws IOException;
 
+    /**
+     * Method that can be used to determine whether calling of textCharacters() would be the most efficient way to
+     * access textual content for the event parser currently points to.
+     *
+     * Default implementation simply returns false since only actual
+     * implementation class has knowledge of its internal buffering
+     * state.
+     *
+     * This method shouldn't be used to check if the token contains text or not.
+     */
     boolean hasTextCharacters();
 
     char[] textCharacters() throws IOException;

--- a/src/main/java/org/elasticsearch/index/query/SimpleQueryStringParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SimpleQueryStringParser.java
@@ -160,7 +160,7 @@ public class SimpleQueryStringParser implements QueryParser {
                                 "[" + NAME + "] default operator [" + op + "] is not allowed");
                     }
                 } else if ("flags".equals(currentFieldName)) {
-                    if (parser.hasTextCharacters()) {
+                    if (parser.currentToken() != XContentParser.Token.VALUE_NUMBER) {
                         // Possible options are:
                         // ALL, NONE, AND, OR, PREFIX, PHRASE, PRECEDENCE, ESCAPE, WHITESPACE, FUZZY, NEAR, SLOP
                         flags = SimpleQueryStringFlag.resolveFlags(parser.text());

--- a/src/main/java/org/elasticsearch/index/query/TemplateQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TemplateQueryParser.java
@@ -115,7 +115,7 @@ public class TemplateQueryParser implements QueryParser {
                 currentFieldName = parser.currentName();
             } else if (parameterMap.containsKey(currentFieldName)) {
                 type = parameterMap.get(currentFieldName);
-                if (token == XContentParser.Token.START_OBJECT && !parser.hasTextCharacters()) {
+                if (token == XContentParser.Token.START_OBJECT) {
                     XContentBuilder builder = XContentBuilder.builder(parser.contentType().xContent());
                     builder.copyCurrentStructure(parser);
                     templateNameOrTemplateContent = builder.string();

--- a/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestParser.java
+++ b/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestParser.java
@@ -132,7 +132,7 @@ public final class PhraseSuggestParser implements SuggestContextParser {
                             fieldName = parser.currentName();
                         } else if ("query".equals(fieldName) || "filter".equals(fieldName)) {
                             String templateNameOrTemplateContent;
-                            if (token == XContentParser.Token.START_OBJECT && !parser.hasTextCharacters()) {
+                            if (token == XContentParser.Token.START_OBJECT) {
                                 XContentBuilder builder = XContentBuilder.builder(parser.contentType().xContent());
                                 builder.copyCurrentStructure(parser);
                                 templateNameOrTemplateContent = builder.string();


### PR DESCRIPTION
Incorrect usage of XContentParser.hasTextCharacters() can result in NumberFormatException as well as other possible issues in template query parser and phrase suggest parsers.

Fixes #7875
