### PR TITLE
Fix optimize behavior with 'force' and 'flush' flags.

### DIFF
--- a/src/main/java/org/elasticsearch/index/merge/policy/ElasticsearchMergePolicy.java
+++ b/src/main/java/org/elasticsearch/index/merge/policy/ElasticsearchMergePolicy.java
@@ -196,20 +196,22 @@ public final class ElasticsearchMergePolicy extends MergePolicy {
     public MergeSpecification findForcedMerges(SegmentInfos segmentInfos,
         int maxSegmentCount, Map<SegmentCommitInfo,Boolean> segmentsToMerge, IndexWriter writer)
         throws IOException {
-      if (force) {
-          List<SegmentCommitInfo> segments = Lists.newArrayList();
-          for (SegmentCommitInfo info : segmentInfos) {
-              if (segmentsToMerge.containsKey(info)) {
-                  segments.add(info);
-              }
-          }
-          if (!segments.isEmpty()) {
-              MergeSpecification spec = new IndexUpgraderMergeSpecification();
-              spec.add(new OneMerge(segments));
-              return spec;
-          }
-      }
-      return upgradedMergeSpecification(delegate.findForcedMerges(segmentInfos, maxSegmentCount, segmentsToMerge, writer));
+        MergeSpecification spec = delegate.findForcedMerges(segmentInfos, maxSegmentCount, segmentsToMerge, writer);
+
+        if (spec == null && force) {
+            List<SegmentCommitInfo> segments = Lists.newArrayList();
+            for (SegmentCommitInfo info : segmentInfos) {
+                if (segmentsToMerge.containsKey(info)) {
+                    segments.add(info);
+                }
+            }
+            if (!segments.isEmpty()) {
+                spec = new IndexUpgraderMergeSpecification();
+                spec.add(new OneMerge(segments));
+                return spec;
+            }
+        }
+        return upgradedMergeSpecification(spec);
     }
 
     @Override


### PR DESCRIPTION
This does the following:
- Make 'force' flag only build a merge if the delegate MP returned no merges
- Add async handling for 'flush' when 'waitForMerges' is false
- Remove flush at the beginning of optimize.  This is something the user can
  do if they wish, before calling optimize.

closes #7886
closes #7904
