### PR TITLE
Indices API: fixes GET Alias API backwards compatibility

### DIFF
--- a/docs/reference/indices/aliases.asciidoc
+++ b/docs/reference/indices/aliases.asciidoc
@@ -314,6 +314,9 @@ The rest endpoint is: `/{index}/_alias/{alias}`.
 
 coming[1.4.0.Beta,The API will always include an `aliases` section, even if there aren't any aliases. Previous versions would not return the `aliases` section]
 
+WARNING: For future versions of Elasticsearch, the default <<multi-index>> options will error if a requested index is unavailable. This is to bring 
+this API in line with the other indices GET APIs
+
 [float]
 ==== Examples:
 

--- a/docs/reference/migration/migrate_1_4.asciidoc
+++ b/docs/reference/migration/migrate_1_4.asciidoc
@@ -32,7 +32,7 @@ Add or update a mapping via the <<indices-create-index,create index>> or
 [float]
 === Indices APIs
 
-The <<warmer-retrieving, get warmer api>> will return a section for `warmers` even if there are
+The <<warmer-retrieving, get warmer api>> will return a section for `warmers` even if there are 
 no warmers.  This ensures that the following two examples are equivalent:
 
 [source,js]
@@ -42,7 +42,7 @@ curl -XGET 'http://localhost:9200/_all/_warmers'
 curl -XGET 'http://localhost:9200/_warmers'
 --------------------------------------------------
 
-The <<alias-retrieving, get alias api>> will return a section for `aliases` even if there are
+The <<alias-retrieving, get alias api>> will return a section for `aliases` even if there are 
 no aliases.  This ensures that the following two examples are equivalent:
 
 [source,js]
@@ -52,10 +52,7 @@ curl -XGET 'http://localhost:9200/_all/_aliases'
 curl -XGET 'http://localhost:9200/_aliases'
 --------------------------------------------------
 
-In addition, the <<alias-retrieving, get alias api>> now supports <<multi-index>> options and, by default, will
-produce an error response if a requested index does not exist.
-
-The <<indices-get-mapping, get mapping api>> will return a section for `mappings` even if there are
+The <<indices-get-mapping, get mapping api>> will return a section for `mappings` even if there are 
 no mappings.  This ensures that the following two examples are equivalent:
 
 [source,js]

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/get/RestGetIndicesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/get/RestGetIndicesAction.java
@@ -69,7 +69,10 @@ public class RestGetIndicesAction extends BaseRestHandler {
         if (features != null) {
             getIndexRequest.features(features);
         }
-        getIndexRequest.indicesOptions(IndicesOptions.fromRequest(request, getIndexRequest.indicesOptions()));
+        // The order of calls to the request is important here. We must set the indices and features before 
+        // we call getIndexRequest.indicesOptions(); or we might get the wrong default indices options
+        IndicesOptions defaultIndicesOptions = getIndexRequest.indicesOptions();
+        getIndexRequest.indicesOptions(IndicesOptions.fromRequest(request, defaultIndicesOptions));
         getIndexRequest.local(request.paramAsBoolean("local", getIndexRequest.local()));
         client.admin().indices().getIndex(getIndexRequest, new RestBuilderListener<GetIndexResponse>(channel) {
 

--- a/src/test/java/org/elasticsearch/action/admin/indices/get/GetIndexTests.java
+++ b/src/test/java/org/elasticsearch/action/admin/indices/get/GetIndexTests.java
@@ -242,6 +242,58 @@ public class GetIndexTests extends ElasticsearchIntegrationTest {
         assertEmptyWarmers(response);
     }
 
+    @Test(expected=IndexMissingException.class)
+    public void testNotFoundMapping() {
+        client().admin().indices().prepareGetIndex().addIndices("non_existent_idx").setFeatures("_mapping").get();
+    }
+
+    @Test(expected=IndexMissingException.class)
+    public void testNotFoundMappings() {
+        client().admin().indices().prepareGetIndex().addIndices("non_existent_idx").setFeatures("_mappings").get();
+    }
+
+    @Test(expected=IndexMissingException.class)
+    public void testNotFoundSettings() {
+        client().admin().indices().prepareGetIndex().addIndices("non_existent_idx").setFeatures("_settings").get();
+    }
+
+    @Test(expected=IndexMissingException.class)
+    public void testNotFoundWarmer() {
+        client().admin().indices().prepareGetIndex().addIndices("non_existent_idx").setFeatures("_warmer").get();
+    }
+
+    @Test(expected=IndexMissingException.class)
+    public void testNotFoundWarmers() {
+        client().admin().indices().prepareGetIndex().addIndices("non_existent_idx").setFeatures("_warmers").get();
+    }
+
+    @Test
+    public void testNotFoundAlias() {
+        GetIndexResponse response = client().admin().indices().prepareGetIndex().addIndices("non_existent_idx").setFeatures("_alias").get();
+        String[] indices = response.indices();
+        assertThat(indices, notNullValue());
+        assertThat(indices.length, equalTo(0));
+    }
+
+    @Test(expected=IndexMissingException.class)
+    public void testNotFoundMixedFeatures() {
+        int numFeatures = randomIntBetween(2, allFeatures.length);
+        List<String> features = new ArrayList<String>(numFeatures);
+        for (int i = 0; i < numFeatures; i++) {
+            features.add(randomFrom(allFeatures));
+        }
+        client().admin().indices().prepareGetIndex().addIndices("non_existent_idx")
+                .setFeatures(features.toArray(new String[features.size()])).get();
+    }
+
+    @Test
+    public void testNotFoundAliases() {
+        GetIndexResponse response = client().admin().indices().prepareGetIndex().addIndices("non_existent_idx").setFeatures("_aliases").get();
+        String[] indices = response.indices();
+        assertThat(indices, notNullValue());
+        assertThat(indices.length, equalTo(0));
+    }
+
     private void assertWarmers(GetIndexResponse response, String indexName) {
         ImmutableOpenMap<String, ImmutableList<Entry>> warmers = response.warmers();
         assertThat(warmers, notNullValue());


### PR DESCRIPTION
For just the case when only the aliases are requested, the default indices options are to ignore missing indexes. When requesting any other feature or any combination of features, the default will be to error on missing indices.

Closes #7793
