### PR TITLE
Docs: Clarify that index.routing.allocation.total_shards_per_node applies to replica and primary

### DIFF
--- a/docs/reference/index-modules/allocation.asciidoc
+++ b/docs/reference/index-modules/allocation.asciidoc
@@ -92,7 +92,7 @@ curl -XPUT localhost:9200/_cluster/settings -d '{
 === Total Shards Per Node
 
 The `index.routing.allocation.total_shards_per_node` setting allows to
-control how many total shards for an index will be allocated per node.
+control how many total shards (replicas and primaries) for an index will be allocated per node.
 It can be dynamically set on a live index using the update index
 settings API.
 

--- a/docs/reference/indices/update-settings.asciidoc
+++ b/docs/reference/indices/update-settings.asciidoc
@@ -119,7 +119,7 @@ settings API:
     * `none` - No shard allocation is allowed.
 
 `index.routing.allocation.total_shards_per_node`::
-    Controls the total number of shards allowed to be allocated on a single node. Defaults to unbounded (`-1`).
+    Controls the total number of shards (replicas and primaries) allowed to be allocated on a single node. Defaults to unbounded (`-1`).
 
 `index.recovery.initial_shards`::
     When using local gateway a particular shard is recovered only if there can be allocated quorum shards in the cluster. It can be set to:


### PR DESCRIPTION
Clarify that `index.routing.allocation.total_shards_per_node` applies to both primary and replica shards
