### PR TITLE
Fix serialization of short[] arays.

### DIFF
--- a/src/main/java/org/elasticsearch/common/xcontent/XContentBuilder.java
+++ b/src/main/java/org/elasticsearch/common/xcontent/XContentBuilder.java
@@ -1272,7 +1272,7 @@ public final class XContentBuilder implements BytesStream, Releasable {
             generator.writeEndArray();
         } else if (value instanceof short[]) {
             generator.writeStartArray();
-            for (float v : (short[]) value) {
+            for (short v : (short[]) value) {
                 generator.writeNumber(v);
             }
             generator.writeEndArray();


### PR DESCRIPTION
short[] were mistakenly encoded as a float[]. This is not an issue for the
text-based xcontents that we have (yaml, json) since floats can represent any
short value and are serialized as strings. However, this will make the binary
xcontents serialize shorts as int instead of floats.

Close #7845
