### PR TITLE
Docs: Added breaking changes docs for Indices APIs

### DIFF
--- a/docs/reference/migration/migrate_1_x.asciidoc
+++ b/docs/reference/migration/migrate_1_x.asciidoc
@@ -58,9 +58,6 @@ curl -XGET 'http://localhost:9200/_all/_aliases'
 curl -XGET 'http://localhost:9200/_aliases'
 --------------------------------------------------
 
-In addition, the <<alias-retrieving, get alias api>> now supports <<multi-index>> options and, by default, will
-produce an error response if a requested index does not exist.
-
 The <<indices-get-mapping, get mapping api>> will return a section for `mappings` even if there are 
 no mappings.  This ensures that the following two examples are equivalent:
 

--- a/docs/reference/migration/migrate_2_0.asciidoc
+++ b/docs/reference/migration/migrate_2_0.asciidoc
@@ -1,0 +1,12 @@
+[[breaking-changes-2.0]]
+== Breaking changes in 2.0
+
+This section discusses the changes that you need to be aware of when migrating
+your application to Elasticsearch 2.0.
+
+=== Indices API
+
+The <<alias-retrieving, get alias api>> will, by default produce an error response 
+if a requested index does not exist. This change brings the defaults for this API in 
+line with the other Indices APIs. The <<multi-index>> options can be used on a request 
+to change this behavior


### PR DESCRIPTION
Adds the breaking changes defaults for the change of default indices options for the GET Aliases API
