### PR TITLE
Fixes many misbehaving user parameters

### DIFF
--- a/docs/reference/migration/migrate_2_0.asciidoc
+++ b/docs/reference/migration/migrate_2_0.asciidoc
@@ -15,7 +15,11 @@ to change this behavior
 
 Partial fields were deprecated since 1.0.0beta1 in favor of <<search-request-source-filtering,source filtering>>.
 
-=== More Like This Field
+=== More Like This (MLT)
 
-The More Like This Field query has been removed in favor of the <<query-dsl-mlt-query, More Like This Query>>
-restrained set to a specific `field`.
+* The MLT Field Query has been removed in favor of the <<query-dsl-mlt-query,
+  More Like This Query>> restrained set to a specific `field`.
+
+* The MLT API has been improved to better take into account `max_query_terms`
+  and `minimum_should_match`. As a consequence the query should return
+  different but more relevant results.

--- a/src/main/java/org/elasticsearch/action/termvector/TermVectorFields.java
+++ b/src/main/java/org/elasticsearch/action/termvector/TermVectorFields.java
@@ -391,7 +391,7 @@ public final class TermVectorFields extends Fields {
         }
     }
 
-    private final class TermVectorDocsAndPosEnum extends DocsAndPositionsEnum {
+    public static final class TermVectorDocsAndPosEnum extends DocsAndPositionsEnum {
         private boolean hasPositions;
         private boolean hasOffsets;
         private boolean hasPayloads;
@@ -403,7 +403,7 @@ public final class TermVectorFields extends Fields {
         private BytesRefBuilder[] payloads;
         private int[] endOffsets;
 
-        private DocsAndPositionsEnum reset(int[] positions, int[] startOffsets, int[] endOffsets, BytesRefBuilder[] payloads, int freq) {
+        DocsAndPositionsEnum reset(int[] positions, int[] startOffsets, int[] endOffsets, BytesRefBuilder[] payloads, int freq) {
             curPos = -1;
             doc = -1;
             this.hasPositions = positions != null;

--- a/src/main/java/org/elasticsearch/action/termvector/TermVectorResponseParser.java
+++ b/src/main/java/org/elasticsearch/action/termvector/TermVectorResponseParser.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.termvector;
+
+import org.apache.lucene.analysis.core.KeywordAnalyzer;
+import org.apache.lucene.index.Fields;
+import org.apache.lucene.index.MultiFields;
+import org.apache.lucene.index.memory.MemoryIndex;
+import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.xcontent.XContentParser;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * This class is meant to parse the JSON response of a {@link TermVectorResponse} so that term vectors
+ * could be passed from {@link org.elasticsearch.action.mlt.TransportMoreLikeThisAction}
+ * to {@link org.elasticsearch.index.query.MoreLikeThisQueryParser}.
+ *
+ * <p>
+ * At the moment only <em>_index</em>, <em>_type</em>, <em>_id</em> and <em>term_vectors</em> are
+ * parsed from the response. Term vectors are returned as a {@link Fields} object.
+ * </p>
+*/
+public class TermVectorResponseParser {
+
+    public class ParsedTermVectorResponse {
+
+        private final String index;
+
+        private final String type;
+
+        private final String id;
+
+        private final Fields termVectorFields;
+
+        public ParsedTermVectorResponse(String index, String type, String id, Fields termVectorResponseFields) {
+            this.index = index;
+            this.type = type;
+            this.id = id;
+            this.termVectorFields = termVectorResponseFields;
+        }
+
+        public String index() {
+            return index;
+        }
+
+        public String type() {
+            return type;
+        }
+
+        public String id() {
+            return id;
+        }
+
+        public Fields termVectorFields() {
+            return termVectorFields;
+        }
+    }
+
+    private XContentParser parser;
+
+    public TermVectorResponseParser(XContentParser parser) throws IOException {
+        this.parser = parser;
+    }
+
+    public ParsedTermVectorResponse parse() throws IOException {
+        String index = null;
+        String type = null;
+        String id = null;
+        Fields termVectorFields = null;
+        XContentParser.Token token;
+        String currentFieldName = null;
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                currentFieldName = parser.currentName();
+            } else if (currentFieldName != null) {
+                if (currentFieldName.equals("_index")) {
+                    index = parser.text();
+                } else if (currentFieldName.equals("_type")) {
+                    type = parser.text();
+                } else if (currentFieldName.equals("_id")) {
+                    id = parser.text();
+                } else if (currentFieldName.equals("term_vectors")) {
+                    termVectorFields = parseTermVectors();
+                }
+            }
+        }
+        if (index == null || type == null || id == null || termVectorFields == null) {
+            throw new ElasticsearchParseException("\"_index\", \"_type\", \"_id\" or \"term_vectors\" missing from the response!");
+        }
+        return new ParsedTermVectorResponse(index, type, id, termVectorFields);
+    }
+
+    private Fields parseTermVectors() throws IOException {
+        MemoryIndex index = new MemoryIndex();
+        XContentParser.Token token;
+        String currentFieldName = null;
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                currentFieldName = parser.currentName();
+                while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+                    if (parser.currentName().equals("field_statistics")) {
+                        parser.skipChildren(); // not implemented
+                    } else if (parser.currentName().equals("terms")) {
+                        parser.nextToken();
+                        addToMemoryIndex(index, currentFieldName, parser.map());
+                    }
+                }
+            }
+        }
+        return MultiFields.getFields(index.createSearcher().getIndexReader());
+    }
+
+    private void addToMemoryIndex(MemoryIndex index, String fieldName, Map<String, Object> termInfo) throws IOException {
+        for (Map.Entry<String, Object> term : termInfo.entrySet()) {
+            int termFreq = (int) ((Map) (term.getValue())).get("term_freq");
+            for (int i = 0; i < termFreq; i++) {
+                index.addField(fieldName, term.getKey(), new KeywordAnalyzer());
+            }
+        }
+    }
+}
+

