### PR TITLE
Be stricter parsing ids for ids query

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/IdsQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/IdsQueryParser.java
@@ -70,11 +70,17 @@ public class IdsQueryParser implements QueryParser {
                 if ("values".equals(currentFieldName)) {
                     idsProvided = true;
                     while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
-                        BytesRef value = parser.utf8BytesOrNull();
-                        if (value == null) {
-                            throw new QueryParsingException(parseContext.index(), "No value specified for term filter");
+                        if ((token == XContentParser.Token.VALUE_STRING) ||
+                                (token == XContentParser.Token.VALUE_NUMBER)) {
+                            BytesRef value = parser.utf8BytesOrNull();
+                            if (value == null) {
+                                throw new QueryParsingException(parseContext.index(), "No value specified for term filter");
+                            }
+                            ids.add(value);
+                        } else {
+                            throw new QueryParsingException(parseContext.index(),
+                                    "Illegal value for id, expecting a string or number, got: " + token);
                         }
-                        ids.add(value);
                     }
                 } else if ("types".equals(currentFieldName) || "type".equals(currentFieldName)) {
                     types = new ArrayList<>();
@@ -125,4 +131,3 @@ public class IdsQueryParser implements QueryParser {
         return query;
     }
 }
-


### PR DESCRIPTION
Adds a check to make sure that all ids in the query are either strings
or numbers. This is to prevent the case where a user accidentally
specifies:

"ids": [["1", "2"]]

(note the double array)

With this change, an exception will be thrown since the second "[" is
not a string or number, it is a Token.START_ARRAY.

Fixes #7686
