### PR TITLE
Cleaner query parse error feedback

### DIFF
--- a/src/main/java/org/elasticsearch/action/search/TransportMultiSearchAction.java
+++ b/src/main/java/org/elasticsearch/action/search/TransportMultiSearchAction.java
@@ -62,7 +62,7 @@ public class TransportMultiSearchAction extends HandledTransportAction<MultiSear
             searchAction.execute(searchRequest, new ActionListener<SearchResponse>() {
                 @Override
                 public void onResponse(SearchResponse searchResponse) {
-                    responses.set(index, new MultiSearchResponse.Item(searchResponse, null));
+                    responses.set(index, new MultiSearchResponse.Item(searchResponse, null, null));
                     if (counter.decrementAndGet() == 0) {
                         finishHim();
                     }
@@ -70,7 +70,8 @@ public class TransportMultiSearchAction extends HandledTransportAction<MultiSear
 
                 @Override
                 public void onFailure(Throwable e) {
-                    responses.set(index, new MultiSearchResponse.Item(null, ExceptionsHelper.detailedMessage(e)));
+                    responses.set(index, new MultiSearchResponse.Item(null, ExceptionsHelper.detailedMessage(e), 
+                            ExceptionsHelper.getAnyXContentExplanation(e)));
                     if (counter.decrementAndGet() == 0) {
                         finishHim();
                     }

--- a/src/main/java/org/elasticsearch/common/xcontent/XContentLocation.java
+++ b/src/main/java/org/elasticsearch/common/xcontent/XContentLocation.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.xcontent;
+
+public class XContentLocation {
+    private int lineNumber;
+    private int columnNumber;
+
+    public XContentLocation(int lineNumber, int columnNumber) {
+        super();
+        this.lineNumber = lineNumber;
+        this.columnNumber = columnNumber;
+    }
+
+    public int getLineNumber() {
+        return lineNumber;
+    }
+
+    public int getColumnNumber() {
+        return columnNumber;
+    }
+
+}

--- a/src/main/java/org/elasticsearch/common/xcontent/XContentParser.java
+++ b/src/main/java/org/elasticsearch/common/xcontent/XContentParser.java
@@ -241,4 +241,11 @@ public interface XContentParser extends Releasable {
      *
      */
     byte[] binaryValue() throws IOException;
+    
+    /**
+     * Used for error reporting to highlight where syntax errors occur in
+     * content being parsed.
+     * @return last token's location or null if cannot be determined
+     */
+    XContentLocation getTokenLocation();
 }

--- a/src/main/java/org/elasticsearch/common/xcontent/json/JsonXContentParser.java
+++ b/src/main/java/org/elasticsearch/common/xcontent/json/JsonXContentParser.java
@@ -19,11 +19,13 @@
 
 package org.elasticsearch.common.xcontent.json;
 
+import com.fasterxml.jackson.core.JsonLocation;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.ElasticsearchIllegalStateException;
+import org.elasticsearch.common.xcontent.XContentLocation;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.support.AbstractXContentParser;
 
@@ -231,5 +233,15 @@ public class JsonXContentParser extends AbstractXContentParser {
                 return Token.VALUE_EMBEDDED_OBJECT;
         }
         throw new ElasticsearchIllegalStateException("No matching token for json_token [" + token + "]");
+    }
+
+    @Override
+    public XContentLocation getTokenLocation() {
+        XContentLocation result = null;
+        JsonLocation loc = parser.getTokenLocation();
+        if (loc != null) {
+            result = new XContentLocation(loc.getLineNr(), loc.getColumnNr());
+        }
+        return result;
     }
 }

--- a/src/main/java/org/elasticsearch/index/percolator/PercolatorQueriesRegistry.java
+++ b/src/main/java/org/elasticsearch/index/percolator/PercolatorQueriesRegistry.java
@@ -206,7 +206,7 @@ public class PercolatorQueriesRegistry extends AbstractIndexShardComponent {
             context.setAllowUnmappedFields(allowUnmappedFields);
             return queryParserService.parseInnerQuery(context);
         } catch (IOException e) {
-            throw new QueryParsingException(queryParserService.index(), "Failed to parse", e);
+            throw new QueryParsingException(queryParserService.index(), "Failed to parse", parser.getTokenLocation(), e);
         } finally {
             if (type != null) {
                 QueryParseContext.setTypes(previousTypes);

--- a/src/main/java/org/elasticsearch/index/query/AndFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/AndFilterParser.java
@@ -97,14 +97,14 @@ public class AndFilterParser implements FilterParser {
                     } else if ("_cache_key".equals(currentFieldName) || "_cacheKey".equals(currentFieldName)) {
                         cacheKey = new CacheKeyFilter.Key(parser.text());
                     } else {
-                        throw new QueryParsingException(parseContext.index(), "[and] filter does not support [" + currentFieldName + "]");
+                        throw new QueryParsingException(parseContext.index(), "[and] filter does not support [" + currentFieldName + "]", parser.getTokenLocation());
                     }
                 }
             }
         }
 
         if (!filtersFound) {
-            throw new QueryParsingException(parseContext.index(), "[and] filter requires 'filters' to be set on it'");
+            throw new QueryParsingException(parseContext.index(), "[and] filter requires 'filters' to be set on it'", parser.getTokenLocation());
         }
 
         if (filters.isEmpty()) {

--- a/src/main/java/org/elasticsearch/index/query/BoolFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/BoolFilterParser.java
@@ -83,7 +83,7 @@ public class BoolFilterParser implements FilterParser {
                         boolFilter.add(new FilterClause(filter, BooleanClause.Occur.SHOULD));
                     }
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[bool] filter does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[bool] filter does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.START_ARRAY) {
                 if ("must".equals(currentFieldName)) {
@@ -111,7 +111,7 @@ public class BoolFilterParser implements FilterParser {
                         }
                     }
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[bool] filter does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[bool] filter does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             } else if (token.isValue()) {
                 if ("_cache".equals(currentFieldName)) {
@@ -121,13 +121,13 @@ public class BoolFilterParser implements FilterParser {
                 } else if ("_cache_key".equals(currentFieldName) || "_cacheKey".equals(currentFieldName)) {
                     cacheKey = new CacheKeyFilter.Key(parser.text());
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[bool] filter does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[bool] filter does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             }
         }
 
         if (!hasAnyFilter) {
-            throw new QueryParsingException(parseContext.index(), "[bool] filter has no inner should/must/must_not elements");
+            throw new QueryParsingException(parseContext.index(), "[bool] filter has no inner should/must/must_not elements", parser.getTokenLocation());
         }
 
         if (boolFilter.clauses().isEmpty()) {

--- a/src/main/java/org/elasticsearch/index/query/BoolQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/BoolQueryParser.java
@@ -85,7 +85,7 @@ public class BoolQueryParser implements QueryParser {
                         clauses.add(new BooleanClause(query, BooleanClause.Occur.SHOULD));
                     }
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[bool] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[bool] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.START_ARRAY) {
                 if ("must".equals(currentFieldName)) {
@@ -110,7 +110,7 @@ public class BoolQueryParser implements QueryParser {
                         }
                     }
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "bool query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "bool query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             } else if (token.isValue()) {
                 if ("disable_coord".equals(currentFieldName) || "disableCoord".equals(currentFieldName)) {
@@ -126,7 +126,7 @@ public class BoolQueryParser implements QueryParser {
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[bool] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[bool] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             }
         }

--- a/src/main/java/org/elasticsearch/index/query/BoostingQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/BoostingQueryParser.java
@@ -66,7 +66,7 @@ public class BoostingQueryParser implements QueryParser {
                     negativeQuery = parseContext.parseInnerQuery();
                     negativeQueryFound = true;
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[boosting] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[boosting] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             } else if (token.isValue()) {
                 if ("negative_boost".equals(currentFieldName) || "negativeBoost".equals(currentFieldName)) {
@@ -74,19 +74,19 @@ public class BoostingQueryParser implements QueryParser {
                 } else if ("boost".equals(currentFieldName)) {
                     boost = parser.floatValue();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[boosting] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[boosting] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             }
         }
 
         if (positiveQuery == null && !positiveQueryFound) {
-            throw new QueryParsingException(parseContext.index(), "[boosting] query requires 'positive' query to be set'");
+            throw new QueryParsingException(parseContext.index(), "[boosting] query requires 'positive' query to be set'", parser.getTokenLocation());
         }
         if (negativeQuery == null && !negativeQueryFound) {
-            throw new QueryParsingException(parseContext.index(), "[boosting] query requires 'negative' query to be set'");
+            throw new QueryParsingException(parseContext.index(), "[boosting] query requires 'negative' query to be set'", parser.getTokenLocation());
         }
         if (negativeBoost == -1) {
-            throw new QueryParsingException(parseContext.index(), "[boosting] query requires 'negative_boost' to be set'");
+            throw new QueryParsingException(parseContext.index(), "[boosting] query requires 'negative_boost' to be set'", parser.getTokenLocation());
         }
 
         // parsers returned null

--- a/src/main/java/org/elasticsearch/index/query/CommonTermsQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/CommonTermsQueryParser.java
@@ -68,7 +68,7 @@ public class CommonTermsQueryParser implements QueryParser {
         XContentParser parser = parseContext.parser();
         XContentParser.Token token = parser.nextToken();
         if (token != XContentParser.Token.FIELD_NAME) {
-            throw new QueryParsingException(parseContext.index(), "[common] query malformed, no field");
+            throw new QueryParsingException(parseContext.index(), "[common] query malformed, no field", parser.getTokenLocation());
         }
         String fieldName = parser.currentName();
         Object value = null;
@@ -99,12 +99,12 @@ public class CommonTermsQueryParser implements QueryParser {
                                 } else if ("high_freq".equals(innerFieldName) || "highFreq".equals(innerFieldName)) {
                                     highFreqMinimumShouldMatch = parser.text();
                                 } else {
-                                    throw new QueryParsingException(parseContext.index(), "[common] query does not support [" + innerFieldName + "] for [" + currentFieldName + "]");
+                                    throw new QueryParsingException(parseContext.index(), "[common] query does not support [" + innerFieldName + "] for [" + currentFieldName + "]", parser.getTokenLocation());
                                 }
                             }
                         }
                     } else {
-                        throw new QueryParsingException(parseContext.index(), "[common] query does not support [" + currentFieldName + "]");
+                        throw new QueryParsingException(parseContext.index(), "[common] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                     }
                 } else if (token.isValue()) {
                     if ("query".equals(currentFieldName)) {
@@ -112,7 +112,7 @@ public class CommonTermsQueryParser implements QueryParser {
                     } else if ("analyzer".equals(currentFieldName)) {
                         String analyzer = parser.text();
                         if (parseContext.analysisService().analyzer(analyzer) == null) {
-                            throw new QueryParsingException(parseContext.index(), "[common] analyzer [" + parser.text() + "] not found");
+                            throw new QueryParsingException(parseContext.index(), "[common] analyzer [" + parser.text() + "] not found", parser.getTokenLocation());
                         }
                         queryAnalyzer = analyzer;
                     } else if ("disable_coord".equals(currentFieldName) || "disableCoord".equals(currentFieldName)) {
@@ -127,7 +127,7 @@ public class CommonTermsQueryParser implements QueryParser {
                             highFreqOccur = BooleanClause.Occur.MUST;
                         } else {
                             throw new QueryParsingException(parseContext.index(),
-                                    "[common] query requires operator to be either 'and' or 'or', not [" + op + "]");
+                                    "[common] query requires operator to be either 'and' or 'or', not [" + op + "]", parser.getTokenLocation());
                         }
                     } else if ("low_freq_operator".equals(currentFieldName) || "lowFreqOperator".equals(currentFieldName)) {
                         String op = parser.text();
@@ -137,7 +137,7 @@ public class CommonTermsQueryParser implements QueryParser {
                             lowFreqOccur = BooleanClause.Occur.MUST;
                         } else {
                             throw new QueryParsingException(parseContext.index(),
-                                    "[common] query requires operator to be either 'and' or 'or', not [" + op + "]");
+                                    "[common] query requires operator to be either 'and' or 'or', not [" + op + "]", parser.getTokenLocation());
                         }
                     } else if ("minimum_should_match".equals(currentFieldName) || "minimumShouldMatch".equals(currentFieldName)) {
                         lowFreqMinimumShouldMatch = parser.text();
@@ -146,7 +146,7 @@ public class CommonTermsQueryParser implements QueryParser {
                     } else if ("_name".equals(currentFieldName)) {
                         queryName = parser.text();
                     } else {
-                        throw new QueryParsingException(parseContext.index(), "[common] query does not support [" + currentFieldName + "]");
+                        throw new QueryParsingException(parseContext.index(), "[common] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                     }
                 }
             }
@@ -158,12 +158,13 @@ public class CommonTermsQueryParser implements QueryParser {
             if (token != XContentParser.Token.END_OBJECT) {
                 throw new QueryParsingException(
                         parseContext.index(),
-                        "[common] query parsed in simplified form, with direct field name, but included more options than just the field name, possibly use its 'options' form, with 'query' element?");
+                        "[common] query parsed in simplified form, with direct field name, but included more options than just the field name, possibly use its 'options' form, with 'query' element?", 
+                        parser.getTokenLocation());
             }
         }
 
         if (value == null) {
-            throw new QueryParsingException(parseContext.index(), "No text specified for text query");
+            throw new QueryParsingException(parseContext.index(), "No text specified for text query", parser.getTokenLocation());
         }
         FieldMapper<?> mapper = null;
         String field;

--- a/src/main/java/org/elasticsearch/index/query/ConstantScoreQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/ConstantScoreQueryParser.java
@@ -70,7 +70,7 @@ public class ConstantScoreQueryParser implements QueryParser {
                     query = parseContext.parseInnerQuery();
                     queryFound = true;
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[constant_score] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[constant_score] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             } else if (token.isValue()) {
                 if ("boost".equals(currentFieldName)) {
@@ -80,12 +80,12 @@ public class ConstantScoreQueryParser implements QueryParser {
                 } else if ("_cache_key".equals(currentFieldName) || "_cacheKey".equals(currentFieldName)) {
                     cacheKey = new CacheKeyFilter.Key(parser.text());
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[constant_score] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[constant_score] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             }
         }
         if (!filterFound && !queryFound) {
-            throw new QueryParsingException(parseContext.index(), "[constant_score] requires either 'filter' or 'query' element");
+            throw new QueryParsingException(parseContext.index(), "[constant_score] requires either 'filter' or 'query' element", parser.getTokenLocation());
         }
 
         if (query == null && filter == null) {

--- a/src/main/java/org/elasticsearch/index/query/DisMaxQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/DisMaxQueryParser.java
@@ -70,7 +70,7 @@ public class DisMaxQueryParser implements QueryParser {
                         queries.add(query);
                     }
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[dis_max] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[dis_max] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.START_ARRAY) {
                 if ("queries".equals(currentFieldName)) {
@@ -83,7 +83,7 @@ public class DisMaxQueryParser implements QueryParser {
                         token = parser.nextToken();
                     }
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[dis_max] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[dis_max] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             } else {
                 if ("boost".equals(currentFieldName)) {
@@ -93,13 +93,13 @@ public class DisMaxQueryParser implements QueryParser {
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[dis_max] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[dis_max] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             }
         }
 
         if (!queriesFound) {
-            throw new QueryParsingException(parseContext.index(), "[dis_max] requires 'queries' field");
+            throw new QueryParsingException(parseContext.index(), "[dis_max] requires 'queries' field", parser.getTokenLocation());
         }
 
         if (queries.isEmpty()) {

--- a/src/main/java/org/elasticsearch/index/query/ExistsFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/ExistsFilterParser.java
@@ -71,13 +71,13 @@ public class ExistsFilterParser implements FilterParser {
                 } else if ("_name".equals(currentFieldName)) {
                     filterName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[exists] filter does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[exists] filter does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             }
         }
 
         if (fieldPattern == null) {
-            throw new QueryParsingException(parseContext.index(), "exists must be provided with a [field]");
+            throw new QueryParsingException(parseContext.index(), "exists must be provided with a [field]", parser.getTokenLocation());
         }
 
         return newFilter(parseContext, fieldPattern, filterName);

--- a/src/main/java/org/elasticsearch/index/query/FQueryFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/FQueryFilterParser.java
@@ -65,7 +65,7 @@ public class FQueryFilterParser implements FilterParser {
                     queryFound = true;
                     query = parseContext.parseInnerQuery();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[fquery] filter does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[fquery] filter does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             } else if (token.isValue()) {
                 if ("_name".equals(currentFieldName)) {
@@ -75,12 +75,12 @@ public class FQueryFilterParser implements FilterParser {
                 } else if ("_cache_key".equals(currentFieldName) || "_cacheKey".equals(currentFieldName)) {
                     cacheKey = new CacheKeyFilter.Key(parser.text());
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[fquery] filter does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[fquery] filter does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             }
         }
         if (!queryFound) {
-            throw new QueryParsingException(parseContext.index(), "[fquery] requires 'query' element");
+            throw new QueryParsingException(parseContext.index(), "[fquery] requires 'query' element", parser.getTokenLocation());
         }
         if (query == null) {
             return null;

--- a/src/main/java/org/elasticsearch/index/query/FieldMaskingSpanQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/FieldMaskingSpanQueryParser.java
@@ -64,11 +64,11 @@ public class FieldMaskingSpanQueryParser implements QueryParser {
                 if ("query".equals(currentFieldName)) {
                     Query query = parseContext.parseInnerQuery();
                     if (!(query instanceof SpanQuery)) {
-                        throw new QueryParsingException(parseContext.index(), "[field_masking_span] query] must be of type span query");
+                        throw new QueryParsingException(parseContext.index(), "[field_masking_span] query] must be of type span query", parser.getTokenLocation());
                     }
                     inner = (SpanQuery) query;
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[field_masking_span] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[field_masking_span] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             } else {
                 if ("boost".equals(currentFieldName)) {
@@ -78,15 +78,15 @@ public class FieldMaskingSpanQueryParser implements QueryParser {
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[field_masking_span] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[field_masking_span] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             }
         }
         if (inner == null) {
-            throw new QueryParsingException(parseContext.index(), "field_masking_span must have [query] span query clause");
+            throw new QueryParsingException(parseContext.index(), "field_masking_span must have [query] span query clause", parser.getTokenLocation());
         }
         if (field == null) {
-            throw new QueryParsingException(parseContext.index(), "field_masking_span must have [field] set for it");
+            throw new QueryParsingException(parseContext.index(), "field_masking_span must have [field] set for it", parser.getTokenLocation());
         }
 
         FieldMapper mapper = parseContext.fieldMapper(field);

--- a/src/main/java/org/elasticsearch/index/query/FilteredQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/FilteredQueryParser.java
@@ -142,7 +142,8 @@ public class FilteredQueryParser implements QueryParser {
                     filterFound = true;
                     filter = parseContext.parseInnerFilter();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[filtered] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[filtered] query does not support [" + currentFieldName + "]", 
+                            parser.getTokenLocation());
                 }
             } else if (token.isValue()) {
                 if ("strategy".equals(currentFieldName)) {
@@ -164,7 +165,7 @@ public class FilteredQueryParser implements QueryParser {
                     } else if ("leap_frog_filter_first".equals(value) || "leapFrogFilterFirst".equals(value)) {
                         filterStrategy = FilteredQuery.LEAP_FROG_FILTER_FIRST_STRATEGY;
                     } else {
-                        throw new QueryParsingException(parseContext.index(), "[filtered] strategy value not supported [" + value + "]");
+                        throw new QueryParsingException(parseContext.index(), "[filtered] strategy value not supported [" + value + "]", parser.getTokenLocation());
                     }
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
@@ -175,7 +176,7 @@ public class FilteredQueryParser implements QueryParser {
                 } else if ("_cache_key".equals(currentFieldName) || "_cacheKey".equals(currentFieldName)) {
                     cacheKey = new CacheKeyFilter.Key(parser.text());
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[filtered] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[filtered] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             }
         }

--- a/src/main/java/org/elasticsearch/index/query/FuzzyLikeThisFieldQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/FuzzyLikeThisFieldQueryParser.java
@@ -78,14 +78,14 @@ public class FuzzyLikeThisFieldQueryParser implements QueryParser {
 
         XContentParser.Token token = parser.nextToken();
         if (token != XContentParser.Token.FIELD_NAME) {
-            throw new QueryParsingException(parseContext.index(), "[flt_field] query malformed, no field");
+            throw new QueryParsingException(parseContext.index(), "[flt_field] query malformed, no field", parser.getTokenLocation());
         }
         String fieldName = parser.currentName();
 
         // now, we move after the field name, which starts the object
         token = parser.nextToken();
         if (token != XContentParser.Token.START_OBJECT) {
-            throw new QueryParsingException(parseContext.index(), "[flt_field] query malformed, no start_object");
+            throw new QueryParsingException(parseContext.index(), "[flt_field] query malformed, no start_object", parser.getTokenLocation());
         }
 
 
@@ -113,13 +113,13 @@ public class FuzzyLikeThisFieldQueryParser implements QueryParser {
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[flt_field] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[flt_field] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             }
         }
 
         if (likeText == null) {
-            throw new QueryParsingException(parseContext.index(), "fuzzy_like_This_field requires 'like_text' to be specified");
+            throw new QueryParsingException(parseContext.index(), "fuzzy_like_This_field requires 'like_text' to be specified", parser.getTokenLocation());
         }
 
         MapperService.SmartNameFieldMappers smartNameFieldMappers = parseContext.smartFieldMappers(fieldName);
@@ -150,7 +150,7 @@ public class FuzzyLikeThisFieldQueryParser implements QueryParser {
         // move to the next end object, to close the field name
         token = parser.nextToken();
         if (token != XContentParser.Token.END_OBJECT) {
-            throw new QueryParsingException(parseContext.index(), "[flt_field] query malformed, no end_object");
+            throw new QueryParsingException(parseContext.index(), "[flt_field] query malformed, no end_object", parser.getTokenLocation());
         }
         assert token == XContentParser.Token.END_OBJECT;
 

--- a/src/main/java/org/elasticsearch/index/query/FuzzyLikeThisQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/FuzzyLikeThisQueryParser.java
@@ -100,7 +100,7 @@ public class FuzzyLikeThisQueryParser implements QueryParser {
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[flt] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[flt] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.START_ARRAY) {
                 if ("fields".equals(currentFieldName)) {
@@ -109,13 +109,13 @@ public class FuzzyLikeThisQueryParser implements QueryParser {
                         fields.add(parseContext.indexName(parser.text()));
                     }
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[flt] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[flt] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             }
         }
 
         if (likeText == null) {
-            throw new QueryParsingException(parseContext.index(), "fuzzy_like_this requires 'like_text' to be specified");
+            throw new QueryParsingException(parseContext.index(), "fuzzy_like_this requires 'like_text' to be specified", parser.getTokenLocation());
         }
 
         if (analyzer == null) {
@@ -126,7 +126,7 @@ public class FuzzyLikeThisQueryParser implements QueryParser {
         if (fields == null) {
             fields = Lists.newArrayList(parseContext.defaultField());
         } else if (fields.isEmpty()) {
-            throw new QueryParsingException(parseContext.index(), "fuzzy_like_this requires 'fields' to be non-empty");
+            throw new QueryParsingException(parseContext.index(), "fuzzy_like_this requires 'fields' to be non-empty", parser.getTokenLocation());
         }
         for (Iterator<String> it = fields.iterator(); it.hasNext(); ) {
             final String fieldName = it.next();

--- a/src/main/java/org/elasticsearch/index/query/FuzzyQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/FuzzyQueryParser.java
@@ -59,7 +59,7 @@ public class FuzzyQueryParser implements QueryParser {
 
         XContentParser.Token token = parser.nextToken();
         if (token != XContentParser.Token.FIELD_NAME) {
-            throw new QueryParsingException(parseContext.index(), "[fuzzy] query malformed, no field");
+            throw new QueryParsingException(parseContext.index(), "[fuzzy] query malformed, no field", parser.getTokenLocation());
         }
         String fieldName = parser.currentName();
 
@@ -97,7 +97,7 @@ public class FuzzyQueryParser implements QueryParser {
                     } else if ("_name".equals(currentFieldName)) {
                         queryName = parser.text();
                     } else {
-                        throw new QueryParsingException(parseContext.index(), "[fuzzy] query does not support [" + currentFieldName + "]");
+                        throw new QueryParsingException(parseContext.index(), "[fuzzy] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                     }
                 }
             }
@@ -109,7 +109,7 @@ public class FuzzyQueryParser implements QueryParser {
         }
 
         if (value == null) {
-            throw new QueryParsingException(parseContext.index(), "No value specified for fuzzy query");
+            throw new QueryParsingException(parseContext.index(), "No value specified for fuzzy query", parser.getTokenLocation());
         }
 
         Query query = null;

--- a/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxFilterParser.java
@@ -148,7 +148,7 @@ public class GeoBoundingBoxFilterParser implements FilterParser {
                 } else if ("type".equals(currentFieldName)) {
                     type = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[geo_bbox] filter does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[geo_bbox] filter does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             }
         }
@@ -170,11 +170,11 @@ public class GeoBoundingBoxFilterParser implements FilterParser {
 
         MapperService.SmartNameFieldMappers smartMappers = parseContext.smartFieldMappers(fieldName);
         if (smartMappers == null || !smartMappers.hasMapper()) {
-            throw new QueryParsingException(parseContext.index(), "failed to find geo_point field [" + fieldName + "]");
+            throw new QueryParsingException(parseContext.index(), "failed to find geo_point field [" + fieldName + "]", parser.getTokenLocation());
         }
         FieldMapper<?> mapper = smartMappers.mapper();
         if (!(mapper instanceof GeoPointFieldMapper)) {
-            throw new QueryParsingException(parseContext.index(), "field [" + fieldName + "] is not a geo_point field");
+            throw new QueryParsingException(parseContext.index(), "field [" + fieldName + "] is not a geo_point field", parser.getTokenLocation());
         }
         GeoPointFieldMapper geoMapper = ((GeoPointFieldMapper) mapper);
 
@@ -185,7 +185,7 @@ public class GeoBoundingBoxFilterParser implements FilterParser {
             IndexGeoPointFieldData indexFieldData = parseContext.getForField(mapper);
             filter = new InMemoryGeoBoundingBoxFilter(topLeft, bottomRight, indexFieldData);
         } else {
-            throw new QueryParsingException(parseContext.index(), "geo bounding box type [" + type + "] not supported, either 'indexed' or 'memory' are allowed");
+            throw new QueryParsingException(parseContext.index(), "geo bounding box type [" + type + "] not supported, either 'indexed' or 'memory' are allowed", parser.getTokenLocation());
         }
 
         if (cache) {

--- a/src/main/java/org/elasticsearch/index/query/GeoDistanceFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoDistanceFilterParser.java
@@ -99,7 +99,7 @@ public class GeoDistanceFilterParser implements FilterParser {
                         } else if (currentName.equals(GeoPointFieldMapper.Names.GEOHASH)) {
                             GeoHashUtils.decode(parser.text(), point);
                         } else {
-                            throw new QueryParsingException(parseContext.index(), "[geo_distance] filter does not support [" + currentFieldName + "]");
+                            throw new QueryParsingException(parseContext.index(), "[geo_distance] filter does not support [" + currentFieldName + "]", parser.getTokenLocation());
                         }
                     }
                 }
@@ -142,7 +142,7 @@ public class GeoDistanceFilterParser implements FilterParser {
         }
 
         if (vDistance == null) {
-            throw new QueryParsingException(parseContext.index(), "geo_distance requires 'distance' to be specified");
+            throw new QueryParsingException(parseContext.index(), "geo_distance requires 'distance' to be specified", parser.getTokenLocation());
         } else if (vDistance instanceof Number) {
             distance = DistanceUnit.DEFAULT.convert(((Number) vDistance).doubleValue(), unit);
         } else {
@@ -156,11 +156,11 @@ public class GeoDistanceFilterParser implements FilterParser {
 
         MapperService.SmartNameFieldMappers smartMappers = parseContext.smartFieldMappers(fieldName);
         if (smartMappers == null || !smartMappers.hasMapper()) {
-            throw new QueryParsingException(parseContext.index(), "failed to find geo_point field [" + fieldName + "]");
+            throw new QueryParsingException(parseContext.index(), "failed to find geo_point field [" + fieldName + "]", parser.getTokenLocation());
         }
         FieldMapper<?> mapper = smartMappers.mapper();
         if (!(mapper instanceof GeoPointFieldMapper)) {
-            throw new QueryParsingException(parseContext.index(), "field [" + fieldName + "] is not a geo_point field");
+            throw new QueryParsingException(parseContext.index(), "field [" + fieldName + "] is not a geo_point field", parser.getTokenLocation());
         }
         GeoPointFieldMapper geoMapper = ((GeoPointFieldMapper) mapper);
 

--- a/src/main/java/org/elasticsearch/index/query/GeoDistanceRangeFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoDistanceRangeFilterParser.java
@@ -197,11 +197,11 @@ public class GeoDistanceRangeFilterParser implements FilterParser {
 
         MapperService.SmartNameFieldMappers smartMappers = parseContext.smartFieldMappers(fieldName);
         if (smartMappers == null || !smartMappers.hasMapper()) {
-            throw new QueryParsingException(parseContext.index(), "failed to find geo_point field [" + fieldName + "]");
+            throw new QueryParsingException(parseContext.index(), "failed to find geo_point field [" + fieldName + "]", parser.getTokenLocation());
         }
         FieldMapper<?> mapper = smartMappers.mapper();
         if (!(mapper instanceof GeoPointFieldMapper)) {
-            throw new QueryParsingException(parseContext.index(), "field [" + fieldName + "] is not a geo_point field");
+            throw new QueryParsingException(parseContext.index(), "field [" + fieldName + "] is not a geo_point field", parser.getTokenLocation());
         }
         GeoPointFieldMapper geoMapper = ((GeoPointFieldMapper) mapper);
 

--- a/src/main/java/org/elasticsearch/index/query/GeoPolygonFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoPolygonFilterParser.java
@@ -96,10 +96,10 @@ public class GeoPolygonFilterParser implements FilterParser {
                                 shell.add(GeoUtils.parseGeoPoint(parser));
                             }
                         } else {
-                            throw new QueryParsingException(parseContext.index(), "[geo_polygon] filter does not support [" + currentFieldName + "]");
+                            throw new QueryParsingException(parseContext.index(), "[geo_polygon] filter does not support [" + currentFieldName + "]", parser.getTokenLocation());
                         }
                     } else {
-                        throw new QueryParsingException(parseContext.index(), "[geo_polygon] filter does not support token type [" + token.name() + "] under [" + currentFieldName + "]");
+                        throw new QueryParsingException(parseContext.index(), "[geo_polygon] filter does not support token type [" + token.name() + "] under [" + currentFieldName + "]", parser.getTokenLocation());
                     }
                 }
             } else if (token.isValue()) {
@@ -113,25 +113,25 @@ public class GeoPolygonFilterParser implements FilterParser {
                     normalizeLat = parser.booleanValue();
                     normalizeLon = parser.booleanValue();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[geo_polygon] filter does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[geo_polygon] filter does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             } else {
-                throw new QueryParsingException(parseContext.index(), "[geo_polygon] unexpected token type [" + token.name() + "]");
+                throw new QueryParsingException(parseContext.index(), "[geo_polygon] unexpected token type [" + token.name() + "]", parser.getTokenLocation());
             }
         }
 
         if (shell.isEmpty()) {
-            throw new QueryParsingException(parseContext.index(), "no points defined for geo_polygon filter");
+            throw new QueryParsingException(parseContext.index(), "no points defined for geo_polygon filter", parser.getTokenLocation());
         } else {
             if (shell.size() < 3) {
-                throw new QueryParsingException(parseContext.index(), "to few points defined for geo_polygon filter");
+                throw new QueryParsingException(parseContext.index(), "to few points defined for geo_polygon filter", parser.getTokenLocation());
             }
             GeoPoint start = shell.get(0);
             if (!start.equals(shell.get(shell.size() - 1))) {
                 shell.add(start);
             }
             if (shell.size() < 4) {
-                throw new QueryParsingException(parseContext.index(), "to few points defined for geo_polygon filter");
+                throw new QueryParsingException(parseContext.index(), "to few points defined for geo_polygon filter", parser.getTokenLocation());
             }
         }
 
@@ -143,11 +143,11 @@ public class GeoPolygonFilterParser implements FilterParser {
 
         MapperService.SmartNameFieldMappers smartMappers = parseContext.smartFieldMappers(fieldName);
         if (smartMappers == null || !smartMappers.hasMapper()) {
-            throw new QueryParsingException(parseContext.index(), "failed to find geo_point field [" + fieldName + "]");
+            throw new QueryParsingException(parseContext.index(), "failed to find geo_point field [" + fieldName + "]", parser.getTokenLocation());
         }
         FieldMapper<?> mapper = smartMappers.mapper();
         if (!(mapper instanceof GeoPointFieldMapper)) {
-            throw new QueryParsingException(parseContext.index(), "field [" + fieldName + "] is not a geo_point field");
+            throw new QueryParsingException(parseContext.index(), "field [" + fieldName + "] is not a geo_point field", parser.getTokenLocation());
         }
 
         IndexGeoPointFieldData indexFieldData = parseContext.getForField(mapper);

--- a/src/main/java/org/elasticsearch/index/query/GeoShapeFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoShapeFilterParser.java
@@ -113,7 +113,7 @@ public class GeoShapeFilterParser implements FilterParser {
                         } else if ("relation".equals(currentFieldName)) {
                             shapeRelation = ShapeRelation.getRelationByName(parser.text());
                             if (shapeRelation == null) {
-                                throw new QueryParsingException(parseContext.index(), "Unknown shape operation [" + parser.text() + "]");
+                                throw new QueryParsingException(parseContext.index(), "Unknown shape operation [" + parser.text() + "]", parser.getTokenLocation());
                             }
                         } else if ("strategy".equals(currentFieldName)) {
                             strategyName = parser.text();
@@ -134,13 +134,13 @@ public class GeoShapeFilterParser implements FilterParser {
                                 }
                             }
                             if (id == null) {
-                                throw new QueryParsingException(parseContext.index(), "ID for indexed shape not provided");
+                                throw new QueryParsingException(parseContext.index(), "ID for indexed shape not provided", parser.getTokenLocation());
                             } else if (type == null) {
-                                throw new QueryParsingException(parseContext.index(), "Type for indexed shape not provided");
+                                throw new QueryParsingException(parseContext.index(), "Type for indexed shape not provided", parser.getTokenLocation());
                             }
                             shape = fetchService.fetch(id, type, index, shapePath);
                         }  else {
-                            throw new QueryParsingException(parseContext.index(), "[geo_shape] filter does not support [" + currentFieldName + "]");
+                            throw new QueryParsingException(parseContext.index(), "[geo_shape] filter does not support [" + currentFieldName + "]", parser.getTokenLocation());
                         }
                     }
                 }
@@ -152,26 +152,26 @@ public class GeoShapeFilterParser implements FilterParser {
                 } else if ("_cache_key".equals(currentFieldName)) {
                     cacheKey = new CacheKeyFilter.Key(parser.text());
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[geo_shape] filter does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[geo_shape] filter does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             }
         }
 
         if (shape == null) {
-            throw new QueryParsingException(parseContext.index(), "No Shape defined");
+            throw new QueryParsingException(parseContext.index(), "No Shape defined", parser.getTokenLocation());
         } else if (shapeRelation == null) {
-            throw new QueryParsingException(parseContext.index(), "No Shape Relation defined");
+            throw new QueryParsingException(parseContext.index(), "No Shape Relation defined", parser.getTokenLocation());
         }
 
         MapperService.SmartNameFieldMappers smartNameFieldMappers = parseContext.smartFieldMappers(fieldName);
         if (smartNameFieldMappers == null || !smartNameFieldMappers.hasMapper()) {
-            throw new QueryParsingException(parseContext.index(), "Failed to find geo_shape field [" + fieldName + "]");
+            throw new QueryParsingException(parseContext.index(), "Failed to find geo_shape field [" + fieldName + "]", parser.getTokenLocation());
         }
 
         FieldMapper fieldMapper = smartNameFieldMappers.mapper();
         // TODO: This isn't the nicest way to check this
         if (!(fieldMapper instanceof GeoShapeFieldMapper)) {
-            throw new QueryParsingException(parseContext.index(), "Field [" + fieldName + "] is not a geo_shape");
+            throw new QueryParsingException(parseContext.index(), "Field [" + fieldName + "] is not a geo_shape", parser.getTokenLocation());
         }
 
         GeoShapeFieldMapper shapeFieldMapper = (GeoShapeFieldMapper) fieldMapper;

--- a/src/main/java/org/elasticsearch/index/query/GeoShapeQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoShapeQueryParser.java
@@ -94,7 +94,7 @@ public class GeoShapeQueryParser implements QueryParser {
                         } else if ("relation".equals(currentFieldName)) {
                             shapeRelation = ShapeRelation.getRelationByName(parser.text());
                             if (shapeRelation == null) {
-                                throw new QueryParsingException(parseContext.index(), "Unknown shape operation [" + parser.text() + " ]");
+                                throw new QueryParsingException(parseContext.index(), "Unknown shape operation [" + parser.text() + " ]", parser.getTokenLocation());
                             }
                         } else if ("indexed_shape".equals(currentFieldName) || "indexedShape".equals(currentFieldName)) {
                             while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
@@ -113,13 +113,13 @@ public class GeoShapeQueryParser implements QueryParser {
                                 }
                             }
                             if (id == null) {
-                                throw new QueryParsingException(parseContext.index(), "ID for indexed shape not provided");
+                                throw new QueryParsingException(parseContext.index(), "ID for indexed shape not provided", parser.getTokenLocation());
                             } else if (type == null) {
-                                throw new QueryParsingException(parseContext.index(), "Type for indexed shape not provided");
+                                throw new QueryParsingException(parseContext.index(), "Type for indexed shape not provided", parser.getTokenLocation());
                             }
                             shape = fetchService.fetch(id, type, index, shapePath);
                         } else {
-                            throw new QueryParsingException(parseContext.index(), "[geo_shape] query does not support [" + currentFieldName + "]");
+                            throw new QueryParsingException(parseContext.index(), "[geo_shape] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                         }
                     }
                 }
@@ -129,26 +129,26 @@ public class GeoShapeQueryParser implements QueryParser {
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[geo_shape] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[geo_shape] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             }
         }
 
         if (shape == null) {
-            throw new QueryParsingException(parseContext.index(), "No Shape defined");
+            throw new QueryParsingException(parseContext.index(), "No Shape defined", parser.getTokenLocation());
         } else if (shapeRelation == null) {
-            throw new QueryParsingException(parseContext.index(), "No Shape Relation defined");
+            throw new QueryParsingException(parseContext.index(), "No Shape Relation defined", parser.getTokenLocation());
         }
 
         MapperService.SmartNameFieldMappers smartNameFieldMappers = parseContext.smartFieldMappers(fieldName);
         if (smartNameFieldMappers == null || !smartNameFieldMappers.hasMapper()) {
-            throw new QueryParsingException(parseContext.index(), "Failed to find geo_shape field [" + fieldName + "]");
+            throw new QueryParsingException(parseContext.index(), "Failed to find geo_shape field [" + fieldName + "]", parser.getTokenLocation());
         }
 
         FieldMapper fieldMapper = smartNameFieldMappers.mapper();
         // TODO: This isn't the nicest way to check this
         if (!(fieldMapper instanceof GeoShapeFieldMapper)) {
-            throw new QueryParsingException(parseContext.index(), "Field [" + fieldName + "] is not a geo_shape");
+            throw new QueryParsingException(parseContext.index(), "Field [" + fieldName + "] is not a geo_shape", parser.getTokenLocation());
         }
 
         GeoShapeFieldMapper shapeFieldMapper = (GeoShapeFieldMapper) fieldMapper;

--- a/src/main/java/org/elasticsearch/index/query/GeohashCellFilter.java
+++ b/src/main/java/org/elasticsearch/index/query/GeohashCellFilter.java
@@ -265,22 +265,22 @@ public class GeohashCellFilter {
             }
 
             if (geohash == null) {
-                throw new QueryParsingException(parseContext.index(), "no geohash value provided to geohash_cell filter");
+                throw new QueryParsingException(parseContext.index(), "no geohash value provided to geohash_cell filter", parser.getTokenLocation());
             }
 
             MapperService.SmartNameFieldMappers smartMappers = parseContext.smartFieldMappers(fieldName);
             if (smartMappers == null || !smartMappers.hasMapper()) {
-                throw new QueryParsingException(parseContext.index(), "failed to find geo_point field [" + fieldName + "]");
+                throw new QueryParsingException(parseContext.index(), "failed to find geo_point field [" + fieldName + "]", parser.getTokenLocation());
             }
 
             FieldMapper<?> mapper = smartMappers.mapper();
             if (!(mapper instanceof GeoPointFieldMapper)) {
-                throw new QueryParsingException(parseContext.index(), "field [" + fieldName + "] is not a geo_point field");
+                throw new QueryParsingException(parseContext.index(), "field [" + fieldName + "] is not a geo_point field", parser.getTokenLocation());
             }
 
             GeoPointFieldMapper geoMapper = ((GeoPointFieldMapper) mapper);
             if (!geoMapper.isEnableGeohashPrefix()) {
-                throw new QueryParsingException(parseContext.index(), "can't execute geohash_cell on field [" + fieldName + "], geohash_prefix is not enabled");
+                throw new QueryParsingException(parseContext.index(), "can't execute geohash_cell on field [" + fieldName + "], geohash_prefix is not enabled", parser.getTokenLocation());
             }
 
             if(levels > 0) {

--- a/src/main/java/org/elasticsearch/index/query/HasChildFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/HasChildFilterParser.java
@@ -87,7 +87,7 @@ public class HasChildFilterParser implements FilterParser {
                     innerFilter = new XContentStructure.InnerFilter(parseContext, childType == null ? null : new String[] {childType});
                     filterFound = true;
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[has_child] filter does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[has_child] filter does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             } else if (token.isValue()) {
                 if ("type".equals(currentFieldName) || "child_type".equals(currentFieldName) || "childType".equals(currentFieldName)) {
@@ -105,15 +105,15 @@ public class HasChildFilterParser implements FilterParser {
                 } else if ("max_children".equals(currentFieldName) || "maxChildren".equals(currentFieldName)) {
                     maxChildren = parser.intValue(true);
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[has_child] filter does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[has_child] filter does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             }
         }
         if (!queryFound && !filterFound) {
-            throw new QueryParsingException(parseContext.index(), "[has_child] filter requires 'query' or 'filter' field");
+            throw new QueryParsingException(parseContext.index(), "[has_child] filter requires 'query' or 'filter' field", parser.getTokenLocation());
         }
         if (childType == null) {
-            throw new QueryParsingException(parseContext.index(), "[has_child] filter requires 'type' field");
+            throw new QueryParsingException(parseContext.index(), "[has_child] filter requires 'type' field", parser.getTokenLocation());
         }
 
         Query query;
@@ -129,11 +129,11 @@ public class HasChildFilterParser implements FilterParser {
 
         DocumentMapper childDocMapper = parseContext.mapperService().documentMapper(childType);
         if (childDocMapper == null) {
-            throw new QueryParsingException(parseContext.index(), "No mapping for for type [" + childType + "]");
+            throw new QueryParsingException(parseContext.index(), "No mapping for for type [" + childType + "]", parser.getTokenLocation());
         }
         ParentFieldMapper parentFieldMapper = childDocMapper.parentFieldMapper();
         if (!parentFieldMapper.active()) {
-            throw new QueryParsingException(parseContext.index(), "Type [" + childType + "] does not have parent mapping");
+            throw new QueryParsingException(parseContext.index(), "Type [" + childType + "] does not have parent mapping", parser.getTokenLocation());
         }
         String parentType = parentFieldMapper.type();
 
@@ -142,11 +142,11 @@ public class HasChildFilterParser implements FilterParser {
 
         DocumentMapper parentDocMapper = parseContext.mapperService().documentMapper(parentType);
         if (parentDocMapper == null) {
-            throw new QueryParsingException(parseContext.index(), "[has_child]  Type [" + childType + "] points to a non existent parent type [" + parentType + "]");
+            throw new QueryParsingException(parseContext.index(), "[has_child]  Type [" + childType + "] points to a non existent parent type [" + parentType + "]", parser.getTokenLocation());
         }
 
         if (maxChildren > 0 && maxChildren < minChildren) {
-            throw new QueryParsingException(parseContext.index(), "[has_child] 'max_children' is less than 'min_children'");
+            throw new QueryParsingException(parseContext.index(), "[has_child] 'max_children' is less than 'min_children'", parser.getTokenLocation());
         }
 
         BitDocIdSetFilter nonNestedDocsFilter = null;

--- a/src/main/java/org/elasticsearch/index/query/HasChildQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/HasChildQueryParser.java
@@ -84,7 +84,7 @@ public class HasChildQueryParser implements QueryParser {
                     iq = new XContentStructure.InnerQuery(parseContext, childType == null ? null : new String[] { childType });
                     queryFound = true;
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[has_child] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[has_child] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             } else if (token.isValue()) {
                 if ("type".equals(currentFieldName) || "child_type".equals(currentFieldName) || "childType".equals(currentFieldName)) {
@@ -104,15 +104,15 @@ public class HasChildQueryParser implements QueryParser {
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[has_child] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[has_child] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             }
         }
         if (!queryFound) {
-            throw new QueryParsingException(parseContext.index(), "[has_child] requires 'query' field");
+            throw new QueryParsingException(parseContext.index(), "[has_child] requires 'query' field", parser.getTokenLocation());
         }
         if (childType == null) {
-            throw new QueryParsingException(parseContext.index(), "[has_child] requires 'type' field");
+            throw new QueryParsingException(parseContext.index(), "[has_child] requires 'type' field", parser.getTokenLocation());
         }
 
         Query innerQuery = iq.asQuery(childType);
@@ -124,26 +124,26 @@ public class HasChildQueryParser implements QueryParser {
 
         DocumentMapper childDocMapper = parseContext.mapperService().documentMapper(childType);
         if (childDocMapper == null) {
-            throw new QueryParsingException(parseContext.index(), "[has_child] No mapping for for type [" + childType + "]");
+            throw new QueryParsingException(parseContext.index(), "[has_child] No mapping for for type [" + childType + "]", parser.getTokenLocation());
         }
         if (!childDocMapper.parentFieldMapper().active()) {
-            throw new QueryParsingException(parseContext.index(), "[has_child]  Type [" + childType + "] does not have parent mapping");
+            throw new QueryParsingException(parseContext.index(), "[has_child]  Type [" + childType + "] does not have parent mapping", parser.getTokenLocation());
         }
 
         ParentFieldMapper parentFieldMapper = childDocMapper.parentFieldMapper();
         if (!parentFieldMapper.active()) {
-            throw new QueryParsingException(parseContext.index(), "[has_child] _parent field not configured");
+            throw new QueryParsingException(parseContext.index(), "[has_child] _parent field not configured", parser.getTokenLocation());
         }
 
         String parentType = parentFieldMapper.type();
         DocumentMapper parentDocMapper = parseContext.mapperService().documentMapper(parentType);
         if (parentDocMapper == null) {
             throw new QueryParsingException(parseContext.index(), "[has_child]  Type [" + childType
-                    + "] points to a non existent parent type [" + parentType + "]");
+                    + "] points to a non existent parent type [" + parentType + "]", parser.getTokenLocation());
         }
 
         if (maxChildren > 0 && maxChildren < minChildren) {
-            throw new QueryParsingException(parseContext.index(), "[has_child] 'max_children' is less than 'min_children'");
+            throw new QueryParsingException(parseContext.index(), "[has_child] 'max_children' is less than 'min_children'", parser.getTokenLocation());
         }
 
         BitDocIdSetFilter nonNestedDocsFilter = null;

--- a/src/main/java/org/elasticsearch/index/query/HasParentFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/HasParentFilterParser.java
@@ -76,7 +76,7 @@ public class HasParentFilterParser implements FilterParser {
                     innerFilter = new XContentStructure.InnerFilter(parseContext, parentType == null ? null : new String[] {parentType});
                     filterFound = true;
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[has_parent] filter does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[has_parent] filter does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             } else if (token.isValue()) {
                 if ("type".equals(currentFieldName) || "parent_type".equals(currentFieldName) || "parentType".equals(currentFieldName)) {
@@ -88,15 +88,15 @@ public class HasParentFilterParser implements FilterParser {
                 } else if ("_cache_key".equals(currentFieldName) || "_cacheKey".equals(currentFieldName)) {
                     // noop to be backwards compatible
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[has_parent] filter does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[has_parent] filter does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             }
         }
         if (!queryFound && !filterFound) {
-            throw new QueryParsingException(parseContext.index(), "[has_parent] filter requires 'query' or 'filter' field");
+            throw new QueryParsingException(parseContext.index(), "[has_parent] filter requires 'query' or 'filter' field", parser.getTokenLocation());
         }
         if (parentType == null) {
-            throw new QueryParsingException(parseContext.index(), "[has_parent] filter requires 'parent_type' field");
+            throw new QueryParsingException(parseContext.index(), "[has_parent] filter requires 'parent_type' field", parser.getTokenLocation());
         }
 
         Query innerQuery;

--- a/src/main/java/org/elasticsearch/index/query/HasParentQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/HasParentQueryParser.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.lucene.search.NotFilter;
 import org.elasticsearch.common.lucene.search.XBooleanFilter;
+import org.elasticsearch.common.xcontent.XContentLocation;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.fielddata.plain.ParentChildIndexFieldData;
 import org.elasticsearch.index.mapper.DocumentMapper;
@@ -81,7 +82,7 @@ public class HasParentQueryParser implements QueryParser {
                     iq = new XContentStructure.InnerQuery(parseContext, parentType == null ? null : new String[] {parentType});
                     queryFound = true;
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[has_parent] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[has_parent] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             } else if (token.isValue()) {
                 if ("type".equals(currentFieldName) || "parent_type".equals(currentFieldName) || "parentType".equals(currentFieldName)) {
@@ -105,15 +106,15 @@ public class HasParentQueryParser implements QueryParser {
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[has_parent] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[has_parent] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             }
         }
         if (!queryFound) {
-            throw new QueryParsingException(parseContext.index(), "[has_parent] query requires 'query' field");
+            throw new QueryParsingException(parseContext.index(), "[has_parent] query requires 'query' field", parser.getTokenLocation());
         }
         if (parentType == null) {
-            throw new QueryParsingException(parseContext.index(), "[has_parent] query requires 'parent_type' field");
+            throw new QueryParsingException(parseContext.index(), "[has_parent] query requires 'parent_type' field", parser.getTokenLocation());
         }
 
         Query innerQuery = iq.asQuery(parentType);
@@ -138,7 +139,7 @@ public class HasParentQueryParser implements QueryParser {
     static Query createParentQuery(Query innerQuery, String parentType, boolean score, QueryParseContext parseContext) {
         DocumentMapper parentDocMapper = parseContext.mapperService().documentMapper(parentType);
         if (parentDocMapper == null) {
-            throw new QueryParsingException(parseContext.index(), "[has_parent] query configured 'parent_type' [" + parentType + "] is not a valid type");
+            throw new QueryParsingException(parseContext.index(), "[has_parent] query configured 'parent_type' [" + parentType + "] is not a valid type", null);
         }
 
         Set<String> parentTypes = new HashSet<>(5);
@@ -156,7 +157,7 @@ public class HasParentQueryParser implements QueryParser {
             }
         }
         if (parentChildIndexFieldData == null) {
-            throw new QueryParsingException(parseContext.index(), "[has_parent] no _parent field configured");
+            throw new QueryParsingException(parseContext.index(), "[has_parent] no _parent field configured", (XContentLocation) null);
         }
 
         Filter parentFilter = null;

--- a/src/main/java/org/elasticsearch/index/query/IdsFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/IdsFilterParser.java
@@ -67,7 +67,7 @@ public class IdsFilterParser implements FilterParser {
                     while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                         BytesRef value = parser.utf8BytesOrNull();
                         if (value == null) {
-                            throw new QueryParsingException(parseContext.index(), "No value specified for term filter");
+                            throw new QueryParsingException(parseContext.index(), "No value specified for term filter", parser.getTokenLocation());
                         }
                         ids.add(value);
                     }
@@ -76,12 +76,12 @@ public class IdsFilterParser implements FilterParser {
                     while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                         String value = parser.textOrNull();
                         if (value == null) {
-                            throw new QueryParsingException(parseContext.index(), "No type specified for term filter");
+                            throw new QueryParsingException(parseContext.index(), "No type specified for term filter", parser.getTokenLocation());
                         }
                         types.add(value);
                     }
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[ids] filter does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[ids] filter does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             } else if (token.isValue()) {
                 if ("type".equals(currentFieldName) || "_type".equals(currentFieldName)) {
@@ -89,13 +89,13 @@ public class IdsFilterParser implements FilterParser {
                 } else if ("_name".equals(currentFieldName)) {
                     filterName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[ids] filter does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[ids] filter does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             }
         }
 
         if (!idsProvided) {
-            throw new QueryParsingException(parseContext.index(), "[ids] filter requires providing a values element");
+            throw new QueryParsingException(parseContext.index(), "[ids] filter requires providing a values element", parser.getTokenLocation());
         }
 
         if (ids.isEmpty()) {

--- a/src/main/java/org/elasticsearch/index/query/IdsQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/IdsQueryParser.java
@@ -74,12 +74,12 @@ public class IdsQueryParser implements QueryParser {
                                 (token == XContentParser.Token.VALUE_NUMBER)) {
                             BytesRef value = parser.utf8BytesOrNull();
                             if (value == null) {
-                                throw new QueryParsingException(parseContext.index(), "No value specified for term filter");
+                                throw new QueryParsingException(parseContext.index(), "No value specified for term filter", parser.getTokenLocation());
                             }
                             ids.add(value);
                         } else {
                             throw new QueryParsingException(parseContext.index(),
-                                    "Illegal value for id, expecting a string or number, got: " + token);
+                                    "Illegal value for id, expecting a string or number, got: " + token, parser.getTokenLocation());
                         }
                     }
                 } else if ("types".equals(currentFieldName) || "type".equals(currentFieldName)) {
@@ -87,12 +87,12 @@ public class IdsQueryParser implements QueryParser {
                     while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                         String value = parser.textOrNull();
                         if (value == null) {
-                            throw new QueryParsingException(parseContext.index(), "No type specified for term filter");
+                            throw new QueryParsingException(parseContext.index(), "No type specified for term filter", parser.getTokenLocation());
                         }
                         types.add(value);
                     }
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[ids] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[ids] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             } else if (token.isValue()) {
                 if ("type".equals(currentFieldName) || "_type".equals(currentFieldName)) {
@@ -102,13 +102,13 @@ public class IdsQueryParser implements QueryParser {
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[ids] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[ids] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             }
         }
 
         if (!idsProvided) {
-            throw new QueryParsingException(parseContext.index(), "[ids] query, no ids values provided");
+            throw new QueryParsingException(parseContext.index(), "[ids] query, no ids values provided", parser.getTokenLocation());
         }
 
         if (ids.isEmpty()) {

--- a/src/main/java/org/elasticsearch/index/query/IndexQueryParserService.java
+++ b/src/main/java/org/elasticsearch/index/query/IndexQueryParserService.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.query;
 
 import com.google.common.collect.ImmutableMap;
+
 import org.apache.lucene.search.Filter;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.CloseableThreadLocal;
@@ -33,6 +34,7 @@ import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentLocation;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.AbstractIndexComponent;
 import org.elasticsearch.index.Index;
@@ -204,7 +206,7 @@ public class IndexQueryParserService extends AbstractIndexComponent {
         } catch (QueryParsingException e) {
             throw e;
         } catch (Exception e) {
-            throw new QueryParsingException(index, "Failed to parse", e);
+            throw new QueryParsingException(index, "Failed to parse", parser.getTokenLocation(), e);
         } finally {
             if (parser != null) {
                 parser.close();
@@ -224,7 +226,7 @@ public class IndexQueryParserService extends AbstractIndexComponent {
         } catch (QueryParsingException e) {
             throw e;
         } catch (Exception e) {
-            throw new QueryParsingException(index, "Failed to parse", e);
+            throw new QueryParsingException(index, "Failed to parse", parser.getTokenLocation(), e);
         } finally {
             if (parser != null) {
                 parser.close();
@@ -244,7 +246,7 @@ public class IndexQueryParserService extends AbstractIndexComponent {
         } catch (QueryParsingException e) {
             throw e;
         } catch (Exception e) {
-            throw new QueryParsingException(index, "Failed to parse", e);
+            throw new QueryParsingException(index, "Failed to parse", parser.getTokenLocation(), e);
         } finally {
             if (parser != null) {
                 parser.close();
@@ -260,7 +262,7 @@ public class IndexQueryParserService extends AbstractIndexComponent {
         } catch (QueryParsingException e) {
             throw e;
         } catch (Exception e) {
-            throw new QueryParsingException(index, "Failed to parse [" + source + "]", e);
+            throw new QueryParsingException(index, "Failed to parse [" + source + "]", parser.getTokenLocation(), e);
         } finally {
             if (parser != null) {
                 parser.close();
@@ -276,7 +278,7 @@ public class IndexQueryParserService extends AbstractIndexComponent {
         try {
             return innerParse(context, parser);
         } catch (IOException e) {
-            throw new QueryParsingException(index, "Failed to parse", e);
+            throw new QueryParsingException(index, "Failed to parse", parser.getTokenLocation(), e);
         }
     }
 
@@ -353,7 +355,7 @@ public class IndexQueryParserService extends AbstractIndexComponent {
                         XContentParser qSourceParser = XContentFactory.xContent(querySource).createParser(querySource);
                         parsedQuery = parse(qSourceParser);
                     } else {
-                        throw new QueryParsingException(index(), "request does not support [" + fieldName + "]");
+                        throw new QueryParsingException(index(), "request does not support [" + fieldName + "]", parser.getTokenLocation());
                     }
                 }
             }
@@ -363,10 +365,10 @@ public class IndexQueryParserService extends AbstractIndexComponent {
         } catch (QueryParsingException e) {
             throw e;
         } catch (Throwable e) {
-            throw new QueryParsingException(index, "Failed to parse", e);
+            throw new QueryParsingException(index, "Failed to parse", null, e);
         }
 
-        throw new QueryParsingException(index(), "Required query is missing");
+        throw new QueryParsingException(index(), "Required query is missing", (XContentLocation) null);
     }
 
     private ParsedQuery innerParse(QueryParseContext parseContext, XContentParser parser) throws IOException, QueryParsingException {

--- a/src/main/java/org/elasticsearch/index/query/IndicesFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/IndicesFilterParser.java
@@ -83,30 +83,30 @@ public class IndicesFilterParser implements FilterParser {
                         noMatchFilter = parseContext.parseInnerFilter();
                     }
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[indices] filter does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[indices] filter does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.START_ARRAY) {
                 if ("indices".equals(currentFieldName)) {
                     if (indicesFound) {
-                        throw  new QueryParsingException(parseContext.index(), "[indices] indices or index already specified");
+                        throw  new QueryParsingException(parseContext.index(), "[indices] indices or index already specified", parser.getTokenLocation());
                     }
                     indicesFound = true;
                     Collection<String> indices = new ArrayList<>();
                     while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
                         String value = parser.textOrNull();
                         if (value == null) {
-                            throw new QueryParsingException(parseContext.index(), "[indices] no value specified for 'indices' entry");
+                            throw new QueryParsingException(parseContext.index(), "[indices] no value specified for 'indices' entry", parser.getTokenLocation());
                         }
                         indices.add(value);
                     }
                     currentIndexMatchesIndices = matchesIndices(parseContext.index().name(), indices.toArray(new String[indices.size()]));
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[indices] filter does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[indices] filter does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             } else if (token.isValue()) {
                 if ("index".equals(currentFieldName)) {
                     if (indicesFound) {
-                        throw  new QueryParsingException(parseContext.index(), "[indices] indices or index already specified");
+                        throw  new QueryParsingException(parseContext.index(), "[indices] indices or index already specified", parser.getTokenLocation());
                     }
                     indicesFound = true;
                     currentIndexMatchesIndices = matchesIndices(parseContext.index().name(), parser.text());
@@ -120,15 +120,15 @@ public class IndicesFilterParser implements FilterParser {
                 } else if ("_name".equals(currentFieldName)) {
                     filterName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[indices] filter does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[indices] filter does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             }
         }
         if (!filterFound) {
-            throw new QueryParsingException(parseContext.index(), "[indices] requires 'filter' element");
+            throw new QueryParsingException(parseContext.index(), "[indices] requires 'filter' element", parser.getTokenLocation());
         }
         if (!indicesFound) {
-            throw new QueryParsingException(parseContext.index(), "[indices] requires 'indices' or 'index' element");
+            throw new QueryParsingException(parseContext.index(), "[indices] requires 'indices' or 'index' element", parser.getTokenLocation());
         }
 
         Filter chosenFilter;

--- a/src/main/java/org/elasticsearch/index/query/IndicesQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/IndicesQueryParser.java
@@ -76,30 +76,30 @@ public class IndicesQueryParser implements QueryParser {
                 } else if ("no_match_query".equals(currentFieldName)) {
                     innerNoMatchQuery = new XContentStructure.InnerQuery(parseContext, null);
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[indices] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[indices] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.START_ARRAY) {
                 if ("indices".equals(currentFieldName)) {
                     if (indicesFound) {
-                        throw  new QueryParsingException(parseContext.index(), "[indices] indices or index already specified");
+                        throw  new QueryParsingException(parseContext.index(), "[indices] indices or index already specified", parser.getTokenLocation());
                     }
                     indicesFound = true;
                     Collection<String> indices = new ArrayList<>();
                     while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
                         String value = parser.textOrNull();
                         if (value == null) {
-                            throw new QueryParsingException(parseContext.index(), "[indices] no value specified for 'indices' entry");
+                            throw new QueryParsingException(parseContext.index(), "[indices] no value specified for 'indices' entry", parser.getTokenLocation());
                         }
                         indices.add(value);
                     }
                     currentIndexMatchesIndices = matchesIndices(parseContext.index().name(), indices.toArray(new String[indices.size()]));
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[indices] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[indices] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             } else if (token.isValue()) {
                 if ("index".equals(currentFieldName)) {
                     if (indicesFound) {
-                        throw  new QueryParsingException(parseContext.index(), "[indices] indices or index already specified");
+                        throw  new QueryParsingException(parseContext.index(), "[indices] indices or index already specified", parser.getTokenLocation());
                     }
                     indicesFound = true;
                     currentIndexMatchesIndices = matchesIndices(parseContext.index().name(), parser.text());
@@ -113,15 +113,15 @@ public class IndicesQueryParser implements QueryParser {
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[indices] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[indices] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             }
         }
         if (!queryFound) {
-            throw new QueryParsingException(parseContext.index(), "[indices] requires 'query' element");
+            throw new QueryParsingException(parseContext.index(), "[indices] requires 'query' element", parser.getTokenLocation());
         }
         if (!indicesFound) {
-            throw new QueryParsingException(parseContext.index(), "[indices] requires 'indices' or 'index' element");
+            throw new QueryParsingException(parseContext.index(), "[indices] requires 'indices' or 'index' element", parser.getTokenLocation());
         }
 
         Query chosenQuery;

--- a/src/main/java/org/elasticsearch/index/query/LimitFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/LimitFilterParser.java
@@ -53,13 +53,13 @@ public class LimitFilterParser implements FilterParser {
                 if ("value".equals(currentFieldName)) {
                     limit = parser.intValue();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[limit] filter does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[limit] filter does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             }
         }
 
         if (limit == -1) {
-            throw new QueryParsingException(parseContext.index(), "No value specified for limit filter");
+            throw new QueryParsingException(parseContext.index(), "No value specified for limit filter", parser.getTokenLocation());
         }
 
         return new LimitFilter(limit);

--- a/src/main/java/org/elasticsearch/index/query/MatchAllQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MatchAllQueryParser.java
@@ -59,7 +59,7 @@ public class MatchAllQueryParser implements QueryParser {
                 if ("boost".equals(currentFieldName)) {
                     boost = parser.floatValue();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[match_all] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[match_all] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             }
         }

--- a/src/main/java/org/elasticsearch/index/query/MatchQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MatchQueryParser.java
@@ -65,7 +65,7 @@ public class MatchQueryParser implements QueryParser {
 
         XContentParser.Token token = parser.nextToken();
         if (token != XContentParser.Token.FIELD_NAME) {
-            throw new QueryParsingException(parseContext.index(), "[match] query malformed, no field");
+            throw new QueryParsingException(parseContext.index(), "[match] query malformed, no field", parser.getTokenLocation());
         }
         String fieldName = parser.currentName();
 
@@ -93,12 +93,12 @@ public class MatchQueryParser implements QueryParser {
                         } else if ("phrase_prefix".equals(tStr) || "phrasePrefix".equals(currentFieldName)) {
                             type = MatchQuery.Type.PHRASE_PREFIX;
                         } else {
-                            throw new QueryParsingException(parseContext.index(), "[match] query does not support type " + tStr);
+                            throw new QueryParsingException(parseContext.index(), "[match] query does not support type " + tStr, parser.getTokenLocation());
                         }
                     } else if ("analyzer".equals(currentFieldName)) {
                         String analyzer = parser.text();
                         if (parseContext.analysisService().analyzer(analyzer) == null) {
-                            throw new QueryParsingException(parseContext.index(), "[match] analyzer [" + parser.text() + "] not found");
+                            throw new QueryParsingException(parseContext.index(), "[match] analyzer [" + parser.text() + "] not found", parser.getTokenLocation());
                         }
                         matchQuery.setAnalyzer(analyzer);
                     } else if ("boost".equals(currentFieldName)) {
@@ -118,7 +118,7 @@ public class MatchQueryParser implements QueryParser {
                         } else if ("and".equalsIgnoreCase(op)) {
                             matchQuery.setOccur(BooleanClause.Occur.MUST);
                         } else {
-                            throw new QueryParsingException(parseContext.index(), "text query requires operator to be either 'and' or 'or', not [" + op + "]");
+                            throw new QueryParsingException(parseContext.index(), "text query requires operator to be either 'and' or 'or', not [" + op + "]", parser.getTokenLocation());
                         }
                     } else if ("minimum_should_match".equals(currentFieldName) || "minimumShouldMatch".equals(currentFieldName)) {
                         minimumShouldMatch = parser.textOrNull();
@@ -139,12 +139,12 @@ public class MatchQueryParser implements QueryParser {
                         } else if ("all".equalsIgnoreCase(zeroTermsDocs)) {
                             matchQuery.setZeroTermsQuery(MatchQuery.ZeroTermsQuery.ALL);
                         } else {
-                            throw new QueryParsingException(parseContext.index(), "Unsupported zero_terms_docs value [" + zeroTermsDocs + "]");
+                            throw new QueryParsingException(parseContext.index(), "Unsupported zero_terms_docs value [" + zeroTermsDocs + "]", parser.getTokenLocation());
                         }
                     } else if ("_name".equals(currentFieldName)) {
                         queryName = parser.text();
                     } else {
-                        throw new QueryParsingException(parseContext.index(), "[match] query does not support [" + currentFieldName + "]");
+                        throw new QueryParsingException(parseContext.index(), "[match] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                     }
                 }
             }
@@ -154,12 +154,12 @@ public class MatchQueryParser implements QueryParser {
             // move to the next token
             token = parser.nextToken();
             if (token != XContentParser.Token.END_OBJECT) {
-                throw new QueryParsingException(parseContext.index(), "[match] query parsed in simplified form, with direct field name, but included more options than just the field name, possibly use its 'options' form, with 'query' element?");
+                throw new QueryParsingException(parseContext.index(), "[match] query parsed in simplified form, with direct field name, but included more options than just the field name, possibly use its 'options' form, with 'query' element?", parser.getTokenLocation());
             }
         }
 
         if (value == null) {
-            throw new QueryParsingException(parseContext.index(), "No text specified for text query");
+            throw new QueryParsingException(parseContext.index(), "No text specified for text query", parser.getTokenLocation());
         }
 
         Query query = matchQuery.parse(type, fieldName, value);

--- a/src/main/java/org/elasticsearch/index/query/MissingFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MissingFilterParser.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.lucene.search.NotFilter;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.lucene.search.XBooleanFilter;
+import org.elasticsearch.common.xcontent.XContentLocation;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.cache.filter.support.CacheKeyFilter;
 import org.elasticsearch.index.mapper.FieldMappers;
@@ -80,13 +81,13 @@ public class MissingFilterParser implements FilterParser {
                 } else if ("_name".equals(currentFieldName)) {
                     filterName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[missing] filter does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[missing] filter does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             }
         }
 
         if (fieldPattern == null) {
-            throw new QueryParsingException(parseContext.index(), "missing must be provided with a [field]");
+            throw new QueryParsingException(parseContext.index(), "missing must be provided with a [field]", parser.getTokenLocation());
         }
 
         return newFilter(parseContext, fieldPattern, existence, nullValue, filterName);
@@ -94,7 +95,7 @@ public class MissingFilterParser implements FilterParser {
 
     public static Filter newFilter(QueryParseContext parseContext, String fieldPattern, boolean existence, boolean nullValue, String filterName) {
         if (!existence && !nullValue) {
-            throw new QueryParsingException(parseContext.index(), "missing must have either existence, or null_value, or both set to true");
+            throw new QueryParsingException(parseContext.index(), "missing must have either existence, or null_value, or both set to true", (XContentLocation) null);
         }
 
         final FieldMappers fieldNamesMapper = parseContext.mapperService().indexName(FieldNamesFieldMapper.NAME);

--- a/src/main/java/org/elasticsearch/index/query/MoreLikeThisFieldQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MoreLikeThisFieldQueryParser.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query;
+
+import com.google.common.collect.Sets;
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.search.Query;
+import org.elasticsearch.ElasticsearchIllegalArgumentException;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.lucene.search.MoreLikeThisQuery;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.analysis.Analysis;
+import org.elasticsearch.index.mapper.MapperService;
+
+import java.io.IOException;
+import java.util.Set;
+
+import static org.elasticsearch.index.query.support.QueryParsers.wrapSmartNameQuery;
+
+/**
+ *
+ */
+public class MoreLikeThisFieldQueryParser implements QueryParser {
+
+    public static final String NAME = "mlt_field";
+
+    @Inject
+    public MoreLikeThisFieldQueryParser() {
+    }
+
+    @Override
+    public String[] names() {
+        return new String[]{NAME, "more_like_this_field", Strings.toCamelCase(NAME), "moreLikeThisField"};
+    }
+
+    
+    @Override
+    public Query parse(QueryParseContext parseContext) throws IOException, QueryParsingException {
+        XContentParser parser = parseContext.parser();
+
+        XContentParser.Token token = parser.nextToken();
+        assert token == XContentParser.Token.FIELD_NAME;
+        String fieldName = parser.currentName();
+
+        // now, we move after the field name, which starts the object
+        token = parser.nextToken();
+        assert token == XContentParser.Token.START_OBJECT;
+
+
+        MoreLikeThisQuery mltQuery = new MoreLikeThisQuery();
+        mltQuery.setSimilarity(parseContext.searchSimilarity());
+        Analyzer analyzer = null;
+        boolean failOnUnsupportedField = true;
+        String queryName = null;
+
+        String currentFieldName = null;
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                currentFieldName = parser.currentName();
+            } else if (token.isValue()) {
+                if (MoreLikeThisQueryParser.Fields.LIKE_TEXT.match(currentFieldName,parseContext.parseFlags()) ) {
+                    mltQuery.setLikeText(parser.text());
+                } else if (MoreLikeThisQueryParser.Fields.MIN_TERM_FREQ.match(currentFieldName,parseContext.parseFlags()) ) {
+                    mltQuery.setMinTermFrequency(parser.intValue());
+                } else if (MoreLikeThisQueryParser.Fields.MAX_QUERY_TERMS.match(currentFieldName,parseContext.parseFlags())) {
+                    mltQuery.setMaxQueryTerms(parser.intValue());
+                } else if (MoreLikeThisQueryParser.Fields.MIN_DOC_FREQ.match(currentFieldName,parseContext.parseFlags())) {
+                    mltQuery.setMinDocFreq(parser.intValue());
+                } else if (MoreLikeThisQueryParser.Fields.MAX_DOC_FREQ.match(currentFieldName,parseContext.parseFlags())) {
+                    mltQuery.setMaxDocFreq(parser.intValue());
+                } else if (MoreLikeThisQueryParser.Fields.MIN_WORD_LENGTH.match(currentFieldName,parseContext.parseFlags())) {
+                    mltQuery.setMinWordLen(parser.intValue());
+                } else if (MoreLikeThisQueryParser.Fields.MAX_WORD_LENGTH.match(currentFieldName,parseContext.parseFlags())) {
+                    mltQuery.setMaxWordLen(parser.intValue());
+                } else if (MoreLikeThisQueryParser.Fields.BOOST_TERMS.match(currentFieldName,parseContext.parseFlags())) {
+                    float boostFactor = parser.floatValue();
+                    if (boostFactor != 0) {
+                        mltQuery.setBoostTerms(true);
+                        mltQuery.setBoostTermsFactor(boostFactor);
+                    }
+                } else if (MoreLikeThisQueryParser.Fields.MINIMUM_SHOULD_MATCH.match(currentFieldName,parseContext.parseFlags())) {
+                    mltQuery.setMinimumShouldMatch(parser.text());
+                } else if (MoreLikeThisQueryParser.Fields.PERCENT_TERMS_TO_MATCH.match(currentFieldName,parseContext.parseFlags())) {
+                    mltQuery.setMinimumShouldMatch(Math.round(parser.floatValue() * 100) + "%");
+                } else if ("analyzer".equals(currentFieldName)) {
+                    analyzer = parseContext.analysisService().analyzer(parser.text());
+                } else if ("boost".equals(currentFieldName)) {
+                    mltQuery.setBoost(parser.floatValue());
+                } else if (MoreLikeThisQueryParser.Fields.FAIL_ON_UNSUPPORTED_FIELD.match(currentFieldName,parseContext.parseFlags())) {
+                    failOnUnsupportedField = parser.booleanValue();
+                } else if ("_name".equals(currentFieldName)) {
+                    queryName = parser.text();
+                } else {
+                    throw new QueryParsingException(parseContext.index(), "[mlt_field] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
+                }
+            } else if (token == XContentParser.Token.START_ARRAY) {
+                if (MoreLikeThisQueryParser.Fields.STOP_WORDS.match(currentFieldName,parseContext.parseFlags())) {
+
+                    Set<String> stopWords = Sets.newHashSet();
+                    while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
+                        stopWords.add(parser.text());
+                    }
+                    mltQuery.setStopWords(stopWords);
+                } else {
+                    throw new QueryParsingException(parseContext.index(), "[mlt_field] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
+                }
+            }
+        }
+
+        if (mltQuery.getLikeText() == null) {
+            throw new QueryParsingException(parseContext.index(), "more_like_this_field requires 'like_text' to be specified", parser.getTokenLocation());
+        }
+
+        // move to the next end object, to close the field name
+        token = parser.nextToken();
+        assert token == XContentParser.Token.END_OBJECT;
+
+        MapperService.SmartNameFieldMappers smartNameFieldMappers = parseContext.smartFieldMappers(fieldName);
+        if (smartNameFieldMappers != null) {
+            if (smartNameFieldMappers.hasMapper()) {
+                fieldName = smartNameFieldMappers.mapper().names().indexName();
+            }
+            if (analyzer == null) {
+                analyzer = smartNameFieldMappers.searchAnalyzer();
+            }
+        }
+        if (analyzer == null) {
+            analyzer = parseContext.mapperService().searchAnalyzer();
+        }
+        if (!Analysis.generatesCharacterTokenStream(analyzer, fieldName)) {
+            if (failOnUnsupportedField) {
+                throw new ElasticsearchIllegalArgumentException("more_like_this_field doesn't support binary/numeric fields: [" + fieldName + "]");
+            } else {
+                return null;
+            }
+        }
+        mltQuery.setAnalyzer(analyzer);
+        mltQuery.setMoreLikeFields(new String[]{fieldName});
+        Query query = wrapSmartNameQuery(mltQuery, smartNameFieldMappers, parseContext);
+        if (queryName != null) {
+            parseContext.addNamedQuery(queryName, query);
+        }
+        return query;
+    }
+}

--- a/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryParser.java
@@ -21,6 +21,7 @@ package org.elasticsearch.index.query;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.queries.TermsFilter;
 import org.apache.lucene.search.BooleanClause;
@@ -147,7 +148,7 @@ public class MoreLikeThisQueryParser implements QueryParser {
                 } else if (Fields.INCLUDE.match(currentFieldName, parseContext.parseFlags())) {
                     include = parser.booleanValue();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[mlt] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[mlt] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.START_ARRAY) {
                 if (Fields.STOP_WORDS.match(currentFieldName, parseContext.parseFlags())) {
@@ -180,22 +181,23 @@ public class MoreLikeThisQueryParser implements QueryParser {
                         parseLikeField(parser, likeTexts, items);
                     }
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[mlt] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[mlt] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.START_OBJECT) {
                 if (Fields.LIKE.match(currentFieldName, parseContext.parseFlags())) {
                     parseLikeField(parser, likeTexts, items);
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[mlt] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[mlt] query does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             }
         }
 
         if (likeTexts.isEmpty() && items.isEmpty()) {
-            throw new QueryParsingException(parseContext.index(), "more_like_this requires at least 'like_text' or 'ids/docs' to be specified");
+            throw new QueryParsingException(parseContext.index(), "more_like_this requires at least 'like_text' or 'ids/docs' to be specified", parser.getTokenLocation());
         }
         if (moreLikeFields != null && moreLikeFields.isEmpty()) {
-            throw new QueryParsingException(parseContext.index(), "more_like_this requires 'fields' to be non-empty");
+            throw new QueryParsingException(parseContext.index(), "more_like_this requires 'fields' to be non-empty", parser.getTokenLocation());
         }
 
         // set analyzer
@@ -236,7 +238,7 @@ public class MoreLikeThisQueryParser implements QueryParser {
                 if (item.type() == null) {
                     if (parseContext.queryTypes().size() > 1) {
                         throw new QueryParsingException(parseContext.index(),
-                                "ambiguous type for item with id: " + item.id() + " and index: " + item.index());
+                                "ambiguous type for item with id: " + item.id() + " and index: " + item.index(), parser.getTokenLocation());
                     } else {
                         item.type(parseContext.queryTypes().iterator().next());
                     }

--- a/src/main/java/org/elasticsearch/index/query/MultiMatchQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MultiMatchQueryParser.java
@@ -78,7 +78,7 @@ public class MultiMatchQueryParser implements QueryParser {
                     extractFieldAndBoost(parseContext, parser, fieldNameWithBoosts);
                 } else {
                     throw new QueryParsingException(parseContext.index(), "[" + NAME + "] query does not support [" + currentFieldName
-                            + "]");
+                            + "]", parser.getTokenLocation());
                 }
             } else if (token.isValue()) {
                 if ("query".equals(currentFieldName)) {
@@ -88,7 +88,7 @@ public class MultiMatchQueryParser implements QueryParser {
                 } else if ("analyzer".equals(currentFieldName)) {
                     String analyzer = parser.text();
                     if (parseContext.analysisService().analyzer(analyzer) == null) {
-                        throw new QueryParsingException(parseContext.index(), "["+ NAME +"] analyzer [" + parser.text() + "] not found");
+                        throw new QueryParsingException(parseContext.index(), "["+ NAME +"] analyzer [" + parser.text() + "] not found", parser.getTokenLocation());
                     }
                     multiMatchQuery.setAnalyzer(analyzer);
                 } else if ("boost".equals(currentFieldName)) {
@@ -108,7 +108,7 @@ public class MultiMatchQueryParser implements QueryParser {
                     } else if ("and".equalsIgnoreCase(op)) {
                         multiMatchQuery.setOccur(BooleanClause.Occur.MUST);
                     } else {
-                        throw new QueryParsingException(parseContext.index(), "text query requires operator to be either 'and' or 'or', not [" + op + "]");
+                        throw new QueryParsingException(parseContext.index(), "text query requires operator to be either 'and' or 'or', not [" + op + "]", parser.getTokenLocation());
                     }
                 } else if ("minimum_should_match".equals(currentFieldName) || "minimumShouldMatch".equals(currentFieldName)) {
                     minimumShouldMatch = parser.textOrNull();
@@ -131,22 +131,22 @@ public class MultiMatchQueryParser implements QueryParser {
                     } else if ("all".equalsIgnoreCase(zeroTermsDocs)) {
                         multiMatchQuery.setZeroTermsQuery(MatchQuery.ZeroTermsQuery.ALL);
                     } else {
-                        throw new QueryParsingException(parseContext.index(), "Unsupported zero_terms_docs value [" + zeroTermsDocs + "]");
+                        throw new QueryParsingException(parseContext.index(), "Unsupported zero_terms_docs value [" + zeroTermsDocs + "]", parser.getTokenLocation());
                     }
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[match] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[match] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             }
         }
 
         if (value == null) {
-            throw new QueryParsingException(parseContext.index(), "No text specified for match_all query");
+            throw new QueryParsingException(parseContext.index(), "No text specified for match_all query", parser.getTokenLocation());
         }
 
         if (fieldNameWithBoosts.isEmpty()) {
-            throw new QueryParsingException(parseContext.index(), "No fields specified for match_all query");
+            throw new QueryParsingException(parseContext.index(), "No fields specified for match_all query", parser.getTokenLocation());
         }
         if (type == null) {
             type = MultiMatchQueryBuilder.Type.BEST_FIELDS;

--- a/src/main/java/org/elasticsearch/index/query/NestedFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/NestedFilterParser.java
@@ -84,7 +84,7 @@ public class NestedFilterParser implements FilterParser {
                         filterFound = true;
                         filter = parseContext.parseInnerFilter();
                     } else {
-                        throw new QueryParsingException(parseContext.index(), "[nested] filter does not support [" + currentFieldName + "]");
+                        throw new QueryParsingException(parseContext.index(), "[nested] filter does not support [" + currentFieldName + "]", parser.getTokenLocation());
                     }
                 } else if (token.isValue()) {
                     if ("path".equals(currentFieldName)) {
@@ -98,15 +98,15 @@ public class NestedFilterParser implements FilterParser {
                     } else if ("_cache_key".equals(currentFieldName) || "_cacheKey".equals(currentFieldName)) {
                         cacheKey = new CacheKeyFilter.Key(parser.text());
                     } else {
-                        throw new QueryParsingException(parseContext.index(), "[nested] filter does not support [" + currentFieldName + "]");
+                        throw new QueryParsingException(parseContext.index(), "[nested] filter does not support [" + currentFieldName + "]", parser.getTokenLocation());
                     }
                 }
             }
             if (!queryFound && !filterFound) {
-                throw new QueryParsingException(parseContext.index(), "[nested] requires either 'query' or 'filter' field");
+                throw new QueryParsingException(parseContext.index(), "[nested] requires either 'query' or 'filter' field", parser.getTokenLocation());
             }
             if (path == null) {
-                throw new QueryParsingException(parseContext.index(), "[nested] requires 'path' field");
+                throw new QueryParsingException(parseContext.index(), "[nested] requires 'path' field", parser.getTokenLocation());
             }
 
             if (query == null && filter == null) {
@@ -121,14 +121,14 @@ public class NestedFilterParser implements FilterParser {
 
             MapperService.SmartNameObjectMapper mapper = parseContext.smartObjectMapper(path);
             if (mapper == null) {
-                throw new QueryParsingException(parseContext.index(), "[nested] failed to find nested object under path [" + path + "]");
+                throw new QueryParsingException(parseContext.index(), "[nested] failed to find nested object under path [" + path + "]", parser.getTokenLocation());
             }
             ObjectMapper objectMapper = mapper.mapper();
             if (objectMapper == null) {
-                throw new QueryParsingException(parseContext.index(), "[nested] failed to find nested object under path [" + path + "]");
+                throw new QueryParsingException(parseContext.index(), "[nested] failed to find nested object under path [" + path + "]", parser.getTokenLocation());
             }
             if (!objectMapper.nested().isNested()) {
-                throw new QueryParsingException(parseContext.index(), "[nested] nested object under path [" + path + "] is not of nested type");
+                throw new QueryParsingException(parseContext.index(), "[nested] nested object under path [" + path + "] is not of nested type", parser.getTokenLocation());
             }
 
             BitDocIdSetFilter childFilter = parseContext.bitsetFilter(objectMapper.nestedTypeFilter());

--- a/src/main/java/org/elasticsearch/index/query/NestedQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/NestedQueryParser.java
@@ -83,7 +83,7 @@ public class NestedQueryParser implements QueryParser {
                         filterFound = true;
                         filter = parseContext.parseInnerFilter();
                     } else {
-                        throw new QueryParsingException(parseContext.index(), "[nested] query does not support [" + currentFieldName + "]");
+                        throw new QueryParsingException(parseContext.index(), "[nested] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                     }
                 } else if (token.isValue()) {
                     if ("path".equals(currentFieldName)) {
@@ -101,20 +101,20 @@ public class NestedQueryParser implements QueryParser {
                         } else if ("none".equals(sScoreMode)) {
                             scoreMode = ScoreMode.None;
                         } else {
-                            throw new QueryParsingException(parseContext.index(), "illegal score_mode for nested query [" + sScoreMode + "]");
+                            throw new QueryParsingException(parseContext.index(), "illegal score_mode for nested query [" + sScoreMode + "]", parser.getTokenLocation());
                         }
                     } else if ("_name".equals(currentFieldName)) {
                         queryName = parser.text();
                     } else {
-                        throw new QueryParsingException(parseContext.index(), "[nested] query does not support [" + currentFieldName + "]");
+                        throw new QueryParsingException(parseContext.index(), "[nested] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                     }
                 }
             }
             if (!queryFound && !filterFound) {
-                throw new QueryParsingException(parseContext.index(), "[nested] requires either 'query' or 'filter' field");
+                throw new QueryParsingException(parseContext.index(), "[nested] requires either 'query' or 'filter' field", parser.getTokenLocation());
             }
             if (path == null) {
-                throw new QueryParsingException(parseContext.index(), "[nested] requires 'path' field");
+                throw new QueryParsingException(parseContext.index(), "[nested] requires 'path' field", parser.getTokenLocation());
             }
 
             if (query == null && filter == null) {
@@ -127,14 +127,14 @@ public class NestedQueryParser implements QueryParser {
 
             MapperService.SmartNameObjectMapper mapper = parseContext.smartObjectMapper(path);
             if (mapper == null) {
-                throw new QueryParsingException(parseContext.index(), "[nested] failed to find nested object under path [" + path + "]");
+                throw new QueryParsingException(parseContext.index(), "[nested] failed to find nested object under path [" + path + "]", parser.getTokenLocation());
             }
             ObjectMapper objectMapper = mapper.mapper();
             if (objectMapper == null) {
-                throw new QueryParsingException(parseContext.index(), "[nested] failed to find nested object under path [" + path + "]");
+                throw new QueryParsingException(parseContext.index(), "[nested] failed to find nested object under path [" + path + "]", parser.getTokenLocation());
             }
             if (!objectMapper.nested().isNested()) {
-                throw new QueryParsingException(parseContext.index(), "[nested] nested object under path [" + path + "] is not of nested type");
+                throw new QueryParsingException(parseContext.index(), "[nested] nested object under path [" + path + "] is not of nested type", parser.getTokenLocation());
             }
 
             BitDocIdSetFilter childFilter = parseContext.bitsetFilter(objectMapper.nestedTypeFilter());

--- a/src/main/java/org/elasticsearch/index/query/NotFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/NotFilterParser.java
@@ -79,13 +79,13 @@ public class NotFilterParser implements FilterParser {
                 } else if ("_cache_key".equals(currentFieldName) || "_cacheKey".equals(currentFieldName)) {
                     cacheKey = new CacheKeyFilter.Key(parser.text());
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[not] filter does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[not] filter does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             }
         }
 
         if (!filterFound) {
-            throw new QueryParsingException(parseContext.index(), "filter is required when using `not` filter");
+            throw new QueryParsingException(parseContext.index(), "filter is required when using `not` filter", parser.getTokenLocation());
         }
 
         if (filter == null) {

--- a/src/main/java/org/elasticsearch/index/query/OrFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/OrFilterParser.java
@@ -97,14 +97,14 @@ public class OrFilterParser implements FilterParser {
                     } else if ("_cache_key".equals(currentFieldName) || "_cacheKey".equals(currentFieldName)) {
                         cacheKey = new CacheKeyFilter.Key(parser.text());
                     } else {
-                        throw new QueryParsingException(parseContext.index(), "[or] filter does not support [" + currentFieldName + "]");
+                        throw new QueryParsingException(parseContext.index(), "[or] filter does not support [" + currentFieldName + "]", parser.getTokenLocation());
                     }
                 }
             }
         }
 
         if (!filtersFound) {
-            throw new QueryParsingException(parseContext.index(), "[or] filter requires 'filters' to be set on it'");
+            throw new QueryParsingException(parseContext.index(), "[or] filter requires 'filters' to be set on it'", parser.getTokenLocation());
         }
 
         if (filters.isEmpty()) {

--- a/src/main/java/org/elasticsearch/index/query/PrefixFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/PrefixFilterParser.java
@@ -78,7 +78,7 @@ public class PrefixFilterParser implements FilterParser {
         }
 
         if (value == null) {
-            throw new QueryParsingException(parseContext.index(), "No value specified for prefix filter");
+            throw new QueryParsingException(parseContext.index(), "No value specified for prefix filter", parser.getTokenLocation());
         }
 
         Filter filter = null;

--- a/src/main/java/org/elasticsearch/index/query/PrefixQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/PrefixQueryParser.java
@@ -55,7 +55,7 @@ public class PrefixQueryParser implements QueryParser {
 
         XContentParser.Token token = parser.nextToken();
         if (token != XContentParser.Token.FIELD_NAME) {
-            throw new QueryParsingException(parseContext.index(), "[prefix] query malformed, no field");
+            throw new QueryParsingException(parseContext.index(), "[prefix] query malformed, no field", parser.getTokenLocation());
         }
         String fieldName = parser.currentName();
         String rewriteMethod = null;
@@ -82,7 +82,7 @@ public class PrefixQueryParser implements QueryParser {
                         queryName = parser.text();
                     }
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[prefix] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[prefix] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             }
             parser.nextToken();
@@ -92,7 +92,7 @@ public class PrefixQueryParser implements QueryParser {
         }
 
         if (value == null) {
-            throw new QueryParsingException(parseContext.index(), "No value specified for prefix query");
+            throw new QueryParsingException(parseContext.index(), "No value specified for prefix query", parser.getTokenLocation());
         }
 
         MultiTermQuery.RewriteMethod method = QueryParsers.parseRewriteMethod(rewriteMethod, null);

--- a/src/main/java/org/elasticsearch/index/query/QueryParseContext.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryParseContext.java
@@ -21,6 +21,7 @@ package org.elasticsearch.index.query;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
+
 import org.apache.lucene.queryparser.classic.MapperQueryParser;
 import org.apache.lucene.queryparser.classic.QueryParserSettings;
 import org.apache.lucene.search.Filter;
@@ -49,7 +50,11 @@ import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.lookup.SearchLookup;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
 
 /**
  *
@@ -226,23 +231,23 @@ public class QueryParseContext {
         if (parser.currentToken() != XContentParser.Token.START_OBJECT) {
             token = parser.nextToken();
             if (token != XContentParser.Token.START_OBJECT) {
-                throw new QueryParsingException(index, "[_na] query malformed, must start with start_object");
+                throw new QueryParsingException(index, "[_na] query malformed, must start with start_object", parser.getTokenLocation());
             }
         }
         token = parser.nextToken();
         if (token != XContentParser.Token.FIELD_NAME) {
-            throw new QueryParsingException(index, "[_na] query malformed, no field after start_object");
+            throw new QueryParsingException(index, "[_na] query malformed, no field after start_object", parser.getTokenLocation());
         }
         String queryName = parser.currentName();
         // move to the next START_OBJECT
         token = parser.nextToken();
         if (token != XContentParser.Token.START_OBJECT && token != XContentParser.Token.START_ARRAY) {
-            throw new QueryParsingException(index, "[_na] query malformed, no field after start_object");
+            throw new QueryParsingException(index, "[_na] query malformed, no field after start_object", parser.getTokenLocation());
         }
 
         QueryParser queryParser = indexQueryParser.queryParser(queryName);
         if (queryParser == null) {
-            throw new QueryParsingException(index, "No query registered for [" + queryName + "]");
+            throw new QueryParsingException(index, "No query registered for [" + queryName + "]", parser.getTokenLocation());
         }
         Query result = queryParser.parse(this);
         if (parser.currentToken() == XContentParser.Token.END_OBJECT || parser.currentToken() == XContentParser.Token.END_ARRAY) {
@@ -266,7 +271,7 @@ public class QueryParseContext {
         if (parser.currentToken() != XContentParser.Token.START_OBJECT) {
             token = parser.nextToken();
             if (token != XContentParser.Token.START_OBJECT) {
-                throw new QueryParsingException(index, "[_na] filter malformed, must start with start_object");
+                throw new QueryParsingException(index, "[_na] filter malformed, must start with start_object", parser.getTokenLocation());
             }
         }
         token = parser.nextToken();
@@ -275,18 +280,18 @@ public class QueryParseContext {
             if (token == XContentParser.Token.END_OBJECT || token == XContentParser.Token.VALUE_NULL) {
                 return null;
             }
-            throw new QueryParsingException(index, "[_na] filter malformed, no field after start_object");
+            throw new QueryParsingException(index, "[_na] filter malformed, no field after start_object", parser.getTokenLocation());
         }
         String filterName = parser.currentName();
         // move to the next START_OBJECT or START_ARRAY
         token = parser.nextToken();
         if (token != XContentParser.Token.START_OBJECT && token != XContentParser.Token.START_ARRAY) {
-            throw new QueryParsingException(index, "[_na] filter malformed, no field after start_object");
+            throw new QueryParsingException(index, "[_na] filter malformed, no field after start_object", parser.getTokenLocation());
         }
 
         FilterParser filterParser = indexQueryParser.filterParser(filterName);
         if (filterParser == null) {
-            throw new QueryParsingException(index, "No filter registered for [" + filterName + "]");
+            throw new QueryParsingException(index, "No filter registered for [" + filterName + "]", parser.getTokenLocation());
         }
         Filter result = executeFilterParser(filterParser);
         if (parser.currentToken() == XContentParser.Token.END_OBJECT || parser.currentToken() == XContentParser.Token.END_ARRAY) {
@@ -299,7 +304,7 @@ public class QueryParseContext {
     public Filter parseInnerFilter(String filterName) throws IOException, QueryParsingException {
         FilterParser filterParser = indexQueryParser.filterParser(filterName);
         if (filterParser == null) {
-            throw new QueryParsingException(index, "No filter registered for [" + filterName + "]");
+            throw new QueryParsingException(index, "No filter registered for [" + filterName + "]", parser.getTokenLocation());
         }
         return executeFilterParser(filterParser);
     }
@@ -357,7 +362,7 @@ public class QueryParseContext {
         } else {
             Version indexCreatedVersion = indexQueryParser.getIndexCreatedVersion();
             if (fieldMapping == null && indexCreatedVersion.onOrAfter(Version.V_1_4_0_Beta1)) {
-                throw new QueryParsingException(index, "Strict field resolution and no field mapping can be found for the field with name [" + name + "]");
+                throw new QueryParsingException(index, "Strict field resolution and no field mapping can be found for the field with name [" + name + "]", parser.getTokenLocation());
             } else {
                 return fieldMapping;
             }

--- a/src/main/java/org/elasticsearch/index/query/QueryParserUtils.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryParserUtils.java
@@ -35,11 +35,12 @@ public final class QueryParserUtils {
     public static void ensureNotDeleteByQuery(String name, QueryParseContext parseContext) {
         SearchContext context = SearchContext.current();
         if (context == null) {
-            throw new QueryParsingException(parseContext.index(), "[" + name + "] query and filter requires a search context");
+            throw new QueryParsingException(parseContext.index(), "[" + name + "] query and filter requires a search context", null);
         }
 
         if (TransportShardDeleteByQueryAction.DELETE_BY_QUERY_API.equals(context.source())) {
-            throw new QueryParsingException(parseContext.index(), "[" + name + "] query and filter unsupported in delete_by_query api");
+            throw new QueryParsingException(parseContext.index(), "[" + name + "] query and filter unsupported in delete_by_query api",
+                    null);
         }
     }
 

--- a/src/main/java/org/elasticsearch/index/query/QueryParsingException.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryParsingException.java
@@ -19,25 +19,53 @@
 
 package org.elasticsearch.index.query;
 
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentLocation;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexException;
 import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.search.ParseErrorDetails;
+
+import java.io.IOException;
 
 /**
- *
+ * We only offer constructors that takes XContentLocation parameter to encourage
+ * developers of parsers to pass detailed information back with all exceptions.
  */
-public class QueryParsingException extends IndexException {
+public class QueryParsingException extends IndexException implements ToXContent {
 
-    public QueryParsingException(Index index, String msg) {
-        super(index, msg);
+    private ToXContent xContentExplanation;
+
+
+    public QueryParsingException(Index index, String msg, @Nullable XContentLocation location) {
+          this(index, msg, location, null);
     }
 
-    public QueryParsingException(Index index, String msg, Throwable cause) {
+    
+    public QueryParsingException(Index index, String msg, @Nullable XContentLocation location, Throwable cause) {
         super(index, msg, cause);
+        if (location != null) {
+            xContentExplanation = new ParseErrorDetails(msg, location.getLineNumber(), location.getColumnNumber());
+        } else {
+            xContentExplanation = ExceptionsHelper.getAnyXContentExplanation(cause);
+        }
     }
 
     @Override
     public RestStatus status() {
         return RestStatus.BAD_REQUEST;
     }
+
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        if (xContentExplanation != null) {
+            xContentExplanation.toXContent(builder, params);
+        }
+        return builder;
+    }
+    
 }

--- a/src/main/java/org/elasticsearch/index/query/QueryStringQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryStringQueryParser.java
@@ -21,6 +21,7 @@ package org.elasticsearch.index.query;
 
 import com.carrotsearch.hppc.ObjectFloatOpenHashMap;
 import com.google.common.collect.Lists;
+
 import org.apache.lucene.queryparser.classic.MapperQueryParser;
 import org.apache.lucene.queryparser.classic.QueryParserSettings;
 import org.apache.lucene.search.BooleanQuery;
@@ -125,7 +126,7 @@ public class QueryStringQueryParser implements QueryParser {
                         }
                     }
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[query_string] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[query_string] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             } else if (token.isValue()) {
                 if ("query".equals(currentFieldName)) {
@@ -139,18 +140,18 @@ public class QueryStringQueryParser implements QueryParser {
                     } else if ("and".equalsIgnoreCase(op)) {
                         qpSettings.defaultOperator(org.apache.lucene.queryparser.classic.QueryParser.Operator.AND);
                     } else {
-                        throw new QueryParsingException(parseContext.index(), "Query default operator [" + op + "] is not allowed");
+                        throw new QueryParsingException(parseContext.index(), "Query default operator [" + op + "] is not allowed", parser.getTokenLocation());
                     }
                 } else if ("analyzer".equals(currentFieldName)) {
                     NamedAnalyzer analyzer = parseContext.analysisService().analyzer(parser.text());
                     if (analyzer == null) {
-                        throw new QueryParsingException(parseContext.index(), "[query_string] analyzer [" + parser.text() + "] not found");
+                        throw new QueryParsingException(parseContext.index(), "[query_string] analyzer [" + parser.text() + "] not found", parser.getTokenLocation());
                     }
                     qpSettings.forcedAnalyzer(analyzer);
                 } else if ("quote_analyzer".equals(currentFieldName) || "quoteAnalyzer".equals(currentFieldName)) {
                     NamedAnalyzer analyzer = parseContext.analysisService().analyzer(parser.text());
                     if (analyzer == null) {
-                        throw new QueryParsingException(parseContext.index(), "[query_string] quote_analyzer [" + parser.text() + "] not found");
+                        throw new QueryParsingException(parseContext.index(), "[query_string] quote_analyzer [" + parser.text() + "] not found", parser.getTokenLocation());
                     }
                     qpSettings.forcedQuoteAnalyzer(analyzer);
                 } else if ("allow_leading_wildcard".equals(currentFieldName) || "allowLeadingWildcard".equals(currentFieldName)) {
@@ -196,17 +197,18 @@ public class QueryStringQueryParser implements QueryParser {
                     try {
                         qpSettings.timeZone(DateMathParser.parseZone(parser.text()));
                     } catch (IllegalArgumentException e) {
-                        throw new QueryParsingException(parseContext.index(), "[query_string] time_zone [" + parser.text() + "] is unknown");
+                        throw new QueryParsingException(parseContext.index(),
+                                "[query_string] time_zone [" + parser.text() + "] is unknown", parser.getTokenLocation());
                     }
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[query_string] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[query_string] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             }
         }
         if (qpSettings.queryString() == null) {
-            throw new QueryParsingException(parseContext.index(), "query_string must be provided with a [query]");
+            throw new QueryParsingException(parseContext.index(), "query_string must be provided with a [query]", parser.getTokenLocation());
         }
         qpSettings.defaultAnalyzer(parseContext.mapperService().searchAnalyzer());
         qpSettings.defaultQuoteAnalyzer(parseContext.mapperService().searchQuoteAnalyzer());
@@ -244,7 +246,8 @@ public class QueryStringQueryParser implements QueryParser {
             }
             return query;
         } catch (org.apache.lucene.queryparser.classic.ParseException e) {
-            throw new QueryParsingException(parseContext.index(), "Failed to parse query [" + qpSettings.queryString() + "]", e);
+            throw new QueryParsingException(parseContext.index(), "Failed to parse query [" + qpSettings.queryString() + "]", 
+                    parser.getTokenLocation(), e);
         }
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/RangeFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/RangeFilterParser.java
@@ -105,7 +105,7 @@ public class RangeFilterParser implements FilterParser {
                         } else if ("format".equals(currentFieldName)) {
                             forcedDateParser = new DateMathParser(Joda.forPattern(parser.text()), DateFieldMapper.Defaults.TIME_UNIT);
                         } else {
-                            throw new QueryParsingException(parseContext.index(), "[range] filter does not support [" + currentFieldName + "]");
+                            throw new QueryParsingException(parseContext.index(), "[range] filter does not support [" + currentFieldName + "]", parser.getTokenLocation());
                         }
                     }
                 }
@@ -119,13 +119,13 @@ public class RangeFilterParser implements FilterParser {
                 } else if ("execution".equals(currentFieldName)) {
                     execution = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[range] filter does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[range] filter does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             }
         }
 
         if (fieldName == null) {
-            throw new QueryParsingException(parseContext.index(), "[range] filter no field specified for range filter");
+            throw new QueryParsingException(parseContext.index(), "[range] filter no field specified for range filter", parser.getTokenLocation());
         }
 
         Filter filter = null;
@@ -140,12 +140,12 @@ public class RangeFilterParser implements FilterParser {
                     FieldMapper mapper = smartNameFieldMappers.mapper();
                     if (mapper instanceof DateFieldMapper) {
                         if ((from instanceof Number || to instanceof Number) && timeZone != null) {
-                            throw new QueryParsingException(parseContext.index(), "[range] time_zone when using ms since epoch format as it's UTC based can not be applied to [" + fieldName + "]");
+                            throw new QueryParsingException(parseContext.index(), "[range] time_zone when using ms since epoch format as it's UTC based can not be applied to [" + fieldName + "]", parser.getTokenLocation());
                         }
                         filter = ((DateFieldMapper) mapper).rangeFilter(from, to, includeLower, includeUpper, timeZone, forcedDateParser, parseContext, explicitlyCached);
                     } else  {
                         if (timeZone != null) {
-                            throw new QueryParsingException(parseContext.index(), "[range] time_zone can not be applied to non date field [" + fieldName + "]");
+                            throw new QueryParsingException(parseContext.index(), "[range] time_zone can not be applied to non date field [" + fieldName + "]", parser.getTokenLocation());
                         }
                         filter = mapper.rangeFilter(from, to, includeLower, includeUpper, parseContext);
                     }
@@ -155,21 +155,21 @@ public class RangeFilterParser implements FilterParser {
                     }
                     FieldMapper mapper = smartNameFieldMappers.mapper();
                     if (!(mapper instanceof NumberFieldMapper)) {
-                        throw new QueryParsingException(parseContext.index(), "[range] filter field [" + fieldName + "] is not a numeric type");
+                        throw new QueryParsingException(parseContext.index(), "[range] filter field [" + fieldName + "] is not a numeric type", parser.getTokenLocation());
                     }
                     if (mapper instanceof DateFieldMapper) {
                         if ((from instanceof Number || to instanceof Number) && timeZone != null) {
-                            throw new QueryParsingException(parseContext.index(), "[range] time_zone when using ms since epoch format as it's UTC based can not be applied to [" + fieldName + "]");
+                            throw new QueryParsingException(parseContext.index(), "[range] time_zone when using ms since epoch format as it's UTC based can not be applied to [" + fieldName + "]", parser.getTokenLocation());
                         }
                         filter = ((DateFieldMapper) mapper).rangeFilter(parseContext, from, to, includeLower, includeUpper, timeZone, forcedDateParser, parseContext, explicitlyCached);
                     } else {
                         if (timeZone != null) {
-                            throw new QueryParsingException(parseContext.index(), "[range] time_zone can not be applied to non date field [" + fieldName + "]");
+                            throw new QueryParsingException(parseContext.index(), "[range] time_zone can not be applied to non date field [" + fieldName + "]", parser.getTokenLocation());
                         }
                         filter = ((NumberFieldMapper) mapper).rangeFilter(parseContext, from, to, includeLower, includeUpper, parseContext);
                     }
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[range] filter doesn't support [" + execution + "] execution");
+                    throw new QueryParsingException(parseContext.index(), "[range] filter doesn't support [" + execution + "] execution", parser.getTokenLocation());
                 }
             }
         }

--- a/src/main/java/org/elasticsearch/index/query/RangeQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/RangeQueryParser.java
@@ -57,12 +57,12 @@ public class RangeQueryParser implements QueryParser {
 
         XContentParser.Token token = parser.nextToken();
         if (token != XContentParser.Token.FIELD_NAME) {
-            throw new QueryParsingException(parseContext.index(), "[range] query malformed, no field to indicate field name");
+            throw new QueryParsingException(parseContext.index(), "[range] query malformed, no field to indicate field name", parser.getTokenLocation());
         }
         String fieldName = parser.currentName();
         token = parser.nextToken();
         if (token != XContentParser.Token.START_OBJECT) {
-            throw new QueryParsingException(parseContext.index(), "[range] query malformed, after field missing start object");
+            throw new QueryParsingException(parseContext.index(), "[range] query malformed, after field missing start object", parser.getTokenLocation());
         }
 
         Object from = null;
@@ -108,7 +108,7 @@ public class RangeQueryParser implements QueryParser {
                 } else if ("format".equals(currentFieldName)) {
                     forcedDateParser = new DateMathParser(Joda.forPattern(parser.text()), DateFieldMapper.Defaults.TIME_UNIT);
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[range] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[range] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             }
         }
@@ -116,7 +116,7 @@ public class RangeQueryParser implements QueryParser {
         // move to the next end object, to close the field name
         token = parser.nextToken();
         if (token != XContentParser.Token.END_OBJECT) {
-            throw new QueryParsingException(parseContext.index(), "[range] query malformed, does not end with an object");
+            throw new QueryParsingException(parseContext.index(), "[range] query malformed, does not end with an object", parser.getTokenLocation());
         }
 
         Query query = null;
@@ -126,12 +126,12 @@ public class RangeQueryParser implements QueryParser {
                 FieldMapper mapper = smartNameFieldMappers.mapper();
                 if (mapper instanceof DateFieldMapper) {
                     if ((from instanceof Number || to instanceof Number) && timeZone != null) {
-                        throw new QueryParsingException(parseContext.index(), "[range] time_zone when using ms since epoch format as it's UTC based can not be applied to [" + fieldName + "]");
+                        throw new QueryParsingException(parseContext.index(), "[range] time_zone when using ms since epoch format as it's UTC based can not be applied to [" + fieldName + "]", parser.getTokenLocation());
                     }
                     query = ((DateFieldMapper) mapper).rangeQuery(from, to, includeLower, includeUpper, timeZone, forcedDateParser, parseContext);
                 } else  {
                     if (timeZone != null) {
-                        throw new QueryParsingException(parseContext.index(), "[range] time_zone can not be applied to non date field [" + fieldName + "]");
+                        throw new QueryParsingException(parseContext.index(), "[range] time_zone can not be applied to non date field [" + fieldName + "]", parser.getTokenLocation());
                     }
                     //LUCENE 4 UPGRADE Mapper#rangeQuery should use bytesref as well?
                     query = mapper.rangeQuery(from, to, includeLower, includeUpper, parseContext);

--- a/src/main/java/org/elasticsearch/index/query/RegexpFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/RegexpFilterParser.java
@@ -80,7 +80,7 @@ public class RegexpFilterParser implements FilterParser {
                         } else if ("flags_value".equals(currentFieldName)) {
                             flagsValue = parser.intValue();
                         } else {
-                            throw new QueryParsingException(parseContext.index(), "[regexp] filter does not support [" + currentFieldName + "]");
+                            throw new QueryParsingException(parseContext.index(), "[regexp] filter does not support [" + currentFieldName + "]", parser.getTokenLocation());
                         }
                     }
                 }
@@ -104,7 +104,7 @@ public class RegexpFilterParser implements FilterParser {
         }
 
         if (value == null) {
-            throw new QueryParsingException(parseContext.index(), "No value specified for regexp filter");
+            throw new QueryParsingException(parseContext.index(), "No value specified for regexp filter", parser.getTokenLocation());
         }
 
         Filter filter = null;

--- a/src/main/java/org/elasticsearch/index/query/RegexpQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/RegexpQueryParser.java
@@ -56,7 +56,7 @@ public class RegexpQueryParser implements QueryParser {
 
         XContentParser.Token token = parser.nextToken();
         if (token != XContentParser.Token.FIELD_NAME) {
-            throw new QueryParsingException(parseContext.index(), "[regexp] query malformed, no field");
+            throw new QueryParsingException(parseContext.index(), "[regexp] query malformed, no field", parser.getTokenLocation());
         }
         String fieldName = parser.currentName();
         String rewriteMethod = null;
@@ -90,7 +90,7 @@ public class RegexpQueryParser implements QueryParser {
                         queryName = parser.text();
                     }
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[regexp] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[regexp] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             }
             parser.nextToken();
@@ -100,7 +100,7 @@ public class RegexpQueryParser implements QueryParser {
         }
 
         if (value == null) {
-            throw new QueryParsingException(parseContext.index(), "No value specified for regexp query");
+            throw new QueryParsingException(parseContext.index(), "No value specified for regexp query", parser.getTokenLocation());
         }
 
         MultiTermQuery.RewriteMethod method = QueryParsers.parseRewriteMethod(rewriteMethod, null);

--- a/src/main/java/org/elasticsearch/index/query/ScriptFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/ScriptFilterParser.java
@@ -19,9 +19,6 @@
 
 package org.elasticsearch.index.query;
 
-import java.io.IOException;
-import java.util.Map;
-
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.BitsFilteredDocIdSet;
 import org.apache.lucene.search.DocIdSet;
@@ -38,6 +35,9 @@ import org.elasticsearch.script.ScriptParameterParser.ScriptParameterValue;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.script.SearchScript;
 import org.elasticsearch.search.lookup.SearchLookup;
+
+import java.io.IOException;
+import java.util.Map;
 
 import static com.google.common.collect.Maps.newHashMap;
 
@@ -82,7 +82,7 @@ public class ScriptFilterParser implements FilterParser {
                 if ("params".equals(currentFieldName)) {
                     params = parser.map();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[script] filter does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[script] filter does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             } else if (token.isValue()) {
                 if ("_name".equals(currentFieldName)) {
@@ -92,7 +92,7 @@ public class ScriptFilterParser implements FilterParser {
                 } else if ("_cache_key".equals(currentFieldName) || "_cacheKey".equals(currentFieldName)) {
                     cacheKey = new CacheKeyFilter.Key(parser.text());
                 } else if (!scriptParameterParser.token(currentFieldName, token, parser)){
-                    throw new QueryParsingException(parseContext.index(), "[script] filter does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[script] filter does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             }
         }
@@ -105,7 +105,7 @@ public class ScriptFilterParser implements FilterParser {
         scriptLang = scriptParameterParser.lang();
 
         if (script == null) {
-            throw new QueryParsingException(parseContext.index(), "script must be provided with a [script] filter");
+            throw new QueryParsingException(parseContext.index(), "script must be provided with a [script] filter", parser.getTokenLocation());
         }
         if (params == null) {
             params = newHashMap();

--- a/src/main/java/org/elasticsearch/index/query/SimpleQueryStringParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SimpleQueryStringParser.java
@@ -137,7 +137,7 @@ public class SimpleQueryStringParser implements QueryParser {
                     }
                 } else {
                     throw new QueryParsingException(parseContext.index(),
-                            "[" + NAME + "] query does not support [" + currentFieldName + "]");
+                            "[" + NAME + "] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             } else if (token.isValue()) {
                 if ("query".equals(currentFieldName)) {
@@ -145,7 +145,7 @@ public class SimpleQueryStringParser implements QueryParser {
                 } else if ("analyzer".equals(currentFieldName)) {
                     analyzer = parseContext.analysisService().analyzer(parser.text());
                     if (analyzer == null) {
-                        throw new QueryParsingException(parseContext.index(), "[" + NAME + "] analyzer [" + parser.text() + "] not found");
+                        throw new QueryParsingException(parseContext.index(), "[" + NAME + "] analyzer [" + parser.text() + "] not found", parser.getTokenLocation());
                     }
                 } else if ("field".equals(currentFieldName)) {
                     field = parser.text();
@@ -157,7 +157,7 @@ public class SimpleQueryStringParser implements QueryParser {
                         defaultOperator = BooleanClause.Occur.MUST;
                     } else {
                         throw new QueryParsingException(parseContext.index(),
-                                "[" + NAME + "] default operator [" + op + "] is not allowed");
+                                "[" + NAME + "] default operator [" + op + "] is not allowed", parser.getTokenLocation());
                     }
                 } else if ("flags".equals(currentFieldName)) {
                     if (parser.currentToken() != XContentParser.Token.VALUE_NUMBER) {
@@ -181,14 +181,14 @@ public class SimpleQueryStringParser implements QueryParser {
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[" + NAME + "] unsupported field [" + parser.currentName() + "]");
+                    throw new QueryParsingException(parseContext.index(), "[" + NAME + "] unsupported field [" + parser.currentName() + "]", parser.getTokenLocation());
                 }
             }
         }
 
         // Query text is required
         if (queryBody == null) {
-            throw new QueryParsingException(parseContext.index(), "[" + NAME + "] query text missing");
+            throw new QueryParsingException(parseContext.index(), "[" + NAME + "] query text missing", parser.getTokenLocation());
         }
 
         // Support specifying only a field instead of a map

--- a/src/main/java/org/elasticsearch/index/query/SpanFirstQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanFirstQueryParser.java
@@ -63,11 +63,11 @@ public class SpanFirstQueryParser implements QueryParser {
                 if ("match".equals(currentFieldName)) {
                     Query query = parseContext.parseInnerQuery();
                     if (!(query instanceof SpanQuery)) {
-                        throw new QueryParsingException(parseContext.index(), "spanFirst [match] must be of type span query");
+                        throw new QueryParsingException(parseContext.index(), "spanFirst [match] must be of type span query", parser.getTokenLocation());
                     }
                     match = (SpanQuery) query;
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[span_first] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[span_first] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             } else {
                 if ("boost".equals(currentFieldName)) {
@@ -77,15 +77,15 @@ public class SpanFirstQueryParser implements QueryParser {
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[span_first] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[span_first] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             }
         }
         if (match == null) {
-            throw new QueryParsingException(parseContext.index(), "spanFirst must have [match] span query clause");
+            throw new QueryParsingException(parseContext.index(), "spanFirst must have [match] span query clause", parser.getTokenLocation());
         }
         if (end == -1) {
-            throw new QueryParsingException(parseContext.index(), "spanFirst must have [end] set for it");
+            throw new QueryParsingException(parseContext.index(), "spanFirst must have [end] set for it", parser.getTokenLocation());
         }
 
         SpanFirstQuery query = new SpanFirstQuery(match, end);

--- a/src/main/java/org/elasticsearch/index/query/SpanMultiTermQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanMultiTermQueryParser.java
@@ -51,17 +51,17 @@ public class SpanMultiTermQueryParser implements QueryParser {
 
         Token token = parser.nextToken();
         if (!MATCH_NAME.equals(parser.currentName()) || token != XContentParser.Token.FIELD_NAME) {
-            throw new QueryParsingException(parseContext.index(), "spanMultiTerm must have [" + MATCH_NAME + "] multi term query clause");
+            throw new QueryParsingException(parseContext.index(), "spanMultiTerm must have [" + MATCH_NAME + "] multi term query clause", parser.getTokenLocation());
         }
 
         token = parser.nextToken();
         if (token != XContentParser.Token.START_OBJECT) {
-            throw new QueryParsingException(parseContext.index(), "spanMultiTerm must have [" + MATCH_NAME + "] multi term query clause");
+            throw new QueryParsingException(parseContext.index(), "spanMultiTerm must have [" + MATCH_NAME + "] multi term query clause", parser.getTokenLocation());
         }
 
         Query subQuery = parseContext.parseInnerQuery();
         if (!(subQuery instanceof MultiTermQuery)) {
-            throw new QueryParsingException(parseContext.index(), "spanMultiTerm [" + MATCH_NAME + "] must be of type multi term query");
+            throw new QueryParsingException(parseContext.index(), "spanMultiTerm [" + MATCH_NAME + "] must be of type multi term query", parser.getTokenLocation());
         }
 
         parser.nextToken();

--- a/src/main/java/org/elasticsearch/index/query/SpanNearQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanNearQueryParser.java
@@ -69,12 +69,12 @@ public class SpanNearQueryParser implements QueryParser {
                     while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                         Query query = parseContext.parseInnerQuery();
                         if (!(query instanceof SpanQuery)) {
-                            throw new QueryParsingException(parseContext.index(), "spanNear [clauses] must be of type span query");
+                            throw new QueryParsingException(parseContext.index(), "spanNear [clauses] must be of type span query", parser.getTokenLocation());
                         }
                         clauses.add((SpanQuery) query);
                     }
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[span_near] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[span_near] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             } else if (token.isValue()) {
                 if ("in_order".equals(currentFieldName) || "inOrder".equals(currentFieldName)) {
@@ -88,17 +88,17 @@ public class SpanNearQueryParser implements QueryParser {
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[span_near] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[span_near] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             } else {
-                throw new QueryParsingException(parseContext.index(), "[span_near] query does not support [" + currentFieldName + "]");
+                throw new QueryParsingException(parseContext.index(), "[span_near] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
             }
         }
         if (clauses.isEmpty()) {
-            throw new QueryParsingException(parseContext.index(), "span_near must include [clauses]");
+            throw new QueryParsingException(parseContext.index(), "span_near must include [clauses]", parser.getTokenLocation());
         }
         if (slop == null) {
-            throw new QueryParsingException(parseContext.index(), "span_near must include [slop]");
+            throw new QueryParsingException(parseContext.index(), "span_near must include [slop]", parser.getTokenLocation());
         }
 
         SpanNearQuery query = new SpanNearQuery(clauses.toArray(new SpanQuery[clauses.size()]), slop.intValue(), inOrder, collectPayloads);

--- a/src/main/java/org/elasticsearch/index/query/SpanNotQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanNotQueryParser.java
@@ -63,17 +63,17 @@ public class SpanNotQueryParser implements QueryParser {
                 if ("include".equals(currentFieldName)) {
                     Query query = parseContext.parseInnerQuery();
                     if (!(query instanceof SpanQuery)) {
-                        throw new QueryParsingException(parseContext.index(), "spanNot [include] must be of type span query");
+                        throw new QueryParsingException(parseContext.index(), "spanNot [include] must be of type span query", parser.getTokenLocation());
                     }
                     include = (SpanQuery) query;
                 } else if ("exclude".equals(currentFieldName)) {
                     Query query = parseContext.parseInnerQuery();
                     if (!(query instanceof SpanQuery)) {
-                        throw new QueryParsingException(parseContext.index(), "spanNot [exclude] must be of type span query");
+                        throw new QueryParsingException(parseContext.index(), "spanNot [exclude] must be of type span query", parser.getTokenLocation());
                     }
                     exclude = (SpanQuery) query;
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[span_not] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[span_not] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             } else {
                 if ("boost".equals(currentFieldName)) {
@@ -81,15 +81,15 @@ public class SpanNotQueryParser implements QueryParser {
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[span_not] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[span_not] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             }
         }
         if (include == null) {
-            throw new QueryParsingException(parseContext.index(), "spanNot must have [include] span query clause");
+            throw new QueryParsingException(parseContext.index(), "spanNot must have [include] span query clause", parser.getTokenLocation());
         }
         if (exclude == null) {
-            throw new QueryParsingException(parseContext.index(), "spanNot must have [exclude] span query clause");
+            throw new QueryParsingException(parseContext.index(), "spanNot must have [exclude] span query clause", parser.getTokenLocation());
         }
 
         SpanNotQuery query = new SpanNotQuery(include, exclude);

--- a/src/main/java/org/elasticsearch/index/query/SpanOrQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanOrQueryParser.java
@@ -66,12 +66,12 @@ public class SpanOrQueryParser implements QueryParser {
                     while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                         Query query = parseContext.parseInnerQuery();
                         if (!(query instanceof SpanQuery)) {
-                            throw new QueryParsingException(parseContext.index(), "spanOr [clauses] must be of type span query");
+                            throw new QueryParsingException(parseContext.index(), "spanOr [clauses] must be of type span query", parser.getTokenLocation());
                         }
                         clauses.add((SpanQuery) query);
                     }
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[span_or] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[span_or] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             } else {
                 if ("boost".equals(currentFieldName)) {
@@ -79,12 +79,12 @@ public class SpanOrQueryParser implements QueryParser {
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[span_or] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[span_or] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             }
         }
         if (clauses.isEmpty()) {
-            throw new QueryParsingException(parseContext.index(), "spanOr must include [clauses]");
+            throw new QueryParsingException(parseContext.index(), "spanOr must include [clauses]", parser.getTokenLocation());
         }
 
         SpanOrQuery query = new SpanOrQuery(clauses.toArray(new SpanQuery[clauses.size()]));

--- a/src/main/java/org/elasticsearch/index/query/SpanTermQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanTermQueryParser.java
@@ -77,7 +77,7 @@ public class SpanTermQueryParser implements QueryParser {
                     } else if ("_name".equals(currentFieldName)) {
                         queryName = parser.text();
                     } else {
-                        throw new QueryParsingException(parseContext.index(), "[span_term] query does not support [" + currentFieldName + "]");
+                        throw new QueryParsingException(parseContext.index(), "[span_term] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                     }
                 }
             }
@@ -89,7 +89,7 @@ public class SpanTermQueryParser implements QueryParser {
         }
 
         if (value == null) {
-            throw new QueryParsingException(parseContext.index(), "No value specified for term query");
+            throw new QueryParsingException(parseContext.index(), "No value specified for term query", parser.getTokenLocation());
         }
 
         BytesRef valueBytes = null;

--- a/src/main/java/org/elasticsearch/index/query/TermFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TermFilterParser.java
@@ -81,7 +81,7 @@ public class TermFilterParser implements FilterParser {
                         } else if ("_cache_key".equals(currentFieldName) || "_cacheKey".equals(currentFieldName)) {
                             cacheKey = new CacheKeyFilter.Key(parser.text());
                         } else {
-                            throw new QueryParsingException(parseContext.index(), "[term] filter does not support [" + currentFieldName + "]");
+                            throw new QueryParsingException(parseContext.index(), "[term] filter does not support [" + currentFieldName + "]", parser.getTokenLocation());
                         }
                     }
                 }
@@ -100,11 +100,11 @@ public class TermFilterParser implements FilterParser {
         }
 
         if (fieldName == null) {
-            throw new QueryParsingException(parseContext.index(), "No field specified for term filter");
+            throw new QueryParsingException(parseContext.index(), "No field specified for term filter", parser.getTokenLocation());
         }
 
         if (value == null) {
-            throw new QueryParsingException(parseContext.index(), "No value specified for term filter");
+            throw new QueryParsingException(parseContext.index(), "No value specified for term filter", parser.getTokenLocation());
         }
 
         Filter filter = null;

--- a/src/main/java/org/elasticsearch/index/query/TermQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TermQueryParser.java
@@ -53,7 +53,7 @@ public class TermQueryParser implements QueryParser {
 
         XContentParser.Token token = parser.nextToken();
         if (token != XContentParser.Token.FIELD_NAME) {
-            throw new QueryParsingException(parseContext.index(), "[term] query malformed, no field");
+            throw new QueryParsingException(parseContext.index(), "[term] query malformed, no field", parser.getTokenLocation());
         }
         String fieldName = parser.currentName();
 
@@ -76,7 +76,7 @@ public class TermQueryParser implements QueryParser {
                     } else if ("_name".equals(currentFieldName)) {
                         queryName = parser.text();
                     } else {
-                        throw new QueryParsingException(parseContext.index(), "[term] query does not support [" + currentFieldName + "]");
+                        throw new QueryParsingException(parseContext.index(), "[term] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                     }
                 }
             }
@@ -88,7 +88,7 @@ public class TermQueryParser implements QueryParser {
         }
 
         if (value == null) {
-            throw new QueryParsingException(parseContext.index(), "No value specified for term query");
+            throw new QueryParsingException(parseContext.index(), "No value specified for term query", parser.getTokenLocation());
         }
 
         Query query = null;

--- a/src/main/java/org/elasticsearch/index/query/TermsFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TermsFilterParser.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.query;
 
 import com.google.common.collect.Lists;
+
 import org.apache.lucene.index.Term;
 import org.apache.lucene.queries.TermFilter;
 import org.apache.lucene.queries.TermsFilter;
@@ -102,14 +103,15 @@ public class TermsFilterParser implements FilterParser {
                 currentFieldName = parser.currentName();
             } else if (token == XContentParser.Token.START_ARRAY) {
                 if  (fieldName != null) {
-                    throw new QueryParsingException(parseContext.index(), "[terms] filter does not support multiple fields");
+                    throw new QueryParsingException(parseContext.index(), "[terms] filter does not support multiple fields",
+                            parser.getTokenLocation());
                 }
                 fieldName = currentFieldName;
 
                 while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                     Object value = parser.objectBytes();
                     if (value == null) {
-                        throw new QueryParsingException(parseContext.index(), "No value specified for terms filter");
+                        throw new QueryParsingException(parseContext.index(), "No value specified for terms filter", parser.getTokenLocation());
                     }
                     terms.add(value);
                 }
@@ -132,18 +134,18 @@ public class TermsFilterParser implements FilterParser {
                         } else if ("cache".equals(currentFieldName)) {
                             lookupCache = parser.booleanValue();
                         } else {
-                            throw new QueryParsingException(parseContext.index(), "[terms] filter does not support [" + currentFieldName + "] within lookup element");
+                            throw new QueryParsingException(parseContext.index(), "[terms] filter does not support [" + currentFieldName + "] within lookup element", parser.getTokenLocation());
                         }
                     }
                 }
                 if (lookupType == null) {
-                    throw new QueryParsingException(parseContext.index(), "[terms] filter lookup element requires specifying the type");
+                    throw new QueryParsingException(parseContext.index(), "[terms] filter lookup element requires specifying the type", parser.getTokenLocation());
                 }
                 if (lookupId == null) {
-                    throw new QueryParsingException(parseContext.index(), "[terms] filter lookup element requires specifying the id");
+                    throw new QueryParsingException(parseContext.index(), "[terms] filter lookup element requires specifying the id", parser.getTokenLocation());
                 }
                 if (lookupPath == null) {
-                    throw new QueryParsingException(parseContext.index(), "[terms] filter lookup element requires specifying the path");
+                    throw new QueryParsingException(parseContext.index(), "[terms] filter lookup element requires specifying the path", parser.getTokenLocation());
                 }
             } else if (token.isValue()) {
                 if (EXECUTION_KEY.equals(currentFieldName)) {
@@ -155,13 +157,13 @@ public class TermsFilterParser implements FilterParser {
                 } else if ("_cache_key".equals(currentFieldName) || "_cacheKey".equals(currentFieldName)) {
                     cacheKey = new CacheKeyFilter.Key(parser.text());
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[terms] filter does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[terms] filter does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             }
         }
 
         if (fieldName == null) {
-            throw new QueryParsingException(parseContext.index(), "terms filter requires a field name, followed by array of terms");
+            throw new QueryParsingException(parseContext.index(), "terms filter requires a field name, followed by array of terms", parser.getTokenLocation());
         }
 
         FieldMapper fieldMapper = null;
@@ -328,7 +330,7 @@ public class TermsFilterParser implements FilterParser {
                     filter = parseContext.cacheFilter(filter, cacheKey);
                 }
             } else {
-                throw new QueryParsingException(parseContext.index(), "terms filter execution value [" + execution + "] not supported");
+                throw new QueryParsingException(parseContext.index(), "terms filter execution value [" + execution + "] not supported", parser.getTokenLocation());
             }
 
             filter = wrapSmartNameFilter(filter, smartNameFieldMappers, parseContext);

--- a/src/main/java/org/elasticsearch/index/query/TermsQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TermsQueryParser.java
@@ -76,13 +76,14 @@ public class TermsQueryParser implements QueryParser {
                 currentFieldName = parser.currentName();
             } else if (token == XContentParser.Token.START_ARRAY) {
                 if  (fieldName != null) {
-                    throw new QueryParsingException(parseContext.index(), "[terms] query does not support multiple fields");
+                    throw new QueryParsingException(parseContext.index(), "[terms] query does not support multiple fields",
+                            parser.getTokenLocation());
                 }
                 fieldName = currentFieldName;
                 while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                     Object value = parser.objectBytes();
                     if (value == null) {
-                        throw new QueryParsingException(parseContext.index(), "No value specified for terms query");
+                        throw new QueryParsingException(parseContext.index(), "No value specified for terms query", parser.getTokenLocation());
                     }
                     values.add(value);
                 }
@@ -98,15 +99,15 @@ public class TermsQueryParser implements QueryParser {
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[terms] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[terms] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             } else {
-                throw new QueryParsingException(parseContext.index(), "[terms] query does not support [" + currentFieldName + "]");
+                throw new QueryParsingException(parseContext.index(), "[terms] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
             }
         }
 
         if (fieldName == null) {
-            throw new QueryParsingException(parseContext.index(), "No field specified for terms query");
+            throw new QueryParsingException(parseContext.index(), "No field specified for terms query", parser.getTokenLocation());
         }
 
         FieldMapper mapper = null;

--- a/src/main/java/org/elasticsearch/index/query/TopChildrenQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TopChildrenQueryParser.java
@@ -81,7 +81,7 @@ public class TopChildrenQueryParser implements QueryParser {
                     iq = new XContentStructure.InnerQuery(parseContext, childType == null ? null : new String[] {childType});
                     queryFound = true;
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[top_children] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[top_children] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             } else if (token.isValue()) {
                 if ("type".equals(currentFieldName)) {
@@ -99,15 +99,15 @@ public class TopChildrenQueryParser implements QueryParser {
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[top_children] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[top_children] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             }
         }
         if (!queryFound) {
-            throw new QueryParsingException(parseContext.index(), "[top_children] requires 'query' field");
+            throw new QueryParsingException(parseContext.index(), "[top_children] requires 'query' field", parser.getTokenLocation());
         }
         if (childType == null) {
-            throw new QueryParsingException(parseContext.index(), "[top_children] requires 'type' field");
+            throw new QueryParsingException(parseContext.index(), "[top_children] requires 'type' field", parser.getTokenLocation());
         }
 
         Query innerQuery = iq.asQuery(childType);
@@ -118,11 +118,11 @@ public class TopChildrenQueryParser implements QueryParser {
 
         DocumentMapper childDocMapper = parseContext.mapperService().documentMapper(childType);
         if (childDocMapper == null) {
-            throw new QueryParsingException(parseContext.index(), "No mapping for for type [" + childType + "]");
+            throw new QueryParsingException(parseContext.index(), "No mapping for for type [" + childType + "]", parser.getTokenLocation());
         }
         ParentFieldMapper parentFieldMapper = childDocMapper.parentFieldMapper();
         if (!parentFieldMapper.active()) {
-            throw new QueryParsingException(parseContext.index(), "Type [" + childType + "] does not have parent mapping");
+            throw new QueryParsingException(parseContext.index(), "Type [" + childType + "] does not have parent mapping", parser.getTokenLocation());
         }
         String parentType = childDocMapper.parentFieldMapper().type();
 

--- a/src/main/java/org/elasticsearch/index/query/TypeFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TypeFilterParser.java
@@ -49,15 +49,15 @@ public class TypeFilterParser implements FilterParser {
 
         XContentParser.Token token = parser.nextToken();
         if (token != XContentParser.Token.FIELD_NAME) {
-            throw new QueryParsingException(parseContext.index(), "[type] filter should have a value field, and the type name");
+            throw new QueryParsingException(parseContext.index(), "[type] filter should have a value field, and the type name", parser.getTokenLocation());
         }
         String fieldName = parser.currentName();
         if (!fieldName.equals("value")) {
-            throw new QueryParsingException(parseContext.index(), "[type] filter should have a value field, and the type name");
+            throw new QueryParsingException(parseContext.index(), "[type] filter should have a value field, and the type name", parser.getTokenLocation());
         }
         token = parser.nextToken();
         if (token != XContentParser.Token.VALUE_STRING) {
-            throw new QueryParsingException(parseContext.index(), "[type] filter should have a value field, and the type name");
+            throw new QueryParsingException(parseContext.index(), "[type] filter should have a value field, and the type name", parser.getTokenLocation());
         }
         BytesRef type = parser.utf8Bytes();
         // move to the next token

--- a/src/main/java/org/elasticsearch/index/query/WildcardQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/WildcardQueryParser.java
@@ -54,7 +54,7 @@ public class WildcardQueryParser implements QueryParser {
 
         XContentParser.Token token = parser.nextToken();
         if (token != XContentParser.Token.FIELD_NAME) {
-            throw new QueryParsingException(parseContext.index(), "[wildcard] query malformed, no field");
+            throw new QueryParsingException(parseContext.index(), "[wildcard] query malformed, no field", parser.getTokenLocation());
         }
         String fieldName = parser.currentName();
         String rewriteMethod = null;
@@ -80,7 +80,7 @@ public class WildcardQueryParser implements QueryParser {
                     } else if ("_name".equals(currentFieldName)) {
                         queryName = parser.text();
                     } else {
-                        throw new QueryParsingException(parseContext.index(), "[wildcard] query does not support [" + currentFieldName + "]");
+                        throw new QueryParsingException(parseContext.index(), "[wildcard] query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                     }
                 }
             }
@@ -91,7 +91,7 @@ public class WildcardQueryParser implements QueryParser {
         }
 
         if (value == null) {
-            throw new QueryParsingException(parseContext.index(), "No value specified for prefix query");
+            throw new QueryParsingException(parseContext.index(), "No value specified for prefix query", parser.getTokenLocation());
         }
 
         BytesRef valueBytes;

--- a/src/main/java/org/elasticsearch/index/query/WrapperFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/WrapperFilterParser.java
@@ -48,11 +48,11 @@ public class WrapperFilterParser implements FilterParser {
 
         XContentParser.Token token = parser.nextToken();
         if (token != XContentParser.Token.FIELD_NAME) {
-            throw new QueryParsingException(parseContext.index(), "[wrapper] filter malformed");
+            throw new QueryParsingException(parseContext.index(), "[wrapper] filter malformed", parser.getTokenLocation());
         }
         String fieldName = parser.currentName();
         if (!fieldName.equals("filter")) {
-            throw new QueryParsingException(parseContext.index(), "[wrapper] filter malformed");
+            throw new QueryParsingException(parseContext.index(), "[wrapper] filter malformed", parser.getTokenLocation());
         }
         parser.nextToken();
 

--- a/src/main/java/org/elasticsearch/index/query/WrapperQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/WrapperQueryParser.java
@@ -48,11 +48,11 @@ public class WrapperQueryParser implements QueryParser {
 
         XContentParser.Token token = parser.nextToken();
         if (token != XContentParser.Token.FIELD_NAME) {
-            throw new QueryParsingException(parseContext.index(), "[wrapper] query malformed");
+            throw new QueryParsingException(parseContext.index(), "[wrapper] query malformed", parser.getTokenLocation());
         }
         String fieldName = parser.currentName();
         if (!fieldName.equals("query")) {
-            throw new QueryParsingException(parseContext.index(), "[wrapper] query malformed");
+            throw new QueryParsingException(parseContext.index(), "[wrapper] query malformed", parser.getTokenLocation());
         }
         parser.nextToken();
 

--- a/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionParser.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionParser.java
@@ -154,7 +154,7 @@ public abstract class DecayFunctionParser implements ScoreFunctionParser {
         // the doc later
         MapperService.SmartNameFieldMappers smartMappers = parseContext.smartFieldMappers(fieldName);
         if (smartMappers == null || !smartMappers.hasMapper()) {
-            throw new QueryParsingException(parseContext.index(), "Unknown field [" + fieldName + "]");
+            throw new QueryParsingException(parseContext.index(), "Unknown field [" + fieldName + "]", parser.getTokenLocation());
         }
 
         FieldMapper<?> mapper = smartMappers.fieldMappers().mapper();
@@ -168,7 +168,7 @@ public abstract class DecayFunctionParser implements ScoreFunctionParser {
             return parseNumberVariable(fieldName, parser, parseContext, (NumberFieldMapper<?>) mapper, mode);
         } else {
             throw new QueryParsingException(parseContext.index(), "Field " + fieldName + " is of type " + mapper.fieldType()
-                    + ", but only numeric types are supported.");
+                    + ", but only numeric types are supported.", parser.getTokenLocation());
         }
     }
 

--- a/src/main/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryParser.java
@@ -190,7 +190,7 @@ public class FunctionScoreQueryParser implements QueryParser {
             Float functionWeight = null;
             if (token != XContentParser.Token.START_OBJECT) {
                 throw new QueryParsingException(parseContext.index(), NAME + ": malformed query, expected a "
-                        + XContentParser.Token.START_OBJECT + " while parsing functions but got a " + token);
+                        + XContentParser.Token.START_OBJECT + " while parsing functions but got a " + token, parser.getTokenLocation());
             } else {
                 while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
                     if (token == XContentParser.Token.FIELD_NAME) {
@@ -240,7 +240,7 @@ public class FunctionScoreQueryParser implements QueryParser {
         } else if ("first".equals(scoreMode)) {
             return FiltersFunctionScoreQuery.ScoreMode.First;
         } else {
-            throw new QueryParsingException(parseContext.index(), NAME + " illegal score_mode [" + scoreMode + "]");
+            throw new QueryParsingException(parseContext.index(), NAME + " illegal score_mode [" + scoreMode + "]", parser.getTokenLocation());
         }
     }
 
@@ -248,7 +248,7 @@ public class FunctionScoreQueryParser implements QueryParser {
         String boostMode = parser.text();
         CombineFunction cf = combineFunctionsMap.get(boostMode);
         if (cf == null) {
-            throw new QueryParsingException(parseContext.index(), NAME + " illegal boost_mode [" + boostMode + "]");
+            throw new QueryParsingException(parseContext.index(), NAME + " illegal boost_mode [" + boostMode + "]", parser.getTokenLocation());
         }
         return cf;
     }

--- a/src/main/java/org/elasticsearch/index/query/functionscore/ScoreFunctionParserMapper.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/ScoreFunctionParserMapper.java
@@ -22,6 +22,7 @@ package org.elasticsearch.index.query.functionscore;
 import com.google.common.collect.ImmutableMap;
 import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.xcontent.XContentLocation;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.query.QueryParsingException;
 
@@ -45,7 +46,7 @@ public class ScoreFunctionParserMapper {
     public ScoreFunctionParser get(Index index, String parserName) {
         ScoreFunctionParser functionParser = get(parserName);
         if (functionParser == null) {
-            throw new QueryParsingException(index, "No function with the name [" + parserName + "] is registered.");
+            throw new QueryParsingException(index, "No function with the name [" + parserName + "] is registered.", (XContentLocation) null);
         }
         return functionParser;
     }

--- a/src/main/java/org/elasticsearch/index/query/functionscore/fieldvaluefactor/FieldValueFactorFunctionParser.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/fieldvaluefactor/FieldValueFactorFunctionParser.java
@@ -68,13 +68,13 @@ public class FieldValueFactorFunctionParser implements ScoreFunctionParser {
                 } else if ("modifier".equals(currentFieldName)) {
                     modifier = FieldValueFactorFunction.Modifier.valueOf(parser.text().toUpperCase(Locale.ROOT));
                 } else {
-                    throw new QueryParsingException(parseContext.index(), NAMES[0] + " query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), NAMES[0] + " query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             }
         }
 
         if (field == null) {
-            throw new QueryParsingException(parseContext.index(), "[" + NAMES[0] + "] required field 'field' missing");
+            throw new QueryParsingException(parseContext.index(), "[" + NAMES[0] + "] required field 'field' missing", parser.getTokenLocation());
         }
 
         SearchContext searchContext = SearchContext.current();

--- a/src/main/java/org/elasticsearch/index/query/functionscore/random/RandomScoreFunctionParser.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/random/RandomScoreFunctionParser.java
@@ -21,6 +21,7 @@
 package org.elasticsearch.index.query.functionscore.random;
 
 import com.google.common.primitives.Longs;
+
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.lucene.search.function.RandomScoreFunction;
 import org.elasticsearch.common.lucene.search.function.ScoreFunction;
@@ -66,15 +67,17 @@ public class RandomScoreFunctionParser implements ScoreFunctionParser {
                         } else if (parser.numberType() == XContentParser.NumberType.LONG) {
                             seed = Longs.hashCode(parser.longValue());
                         } else {
-                            throw new QueryParsingException(parseContext.index(), "random_score seed must be an int, long or string, not '" + token.toString() + "'");
+                            throw new QueryParsingException(parseContext.index(), "random_score seed must be an int, long or string, not '"
+                                    + token.toString() + "'", parser.getTokenLocation());
                         }
                     } else if (token == XContentParser.Token.VALUE_STRING) {
                         seed = parser.text().hashCode();
                     } else {
-                        throw new QueryParsingException(parseContext.index(), "random_score seed must be an int/long or string, not '" + token.toString() + "'");
+                        throw new QueryParsingException(parseContext.index(), "random_score seed must be an int/long or string, not '"
+                                + token.toString() + "'", parser.getTokenLocation());
                     }
                 } else {
-                    throw new QueryParsingException(parseContext.index(), NAMES[0] + " query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), NAMES[0] + " query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             }
         }

--- a/src/main/java/org/elasticsearch/index/query/functionscore/script/ScriptScoreFunctionParser.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/script/ScriptScoreFunctionParser.java
@@ -68,11 +68,11 @@ public class ScriptScoreFunctionParser implements ScoreFunctionParser {
                 if ("params".equals(currentFieldName)) {
                     vars = parser.map();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), NAMES[0] + " query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), NAMES[0] + " query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             } else if (token.isValue()) {
                 if (!scriptParameterParser.token(currentFieldName, token, parser)) {
-                    throw new QueryParsingException(parseContext.index(), NAMES[0] + " query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), NAMES[0] + " query does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             }
         }
@@ -85,7 +85,7 @@ public class ScriptScoreFunctionParser implements ScoreFunctionParser {
         scriptLang = scriptParameterParser.lang();
 
         if (script == null) {
-            throw new QueryParsingException(parseContext.index(), NAMES[0] + " requires 'script' field");
+            throw new QueryParsingException(parseContext.index(), NAMES[0] + " requires 'script' field", parser.getTokenLocation());
         }
 
         SearchScript searchScript;
@@ -93,7 +93,7 @@ public class ScriptScoreFunctionParser implements ScoreFunctionParser {
             searchScript = parseContext.scriptService().search(parseContext.lookup(), scriptLang, script, scriptType, vars);
             return new ScriptScoreFunction(script, vars, searchScript);
         } catch (Exception e) {
-            throw new QueryParsingException(parseContext.index(), NAMES[0] + " the script could not be loaded", e);
+            throw new QueryParsingException(parseContext.index(), NAMES[0] + " the script could not be loaded", parser.getTokenLocation(), e);
         }
     }
 }

--- a/src/main/java/org/elasticsearch/search/ParseErrorDetails.java
+++ b/src/main/java/org/elasticsearch/search/ParseErrorDetails.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search;
+
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.io.Serializable;
+
+/**
+ * Class for holding fined-grained details of a parse error including
+ * line and column numbers with a message. Can be serialized using
+ * regular Java serialization (for use between nodes) and can supply 
+ * details as XContent (typically for REST responses). 
+ */
+public class ParseErrorDetails implements ToXContent, Serializable {
+    
+    private String parseMsg;
+    private int parseErrorLine = -1;
+    private int parseErrorCol = -1;
+    
+    public ParseErrorDetails(String parseMsg, int parseErrorLine, int parseErrorCol) {
+        super();
+        this.parseMsg = parseMsg;
+        this.parseErrorLine = parseErrorLine;
+        this.parseErrorCol = parseErrorCol;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject("parse_failure");
+        builder.field("line", parseErrorLine);
+        builder.field("col", parseErrorCol);
+        builder.field("message", parseMsg);
+        builder.endObject();                
+        return builder;
+    }
+    
+}

--- a/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/src/main/java/org/elasticsearch/search/SearchService.java
@@ -668,7 +668,7 @@ public class SearchService extends AbstractLifecycleComponent<SearchService> {
                     parser.nextToken();
                     SearchParseElement element = elementParsers.get(fieldName);
                     if (element == null) {
-                        throw new SearchParseException(context, "No parser for element [" + fieldName + "]");
+                        throw new SearchParseException(context, "No parser for element [" + fieldName + "]", parser.getTokenLocation());
                     }
                     element.parse(parser, context);
                 } else {
@@ -686,7 +686,9 @@ public class SearchService extends AbstractLifecycleComponent<SearchService> {
             } catch (Throwable e1) {
                 // ignore
             }
-            throw new SearchParseException(context, "Failed to parse source [" + sSource + "]", e);
+            // arguably not useful to take structured sSource value and wrap in a text message here - just makes any parsing harder.
+            // I guess we have to preserve it for those clients that have written err msg parsers already to deal with this format.
+            throw new SearchParseException(context, "Failed to parse source [" + sSource + "]", e, null);
         } finally {
             if (parser != null) {
                 parser.close();

--- a/src/main/java/org/elasticsearch/search/aggregations/AggregatorParsers.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/AggregatorParsers.java
@@ -86,16 +86,19 @@ public class AggregatorParsers {
         XContentParser.Token token = null;
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
             if (token != XContentParser.Token.FIELD_NAME) {
-                throw new SearchParseException(context, "Unexpected token " + token + " in [aggs]: aggregations definitions must start with the name of the aggregation.");
+                throw new SearchParseException(context, "Unexpected token " + token + " in [aggs]: aggregations definitions must start with the name of the aggregation.", 
+                        parser.getTokenLocation());
             }
             final String aggregationName = parser.currentName();
             if (!validAggMatcher.reset(aggregationName).matches()) {
-                throw new SearchParseException(context, "Invalid aggregation name [" + aggregationName + "]. Aggregation names must be alpha-numeric and can only contain '_' and '-'");
+                throw new SearchParseException(context, "Invalid aggregation name [" + aggregationName + "]. Aggregation names must be alpha-numeric and can only contain '_' and '-'", 
+                        parser.getTokenLocation());
             }
 
             token = parser.nextToken();
             if (token != XContentParser.Token.START_OBJECT) {
-                throw new SearchParseException(context, "Aggregation definition for [" + aggregationName + " starts with a [" + token + "], expected a [" + XContentParser.Token.START_OBJECT + "].");
+                throw new SearchParseException(context, "Aggregation definition for [" + aggregationName + " starts with a [" + token + "], expected a [" + XContentParser.Token.START_OBJECT + "].", 
+                        parser.getTokenLocation());
             }
 
             AggregatorFactory factory = null;
@@ -105,13 +108,15 @@ public class AggregatorParsers {
 
             while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
                 if (token != XContentParser.Token.FIELD_NAME) {
-                    throw new SearchParseException(context, "Expected [" + XContentParser.Token.FIELD_NAME + "] under a [" + XContentParser.Token.START_OBJECT + "], but got a [" + token + "] in [" + aggregationName + "]");
+                    throw new SearchParseException(context, "Expected [" + XContentParser.Token.FIELD_NAME + "] under a [" + XContentParser.Token.START_OBJECT + "], but got a [" + token + "] in [" + aggregationName + "]", 
+                            parser.getTokenLocation());
                 }
                 final String fieldName = parser.currentName();
 
                 token = parser.nextToken();
                 if (token != XContentParser.Token.START_OBJECT) {
-                    throw new SearchParseException(context, "Expected [" + XContentParser.Token.START_OBJECT + "] under [" + fieldName + "], but got a [" + token + "] in [" + aggregationName + "]");
+                    throw new SearchParseException(context, "Expected [" + XContentParser.Token.START_OBJECT + "] under [" + fieldName + "], but got a [" + token + "] in [" + aggregationName + "]", 
+                            parser.getTokenLocation());
                 }
 
                 switch (fieldName) {
@@ -121,24 +126,26 @@ public class AggregatorParsers {
                     case "aggregations":
                     case "aggs":
                         if (subFactories != null) {
-                            throw new SearchParseException(context, "Found two sub aggregation definitions under [" + aggregationName + "]");
+                            throw new SearchParseException(context, "Found two sub aggregation definitions under [" + aggregationName + "]", 
+                                    parser.getTokenLocation());
                         }
                         subFactories = parseAggregators(parser, context, level+1);
                         break;
                     default:
                         if (factory != null) {
-                            throw new SearchParseException(context, "Found two aggregation type definitions in [" + aggregationName + "]: [" + factory.type + "] and [" + fieldName + "]");
+                            throw new SearchParseException(context, "Found two aggregation type definitions in [" + aggregationName + "]: [" + factory.type + "] and [" + fieldName + "]", parser.getTokenLocation());
                         }
                         Aggregator.Parser aggregatorParser = parser(fieldName);
                         if (aggregatorParser == null) {
-                            throw new SearchParseException(context, "Could not find aggregator type [" + fieldName + "] in [" + aggregationName + "]");
+                            throw new SearchParseException(context, "Could not find aggregator type [" + fieldName + "] in [" + aggregationName + "]", 
+                                    parser.getTokenLocation());
                         }
                         factory = aggregatorParser.parse(aggregationName, parser, context);
                 }
             }
 
             if (factory == null) {
-                throw new SearchParseException(context, "Missing definition for aggregation [" + aggregationName + "]");
+                throw new SearchParseException(context, "Missing definition for aggregation [" + aggregationName + "]", parser.getTokenLocation());
             }
 
             if (metaData != null) {

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/children/ChildrenParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/children/ChildrenParser.java
@@ -56,30 +56,32 @@ public class ChildrenParser implements Aggregator.Parser {
                 if ("type".equals(currentFieldName)) {
                     childType = parser.text();
                 } else {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].", 
+                            parser.getTokenLocation());
                 }
             } else {
-                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].");
+                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].", 
+                        parser.getTokenLocation());
             }
         }
 
         if (childType == null) {
-            throw new SearchParseException(context, "Missing [child_type] field for children aggregation [" + aggregationName + "]");
+            throw new SearchParseException(context, "Missing [child_type] field for children aggregation [" + aggregationName + "]", parser.getTokenLocation());
         }
 
         DocumentMapper childDocMapper = context.mapperService().documentMapper(childType);
         if (childDocMapper == null) {
-            throw new SearchParseException(context, "[children] No mapping for for type [" + childType + "]");
+            throw new SearchParseException(context, "[children] No mapping for for type [" + childType + "]", parser.getTokenLocation());
         }
         ParentFieldMapper parentFieldMapper = childDocMapper.parentFieldMapper();
         if (!parentFieldMapper.active()) {
-            throw new SearchParseException(context, "[children] _parent field not configured");
+            throw new SearchParseException(context, "[children] _parent field not configured", parser.getTokenLocation());
         }
 
         String parentType = parentFieldMapper.type();
         DocumentMapper parentDocMapper = context.mapperService().documentMapper(parentType);
         if (parentDocMapper == null) {
-            throw new SearchParseException(context, "[children]  Type [" + childType + "] points to a non existent parent type [" + parentType + "]");
+            throw new SearchParseException(context, "[children]  Type [" + childType + "] points to a non existent parent type [" + parentType + "]", parser.getTokenLocation());
         }
 
         Filter parentFilter = context.filterCache().cache(parentDocMapper.typeFilter());

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/filters/FiltersParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/filters/FiltersParser.java
@@ -64,7 +64,8 @@ public class FiltersParser implements Aggregator.Parser {
                         }
                     }
                 } else {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].", 
+                            parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.START_ARRAY) {
                 if ("filters".equals(currentFieldName)) {
@@ -76,10 +77,12 @@ public class FiltersParser implements Aggregator.Parser {
                         idx++;
                     }
                 } else {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].", 
+                            parser.getTokenLocation());
                 }
             } else {
-                throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].", 
+                        parser.getTokenLocation());
             }
         }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramParser.java
@@ -112,7 +112,7 @@ public class DateHistogramParser implements Aggregator.Parser {
                 } else if ("interval".equals(currentFieldName)) {
                     interval = parser.text();
                 } else {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.VALUE_BOOLEAN) {
                 if ("keyed".equals(currentFieldName)) {
@@ -120,7 +120,7 @@ public class DateHistogramParser implements Aggregator.Parser {
                 } else if ("pre_zone_adjust_large_interval".equals(currentFieldName) || "preZoneAdjustLargeInterval".equals(currentFieldName)) {
                     preZoneAdjustLargeInterval = parser.booleanValue();
                 } else {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.VALUE_NUMBER) {
                 if ("min_doc_count".equals(currentFieldName) || "minDocCount".equals(currentFieldName)) {
@@ -132,7 +132,7 @@ public class DateHistogramParser implements Aggregator.Parser {
                 } else if ("post_zone".equals(currentFieldName) || "postZone".equals(currentFieldName)) {
                     postZone = DateTimeZone.forOffsetHours(parser.intValue());
                 } else {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.START_OBJECT) {
                 if ("order".equals(currentFieldName)) {
@@ -157,7 +157,8 @@ public class DateHistogramParser implements Aggregator.Parser {
                             } else if ("max".equals(currentFieldName)) {
                                 extendedBounds.maxAsStr = parser.text();
                             } else {
-                                throw new SearchParseException(context, "Unknown extended_bounds key for a " + token + " in aggregation [" + aggregationName + "]: [" + currentFieldName + "].");
+                                throw new SearchParseException(context, "Unknown extended_bounds key for a " + token + " in aggregation [" + aggregationName + "]: [" + currentFieldName + "].", 
+                                        parser.getTokenLocation());
                             }
                         } else if (token == XContentParser.Token.VALUE_NUMBER) {
                             if ("min".equals(currentFieldName)) {
@@ -165,23 +166,26 @@ public class DateHistogramParser implements Aggregator.Parser {
                             } else if ("max".equals(currentFieldName)) {
                                 extendedBounds.max = parser.longValue();
                             } else {
-                                throw new SearchParseException(context, "Unknown extended_bounds key for a " + token + " in aggregation [" + aggregationName + "]: [" + currentFieldName + "].");
+                                throw new SearchParseException(context, "Unknown extended_bounds key for a " + token + " in aggregation [" + aggregationName + "]: [" + currentFieldName + "].", 
+                                        parser.getTokenLocation());
                             }
                         } else {
-                            throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                            throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].", 
+                                    parser.getTokenLocation());
                         }
                     }
 
                 } else {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].", 
+                            parser.getTokenLocation());
                 }
             } else {
-                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].");
+                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].", parser.getTokenLocation());
             }
         }
 
         if (interval == null) {
-            throw new SearchParseException(context, "Missing required field [interval] for histogram aggregation [" + aggregationName + "]");
+            throw new SearchParseException(context, "Missing required field [interval] for histogram aggregation [" + aggregationName + "]", parser.getTokenLocation());
         }
 
         TimeZoneRounding.Builder tzRoundingBuilder;

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/ExtendedBounds.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/ExtendedBounds.java
@@ -56,7 +56,7 @@ public class ExtendedBounds {
         }
         if (min != null && max != null && min.compareTo(max) > 0) {
             throw new SearchParseException(context, "[extended_bounds.min][" + min + "] cannot be greater than " +
-                    "[extended_bounds.max][" + max + "] for histogram aggregation [" + aggName + "]");
+                    "[extended_bounds.max][" + max + "] for histogram aggregation [" + aggName + "]", null);
         }
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/HistogramParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/HistogramParser.java
@@ -78,7 +78,7 @@ public class HistogramParser implements Aggregator.Parser {
                 } else if ("post_offset".equals(currentFieldName) || "postOffset".equals(currentFieldName)) {
                     postOffset = parser.longValue();
                 } else {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in aggregation [" + aggregationName + "]: [" + currentFieldName + "].");
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in aggregation [" + aggregationName + "]: [" + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.START_OBJECT) {
                 if ("order".equals(currentFieldName)) {
@@ -89,7 +89,7 @@ public class HistogramParser implements Aggregator.Parser {
                             String dir = parser.text();
                             boolean asc = "asc".equals(dir);
                             if (!asc && !"desc".equals(dir)) {
-                                throw new SearchParseException(context, "Unknown order direction [" + dir + "] in aggregation [" + aggregationName + "]. Should be either [asc] or [desc]");
+                                throw new SearchParseException(context, "Unknown order direction [" + dir + "] in aggregation [" + aggregationName + "]. Should be either [asc] or [desc]", parser.getTokenLocation());
                             }
                             order = resolveOrder(currentFieldName, asc);
                         }
@@ -105,21 +105,22 @@ public class HistogramParser implements Aggregator.Parser {
                             } else if ("max".equals(currentFieldName)) {
                                 extendedBounds.max = parser.longValue(true);
                             } else {
-                                throw new SearchParseException(context, "Unknown extended_bounds key for a " + token + " in aggregation [" + aggregationName + "]: [" + currentFieldName + "].");
+                                throw new SearchParseException(context, "Unknown extended_bounds key for a " + token + " in aggregation [" + aggregationName + "]: [" + currentFieldName + "].", 
+                                        parser.getTokenLocation());
                             }
                         }
                     }
 
                 } else {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in aggregation [" + aggregationName + "]: [" + currentFieldName + "].");
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in aggregation [" + aggregationName + "]: [" + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else {
-                throw new SearchParseException(context, "Unexpected token " + token + " in aggregation [" + aggregationName + "].");
+                throw new SearchParseException(context, "Unexpected token " + token + " in aggregation [" + aggregationName + "].", parser.getTokenLocation());
             }
         }
 
         if (interval < 0) {
-            throw new SearchParseException(context, "Missing required field [interval] for histogram aggregation [" + aggregationName + "]");
+            throw new SearchParseException(context, "Missing required field [interval] for histogram aggregation [" + aggregationName + "]", parser.getTokenLocation());
         }
         
         Rounding rounding = new Rounding.Interval(interval);

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/missing/MissingParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/missing/MissingParser.java
@@ -52,7 +52,7 @@ public class MissingParser implements Aggregator.Parser {
             } else if (vsParser.token(currentFieldName, token, parser)) {
                 continue;
             } else {
-                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].");
+                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].", parser.getTokenLocation());
             }
         }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/NestedParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/NestedParser.java
@@ -49,16 +49,16 @@ public class NestedParser implements Aggregator.Parser {
                 if ("path".equals(currentFieldName)) {
                     path = parser.text();
                 } else {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else {
-                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].");
+                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].", parser.getTokenLocation());
             }
         }
 
         if (path == null) {
             // "field" doesn't exist, so we fall back to the context of the ancestors
-            throw new SearchParseException(context, "Missing [path] field for nested aggregation [" + aggregationName + "]");
+            throw new SearchParseException(context, "Missing [path] field for nested aggregation [" + aggregationName + "]", parser.getTokenLocation());
         }
 
         return new NestedAggregator.Factory(aggregationName, path);

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/ReverseNestedAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/ReverseNestedAggregator.java
@@ -55,7 +55,7 @@ public class ReverseNestedAggregator extends SingleBucketAggregator implements R
         // Early validation
         NestedAggregator closestNestedAggregator = findClosestNestedAggregator(parent);
         if (closestNestedAggregator == null) {
-            throw new SearchParseException(context.searchContext(), "Reverse nested aggregation [" + name + "] can only be used inside a [nested] aggregation");
+            throw new SearchParseException(context.searchContext(), "Reverse nested aggregation [" + name + "] can only be used inside a [nested] aggregation", null);
         }
         if (nestedPath == null) {
             parentFilter = SearchContext.current().bitsetFilterCache().getBitDocIdSetFilter(NonNestedDocsFilter.INSTANCE);

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/ReverseNestedParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/ReverseNestedParser.java
@@ -49,10 +49,10 @@ public class ReverseNestedParser implements Aggregator.Parser {
                 if ("path".equals(currentFieldName)) {
                     path = parser.text();
                 } else {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else {
-                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].");
+                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].", parser.getTokenLocation());
             }
         }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/range/RangeParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/range/RangeParser.java
@@ -89,21 +89,21 @@ public class RangeParser implements Aggregator.Parser {
                         ranges.add(new RangeAggregator.Range(key, from, fromAsStr, to, toAsStr));
                     }
                 } else {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.VALUE_BOOLEAN) {
                 if ("keyed".equals(currentFieldName)) {
                     keyed = parser.booleanValue();
                 } else {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else {
-                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].");
+                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].", parser.getTokenLocation());
             }
         }
 
         if (ranges == null) {
-            throw new SearchParseException(context, "Missing [ranges] in ranges aggregator [" + aggregationName + "]");
+            throw new SearchParseException(context, "Missing [ranges] in ranges aggregator [" + aggregationName + "]", parser.getTokenLocation());
         }
 
         return new RangeAggregator.Factory(aggregationName, vsParser.config(), InternalRange.FACTORY, ranges, keyed);

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/range/date/DateRangeParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/range/date/DateRangeParser.java
@@ -79,7 +79,7 @@ public class DateRangeParser implements Aggregator.Parser {
                                 } else if ("to".equals(toOrFromOrKey)) {
                                     to = parser.doubleValue();
                                 } else {
-                                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].", parser.getTokenLocation());
                                 }
                             } else if (token == XContentParser.Token.VALUE_STRING) {
                                 if ("from".equals(toOrFromOrKey)) {
@@ -89,7 +89,7 @@ public class DateRangeParser implements Aggregator.Parser {
                                 } else if ("key".equals(toOrFromOrKey)) {
                                     key = parser.text();
                                 } else {
-                                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].", parser.getTokenLocation());
                                 }
                             }
                         }
@@ -100,15 +100,15 @@ public class DateRangeParser implements Aggregator.Parser {
                 if ("keyed".equals(currentFieldName)) {
                     keyed = parser.booleanValue();
                 } else {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else {
-                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].");
+                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].", parser.getTokenLocation());
             }
         }
 
         if (ranges == null) {
-            throw new SearchParseException(context, "Missing [ranges] in ranges aggregator [" + aggregationName + "]");
+            throw new SearchParseException(context, "Missing [ranges] in ranges aggregator [" + aggregationName + "]", parser.getTokenLocation());
         }
 
         return new RangeAggregator.Factory(aggregationName, vsParser.config(), InternalDateRange.FACTORY, ranges, keyed);

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/range/geodistance/GeoDistanceParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/range/geodistance/GeoDistanceParser.java
@@ -94,13 +94,13 @@ public class GeoDistanceParser implements Aggregator.Parser {
                 } else if ("distance_type".equals(currentFieldName) || "distanceType".equals(currentFieldName)) {
                     distanceType = GeoDistance.fromString(parser.text());
                 } else {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.VALUE_BOOLEAN) {
                 if ("keyed".equals(currentFieldName)) {
                     keyed = parser.booleanValue();
                 } else {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.START_ARRAY) {
                 if ("ranges".equals(currentFieldName)) {
@@ -134,20 +134,20 @@ public class GeoDistanceParser implements Aggregator.Parser {
                         ranges.add(new RangeAggregator.Range(key(key, from, to), from, fromAsStr, to, toAsStr));
                     }
                 } else  {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else {
-                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].");
+                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].", parser.getTokenLocation());
             }
         }
 
         if (ranges == null) {
-            throw new SearchParseException(context, "Missing [ranges] in geo_distance aggregator [" + aggregationName + "]");
+            throw new SearchParseException(context, "Missing [ranges] in geo_distance aggregator [" + aggregationName + "]", parser.getTokenLocation());
         }
 
         GeoPoint origin = geoPointParser.geoPoint();
         if (origin == null) {
-            throw new SearchParseException(context, "Missing [origin] in geo_distance aggregator [" + aggregationName + "]");
+            throw new SearchParseException(context, "Missing [origin] in geo_distance aggregator [" + aggregationName + "]", parser.getTokenLocation());
         }
 
         return new GeoDistanceFactory(aggregationName, vsParser.config(), InternalGeoDistance.FACTORY, origin, unit, distanceType, ranges, keyed);

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ipv4/IpRangeParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ipv4/IpRangeParser.java
@@ -99,21 +99,21 @@ public class IpRangeParser implements Aggregator.Parser {
                         ranges.add(range);
                     }
                 } else {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.VALUE_BOOLEAN) {
                 if ("keyed".equals(currentFieldName)) {
                     keyed = parser.booleanValue();
                 } else {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else {
-                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].");
+                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].", parser.getTokenLocation());
             }
         }
 
         if (ranges == null) {
-            throw new SearchParseException(context, "Missing [ranges] in ranges aggregator [" + aggregationName + "]");
+            throw new SearchParseException(context, "Missing [ranges] in ranges aggregator [" + aggregationName + "]", parser.getTokenLocation());
         }
 
         return new RangeAggregator.Factory(aggregationName, vsParser.config(), InternalIPv4Range.FACTORY, ranges, keyed);
@@ -122,7 +122,7 @@ public class IpRangeParser implements Aggregator.Parser {
     private static void parseMaskRange(String cidr, RangeAggregator.Range range, String aggregationName, SearchContext ctx) {
         long[] fromTo = IPv4RangeBuilder.cidrMaskToMinMax(cidr);
         if (fromTo == null) {
-            throw new SearchParseException(ctx, "invalid CIDR mask [" + cidr + "] in aggregation [" + aggregationName + "]");
+            throw new SearchParseException(ctx, "invalid CIDR mask [" + cidr + "] in aggregation [" + aggregationName + "]", null);
         }
         range.from = fromTo[0] < 0 ? Double.NEGATIVE_INFINITY : fromTo[0];
         range.to = fromTo[1] < 0 ? Double.POSITIVE_INFINITY : fromTo[1];

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsParametersParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsParametersParser.java
@@ -67,10 +67,10 @@ public class SignificantTermsParametersParser extends AbstractTermsParametersPar
             } else if (BACKGROUND_FILTER.match(currentFieldName)) {
                 filter = context.queryParserService().parseInnerFilter(parser).filter();
             } else {
-                throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].", parser.getTokenLocation());
             }
         } else {
-            throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+            throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].", parser.getTokenLocation());
         }
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsParametersParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsParametersParser.java
@@ -56,7 +56,7 @@ public class TermsParametersParser extends AbstractTermsParametersParser {
             if ("order".equals(currentFieldName)) {
                 this.orderElements = Collections.singletonList(parseOrderParam(aggregationName, parser, context));
             } else {
-                throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].", parser.getTokenLocation());
             }
         } else if (token == XContentParser.Token.START_ARRAY) {
             if ("order".equals(currentFieldName)) {
@@ -66,18 +66,18 @@ public class TermsParametersParser extends AbstractTermsParametersParser {
                         OrderElement orderParam = parseOrderParam(aggregationName, parser, context);
                         orderElements.add(orderParam);
                     } else {
-                        throw new SearchParseException(context, "Order elements must be of type object in [" + aggregationName + "].");
+                        throw new SearchParseException(context, "Order elements must be of type object in [" + aggregationName + "].", parser.getTokenLocation());
                     }
                 }
             } else {
-                throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].", parser.getTokenLocation());
             }
         } else if (token == XContentParser.Token.VALUE_BOOLEAN) {
             if (SHOW_TERM_DOC_COUNT_ERROR.match(currentFieldName)) {
                 showTermDocCountError = parser.booleanValue();
             }
         } else {
-            throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+            throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].", parser.getTokenLocation());
         }
     }
 
@@ -96,14 +96,14 @@ public class TermsParametersParser extends AbstractTermsParametersParser {
                 } else if ("desc".equalsIgnoreCase(dir)) {
                     orderAsc = false;
                 } else {
-                    throw new SearchParseException(context, "Unknown terms order direction [" + dir + "] in terms aggregation [" + aggregationName + "]");
+                    throw new SearchParseException(context, "Unknown terms order direction [" + dir + "] in terms aggregation [" + aggregationName + "]", parser.getTokenLocation());
                 }
             } else {
-                throw new SearchParseException(context, "Unexpected token " + token + " for [order] in [" + aggregationName + "].");
+                throw new SearchParseException(context, "Unexpected token " + token + " for [order] in [" + aggregationName + "].", parser.getTokenLocation());
             }
         }
         if (orderKey == null) {
-            throw new SearchParseException(context, "Must specify at least one field for [order] in [" + aggregationName + "].");
+            throw new SearchParseException(context, "Must specify at least one field for [order] in [" + aggregationName + "].", parser.getTokenLocation());
         } else {
             orderParam = new OrderElement(orderKey, orderAsc);
         }

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/NumericValuesSourceMetricsAggregatorParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/NumericValuesSourceMetricsAggregatorParser.java
@@ -62,7 +62,7 @@ public abstract class NumericValuesSourceMetricsAggregatorParser<S extends Inter
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
             } else if (!vsParser.token(currentFieldName, token, parser)) {
-                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].");
+                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].", parser.getTokenLocation());
             }
         }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/CardinalityParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/CardinalityParser.java
