### PR TITLE
Change IndexPrimaryShardNotAllocatedException from 409 to 500

### DIFF
--- a/src/main/java/org/elasticsearch/indices/IndexPrimaryShardNotAllocatedException.java
+++ b/src/main/java/org/elasticsearch/indices/IndexPrimaryShardNotAllocatedException.java
@@ -35,6 +35,6 @@ public class IndexPrimaryShardNotAllocatedException extends IndexException {
 
     @Override
     public RestStatus status() {
-        return RestStatus.CONFLICT;
+        return RestStatus.INTERNAL_SERVER_ERROR;
     }
 }


### PR DESCRIPTION
Closes #7632

Change IndexPrimaryShardNotAllocatedException from 409 (RestStatus.CONFLICT) to 500 (RestStatus.INTERNAL_SERVER_ERROR)
