### PR TITLE
Remove MasterFaultDetection.Listener.notListedOnMaster

### DIFF
--- a/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -1161,17 +1161,6 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
         public void onMasterFailure(DiscoveryNode masterNode, String reason) {
             handleMasterGone(masterNode, reason);
         }
-
-        @Override
-        public void notListedOnMaster() {
-            // got disconnected from the master, send a join request
-            DiscoveryNodes nodes = nodes();
-            try {
-                membership.sendJoinRequest(nodes.masterNode(), nodes.localNode());
-            } catch (Exception e) {
-                logger.warn("failed to send join request on disconnection from master [{}]", nodes.masterNode());
-            }
-        }
     }
 
     boolean isRejoinOnMasterGone() {

--- a/src/test/java/org/elasticsearch/discovery/ZenFaultDetectionTests.java
+++ b/src/test/java/org/elasticsearch/discovery/ZenFaultDetectionTests.java
@@ -187,11 +187,6 @@ public class ZenFaultDetectionTests extends ElasticsearchTestCase {
                 failureReason[0] = reason;
                 notified.countDown();
             }
-
-            @Override
-            public void notListedOnMaster() {
-
-            }
         });
         // will raise a disconnect on A
         serviceB.stop();


### PR DESCRIPTION
It is never used in practice. We treat it as a master failure (using NodeDoesNotExistOnMasterException).