@@ -62,10 +62,10 @@ public class CardinalityParser implements Aggregator.Parser {
                 } else if (PRECISION_THRESHOLD.match(currentFieldName)) {
                     precisionThreshold = parser.longValue();
                 } else {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + name + "]: [" + currentFieldName + "].");
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + name + "]: [" + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else {
-                throw new SearchParseException(context, "Unexpected token " + token + " in [" + name + "].");
+                throw new SearchParseException(context, "Unexpected token " + token + " in [" + name + "].", parser.getTokenLocation());
             }
         }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/geobounds/GeoBoundsParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/geobounds/GeoBoundsParser.java
@@ -56,10 +56,10 @@ public class GeoBoundsParser implements Aggregator.Parser {
                 if ("wrap_longitude".equals(currentFieldName) || "wrapLongitude".equals(currentFieldName)) {
                     wrapLongitude = parser.booleanValue();
                 } else {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in aggregation [" + aggregationName + "]: [" + currentFieldName + "].");
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in aggregation [" + aggregationName + "]: [" + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else {
-                throw new SearchParseException(context, "Unknown key for a " + token + " in aggregation [" + aggregationName + "]: [" + currentFieldName + "].");
+                throw new SearchParseException(context, "Unknown key for a " + token + " in aggregation [" + aggregationName + "]: [" + currentFieldName + "].", parser.getTokenLocation());
             }
         }
         return new GeoBoundsAggregator.Factory(aggregationName, vsParser.config(), wrapLongitude);

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/AbstractPercentilesParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/AbstractPercentilesParser.java
@@ -65,22 +65,24 @@ public abstract class AbstractPercentilesParser implements Aggregator.Parser {
                     keys = values.toArray();
                     Arrays.sort(keys);
                 } else {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.VALUE_BOOLEAN) {
                 if ("keyed".equals(currentFieldName)) {
                     keyed = parser.booleanValue();
                 } else {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].", 
+                            parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.VALUE_NUMBER) {
                 if ("compression".equals(currentFieldName)) {
                     compression = parser.doubleValue();
                 } else {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].", 
+                            parser.getTokenLocation());
                 }
             } else {
-                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].");
+                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].", parser.getTokenLocation());
             }
         }
         return buildFactory(context, aggregationName, vsParser.config(), keys, compression, keyed);

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/PercentileRanksParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/PercentileRanksParser.java
@@ -40,7 +40,7 @@ public class PercentileRanksParser extends AbstractPercentilesParser {
     
     protected AggregatorFactory buildFactory(SearchContext context, String aggregationName, ValuesSourceConfig<Numeric> valuesSourceConfig, double[] keys, double compression, boolean keyed) {
         if (keys == null) {
-            throw new SearchParseException(context, "Missing token values in [" + aggregationName + "].");
+            throw new SearchParseException(context, "Missing token values in [" + aggregationName + "].", null);
         }
         return new PercentileRanksAggregator.Factory(aggregationName, valuesSourceConfig, keys, compression, keyed);
     }

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/scripted/ScriptedMetricAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/scripted/ScriptedMetricAggregator.java
@@ -33,7 +33,10 @@ import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 
 public class ScriptedMetricAggregator extends MetricsAggregator {
@@ -179,7 +182,7 @@ public class ScriptedMetricAggregator extends MetricsAggregator {
                 clone = original;
             } else {
                 throw new SearchParseException(context, "Can only clone primitives, String, ArrayList, and HashMap. Found: "
-                        + original.getClass().getCanonicalName());
+                        + original.getClass().getCanonicalName(), null);
             }
             return clone;
         }

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/scripted/ScriptedMetricParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/scripted/ScriptedMetricParser.java
@@ -72,14 +72,14 @@ public class ScriptedMetricParser implements Aggregator.Parser {
                 } else if (REDUCE_PARAMS_FIELD.match(currentFieldName)) {
                   reduceParams = parser.map();
                 } else {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else if (token.isValue()) {
                 if (!scriptParameterParser.token(currentFieldName, token, parser)) {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else {
-                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].");
+                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].", parser.getTokenLocation());
             }
         }
         
