### PR TITLE
Added graceful shutdown behaviour

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1220,7 +1220,10 @@
                                 <exclude>org/elasticsearch/common/cli/Terminal*</exclude>
                                 <exclude>org/elasticsearch/plugins/PluginManager.class</exclude>
                                 <exclude>org/elasticsearch/common/http/client/HttpDownloadHelper.class</exclude>
+                                <exclude>org/elasticsearch/node/internal/InternalNode$2.class</exclude>
+                                <exclude>org/elasticsearch/node/internal/InternalNode.class</exclude>
                                 <exclude>org/elasticsearch/bootstrap/Bootstrap.class</exclude>
+                                <exclude>org/elasticsearch/bootstrap/Bootstrap$1.class</exclude>
                                 <exclude>org/elasticsearch/Version.class</exclude>
                                 <exclude>org/elasticsearch/common/lucene/search/Queries$QueryWrapperFilterFactory.class</exclude>
                                 <!-- end excludes for valid system-out -->

--- a/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
+++ b/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
@@ -37,6 +37,8 @@ import org.elasticsearch.monitor.process.JmxProcessProbe;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.node.NodeBuilder;
 import org.elasticsearch.node.internal.InternalSettingsPreparer;
+import sun.misc.Signal;
+import sun.misc.SignalHandler;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -59,6 +61,9 @@ public class Bootstrap {
 
     private static Bootstrap bootstrap;
 
+    private final ESLogger logger = Loggers.getLogger(getClass());
+
+
     private void setup(boolean addShutdownHook, Tuple<Settings, Environment> tuple) throws Exception {
 //        Loggers.getLogger(Bootstrap.class, tuple.v1().get("name")).info("heap_size {}/{}", JvmStats.jvmStats().mem().heapCommitted(), JvmInfo.jvmInfo().mem().heapMax());
         if (tuple.v1().getAsBoolean("bootstrap.mlockall", false)) {
@@ -68,6 +73,23 @@ public class Bootstrap {
 
         NodeBuilder nodeBuilder = NodeBuilder.nodeBuilder().settings(tuple.v1()).loadConfigSettings(false);
         node = nodeBuilder.build();
+
+        try {
+            Signal signal = new Signal("USR2");
+            Signal.handle(signal, new SignalHandler() {
+                @Override
+                public void handle(Signal sig) {
+                    if (node.disable()) {
+                        System.exit(0); // this calls the shutdown hook and does node.close()
+                    } else {
+                        node.start();
+                    }
+                }
+            });
+        } catch (IllegalArgumentException e) {
+            logger.warn("SIGUSR2 signal not supported on {}.", System.getProperty("os.name"));
+        }
+
         if (addShutdownHook) {
             Runtime.getRuntime().addShutdownHook(new Thread() {
                 @Override

--- a/src/main/java/org/elasticsearch/cluster/action/index/MappingUpdatedAction.java
+++ b/src/main/java/org/elasticsearch/cluster/action/index/MappingUpdatedAction.java
@@ -105,8 +105,14 @@ public class MappingUpdatedAction extends TransportMasterNodeOperationAction<Map
     }
 
     public void stop() {
-        this.masterMappingUpdater.close();
-        this.masterMappingUpdater = null;
+        disable();
+    }
+
+    public void disable() {
+        if (this.masterMappingUpdater != null) {
+            this.masterMappingUpdater.close();
+            this.masterMappingUpdater = null;
+        }
     }
 
     public void updateMappingOnMaster(String index, DocumentMapper documentMapper, String indexUUID) {

--- a/src/main/java/org/elasticsearch/cluster/routing/allocation/deallocator/AbstractDeallocator.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/allocation/deallocator/AbstractDeallocator.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.routing.allocation.deallocator;
+
+import com.google.common.base.Joiner;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
+import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsResponse;
+import org.elasticsearch.action.admin.cluster.settings.TransportClusterUpdateSettingsAction;
+import org.elasticsearch.action.admin.indices.settings.put.TransportUpdateSettingsAction;
+import org.elasticsearch.action.support.TransportAction;
+import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider;
+import org.elasticsearch.common.component.AbstractComponent;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
+
+import java.util.Locale;
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+public abstract class AbstractDeallocator extends AbstractComponent implements Deallocator {
+
+    static final String EXCLUDE_NODE_ID_FROM_INDEX = "index.routing.allocation.exclude._id";
+    static final String CLUSTER_ROUTING_EXCLUDE_BY_NODE_ID = "cluster.routing.allocation.exclude._id";
+    static final Joiner COMMA_JOINER = Joiner.on(',');
+    static final String[] EMPTY_STRING_ARRAY = new String[0];
+
+    /**
+     * executor with only 1 Thread, ensuring linearized execution of
+     * requests changing cluster state
+     */
+    public static class ClusterChangeExecutor implements Closeable {
+        private ExecutorService executor;
+
+        public ClusterChangeExecutor() {
+            executor = Executors.newSingleThreadExecutor(EsExecutors.daemonThreadFactory("deallocator"));
+        }
+
+        public <TRequest extends ActionRequest, TResponse extends ActionResponse> void enqueue(
+                final TRequest request,
+                final TransportAction<TRequest, TResponse> action,
+                final ActionListener<TResponse> listener) {
+            executor.execute(new Runnable() {
+                @Override
+                public void run() {
+                    // execute synchronously
+                    try {
+                        listener.onResponse(
+                                action.execute(request).actionGet()
+                        );
+                    } catch (Exception e) {
+                        listener.onFailure(e);
+                    }
+                }
+            });
+        }
+
+        public <TRequest extends ActionRequest, TResponse extends ActionResponse> void enqueue(
+                final TRequest requests[],
+                final TransportAction<TRequest, TResponse> action,
+                final ActionListener<TResponse> listener) {
+            executor.execute(new Runnable() {
+                @Override
+                public void run() {
+                    for (final TRequest request : requests) {
+                        // execute synchronously
+                        try {
+                            listener.onResponse(
+                                    action.execute(request).actionGet()
+                            );
+                        } catch (Exception e) {
+                            listener.onFailure(e);
+                        }
+                    }
+                }
+            });
+        }
+
+        @Override
+        public void close() throws IOException {
+            executor.shutdown();
+            try {
+                executor.awaitTermination(20, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.interrupted();
+            }
+            executor.shutdownNow();
+        }
+    }
+
+    protected final ClusterChangeExecutor clusterChangeExecutor;
+    protected final ClusterService clusterService;
+    protected final TransportUpdateSettingsAction updateSettingsAction;
+    protected final TransportClusterUpdateSettingsAction clusterUpdateSettingsAction;
+    protected final AtomicReference<String> allocationEnableSetting = new AtomicReference<>();
+    protected final Settings clusterSettings;
+
+    private String localNodeId;
+
+    public AbstractDeallocator(ClusterService clusterService, TransportUpdateSettingsAction indicesUpdateSettingsAction,
+                               TransportClusterUpdateSettingsAction clusterUpdateSettingsAction, Settings clusterSettings) {
+        super(ImmutableSettings.EMPTY);
+        this.clusterService = clusterService;
+        this.clusterChangeExecutor = new ClusterChangeExecutor();
+        this.updateSettingsAction = indicesUpdateSettingsAction;
+        this.clusterUpdateSettingsAction = clusterUpdateSettingsAction;
+        this.clusterSettings = clusterSettings;
+    }
+
+    public String localNodeId() {
+        if (localNodeId == null) {
+            localNodeId = clusterService.localNode().id();
+        }
+        return localNodeId;
+    }
+
+
+    protected void setAllocationEnableSetting(final String value) {
+        ClusterUpdateSettingsRequest request = new ClusterUpdateSettingsRequest();
+        request.transientSettings(ImmutableSettings.builder().put(
+                EnableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ENABLE,
+                value));
+        clusterChangeExecutor.enqueue(request, clusterUpdateSettingsAction, new ActionListener<ClusterUpdateSettingsResponse>() {
+            @Override
+            public void onResponse(ClusterUpdateSettingsResponse response) {
+                logger.trace("[{}] setting '{}' successfully set to {}", localNodeId(), EnableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ENABLE, value);
+            }
+
+            @Override
+            public void onFailure(Throwable e) {
+                logger.error("[{}] error setting '{}'", e, localNodeId(), EnableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ENABLE);
+            }
+        });
+    }
+
+    protected void trackAllocationEnableSetting() {
+        String value = clusterService.state().metaData().settings().get( /// need to be transientSettings() in our version
+                EnableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ENABLE);
+        if (value == null) value = EnableAllocationDecider.Allocation.ALL.name().toLowerCase(Locale.ENGLISH);
+        allocationEnableSetting.set(value);
+    }
+
+    protected void resetAllocationEnableSetting() {
+        String resetValue = allocationEnableSetting.get();
+        logger.trace("reset allocation.enable to {}", resetValue);
+        if (resetValue != null) {
+            setAllocationEnableSetting(resetValue);
+        } else {
+            resetValue = clusterSettings.get(EnableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ENABLE);
+            if (resetValue == null) resetValue = EnableAllocationDecider.Allocation.ALL.name().toLowerCase(Locale.ENGLISH);
+            setAllocationEnableSetting(resetValue);
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        clusterChangeExecutor.close();
+    }
+}

--- a/src/main/java/org/elasticsearch/cluster/routing/allocation/deallocator/AllShardsDeallocator.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/allocation/deallocator/AllShardsDeallocator.java
@@ -1,0 +1,306 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.routing.allocation.deallocator;
+
+import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
+import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
+import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsResponse;
+import org.elasticsearch.action.admin.cluster.settings.TransportClusterUpdateSettingsAction;
+import org.elasticsearch.action.admin.indices.settings.put.TransportUpdateSettingsAction;
+import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateListener;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.routing.RoutingNode;
+import org.elasticsearch.cluster.routing.ShardRoutingState;
+import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+
+import java.util.Locale;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class AllShardsDeallocator extends AbstractDeallocator implements ClusterStateListener {
+    private final Object futureLock = new Object();
+    private final Object excludeNodesLock = new Object();
+
+    private volatile Set<String> deallocatingNodes;
+    private volatile SettableFuture<DeallocationResult> waitForFullDeallocation = null;
+    private final AtomicBoolean waitForResetSetting = new AtomicBoolean(false);
+
+
+    @Inject
+    public AllShardsDeallocator(ClusterService clusterService,
+                                TransportUpdateSettingsAction indicesUpdateSettingsAction,
+                                TransportClusterUpdateSettingsAction clusterUpdateSettingsAction,
+                                Settings clusterSettings) {
+        super(clusterService, indicesUpdateSettingsAction, clusterUpdateSettingsAction, clusterSettings);
+        this.deallocatingNodes = Sets.newHashSet();
+        this.clusterService.add(this);
+    }
+
+    /**
+     * @see Deallocator
+     *
+     * @return a future that is set when the node is fully decommissioned
+     */
+    @Override
+    public ListenableFuture<DeallocationResult> deallocate() {
+        RoutingNode node = clusterService.state().routingNodes().node(localNodeId());
+        if (isDeallocating()) {
+            throw new IllegalStateException("node already waiting for complete deallocation");
+        }
+        logger.info("[{}] starting full deallocation...", localNodeId());
+        if (node == null || node.size() == 0) {
+            return Futures.immediateFuture(DeallocationResult.SUCCESS_NOTHING_HAPPENED);
+        }
+
+        // enable all allocation to make sure shards are moved, keep the old value
+        trackAllocationEnableSetting();
+        setAllocationEnableSetting(EnableAllocationDecider.Allocation.ALL.name().toLowerCase(Locale.ENGLISH));
+
+        final SettableFuture<DeallocationResult> future = waitForFullDeallocation = SettableFuture.create();
+        ClusterUpdateSettingsRequest request = new ClusterUpdateSettingsRequest();
+        synchronized (excludeNodesLock) {
+            deallocatingNodes.add(localNodeId());
+            request.transientSettings(ImmutableSettings.builder()
+                    .put(CLUSTER_ROUTING_EXCLUDE_BY_NODE_ID, COMMA_JOINER.join(deallocatingNodes))
+                    .build());
+        }
+        clusterChangeExecutor.enqueue(request, clusterUpdateSettingsAction,
+                new ActionListener<ClusterUpdateSettingsResponse>() {
+                    @Override
+                    public void onResponse(ClusterUpdateSettingsResponse response) {
+                        logExcludedNodes(response.getTransientSettings());
+                        // future will be set when node has no shards
+                    }
+
+                    @Override
+                    public void onFailure(Throwable e) {
+                        logger.error("[{}] error disabling allocation", e, localNodeId());
+                        cancelWithExceptionIfPresent(e);
+                    }
+                });
+        return future;
+    }
+
+    private void cancelWithExceptionIfPresent(final Throwable e) {
+        synchronized (futureLock) {
+            final SettableFuture<DeallocationResult> future = waitForFullDeallocation;
+            if (future != null) {
+                logger.error("[{}] full deallocation cancelled due to an error", e, localNodeId());
+                resetAllocationEnableSetting();
+                clusterService.add(new ClusterStateListener() {
+                    @Override
+                    public void clusterChanged(ClusterChangedEvent event) {
+                        String enableSetting = event.state().metaData().settings()
+                                .get(EnableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ENABLE);
+                        if (event.metaDataChanged()
+                                && (enableSetting == null || enableSetting.equals(allocationEnableSetting.get()))) {
+                            future.setException(e);
+                            clusterService.remove(this);
+                        }
+                    }
+                });
+                waitForFullDeallocation = null;
+            }
+        }
+    }
+
+    private void cancelIfPresent() {
+        synchronized (futureLock) {
+            SettableFuture<DeallocationResult> future = waitForFullDeallocation;
+            if (future != null) {
+                resetAllocationEnableSetting();
+                final SettableFuture<Void> resetSettingFuture = SettableFuture.create();
+                clusterService.add(new ClusterStateListener() {
+                    @Override
+                    public void clusterChanged(ClusterChangedEvent event) {
+                        String enableSetting = event.state().metaData().settings()
+                                .get(EnableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ENABLE);
+                        if (event.metaDataChanged()
+                                && (enableSetting == null || enableSetting.equals(allocationEnableSetting.get()))) {
+                            resetSettingFuture.set(null);
+                            clusterService.remove(this);
+                        }
+                    }
+                });
+                try {
+                    resetSettingFuture.get(10, TimeUnit.SECONDS);
+                } catch (InterruptedException | TimeoutException | ExecutionException e) {
+                    // proceed, what can we do?
+                }
+                future.cancel(true);
+                waitForFullDeallocation = null;
+            }
+        }
+    }
+
+    @Override
+    public boolean cancel() {
+        boolean cancelled = removeExclusion(localNodeId());
+        cancelIfPresent();
+        if (cancelled) {
+            logger.debug("[{}] deallocation cancelled", localNodeId());
+        } else {
+            logger.debug("[{}] node not deallocating", localNodeId());
+        }
+        return cancelled;
+    }
+
+    @Override
+    public boolean isDeallocating() {
+        return waitForFullDeallocation != null || deallocatingNodes.contains(localNodeId());
+    }
+
+    /**
+     * can deallocate if:
+     * we have one spare node which does not contain a replica or primary
+     * of any index which has shards on this node,
+     * so we can move the shards on this node to it.
+     *
+     * More technically: number of data nodes > (maximum number_of_replicas of indices with shards on this node + 1)
+     */
+    @Override
+    public boolean canDeallocate() {
+        ClusterState clusterState = clusterService.state();
+        int numNodes = clusterState.nodes().dataNodes().size();
+        int maxReplicas = -1;
+        RoutingNode localNode = clusterState.routingNodes().node(localNodeId());
+        for (ObjectObjectCursor<String, IndexMetaData> entry : clusterState.metaData().indices()) {
+            if (!localNode.shardsWithState(entry.key, ShardRoutingState.STARTED, ShardRoutingState.INITIALIZING, ShardRoutingState.RELOCATING).isEmpty()) {
+                maxReplicas = Math.max(maxReplicas, entry.value.numberOfReplicas());
+            }
+        }
+        return numNodes > maxReplicas+1;
+    }
+
+    /**
+     * @return true if this node has no shards
+     */
+    @Override
+    public boolean isNoOp() {
+        ClusterState state = clusterService.state();
+        RoutingNode node = state.routingNodes().node(localNodeId());
+        return node.size() == 0;
+    }
+
+    /**
+     * <ul>
+     *     <li>remove exclusion for previously excluded nodeId that has been removed from the cluster
+     *     <li>wait for excluded nodes to have all their shards moved
+     * </ul>
+     */
+    @Override
+    public void clusterChanged(ClusterChangedEvent event) {
+        // apply new settings
+        if (event.metaDataChanged()) {
+            Settings settings = event.state().metaData().settings();
+            synchronized (excludeNodesLock) {
+                deallocatingNodes = Sets.newHashSet(settings.getAsArray(CLUSTER_ROUTING_EXCLUDE_BY_NODE_ID, EMPTY_STRING_ARRAY, true));
+            }
+            synchronized (futureLock) {
+                SettableFuture<DeallocationResult> future = waitForFullDeallocation;
+                String enableSetting = event.state().metaData().settings()
+                        .get(EnableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ENABLE);
+                if (future != null
+                        && waitForResetSetting.get()
+                        && (enableSetting == null || enableSetting.equalsIgnoreCase(allocationEnableSetting.get()))) {
+                    logger.info("[{}] deallocation successful.", localNodeId());
+                    waitForFullDeallocation = null;
+                    future.set(DeallocationResult.SUCCESS);
+                }
+            }
+        }
+
+        // remove removed nodes from deallocatingNodes list if we are master
+        if (event.state().nodes().localNodeMaster()) {
+            for (DiscoveryNode node : event.nodesDelta().removedNodes()) {
+                if (removeExclusion(node.id())) {
+                    logger.trace("[{}] removed removed node {}", localNodeId(), node.id());
+                }
+            }
+        }
+
+        // check for successful deallocation
+        if (waitForFullDeallocation != null) {
+            RoutingNode node = event.state().routingNodes().node(localNodeId());
+            if (node.numberOfShardsWithState(ShardRoutingState.STARTED, ShardRoutingState.INITIALIZING, ShardRoutingState.RELOCATING) == 0) {
+                // wait for reset settings and then succeed, see above
+                if (!waitForResetSetting.get()) {
+                    resetAllocationEnableSetting();
+                    waitForResetSetting.set(true);
+                }
+            } else if (logger.isTraceEnabled()) {
+                logger.trace("[{}] still {} started, {} initializing and {} relocating shards remaining",
+                        localNodeId(),
+                        node.numberOfShardsWithState(ShardRoutingState.STARTED),
+                        node.numberOfShardsWithState(ShardRoutingState.INITIALIZING),
+                        node.numberOfShardsWithState(ShardRoutingState.RELOCATING));
+            }
+        }
+
+    }
+
+    /**
+     * asynchronously remove exclusion for a node with id <code>nodeId</code> if it exists
+     * @return true if the exclusion existed and will be removed
+     */
+    private boolean removeExclusion(final String nodeId) {
+        synchronized (excludeNodesLock) {
+            boolean removed = deallocatingNodes.remove(nodeId);
+            if (removed) {
+                ClusterUpdateSettingsRequest request = new ClusterUpdateSettingsRequest();
+                request.transientSettings(ImmutableSettings.builder()
+                        .put(CLUSTER_ROUTING_EXCLUDE_BY_NODE_ID, COMMA_JOINER.join(deallocatingNodes))
+                        .build());
+                clusterChangeExecutor.enqueue(request, clusterUpdateSettingsAction,
+                        new ActionListener<ClusterUpdateSettingsResponse>() {
+                            @Override
+                            public void onResponse(ClusterUpdateSettingsResponse response) {
+                                logExcludedNodes(response.getTransientSettings());
+                            }
+
+                            @Override
+                            public void onFailure(Throwable e) {
+                                logger.error("[{}] error removing node '{}' from exclusion list", localNodeId(), nodeId, e);
+                            }
+                        });
+            }
+            return removed;
+        }
+    }
+
+    private void logExcludedNodes(Settings transientSettings) {
+        logger.debug("[{}] excluded nodes now set to: {}", localNodeId(), transientSettings.get(CLUSTER_ROUTING_EXCLUDE_BY_NODE_ID));
+    }
+}

--- a/src/main/java/org/elasticsearch/cluster/routing/allocation/deallocator/DeallocationCancelledException.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/allocation/deallocator/DeallocationCancelledException.java
@@ -17,30 +17,20 @@
  * under the License.
  */
 
-package org.elasticsearch.node.internal;
 
-import org.elasticsearch.cluster.service.GracefulStop;
-import org.elasticsearch.common.inject.AbstractModule;
-import org.elasticsearch.node.Node;
-import org.elasticsearch.node.service.NodeService;
-import org.elasticsearch.node.settings.NodeSettingsService;
+package org.elasticsearch.cluster.routing.allocation.deallocator;
 
-/**
- *
- */
-public class NodeModule extends AbstractModule {
+import java.util.Locale;
 
-    private final Node node;
+public class DeallocationCancelledException extends Exception {
 
-    public NodeModule(Node node) {
-        this.node = node;
+    private static final String MESSAGE_TMPL = "Deallocation cancelled for node '%s'";
+
+    public DeallocationCancelledException(String nodeId) {
+        super(String.format(Locale.ENGLISH, MESSAGE_TMPL, nodeId));
     }
 
-    @Override
-    protected void configure() {
-        bind(Node.class).toInstance(node);
-        bind(NodeSettingsService.class).asEagerSingleton();
-        bind(NodeService.class).asEagerSingleton();
-        bind(GracefulStop.class).asEagerSingleton();
+    public DeallocationCancelledException(String nodeId, Throwable cause) {
+        super(String.format(Locale.ENGLISH, MESSAGE_TMPL, nodeId), cause);
     }
 }

--- a/src/main/java/org/elasticsearch/cluster/routing/allocation/deallocator/DeallocationFailedException.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/allocation/deallocator/DeallocationFailedException.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.elasticsearch.cluster.routing.allocation.deallocator;
+
+import org.elasticsearch.cluster.routing.MutableShardRouting;
+import org.elasticsearch.cluster.routing.RoutingNode;
+import org.elasticsearch.common.Nullable;
+
+import java.util.Locale;
+
+public class DeallocationFailedException extends Exception {
+
+    private final static String TMPL = "Failed to move shard '%d' (%s) of index '%s' from node '%s'";
+    private final static String TMPL_SIMPLE = "Failed to deallocate node '%s'";
+
+
+    public DeallocationFailedException(String reason) {
+        super(reason);
+    }
+
+    public DeallocationFailedException(RoutingNode node) {
+        super(String.format(Locale.ENGLISH, TMPL_SIMPLE, node.nodeId()));
+    }
+
+    public DeallocationFailedException(RoutingNode node, MutableShardRouting shard) {
+        this(node, shard, null);
+    }
+
+    public DeallocationFailedException(RoutingNode node,
+                                       MutableShardRouting shard,
+                                       @Nullable String reason) {
+        super(String.format(Locale.ENGLISH, TMPL,
+                shard.id(),
+                shard.primary() ? "primary" : "replica",
+                shard.index(),
+                node.nodeId()) + (reason == null ? "" : ": " + reason));
+    }
+
+    public DeallocationFailedException(RoutingNode node,
+                                       MutableShardRouting shard,
+                                       Throwable cause,
+                                       @Nullable String reason) {
+        super(String.format(Locale.ENGLISH, TMPL,
+                shard.id(),
+                shard.primary() ? "primary" : "replica",
+                shard.index(),
+                node.nodeId()) + (reason == null ? "" : ": " + reason), cause);
+    }
+}

--- a/src/main/java/org/elasticsearch/cluster/routing/allocation/deallocator/Deallocator.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/allocation/deallocator/Deallocator.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.elasticsearch.cluster.routing.allocation.deallocator;
+
+import com.google.common.util.concurrent.ListenableFuture;
+
+import java.io.Closeable;
+
+/**
+ * deallocates shards on one node, moving them to other nodes
+ */
+public interface Deallocator extends Closeable {
+
+    public static class DeallocationResult {
+
+        public static final DeallocationResult SUCCESS_NOTHING_HAPPENED = new DeallocationResult(true, false);
+        public static final DeallocationResult SUCCESS = new DeallocationResult(true, true);
+        private final boolean success;
+        private final boolean didDeallocate;
+
+        protected DeallocationResult(boolean success, boolean didDeallocate) {
+            this.success = success;
+            this.didDeallocate = didDeallocate;
+        }
+
+
+        public boolean success() {
+            return success;
+        }
+
+
+        public boolean didDeallocate() {
+            return didDeallocate;
+        }
+    }
+
+    /**
+     * asynchronously deallocate shard of the local node
+     *
+     */
+    public ListenableFuture<DeallocationResult> deallocate();
+
+    /**
+     * cancel a currently running deallocation
+     *
+     * this is not similar to a rollback, if some shards have already been
+     * moved they will not be moved back by this method.
+     *
+     * @return true if a running deallocation was stopped
+     */
+    public boolean cancel();
+
+    public boolean isDeallocating();
+
+    /**
+     * @return true if this deallocator can finish its job succesfully
+     */
+    public boolean canDeallocate();
+
+    /**
+     * @return true if this deallocator would have nothing to do on deallocate()
+     */
+    public boolean isNoOp();
+}

--- a/src/main/java/org/elasticsearch/cluster/routing/allocation/deallocator/DeallocatorModule.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/allocation/deallocator/DeallocatorModule.java
@@ -17,30 +17,16 @@
  * under the License.
  */
 
-package org.elasticsearch.node.internal;
 
-import org.elasticsearch.cluster.service.GracefulStop;
+package org.elasticsearch.cluster.routing.allocation.deallocator;
+
 import org.elasticsearch.common.inject.AbstractModule;
-import org.elasticsearch.node.Node;
-import org.elasticsearch.node.service.NodeService;
-import org.elasticsearch.node.settings.NodeSettingsService;
 
-/**
- *
- */
-public class NodeModule extends AbstractModule {
-
-    private final Node node;
-
-    public NodeModule(Node node) {
-        this.node = node;
-    }
-
+public class DeallocatorModule extends AbstractModule {
     @Override
     protected void configure() {
-        bind(Node.class).toInstance(node);
-        bind(NodeSettingsService.class).asEagerSingleton();
-        bind(NodeService.class).asEagerSingleton();
-        bind(GracefulStop.class).asEagerSingleton();
+        bind(AllShardsDeallocator.class).asEagerSingleton();
+        bind(PrimariesDeallocator.class).asEagerSingleton();
+        bind(Deallocators.class).asEagerSingleton();
     }
 }

--- a/src/main/java/org/elasticsearch/cluster/routing/allocation/deallocator/Deallocators.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/allocation/deallocator/Deallocators.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.elasticsearch.cluster.routing.allocation.deallocator;
+
+import com.google.common.base.Objects;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+
+import java.io.IOException;
+import java.util.Locale;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class Deallocators implements Deallocator {
+
+    public static final String GRACEFUL_STOP_MIN_AVAILABILITY = "cluster.graceful_stop.min_availability";
+
+    public static class MinAvailability {
+        public static final String FULL = "full";
+        public static final String PRIMARIES = "primaries";
+        public static final String NONE = "none";
+    }
+
+    private final AllShardsDeallocator allShardsDeallocator;
+    private final PrimariesDeallocator primariesDeallocator;
+    private final ClusterService clusterService;
+
+    private AtomicReference<Deallocator> pendingDeallocation = new AtomicReference<>();
+
+    private Deallocator noOpDeallocator = new Deallocator() {
+        @Override
+        public ListenableFuture<DeallocationResult> deallocate() {
+            return Futures.immediateFuture(DeallocationResult.SUCCESS_NOTHING_HAPPENED);
+        }
+
+        @Override
+        public boolean cancel() {
+            return false;
+        }
+
+        @Override
+        public boolean isDeallocating() {
+            return false;
+        }
+
+        @Override
+        public boolean canDeallocate() {
+            return true;
+        }
+
+        @Override
+        public boolean isNoOp() {
+            return true;
+        }
+
+        @Override
+        public void close() throws IOException {
+        }
+    };
+
+    @Inject
+    public Deallocators(ClusterService clusterService, AllShardsDeallocator allShardsDeallocator, PrimariesDeallocator primariesDeallocator) {
+        this.clusterService = clusterService;
+        this.allShardsDeallocator = allShardsDeallocator;
+        this.primariesDeallocator = primariesDeallocator;
+    }
+
+    @Override
+    public void close() throws IOException {
+        allShardsDeallocator.close();
+        primariesDeallocator.close();
+    }
+
+    @Override
+    public ListenableFuture<Deallocator.DeallocationResult> deallocate() {
+        final Deallocator deallocator = deallocator();
+        if (!pendingDeallocation.compareAndSet(null, deallocator)) {
+            throw new IllegalStateException("Node already deallocating");
+        }
+        ListenableFuture<DeallocationResult> future = deallocator.deallocate();
+        Futures.addCallback(future, new FutureCallback<DeallocationResult>() {
+            @Override
+            public void onSuccess(DeallocationResult result) {
+                pendingDeallocation.compareAndSet(deallocator, null);
+            }
+
+            @Override
+            public void onFailure(Throwable throwable) {
+                pendingDeallocation.compareAndSet(deallocator, null);
+            }
+        });
+        return future;
+    }
+
+    @Override
+    public boolean cancel() {
+        Deallocator deallocator = pendingDeallocation.getAndSet(null);
+        return deallocator != null && deallocator.cancel();
+    }
+
+    @Override
+    public boolean isDeallocating() {
+        Deallocator deallocator = Objects.firstNonNull(pendingDeallocation.get(), deallocator());
+        return deallocator.isDeallocating();
+    }
+
+    @Override
+    public boolean canDeallocate() {
+        Deallocator deallocator = Objects.firstNonNull(pendingDeallocation.get(), deallocator());
+        return deallocator.canDeallocate();
+    }
+
+    @Override
+    public boolean isNoOp() {
+        Deallocator deallocator = Objects.firstNonNull(pendingDeallocation.get(), deallocator());
+        return deallocator.isNoOp();
+    }
+
+    /**
+     * get deallocator according to current min_availability setting.
+     * this might not be the one this node is currently deallocating with.
+     */
+    private Deallocator deallocator() {
+        Deallocator deallocator;
+        String minAvailability = clusterService.state().metaData().settings().get(GRACEFUL_STOP_MIN_AVAILABILITY, MinAvailability.PRIMARIES);
+        switch (minAvailability) {
+            case MinAvailability.PRIMARIES:
+                deallocator = primariesDeallocator;
+                break;
+            case MinAvailability.FULL:
+                deallocator = allShardsDeallocator;
+                break;
+            case MinAvailability.NONE:
+                deallocator = noOpDeallocator;
+                break;
+            default:
+                throw new IllegalArgumentException(String.format(Locale.ENGLISH, "invalid setting for '%s'", GRACEFUL_STOP_MIN_AVAILABILITY));
+        }
+        return deallocator;
+    }
+}

--- a/src/main/java/org/elasticsearch/cluster/routing/allocation/deallocator/PrimariesDeallocator.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/allocation/deallocator/PrimariesDeallocator.java
@@ -1,0 +1,506 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.routing.allocation.deallocator;
+
+import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
+import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.cluster.health.*;
+import org.elasticsearch.action.admin.cluster.settings.TransportClusterUpdateSettingsAction;
+import org.elasticsearch.action.admin.indices.settings.put.TransportUpdateSettingsAction;
+import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest;
+import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsResponse;
+import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateListener;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.routing.RoutingNode;
+import org.elasticsearch.cluster.routing.ShardRoutingState;
+import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.indices.IndexMissingException;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * This deallocator only deallocates primary shards that have no replica.
+ * Other primary shards are not moved as their replicas can take over.
+ *
+ * Internally it excludes the local node for shard deallocation for every index with currently 0 replicas
+ * that has shards on this node.
+ * This will move the primary shards on this node to another but leaves everything else as is.
+ */
+public class PrimariesDeallocator extends AbstractDeallocator implements ClusterStateListener {
+
+    private final TransportClusterHealthAction transportClusterHealthAction;
+    private final Object localNodeFutureLock = new Object();
+    private volatile SettableFuture<DeallocationResult> localNodeFuture;
+
+    private final Object deallocatingIndicesLock = new Object();
+    private volatile Map<String, Set<String>> deallocatingIndices;
+    private final Set<String> newIndices = Sets.newConcurrentHashSet();
+
+    private final AtomicBoolean waitForResetSetting = new AtomicBoolean(false);
+
+    @Inject
+    public PrimariesDeallocator(ClusterService clusterService,
+                                TransportClusterUpdateSettingsAction clusterUpdateSettingsAction,
+                                TransportClusterHealthAction clusterHealthAction,
+                                TransportUpdateSettingsAction indicesUpdateSettingsAction,
+                                Settings clusterSettings) {
+        super(clusterService, indicesUpdateSettingsAction, clusterUpdateSettingsAction, clusterSettings);
+        this.deallocatingIndices = new ConcurrentHashMap<>();
+        this.transportClusterHealthAction = clusterHealthAction;
+        this.clusterService.add(this);
+    }
+
+
+
+    /**
+     * return a set with all the indices that have zero replicas
+     *
+     * @param clusterMetaData the current clusterMetaData
+     */
+    private Set<String> zeroReplicaIndices(MetaData clusterMetaData) {
+        final Set<String> zeroReplicaIndices = new HashSet<>();
+        for (ObjectObjectCursor<String, IndexMetaData> entry : clusterMetaData.indices()) {
+            if (entry.value.numberOfReplicas() == 0) {
+                zeroReplicaIndices.add(entry.key);
+            }
+        }
+        return zeroReplicaIndices;
+    }
+
+    /**
+     * return a set with all the indices that have
+     *
+     *  * zero replicas
+     *  * a shard (must be primary) on the local node
+     *
+     * @param clusterMetaData the current clusterMetaData
+     */
+    private Set<String> localZeroReplicaIndices(RoutingNode routingNode, MetaData clusterMetaData) {
+        final Set<String> zeroReplicaIndices = new HashSet<>();
+        for (ObjectObjectCursor<String, IndexMetaData> entry : clusterMetaData.indices()) {
+            if (entry.value.numberOfReplicas() == 0) {
+                if (!routingNode.shardsWithState(entry.key, ShardRoutingState.INITIALIZING, ShardRoutingState.STARTED, ShardRoutingState.RELOCATING).isEmpty()) {
+                    zeroReplicaIndices.add(entry.key);
+                }
+            }
+        }
+        return zeroReplicaIndices;
+    }
+
+    private Set<String> localNewIndices(RoutingNode node, MetaData clusterMetaData) {
+        final Set<String> newLocalIndices = new HashSet<>();
+        synchronized (newIndices) {
+            for (String index : newIndices) {
+                IndexMetaData indexMetaData = clusterMetaData.index(index);
+                if (indexMetaData != null && indexMetaData.numberOfReplicas() == 0) {
+                    if (!node.shardsWithState(index, ShardRoutingState.INITIALIZING, ShardRoutingState.STARTED, ShardRoutingState.RELOCATING).isEmpty()) {
+                        newLocalIndices.add(index);
+                    }
+                }
+            }
+        }
+        return newLocalIndices;
+    }
+
+    @Override
+    public ListenableFuture<DeallocationResult> deallocate() {
+        if (isDeallocating()) {
+            throw new IllegalStateException("node already waiting for primary only deallocation");
+        }
+        logger.info("[{}] starting primaries deallocation...", localNodeId());
+        ClusterState state = clusterService.state();
+        final RoutingNode node = state.routingNodes().node(localNodeId());
+        if (node.size() == 0) {
+            return Futures.immediateFuture(DeallocationResult.SUCCESS_NOTHING_HAPPENED);
+        }
+        MetaData clusterMetaData = state.metaData();
+        if (localZeroReplicaIndices(node, clusterMetaData).isEmpty()) {
+            // no zero replica primaries on node
+            return Futures.immediateFuture(DeallocationResult.SUCCESS_NOTHING_HAPPENED);
+        }
+
+        final Set<String> zeroReplicaIndices = zeroReplicaIndices(clusterMetaData);
+        
+        // enable PRIMARIES allocation to make sure shards are moved, keep the old value
+        trackAllocationEnableSetting();
+        setAllocationEnableSetting(EnableAllocationDecider.Allocation.PRIMARIES.name().toLowerCase(Locale.ENGLISH));
+
+        SettableFuture<DeallocationResult> future;
+        synchronized (localNodeFutureLock) {
+            localNodeFuture = future = SettableFuture.create();
+        }
+        excludeNodeFromIndices(zeroReplicaIndices, new ActionListener<UpdateSettingsResponse>() {
+            @Override
+            public void onResponse(UpdateSettingsResponse updateSettingsResponse) {
+                logger.trace("successfully updated index settings");
+                // do nothing
+            }
+
+            @Override
+            public void onFailure(Throwable e) {
+                logger.error("error updating index settings", e);
+                cancelWithExceptionIfPresent(e);
+            }
+        });
+        return future;
+    }
+
+    /**
+     * configures the index so no shard will be allocated on the local node and existing
+     * shards will be moved from it.
+     * @param indices a set containing the indices which should be removed from the local node
+     * @param listener an ActionListener that is called for every UpdateSettingsRequest
+     */
+    private void excludeNodeFromIndices(final Set<String> indices,
+                                        ActionListener<UpdateSettingsResponse> listener) {
+        UpdateSettingsRequest[] settingsRequests = new UpdateSettingsRequest[indices.size()];
+        synchronized (deallocatingIndicesLock) {
+            int i = 0;
+            for (String index : indices) {
+                Set<String> excludeNodes = deallocatingIndices.get(index);
+                if (excludeNodes == null) {
+                    excludeNodes = new HashSet<>();
+                    deallocatingIndices.put(index, excludeNodes);
+                }
+                excludeNodes.add(localNodeId());
+                settingsRequests[i++] = new UpdateSettingsRequest(
+                        ImmutableSettings.builder()
+                                .put(EXCLUDE_NODE_ID_FROM_INDEX, COMMA_JOINER.join(excludeNodes))
+                                .build(),
+                        index);
+            }
+
+        }
+        if (settingsRequests.length > 0) {
+            clusterChangeExecutor.enqueue(settingsRequests, updateSettingsAction, listener);
+        }
+    }
+
+    private boolean cancelWithExceptionIfPresent(final Throwable e) {
+        boolean result = false;
+        synchronized (localNodeFutureLock) {
+            final SettableFuture<DeallocationResult> future = localNodeFuture;
+            if (future != null) {
+                logger.error("[{}] primaries deallocation cancelled due to an error", e, localNodeId());
+                // delay setting the exception on the future
+                // until the allocation.enable setting is reset
+                resetAllocationEnableSetting();
+                clusterService.add(new ClusterStateListener() {
+                    @Override
+                    public void clusterChanged(ClusterChangedEvent event) {
+                        String enableSetting = event.state().metaData().settings()
+                                .get(EnableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ENABLE);
+                        if (event.metaDataChanged()
+                                && (enableSetting == null || enableSetting.equals(allocationEnableSetting.get()))) {
+                            future.setException(e);
+                            clusterService.remove(this);
+                        }
+                    }
+                });
+                localNodeFuture = null;
+                newIndices.clear();
+                result = true;
+            }
+        }
+        return result;
+    }
+
+    private boolean cancelIfPresent() {
+        boolean result = false;
+        synchronized (localNodeFutureLock) {
+            SettableFuture<DeallocationResult> future = localNodeFuture;
+            if (future != null) {
+                // reset setting and
+                // synchronously wait until the allocation.enable setting is reset
+                resetAllocationEnableSetting();
+                final SettableFuture<Void> resetSettingFuture = SettableFuture.create();
+                clusterService.add(new ClusterStateListener() {
+                    @Override
+                    public void clusterChanged(ClusterChangedEvent event) {
+                        String enableSetting = event.state().metaData().settings()
+                                .get(EnableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ENABLE);
+                        if (event.metaDataChanged()
+                                && (enableSetting == null || enableSetting.equals(allocationEnableSetting.get()))) {
+                            resetSettingFuture.set(null);
+                            clusterService.remove(this);
+                        }
+                    }
+                });
+                try {
+                    resetSettingFuture.get(10, TimeUnit.SECONDS);
+                } catch (InterruptedException | TimeoutException | ExecutionException e) {
+                    logger.error("error waiting for reset of {} setting", e, EnableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ENABLE);
+                    // proceed
+                }
+                future.cancel(true);
+                localNodeFuture = null;
+                newIndices.clear();
+                result = true;
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public boolean cancel() {
+        boolean cancelled = removeExclusion(localNodeId());
+        cancelled |= cancelIfPresent();
+        if (cancelled) {
+            logger.info("[{}] primaries deallocation cancelled", localNodeId());
+        } else {
+            logger.debug("[{}] node not deallocating", localNodeId());
+        }
+
+        return cancelled;
+    }
+
+    private boolean removeExclusion(final String nodeId) {
+        synchronized (deallocatingIndicesLock) {
+            Set<String> changed = new HashSet<>();
+            for (Map.Entry<String, Set<String>> entry : deallocatingIndices.entrySet()) {
+                Set<String> excludeNodes = entry.getValue();
+                if (excludeNodes.remove(nodeId)) {
+                    changed.add(entry.getKey());
+                }
+                if (excludeNodes.isEmpty()) {
+                    deallocatingIndices.remove(entry.getKey());
+                }
+            }
+            if (!changed.isEmpty()) {
+                UpdateSettingsRequest[] requests = new UpdateSettingsRequest[changed.size()];
+                int i = 0;
+                for (final String index : changed) {
+                    Settings settings = ImmutableSettings.builder().put(EXCLUDE_NODE_ID_FROM_INDEX,
+                            COMMA_JOINER.join(Objects.firstNonNull(deallocatingIndices.get(index), Collections.EMPTY_SET))).build();
+                    requests[i++] = new UpdateSettingsRequest(settings, index);
+
+                }
+                clusterChangeExecutor.enqueue(requests,updateSettingsAction, new ActionListener<UpdateSettingsResponse>() {
+                    @Override
+                    public void onResponse(UpdateSettingsResponse updateSettingsResponse) {
+                        logger.trace("[{}] excluded node {} from some index", localNodeId(), nodeId);
+                    }
+
+                    @Override
+                    public void onFailure(Throwable e) {
+                        logger.error("[{}] error removing exclusion for node {}", e, localNodeId(), nodeId);
+                    }
+                });
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean isDeallocating() {
+        return localNodeFuture != null || localNodeIsExcluded();
+    }
+
+    /**
+     * This deallocator can always deallocate
+     */
+    @Override
+    public boolean canDeallocate() {
+        return true;
+    }
+
+    /**
+     * @return true if this node has no primary shards with 0 replicas
+     * or no shards at all
+     */
+    @Override
+    public boolean isNoOp() {
+        ClusterState state = clusterService.state();
+        RoutingNode node = state.routingNodes().node(localNodeId());
+        return node.size() == 0 || localZeroReplicaIndices(node, state.metaData()).isEmpty();
+    }
+
+    private boolean localNodeIsExcluded() {
+        synchronized (deallocatingIndicesLock) {
+            for (Set<String> excludeNodes : deallocatingIndices.values()) {
+                if (excludeNodes != null && excludeNodes.contains(localNodeId())) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void clusterChanged(ClusterChangedEvent event) {
+        if (event.metaDataChanged()) {
+            synchronized (deallocatingIndicesLock) {
+                // update deallocating nodes from new cluster state
+                for (ObjectObjectCursor<String, IndexMetaData> entry : event.state().metaData().indices()) {
+                    String[] excludeNodesSetting = entry.value.settings().getAsArray(EXCLUDE_NODE_ID_FROM_INDEX, EMPTY_STRING_ARRAY, true);
+                    if (excludeNodesSetting.length > 0) {
+                        List<String> excludeNodes = Arrays.asList(excludeNodesSetting);
+                        if (!excludeNodes.isEmpty()) {
+                            deallocatingIndices.put(entry.key, Sets.newHashSet(excludeNodes));
+                        }
+                    }
+                }
+                if (logger.isTraceEnabled()) {
+                    logger.trace("new deallocating indices: {}", COMMA_JOINER.withKeyValueSeparator(":").join(deallocatingIndices));
+                }
+            }
+
+            synchronized (localNodeFutureLock) {
+                String enableSetting = event.state().metaData().settings()
+                        .get(EnableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ENABLE);
+                if (localNodeFuture != null
+                        && waitForResetSetting.get()
+                        && (enableSetting == null || enableSetting.equalsIgnoreCase(allocationEnableSetting.get()))) {
+                    // setting was reset, finally done
+                    logger.info("[{}] primaries deallocation successful", localNodeId());
+                    localNodeFuture.set(DeallocationResult.SUCCESS);
+                    localNodeFuture = null;
+                    newIndices.clear();
+                }
+            }
+        }
+
+        // exclusive master operation
+        if (event.state().nodes().localNodeMaster()) {
+            clusterChangedOnMaster(event);
+        }
+
+        if (localNodeFuture != null) { // not inside lock
+            // add exclusion for all new indices, too
+            List<String> createdIndices = event.indicesCreated();
+            if (!createdIndices.isEmpty()) {
+                newIndices.addAll(createdIndices);
+                // wait for indices to become available first
+                ClusterHealthRequest request = new ClusterHealthRequest(newIndices.toArray(new String[newIndices.size()]));
+                request.timeout(new TimeValue(60 * 1000)); // wait 60 seconds max
+                request.waitForYellowStatus();
+                clusterChangeExecutor.enqueue(request, transportClusterHealthAction, new ActionListener<ClusterHealthResponse>() {
+                    @Override
+                    public void onResponse(ClusterHealthResponse clusterIndexHealths) {
+                        if (clusterIndexHealths.isTimedOut()) {
+                            // some of the new indices did not reach yellow state,
+                            // if so, we cannot fulfil the primaries min_availability, so give up
+                            for (Map.Entry<String, ClusterIndexHealth> entry : clusterIndexHealths.getIndices().entrySet()) {
+                                if (entry.getValue().getStatus().equals(ClusterHealthStatus.RED)) {
+                                    logger.trace("Index '{}' did not reach yellow state: {}.",
+                                            entry.getKey(),
+                                            entry.getValue().getStatus().name());
+                                    cancelWithExceptionIfPresent(
+                                            new DeallocationFailedException(
+                                                    String.format(Locale.ENGLISH,
+                                                            "Index '%s' did not reach yellow state",
+                                                            entry.getKey()
+                                                    )
+                                            )
+                                    );
+                                }
+                            }
+
+                        }
+                    }
+
+                    @Override
+                    public void onFailure(Throwable e) {
+                        logger.error("error waiting for yellow status on new indices", e);
+                        cancelWithExceptionIfPresent(e);
+                    }
+                });
+                // exclude localNode from new indices
+                excludeNodeFromIndices(newIndices, new ActionListener<UpdateSettingsResponse>() {
+                    private int retryCounter = 0;
+
+                    @Override
+                    public void onResponse(UpdateSettingsResponse updateSettingsResponse) {
+                        logger.trace("successfully updated index settings for new index");
+                        // do nothing
+                    }
+
+                    @Override
+                    public void onFailure(Throwable e) {
+                        retryCounter++;
+                        if (e instanceof IndexMissingException && retryCounter < 3) {
+                            String index = ((IndexMissingException) e).index().name();
+                            // retry
+                            excludeNodeFromIndices(ImmutableSet.of(index), this);
+                        } else {
+                            logger.error("error updating index settings for new index", e);
+                            cancelWithExceptionIfPresent(e);
+                        }
+                    }
+                });
+            }
+        }
+
+        synchronized (localNodeFutureLock) {
+            if (localNodeFuture != null) {
+                RoutingNode node = event.state().routingNodes().node(localNodeId());
+                MetaData clusterMetaData = event.state().metaData();
+                Set<String> localZeroReplicaIndices = localZeroReplicaIndices(node, clusterMetaData);
+                Set<String> localNewIndices = localNewIndices(node, clusterMetaData);
+
+                if (localZeroReplicaIndices.isEmpty() && localNewIndices.isEmpty()) {
+                    // wait until cluster setting routing.allocation.enable is reset, then succeed
+                    if (!waitForResetSetting.get()) {
+                        resetAllocationEnableSetting();
+                        waitForResetSetting.set(true);
+                    }
+                } else {
+                    logger.trace("[{}] zero replica primaries left for indices: {}", localNodeId(), COMMA_JOINER.join(localZeroReplicaIndices));
+                }
+            }
+        }
+
+    }
+
+    /**
+     * handle ClusterChangedEvent when local node is master
+     */
+    private void clusterChangedOnMaster(ClusterChangedEvent event) {
+        // remove removed nodes from deallocatingNodes list if we are master
+        if (event.nodesRemoved()) {
+            for (DiscoveryNode node : event.nodesDelta().removedNodes()) {
+                if (removeExclusion(node.id())) {
+                    logger.trace("[{}] removed removed node {}", localNodeId(), node.id());
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/org/elasticsearch/cluster/service/GracefulStop.java
+++ b/src/main/java/org/elasticsearch/cluster/service/GracefulStop.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.service;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.routing.allocation.deallocator.Deallocator;
+import org.elasticsearch.cluster.routing.allocation.deallocator.Deallocators;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.node.settings.NodeSettingsService;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class GracefulStop implements Closeable {
+
+    private final Deallocators deallocators;
+    private final ClusterService clusterService;
+    private AtomicBoolean forceStop = new AtomicBoolean(false);
+    private AtomicBoolean reallocate = new AtomicBoolean(true);
+    private AtomicReference<TimeValue> timeout = new AtomicReference<>();
+    private final ESLogger logger = Loggers.getLogger(getClass());
+    private ListenableFuture<Deallocator.DeallocationResult> deallocateFuture;
+
+    @Override
+    public void close() throws IOException {
+        deallocators.close();
+    }
+
+    public static class SettingNames {
+        public static final String TIMEOUT = "cluster.graceful_stop.timeout";
+        public static final String FORCE = "cluster.graceful_stop.force";
+        public static final String REALLOCATE = "cluster.graceful_stop.reallocate";
+    }
+
+    @Inject
+    public GracefulStop(Settings settings,
+                        ClusterService clusterService,
+                        NodeSettingsService nodeSettingsService,
+                        Deallocators deallocators) {
+        this.deallocators = deallocators;
+        this.clusterService = clusterService;
+        timeout.set(TimeValue.parseTimeValue(settings.get(SettingNames.TIMEOUT, "2h"), TimeValue.timeValueHours(2)));
+        forceStop.set(settings.getAsBoolean(SettingNames.FORCE, false));
+        reallocate.set(settings.getAsBoolean(SettingNames.REALLOCATE, true));
+        nodeSettingsService.addListener(new NodeSettingsService.Listener() {
+            @Override
+            public void onRefreshSettings(Settings settings) {
+                forceStop.set(settings.getAsBoolean(SettingNames.FORCE, false));
+                timeout.set(TimeValue.parseTimeValue(settings.get(SettingNames.TIMEOUT, "2h"), TimeValue.timeValueHours(2)));
+                reallocate.set(settings.getAsBoolean(SettingNames.REALLOCATE, true));
+            }
+        });
+    }
+
+    public boolean forceStop() {
+        return forceStop.get();
+    }
+
+    public boolean reallocate() {
+        return reallocate.get();
+    }
+
+    public boolean isSingleNode() {
+        return clusterService.state().nodes().size() == 1;
+    }
+
+    public boolean deallocate() {
+        if (isSingleNode()) {
+            return true; // shortcut for single node cluster
+        }
+        if (reallocate()) {
+            if (deallocators.canDeallocate()) {
+                deallocateFuture = deallocators.deallocate();
+                try {
+                    TimeValue timeValue = timeout.get();
+                    Deallocator.DeallocationResult deallocationResult = deallocateFuture.get(timeValue.getSeconds(), TimeUnit.SECONDS);
+
+                    return deallocationResult.success();
+                } catch (InterruptedException | ExecutionException | TimeoutException e) {
+                    logger.error("error while de-allocating node", e);
+                    deallocators.cancel(); // cancel so state will be reset
+                    return false;
+                }
+            } else {
+                logger.error("cannot deallocate");
+                return false;
+            }
+        } else {
+            // return true, if a node shutdown would result in the desired min_availability
+            return deallocators.isNoOp();
+        }
+    }
+
+    public void cancelDeAllocationIfRunning() {
+        if (deallocators.isDeallocating()) {
+            deallocators.cancel();
+        }
+        if (deallocateFuture != null) {
+            deallocateFuture.cancel(true);
+            deallocateFuture = null;
+        }
+    }
+}

--- a/src/main/java/org/elasticsearch/cluster/settings/ClusterDynamicSettingsModule.java
+++ b/src/main/java/org/elasticsearch/cluster/settings/ClusterDynamicSettingsModule.java
@@ -24,7 +24,9 @@ import org.elasticsearch.cluster.InternalClusterInfoService;
 import org.elasticsearch.cluster.action.index.MappingUpdatedAction;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllocator;
+import org.elasticsearch.cluster.routing.allocation.deallocator.Deallocators;
 import org.elasticsearch.cluster.routing.allocation.decider.*;
+import org.elasticsearch.cluster.service.GracefulStop;
 import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.discovery.DiscoverySettings;
 import org.elasticsearch.discovery.zen.ZenDiscovery;
@@ -96,6 +98,10 @@ public class ClusterDynamicSettingsModule extends AbstractModule {
         clusterDynamicSettings.addDynamicSetting(HierarchyCircuitBreakerService.FIELDDATA_CIRCUIT_BREAKER_OVERHEAD_SETTING, Validator.NON_NEGATIVE_DOUBLE);
         clusterDynamicSettings.addDynamicSetting(HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_LIMIT_SETTING, Validator.MEMORY_SIZE);
         clusterDynamicSettings.addDynamicSetting(HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_OVERHEAD_SETTING, Validator.NON_NEGATIVE_DOUBLE);
+        clusterDynamicSettings.addDynamicSetting(GracefulStop.SettingNames.TIMEOUT, Validator.TIME_NON_NEGATIVE);
+        clusterDynamicSettings.addDynamicSetting(GracefulStop.SettingNames.FORCE, Validator.BOOLEAN);
+        clusterDynamicSettings.addDynamicSetting(GracefulStop.SettingNames.REALLOCATE, Validator.BOOLEAN);
+        clusterDynamicSettings.addDynamicSetting(Deallocators.GRACEFUL_STOP_MIN_AVAILABILITY);
     }
 
     public void addDynamicSettings(String... settings) {

--- a/src/main/java/org/elasticsearch/common/component/LifecycleComponent.java
+++ b/src/main/java/org/elasticsearch/common/component/LifecycleComponent.java
@@ -32,6 +32,19 @@ public interface LifecycleComponent<T> extends CloseableComponent {
 
     void removeLifecycleListener(LifecycleListener listener);
 
+    /**
+     * Disable a component. <br />
+     * This can be called before {@link #stop()} to put a component into the disabled state.
+     *
+     * In the disabled state a component will reject new operations and wait for all pending operations to complete.
+     */
+    T disable() throws ElasticsearchException;
+
+    /**
+     * Starts a component. <br />
+     * If the component was just disabled it will re-enable the component again but not invoke a full start
+     * so handlers like {@link org.elasticsearch.common.component.LifecycleListener#beforeStart()} aren't called.
+     */
     T start() throws ElasticsearchException;
 
     T stop() throws ElasticsearchException;

--- a/src/main/java/org/elasticsearch/common/netty/OpenChannelsHandler.java
+++ b/src/main/java/org/elasticsearch/common/netty/OpenChannelsHandler.java
@@ -19,12 +19,21 @@
 
 package org.elasticsearch.common.netty;
 
+import com.google.common.util.concurrent.SettableFuture;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.metrics.CounterMetric;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.jboss.netty.channel.*;
+import org.jboss.netty.handler.codec.http.DefaultHttpResponse;
+import org.jboss.netty.handler.codec.http.HttpHeaders;
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+import org.jboss.netty.handler.codec.http.HttpVersion;
 
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  *
@@ -35,6 +44,9 @@ public class OpenChannelsHandler implements ChannelUpstreamHandler {
     final Set<Channel> openChannels = ConcurrentCollections.newConcurrentSet();
     final CounterMetric openChannelsMetric = new CounterMetric();
     final CounterMetric totalChannelsMetric = new CounterMetric();
+
+    final AtomicBoolean disabled = new AtomicBoolean(false);
+    final SettableFuture<Boolean> noOpenChannels = SettableFuture.create();
 
     final ESLogger logger;
 
@@ -47,6 +59,9 @@ public class OpenChannelsHandler implements ChannelUpstreamHandler {
             boolean removed = openChannels.remove(future.getChannel());
             if (removed) {
                 openChannelsMetric.dec();
+                if (disabled.get() && openChannels.isEmpty()) {
+                    noOpenChannels.set(true);
+                }
             }
             if (logger.isTraceEnabled()) {
                 logger.trace("channel closed: {}", future.getChannel());
@@ -56,6 +71,13 @@ public class OpenChannelsHandler implements ChannelUpstreamHandler {
 
     @Override
     public void handleUpstream(ChannelHandlerContext ctx, ChannelEvent e) throws Exception {
+        if (e instanceof UpstreamMessageEvent && disabled.get()) {
+            // TODO transport response?
+            DefaultHttpResponse response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.SERVICE_UNAVAILABLE);
+            HttpHeaders.setContentLength(response, 0);
+            ctx.getChannel().write(response).addListener(ChannelFutureListener.CLOSE);
+            return;
+        }
         if (e instanceof ChannelStateEvent) {
             ChannelStateEvent evt = (ChannelStateEvent) e;
             // OPEN is also sent to when closing channel, but with FALSE on it to indicate it closes
@@ -80,6 +102,23 @@ public class OpenChannelsHandler implements ChannelUpstreamHandler {
 
     public long totalChannels() {
         return totalChannelsMetric.count();
+    }
+
+    public void enable() {
+        disabled.set(false);
+    }
+
+    public void disable() {
+        disabled.set(true);
+        if (openChannels.isEmpty()) {
+            return;
+        }
+        try {
+            // impatiently wait for some clients to be done
+            noOpenChannels.get(5, TimeUnit.SECONDS);
+        } catch (InterruptedException | TimeoutException | ExecutionException e) {
+            Thread.interrupted();
+        }
     }
 
     public void close() {

--- a/src/main/java/org/elasticsearch/common/util/concurrent/FutureUtils.java
+++ b/src/main/java/org/elasticsearch/common/util/concurrent/FutureUtils.java
@@ -18,9 +18,6 @@
  */
 
 package org.elasticsearch.common.util.concurrent;
-
-import org.elasticsearch.ElasticsearchIllegalArgumentException;
-
 import java.util.concurrent.Future;
 
 /**

--- a/src/main/java/org/elasticsearch/discovery/DiscoveryService.java
+++ b/src/main/java/org/elasticsearch/discovery/DiscoveryService.java
@@ -133,7 +133,7 @@ public class DiscoveryService extends AbstractLifecycleComponent<DiscoveryServic
      * event based on the response gotten from all nodes
      */
     public void publish(ClusterState clusterState, Discovery.AckListener ackListener) {
-        if (lifecycle.started()) {
+        if (lifecycle.started() || lifecycle.disabled()) {
             discovery.publish(clusterState, ackListener);
         }
     }

--- a/src/main/java/org/elasticsearch/discovery/zen/ping/ZenPingService.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ping/ZenPingService.java
@@ -89,7 +89,7 @@ public class ZenPingService extends AbstractLifecycleComponent<ZenPing> implemen
 
     @Override
     public void setPingContextProvider(PingContextProvider contextProvider) {
-        if (lifecycle.started()) {
+        if (lifecycle.started() || lifecycle.disabled()) {
             throw new ElasticsearchIllegalStateException("Can't set nodes provider when started");
         }
         for (ZenPing zenPing : zenPings) {

--- a/src/main/java/org/elasticsearch/discovery/zen/ping/multicast/MulticastZenPing.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ping/multicast/MulticastZenPing.java
@@ -112,7 +112,7 @@ public class MulticastZenPing extends AbstractLifecycleComponent<ZenPing> implem
 
     @Override
     public void setPingContextProvider(PingContextProvider nodesProvider) {
-        if (lifecycle.started()) {
+        if (lifecycle.started() || lifecycle.disabled()) {
             throw new ElasticsearchIllegalStateException("Can't set nodes provider when started");
         }
         this.contextProvider = nodesProvider;
@@ -427,7 +427,7 @@ public class MulticastZenPing extends AbstractLifecycleComponent<ZenPing> implem
                     handleNodePingRequest(id, requestingNodeX, clusterName);
                 }
             } catch (Exception e) {
-                if (!lifecycle.started() || (e instanceof EsRejectedExecutionException)) {
+                if (!(lifecycle.started() || lifecycle.disabled()) || (e instanceof EsRejectedExecutionException)) {
                     logger.debug("failed to read requesting data from {}", e, address);
                 } else {
                     logger.warn("failed to read requesting data from {}", e, address);
@@ -547,7 +547,7 @@ public class MulticastZenPing extends AbstractLifecycleComponent<ZenPing> implem
                                 }
                             });
                         } catch (Exception e) {
-                            if (lifecycle.started()) {
+                            if (lifecycle.started() || lifecycle.disabled()) {
                                 logger.warn("failed to connect to requesting node {}", e, requestingNode);
                             }
                         }
@@ -557,7 +557,7 @@ public class MulticastZenPing extends AbstractLifecycleComponent<ZenPing> implem
                 transportService.sendRequest(requestingNode, ACTION_NAME, multicastPingResponse, new EmptyTransportResponseHandler(ThreadPool.Names.SAME) {
                     @Override
                     public void handleException(TransportException exp) {
-                        if (lifecycle.started()) {
+                        if (lifecycle.started() || lifecycle.disabled()) {
                             logger.warn("failed to receive confirmation on sent ping response to [{}]", exp, requestingNode);
                         }
                     }

--- a/src/main/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPing.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPing.java
@@ -460,8 +460,8 @@ public class UnicastZenPing extends AbstractLifecycleComponent<ZenPing> implemen
     }
 
     private UnicastPingResponse handlePingRequest(final UnicastPingRequest request) {
-        if (!lifecycle.started()) {
-            throw new ElasticsearchIllegalStateException("received ping request while not started");
+        if (!lifecycle.started() && !lifecycle.disabled()) {
+            throw new ElasticsearchIllegalStateException("received ping request while state is " + lifecycle);
         }
         temporalResponses.add(request.pingResponse);
         threadPool.schedule(TimeValue.timeValueMillis(request.timeout.millis() * 2), ThreadPool.Names.SAME, new Runnable() {

--- a/src/main/java/org/elasticsearch/http/HttpServer.java
+++ b/src/main/java/org/elasticsearch/http/HttpServer.java
@@ -104,6 +104,16 @@ public class HttpServer extends AbstractLifecycleComponent<HttpServer> {
         transport.close();
     }
 
+    @Override
+    protected void doDisable() throws ElasticsearchException {
+       transport.disable();
+    }
+
+    @Override
+    protected void doEnable() throws ElasticsearchException {
+        transport.start();
+    }
+
     public HttpInfo info() {
         return transport.info();
     }

--- a/src/main/java/org/elasticsearch/http/netty/NettyHttpServerTransport.java
+++ b/src/main/java/org/elasticsearch/http/netty/NettyHttpServerTransport.java
@@ -293,6 +293,20 @@ public class NettyHttpServerTransport extends AbstractLifecycleComponent<HttpSer
     }
 
     @Override
+    protected void doDisable() throws ElasticsearchException {
+        if (serverOpenChannels != null) {
+            serverOpenChannels.disable();
+        }
+    }
+
+    @Override
+    protected void doEnable() throws ElasticsearchException {
+        if (serverOpenChannels != null) {
+            serverOpenChannels.enable();
+        }
+    }
+
+    @Override
     protected void doClose() throws ElasticsearchException {
     }
 
@@ -326,7 +340,7 @@ public class NettyHttpServerTransport extends AbstractLifecycleComponent<HttpSer
             }
             ctx.getChannel().close();
         } else {
-            if (!lifecycle.started()) {
+            if (!(lifecycle.started() || lifecycle.disabled())) {
                 // ignore
                 return;
             }

--- a/src/main/java/org/elasticsearch/indices/InternalIndicesService.java
+++ b/src/main/java/org/elasticsearch/indices/InternalIndicesService.java
@@ -248,7 +248,7 @@ public class InternalIndicesService extends AbstractLifecycleComponent<IndicesSe
      */
     public boolean changesAllowed() {
         // we check on stop here since we defined stop when we delete the indices
-        return lifecycle.started();
+        return lifecycle.started() || lifecycle.disabled();
     }
 
     @Override
@@ -278,7 +278,7 @@ public class InternalIndicesService extends AbstractLifecycleComponent<IndicesSe
     }
 
     public synchronized IndexService createIndex(String sIndexName, Settings settings, String localNodeId) throws ElasticsearchException {
-        if (!lifecycle.started()) {
+        if (!lifecycle.started() && !lifecycle.disabled()) {
             throw new ElasticsearchIllegalStateException("Can't create an index [" + sIndexName + "], node is closed");
         }
         Index index = new Index(sIndexName);

--- a/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -155,7 +155,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent<Indic
             return;
         }
 
-        if (!lifecycle.started()) {
+        if (!(lifecycle.started() || lifecycle.disabled())) {
             return;
         }
 

--- a/src/main/java/org/elasticsearch/node/Node.java
+++ b/src/main/java/org/elasticsearch/node/Node.java
@@ -55,6 +55,11 @@ public interface Node extends Releasable{
     Node stop();
 
     /**
+     * disables the node,
+     */
+    boolean disable();
+
+    /**
      * Closes the node (and {@link #stop}s if its running).
      */
     void close();
@@ -63,4 +68,9 @@ public interface Node extends Releasable{
      * Returns <tt>true</tt> if the node is closed.
      */
     boolean isClosed();
+
+    /**
+     * Returns <tt>true</tt> if the node is disabled.
+     */
+    boolean isDisabled();
 }

--- a/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/src/main/java/org/elasticsearch/search/SearchService.java
@@ -847,7 +847,6 @@ public class SearchService extends AbstractLifecycleComponent<SearchService> {
                     if (fieldDataType.getLoading() == Loading.LAZY) {
                         continue;
                     }
-
                     final String indexName = fieldMapper.names().indexName();
                     if (warmUp.containsKey(indexName)) {
                         continue;

--- a/src/test/java/org/elasticsearch/client/transport/InternalTransportClientTests.java
+++ b/src/test/java/org/elasticsearch/client/transport/InternalTransportClientTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.client.transport;
 
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.*;
 import org.elasticsearch.action.admin.cluster.ClusterAction;
@@ -37,6 +38,7 @@ import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.transport.LocalTransportAddress;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.Transport;
 import org.elasticsearch.transport.TransportService;
 import org.junit.Test;
 
@@ -68,6 +70,12 @@ public class InternalTransportClientTests extends ElasticsearchTestCase {
                 @Override
                 protected TestResponse newResponse() {
                     return new TestResponse();
+                }
+
+                @Override
+                public Transport disable() throws ElasticsearchException {
+                    transport.disable();
+                    return this;
                 }
             };
             transportService = new TransportService(ImmutableSettings.EMPTY, transport, threadPool);

--- a/src/test/java/org/elasticsearch/client/transport/TransportClientNodesServiceTests.java
+++ b/src/test/java/org/elasticsearch/client/transport/TransportClientNodesServiceTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.client.transport;
 
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.support.Headers;
@@ -56,6 +57,12 @@ public class TransportClientNodesServiceTests extends ElasticsearchTestCase {
                 @Override
                 protected TestResponse newResponse() {
                     return  new TestResponse();
+                }
+
+                @Override
+                public Transport disable() throws ElasticsearchException {
+                    transport.disable();
+                    return this;
                 }
             };
             transportService = new TransportService(ImmutableSettings.EMPTY, transport, threadPool);

--- a/src/test/java/org/elasticsearch/cluster/graceful/GracefulStopSingleNodeTest.java
+++ b/src/test/java/org/elasticsearch/cluster/graceful/GracefulStopSingleNodeTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.graceful;
+
+import org.elasticsearch.cluster.routing.allocation.deallocator.Deallocators;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+
+@ElasticsearchIntegrationTest.ClusterScope(
+        scope= ElasticsearchIntegrationTest.Scope.TEST,
+        numDataNodes = 1,
+        numClientNodes = 0,
+        enableRandomBenchNodes = false)
+public class GracefulStopSingleNodeTest extends GracefulStopTestBase {
+
+    private void assertSingleNodeGracefulStop() {
+        assertThat(gracefulStop.deallocate(), is(true));
+        assertThat(deallocators.isDeallocating(), is(false));
+    }
+
+    @Test
+    public void testNoReallocateCouldNotDeallocate() throws Exception {
+        setSettings(false, false, Deallocators.MinAvailability.FULL, "2m");
+        createIndex(3, 0, 10);
+        assertSingleNodeGracefulStop();
+    }
+
+    @Test
+    public void testNoReallocateCouldDeallocate() throws Exception {
+        setSettings(false, false, Deallocators.MinAvailability.FULL, "2m");
+        createIndex(3, 1, 10);
+        assertSingleNodeGracefulStop();
+    }
+
+    @Test
+    public void testReallocateFullCouldNotDeallocate() throws Exception {
+        setSettings(false, true, Deallocators.MinAvailability.FULL, "2m");
+        createIndex(3, 1, 10);
+        assertSingleNodeGracefulStop();
+    }
+
+    @Test
+    public void testReallocateFullCouldDeallocate() throws Exception {
+        setSettings(false, true, Deallocators.MinAvailability.FULL, "2m");
+        assertSingleNodeGracefulStop();
+    }
+
+    @Test
+    public void testNoReallocatePrimaries() throws Exception {
+        setSettings(false, false, Deallocators.MinAvailability.PRIMARIES, "2m");
+        createIndex(3, 0, 10);
+        assertSingleNodeGracefulStop();
+    }
+
+    @Test
+    public void testReallocatePrimaries() throws Exception {
+        setSettings(false, true, Deallocators.MinAvailability.PRIMARIES, "2m");
+        createIndex(3, 0, 10);
+        assertSingleNodeGracefulStop();
+    }
+
+    @Test
+    public void testNoReallocateNone() throws Exception {
+        setSettings(false, false, Deallocators.MinAvailability.NONE, "2m");
+        createIndex(3, 0, 10);
+        assertSingleNodeGracefulStop();
+    }
+
+    @Test
+    public void testReallocateNone() throws Exception {
+        setSettings(false, true, Deallocators.MinAvailability.NONE, "2m");
+        createIndex(3, 0, 10);
+        assertSingleNodeGracefulStop();
+    }
+}

--- a/src/test/java/org/elasticsearch/cluster/graceful/GracefulStopTest.java
+++ b/src/test/java/org/elasticsearch/cluster/graceful/GracefulStopTest.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.graceful;
+
+import org.elasticsearch.cluster.routing.allocation.deallocator.Deallocators;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+
+@ElasticsearchIntegrationTest.ClusterScope(
+        scope= ElasticsearchIntegrationTest.Scope.TEST,
+        numDataNodes = 3,
+        numClientNodes = 0,
+        enableRandomBenchNodes = false)
+public class GracefulStopTest extends GracefulStopTestBase {
+
+    @Test
+    public void testNoReallocateCannotDeallocate() throws Exception {
+        setSettings(false, false, Deallocators.MinAvailability.FULL, "2m");
+        createIndex(3, 0, 10);
+
+        assertThat(gracefulStop.reallocate(), is(false));
+        // cannot deallocate
+        assertThat(gracefulStop.deallocate(), is(false));
+        assertThat(deallocators.isDeallocating(), is(false));
+        assertAllocationSettingsGotReset();
+    }
+
+    @Test
+    public void testNoReallocate() throws Exception {
+        setSettings(false, false, Deallocators.MinAvailability.PRIMARIES, "2m");
+        createIndex(3, 1, 10);
+
+        assertThat(gracefulStop.reallocate(), is(false));
+        assertThat(gracefulStop.deallocate(), is(true));
+        assertThat(deallocators.isDeallocating(), is(false));
+        assertAllocationSettingsGotReset();
+    }
+
+    @Test
+    public void testReallocateMinAvailabilityFull() throws Exception {
+        setSettings(false, true, Deallocators.MinAvailability.FULL, "2m");
+        createIndex(3, 1, 10);
+
+        assertThat(gracefulStop.reallocate(), is(true));
+        assertThat(gracefulStop.deallocate(), is(true));
+        assertThat(deallocators.isDeallocating(), is(true)); // still deallocated
+        assertAllocationSettingsGotReset();
+    }
+
+    @Test
+    public void testReallocateMinAvailabilityFullCannotDeallocate() throws Exception {
+        setSettings(false, true, Deallocators.MinAvailability.FULL, "2m");
+        createIndex(3, 2, 10);
+
+        assertThat(gracefulStop.reallocate(), is(true));
+        assertThat(gracefulStop.deallocate(), is(false));
+        assertThat(deallocators.isDeallocating(), is(false)); // not deallocating
+        assertAllocationSettingsGotReset();
+    }
+
+    @Test
+    public void testNoReallocateMinAvailabilityFull() throws Exception {
+        setSettings(false, false, Deallocators.MinAvailability.FULL, "2m");
+        createIndex(3, 1, 10);
+
+        assertThat(gracefulStop.reallocate(), is(false));
+        assertThat(gracefulStop.deallocate(), is(false));
+        assertThat(deallocators.isDeallocating(), is(false));
+        assertAllocationSettingsGotReset();
+    }
+
+    @Test
+    public void testReallocateMinAvailabilityPrimaries() throws Exception {
+        setSettings(false, true, Deallocators.MinAvailability.PRIMARIES, "2m");
+        createIndex(30, 0, 10);
+
+        assertThat(gracefulStop.reallocate(), is(true));
+        assertThat(gracefulStop.deallocate(), is(true));
+        assertThat(deallocators.isDeallocating(), is(true)); // still deallocating
+        assertAllocationSettingsGotReset();
+    }
+
+    @Test
+    public void testReallocateMinAvailabilityNone() throws Exception {
+        setSettings(false, true, Deallocators.MinAvailability.NONE, "2m");
+        createIndex(30, 2, 10);
+
+        assertThat(gracefulStop.reallocate(), is(true));
+        assertThat(gracefulStop.deallocate(), is(true));
+        assertThat(deallocators.isDeallocating(), is(false)); // not deallocating
+        assertAllocationSettingsGotReset();
+    }
+
+    @Test
+    public void testTimeout() throws Exception {
+        setSettings(false, true, Deallocators.MinAvailability.PRIMARIES, "1ms");
+        createIndex(30, 0, 30);
+
+        assertThat(gracefulStop.reallocate(), is(true));
+        assertThat(gracefulStop.deallocate(), is(false));
+        assertAllocationSettingsGotReset();
+    }
+}

--- a/src/test/java/org/elasticsearch/cluster/graceful/GracefulStopTestBase.java
+++ b/src/test/java/org/elasticsearch/cluster/graceful/GracefulStopTestBase.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.graceful;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableMap;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.routing.allocation.deallocator.Deallocators;
+import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider;
+import org.elasticsearch.cluster.service.GracefulStop;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.InternalTestCluster;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
+
+import java.util.concurrent.TimeUnit;
+
+public class GracefulStopTestBase extends ElasticsearchIntegrationTest {
+
+    static String mappingSource;
+
+    GracefulStop gracefulStop;
+    Deallocators deallocators;
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @BeforeClass
+    public static void prepareClass() throws Exception {
+        mappingSource = XContentFactory.jsonBuilder().startObject().startObject("properties")
+                .startObject("_id")
+                .field("type", "integer")
+                .endObject()
+                .startObject("name")
+                .field("type", "string")
+                .endObject()
+                .endObject()
+                .endObject().string();
+    }
+
+    @Before
+    public void prepare() {
+        DiscoveryNode takeDownNode = clusterService().state().nodes().dataNodes().values().iterator().next().value;
+        gracefulStop = ((InternalTestCluster) cluster()).getInstance(GracefulStop.class, takeDownNode.name());
+        deallocators = ((InternalTestCluster) cluster()).getInstance(Deallocators.class, takeDownNode.name());
+    }
+
+    @After
+    public void cleanUp() {
+        // reset to default
+        setSettings(false, true, "primaries", "2h");
+        gracefulStop = null;
+        deallocators = null;
+    }
+
+    protected void setSettings(boolean force, boolean reallocate, String minAvailability, String timeOut) {
+        client().admin().cluster().prepareUpdateSettings()
+                .setTransientSettings(ImmutableSettings.builder()
+                        .put("cluster.graceful_stop.force", force)
+                        .put("cluster.graceful_stop.reallocate", reallocate)
+                        .put("cluster.graceful_stop.min_availability", minAvailability)
+                        .put("cluster.graceful_stop.timeout", timeOut)).execute().actionGet();
+    }
+
+    /**
+     * asserting the cluster.routing.allocation.enable setting got reset to null
+     */
+    private static final Predicate ALLOCATION_SETTINGS_GOT_RESET = new Predicate() {
+        @Override
+        public boolean apply(Object input) {
+            String enableSetting = internalCluster().clusterService().state().metaData()
+                    .settings().get(EnableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ENABLE);
+            return enableSetting == null || EnableAllocationDecider.Allocation.ALL.name().equalsIgnoreCase(enableSetting);
+        }
+    };
+
+    protected void assertAllocationSettingsGotReset() throws Exception {
+        assertTrue("'cluster.routing.allocation.enable' did not get reset", awaitBusy(ALLOCATION_SETTINGS_GOT_RESET, 5, TimeUnit.SECONDS));
+    }
+
+    protected void createIndex(int shards, int replicas, int records) {
+        client().admin().indices()
+                .prepareCreate("t2")
+                .addMapping("default", mappingSource)
+                .setSettings(ImmutableSettings.builder().put("number_of_shards", shards).put("number_of_replicas", replicas))
+                .execute().actionGet();
+        for (int i = 0; i < records; i++) {
+            client().prepareIndex("t2", "default")
+                    .setId(String.valueOf(randomInt()))
+                    .setSource(ImmutableMap.<String, Object>of("name", randomAsciiOfLength(10))).execute().actionGet();
+        }
+        refresh();
+    }
+}

--- a/src/test/java/org/elasticsearch/cluster/routing/allocation/deallocator/AllShardsDeallocatorTest.java
+++ b/src/test/java/org/elasticsearch/cluster/routing/allocation/deallocator/AllShardsDeallocatorTest.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.elasticsearch.cluster.routing.allocation.deallocator;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.ListenableFuture;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthStatus;
+import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.InternalTestCluster;
+import org.junit.Test;
+
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.hamcrest.Matchers.is;
+
+@ElasticsearchIntegrationTest.ClusterScope(scope = ElasticsearchIntegrationTest.Scope.TEST, numDataNodes = 3)
+public class AllShardsDeallocatorTest extends DeallocatorTest {
+
+    static {
+        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
+        Loggers.getLogger(AllShardsDeallocator.class).setLevel("TRACE");
+        System.setProperty(TESTS_CLUSTER, ""); // ensure InternalTestCluster
+    }
+
+    @Test
+    public void testDeallocate() throws Exception {
+        createIndices();
+
+        AllShardsDeallocator allShardsDeallocator = ((InternalTestCluster)cluster()).getInstance(AllShardsDeallocator.class, takeDownNode.name());
+        ListenableFuture<Deallocator.DeallocationResult> future = allShardsDeallocator.deallocate();
+        Deallocator.DeallocationResult result = future.get(1, TimeUnit.MINUTES);
+        assertThat(result.success(), is(true));
+        assertThat(result.didDeallocate(), is(true));
+
+
+        assertThat(
+                ((InternalTestCluster)cluster()).getInstance(ClusterService.class, takeDownNode.name()).state().routingNodes().node(takeDownNode.id()).size(),
+                is(0));
+        ClusterHealthStatus status = client().admin().cluster().prepareHealth().setWaitForGreenStatus().setTimeout("2s").execute().actionGet().getStatus();
+        assertThat(status, is(ClusterHealthStatus.GREEN));
+    }
+
+    @Test
+    public void testDeallocateAllocationEnableSetting() throws Exception {
+        createIndices();
+
+        cluster().client().admin().cluster().prepareUpdateSettings().setTransientSettings(
+                ImmutableSettings.builder().put(EnableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ENABLE, EnableAllocationDecider.Allocation.NONE.name())
+        ).execute().actionGet();
+
+        AllShardsDeallocator allShardsDeallocator = ((InternalTestCluster)cluster()).getInstance(AllShardsDeallocator.class, takeDownNode.name());
+        ListenableFuture<Deallocator.DeallocationResult> future = allShardsDeallocator.deallocate();
+        Deallocator.DeallocationResult result = future.get(1, TimeUnit.MINUTES);
+        assertThat(result.success(), is(true));
+        assertThat(result.didDeallocate(), is(true));
+
+        ClusterHealthStatus status = client().admin().cluster().prepareHealth().setWaitForGreenStatus().setTimeout("2s").execute().actionGet().getStatus();
+        assertThat(status, is(ClusterHealthStatus.GREEN));
+
+        waitFor(new Predicate<Void>() {
+            @Override
+            public boolean apply(Void aVoid) {
+                ClusterState newState = ((InternalTestCluster)cluster()).getInstance(ClusterService.class, takeDownNode.name()).state();
+
+                return newState.metaData().settings().get(EnableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ENABLE, "").equals(EnableAllocationDecider.Allocation.NONE.name()) &&
+                    newState.routingNodes().node(takeDownNode.id()).size() == 0;
+            }
+        }, 100);
+    }
+
+    @Test
+    public void testDeallocateFailCannotMoveShards() throws Exception {
+        client().admin().indices()
+                .prepareCreate("t2")
+                .addMapping("default", mappingSource)
+                .setSettings(ImmutableSettings.builder().put("number_of_shards", 2).put("number_of_replicas", 2))
+                .execute().actionGet();
+        ensureGreen();
+
+        for (int i = 0; i < 4; i++) {
+            client().prepareIndex("t2", "default")
+                    .setId(String.valueOf(randomInt()))
+                    .setSource(ImmutableMap.<String, Object>of("name", randomAsciiOfLength(10))).execute().actionGet();
+
+        }
+        refresh();
+
+        AllShardsDeallocator allShardsDeallocator = ((InternalTestCluster)cluster()).getInstance(AllShardsDeallocator.class, takeDownNode.name());
+        ListenableFuture<Deallocator.DeallocationResult> future = allShardsDeallocator.deallocate();
+        try {
+            future.get(2, TimeUnit.SECONDS);
+            fail("no TimeoutException occurred");
+        } catch (TimeoutException e) {
+            assertThat(clusterService().state().routingNodes().node(takeDownNode.id()).size(), is(2));
+        }
+    }
+
+    @Test
+    public void testCancelAllocationEnableSetting() throws Exception {
+        createIndices();
+
+        cluster().client().admin().cluster().prepareUpdateSettings().setTransientSettings(
+                ImmutableSettings.builder().put(EnableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ENABLE, EnableAllocationDecider.Allocation.NONE.name())
+        ).execute().actionGet();
+
+        AllShardsDeallocator allShardsDeallocator = ((InternalTestCluster)cluster()).getInstance(AllShardsDeallocator.class, takeDownNode.name());
+        assertThat(allShardsDeallocator.cancel(), is(false));
+        ListenableFuture<Deallocator.DeallocationResult> future = allShardsDeallocator.deallocate();
+        assertThat(allShardsDeallocator.isDeallocating(), is(true));
+        assertThat(allShardsDeallocator.cancel(), is(true));
+        assertThat(allShardsDeallocator.isDeallocating(), is(false));
+
+        try {
+            future.get(1, TimeUnit.SECONDS);
+            fail("no CancellationException thrown");
+        } catch (CancellationException e) {
+            // glad we reached this point
+        }
+
+        waitFor(new Predicate<Void>() {
+            @Override
+            public boolean apply(Void aVoid) {
+                ClusterState newState = ((InternalTestCluster)cluster()).getInstance(ClusterService.class, takeDownNode.name()).state();
+                return newState.metaData().settings().get(EnableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ENABLE, "").equals(EnableAllocationDecider.Allocation.NONE.name());
+            }
+        }, 100);
+    }
+
+    @Test
+    public void testCancel() throws Exception {
+        createIndices();
+
+        AllShardsDeallocator allShardsDeallocator = ((InternalTestCluster)cluster()).getInstance(AllShardsDeallocator.class, takeDownNode.name());
+        assertThat(allShardsDeallocator.cancel(), is(false));
+        ListenableFuture<Deallocator.DeallocationResult> future = allShardsDeallocator.deallocate();
+        assertThat(allShardsDeallocator.isDeallocating(), is(true));
+        assertThat(allShardsDeallocator.cancel(), is(true));
+        assertThat(allShardsDeallocator.isDeallocating(), is(false));
+
+        assertThat(future.isDone(), is(true));
+        assertThat(future.isCancelled(), is(true));
+
+        expectedException.expect(CancellationException.class);
+
+        future.get(1, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void testDeallocationNoOps() throws Exception {
+        AllShardsDeallocator allShardsDeallocator = ((InternalTestCluster)cluster()).getInstance(AllShardsDeallocator.class, takeDownNode.name());
+
+        // NOOP
+        Deallocator.DeallocationResult result = allShardsDeallocator.deallocate().get(1, TimeUnit.SECONDS);
+        assertThat(result.success(), is(true));
+        assertThat(result.didDeallocate(), is(false));
+
+        createIndices();
+
+        // DOUBLE deallocation
+        allShardsDeallocator.deallocate();
+
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("node already waiting for complete deallocation");
+        allShardsDeallocator.deallocate();
+    }
+}

--- a/src/test/java/org/elasticsearch/cluster/routing/allocation/deallocator/DeallocatorTest.java
+++ b/src/test/java/org/elasticsearch/cluster/routing/allocation/deallocator/DeallocatorTest.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.routing.allocation.deallocator;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.SettableFuture;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.routing.RoutingNode;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+public class DeallocatorTest extends ElasticsearchIntegrationTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    protected DiscoveryNode takeDownNode;
+
+    protected static String mappingSource;
+
+    private ThreadPool threadPool = new ThreadPool(getClass().getName());
+
+    /**
+     * wait until condition returns true or timeOutMillis have gone
+     */
+    protected void waitFor(final Predicate<Void> condition, long timeOutMillis) {
+        final SettableFuture<Void> future = SettableFuture.create();
+        threadPool.generic().execute(new Runnable() {
+            @Override
+            public void run() {
+                while (!condition.apply(null)) {
+                    try {
+                        Thread.sleep(10);
+                    } catch (InterruptedException e) {
+                        future.setException(e);
+                    }
+                }
+                future.set(null);
+            }
+        });
+        try {
+            assertThat(future.get(timeOutMillis, TimeUnit.MILLISECONDS), is(nullValue()));
+        } catch (InterruptedException|TimeoutException |ExecutionException e) {
+            fail(e.getMessage());
+        }
+    }
+
+    @BeforeClass
+    public static void prepareClass() throws IOException {
+        mappingSource = XContentFactory.jsonBuilder().startObject().startObject("properties")
+                .startObject("_id")
+                .field("type", "integer")
+                .endObject()
+                .startObject("name")
+                .field("type", "string")
+                .endObject()
+                .endObject()
+                .endObject().string();
+    }
+
+    @Before
+    public void prepare() throws Exception {
+        RoutingNode[] nodes = clusterService().state().routingNodes().toArray();
+        takeDownNode = nodes[randomInt(nodes.length-1)].node();
+    }
+
+    protected void createIndices() throws Exception {
+        client().admin().indices()
+                .prepareCreate("t0")
+                .addMapping("default", mappingSource)
+                .setSettings(ImmutableSettings.builder().put("number_of_shards", 2).put("number_of_replicas", 0))
+                .execute().actionGet();
+        client().admin().indices()
+                .prepareCreate("t1")
+                .addMapping("default",mappingSource)
+                .setSettings(ImmutableSettings.builder().put("number_of_shards", 2).put("number_of_replicas", 1))
+                .execute().actionGet();
+        ensureGreen();
+
+        for (String table : Arrays.asList("t0", "t1")) {
+            for (int i = 0; i<10; i++) {
+                client().prepareIndex(table, "default")
+                        .setId(String.valueOf(randomInt()))
+                        .setSource(ImmutableMap.<String, Object>of("name", randomAsciiOfLength(10))).execute().actionGet();
+            }
+        }
+        refresh();
+    }
+}

--- a/src/test/java/org/elasticsearch/cluster/routing/allocation/deallocator/DeallocatorsTest.java
+++ b/src/test/java/org/elasticsearch/cluster/routing/allocation/deallocator/DeallocatorsTest.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.elasticsearch.cluster.routing.allocation.deallocator;
+
+import com.carrotsearch.randomizedtesting.annotations.Repeat;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.ListenableFuture;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.InternalTestCluster;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.Matchers.is;
+
+@ElasticsearchIntegrationTest.ClusterScope(scope = ElasticsearchIntegrationTest.Scope.TEST, numDataNodes = 2, numClientNodes = 0)
+public class DeallocatorsTest extends ElasticsearchIntegrationTest {
+
+    static {
+        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
+        System.setProperty(TESTS_CLUSTER, ""); // ensure InternalTestCluster
+    }
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Repeat(iterations = 2)
+    @Test
+    public void testDeallocatorsDeallocate() throws Exception {
+        Deallocators deallocator = ((InternalTestCluster) cluster()).getInstance(Deallocators.class);
+
+        client().admin().cluster().prepareUpdateSettings().setTransientSettings(
+                ImmutableSettings.builder().put(Deallocators.GRACEFUL_STOP_MIN_AVAILABILITY, "full")
+        ).execute().actionGet();
+        client().admin().indices()
+                .prepareCreate("t0")
+                .addMapping("default", XContentFactory.jsonBuilder().startObject().startObject("properties")
+                        .startObject("_id")
+                        .field("type", "integer")
+                        .endObject()
+                        .startObject("name")
+                        .field("type", "string")
+                        .endObject()
+                        .endObject()
+                        .endObject().string())
+                .setSettings(ImmutableSettings.builder().put("number_of_shards", 2).put("number_of_replicas", 0))
+                .execute().actionGet();
+        ensureGreen();
+        client().prepareIndex("t0", "default")
+                .setId(String.valueOf(randomInt()))
+                .setSource(ImmutableMap.<String, Object>of("name", randomAsciiOfLength(10))).execute().actionGet();
+        client().prepareIndex("t0", "default")
+                .setId(String.valueOf(randomInt()))
+                .setSource(ImmutableMap.<String, Object>of("name", randomAsciiOfLength(10))).execute().actionGet();
+        refresh();
+
+        ListenableFuture<Deallocator.DeallocationResult> future = deallocator.deallocate();
+        Deallocator.DeallocationResult result = future.get(10, TimeUnit.SECONDS);
+        assertThat(result.success(), is(true));
+        assertThat(result.didDeallocate(), is(true));
+        ensureGreen(); // wait for clusterstate to propagate
+        assertThat(deallocator.isDeallocating(), is(true)); // node not shut down yet, still seen as deallocating
+    }
+
+    @Repeat(iterations = 2)
+    @Test
+    public void testDeallocatorsDeallocateOngoing() throws Exception {
+        Deallocators deallocator = ((InternalTestCluster) cluster()).getInstance(Deallocators.class);
+
+        client().admin().cluster().prepareUpdateSettings().setTransientSettings(
+                ImmutableSettings.builder().put(Deallocators.GRACEFUL_STOP_MIN_AVAILABILITY, "full")
+        ).execute().actionGet();
+        client().admin().indices()
+                .prepareCreate("t0")
+                .addMapping("default", XContentFactory.jsonBuilder().startObject().startObject("properties")
+                        .startObject("_id")
+                        .field("type", "integer")
+                        .endObject()
+                        .startObject("name")
+                        .field("type", "string")
+                        .endObject()
+                        .endObject()
+                        .endObject().string())
+                .setSettings(ImmutableSettings.builder().put("number_of_shards", 2).put("number_of_replicas", 1))
+                .execute().actionGet();
+        ensureGreen();
+        client().prepareIndex("t0", "default")
+                .setId(String.valueOf(randomInt()))
+                .setSource(ImmutableMap.<String, Object>of("name", randomAsciiOfLength(10))).execute().actionGet();
+        client().prepareIndex("t0", "default")
+                .setId(String.valueOf(randomInt()))
+                .setSource(ImmutableMap.<String, Object>of("name", randomAsciiOfLength(10))).execute().actionGet();
+        refresh();
+
+        ListenableFuture<Deallocator.DeallocationResult> future = deallocator.deallocate();
+        assertThat(deallocator.isDeallocating(), is(true));
+        assertThat(future.isDone(), is(false));
+
+        // change setting
+        client().admin().cluster().prepareUpdateSettings().setTransientSettings(
+                ImmutableSettings.builder().put(Deallocators.GRACEFUL_STOP_MIN_AVAILABILITY, "none")
+        ).execute().actionGet();
+
+        // still deallocating
+        assertThat(deallocator.isDeallocating(), is(true));
+        assertThat(future.isDone(), is(false));
+
+        deallocator.cancel();
+
+        // change setting
+        client().admin().cluster().prepareUpdateSettings().setTransientSettings(
+                ImmutableSettings.builder().put(Deallocators.GRACEFUL_STOP_MIN_AVAILABILITY, "primaries")
+        ).execute().actionGet();
+        assertThat(deallocator.isDeallocating(), is(false));
+
+        expectedException.expect(CancellationException.class);
+        try {
+            future.get(1, TimeUnit.SECONDS);
+        } catch (ExecutionException e) {
+            throw (Exception)e.getCause();
+        }
+    }
+
+}

--- a/src/test/java/org/elasticsearch/cluster/routing/allocation/deallocator/PrimariesDeallocatorTest.java
+++ b/src/test/java/org/elasticsearch/cluster/routing/allocation/deallocator/PrimariesDeallocatorTest.java
@@ -1,0 +1,220 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.elasticsearch.cluster.routing.allocation.deallocator;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.ListenableFuture;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthStatus;
+import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.routing.ShardRoutingState;
+import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.InternalTestCluster;
+import org.junit.Test;
+
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.Matchers.*;
+
+@ElasticsearchIntegrationTest.ClusterScope(scope = ElasticsearchIntegrationTest.Scope.TEST, numDataNodes = 2)
+public class PrimariesDeallocatorTest extends DeallocatorTest {
+
+    static {
+        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
+        Loggers.getLogger(PrimariesDeallocator.class).setLevel("TRACE");
+        System.setProperty(TESTS_CLUSTER, ""); // ensure InternalTestCluster
+    }
+
+    @Test
+    public void testDeallocate() throws Exception {
+        createIndices();
+
+        PrimariesDeallocator deallocator = ((InternalTestCluster)cluster()).getInstance(PrimariesDeallocator.class, takeDownNode.name());
+        ListenableFuture<Deallocator.DeallocationResult> future = deallocator.deallocate();
+        Deallocator.DeallocationResult result = future.get(1, TimeUnit.MINUTES);
+        assertThat(result.success(), is(true));
+        assertThat(result.didDeallocate(), is(true));
+
+        ensureGreen("t0");
+
+        assertThat(clusterService().state().routingNodes().node(takeDownNode.id()).shardsWithState("t0", ShardRoutingState.STARTED, ShardRoutingState.INITIALIZING, ShardRoutingState.RELOCATING).size(), is(0));
+        ClusterHealthStatus status = client().admin().cluster().prepareHealth().setWaitForYellowStatus().setTimeout("2s").execute().actionGet().getStatus();
+        assertThat(status, isOneOf(ClusterHealthStatus.GREEN, ClusterHealthStatus.YELLOW));
+    }
+
+    @Test
+    public void testDeallocateAllocationEnableSetting() throws Exception {
+        createIndices();
+
+        cluster().client().admin().cluster().prepareUpdateSettings().setTransientSettings(
+                ImmutableSettings.builder().put(EnableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ENABLE, EnableAllocationDecider.Allocation.NONE.name())
+        ).execute().actionGet();
+        Thread.sleep(100);
+
+        PrimariesDeallocator deallocator = ((InternalTestCluster)cluster()).getInstance(PrimariesDeallocator.class, takeDownNode.name());
+        ListenableFuture<Deallocator.DeallocationResult> future = deallocator.deallocate();
+        Deallocator.DeallocationResult result = future.get(1, TimeUnit.MINUTES);
+        assertThat(result.success(), is(true));
+        assertThat(result.didDeallocate(), is(true));
+
+        ensureGreen("t0");
+
+        ClusterHealthStatus status = client().admin().cluster().prepareHealth().setWaitForYellowStatus().setTimeout("2s").execute().actionGet().getStatus();
+        assertThat(status, isOneOf(ClusterHealthStatus.GREEN, ClusterHealthStatus.YELLOW));
+
+        waitFor(new Predicate<Void>() {
+            @Override
+            public boolean apply(Void aVoid) {
+                ClusterState newState = ((InternalTestCluster)cluster()).getInstance(ClusterService.class, takeDownNode.name()).state();
+                return newState.routingNodes().node(takeDownNode.id())
+                        .shardsWithState("t0", ShardRoutingState.STARTED, ShardRoutingState.INITIALIZING, ShardRoutingState.RELOCATING).size() == 0;
+            }
+        }, 100);
+    }
+
+    @Test
+    public void testDeallocateMultipleZeroReplicaIndices() throws Exception {
+        createIndices();
+        client().admin().indices()
+                .prepareCreate("t2")
+                .addMapping("default", mappingSource)
+                .setSettings(ImmutableSettings.builder().put("number_of_shards", 3).put("number_of_replicas", 0))
+                .execute().actionGet();
+        for (int i = 0; i<1000; i++) {
+            client().prepareIndex("t2", "default")
+                    .setId(String.valueOf(randomInt()))
+                    .setSource(ImmutableMap.<String, Object>of("name", randomAsciiOfLength(10))).execute().actionGet();
+        }
+        refresh();
+
+        PrimariesDeallocator deallocator = ((InternalTestCluster)cluster()).getInstance(PrimariesDeallocator.class, takeDownNode.name());
+        ListenableFuture<Deallocator.DeallocationResult> future = deallocator.deallocate();
+        Deallocator.DeallocationResult result = future.get(1, TimeUnit.MINUTES);
+        assertThat(result.success(), is(true));
+        assertThat(result.didDeallocate(), is(true));
+
+        ensureGreen("t0");
+
+        assertThat(clusterService().state().routingNodes().node(takeDownNode.id()).shardsWithState("t0", ShardRoutingState.STARTED, ShardRoutingState.INITIALIZING, ShardRoutingState.RELOCATING).size(), is(0));
+        ClusterHealthStatus status = client().admin().cluster().prepareHealth().setWaitForYellowStatus().setTimeout("2s").execute().actionGet().getStatus();
+        assertThat(status, is(isOneOf(ClusterHealthStatus.GREEN, ClusterHealthStatus.YELLOW)));
+    }
+
+    @Test
+    public void testCancel() throws Exception {
+        createIndices();
+
+        PrimariesDeallocator deallocator = ((InternalTestCluster)cluster()).getInstance(PrimariesDeallocator.class, takeDownNode.name());
+        assertThat(deallocator.cancel(), is(false));
+        ListenableFuture<Deallocator.DeallocationResult> future = deallocator.deallocate();
+        assertThat(deallocator.isDeallocating(), is(true));
+        assertThat(deallocator.cancel(), is(true));
+        assertThat(deallocator.isDeallocating(), is(false));
+
+        assertThat(future.isDone(), is(true));
+        assertThat(future.isCancelled(), is(true));
+    }
+
+    @Test
+    public void testCancelAllocationEnableSetting() throws Exception {
+        createIndices();
+
+        cluster().client().admin().cluster().prepareUpdateSettings().setTransientSettings(
+                ImmutableSettings.builder().put(EnableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ENABLE, EnableAllocationDecider.Allocation.NONE.name())
+        ).execute().actionGet();
+
+        PrimariesDeallocator deallocator = ((InternalTestCluster)cluster()).getInstance(PrimariesDeallocator.class, takeDownNode.name());
+        assertThat(deallocator.cancel(), is(false));
+        ListenableFuture<Deallocator.DeallocationResult> future = deallocator.deallocate();
+        assertThat(deallocator.isDeallocating(), is(true));
+        assertThat(deallocator.cancel(), is(true));
+        assertThat(deallocator.isDeallocating(), is(false));
+
+        assertThat(future.isDone(), is(true));
+        assertThat(future.isCancelled(), is(true));
+
+        try {
+            future.get(1, TimeUnit.SECONDS);
+            fail("no CancellationException thrown");
+        } catch (CancellationException e) {
+            // fine
+        }
+
+        waitFor(new Predicate<Void>() {
+            @Override
+            public boolean apply(Void aVoid) {
+                ClusterState newState = ((InternalTestCluster)cluster()).getInstance(ClusterService.class, takeDownNode.name()).state();
+
+                return newState.metaData().settings().get(EnableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ENABLE, "").equals(EnableAllocationDecider.Allocation.NONE.name());
+            }
+        }, 100);
+    }
+
+    @Test
+    public void testDeallocateNoOps() throws Exception {
+        PrimariesDeallocator deallocator = ((InternalTestCluster)cluster()).getInstance(PrimariesDeallocator.class, takeDownNode.name());
+
+        // NOOP
+        Deallocator.DeallocationResult result = deallocator.deallocate().get(1, TimeUnit.SECONDS);
+        assertThat(result.success(), is(true));
+        assertThat(result.didDeallocate(), is(false));
+
+        createIndices();
+
+        // DOUBLE deallocation
+        deallocator.deallocate();
+
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("node already waiting for primary only deallocation");
+        deallocator.deallocate();
+    }
+
+    @Test
+    public void testNotOverrideExistingSettings() throws Exception {
+        createIndices();
+        client().admin().indices().prepareUpdateSettings("t0").setSettings(
+                ImmutableSettings.builder().put(PrimariesDeallocator.EXCLUDE_NODE_ID_FROM_INDEX, "abc")
+        ).execute().actionGet();
+
+        PrimariesDeallocator deallocator = ((InternalTestCluster)cluster()).getInstance(PrimariesDeallocator.class, takeDownNode.name());
+        ListenableFuture<Deallocator.DeallocationResult> future = deallocator.deallocate();
+        Deallocator.DeallocationResult result = future.get(1, TimeUnit.MINUTES);
+        assertThat(result.success(), is(true));
+        assertThat(result.didDeallocate(), is(true));
+
+        assertThat(deallocator.cancel(), is(true));
+        ensureGreen();
+
+        waitFor(new Predicate<Void>() {
+            @Override
+            public boolean apply(Void input) {
+                return clusterService().state().metaData().index("t0").settings().get(PrimariesDeallocator.EXCLUDE_NODE_ID_FROM_INDEX).equals("abc");
+            }
+        }, 10000);
+
+    }
+
+}

--- a/src/test/java/org/elasticsearch/node/internal/NodeDisableTest.java
+++ b/src/test/java/org/elasticsearch/node/internal/NodeDisableTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.node.internal;
+
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.transport.InetSocketTransportAddress;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.http.HttpServerTransport;
+import org.elasticsearch.node.NodeBuilder;
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.test.rest.client.http.HttpRequestBuilder;
+import org.elasticsearch.test.rest.client.http.HttpResponse;
+import org.junit.After;
+import org.junit.Test;
+
+import java.net.InetSocketAddress;
+
+import static org.hamcrest.core.Is.is;
+
+public class NodeDisableTest extends ElasticsearchTestCase {
+
+    static {
+        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
+    }
+
+    private InternalNode node;
+
+    @After
+    public void cleanUp() {
+        node.close();
+    }
+
+    @Test
+    public void testHttpDisableAndReEnable() throws Exception {
+        node = (InternalNode)NodeBuilder.nodeBuilder().local(true).data(true).settings(
+                ImmutableSettings.builder()
+                        .put(ClusterName.SETTING, getClass().getName())
+                        .put("node.name", getClass().getName())
+                        .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
+                        .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 0)
+                        .put(EsExecutors.PROCESSORS, 1)
+                        .put("http.enabled", true)
+                        .put("index.store.type", "ram")
+                        .put("config.ignore_system_properties", true)
+                        .put("gateway.type", "none")).build();
+        node.start();
+        HttpServerTransport httpServerTransport = node.injector().getInstance(HttpServerTransport.class);
+        InetSocketAddress address = ((InetSocketTransportAddress) httpServerTransport.boundAddress().publishAddress()).address();
+
+        CloseableHttpClient httpClient = HttpClients.createDefault();
+        HttpResponse response = new HttpRequestBuilder(httpClient)
+                .host(address.getHostName()).port(address.getPort())
+                .path("/")
+                .method("GET").execute();
+        assertThat(response.getStatusCode(), is(200));
+
+        httpClient.close();
+        assertThat(node.disable(), is(true));
+
+        httpClient = HttpClients.createDefault();
+        response = new HttpRequestBuilder(httpClient)
+                .host(address.getHostName()).port(address.getPort())
+                .path("/")
+                .method("GET").execute();
+        assertThat(response.getStatusCode(), is(503));
+
+        node.start();
+
+        response = new HttpRequestBuilder(httpClient)
+                .host(address.getHostName()).port(address.getPort())
+                .path("/")
+                .method("GET").execute();
+        assertThat(response.getStatusCode(), is(200));
+    }
+}

--- a/src/test/java/org/elasticsearch/node/internal/NodeStartStopTest.java
+++ b/src/test/java/org/elasticsearch/node/internal/NodeStartStopTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.elasticsearch.node.internal;
+
+import com.carrotsearch.randomizedtesting.annotations.Repeat;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.node.NodeBuilder;
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.junit.Test;
+
+import java.util.Locale;
+
+public class NodeStartStopTest extends ElasticsearchTestCase {
+
+    static {
+        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
+    }
+
+    @Repeat(iterations = 10)
+    @Test
+    public void testFastStartAndStop() throws Exception {
+        // assert that no exception is thrown when starting and stopping the
+        // internal node in parallel etc.
+        String name = String.format(Locale.ENGLISH, "%s_%d", getClass().getName(), System.currentTimeMillis());
+        final InternalNode node = (InternalNode) NodeBuilder.nodeBuilder().local(true).data(true).settings(
+                ImmutableSettings.builder()
+                        .put(ClusterName.SETTING, name)
+                        .put("node.name", name)
+                        .put("http.enabled", true)
+                        .put("config.ignore_system_properties", true)
+                        .put("gateway.type", "none")).build();
+
+        Thread startThread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                node.start();
+            }
+        });
+        Thread stopThread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                node.stop();
+            }
+        });
+        startThread.start();
+        stopThread.start();
+
+        startThread.join();
+        stopThread.join();
+
+        node.close();
+    }
+}

--- a/src/test/java/org/elasticsearch/test/cluster/NoopClusterService.java
+++ b/src/test/java/org/elasticsearch/test/cluster/NoopClusterService.java
@@ -147,6 +147,11 @@ public class NoopClusterService implements ClusterService {
     }
 
     @Override
+    public ClusterService disable() throws ElasticsearchException {
+        return null;
+    }
+
+    @Override
     public ClusterService start() throws ElasticsearchException {
         return null;
     }

--- a/src/test/java/org/elasticsearch/test/transport/MockTransportService.java
+++ b/src/test/java/org/elasticsearch/test/transport/MockTransportService.java
@@ -388,6 +388,12 @@ public class MockTransportService extends TransportService {
         }
 
         @Override
+        public Transport disable() throws ElasticsearchException {
+            transport.disable();
+            return this;
+        }
+
+        @Override
         public Transport start() throws ElasticsearchException {
             transport.start();
             return this;


### PR DESCRIPTION
We at Crate recently implemented a procedure to gracefully stop nodes moving shards away before finally shutting down in order keep all the data available.
This can be used to perform a rolling upgrade of the cluster **with strong data availability guarantees**.

We've also seen, that there were already some discussions about how to implement that in ES here: https://github.com/elasticsearch/elasticsearch/issues/4248

This PR contains the following changes:
- added new settings called:
  `cluster.graceful_stop.min_availability`, 
  `cluster.graceful_stop.reallocate`, 
  `cluster.graceful_stop.timeout`, 
  `cluster.graceful_stop.force` 
  to control the shutdown behaviour
  (documented here: https://crate.io/docs/en/latest/configuration.html#graceful-stop)
- added signal handling to perform a graceful shutdown on receiving the `USR2` signal (the current implementation depends on classes that are only available in the oracle and openjdk VMs)
- added DISABLED state for `LifecycleComponent` and transition methods

The shutdown process works as follows:
1. after sending graceful shutdown signal, all services of InternalNode will be disabled, the current implementation only rejects new HTTP requests on this node as transport connections are usually steady connections
2. depending on the graceful_stop settings listed above the node will deallocate its shards using the AllShardsDeallocator/PrimariesDeallocator classes
3. node shuts down once de-/reallocation is finished or returns back to its prior state on any error (if `cluster.graceful_stop.force` is not set to true)
