### PR TITLE
[TEST] Make mlt rest tests pass on a single node cluster

### DIFF
--- a/rest-api-spec/test/mlt/20_docs.yaml
+++ b/rest-api-spec/test/mlt/20_docs.yaml
@@ -1,6 +1,12 @@
 ---
 "Basic mlt query with docs":
   - do:
+      indices.create:
+        index: test_1
+        body:
+          settings:
+            number_of_replicas: 0
+  - do:
       index:
           index:  test_1
           type:   test


### PR DESCRIPTION
`wait_on_status: green` otherwise times out and we need to wait for green (and not just yellow) to make sure mappings are propagated.
