### PR TITLE
[TEST] fix CurrentTestFailedMarker to reset its state after each test

### DIFF
--- a/src/test/java/org/elasticsearch/test/CurrentTestFailedMarker.java
+++ b/src/test/java/org/elasticsearch/test/CurrentTestFailedMarker.java
@@ -39,7 +39,7 @@ public class CurrentTestFailedMarker extends RunListener {
     }
 
     @Override
-    public void testRunStarted(Description description) throws Exception {
+    public void testStarted(Description description) throws Exception {
         failed.set(false);
     }
 


### PR DESCRIPTION
The currently used method `testRunStarted` is only called before any tests have been run, we need to reset that state before each test, that's why we need to use `testStarted`.