@@ -114,7 +114,7 @@ public class ScriptedMetricParser implements Aggregator.Parser {
         scriptLang = scriptParameterParser.lang();
         
         if (mapScript == null) {
-            throw new SearchParseException(context, "map_script field is required in [" + aggregationName + "].");
+            throw new SearchParseException(context, "map_script field is required in [" + aggregationName + "].", parser.getTokenLocation());
         }
         return new ScriptedMetricAggregator.Factory(aggregationName, scriptLang, initScriptType, initScript, mapScriptType, mapScript,
                 combineScriptType, combineScript, reduceScriptType, reduceScript, params, reduceParams);

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/TopHitsParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/TopHitsParser.java
@@ -93,7 +93,7 @@ public class TopHitsParser implements Aggregator.Parser {
                             topHitsContext.explain(parser.booleanValue());
                             break;
                         default:
-                            throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                            throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].", parser.getTokenLocation());
                     }
                 } else if (token == XContentParser.Token.START_OBJECT) {
                     switch (currentFieldName) {
@@ -105,7 +105,7 @@ public class TopHitsParser implements Aggregator.Parser {
                             scriptFieldsParseElement.parse(parser, topHitsContext);
                             break;
                         default:
-                            throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                            throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].", parser.getTokenLocation());
                     }
                 } else if (token == XContentParser.Token.START_ARRAY) {
                     switch (currentFieldName) {
@@ -114,10 +114,10 @@ public class TopHitsParser implements Aggregator.Parser {
                             fieldDataFieldsParseElement.parse(parser, topHitsContext);
                             break;
                         default:
-                            throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                            throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].", parser.getTokenLocation());
                     }
                 } else {
-                    throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].");
+                    throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].", parser.getTokenLocation());
                 }
             }
         } catch (Exception e) {

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/valuecount/ValueCountParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/valuecount/ValueCountParser.java
@@ -49,7 +49,7 @@ public class ValueCountParser implements Aggregator.Parser {
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
             } else if (!vsParser.token(currentFieldName, token, parser)) {
-                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].");
+                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].", parser.getTokenLocation());
             }
         }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/support/GeoPointParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/support/GeoPointParser.java
