### PR TITLE
Term(s) Query/Filter : add _index support

### DIFF
--- a/src/test/java/org/elasticsearch/index/query/TermFilterTests.java
+++ b/src/test/java/org/elasticsearch/index/query/TermFilterTests.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query;
+
+import org.junit.Test;
+
+
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.junit.Test;
+
+import java.util.concurrent.ExecutionException;
+
+import static org.hamcrest.Matchers.*;
+
+/**
+ */
+public class TermFilterTests extends TermQueryTests {
+
+    @Test
+    public void testIndexTermFilter() throws InterruptedException, ExecutionException {
+        createIndex( "test1", "test2");
+        ensureGreen( "test1", "test2");
+
+        long docsInTest1 = scaledRandomIntBetween(10,100);
+        long docsInTest2 = scaledRandomIntBetween(10,100);
+
+        indexDocsToIndex("test1", docsInTest1);
+        indexDocsToIndex("test2", docsInTest2);
+
+        {
+            SearchRequest searchRequest = new SearchRequest();
+            searchRequest.indices("_all");
+            String query = "{\"query\":\n" +
+                    "{\n" +
+                    "  \"filtered\": {\n" +
+                    "    \"query\": {\n" +
+                    "      \"match_all\": {}\n" +
+                    "    },\n" +
+                    "    \"filter\": {\n" +
+                    "      \"term\": { \"_index\": { \"value\": \"test1\" }}\n" +
+                    "    }\n" +
+                    "  }\n" +
+                    "} }";
+
+            BytesReference bytesRef = new BytesArray(query);
+            searchRequest.source(bytesRef, false);
+            SearchResponse response = client().search(searchRequest).get();
+
+            assertThat(response.getHits().totalHits(), is(docsInTest1));
+        }
+
+        {
+            SearchRequest searchRequest = new SearchRequest();
+            searchRequest.indices("_all");
+
+            String query = "{\"query\":\n" +
+                    "{\n" +
+                    "  \"filtered\": {\n" +
+                    "    \"query\": {\n" +
+                    "      \"match_all\": {}\n" +
+                    "    },\n" +
+                    "    \"filter\": {\n" +
+                    "      \"term\": { \"_index\": { \"value\": \"test2\" }}\n" +
+                    "    }\n" +
+                    "  }\n" +
+                    "} }";
+
+            BytesReference bytesRef = new BytesArray(query);
+            searchRequest.source(bytesRef, false);
+            SearchResponse response = client().search(searchRequest).get();
+
+            assertThat(response.getHits().totalHits(), is(docsInTest2));
+        }
+
+    }
+
+}

--- a/src/test/java/org/elasticsearch/index/query/TermQueryTests.java
+++ b/src/test/java/org/elasticsearch/index/query/TermQueryTests.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.index.query;
+
+import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import static org.hamcrest.Matchers.*;
+
+public class TermQueryTests extends ElasticsearchIntegrationTest{
+
+    @Test
+    public void testIndexTermQuery() throws InterruptedException, ExecutionException {
+        createIndex( "test1" , "test2");
+        ensureGreen( "test1", "test2");
+
+        long docsInTest1 = scaledRandomIntBetween(10,100);
+        long docsInTest2 = scaledRandomIntBetween(10,100);
+
+        indexDocsToIndex("test1", docsInTest1);
+        indexDocsToIndex("test2", docsInTest2);
+
+        {
+            SearchRequest searchRequest = new SearchRequest();
+            searchRequest.indices("_all");
+
+            String query = "{ \"query\" : " +
+                    "{ \"term\": " +
+                    "{ \"_index\" : " +
+                    "{\"value\" : \"test1\"} " +
+                    "} } } ";
+            BytesReference bytesRef = new BytesArray(query);
+            searchRequest.source(bytesRef, false);
+            SearchResponse response = client().search(searchRequest).get();
+
+            assertThat(response.getHits().totalHits(), is(docsInTest1));
+        }
+
+        {
+            SearchRequest searchRequest = new SearchRequest();
+            searchRequest.indices("_all");
+
+            String query = "{ \"query\" : " +
+                    "{ \"term\": " +
+                    "{ \"_index\" : " +
+                    "{\"value\" : \"test2\"} " +
+                    "} } } ";
+            BytesReference bytesRef = new BytesArray(query);
+            searchRequest.source(bytesRef, false);
+            SearchResponse response = client().search(searchRequest).get();
+
+            assertThat(response.getHits().totalHits(), is(docsInTest2));
+        }
+
+    }
+
+    protected void indexDocsToIndex(String index, long count) throws InterruptedException, ExecutionException {
+        List<IndexRequestBuilder> builders = new ArrayList<>();
+
+        for (int i = 0; i < count; ++i) {
+            builders.add(client().prepareIndex(index, "type", "" + (i + 1) ).setSource("{\"theField\":\"foo\"}"));
+        }
+
+        indexRandom(true,builders);
+    }
+}

