### PR TITLE
add more checks to build_release.py

### DIFF
--- a/dev-tools/build_release.py
+++ b/dev-tools/build_release.py
@@ -660,7 +660,7 @@ if __name__ == '__main__':
         cherry_pick_command = ' and cherry-pick the documentation changes: \'git cherry-pick %s\' to the development branch' % (version_head_hash)
       pending_msg = """
       Release successful pending steps:
-        * create a new vX.Y.Z label on github for the next release (https://github.com/elasticsearch/elasticsearch/labels)
+        * create a new vX.Y.Z label on github for the next release, with label color #dddddd (https://github.com/elasticsearch/elasticsearch/labels)
         * publish the maven artifacts on Sonatype: https://oss.sonatype.org/index.html
            - here is a guide: https://docs.sonatype.org/display/Repository/Sonatype+OSS+Maven+Repository+Usage+Guide#SonatypeOSSMavenRepositoryUsageGuide-8a.ReleaseIt
         * check if the release is there https://oss.sonatype.org/content/repositories/releases/org/elasticsearch/elasticsearch/%(version)s


### PR DESCRIPTION
When I ran build_release.py to release 1.3.3 I noticed the git clone I
was working from had an extra "elasticsearch" subdirectory (probably I
did this earlier) and git status said "# Your branch is ahead of
'origin/1.3' by 33 commits." which is spooky.

I ran "git clean -f", and Simon suggested "git fetch origin" and sure
enough that fixed "git status" to be "clean" again.

I think the release script should check to make sure there are no
untracked files in the area, there are no uncommitted changes, you
have all changes from origin, and you don't have any unpushed changes.

(Separately we should maybe upgrade the git on the build box ... it's
1.7.9.5 now.)

I tried to make these changes to build_release.py but likely messed it
up (git is ... magical to me).

It seems like it would be best overall if the script just made a fresh
clone of the branch for release?  Seems spooky to reuse a clone from
one release to the next...

I also put in a few other cleanups that I noticed when building
1.3.3.
