### PR TITLE
Tests: Improve BWC preconditions to error cleanly on major version difference.

### DIFF
--- a/src/test/java/org/elasticsearch/test/ElasticsearchBackwardsCompatIntegrationTest.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchBackwardsCompatIntegrationTest.java
@@ -34,7 +34,6 @@ import org.junit.Before;
 import org.junit.Ignore;
 
 import java.io.File;
-import java.io.FileFilter;
 import java.io.IOException;
 
 import static org.hamcrest.Matchers.is;
@@ -79,56 +78,28 @@ import static org.hamcrest.Matchers.is;
 @ElasticsearchIntegrationTest.ClusterScope(minNumDataNodes = 0, maxNumDataNodes = 2, scope = ElasticsearchIntegrationTest.Scope.SUITE, numClientNodes = 0, transportClientRatio = 0.0)
 @Ignore
 public abstract class ElasticsearchBackwardsCompatIntegrationTest extends ElasticsearchIntegrationTest {
-    
-    protected static Version bwcVersion;
 
     private static File backwardsCompatibilityPath() {
         String path = System.getProperty(TESTS_BACKWARDS_COMPATIBILITY_PATH);
         if (path == null || path.isEmpty()) {
             throw new IllegalArgumentException("Invalid Backwards tests location path:" + path);
         }
-        File dir = new File(path);
-        if (!dir.isDirectory() || !dir.exists()) {
-            throw new IllegalArgumentException("Backwards tests must exist and be a directory: " + path);
-        }
-        return dir;
-    }
-    
-    private static Version backwardsCompatibilityVersion(File bwcDir) {
         String version = System.getProperty(TESTS_BACKWARDS_COMPATIBILITY_VERSION);
-
         if (version == null || version.isEmpty()) {
-            // choose a random version
-            // TODO: how can we put the version selected in the repeat test command?
-            File[] subdirs = bwcDir.listFiles(new FileFilter() {
-                @Override
-                public boolean accept(File file) {
-                    return file.getName().startsWith("elasticsearch-") && file.isDirectory();
-                }
-            });
-            if (subdirs == null || subdirs.length == 0) {
-                throw new IllegalArgumentException("Backwards dir does not contain any elasticsearch releases: " + bwcDir.getPath());
-            }
-            version = subdirs[randomInt(subdirs.length - 1)].getName().substring("elasticsearch-".length());
-        } else {
-            File dir = new File(bwcDir, "elasticsearch-" + version);
-            if (!dir.exists()) {
-                throw new IllegalArgumentException("Backwards tests location is missing: " + dir.getAbsolutePath());
-            }
-            if (!dir.isDirectory()) {
-                throw new IllegalArgumentException("Backwards tests location is not a directory: " + dir.getAbsolutePath());
-            }
+            throw new IllegalArgumentException("Invalid Backwards tests version:" + version);
         }
-        
-        Version v = Version.fromString(version);
-        if (v == null) {
-            throw new IllegalArgumentException("Backcompat elasticsearch version could not be parsed: " + version);
-        }
-        if (v.major != Version.CURRENT.major) {
+        if (Version.fromString(version).before(Version.CURRENT.minimumCompatibilityVersion())) {
             throw new IllegalArgumentException("Backcompat elasticsearch version must be same major version as current. " +
-                                               "backcompat: " + version + ", current: " + Version.CURRENT.toString());
+                "backcompat: " + version + ", current: " + Version.CURRENT.toString());
         }
-        return v;
+        File file = new File(path, "elasticsearch-" + version);
+        if (!file.exists()) {
+            throw new IllegalArgumentException("Backwards tests location is missing: " + file.getAbsolutePath());
+        }
+        if (!file.isDirectory()) {
+            throw new IllegalArgumentException("Backwards tests location is not a directory: " + file.getAbsolutePath());
+        }
+        return file;
     }
 
     public CompositeTestCluster backwardsCluster() {
@@ -137,10 +108,7 @@ public abstract class ElasticsearchBackwardsCompatIntegrationTest extends Elasti
 
     protected TestCluster buildTestCluster(Scope scope) throws IOException {
         TestCluster cluster = super.buildTestCluster(scope);
-        File bwcDir = backwardsCompatibilityPath();
-        bwcVersion = backwardsCompatibilityVersion(bwcDir);
-        File oldVersionDir = new File(bwcDir, "elasticsearch-" + bwcVersion.toString());
-        ExternalNode externalNode = new ExternalNode(oldVersionDir, randomLong(), new SettingsSource() {
+        ExternalNode externalNode = new ExternalNode(backwardsCompatibilityPath(), randomLong(), new SettingsSource() {
             @Override
             public Settings node(int nodeOrdinal) {
                 return externalNodeSettings(nodeOrdinal);


### PR DESCRIPTION
This change makes running a BWC test on master against a 1.x version produce the following exception:

`java.lang.IllegalArgumentException: Backcompat elasticsearch version must be same major version as current. backcompat: 1.3.2, current: 2.0.0-SNAPSHOT`

It also fixes the @after cleanup to not throw an NPE if there was an error before the cluster was created (which is the case with this error). And finally it makes the backcompat version available (I needed this recently in the analysis bwc tests given a behavior change in lucene that needed to be worked around).