--- a/src/test/java/org/elasticsearch/index/query/TermsFilterTest.java
+++ b/src/test/java/org/elasticsearch/index/query/TermsFilterTest.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.index.query;
+
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
+
+import java.util.concurrent.ExecutionException;
+
+import static org.hamcrest.Matchers.*;
+/**
+ */
+public class TermsFilterTest extends TermQueryTests {
+
+    public void testIndexTermsFilter() throws InterruptedException, ExecutionException {
+
+        createIndex( "test1", "test2", "test3");
+        ensureGreen( "test1", "test2", "test3");
+
+        long docsInTest1 = scaledRandomIntBetween(10,100);
+        long docsInTest2 = scaledRandomIntBetween(10,100);
+        long docsInTest3 = scaledRandomIntBetween(10,100);
+
+
+        indexDocsToIndex("test1", docsInTest1);
+        indexDocsToIndex("test2", docsInTest2);
+        indexDocsToIndex("test3", docsInTest3);
+
+
+        {
+            SearchRequest searchRequest = new SearchRequest();
+            searchRequest.indices("_all");
+            String query = "{\"query\":\n" +
+                    "{\n" +
+                    "  \"filtered\": {\n" +
+                    "    \"query\": {\n" +
+                    "      \"match_all\": {}\n" +
+                    "    },\n" +
+                    "    \"filter\": {\n" +
+                    "      \"terms\": { \"_index\": [ \"test1\" ]}\n" +
+                    "    }\n" +
+                    "  }\n" +
+                    "} }";
+
+            BytesReference bytesRef = new BytesArray(query);
+            searchRequest.source(bytesRef, false);
+            SearchResponse response = client().search(searchRequest).get();
+
+            assertThat(response.getHits().totalHits(), is(docsInTest1));
+        }
+
+        {
+            SearchRequest searchRequest = new SearchRequest();
+            searchRequest.indices("_all");
+
+            String query = "{\"query\":\n" +
+                    "{\n" +
+                    "  \"filtered\": {\n" +
+                    "    \"query\": {\n" +
+                    "      \"match_all\": {}\n" +
+                    "    },\n" +
+                    "    \"filter\": {\n" +
+                    "      \"terms\": { \"_index\": [ \"test2\" ]}\n" +
+                    "    }\n" +
+                    "  }\n" +
+                    "} }";
+
+            BytesReference bytesRef = new BytesArray(query);
+            searchRequest.source(bytesRef, false);
+            SearchResponse response = client().search(searchRequest).get();
+
+            assertThat(response.getHits().totalHits(), is(docsInTest2));
+        }
+
+        {
+            SearchRequest searchRequest = new SearchRequest();
+            searchRequest.indices("_all");
+
+            String query = "{\"query\":\n" +
+                    "{\n" +
+                    "  \"filtered\": {\n" +
+                    "    \"query\": {\n" +
+                    "      \"match_all\": {}\n" +
+                    "    },\n" +
+                    "    \"filter\": {\n" +
+                    "      \"terms\": { \"_index\": [ \"test2\", \"doesNotExist\" ]}\n" +
+                    "    }\n" +
+                    "  }\n" +
+                    "} }";
+
+            BytesReference bytesRef = new BytesArray(query);
+            searchRequest.source(bytesRef, false);
+            SearchResponse response = client().search(searchRequest).get();
+
+            assertThat(response.getHits().totalHits(), is(docsInTest2));
+        }
+
+
+        {
+            SearchRequest searchRequest = new SearchRequest();
+            searchRequest.indices("_all");
+
+            String query = "{\"query\":\n" +
+                    "{\n" +
+                    "  \"filtered\": {\n" +
+                    "    \"query\": {\n" +
+                    "      \"match_all\": {}\n" +
+                    "    },\n" +
+                    "    \"filter\": {\n" +
+                    "      \"terms\": { \"_index\": [ \"test1\", \"test2\", \"test3\"  ]}\n" +
+                    "    }\n" +
+                    "  }\n" +
+                    "} }";
+
+            BytesReference bytesRef = new BytesArray(query);
+            searchRequest.source(bytesRef, false);
+            SearchResponse response = client().search(searchRequest).get();
+
+            assertThat(response.getHits().totalHits(), is(docsInTest1 + docsInTest2 + docsInTest3));
+        }
+
+
+    }
+
+}

