### PR TITLE
Makes script params consistent with other APIs in scripted_metric

### DIFF
--- a/docs/reference/search/aggregations/metrics/scripted-metric-aggregation.asciidoc
+++ b/docs/reference/search/aggregations/metrics/scripted-metric-aggregation.asciidoc
@@ -227,5 +227,12 @@ params::           Optional. An object whose contents will be passed as variable
 reduce_params::    Optional. An object whose contents will be passed as variables to the `reduce_script`. This can be useful to allow the user to control 
                    the behavior of the reduce phase. If this is not specified the variable will be undefined in the reduce_script execution.
 lang::             Optional. The script language used for the scripts. If this is not specified the default scripting language is used.
-script_type::      Optional. The type of script provided.  This can be `inline`, `file` or `indexed`.  The default is `inline`.
+init_script_file:: Optional. Can be used in place of the `init_script` parameter to provide the script using in a file.
+init_script_id:: Optional. Can be used in place of the `init_script` parameter to provide the script using an indexed script.
+map_script_file:: Optional. Can be used in place of the `map_script` parameter to provide the script using in a file.
+map_script_id:: Optional. Can be used in place of the `map_script` parameter to provide the script using an indexed script.
+combine_script_file:: Optional. Can be used in place of the `combine_script` parameter to provide the script using in a file.
+combine_script_id:: Optional. Can be used in place of the `combine_script` parameter to provide the script using an indexed script.
+reduce_script_file:: Optional. Can be used in place of the `reduce_script` parameter to provide the script using in a file.
+reduce_script_id:: Optional. Can be used in place of the `reduce_script` parameter to provide the script using an indexed script.
 

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/scripted/ScriptedMetricBuilder.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/scripted/ScriptedMetricBuilder.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.search.aggregations.metrics.scripted;
 
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.script.ScriptService.ScriptType;
 import org.elasticsearch.search.aggregations.metrics.MetricsAggregationBuilder;
 
 import java.io.IOException;
