### PR TITLE
Removes documentation escape character

### DIFF
--- a/docs/reference/cat/nodes.asciidoc
+++ b/docs/reference/cat/nodes.asciidoc
@@ -67,7 +67,7 @@ mode (`v`). The header name will match the supplied value (e.g.,
 
 ["source","sh",subs="attributes,callouts"]
 --------------------------------------------------
-% curl 192.168.56.10:9200/_cat/nodes?v\&h=id,ip,port,v,m
+% curl 192.168.56.10:9200/_cat/nodes?v&h=id,ip,port,v,m
 id   ip            port version m
 pLSN 192.168.56.30 9300 {version}   m
 k0zy 192.168.56.10 9300 {version}   m


### PR DESCRIPTION
The escape character `\` in the `curl` example doesn't work and should be removed from the documentation.
