### PR TITLE
Show open and closed indices in _cat/indices

### DIFF
--- a/rest-api-spec/test/cat.indices/10_basic.yaml
+++ b/rest-api-spec/test/cat.indices/10_basic.yaml
@@ -24,6 +24,7 @@
   - match:
       $body: |
                /^(green  \s+
+                  (open|close) \s+
                   index1 \s+
                   1      \s+
                   0      \s+

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
@@ -298,8 +298,8 @@ public class RestIndicesAction extends AbstractCatAction {
             IndexMetaData.State state = indexMetaData.getState();
 
             table.startRow();
-            table.addCell(state == IndexMetaData.State.OPEN ? (indexHealth == null ? "red*" : indexHealth.getStatus().toString().toLowerCase(Locale.getDefault())) : null);
-            table.addCell(state.toString().toLowerCase(Locale.getDefault()));
+            table.addCell(state == IndexMetaData.State.OPEN ? (indexHealth == null ? "red*" : indexHealth.getStatus().toString().toLowerCase(Locale.ROOT)) : null);
+            table.addCell(state.toString().toLowerCase(Locale.ROOT));
             table.addCell(index);
             table.addCell(indexHealth == null ? null : indexHealth.getNumberOfShards());
             table.addCell(indexHealth == null ? null : indexHealth.getNumberOfReplicas());

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
@@ -30,6 +30,8 @@ import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.Requests;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.Table;
 import org.elasticsearch.common.inject.Inject;
@@ -69,8 +71,9 @@ public class RestIndicesAction extends AbstractCatAction {
         client.admin().cluster().state(clusterStateRequest, new RestActionListener<ClusterStateResponse>(channel) {
             @Override
             public void processResponse(final ClusterStateResponse clusterStateResponse) {
-                final String[] concreteIndices = clusterStateResponse.getState().metaData().concreteIndices(IndicesOptions.lenientExpandOpen(), indices);
-                ClusterHealthRequest clusterHealthRequest = Requests.clusterHealthRequest(concreteIndices);
+                final String[] concreteIndices = clusterStateResponse.getState().metaData().concreteIndices(IndicesOptions.fromOptions(false, true, true, true), indices);
+                final String[] openIndices = clusterStateResponse.getState().metaData().concreteIndices(IndicesOptions.lenientExpandOpen(), indices);
+                ClusterHealthRequest clusterHealthRequest = Requests.clusterHealthRequest(openIndices);
                 clusterHealthRequest.local(request.paramAsBoolean("local", clusterHealthRequest.local()));
                 client.admin().cluster().health(clusterHealthRequest, new RestActionListener<ClusterHealthResponse>(channel) {
                     @Override
@@ -80,7 +83,7 @@ public class RestIndicesAction extends AbstractCatAction {
                         client.admin().indices().stats(indicesStatsRequest, new RestResponseListener<IndicesStatsResponse>(channel) {
                             @Override
                             public RestResponse buildResponse(IndicesStatsResponse indicesStatsResponse) throws Exception {
-                                Table tab = buildTable(request, concreteIndices, clusterHealthResponse, indicesStatsResponse);
+                                Table tab = buildTable(request, concreteIndices, clusterHealthResponse, indicesStatsResponse, clusterStateResponse.getState().metaData());
                                 return RestTable.buildResponse(tab, channel);
                             }
                         });
@@ -96,6 +99,7 @@ public class RestIndicesAction extends AbstractCatAction {
         Table table = new Table();
         table.startHeaders();
         table.addCell("health", "alias:h;desc:current health status");
+        table.addCell("status", "alias:s;desc:open/close status");
         table.addCell("index", "alias:i,idx;desc:index name");
         table.addCell("pri", "alias:p,shards.primary,shardsPrimary;text-align:right;desc:number of primary shards");
         table.addCell("rep", "alias:r,shards.replica,shardsReplica;text-align:right;desc:number of replica shards");
@@ -284,15 +288,18 @@ public class RestIndicesAction extends AbstractCatAction {
         return table;
     }
 
-    private Table buildTable(RestRequest request, String[] indices, ClusterHealthResponse health, IndicesStatsResponse stats) {
+    private Table buildTable(RestRequest request, String[] indices, ClusterHealthResponse health, IndicesStatsResponse stats, MetaData indexMetaDatas) {
         Table table = getTableWithHeader(request);
 
         for (String index : indices) {
             ClusterIndexHealth indexHealth = health.getIndices().get(index);
             IndexStats indexStats = stats.getIndices().get(index);
+            IndexMetaData indexMetaData = indexMetaDatas.getIndices().get(index);
+            IndexMetaData.State state = indexMetaData.getState();
 
             table.startRow();
-            table.addCell(indexHealth == null ? "red*" : indexHealth.getStatus().toString().toLowerCase(Locale.getDefault()));
+            table.addCell(state == IndexMetaData.State.OPEN ? (indexHealth == null ? "red*" : indexHealth.getStatus().toString().toLowerCase(Locale.getDefault())) : null);
+            table.addCell(state.toString().toLowerCase(Locale.getDefault()));
             table.addCell(index);
             table.addCell(indexHealth == null ? null : indexHealth.getNumberOfShards());
             table.addCell(indexHealth == null ? null : indexHealth.getNumberOfReplicas());


### PR DESCRIPTION
When asking for `GET /_cat/indices?v`, you can now retrieve closed indices in addition to opened ones.

```
health status index              pri rep docs.count docs.deleted store.size pri.store.size
yellow open   .marvel-2014.05.21   1   1       8792            0     21.7mb         21.7mb
       close  test
yellow open   .marvel-2014.05.22   1   1       3871            0     10.7mb         10.7mb
red    open   .marvel-2014.05.27   1   1
```

Closes #7907.