--- a/src/main/java/org/elasticsearch/rest/action/mlt/RestMoreLikeThisAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/mlt/RestMoreLikeThisAction.java
@@ -56,7 +56,8 @@ public class RestMoreLikeThisAction extends BaseRestHandler {
         //needs some work if it is to be used in a REST context like this too
         // See the MoreLikeThisQueryParser constants that hold the valid syntax
         mltRequest.fields(request.paramAsStringArray("mlt_fields", null));
-        mltRequest.minimumShouldMatch(request.param("minimum_should_match", "0"));
+        mltRequest.percentTermsToMatch(request.paramAsFloat("percent_terms_to_match", 0));
+        mltRequest.minimumShouldMatch(request.param("minimum_should_match", mltRequest.minimumShouldMatch()));
         mltRequest.minTermFreq(request.paramAsInt("min_term_freq", -1));
         mltRequest.maxQueryTerms(request.paramAsInt("max_query_terms", -1));
         mltRequest.stopWords(request.paramAsStringArray("stop_words", null));

--- a/src/test/java/org/elasticsearch/mlt/MoreLikeThisActionTests.java
+++ b/src/test/java/org/elasticsearch/mlt/MoreLikeThisActionTests.java
@@ -525,7 +525,7 @@ public class MoreLikeThisActionTests extends ElasticsearchIntegrationTest {
                     .maxQueryTerms(max_query_terms).percentTermsToMatch(0))
                     .actionGet();
             assertSearchResponse(response);
-            assertHitCount(response, values.length);
+            assertHitCount(response, max_query_terms);
         }
     }
 


### PR DESCRIPTION
Previously, the MLT API would create one MLT query per field and per value.
This would make the parameters related to the term selection and query
formation such as `max_query_terms`, `min_term_freq`, `minimum_should_match`
(previously `percent_terms_to_match`) or `boost_terms` behave in an unexpected
manner. Let's take the common example of looking up similar documents with
respect to a list of tag names. Suppose these tags are modeled by a multi-
value field with a keyword analyzer. Performing a MLT request would therefore
result in one MLT query per tag, regardless of the value of `max_query_terms`
or `minimum_should_match`. This would result in a query made of all the tag
names, if `min_term_freq` = 1 (no actual selection of terms is taking place),
or zero tag whatsoever, if `min_term_freq` > 1 (note the default is 2). The
`boost_terms` parameter would also have unexpected effects as it would depend
on the frequency of the term within field value and, again, not within the
whole field.

This commit fixes these issues by calling upon the term vector API and by
directly passing the response (the terms) to the MoreLikeThisQueryParser. Now
both the API and the query yield exactly the same results under any given set
of parameters, but while keeping the added benefit for the API of calling upon
the TV API only once.

Closes #2914
