### PR TITLE
[TEST] Fix config directory for external nodes in bwc tests

### DIFF
--- a/src/test/java/org/elasticsearch/test/ExternalNode.java
+++ b/src/test/java/org/elasticsearch/test/ExternalNode.java
@@ -128,6 +128,7 @@ final class ExternalNode implements Closeable {
         }
 
         params.add("-Des.path.home=" + new File("").getAbsolutePath());
+        params.add("-Des.path.conf=" + path + "/config");
 
         ProcessBuilder builder = new ProcessBuilder(params);
         builder.directory(path);


### PR DESCRIPTION
The logging configuration was expected in the path.home folder which is set to
target/JX
when running the bwc tests from the console.
Therefore the logger could not be initialized with error message:

[INFO] Failed to configure logging...
org.elasticsearch.ElasticsearchException: Failed to load logging configuration
        at org.elasticsearch.common.logging.log4j.LogConfigurator.resolveConfig(LogConfigurator.java:117)
        at org.elasticsearch.common.logging.log4j.LogConfigurator.configure(LogConfigurator.java:81)
        at org.elasticsearch.bootstrap.Bootstrap.setupLogging(Bootstrap.java:96)
        at org.elasticsearch.bootstrap.Bootstrap.main(Bootstrap.java:180)
        at org.elasticsearch.bootstrap.Elasticsearch.main(Elasticsearch.java:32)
Caused by: java.nio.file.NoSuchFileException: /home/britta/es/target/J0/config
        at sun.nio.fs.UnixException.translateToIOException(UnixException.java:86)
        at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:102)
        at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:107)
        at sun.nio.fs.UnixFileAttributeViews$Basic.readAttributes(UnixFileAttributeViews.java:55)
        at sun.nio.fs.UnixFileSystemProvider.readAttributes(UnixFileSystemProvider.java:144)
        at sun.nio.fs.LinuxFileSystemProvider.readAttributes(LinuxFileSystemProvider.java:97)
        at java.nio.file.Files.readAttributes(Files.java:1686)
        at java.nio.file.FileTreeWalker.walk(FileTreeWalker.java:109)
        at java.nio.file.FileTreeWalker.walk(FileTreeWalker.java:69)
        at java.nio.file.Files.walkFileTree(Files.java:2602)
        at org.elasticsearch.common.logging.log4j.LogConfigurator.resolveConfig(LogConfigurator.java:107)
        ... 4 more
log4j:WARN No appenders could be found for logger (node).
log4j:WARN Please initialize the log4j system properly.
log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.

Setting the config directory fixes this.

Logs from external nodes are still not printed properly. They are inserted to the log
whenever the stdout is printed ([WARNING] JVM J0: stdout was not empty...)