@@ -66,7 +66,7 @@ public class GeoPointParser {
                     lat = parser.doubleValue();
                 } else {
                     throw new SearchParseException(context, "malformed [" + currentFieldName + "] geo point array in [" +
-                            aggName + "] " + aggType + " aggregation. a geo point array must be of the form [lon, lat]");
+                            aggName + "] " + aggType + " aggregation. a geo point array must be of the form [lon, lat]", parser.getTokenLocation());
                 }
             }
             point = new GeoPoint(lat, lon);
@@ -88,7 +88,7 @@ public class GeoPointParser {
             }
             if (Double.isNaN(lat) || Double.isNaN(lon)) {
                 throw new SearchParseException(context, "malformed [" + currentFieldName + "] geo point object. either [lat] or [lon] (or both) are " +
-                        "missing in [" + aggName + "] " + aggType + " aggregation");
+                        "missing in [" + aggName + "] " + aggType + " aggregation", parser.getTokenLocation());
             }
             point = new GeoPoint(lat, lon);
             return true;

--- a/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceParser.java
@@ -104,7 +104,7 @@ public class ValuesSourceParser<VS extends ValuesSource> {
                     if (targetValueType != null && input.valueType.isNotA(targetValueType)) {
                         throw new SearchParseException(context, aggType.name() + " aggregation [" + aggName +
                                 "] was configured with an incompatible value type [" + input.valueType + "]. [" + aggType +
-                                "] aggregation can only work on value of type [" + targetValueType + "]");
+                                "] aggregation can only work on value of type [" + targetValueType + "]", parser.getTokenLocation());
                     }
                 } else if (!scriptParameterParser.token(currentFieldName, token, parser)) {
                     return false;

--- a/src/main/java/org/elasticsearch/search/highlight/HighlighterParseElement.java
+++ b/src/main/java/org/elasticsearch/search/highlight/HighlighterParseElement.java
@@ -71,7 +71,7 @@ public class HighlighterParseElement implements SearchParseElement {
         try {
             context.highlight(parse(parser, context.queryParserService()));
         } catch (ElasticsearchIllegalArgumentException ex) {
-            throw new SearchParseException(context, "Error while trying to parse Highlighter element in request");
+            throw new SearchParseException(context, "Error while trying to parse Highlighter element in request", parser.getTokenLocation());
         }
     }
 

--- a/src/main/java/org/elasticsearch/search/query/FromParseElement.java
+++ b/src/main/java/org/elasticsearch/search/query/FromParseElement.java
@@ -35,7 +35,7 @@ public class FromParseElement implements SearchParseElement {
         if (token.isValue()) {
             int from = parser.intValue();
             if (from < 0) {
-                throw new SearchParseException(context, "from is set to [" + from + "] and is expected to be higher or equal to 0");
+                throw new SearchParseException(context, "from is set to [" + from + "] and is expected to be higher or equal to 0", parser.getTokenLocation());
             }
             context.from(from);
         }

--- a/src/main/java/org/elasticsearch/search/query/SizeParseElement.java
+++ b/src/main/java/org/elasticsearch/search/query/SizeParseElement.java
@@ -35,7 +35,7 @@ public class SizeParseElement implements SearchParseElement {
         if (token.isValue()) {
             int size = parser.intValue();
             if (size < 0) {
-                throw new SearchParseException(context, "size is set to [" + size + "] and is expected to be higher or equal to 0");
+                throw new SearchParseException(context, "size is set to [" + size + "] and is expected to be higher or equal to 0", parser.getTokenLocation());
             }
             context.size(size);
         }

--- a/src/main/java/org/elasticsearch/search/sort/ScriptSortParser.java
+++ b/src/main/java/org/elasticsearch/search/sort/ScriptSortParser.java
@@ -109,15 +109,15 @@ public class ScriptSortParser implements SortParser {
         }
 
         if (script == null) {
-            throw new SearchParseException(context, "_script sorting requires setting the script to sort by");
+            throw new SearchParseException(context, "_script sorting requires setting the script to sort by", parser.getTokenLocation());
         }
         if (type == null) {
-            throw new SearchParseException(context, "_script sorting requires setting the type of the script");
+            throw new SearchParseException(context, "_script sorting requires setting the type of the script", parser.getTokenLocation());
         }
         final SearchScript searchScript = context.scriptService().search(context.lookup(), scriptLang, script, scriptType, params);
 
         if (STRING_SORT_TYPE.equals(type) && (sortMode == MultiValueMode.SUM || sortMode == MultiValueMode.AVG)) {
-            throw new SearchParseException(context, "type [string] doesn't support mode [" + sortMode + "]");
+            throw new SearchParseException(context, "type [string] doesn't support mode [" + sortMode + "]", parser.getTokenLocation());
         }
 
         if (sortMode == null) {
@@ -195,7 +195,7 @@ public class ScriptSortParser implements SortParser {
                 };
                 break;
             default:
-                throw new SearchParseException(context, "custom script sort type [" + type + "] not supported");
+                throw new SearchParseException(context, "custom script sort type [" + type + "] not supported", parser.getTokenLocation());
         }
 
         return new SortField("_script", fieldComparatorSource, reverse);

--- a/src/main/java/org/elasticsearch/search/sort/SortParseElement.java
+++ b/src/main/java/org/elasticsearch/search/sort/SortParseElement.java
@@ -208,12 +208,12 @@ public class SortParseElement implements SearchParseElement {
                 if (unmappedType != null) {
                     fieldMapper = context.mapperService().unmappedFieldMapper(unmappedType);
                 } else {
-                    throw new SearchParseException(context, "No mapping found for [" + fieldName + "] in order to sort on");
+                    throw new SearchParseException(context, "No mapping found for [" + fieldName + "] in order to sort on", null);
                 }
             }
 
             if (!fieldMapper.isSortable()) {
-                throw new SearchParseException(context, "Sorting not supported for field[" + fieldName + "]");
+                throw new SearchParseException(context, "Sorting not supported for field[" + fieldName + "]", null);
             }
 
             // Enable when we also know how to detect fields that do tokenize, but only emit one token

--- a/src/test/java/org/elasticsearch/search/basic/InvalidSearchSyntaxReportingTests.java
+++ b/src/test/java/org/elasticsearch/search/basic/InvalidSearchSyntaxReportingTests.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.basic;
+
+import org.elasticsearch.action.search.MultiSearchResponse;
+import org.elasticsearch.action.search.SearchPhaseExecutionException;
+import org.elasticsearch.action.search.ShardSearchFailure;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.BytesStreamInput;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.transport.RemoteTransportException;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.elasticsearch.client.Requests.createIndexRequest;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
+import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.hamcrest.Matchers.*;
+
+/**
+ *
+ */
+public class InvalidSearchSyntaxReportingTests extends ElasticsearchIntegrationTest {
+
+    @Override
+    protected int numberOfReplicas() {
+        return 0;
+    }
+
+    private void prepareData(int numShards) throws Exception {
+
+        ImmutableSettings.Builder settingsBuilder = settingsBuilder().put(indexSettings());
+
+        if (numShards > 0) {
+            settingsBuilder.put(SETTING_NUMBER_OF_SHARDS, numShards);
+        }
+
+        client().admin().indices().create(createIndexRequest("test").settings(settingsBuilder)).actionGet();
+
+        ensureGreen();
+        refresh();
+    }
+
+    @Test
+    public void testBadQueryReporting() throws Exception {
+        assertAcked(prepareCreate("test"));
+        ensureGreen();
+
+        String badQuery = "{\"match_all\":{\"nonsense\":3}}";
+        ToXContent errorReporter = null;
+        try {
+            client().prepareSearch("test").setQuery(badQuery).execute().actionGet();
+        } catch (SearchPhaseExecutionException expected) {
+            if (expected.hasXContent()) {
+                errorReporter = expected;
+            }
+        }
+        assertNotNull("Expected a class that can give breakdown of parse error", errorReporter);
+        XContentBuilder jb = XContentFactory.jsonBuilder();
+        errorReporter.toXContent(jb, ToXContent.EMPTY_PARAMS);
+        String jsonResponse = jb.string();
+        assertTrue("Bad section of query should be in message", jsonResponse.contains("nonsense"));
+    }
+
+    // A custom exception used to illustrate the possibility of new forms of
+    // user input exception which can return arbitrary XContent in results
+    private static final class CustomParseException extends Exception implements ToXContent {
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject("parseFailure");
+            builder.field("reason", "you have exceeded rate limits");
+            builder.field("try_again_in", 5);
+            builder.endObject();
+            return builder;
+        }
+    }
+
+    @Test
+    public void testSerializationOfNewExceptionReporting() throws Exception {
+        // For the bulk searches (deleteByQuery, multiSearch) the operations
+        // rely
+        // on ShardSearchFailure implementing Streamable correctly and
+        // serializing arbitrary
+        // errors
+        ShardSearchFailure sf1 = new ShardSearchFailure(new RemoteTransportException("Remote", new CustomParseException()));
+        assertTrue(sf1.hasXContent());
+        BytesStreamOutput bos = new BytesStreamOutput();
+        sf1.writeTo(bos);
+        BytesReference bytes = bos.bytes();
+        BytesStreamInput bis = new BytesStreamInput(bytes);
+        sf1.readFrom(bis);
+        XContentBuilder jb = XContentFactory.yamlBuilder();
+        assertTrue(sf1.hasXContent());
+        sf1.toXContent(jb, ToXContent.EMPTY_PARAMS);
+        jb.close();
+        String errorResponse = jb.string();
+        assertTrue("error should include message", errorResponse.contains("you have exceeded rate limits"));
+    }
+
+    @Test
+    public void testFailedMultiSearchWithWrongQuery_withFunctionScore() throws Exception {
+        assertAcked(prepareCreate("test"));
+        ensureGreen();
+
+        String badQuery1 = "{\"match_all\":{\"nonsense\":3}}";
+        String goodQuery = "{\"match_all\":{}}";
+        String badQuery2 = "{\"match_all\":{\"nonsense2\":3}}";
+
+        MultiSearchResponse response = client().prepareMultiSearch()
+                // Add custom score query with missing script
+                .add(client().prepareSearch("test").setQuery(badQuery1)).add(client().prepareSearch("test").setQuery(goodQuery))
+                .add(client().prepareSearch("test").setQuery(badQuery2)).execute().actionGet();
+        assertThat(response.getResponses().length, equalTo(3));
+        assertThat(response.getResponses()[0].getFailureMessage(), notNullValue());
+        assertThat(response.getResponses()[1].getFailureMessage(), nullValue());
+        assertThat(response.getResponses()[2].getFailureMessage(), notNullValue());
+    }
+}


### PR DESCRIPTION
Provides the line and column number in user input where errors were spotted and a succinct parse error message, free of server-side stack trace info.

Many "*parser" classes are changed but the core framework changes are:

1) XContentParser can now return a new "XContentLocation" object describing position of last token parsed
2) Existing SearchParseException and QueryParsingException classes have all constructors changed to take an XContentLocation object to encourage supply of detailed parse feedback
3) Common "UserInputException" interface introduced for exceptions relating to user input (the 2 above).
4) SearchPhaseExecutionException that gathers results from many shards holds onto only the first of several (typically duplicate) UserInputExceptions from shards
5) BytesRestResponse outputs extra JSON fields for parse failures including line, column and succinct error message.

Closes #3303
