### PR TITLE
Add a finalize round to multicast pinging

### DIFF
--- a/src/main/java/org/elasticsearch/discovery/zen/ping/ZenPing.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ping/ZenPing.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.discovery.zen.ping;
 
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.component.LifecycleComponent;
@@ -190,5 +189,9 @@ public interface ZenPing extends LifecycleComponent<ZenPing> {
             return pings.values().toArray(new PingResponse[pings.size()]);
         }
 
+        /** the number of nodes for which there are known pings */
+        public synchronized int size() {
+            return pings.size();
+        }
     }
 }


### PR DESCRIPTION
When sending a multicast ping, there is no way to determine how long it will take before all nodes will respond. Currently we send two pings (one at start, one after half timeout) and wait until the ping timeout has passed for all responses to come back. However, if all nodes are fast to respond, there is a relatively large gap between the moment that pings were gathered and the election that is based on them. This commits adds a last ping round (at timeout) where we know the number of nodes we expect to receive answers from. Once all nodes responded, we complete the pinging.