@@ -33,11 +32,18 @@ public class ScriptedMetricBuilder extends MetricsAggregationBuilder {
 
     private Map<String, Object> params = null;
     private Map<String, Object> reduceParams = null;
-    private ScriptType scriptType = null;
     private String initScript = null;
     private String mapScript = null;
     private String combineScript = null;
     private String reduceScript = null;
+    private String initScriptFile = null;
+    private String mapScriptFile = null;
+    private String combineScriptFile = null;
+    private String reduceScriptFile = null;
+    private String initScriptId = null;
+    private String mapScriptId = null;
+    private String combineScriptId = null;
+    private String reduceScriptId = null;
     private String lang = null;
 
     /**
@@ -97,18 +103,74 @@ public class ScriptedMetricBuilder extends MetricsAggregationBuilder {
     }
 
     /**
-     * Set the script language.
+     * Set the <tt>init</tt> script file.
      */
-    public ScriptedMetricBuilder lang(String lang) {
-        this.lang = lang;
+    public ScriptedMetricBuilder initScriptFile(String initScriptFile) {
+        this.initScriptFile = initScriptFile;
         return this;
     }
 
     /**
-     * Set the script type.
+     * Set the <tt>map</tt> script file.
      */
-    public ScriptedMetricBuilder scriptType(ScriptType scriptType) {
-        this.scriptType = scriptType;
+    public ScriptedMetricBuilder mapScriptFile(String mapScriptFile) {
+        this.mapScriptFile = mapScriptFile;
+        return this;
+    }
+
+    /**
+     * Set the <tt>combine</tt> script file.
+     */
+    public ScriptedMetricBuilder combineScriptFile(String combineScriptFile) {
+        this.combineScriptFile = combineScriptFile;
+        return this;
+    }
+
+    /**
+     * Set the <tt>reduce</tt> script file.
+     */
+    public ScriptedMetricBuilder reduceScriptFile(String reduceScriptFile) {
+        this.reduceScriptFile = reduceScriptFile;
+        return this;
+    }
+
+    /**
+     * Set the indexed <tt>init</tt> script id.
+     */
+    public ScriptedMetricBuilder initScriptId(String initScriptId) {
+        this.initScriptId = initScriptId;
+        return this;
+    }
+
+    /**
+     * Set the indexed <tt>map</tt> script id.
+     */
+    public ScriptedMetricBuilder mapScriptId(String mapScriptId) {
+        this.mapScriptId = mapScriptId;
+        return this;
+    }
+
+    /**
+     * Set the indexed <tt>combine</tt> script id.
+     */
+    public ScriptedMetricBuilder combineScriptId(String combineScriptId) {
+        this.combineScriptId = combineScriptId;
+        return this;
+    }
+
+    /**
+     * Set the indexed <tt>reduce</tt> script id.
+     */
+    public ScriptedMetricBuilder reduceScriptId(String reduceScriptId) {
+        this.reduceScriptId = reduceScriptId;
+        return this;
+    }
+
+    /**
+     * Set the script language.
+     */
+    public ScriptedMetricBuilder lang(String lang) {
+        this.lang = lang;
         return this;
     }
 
@@ -140,12 +202,40 @@ public class ScriptedMetricBuilder extends MetricsAggregationBuilder {
             builder.field(ScriptedMetricParser.REDUCE_SCRIPT_FIELD.getPreferredName(), reduceScript);
         }
         
-        if (lang != null) {
-            builder.field(ScriptedMetricParser.LANG_FIELD.getPreferredName(), lang);
+        if (initScriptFile != null) {
+            builder.field(ScriptedMetricParser.INIT_SCRIPT_FILE_FIELD.getPreferredName(), initScriptFile);
         }
         
-        if (scriptType != null) {
-            builder.field(ScriptedMetricParser.SCRIPT_TYPE_FIELD.getPreferredName(), scriptType.name());
+        if (mapScriptFile != null) {
+            builder.field(ScriptedMetricParser.MAP_SCRIPT_FILE_FIELD.getPreferredName(), mapScriptFile);
+        }
+        
+        if (combineScriptFile != null) {
+            builder.field(ScriptedMetricParser.COMBINE_SCRIPT_FILE_FIELD.getPreferredName(), combineScriptFile);
+        }
+        
+        if (reduceScriptFile != null) {
+            builder.field(ScriptedMetricParser.REDUCE_SCRIPT_FILE_FIELD.getPreferredName(), reduceScriptFile);
+        }
+        
+        if (initScriptId != null) {
+            builder.field(ScriptedMetricParser.INIT_SCRIPT_ID_FIELD.getPreferredName(), initScriptId);
+        }
+        
+        if (mapScriptId != null) {
+            builder.field(ScriptedMetricParser.MAP_SCRIPT_ID_FIELD.getPreferredName(), mapScriptId);
+        }
+        
+        if (combineScriptId != null) {
+            builder.field(ScriptedMetricParser.COMBINE_SCRIPT_ID_FIELD.getPreferredName(), combineScriptId);
+        }
+        
+        if (reduceScriptId != null) {
+            builder.field(ScriptedMetricParser.REDUCE_SCRIPT_ID_FIELD.getPreferredName(), reduceScriptId);
+        }
+        
+        if (lang != null) {
+            builder.field(ScriptedMetricParser.LANG_FIELD.getPreferredName(), lang);
         }
     }
 

--- a/src/test/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricTests.java
@@ -24,7 +24,6 @@ import org.elasticsearch.action.indexedscripts.put.PutIndexedScriptResponse;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.script.ScriptService.ScriptType;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.metrics.scripted.ScriptedMetric;
@@ -508,8 +507,8 @@ public class ScriptedMetricTests extends ElasticsearchIntegrationTest {
                 .prepareSearch("idx")
                 .setQuery(matchAllQuery())
                 .addAggregation(
-                        scriptedMetric("scripted").params(params).scriptType(ScriptType.INDEXED).initScript("initScript_indexed")
-                                .mapScript("mapScript_indexed").combineScript("combineScript_indexed").reduceScript("reduceScript_indexed"))
+                        scriptedMetric("scripted").params(params).initScriptId("initScript_indexed")
+                                .mapScriptId("mapScript_indexed").combineScriptId("combineScript_indexed").reduceScriptId("reduceScript_indexed"))
                 .execute().actionGet();
         assertSearchResponse(response);
         assertThat(response.getHits().getTotalHits(), equalTo(numDocs));
@@ -542,9 +541,8 @@ public class ScriptedMetricTests extends ElasticsearchIntegrationTest {
                 .prepareSearch("idx")
                 .setQuery(matchAllQuery())
                 .addAggregation(
-                        scriptedMetric("scripted").params(params).scriptType(ScriptType.FILE).initScript("init_script")
-                                .mapScript("map_script").combineScript("combine_script").reduceScript("reduce_script"))
-                .execute().actionGet();
+                        scriptedMetric("scripted").params(params).initScriptFile("init_script").mapScriptFile("map_script")
+                                .combineScriptFile("combine_script").reduceScriptFile("reduce_script")).execute().actionGet();
         assertSearchResponse(response);
         assertThat(response.getHits().getTotalHits(), equalTo(numDocs));
 


### PR DESCRIPTION
This change removes the script_type parameter form the Scripted Metric Aggregation and adds support for _file and _id suffixes to the init_script, map_script, combine_script and reduce_script parameters to make defining the source of the script consistent with the other APIs which use the ScriptService
