### PR TITLE
Aliases: Throw exception if index is null when creating alias

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequest.java
@@ -306,6 +306,9 @@ public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesReq
                                 + "]: [index] may not be empty string", validationException);
                     }
                 }
+            } else {
+                validationException = addValidationError("Alias action [" + aliasAction.actionType().name().toLowerCase(Locale.ENGLISH)
+                        + "]: [index] may not be null", validationException);
             }
         }
         return validationException;

--- a/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequest.java
@@ -294,10 +294,6 @@ public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesReq
                                 + "]: [alias] may not be empty string", validationException);
                     }
                 }
-                if (CollectionUtils.isEmpty(aliasAction.indices)) {
-                    validationException = addValidationError("Alias action [" + aliasAction.actionType().name().toLowerCase(Locale.ENGLISH)
-                            + "]: indices may not be empty", validationException);
-                }
             }
             if (!CollectionUtils.isEmpty(aliasAction.indices)) {
                 for (String index : aliasAction.indices) {

--- a/src/test/java/org/elasticsearch/aliases/IndexAliasesTests.java
+++ b/src/test/java/org/elasticsearch/aliases/IndexAliasesTests.java
@@ -744,9 +744,31 @@ public class IndexAliasesTests extends ElasticsearchIntegrationTest {
         assertThat(existsResponse.exists(), equalTo(false));
     }
 
-    @Test(expected = IndexMissingException.class)
-    public void testAddAliasNullIndex() {
-        admin().indices().prepareAliases().addAliasAction(AliasAction.newAddAliasAction(null, "alias1")).get();
+    @Test
+    public void testAddAliasNullWithoutExistingIndices() {
+        try {
+            assertAcked(admin().indices().prepareAliases().addAliasAction(AliasAction.newAddAliasAction(null, "alias1")));
+            fail("create alias should have failed due to null index");
+        } catch (ElasticsearchIllegalArgumentException e) {
+            assertThat(e.getMessage(), equalTo("Validation Failed: 1: Alias action [add]: [index] may not be null;"));
+        }
+
+    }
+
+    @Test
+    public void testAddAliasNullWithExistingIndices() throws Exception {
+        logger.info("--> creating index [test]");
+        createIndex("test");
+        ensureGreen();
+
+        logger.info("--> aliasing index [null] with [empty-alias]");
+
+        try {
+            assertAcked(admin().indices().prepareAliases().addAlias((String) null, "empty-alias"));
+            fail("create alias should have failed due to null index");
+        } catch (ElasticsearchIllegalArgumentException e) {
+            assertThat(e.getMessage(), equalTo("Validation Failed: 1: Alias action [add]: [index] may not be null;"));
+        }
     }
 
     @Test(expected = ActionRequestValidationException.class)
@@ -771,7 +793,7 @@ public class IndexAliasesTests extends ElasticsearchIntegrationTest {
             assertTrue("Should throw " + ActionRequestValidationException.class.getSimpleName(), false);
         } catch (ActionRequestValidationException e) {
             assertThat(e.validationErrors(), notNullValue());
-            assertThat(e.validationErrors().size(), equalTo(1));
+            assertThat(e.validationErrors().size(), equalTo(2));
         }
     }
 
@@ -927,22 +949,6 @@ public class IndexAliasesTests extends ElasticsearchIntegrationTest {
         client().admin().indices().prepareAliases()
                 .addAlias("test", "a", FilterBuilders.matchAllFilter()) // <-- no fail, b/c no field mentioned
                 .get();
-    }
-
-    @Test
-    public void testNullIndexOnAlias() throws Exception {
-        logger.info("--> creating index [test]");
-        createIndex("test");
-        ensureGreen();
-
-        logger.info("--> aliasing index [null] with [empty-alias]");
-
-        try {
-            assertAcked(admin().indices().prepareAliases().addAlias((String) null, "empty-alias"));
-            fail("create alias should have failed due to null index");
-        } catch (ElasticsearchIllegalArgumentException e) {
-            assertThat(e.getMessage(), equalTo("Validation Failed: 1: Alias action [add]: [index] may not be null;"));
-        }
     }
     
     private void checkAliases() {

--- a/src/test/java/org/elasticsearch/aliases/IndexAliasesTests.java
+++ b/src/test/java/org/elasticsearch/aliases/IndexAliasesTests.java
@@ -929,6 +929,22 @@ public class IndexAliasesTests extends ElasticsearchIntegrationTest {
                 .get();
     }
 
+    @Test
+    public void testNullIndexOnAlias() throws Exception {
+        logger.info("--> creating index [test]");
+        createIndex("test");
+        ensureGreen();
+
+        logger.info("--> aliasing index [null] with [empty-alias]");
+
+        try {
+            assertAcked(admin().indices().prepareAliases().addAlias((String) null, "empty-alias"));
+            fail("create alias should have failed due to null index");
+        } catch (ElasticsearchIllegalArgumentException e) {
+            assertThat(e.getMessage(), equalTo("Validation Failed: 1: Alias action [add]: [index] may not be null;"));
+        }
+    }
+    
     private void checkAliases() {
         GetAliasesResponse getAliasesResponse = admin().indices().prepareGetAliases("alias1").get();
         assertThat(getAliasesResponse.getAliases().get("test").size(), equalTo(1));


### PR DESCRIPTION
Fixes a bug where alias creation would allow `null` for index name, which thereby applied the alias to _all_ indices.  This patch makes the validator throw an exception if the index is null.

Fixes #7863

``` bash
POST /_aliases
{
   "actions": [
      {
         "add": {
            "alias": "empty-alias",
            "index": null
         }
      }
   ]
}
```

``` json
{
   "error": "ActionRequestValidationException[Validation Failed: 1: Alias action [add]: [index] may not be null;]",
   "status": 400
}
```

Edit:

The reason this bug wasn't caught by the existing tests is because the old test for nullness only validated against a cluster which had zero indices.  The null index is translated into "_all", and since there are no indices, this fails because the index doesn't exist.  So the test passes.

However, as soon as you add an index, "_all" resolves and you get the situation described in the original bug report:  null index is accepted by the alias, resolves to "_all" and gets applied to everything.
