### PR TITLE
Don't let `took` be negative.

### DIFF
--- a/src/main/java/org/elasticsearch/action/search/type/AbstractAsyncAction.java
+++ b/src/main/java/org/elasticsearch/action/search/type/AbstractAsyncAction.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.search.type;
+
+/**
+ * Base implementation for an async action.
+ */
+public class AbstractAsyncAction {
+
+    private final long startTime;
+
+    protected AbstractAsyncAction() {
+        this.startTime = System.currentTimeMillis();
+    }
+
+    /**
+     * Return the time when the action started.
+     */
+    protected final long startTime() {
+        return startTime;
+    }
+
+    /**
+     * Builds how long it took to execute the search.
+     */
+    protected final long buildTookInMillis() {
+        // protect ourselves against time going backwards
+        // negative values don't make sense and we want to be able to serialize that thing as a vLong
+        return Math.max(1, System.currentTimeMillis() - startTime);
+    }
+
+}

--- a/src/main/java/org/elasticsearch/action/search/type/TransportSearchScrollQueryAndFetchAction.java
+++ b/src/main/java/org/elasticsearch/action/search/type/TransportSearchScrollQueryAndFetchAction.java
@@ -64,7 +64,7 @@ public class TransportSearchScrollQueryAndFetchAction extends AbstractComponent 
         new AsyncAction(request, scrollId, listener).start();
     }
 
-    private class AsyncAction {
+    private class AsyncAction extends AbstractAsyncAction {
 
         private final SearchScrollRequest request;
         private volatile boolean useSlowScroll;
@@ -80,8 +80,6 @@ public class TransportSearchScrollQueryAndFetchAction extends AbstractComponent 
 
         private final AtomicInteger successfulOps;
         private final AtomicInteger counter;
-
-        private final long startTime = System.currentTimeMillis();
 
         private AsyncAction(SearchScrollRequest request, ParsedScrollId scrollId, ActionListener<SearchResponse> listener) {
             this.request = request;
@@ -205,7 +203,7 @@ public class TransportSearchScrollQueryAndFetchAction extends AbstractComponent 
                 scrollId = request.scrollId();
             }
             listener.onResponse(new SearchResponse(internalResponse, scrollId, this.scrollId.getContext().length, successfulOps.get(),
-                    System.currentTimeMillis() - startTime, buildShardFailures()));
+                    buildTookInMillis(), buildShardFailures()));
         }
     }
 }

--- a/src/main/java/org/elasticsearch/action/search/type/TransportSearchScrollQueryThenFetchAction.java
+++ b/src/main/java/org/elasticsearch/action/search/type/TransportSearchScrollQueryThenFetchAction.java
@@ -34,8 +34,8 @@ import org.elasticsearch.common.util.concurrent.AtomicArray;
 import org.elasticsearch.search.action.SearchServiceListener;
 import org.elasticsearch.search.action.SearchServiceTransportAction;
 import org.elasticsearch.search.controller.SearchPhaseController;
-import org.elasticsearch.search.fetch.ShardFetchRequest;
 import org.elasticsearch.search.fetch.FetchSearchResult;
+import org.elasticsearch.search.fetch.ShardFetchRequest;
 import org.elasticsearch.search.internal.InternalScrollSearchRequest;
 import org.elasticsearch.search.internal.InternalSearchResponse;
 import org.elasticsearch.search.query.QuerySearchResult;
@@ -67,7 +67,7 @@ public class TransportSearchScrollQueryThenFetchAction extends AbstractComponent
         new AsyncAction(request, scrollId, listener).start();
     }
 
-    private class AsyncAction {
+    private class AsyncAction extends AbstractAsyncAction {
 
         private final SearchScrollRequest request;
 
@@ -84,8 +84,6 @@ public class TransportSearchScrollQueryThenFetchAction extends AbstractComponent
         private volatile ScoreDoc[] sortedShardList;
 
         private final AtomicInteger successfulOps;
-
-        private final long startTime = System.currentTimeMillis();
 
         private volatile boolean useSlowScroll;
 
@@ -258,7 +256,7 @@ public class TransportSearchScrollQueryThenFetchAction extends AbstractComponent
                 scrollId = request.scrollId();
             }
             listener.onResponse(new SearchResponse(internalResponse, scrollId, this.scrollId.getContext().length, successfulOps.get(),
-                    System.currentTimeMillis() - startTime, buildShardFailures()));
+                    buildTookInMillis(), buildShardFailures()));
         }
     }
 }

--- a/src/main/java/org/elasticsearch/action/search/type/TransportSearchScrollScanAction.java
+++ b/src/main/java/org/elasticsearch/action/search/type/TransportSearchScrollScanAction.java
@@ -68,7 +68,7 @@ public class TransportSearchScrollScanAction extends AbstractComponent {
         new AsyncAction(request, scrollId, listener).start();
     }
 
-    private class AsyncAction {
+    private class AsyncAction extends AbstractAsyncAction {
 
         private final SearchScrollRequest request;
 
@@ -83,7 +83,6 @@ public class TransportSearchScrollScanAction extends AbstractComponent {
 
         private final AtomicInteger successfulOps;
         private final AtomicInteger counter;
-        private final long startTime = System.currentTimeMillis();
 
         private AsyncAction(SearchScrollRequest request, ParsedScrollId scrollId, ActionListener<SearchResponse> listener) {
             this.request = request;
@@ -227,7 +226,7 @@ public class TransportSearchScrollScanAction extends AbstractComponent {
                 scrollId = TransportSearchHelper.buildScrollId(this.scrollId.getType(), queryFetchResults, this.scrollId.getAttributes()); // continue moving the total_hits
             }
             listener.onResponse(new SearchResponse(internalResponse, scrollId, this.scrollId.getContext().length, successfulOps.get(),
-                    System.currentTimeMillis() - startTime, buildShardFailures()));
+                    buildTookInMillis(), buildShardFailures()));
         }
     }
 }


### PR DESCRIPTION
`took` is computed based on the system clock and can be negative if the clock
time was updated during the execution of the search request. This commit
protects against these cases by replacing `took` with 1 if the elapsed time is
negative.
