### PR TITLE
Resiliency: Be more conservative if index.version.created is not set

### DIFF
--- a/src/main/java/org/elasticsearch/Version.java
+++ b/src/main/java/org/elasticsearch/Version.java
@@ -396,11 +396,14 @@ public class Version implements Serializable {
 
     /**
      * Return the {@link Version} of Elasticsearch that has been used to create an index given its settings.
+     * @throws ElasticsearchIllegalStateException if the given index settings doesn't contain a value for the key {@value IndexMetaData#SETTING_VERSION_CREATED}
      */
     public static Version indexCreated(Settings indexSettings) {
-        assert indexSettings.get(IndexMetaData.SETTING_UUID) == null // if the UUDI is there the index has actually been created otherwise this might be a test
-                || indexSettings.getAsVersion(IndexMetaData.SETTING_VERSION_CREATED, null) != null : IndexMetaData.SETTING_VERSION_CREATED + " not set in IndexSettings";
-        return indexSettings.getAsVersion(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT);
+        final Version indexVersion = indexSettings.getAsVersion(IndexMetaData.SETTING_VERSION_CREATED, null);
+        if (indexVersion == null) {
+            throw new ElasticsearchIllegalStateException("[" + IndexMetaData.SETTING_VERSION_CREATED + "] is not present in the index settings for index with uuid: [" + indexSettings.get(IndexMetaData.SETTING_UUID) + "]");
+        }
+        return indexVersion;
     }
 
     public static void writeVersion(Version version, StreamOutput out) throws IOException {

--- a/src/main/java/org/elasticsearch/action/admin/indices/analyze/TransportAnalyzeAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/analyze/TransportAnalyzeAction.java
@@ -27,12 +27,14 @@ import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
 import org.apache.lucene.analysis.tokenattributes.TypeAttribute;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.single.custom.TransportSingleCustomOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.routing.ShardsIterator;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.ImmutableSettings;
@@ -60,6 +62,8 @@ public class TransportAnalyzeAction extends TransportSingleCustomOperationAction
     private final IndicesService indicesService;
 
     private final IndicesAnalysisService indicesAnalysisService;
+
+    private static final Settings DEFAULT_SETTINGS = ImmutableSettings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT).build();
 
     @Inject
     public TransportAnalyzeAction(Settings settings, ThreadPool threadPool, ClusterService clusterService, TransportService transportService,
@@ -153,7 +157,7 @@ public class TransportAnalyzeAction extends TransportSingleCustomOperationAction
                 if (tokenizerFactoryFactory == null) {
                     throw new ElasticsearchIllegalArgumentException("failed to find global tokenizer under [" + request.tokenizer() + "]");
                 }
-                tokenizerFactory = tokenizerFactoryFactory.create(request.tokenizer(), ImmutableSettings.Builder.EMPTY_SETTINGS);
+                tokenizerFactory = tokenizerFactoryFactory.create(request.tokenizer(), DEFAULT_SETTINGS);
             } else {
                 tokenizerFactory = indexService.analysisService().tokenizer(request.tokenizer());
                 if (tokenizerFactory == null) {
@@ -171,7 +175,7 @@ public class TransportAnalyzeAction extends TransportSingleCustomOperationAction
                         if (tokenFilterFactoryFactory == null) {
                             throw new ElasticsearchIllegalArgumentException("failed to find global token filter under [" + tokenFilterName + "]");
                         }
-                        tokenFilterFactories[i] = tokenFilterFactoryFactory.create(tokenFilterName, ImmutableSettings.Builder.EMPTY_SETTINGS);
+                        tokenFilterFactories[i] = tokenFilterFactoryFactory.create(tokenFilterName, DEFAULT_SETTINGS);
                     } else {
                         tokenFilterFactories[i] = indexService.analysisService().tokenFilter(tokenFilterName);
                         if (tokenFilterFactories[i] == null) {
@@ -194,7 +198,7 @@ public class TransportAnalyzeAction extends TransportSingleCustomOperationAction
                         if (charFilterFactoryFactory == null) {
                             throw new ElasticsearchIllegalArgumentException("failed to find global char filter under [" + charFilterName + "]");
                         }
-                        charFilterFactories[i] = charFilterFactoryFactory.create(charFilterName, ImmutableSettings.Builder.EMPTY_SETTINGS);
+                        charFilterFactories[i] = charFilterFactoryFactory.create(charFilterName, DEFAULT_SETTINGS);
                     } else {
                         charFilterFactories[i] = indexService.analysisService().charFilter(charFilterName);
                         if (charFilterFactories[i] == null) {

--- a/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
@@ -24,6 +24,7 @@ import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import com.google.common.collect.ImmutableMap;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.ElasticsearchIllegalStateException;
+import org.elasticsearch.Version;
 import org.elasticsearch.cluster.block.ClusterBlock;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.node.DiscoveryNodeFilters;
@@ -193,7 +194,6 @@ public class IndexMetaData {
         this.mappings = mappings;
         this.customs = customs;
         this.totalNumberOfShards = numberOfShards() * (numberOfReplicas() + 1);
-
         this.aliases = aliases;
 
         ImmutableMap<String, String> requireMap = settings.getByPrefix("index.routing.allocation.require.").getAsMap();
@@ -215,6 +215,8 @@ public class IndexMetaData {
             excludeFilters = DiscoveryNodeFilters.buildFromKeyValue(OR, excludeMap);
         }
     }
+
+
 
     public String index() {
         return index;

--- a/src/main/java/org/elasticsearch/index/analysis/Analysis.java
+++ b/src/main/java/org/elasticsearch/index/analysis/Analysis.java
@@ -92,7 +92,7 @@ public class Analysis {
             return Lucene.parseVersion(sVersion, Lucene.ANALYZER_VERSION, logger);
         }
         // resolve the analysis version based on the version the index was created with
-        return indexSettings.getAsVersion(IndexMetaData.SETTING_VERSION_CREATED, org.elasticsearch.Version.CURRENT).luceneVersion;
+        return org.elasticsearch.Version.indexCreated(indexSettings).luceneVersion;
     }
 
     public static boolean isNoStopwords(Settings settings) {

--- a/src/main/java/org/elasticsearch/index/analysis/AnalysisService.java
+++ b/src/main/java/org/elasticsearch/index/analysis/AnalysisService.java
@@ -54,8 +54,9 @@ public class AnalysisService extends AbstractIndexComponent implements Closeable
     private final NamedAnalyzer defaultSearchAnalyzer;
     private final NamedAnalyzer defaultSearchQuoteAnalyzer;
 
-    public AnalysisService(Index index) {
-        this(index, ImmutableSettings.Builder.EMPTY_SETTINGS, null, null, null, null, null);
+
+    public AnalysisService(Index index, Settings indexSettings) {
+        this(index, indexSettings, null, null, null, null, null);
     }
 
     @Inject
@@ -65,7 +66,7 @@ public class AnalysisService extends AbstractIndexComponent implements Closeable
                            @Nullable Map<String, CharFilterFactoryFactory> charFilterFactoryFactories,
                            @Nullable Map<String, TokenFilterFactoryFactory> tokenFilterFactoryFactories) {
         super(index, indexSettings);
-
+        Settings defaultSettings = ImmutableSettings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.indexCreated(indexSettings)).build();
         Map<String, TokenizerFactory> tokenizers = newHashMap();
         if (tokenizerFactoryFactories != null) {
             Map<String, Settings> tokenizersSettings = indexSettings.getGroups("index.analysis.tokenizer");
@@ -75,7 +76,7 @@ public class AnalysisService extends AbstractIndexComponent implements Closeable
 
                 Settings tokenizerSettings = tokenizersSettings.get(tokenizerName);
                 if (tokenizerSettings == null) {
-                    tokenizerSettings = ImmutableSettings.Builder.EMPTY_SETTINGS;
+                    tokenizerSettings = defaultSettings;
                 }
 
                 TokenizerFactory tokenizerFactory = tokenizerFactoryFactory.create(tokenizerName, tokenizerSettings);
@@ -88,12 +89,12 @@ public class AnalysisService extends AbstractIndexComponent implements Closeable
             for (Map.Entry<String, PreBuiltTokenizerFactoryFactory> entry : indicesAnalysisService.tokenizerFactories().entrySet()) {
                 String name = entry.getKey();
                 if (!tokenizers.containsKey(name)) {
-                    tokenizers.put(name, entry.getValue().create(name, ImmutableSettings.Builder.EMPTY_SETTINGS));
+                    tokenizers.put(name, entry.getValue().create(name, defaultSettings));
                 }
                 name = Strings.toCamelCase(entry.getKey());
                 if (!name.equals(entry.getKey())) {
                     if (!tokenizers.containsKey(name)) {
-                        tokenizers.put(name, entry.getValue().create(name, ImmutableSettings.Builder.EMPTY_SETTINGS));
+                        tokenizers.put(name, entry.getValue().create(name, defaultSettings));
                     }
                 }
             }
@@ -110,7 +111,7 @@ public class AnalysisService extends AbstractIndexComponent implements Closeable
 
                 Settings charFilterSettings = charFiltersSettings.get(charFilterName);
                 if (charFilterSettings == null) {
-                    charFilterSettings = ImmutableSettings.Builder.EMPTY_SETTINGS;
+                    charFilterSettings = defaultSettings;
                 }
 
                 CharFilterFactory tokenFilterFactory = charFilterFactoryFactory.create(charFilterName, charFilterSettings);
@@ -123,12 +124,12 @@ public class AnalysisService extends AbstractIndexComponent implements Closeable
             for (Map.Entry<String, PreBuiltCharFilterFactoryFactory> entry : indicesAnalysisService.charFilterFactories().entrySet()) {
                 String name = entry.getKey();
                 if (!charFilters.containsKey(name)) {
-                    charFilters.put(name, entry.getValue().create(name, ImmutableSettings.Builder.EMPTY_SETTINGS));
+                    charFilters.put(name, entry.getValue().create(name, defaultSettings));
                 }
                 name = Strings.toCamelCase(entry.getKey());
                 if (!name.equals(entry.getKey())) {
                     if (!charFilters.containsKey(name)) {
-                        charFilters.put(name, entry.getValue().create(name, ImmutableSettings.Builder.EMPTY_SETTINGS));
+                        charFilters.put(name, entry.getValue().create(name, defaultSettings));
                     }
                 }
             }
@@ -145,7 +146,7 @@ public class AnalysisService extends AbstractIndexComponent implements Closeable
 
                 Settings tokenFilterSettings = tokenFiltersSettings.get(tokenFilterName);
                 if (tokenFilterSettings == null) {
-                    tokenFilterSettings = ImmutableSettings.Builder.EMPTY_SETTINGS;
+                    tokenFilterSettings = defaultSettings;
                 }
 
                 TokenFilterFactory tokenFilterFactory = tokenFilterFactoryFactory.create(tokenFilterName, tokenFilterSettings);
@@ -159,12 +160,12 @@ public class AnalysisService extends AbstractIndexComponent implements Closeable
             for (Map.Entry<String, PreBuiltTokenFilterFactoryFactory> entry : indicesAnalysisService.tokenFilterFactories().entrySet()) {
                 String name = entry.getKey();
                 if (!tokenFilters.containsKey(name)) {
-                    tokenFilters.put(name, entry.getValue().create(name, ImmutableSettings.Builder.EMPTY_SETTINGS));
+                    tokenFilters.put(name, entry.getValue().create(name, defaultSettings));
                 }
                 name = Strings.toCamelCase(entry.getKey());
                 if (!name.equals(entry.getKey())) {
                     if (!tokenFilters.containsKey(name)) {
-                        tokenFilters.put(name, entry.getValue().create(name, ImmutableSettings.Builder.EMPTY_SETTINGS));
+                        tokenFilters.put(name, entry.getValue().create(name, defaultSettings));
                     }
                 }
             }
@@ -180,7 +181,7 @@ public class AnalysisService extends AbstractIndexComponent implements Closeable
 
                 Settings analyzerSettings = analyzersSettings.get(analyzerName);
                 if (analyzerSettings == null) {
-                    analyzerSettings = ImmutableSettings.Builder.EMPTY_SETTINGS;
+                    analyzerSettings = defaultSettings;
                 }
 
                 AnalyzerProvider analyzerFactory = analyzerFactoryFactory.create(analyzerName, analyzerSettings);
@@ -190,7 +191,7 @@ public class AnalysisService extends AbstractIndexComponent implements Closeable
         if (indicesAnalysisService != null) {
             for (Map.Entry<String, PreBuiltAnalyzerProviderFactory> entry : indicesAnalysisService.analyzerProviderFactories().entrySet()) {
                 String name = entry.getKey();
-                Version indexVersion = indexSettings.getAsVersion(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT);
+                Version indexVersion = Version.indexCreated(indexSettings);
                 if (!analyzerProviders.containsKey(name)) {
                     analyzerProviders.put(name, entry.getValue().create(name, ImmutableSettings.settingsBuilder().put(IndexMetaData.SETTING_VERSION_CREATED, indexVersion).build()));
                 }

--- a/src/main/java/org/elasticsearch/index/analysis/EdgeNGramTokenFilterFactory.java
+++ b/src/main/java/org/elasticsearch/index/analysis/EdgeNGramTokenFilterFactory.java
@@ -53,7 +53,7 @@ public class EdgeNGramTokenFilterFactory extends AbstractTokenFilterFactory {
         this.minGram = settings.getAsInt("min_gram", NGramTokenFilter.DEFAULT_MIN_NGRAM_SIZE);
         this.maxGram = settings.getAsInt("max_gram", NGramTokenFilter.DEFAULT_MAX_NGRAM_SIZE);
         this.side = EdgeNGramTokenFilter.Side.getSide(settings.get("side", Lucene43EdgeNGramTokenizer.DEFAULT_SIDE.getLabel()));
-        this.esVersion = indexSettings.getAsVersion(IndexMetaData.SETTING_VERSION_CREATED, org.elasticsearch.Version.CURRENT);
+        this.esVersion = org.elasticsearch.Version.indexCreated(indexSettings);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/analysis/EdgeNGramTokenizerFactory.java
+++ b/src/main/java/org/elasticsearch/index/analysis/EdgeNGramTokenizerFactory.java
@@ -60,7 +60,7 @@ public class EdgeNGramTokenizerFactory extends AbstractTokenizerFactory {
         this.maxGram = settings.getAsInt("max_gram", NGramTokenizer.DEFAULT_MAX_NGRAM_SIZE);
         this.side = Lucene43EdgeNGramTokenizer.Side.getSide(settings.get("side", Lucene43EdgeNGramTokenizer.DEFAULT_SIDE.getLabel()));
         this.matcher = parseTokenChars(settings.getAsArray("token_chars"));
-        this.esVersion = indexSettings.getAsVersion(IndexMetaData.SETTING_VERSION_CREATED, org.elasticsearch.Version.CURRENT);
+        this.esVersion = org.elasticsearch.Version.indexCreated(indexSettings);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/analysis/NGramTokenizerFactory.java
+++ b/src/main/java/org/elasticsearch/index/analysis/NGramTokenizerFactory.java
@@ -96,7 +96,7 @@ public class NGramTokenizerFactory extends AbstractTokenizerFactory {
         this.minGram = settings.getAsInt("min_gram", NGramTokenizer.DEFAULT_MIN_NGRAM_SIZE);
         this.maxGram = settings.getAsInt("max_gram", NGramTokenizer.DEFAULT_MAX_NGRAM_SIZE);
         this.matcher = parseTokenChars(settings.getAsArray("token_chars"));
-        this.esVersion = indexSettings.getAsVersion(IndexMetaData.SETTING_VERSION_CREATED, org.elasticsearch.Version.CURRENT);
+        this.esVersion = org.elasticsearch.Version.indexCreated(indexSettings);
     }
 
     @SuppressWarnings("deprecation")

--- a/src/main/java/org/elasticsearch/index/analysis/PatternAnalyzerProvider.java
+++ b/src/main/java/org/elasticsearch/index/analysis/PatternAnalyzerProvider.java
@@ -76,7 +76,7 @@ public class PatternAnalyzerProvider extends AbstractIndexAnalyzerProvider<Analy
     public PatternAnalyzerProvider(Index index, @IndexSettings Settings indexSettings, Environment env, @Assisted String name, @Assisted Settings settings) {
         super(index, indexSettings, name, settings);
 
-        Version esVersion = indexSettings.getAsVersion(IndexMetaData.SETTING_VERSION_CREATED, org.elasticsearch.Version.CURRENT);
+        Version esVersion = Version.indexCreated(indexSettings);
         final CharArraySet defaultStopwords;
         if (esVersion.onOrAfter(Version.V_1_0_0_RC1)) {
             defaultStopwords = CharArraySet.EMPTY_SET;

--- a/src/main/java/org/elasticsearch/index/analysis/PreBuiltAnalyzerProviderFactory.java
+++ b/src/main/java/org/elasticsearch/index/analysis/PreBuiltAnalyzerProviderFactory.java
@@ -38,7 +38,7 @@ public class PreBuiltAnalyzerProviderFactory implements AnalyzerProviderFactory 
 
     @Override
     public AnalyzerProvider create(String name, Settings settings) {
-        Version indexVersion = settings.getAsVersion(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT);
+        Version indexVersion = Version.indexCreated(settings);
         if (!Version.CURRENT.equals(indexVersion)) {
             PreBuiltAnalyzers preBuiltAnalyzers = PreBuiltAnalyzers.getOrDefault(name, null);
             if (preBuiltAnalyzers != null) {

--- a/src/main/java/org/elasticsearch/index/analysis/PreBuiltCharFilterFactoryFactory.java
+++ b/src/main/java/org/elasticsearch/index/analysis/PreBuiltCharFilterFactoryFactory.java
@@ -34,7 +34,7 @@ public class PreBuiltCharFilterFactoryFactory implements CharFilterFactoryFactor
 
     @Override
     public CharFilterFactory create(String name, Settings settings) {
-        Version indexVersion = settings.getAsVersion(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT);
+        Version indexVersion = Version.indexCreated(settings);
         if (!Version.CURRENT.equals(indexVersion)) {
             PreBuiltCharFilters preBuiltCharFilters = PreBuiltCharFilters.getOrDefault(name, null);
             if (preBuiltCharFilters != null) {

--- a/src/main/java/org/elasticsearch/index/analysis/PreBuiltTokenFilterFactoryFactory.java
+++ b/src/main/java/org/elasticsearch/index/analysis/PreBuiltTokenFilterFactoryFactory.java
@@ -34,7 +34,7 @@ public class PreBuiltTokenFilterFactoryFactory implements TokenFilterFactoryFact
 
     @Override
     public TokenFilterFactory create(String name, Settings settings) {
-        Version indexVersion = settings.getAsVersion(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT);
+        Version indexVersion = Version.indexCreated(settings);
         if (!Version.CURRENT.equals(indexVersion)) {
             PreBuiltTokenFilters preBuiltTokenFilters = PreBuiltTokenFilters.getOrDefault(name, null);
             if (preBuiltTokenFilters != null) {

--- a/src/main/java/org/elasticsearch/index/analysis/PreBuiltTokenizerFactoryFactory.java
+++ b/src/main/java/org/elasticsearch/index/analysis/PreBuiltTokenizerFactoryFactory.java
@@ -34,7 +34,7 @@ public class PreBuiltTokenizerFactoryFactory implements TokenizerFactoryFactory 
 
     @Override
     public TokenizerFactory create(String name, Settings settings) {
-        Version indexVersion = settings.getAsVersion(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT);
+        Version indexVersion = Version.indexCreated(settings);
         if (!Version.CURRENT.equals(indexVersion)) {
             PreBuiltTokenizers preBuiltTokenizers = PreBuiltTokenizers.getOrDefault(name, null);
             if (preBuiltTokenizers != null) {

--- a/src/main/java/org/elasticsearch/index/analysis/StandardAnalyzerProvider.java
+++ b/src/main/java/org/elasticsearch/index/analysis/StandardAnalyzerProvider.java
@@ -42,7 +42,7 @@ public class StandardAnalyzerProvider extends AbstractIndexAnalyzerProvider<Stan
     @Inject
     public StandardAnalyzerProvider(Index index, @IndexSettings Settings indexSettings, Environment env, @Assisted String name, @Assisted Settings settings) {
         super(index, indexSettings, name, settings);
-        this.esVersion = indexSettings.getAsVersion(IndexMetaData.SETTING_VERSION_CREATED, org.elasticsearch.Version.CURRENT);
+        this.esVersion = Version.indexCreated(indexSettings);
         final CharArraySet defaultStopwords;
         if (esVersion.onOrAfter(Version.V_1_0_0_Beta1)) {
             defaultStopwords = CharArraySet.EMPTY_SET;

--- a/src/main/java/org/elasticsearch/index/analysis/StandardHtmlStripAnalyzerProvider.java
+++ b/src/main/java/org/elasticsearch/index/analysis/StandardHtmlStripAnalyzerProvider.java
@@ -41,7 +41,7 @@ public class StandardHtmlStripAnalyzerProvider extends AbstractIndexAnalyzerProv
     @Inject
     public StandardHtmlStripAnalyzerProvider(Index index, @IndexSettings Settings indexSettings, Environment env,  @Assisted String name, @Assisted Settings settings) {
         super(index, indexSettings, name, settings);
-        this.esVersion = indexSettings.getAsVersion(IndexMetaData.SETTING_VERSION_CREATED, org.elasticsearch.Version.CURRENT);
+        this.esVersion = Version.indexCreated(indexSettings);
         final CharArraySet defaultStopwords;
         if (esVersion.onOrAfter(Version.V_1_0_0_RC1)) {
             defaultStopwords = CharArraySet.EMPTY_SET;

--- a/src/main/java/org/elasticsearch/index/analysis/StemmerTokenFilterFactory.java
+++ b/src/main/java/org/elasticsearch/index/analysis/StemmerTokenFilterFactory.java
@@ -76,7 +76,7 @@ public class StemmerTokenFilterFactory extends AbstractTokenFilterFactory {
 
     @Override
     public TokenStream create(TokenStream tokenStream) {
-        final Version indexVersion = indexSettings.getAsVersion(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT);
+        final Version indexVersion = Version.indexCreated(indexSettings);
 
         if ("arabic".equalsIgnoreCase(language)) {
             return new ArabicStemFilter(tokenStream);

--- a/src/main/java/org/elasticsearch/index/analysis/SynonymTokenFilterFactory.java
+++ b/src/main/java/org/elasticsearch/index/analysis/SynonymTokenFilterFactory.java
@@ -80,7 +80,7 @@ public class SynonymTokenFilterFactory extends AbstractTokenFilterFactory {
         if (tokenizerFactoryFactory == null) {
             throw new ElasticsearchIllegalArgumentException("failed to find tokenizer [" + tokenizerName + "] for synonym token filter");
         }
-        final TokenizerFactory tokenizerFactory = tokenizerFactoryFactory.create(tokenizerName, settings);
+        final TokenizerFactory tokenizerFactory = tokenizerFactoryFactory.create(tokenizerName, indexSettings);
 
         Analyzer analyzer = new Analyzer() {
             @Override

--- a/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
@@ -178,17 +178,17 @@ public class DocumentMapper implements ToXContent {
             this.rootMappers.put(IdFieldMapper.class, idFieldMapper);
             this.rootMappers.put(RoutingFieldMapper.class, new RoutingFieldMapper());
             // add default mappers, order is important (for example analyzer should come before the rest to set context.analyzer)
-            this.rootMappers.put(SizeFieldMapper.class, new SizeFieldMapper());
+            this.rootMappers.put(SizeFieldMapper.class, new SizeFieldMapper(indexSettings));
             this.rootMappers.put(IndexFieldMapper.class, new IndexFieldMapper());
-            this.rootMappers.put(SourceFieldMapper.class, new SourceFieldMapper());
+            this.rootMappers.put(SourceFieldMapper.class, new SourceFieldMapper(indexSettings));
             this.rootMappers.put(TypeFieldMapper.class, new TypeFieldMapper());
             this.rootMappers.put(AnalyzerMapper.class, new AnalyzerMapper());
             this.rootMappers.put(AllFieldMapper.class, new AllFieldMapper());
-            this.rootMappers.put(BoostFieldMapper.class, new BoostFieldMapper());
-            this.rootMappers.put(TimestampFieldMapper.class, new TimestampFieldMapper());
-            this.rootMappers.put(TTLFieldMapper.class, new TTLFieldMapper());
+            this.rootMappers.put(BoostFieldMapper.class, new BoostFieldMapper(indexSettings));
+            this.rootMappers.put(TimestampFieldMapper.class, new TimestampFieldMapper(indexSettings));
+            this.rootMappers.put(TTLFieldMapper.class, new TTLFieldMapper(indexSettings));
             this.rootMappers.put(VersionFieldMapper.class, new VersionFieldMapper());
-            this.rootMappers.put(ParentFieldMapper.class, new ParentFieldMapper());
+            this.rootMappers.put(ParentFieldMapper.class, new ParentFieldMapper(indexSettings));
             // _field_names last so that it can see all other fields
             this.rootMappers.put(FieldNamesFieldMapper.class, new FieldNamesFieldMapper(indexSettings));
         }

--- a/src/main/java/org/elasticsearch/index/mapper/Mapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/Mapper.java
@@ -64,7 +64,7 @@ public interface Mapper extends ToXContent {
             if (indexSettings == null) {
                 return null;
             }
-            return indexSettings.getAsVersion(IndexMetaData.SETTING_VERSION_CREATED, null);
+            return Version.indexCreated(indexSettings);
         }
     }
 

--- a/src/main/java/org/elasticsearch/index/mapper/internal/BoostFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/BoostFieldMapper.java
@@ -114,13 +114,13 @@ public class BoostFieldMapper extends NumberFieldMapper<Float> implements Intern
 
     private final Float nullValue;
 
-    public BoostFieldMapper() {
-        this(Defaults.NAME, Defaults.NAME);
+    public BoostFieldMapper(Settings indexSettings) {
+        this(Defaults.NAME, Defaults.NAME, indexSettings);
     }
 
-    protected BoostFieldMapper(String name, String indexName) {
+    protected BoostFieldMapper(String name, String indexName, Settings indexSettings) {
         this(name, indexName, Defaults.PRECISION_STEP_32_BIT, Defaults.BOOST, new FieldType(Defaults.FIELD_TYPE), null,
-                Defaults.NULL_VALUE, null, null, null, ImmutableSettings.EMPTY);
+                Defaults.NULL_VALUE, null, null, null, indexSettings);
     }
 
     protected BoostFieldMapper(String name, String indexName, int precisionStep, float boost, FieldType fieldType, Boolean docValues, Float nullValue,

--- a/src/main/java/org/elasticsearch/index/mapper/internal/ParentFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/ParentFieldMapper.java
@@ -42,6 +42,7 @@ import org.elasticsearch.index.fielddata.FieldDataType;
 import org.elasticsearch.index.mapper.*;
 import org.elasticsearch.index.mapper.core.AbstractFieldMapper;
 import org.elasticsearch.index.query.QueryParseContext;
+import org.elasticsearch.index.settings.IndexSettings;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -61,6 +62,7 @@ public class ParentFieldMapper extends AbstractFieldMapper<Uid> implements Inter
     public static final String NAME = "_parent";
 
     public static final String CONTENT_TYPE = "_parent";
+
 
     public static class Defaults extends AbstractFieldMapper.Defaults {
         public static final String NAME = ParentFieldMapper.NAME;
@@ -150,8 +152,8 @@ public class ParentFieldMapper extends AbstractFieldMapper<Uid> implements Inter
         this.typeAsBytes = type == null ? null : new BytesRef(type);
     }
 
-    public ParentFieldMapper() {
-        this(Defaults.NAME, Defaults.NAME, null, null, null, null);
+    public ParentFieldMapper(Settings indexSettings) {
+        this(Defaults.NAME, Defaults.NAME, null, null, null, indexSettings);
         this.fieldDataType = new FieldDataType("_parent", settingsBuilder().put(Loading.KEY, Loading.LAZY_VALUE));
     }
 

--- a/src/main/java/org/elasticsearch/index/mapper/internal/SizeFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/SizeFieldMapper.java
@@ -95,8 +95,8 @@ public class SizeFieldMapper extends IntegerFieldMapper implements RootMapper {
 
     private EnabledAttributeMapper enabledState;
 
-    public SizeFieldMapper() {
-        this(Defaults.ENABLED_STATE, new FieldType(Defaults.SIZE_FIELD_TYPE), null, null, null, ImmutableSettings.EMPTY);
+    public SizeFieldMapper(Settings indexSettings) {
+        this(Defaults.ENABLED_STATE, new FieldType(Defaults.SIZE_FIELD_TYPE), null, null, null, indexSettings);
     }
 
     public SizeFieldMapper(EnabledAttributeMapper enabled, FieldType fieldType, PostingsFormatProvider postingsProvider,

--- a/src/main/java/org/elasticsearch/index/mapper/internal/SourceFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/SourceFieldMapper.java
@@ -36,6 +36,7 @@ import org.elasticsearch.common.compress.CompressorFactory;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.lucene.Lucene;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
@@ -130,7 +131,7 @@ public class SourceFieldMapper extends AbstractFieldMapper<byte[]> implements In
 
         @Override
         public SourceFieldMapper build(BuilderContext context) {
-            return new SourceFieldMapper(name, enabled, format, compress, compressThreshold, includes, excludes);
+            return new SourceFieldMapper(name, enabled, format, compress, compressThreshold, includes, excludes, context.indexSettings());
         }
     }
 
@@ -189,14 +190,14 @@ public class SourceFieldMapper extends AbstractFieldMapper<byte[]> implements In
 
     private XContentType formatContentType;
 
-    public SourceFieldMapper() {
-        this(Defaults.NAME, Defaults.ENABLED, Defaults.FORMAT, null, -1, null, null);
+    public SourceFieldMapper(Settings indexSettings) {
+        this(Defaults.NAME, Defaults.ENABLED, Defaults.FORMAT, null, -1, null, null, indexSettings);
     }
 
     protected SourceFieldMapper(String name, boolean enabled, String format, Boolean compress, long compressThreshold,
-                                String[] includes, String[] excludes) {
+                                String[] includes, String[] excludes, Settings indexSettings) {
         super(new Names(name, name, name, name), Defaults.BOOST, new FieldType(Defaults.FIELD_TYPE), null,
-                Lucene.KEYWORD_ANALYZER, Lucene.KEYWORD_ANALYZER, null, null, null, null, null, null); // Only stored.
+                Lucene.KEYWORD_ANALYZER, Lucene.KEYWORD_ANALYZER, null, null, null, null, null, indexSettings); // Only stored.
         this.enabled = enabled;
         this.compress = compress;
         this.compressThreshold = compressThreshold;

--- a/src/main/java/org/elasticsearch/index/mapper/internal/TTLFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/TTLFieldMapper.java
@@ -119,8 +119,8 @@ public class TTLFieldMapper extends LongFieldMapper implements InternalMapper, R
     private EnabledAttributeMapper enabledState;
     private long defaultTTL;
 
-    public TTLFieldMapper() {
-        this(new FieldType(Defaults.TTL_FIELD_TYPE), Defaults.ENABLED_STATE, Defaults.DEFAULT, Defaults.IGNORE_MALFORMED, Defaults.COERCE, null, null, null, ImmutableSettings.EMPTY);
+    public TTLFieldMapper(Settings indexSettings) {
+        this(new FieldType(Defaults.TTL_FIELD_TYPE), Defaults.ENABLED_STATE, Defaults.DEFAULT, Defaults.IGNORE_MALFORMED, Defaults.COERCE, null, null, null, indexSettings);
     }
 
     protected TTLFieldMapper(FieldType fieldType, EnabledAttributeMapper enabled, long defaultTTL, Explicit<Boolean> ignoreMalformed,

--- a/src/main/java/org/elasticsearch/index/mapper/internal/TimestampFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/TimestampFieldMapper.java
@@ -145,9 +145,9 @@ public class TimestampFieldMapper extends DateFieldMapper implements InternalMap
     private final String path;
     private final String defaultTimestamp;
 
-    public TimestampFieldMapper() {
+    public TimestampFieldMapper(Settings indexSettings) {
         this(new FieldType(Defaults.FIELD_TYPE), null, Defaults.ENABLED, Defaults.PATH, Defaults.DATE_TIME_FORMATTER, Defaults.DEFAULT_TIMESTAMP,
-                Defaults.ROUND_CEIL, Defaults.IGNORE_MALFORMED, Defaults.COERCE, null, null, null, null, ImmutableSettings.EMPTY);
+                Defaults.ROUND_CEIL, Defaults.IGNORE_MALFORMED, Defaults.COERCE, null, null, null, null, indexSettings);
     }
 
     protected TimestampFieldMapper(FieldType fieldType, Boolean docValues, EnabledAttributeMapper enabledState, String path,

--- a/src/test/java/org/elasticsearch/VersionTests.java
+++ b/src/test/java/org/elasticsearch/VersionTests.java
@@ -111,9 +111,12 @@ public class VersionTests extends ElasticsearchTestCase {
         Version.fromString("WRONG.VERSION");
     }
 
+    @Test(expected = ElasticsearchIllegalStateException.class)
+    public void testVersionNoPresentInSettings() {
+        Version.indexCreated(ImmutableSettings.builder().build());
+    }
+
     public void testVersion() {
-        // test scenario
-        assertEquals(Version.CURRENT, Version.indexCreated(ImmutableSettings.builder().build()));
         // an actual index has a IndexMetaData.SETTING_UUID
         final Version version = randomFrom(Version.V_0_18_0, Version.V_0_90_13, Version.V_1_3_0);
         assertEquals(version, Version.indexCreated(ImmutableSettings.builder().put(IndexMetaData.SETTING_UUID, "foo").put(IndexMetaData.SETTING_VERSION_CREATED, version).build()));

--- a/src/test/java/org/elasticsearch/index/analysis/AnalysisModuleTests.java
+++ b/src/test/java/org/elasticsearch/index/analysis/AnalysisModuleTests.java
@@ -24,7 +24,6 @@ import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.analysis.ar.ArabicNormalizationFilter;
-import org.apache.lucene.analysis.core.KeywordAnalyzer;
 import org.apache.lucene.analysis.core.WhitespaceTokenizer;
 import org.apache.lucene.analysis.fa.PersianNormalizationFilter;
 import org.apache.lucene.analysis.miscellaneous.KeywordRepeatFilter;
@@ -47,11 +46,9 @@ import org.elasticsearch.indices.analysis.IndicesAnalysisModule;
 import org.elasticsearch.indices.analysis.IndicesAnalysisService;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.hamcrest.MatcherAssert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.*;
-import java.lang.reflect.Field;
 import java.util.Set;
 
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
@@ -76,15 +73,20 @@ public class AnalysisModuleTests extends ElasticsearchTestCase {
         return injector.getInstance(AnalysisService.class);
     }
 
+    private static Settings loadFromClasspath(String path) {
+        return settingsBuilder().loadFromClasspath(path).put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT).build();
+
+    }
+
     @Test
     public void testSimpleConfigurationJson() {
-        Settings settings = settingsBuilder().loadFromClasspath("org/elasticsearch/index/analysis/test1.json").build();
+        Settings settings = loadFromClasspath("org/elasticsearch/index/analysis/test1.json");
         testSimpleConfiguration(settings);
     }
 
     @Test
     public void testSimpleConfigurationYaml() {
-        Settings settings = settingsBuilder().loadFromClasspath("org/elasticsearch/index/analysis/test1.yml").build();
+        Settings settings = loadFromClasspath("org/elasticsearch/index/analysis/test1.yml");
         testSimpleConfiguration(settings);
     }
     
@@ -115,7 +117,7 @@ public class AnalysisModuleTests extends ElasticsearchTestCase {
     }
 
     private void assertTokenFilter(String name, Class clazz) {
-        AnalysisService analysisService = AnalysisTestsHelper.createAnalysisServiceFromSettings(ImmutableSettings.settingsBuilder().build());
+        AnalysisService analysisService = AnalysisTestsHelper.createAnalysisServiceFromSettings(ImmutableSettings.settingsBuilder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT).build());
         TokenFilterFactory tokenFilter = analysisService.tokenFilter(name);
         Tokenizer tokenizer = new WhitespaceTokenizer(Version.CURRENT.luceneVersion, new StringReader("foo bar"));
         TokenStream stream = tokenFilter.create(tokenizer);

--- a/src/test/java/org/elasticsearch/index/analysis/AnalysisTestsHelper.java
+++ b/src/test/java/org/elasticsearch/index/analysis/AnalysisTestsHelper.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.index.analysis;
 
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.inject.Injector;
 import org.elasticsearch.common.inject.ModulesBuilder;
 import org.elasticsearch.common.settings.ImmutableSettings;
@@ -44,7 +46,9 @@ public class AnalysisTestsHelper {
     public static AnalysisService createAnalysisServiceFromSettings(
             Settings settings) {
         Index index = new Index("test");
-
+        if (settings.get(IndexMetaData.SETTING_VERSION_CREATED) == null) {
+            settings = ImmutableSettings.builder().put(settings).put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT).build();
+        }
         Injector parentInjector = new ModulesBuilder().add(new SettingsModule(settings),
                 new EnvironmentModule(new Environment(settings)), new IndicesAnalysisModule()).createInjector();
 

--- a/src/test/java/org/elasticsearch/index/analysis/CharFilterTests.java
+++ b/src/test/java/org/elasticsearch/index/analysis/CharFilterTests.java
@@ -18,6 +18,8 @@
  */
 package org.elasticsearch.index.analysis;
 
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.inject.Injector;
 import org.elasticsearch.common.inject.ModulesBuilder;
 import org.elasticsearch.common.settings.Settings;
@@ -42,6 +44,7 @@ public class CharFilterTests extends ElasticsearchTokenStreamTestCase {
     public void testMappingCharFilter() throws Exception {
         Index index = new Index("test");
         Settings settings = settingsBuilder()
+                .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
                 .put("index.analysis.char_filter.my_mapping.type", "mapping")
                 .putArray("index.analysis.char_filter.my_mapping.mappings", "ph=>f", "qu=>q")
                 .put("index.analysis.analyzer.custom_with_char_filter.tokenizer", "standard")
@@ -68,6 +71,7 @@ public class CharFilterTests extends ElasticsearchTokenStreamTestCase {
     public void testHtmlStripCharFilter() throws Exception {
         Index index = new Index("test");
         Settings settings = settingsBuilder()
+                .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
                 .put("index.analysis.analyzer.custom_with_char_filter.tokenizer", "standard")
                 .putArray("index.analysis.analyzer.custom_with_char_filter.char_filter", "html_strip")
                 .build();

--- a/src/test/java/org/elasticsearch/index/analysis/CompoundAnalysisTests.java
+++ b/src/test/java/org/elasticsearch/index/analysis/CompoundAnalysisTests.java
@@ -22,6 +22,8 @@ package org.elasticsearch.index.analysis;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.inject.Injector;
 import org.elasticsearch.common.inject.ModulesBuilder;
 import org.elasticsearch.common.lucene.all.AllEntries;
@@ -108,10 +110,10 @@ public class CompoundAnalysisTests extends ElasticsearchTestCase {
     }
 
     private Settings getJsonSettings() {
-        return settingsBuilder().loadFromClasspath("org/elasticsearch/index/analysis/test1.json").build();
+        return settingsBuilder().loadFromClasspath("org/elasticsearch/index/analysis/test1.json").put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT).build();
     }
 
     private Settings getYamlSettings() {
-        return settingsBuilder().loadFromClasspath("org/elasticsearch/index/analysis/test1.yml").build();
+        return settingsBuilder().loadFromClasspath("org/elasticsearch/index/analysis/test1.yml").put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT).build();
     }
 }

--- a/src/test/java/org/elasticsearch/index/analysis/PatternCaptureTokenFilterTests.java
+++ b/src/test/java/org/elasticsearch/index/analysis/PatternCaptureTokenFilterTests.java
@@ -20,8 +20,11 @@
 package org.elasticsearch.index.analysis;
 
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.inject.Injector;
 import org.elasticsearch.common.inject.ModulesBuilder;
+import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsModule;
 import org.elasticsearch.env.Environment;
@@ -41,7 +44,7 @@ public class PatternCaptureTokenFilterTests extends ElasticsearchTokenStreamTest
     @Test
     public void testPatternCaptureTokenFilter() throws Exception {
         Index index = new Index("test");
-        Settings settings = settingsBuilder().loadFromClasspath("org/elasticsearch/index/analysis/pattern_capture.json").build();
+        Settings settings = settingsBuilder().loadFromClasspath("org/elasticsearch/index/analysis/pattern_capture.json").put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT).build();
         Injector parentInjector = new ModulesBuilder().add(new SettingsModule(settings), new EnvironmentModule(new Environment(settings)), new IndicesAnalysisModule()).createInjector();
         Injector injector = new ModulesBuilder().add(
                 new IndexSettingsModule(index, settings),
@@ -67,7 +70,7 @@ public class PatternCaptureTokenFilterTests extends ElasticsearchTokenStreamTest
     
     @Test(expected=ElasticsearchIllegalArgumentException.class)
     public void testNoPatterns() {
-        new PatternCaptureGroupTokenFilterFactory(new Index("test"), settingsBuilder().build(), "pattern_capture", settingsBuilder().put("pattern", "foobar").build());
+        new PatternCaptureGroupTokenFilterFactory(new Index("test"), settingsBuilder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT).build(), "pattern_capture", settingsBuilder().put("pattern", "foobar").build());
     }
 
 }

--- a/src/test/java/org/elasticsearch/index/analysis/PreBuiltAnalyzerProviderFactoryTests.java
+++ b/src/test/java/org/elasticsearch/index/analysis/PreBuiltAnalyzerProviderFactoryTests.java
@@ -37,12 +37,10 @@ public class PreBuiltAnalyzerProviderFactoryTests extends ElasticsearchTestCase 
     public void testVersioningInFactoryProvider() throws Exception {
         PreBuiltAnalyzerProviderFactory factory = new PreBuiltAnalyzerProviderFactory("default", AnalyzerScope.INDEX, PreBuiltAnalyzers.STANDARD.getAnalyzer(Version.CURRENT));
 
-        AnalyzerProvider currentAnalyzerProvider = factory.create("default", ImmutableSettings.Builder.EMPTY_SETTINGS);
         AnalyzerProvider former090AnalyzerProvider = factory.create("default", ImmutableSettings.settingsBuilder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.V_0_90_0).build());
         AnalyzerProvider currentAnalyzerProviderReference = factory.create("default", ImmutableSettings.settingsBuilder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT).build());
 
         // would love to access the version inside of the lucene analyzer, but that is not possible...
-        assertThat(currentAnalyzerProvider, is(currentAnalyzerProviderReference));
-        assertThat(currentAnalyzerProvider, is(not(former090AnalyzerProvider)));
+        assertThat(currentAnalyzerProviderReference, is(not(former090AnalyzerProvider)));
     }
 }

--- a/src/test/java/org/elasticsearch/index/analysis/PreBuiltCharFilterFactoryFactoryTests.java
+++ b/src/test/java/org/elasticsearch/index/analysis/PreBuiltCharFilterFactoryFactoryTests.java
@@ -37,14 +37,12 @@ public class PreBuiltCharFilterFactoryFactoryTests extends ElasticsearchTestCase
     public void testThatDifferentVersionsCanBeLoaded() {
         PreBuiltCharFilterFactoryFactory factory = new PreBuiltCharFilterFactoryFactory(PreBuiltCharFilters.HTML_STRIP.getCharFilterFactory(Version.CURRENT));
 
-        CharFilterFactory emptySettingsTokenizerFactory = factory.create("html_strip", ImmutableSettings.EMPTY);
         CharFilterFactory former090TokenizerFactory = factory.create("html_strip", ImmutableSettings.settingsBuilder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.V_0_90_0).build());
         CharFilterFactory former090TokenizerFactoryCopy = factory.create("html_strip", ImmutableSettings.settingsBuilder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.V_0_90_0).build());
         CharFilterFactory currentTokenizerFactory = factory.create("html_strip", ImmutableSettings.settingsBuilder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT).build());
 
-        assertThat(emptySettingsTokenizerFactory, is(currentTokenizerFactory));
-        assertThat(emptySettingsTokenizerFactory, is(former090TokenizerFactory));
-        assertThat(emptySettingsTokenizerFactory, is(former090TokenizerFactoryCopy));
+        assertThat(currentTokenizerFactory, is(former090TokenizerFactory));
+        assertThat(currentTokenizerFactory, is(former090TokenizerFactoryCopy));
     }
 
 }

--- a/src/test/java/org/elasticsearch/index/analysis/PreBuiltTokenFilterFactoryFactoryTests.java
+++ b/src/test/java/org/elasticsearch/index/analysis/PreBuiltTokenFilterFactoryFactoryTests.java
@@ -36,27 +36,23 @@ public class PreBuiltTokenFilterFactoryFactoryTests extends ElasticsearchTestCas
     public void testThatCachingWorksForCachingStrategyOne() {
         PreBuiltTokenFilterFactoryFactory factory = new PreBuiltTokenFilterFactoryFactory(PreBuiltTokenFilters.WORD_DELIMITER.getTokenFilterFactory(Version.CURRENT));
 
-        TokenFilterFactory emptySettingsTokenizerFactory = factory.create("word_delimiter", ImmutableSettings.EMPTY);
         TokenFilterFactory former090TokenizerFactory = factory.create("word_delimiter", ImmutableSettings.settingsBuilder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.V_0_90_1).build());
         TokenFilterFactory former090TokenizerFactoryCopy = factory.create("word_delimiter", ImmutableSettings.settingsBuilder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.V_0_90_2).build());
         TokenFilterFactory currentTokenizerFactory = factory.create("word_delimiter", ImmutableSettings.settingsBuilder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT).build());
 
-        assertThat(emptySettingsTokenizerFactory, is(currentTokenizerFactory));
-        assertThat(emptySettingsTokenizerFactory, is(former090TokenizerFactory));
-        assertThat(emptySettingsTokenizerFactory, is(former090TokenizerFactoryCopy));
+        assertThat(currentTokenizerFactory, is(former090TokenizerFactory));
+        assertThat(currentTokenizerFactory, is(former090TokenizerFactoryCopy));
     }
 
     @Test
     public void testThatDifferentVersionsCanBeLoaded() {
         PreBuiltTokenFilterFactoryFactory factory = new PreBuiltTokenFilterFactoryFactory(PreBuiltTokenFilters.STOP.getTokenFilterFactory(Version.CURRENT));
 
-        TokenFilterFactory emptySettingsTokenizerFactory = factory.create("stop", ImmutableSettings.EMPTY);
         TokenFilterFactory former090TokenizerFactory = factory.create("stop", ImmutableSettings.settingsBuilder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.V_0_90_1).build());
         TokenFilterFactory former090TokenizerFactoryCopy = factory.create("stop", ImmutableSettings.settingsBuilder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.V_0_90_2).build());
         TokenFilterFactory currentTokenizerFactory = factory.create("stop", ImmutableSettings.settingsBuilder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT).build());
 
-        assertThat(emptySettingsTokenizerFactory, is(currentTokenizerFactory));
-        assertThat(emptySettingsTokenizerFactory, is(not(former090TokenizerFactory)));
+        assertThat(currentTokenizerFactory, is(not(former090TokenizerFactory)));
         assertThat(former090TokenizerFactory, is(former090TokenizerFactoryCopy));
     }
 

--- a/src/test/java/org/elasticsearch/index/analysis/PreBuiltTokenizerFactoryFactoryTests.java
+++ b/src/test/java/org/elasticsearch/index/analysis/PreBuiltTokenizerFactoryFactoryTests.java
@@ -36,15 +36,13 @@ public class PreBuiltTokenizerFactoryFactoryTests extends ElasticsearchTestCase 
     public void testThatDifferentVersionsCanBeLoaded() {
         PreBuiltTokenizerFactoryFactory factory = new PreBuiltTokenizerFactoryFactory(PreBuiltTokenizers.STANDARD.getTokenizerFactory(Version.CURRENT));
 
-        TokenizerFactory emptySettingsTokenizerFactory = factory.create("standard", ImmutableSettings.EMPTY);
         // different es versions, same lucene version, thus cached
         TokenizerFactory former090TokenizerFactory = factory.create("standard", ImmutableSettings.settingsBuilder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.V_0_90_1).build());
         TokenizerFactory former090TokenizerFactoryCopy = factory.create("standard", ImmutableSettings.settingsBuilder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.V_0_90_2).build());
         TokenizerFactory currentTokenizerFactory = factory.create("standard", ImmutableSettings.settingsBuilder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT).build());
 
-        assertThat(emptySettingsTokenizerFactory, is(currentTokenizerFactory));
-        assertThat(emptySettingsTokenizerFactory, is(not(former090TokenizerFactory)));
-        assertThat(emptySettingsTokenizerFactory, is(not(former090TokenizerFactoryCopy)));
+        assertThat(currentTokenizerFactory, is(not(former090TokenizerFactory)));
+        assertThat(currentTokenizerFactory, is(not(former090TokenizerFactoryCopy)));
         assertThat(former090TokenizerFactory, is(former090TokenizerFactoryCopy));
     }
 

--- a/src/test/java/org/elasticsearch/index/analysis/StopAnalyzerTests.java
+++ b/src/test/java/org/elasticsearch/index/analysis/StopAnalyzerTests.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.index.analysis;
 
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.inject.Injector;
 import org.elasticsearch.common.inject.ModulesBuilder;
 import org.elasticsearch.common.settings.Settings;
@@ -40,7 +42,7 @@ public class StopAnalyzerTests extends ElasticsearchTokenStreamTestCase {
     @Test
     public void testDefaultsCompoundAnalysis() throws Exception {
         Index index = new Index("test");
-        Settings settings = settingsBuilder().loadFromClasspath("org/elasticsearch/index/analysis/stop.json").build();
+        Settings settings = settingsBuilder().loadFromClasspath("org/elasticsearch/index/analysis/stop.json").put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT).build();
         Injector parentInjector = new ModulesBuilder().add(new SettingsModule(settings), new EnvironmentModule(new Environment(settings)), new IndicesAnalysisModule()).createInjector();
         Injector injector = new ModulesBuilder().add(
                 new IndexSettingsModule(index, settings),

--- a/src/test/java/org/elasticsearch/index/analysis/synonyms/SynonymsAnalysisTest.java
+++ b/src/test/java/org/elasticsearch/index/analysis/synonyms/SynonymsAnalysisTest.java
@@ -22,6 +22,8 @@ package org.elasticsearch.index.analysis.synonyms;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.inject.Injector;
 import org.elasticsearch.common.inject.ModulesBuilder;
 import org.elasticsearch.common.logging.ESLogger;
@@ -58,7 +60,9 @@ public class SynonymsAnalysisTest extends ElasticsearchTestCase {
     @Test
     public void testSynonymsAnalysis() throws IOException {
 
-        Settings settings = settingsBuilder().loadFromClasspath("org/elasticsearch/index/analysis/synonyms/synonyms.json").build();
+        Settings settings = settingsBuilder().
+                loadFromClasspath("org/elasticsearch/index/analysis/synonyms/synonyms.json")
+                .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT).build();
 
         Index index = new Index("test");
 

--- a/src/test/java/org/elasticsearch/index/query/TemplateQueryParserTest.java
+++ b/src/test/java/org/elasticsearch/index/query/TemplateQueryParserTest.java
@@ -20,7 +20,9 @@ package org.elasticsearch.index.query;
 
 import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.Query;
+import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.inject.Injector;
 import org.elasticsearch.common.inject.ModulesBuilder;
@@ -68,6 +70,7 @@ public class TemplateQueryParserTest extends ElasticsearchTestCase {
         Settings settings = ImmutableSettings.settingsBuilder()
                 .put("path.conf", this.getResource("config").getPath())
                 .put("name", getClass().getName())
+                .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
                 .build();
 
         Index index = new Index("test");

--- a/src/test/java/org/elasticsearch/index/query/plugin/IndexQueryParserPlugin2Tests.java
+++ b/src/test/java/org/elasticsearch/index/query/plugin/IndexQueryParserPlugin2Tests.java
@@ -19,7 +19,9 @@
 
 package org.elasticsearch.index.query.plugin;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.inject.Injector;
 import org.elasticsearch.common.inject.ModulesBuilder;
@@ -56,7 +58,7 @@ public class IndexQueryParserPlugin2Tests extends ElasticsearchTestCase {
 
     @Test
     public void testCustomInjection() throws InterruptedException {
-        Settings settings = ImmutableSettings.builder().put("name", "testCustomInjection").build();
+        Settings settings = ImmutableSettings.builder().put("name", "testCustomInjection").put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT).build();
 
         IndexQueryParserModule queryParserModule = new IndexQueryParserModule(settings);
         queryParserModule.addQueryParser("my", PluginJsonQueryParser.class);

--- a/src/test/java/org/elasticsearch/index/query/plugin/IndexQueryParserPluginTests.java
+++ b/src/test/java/org/elasticsearch/index/query/plugin/IndexQueryParserPluginTests.java
@@ -19,7 +19,9 @@
 
 package org.elasticsearch.index.query.plugin;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.inject.Injector;
 import org.elasticsearch.common.inject.ModulesBuilder;
@@ -56,7 +58,7 @@ public class IndexQueryParserPluginTests extends ElasticsearchTestCase {
 
     @Test
     public void testCustomInjection() throws InterruptedException {
-        Settings settings = ImmutableSettings.builder().put("name", "testCustomInjection").build();
+        Settings settings = ImmutableSettings.builder().put("name", "testCustomInjection").put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT).build();
 
         IndexQueryParserModule queryParserModule = new IndexQueryParserModule(settings);
         queryParserModule.addProcessor(new IndexQueryParserModule.QueryParsersProcessor() {

--- a/src/test/java/org/elasticsearch/test/ElasticsearchTokenStreamTestCase.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchTokenStreamTestCase.java
@@ -28,6 +28,8 @@ import org.apache.lucene.analysis.BaseTokenStreamTestCase;
 import org.apache.lucene.util.LuceneTestCase;
 import org.apache.lucene.util.TimeUnits;
 import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.test.junit.listeners.ReproduceInfoPrinter;
 
 @Listeners({
@@ -45,5 +47,9 @@ public abstract class ElasticsearchTokenStreamTestCase extends BaseTokenStreamTe
 
     public static Version randomVersion() {
         return ElasticsearchTestCase.randomVersion(random());
+    }
+
+    public ImmutableSettings.Builder newAnalysisSettingsBuilder() {
+        return ImmutableSettings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT);
     }
 }


### PR DESCRIPTION
Today we use the current version which might enable features that are
not supported. We should use the minimal known version rather than
defaulting to the current.
