### PR TITLE
`has_parent` filter must take parent filter into account when executing the inner query/filter

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/HasParentFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/HasParentFilterParser.java
@@ -23,10 +23,6 @@ import org.apache.lucene.search.Query;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.cache.fixedbitset.FixedBitSetFilter;
-import org.elasticsearch.index.fielddata.plain.ParentChildIndexFieldData;
-import org.elasticsearch.index.mapper.DocumentMapper;
-import org.elasticsearch.index.mapper.internal.ParentFieldMapper;
 import org.elasticsearch.index.query.support.XContentStructure;
 import org.elasticsearch.index.search.child.CustomQueryWrappingFilter;
 
@@ -63,7 +59,7 @@ public class HasParentFilterParser implements FilterParser {
         String filterName = null;
         String currentFieldName = null;
         XContentParser.Token token;
-        XContentStructure.InnerQuery innerQuery = null;
+        XContentStructure.InnerQuery iq = null;
         XContentStructure.InnerFilter innerFilter = null;
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
             if (token == XContentParser.Token.FIELD_NAME) {
@@ -74,7 +70,7 @@ public class HasParentFilterParser implements FilterParser {
                 // XContentStructure.<type> facade to parse if available,
                 // or delay parsing if not.
                 if ("query".equals(currentFieldName)) {
-                    innerQuery = new XContentStructure.InnerQuery(parseContext, parentType == null ? null : new String[] {parentType});
+                    iq = new XContentStructure.InnerQuery(parseContext, parentType == null ? null : new String[] {parentType});
                     queryFound = true;
                 } else if ("filter".equals(currentFieldName)) {
                     innerFilter = new XContentStructure.InnerFilter(parseContext, parentType == null ? null : new String[] {parentType});
@@ -103,18 +99,18 @@ public class HasParentFilterParser implements FilterParser {
             throw new QueryParsingException(parseContext.index(), "[has_parent] filter requires 'parent_type' field");
         }
 
-        Query query;
+        Query innerQuery;
         if (queryFound) {
-            query = innerQuery.asQuery(parentType);
+            innerQuery = iq.asQuery(parentType);
         } else {
-            query = innerFilter.asFilter(parentType);
+            innerQuery = innerFilter.asFilter(parentType);
         }
 
-        if (query == null) {
+        if (innerQuery == null) {
             return null;
         }
 
-        Query parentQuery = createParentQuery(query, parentType, false, parseContext);
+        Query parentQuery = createParentQuery(innerQuery, parentType, false, parseContext);
         if (parentQuery == null) {
             return null;
         }

--- a/src/main/java/org/elasticsearch/index/query/HasParentQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/HasParentQueryParser.java
@@ -122,14 +122,7 @@ public class HasParentQueryParser implements QueryParser {
             return null;
         }
 
-        DocumentMapper parentDocMapper = parseContext.mapperService().documentMapper(parentType);
-        if (parentDocMapper == null) {
-            throw new QueryParsingException(parseContext.index(), "[has_parent] query configured 'parent_type' [" + parentType + "] is not a valid type");
-        }
-
         innerQuery.setBoost(boost);
-        // wrap the query with type query
-        innerQuery = new XFilteredQuery(innerQuery, parseContext.cacheFilter(parentDocMapper.typeFilter(), null));
         Query query = createParentQuery(innerQuery, parentType, score, parseContext);
         if (query == null) {
             return null;
@@ -143,8 +136,13 @@ public class HasParentQueryParser implements QueryParser {
     }
 
     static Query createParentQuery(Query innerQuery, String parentType, boolean score, QueryParseContext parseContext) {
+        DocumentMapper parentDocMapper = parseContext.mapperService().documentMapper(parentType);
+        if (parentDocMapper == null) {
+            throw new QueryParsingException(parseContext.index(), "[has_parent] query configured 'parent_type' [" + parentType + "] is not a valid type");
+        }
+
         Set<String> parentTypes = new HashSet<>(5);
-        parentTypes.add(parentType);
+        parentTypes.add(parentDocMapper.type());
         ParentChildIndexFieldData parentChildIndexFieldData = null;
         for (DocumentMapper documentMapper : parseContext.mapperService().docMappers(false)) {
             ParentFieldMapper parentFieldMapper = documentMapper.parentFieldMapper();
@@ -182,11 +180,13 @@ public class HasParentQueryParser implements QueryParser {
             return null;
         }
 
+        // wrap the query with type query
+        innerQuery = new XFilteredQuery(innerQuery, parseContext.cacheFilter(parentDocMapper.typeFilter(), null));
         FixedBitSetFilter childrenFilter = parseContext.fixedBitSetFilter(new NotFilter(parentFilter));
         if (score) {
-            return new ParentQuery(parentChildIndexFieldData, innerQuery, parentType, childrenFilter);
+            return new ParentQuery(parentChildIndexFieldData, innerQuery, parentDocMapper.type(), childrenFilter);
         } else {
-            return new ParentConstantScoreQuery(parentChildIndexFieldData, innerQuery, parentType, childrenFilter);
+            return new ParentConstantScoreQuery(parentChildIndexFieldData, innerQuery, parentDocMapper.type(), childrenFilter);
         }
     }
 


### PR DESCRIPTION
A bug introduced via: #7362

The has_parent query does take the parent filter into account when executing the inner query.