--- a/src/test/java/org/elasticsearch/index/query/TermsQueryTest.java
+++ b/src/test/java/org/elasticsearch/index/query/TermsQueryTest.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.index.query;
+
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.junit.Test;
+
+import java.util.concurrent.ExecutionException;
+
+import static org.hamcrest.Matchers.*;
+
+/**
+ */
+public class TermsQueryTest extends TermQueryTests {
+
+    @Test
+    public void testIndexTermsQuery() throws InterruptedException, ExecutionException {
+        createIndex( "test1", "test2", "test3");
+        ensureGreen( "test1", "test2", "test3");
+
+        long docsInTest1 = scaledRandomIntBetween(10,100);
+        long docsInTest2 = scaledRandomIntBetween(10,100);
+        long docsInTest3 = scaledRandomIntBetween(10,100);
+
+
+        indexDocsToIndex("test1", docsInTest1);
+        indexDocsToIndex("test2", docsInTest2);
+        indexDocsToIndex("test3", docsInTest3);
+
+        {
+            SearchRequest searchRequest = new SearchRequest();
+            searchRequest.indices("_all");
+
+            String query = "{ \"query\" : " +
+                    "{ \"terms\": " +
+                    "{ \"_index\" : [ \"test1\" ] " +
+                    "} } } ";
+            BytesReference bytesRef = new BytesArray(query);
+            searchRequest.source(bytesRef, false);
+            SearchResponse response = client().search(searchRequest).get();
+
+            assertThat(response.getHits().totalHits(), is(docsInTest1));
+        }
+
+        {
+            SearchRequest searchRequest = new SearchRequest();
+            searchRequest.indices("_all");
+
+            String query = "{ \"query\" : " +
+                    "{ \"terms\": " +
+                    "{ \"_index\" : [ \"test2\" ] " +
+                    "} } } ";
+
+
+            BytesReference bytesRef = new BytesArray(query);
+            searchRequest.source(bytesRef, false);
+            SearchResponse response = client().search(searchRequest).get();
+
+            assertThat(response.getHits().totalHits(), is(docsInTest2));
+        }
+
+        {
+            SearchRequest searchRequest = new SearchRequest();
+            searchRequest.indices("_all");
+
+            String query = "{ \"query\" : " +
+                    "{ \"terms\": " +
+                    "{ \"_index\" : [ \"test2\", \"doesNotExist\" ] " +
+                    "} } } ";
+
+
+            BytesReference bytesRef = new BytesArray(query);
+            searchRequest.source(bytesRef, false);
+            SearchResponse response = client().search(searchRequest).get();
+
+            assertThat(response.getHits().totalHits(), is(docsInTest2));
+        }
+
+
+        {
+            SearchRequest searchRequest = new SearchRequest();
+            searchRequest.indices("_all");
+
+            String query = "{ \"query\" : " +
+                    "{ \"terms\": " +
+                    "{ \"_index\" : [ \"test2\", \"test1\", \"test3\" ] " +
+                    "} } } ";
+
+            BytesReference bytesRef = new BytesArray(query);
+            searchRequest.source(bytesRef, false);
+            SearchResponse response = client().search(searchRequest).get();
+
+            assertThat(response.getHits().totalHits(), is(docsInTest1 + docsInTest2 + docsInTest3));
+        }
+
+    }
+
+}


### PR DESCRIPTION
This commit adds support for _index to the term query, terms query, term filter and terms filter.
All of the below queries work as expected :

```
GET /*/_search
{
  "query": {
    "term": {
    "_index": {
      "value": "reddit"
    }
  }}
}

GET /*/_search
{
  "query" :
  {
    "terms": {
      "_index": [
        "reddit2"
        ]
    }
  }
}

GET /*/_search
{
  "query":
   {
     "filtered": {
       "query": {
     "match_all": {}
       },
       "filter": {
          "terms":
          {
            "_index": [  "reddit"]
          }
       }
     }
   }
}

GET /*/_search
{"query":
   {
     "filtered": {
       "query": {
     "match_all": {}
       },
       "filter": {
     "term": { "_index": { "value": "reddit" }}
       }
     }
   } }
```

Since these are evaluated for each index (to resolve mappings) this change simply tests to see if the index is the correct one and returns a MATCH_ALL or MATCH_NO.

Closes #3316
