### PR TITLE
Update id-field.asciidoc

### DIFF
--- a/docs/reference/mapping/fields/id-field.asciidoc
+++ b/docs/reference/mapping/fields/id-field.asciidoc
@@ -11,13 +11,16 @@ using `term`, `terms` or `prefix` queries/filters (including the
 specific `ids` query/filter).
 
 The `_id` field can be enabled to be indexed, and possibly stored,
-using:
+using appropriate mapping attributes:
 
 [source,js]
 --------------------------------------------------
 {
     "tweet" : {
-        "_id" : {"index": "not_analyzed", "store" : false }
+        "_id" : {
+            "index" : "not_analyzed",
+            "store" : true
+        }
     }
 }
 --------------------------------------------------


### PR DESCRIPTION
It is strange to provide an example with `"store" : false` when talking about possibility of enabling the field to be stored.
Broke the line in the mapping in two lines for better readability.
Made a sentence above the mapping more verbose.
