### PR TITLE
Throw exception if null_value is set to `null`

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/core/BooleanFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/BooleanFieldMapper.java
@@ -111,6 +111,9 @@ public class BooleanFieldMapper extends AbstractFieldMapper<Boolean> {
                 String propName = Strings.toUnderscoreCase(entry.getKey());
                 Object propNode = entry.getValue();
                 if (propName.equals("null_value")) {
+                    if (propNode == null) {
+                        throw new MapperParsingException("Property [null_value] cannot be null.");
+                    }
                     builder.nullValue(nodeBooleanValue(propNode));
                 }
             }

--- a/src/main/java/org/elasticsearch/index/mapper/core/ByteFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/ByteFieldMapper.java
@@ -108,6 +108,9 @@ public class ByteFieldMapper extends NumberFieldMapper<Byte> {
                 String propName = Strings.toUnderscoreCase(entry.getKey());
                 Object propNode = entry.getValue();
                 if (propName.equals("null_value")) {
+                    if (propNode == null) {
+                        throw new MapperParsingException("Property [null_value] cannot be null.");
+                    }
                     builder.nullValue(nodeByteValue(propNode));
                 }
             }

--- a/src/main/java/org/elasticsearch/index/mapper/core/DateFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/DateFieldMapper.java
@@ -152,6 +152,9 @@ public class DateFieldMapper extends NumberFieldMapper<Long> {
                 String propName = Strings.toUnderscoreCase(entry.getKey());
                 Object propNode = entry.getValue();
                 if (propName.equals("null_value")) {
+                    if (propNode == null) {
+                        throw new MapperParsingException("Property [null_value] cannot be null.");
+                    }
                     builder.nullValue(propNode.toString());
                 } else if (propName.equals("format")) {
                     builder.dateTimeFormatter(parseDateTimeFormatter(propNode));

--- a/src/main/java/org/elasticsearch/index/mapper/core/DoubleFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/DoubleFieldMapper.java
@@ -111,6 +111,9 @@ public class DoubleFieldMapper extends NumberFieldMapper<Double> {
                 String propName = entry.getKey();
                 Object propNode = entry.getValue();
                 if (propName.equals("nullValue") || propName.equals("null_value")) {
+                    if (propNode == null) {
+                        throw new MapperParsingException("Property [null_value] cannot be null.");
+                    }
                     builder.nullValue(nodeDoubleValue(propNode));
                 }
             }

--- a/src/main/java/org/elasticsearch/index/mapper/core/FloatFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/FloatFieldMapper.java
@@ -112,6 +112,9 @@ public class FloatFieldMapper extends NumberFieldMapper<Float> {
                 String propName = Strings.toUnderscoreCase(entry.getKey());
                 Object propNode = entry.getValue();
                 if (propName.equals("null_value")) {
+                    if (propNode == null) {
+                        throw new MapperParsingException("Property [null_value] cannot be null.");
+                    }
                     builder.nullValue(nodeFloatValue(propNode));
                 }
             }

--- a/src/main/java/org/elasticsearch/index/mapper/core/IntegerFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/IntegerFieldMapper.java
@@ -108,6 +108,9 @@ public class IntegerFieldMapper extends NumberFieldMapper<Integer> {
                 String propName = Strings.toUnderscoreCase(entry.getKey());
                 Object propNode = entry.getValue();
                 if (propName.equals("null_value")) {
+                    if (propNode == null) {
+                        throw new MapperParsingException("Property [null_value] cannot be null.");
+                    }
                     builder.nullValue(nodeIntegerValue(propNode));
                 }
             }

--- a/src/main/java/org/elasticsearch/index/mapper/core/LongFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/LongFieldMapper.java
@@ -108,6 +108,9 @@ public class LongFieldMapper extends NumberFieldMapper<Long> {
                 String propName = Strings.toUnderscoreCase(entry.getKey());
                 Object propNode = entry.getValue();
                 if (propName.equals("null_value")) {
+                    if (propNode == null) {
+                        throw new MapperParsingException("Property [null_value] cannot be null.");
+                    }
                     builder.nullValue(nodeLongValue(propNode));
                 }
             }

--- a/src/main/java/org/elasticsearch/index/mapper/core/ShortFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/ShortFieldMapper.java
@@ -110,6 +110,9 @@ public class ShortFieldMapper extends NumberFieldMapper<Short> {
                 String propName = Strings.toUnderscoreCase(entry.getKey());
                 Object propNode = entry.getValue();
                 if (propName.equals("null_value")) {
+                    if (propNode == null) {
+                        throw new MapperParsingException("Property [null_value] cannot be null.");
+                    }
                     builder.nullValue(nodeShortValue(propNode));
                 }
             }

--- a/src/main/java/org/elasticsearch/index/mapper/core/StringFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/StringFieldMapper.java
@@ -155,6 +155,9 @@ public class StringFieldMapper extends AbstractFieldMapper<String> implements Al
                 String propName = Strings.toUnderscoreCase(entry.getKey());
                 Object propNode = entry.getValue();
                 if (propName.equals("null_value")) {
+                    if (propNode == null) {
+                        throw new MapperParsingException("Property [null_value] cannot be null.");
+                    }
                     builder.nullValue(propNode.toString());
                 } else if (propName.equals("search_quote_analyzer")) {
                     NamedAnalyzer analyzer = parserContext.analysisService().analyzer(propNode.toString());

--- a/src/main/java/org/elasticsearch/index/mapper/ip/IpFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/ip/IpFieldMapper.java
@@ -143,6 +143,9 @@ public class IpFieldMapper extends NumberFieldMapper<Long> {
                 String propName = Strings.toUnderscoreCase(entry.getKey());
                 Object propNode = entry.getValue();
                 if (propName.equals("null_value")) {
+                    if (propNode == null) {
+                        throw new MapperParsingException("Property [null_value] cannot be null.");
+                    }
                     builder.nullValue(propNode.toString());
                 }
             }

--- a/src/test/java/org/elasticsearch/index/mapper/null_value/NullValueTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/null_value/NullValueTests.java
@@ -1,0 +1,65 @@
+package org.elasticsearch.index.mapper.null_value;
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.index.mapper.MapperParsingException;
+import org.elasticsearch.index.service.IndexService;
+import org.elasticsearch.test.ElasticsearchSingleNodeTest;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.*;
+
+/**
+ */
+public class NullValueTests extends ElasticsearchSingleNodeTest {
+
+    @Test
+    public void testNullNull_Value() throws Exception {
+        IndexService indexService = createIndex("test", ImmutableSettings.settingsBuilder().build());
+        String[] typesToTest = {"integer", "long", "double", "float", "short", "date", "ip", "string", "boolean", "byte"};
+
+        for (String type : typesToTest) {
+            String mapping = XContentFactory.jsonBuilder()
+                    .startObject()
+                        .startObject("type")
+                            .startObject("properties")
+                                .startObject("numeric")
+                                    .field("type", type)
+                                    .field("null_value", (String) null)
+                                .endObject()
+                            .endObject()
+                        .endObject()
+                    .endObject().string();
+
+            try {
+                indexService.mapperService().documentMapperParser().parse(mapping);
+                fail("Test should have failed because [null_value] was null.");
+            } catch (MapperParsingException e) {
+                assertThat(e.getMessage(), equalTo("Property [null_value] cannot be null."));
+            }
+
+        }
+
+
+    }
+}


### PR DESCRIPTION
The mapping parser should throw an exception if "null_value" is set to `null`.  

Fixes #7273

``` bash
PUT /foo
{
  "mappings": {
    "bar": {
      "properties": {
        "exception": {
          "null_value": null,
          "type": "integer"
        }
      }
    }
  }
}
```

```
{
   "error": "MapperParsingException[mapping [bar]]; nested: MapperParsingException[Property [null_value] cannot be null.]; ",
   "status": 400
}
```

As a side note, looks like there are a lot of other properties which could be set to null and throw similar errors:  https://github.com/elasticsearch/elasticsearch/blob/master/src/main/java/org/elasticsearch/index/mapper/core/TypeParsers.java#L146-L187

I'm not sure the best way to handle these other than an explicit check for nullness inside each clause...which seems gross.
