### PR TITLE
Aggregations: Memory-bound terms.

### DIFF
--- a/src/main/java/org/elasticsearch/common/util/CountStreamingTopK.java
+++ b/src/main/java/org/elasticsearch/common/util/CountStreamingTopK.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.util;
+
+import com.carrotsearch.hppc.LongIntOpenHashMap;
+
+import java.util.Arrays;
+
+
+/**
+ * A {@link StreamingTopK} implementation that computes top terms, sorted by count.
+ * This implementation is based on the space-saving algorithm described in
+ * https://icmi.cs.ucsb.edu/research/tech_reports/reports/2005-23.pdf.
+ */
+public class CountStreamingTopK extends StreamingTopK {
+
+    // a priority queue that keeps bucket ordered by count
+    static class PriorityQueue {
+
+        final int size;
+        final int[] buckets;       // index in the pq -> bucket
+        final int[] bucketToIndex; // bucket -> index in the pq
+        final long[] counts;       // bucket -> count
+        int maxBucket;
+
+        PriorityQueue(int size) {
+            this.size = size;
+            buckets = new int[1 + size];
+            bucketToIndex = new int[1 + size];
+            Arrays.fill(buckets, size);
+            counts = new long[1 + size];
+        }
+
+        public int size() {
+            return size;
+        }
+
+        /** Return one greater than the largest allocated bucket so far. */
+        public int maxBucket() {
+            return maxBucket;
+        }
+
+        /** Return the bucket id for the given offset, or {@link #size()} if the bucket is not allocated yet. */
+        public int bucket(int i) {
+            return buckets[i + 1];
+        }
+
+        public long count(int bucket) {
+            return counts[bucket];
+        }
+
+        private void swap(int i, int j) {
+            final int bucketJ = buckets[i];
+            final int bucketI = buckets[j];
+            buckets[i] = bucketI;
+            buckets[j] = bucketJ;
+            // keep the reverse mapping up-to-date
+            bucketToIndex[bucketI] = i;
+            bucketToIndex[bucketJ] = j;
+        }
+
+        /**
+         * Add one to the term stored in the given bucket.
+         */
+        public void add(int bucket) {
+            assert bucket < size;
+            int node = bucketToIndex[bucket];
+            final long nodeCount = counts[bucket] + 1;
+            counts[bucket] = nodeCount;
+            while (true) {
+                int left = node << 1;
+                int right = left + 1;
+
+                if (left > size) {
+                    break;
+                }
+
+                int leastChild = left;
+                long leastChildCount = counts[buckets[left]];
+                if (right <= size) {
+                    final long rightChildCount = counts[buckets[right]];
+                    if (rightChildCount < leastChildCount) {
+                        leastChild = right;
+                        leastChildCount = rightChildCount;
+                    }
+                }
+
+                if (nodeCount > leastChildCount) {
+                    swap(node, leastChild);
+                    node = leastChild;
+                } else {
+                    break;
+                }
+            }
+        }
+
+        public int topBucket() {
+            int bucket = buckets[1];
+            if (bucket == size) { // we use size as a sentinel, means not allocated
+                bucket = buckets[1] = maxBucket++;
+                bucketToIndex[bucket] = 1;
+            }
+            return bucket;
+        }
+
+    }
+
+    private final LongIntOpenHashMap termToBucket; // term -> bucket
+    private final long[] terms;                    // bucket -> term
+    private final PriorityQueue counts;
+
+    public CountStreamingTopK(int size) {
+        termToBucket = new LongIntOpenHashMap(size);
+        counts = new PriorityQueue(size);
+        terms = new long[size];
+    }
+
+    @Override
+    public Status add(long term, Status status) {
+        if (termToBucket.containsKey(term)) {
+            // already tracked
+            final int bucket = termToBucket.lget();
+            counts.add(bucket);
+            return status.reset(bucket, false);
+        }
+        // not tracked yet, let's replace the least entry
+        final int bucket = counts.topBucket();
+        if (counts.count(bucket) > 0) {
+            termToBucket.remove(terms[bucket]);
+        }
+        terms[bucket] = term;
+        termToBucket.put(term, bucket);
+        assert termToBucket.size() == counts.maxBucket();
+        counts.add(bucket);
+        return status.reset(bucket, true);
+    }
+
+    @Override
+    public long[] topTerms() {
+        return Arrays.copyOf(terms, counts.maxBucket());
+    }
+
+}

--- a/src/main/java/org/elasticsearch/common/util/StreamingTopK.java
+++ b/src/main/java/org/elasticsearch/common/util/StreamingTopK.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.util;
+
+/**
+ * Base class to compute top terms.
+ */
+public abstract class StreamingTopK {
+
+    /**
+     * The status of an increment.
+     */
+    public static final class Status {
+
+        /**
+         * The bucket the term has been put into. This bucket is a dense integer
+         * between 0 and the size of the {@link StreamingTopK} instance. A value
+         * of <tt>-1</tt> indicates that the term has been ignored since it is
+         * not competitive. As much as possible, {@link StreamingTopK} instances
+         * try to reuse the same bucket for the same term.
+         */
+        public int bucket;
+
+        /**
+         * This value will be true if we are recycling a bucket that has
+         * previously be used for another term.
+         */
+        public boolean recycled;
+
+        Status reset(int bucket, boolean recycled) {
+            this.bucket = bucket;
+            this.recycled = recycled;
+            return this;
+        }
+    }
+
+    /**
+     * Increment the count for the given term and sets information about what
+     * happened into the {@link Status} object.
+     */
+    public abstract Status add(long term, Status status);
+
+    /**
+     * Return an array that maps bucket ids to their associated term.
+     */
+    public abstract long[] topTerms();
+}

--- a/src/main/java/org/elasticsearch/common/util/TermStreamingTopK.java
+++ b/src/main/java/org/elasticsearch/common/util/TermStreamingTopK.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.util;
+
+import com.carrotsearch.hppc.LongIntOpenHashMap;
+import com.google.common.base.Preconditions;
+
+import java.util.Arrays;
+
+/**
+ * A {@link StreamingTopK} implementation that computes top terms, sorted by term.
+ */
+public class TermStreamingTopK extends StreamingTopK {
+
+    // a priority queue that keeps bucket ordered by term
+    static class PriorityQueue {
+
+        final int size;      // max number of elements of the pq
+        final long[] terms;  // index in the pq -> term
+        final int[] buckets; // index in the pq -> bucket id
+        final boolean asc;   
+        int maxBucket;
+
+        PriorityQueue(int size, boolean asc) {
+            this.size = size;
+            terms = new long[1 + size];
+            buckets = new int[1 + size];
+            Arrays.fill(buckets, -1);
+            this.asc = asc;
+            if (asc) {
+                Arrays.fill(terms, Long.MAX_VALUE);
+            } else {
+                Arrays.fill(terms, Long.MIN_VALUE);
+            }
+        }
+
+        public int size() {
+            return size;
+        }
+
+        public int maxBucket() {
+            return maxBucket;
+        }
+
+        private void swap(int i, int j) {
+            final long tmpTerm = terms[i];
+            terms[i] = terms[j];
+            terms[j] = tmpTerm;
+            final int tmpBucket = buckets[i];
+            buckets[i] = buckets[j];
+            buckets[j] = tmpBucket;
+        }
+
+        public boolean lessThan(long i, long j) {
+            return asc ? i <= j : j <= i;
+        }
+
+        public long term(int i) {
+            return terms[i + 1];
+        }
+
+        public int bucket(int i) {
+            return buckets[i + 1];
+        }
+
+        public long topTerm() {
+            return terms[1];
+        }
+
+        /**
+         * Update the top term and return the new top term.
+         */
+        public long updateTopTerm(long topTerm, Status status) {
+            // get the bucket of the least term or allocate a new bucket
+            int bucket = buckets[1];
+            if (bucket < 0) {
+                status.recycled = false;
+                bucket = buckets[1] = maxBucket++;
+            } else {
+                status.recycled = true;
+            }
+            status.bucket = bucket;
+
+            // enforce heap structure
+            terms[1] = topTerm;
+            int node = 1;
+            while (true) {
+                int left = node << 1;
+                int right = left + 1;
+
+                if (left > size) {
+                    break;
+                }
+
+                int target = left;
+                if (right <= size && lessThan(terms[left], terms[right])) {
+                    target = right;
+                }
+
+                if (lessThan(topTerm, terms[target])) {
+                    swap(node, target);
+                    node = target;
+                } else {
+                    break;
+                }
+            }
+
+            return terms[1];
+        }
+
+    }
+
+    private final LongIntOpenHashMap termToBucket;
+    private final PriorityQueue terms;
+    private long topTerm;
+
+    public TermStreamingTopK(int size, boolean asc) {
+        Preconditions.checkArgument(size >= 1);
+        termToBucket = new LongIntOpenHashMap(size);
+        terms = new PriorityQueue(size, asc);
+        topTerm = terms.topTerm();
+    }
+
+    @Override
+    public Status add(long term, Status status) {
+        if (!terms.lessThan(term, topTerm)) {
+            // the new term is not competitive, ignore
+            return status.reset(-1, false);
+        }
+        if (termToBucket.containsKey(term)) {
+            // already tracked
+            final int bucket = termToBucket.lget();
+            return status.reset(bucket, false);
+        }
+        // the new term is not tracked yet, let's replace the least one
+        termToBucket.remove(topTerm);
+        topTerm = terms.updateTopTerm(term, status);
+        termToBucket.put(term, status.bucket);
+        assert termToBucket.size() == terms.maxBucket();
+        return status;
+    }
+
+    @Override
+    public long[] topTerms() {
+        final long[] topTerms = new long[terms.maxBucket()];
+        for (int i = 0; i < terms.size(); ++i) {
+            final int bucket = terms.bucket(i);
+            if (bucket >= 0) {
+                final long term = terms.term(i);
+                topTerms[bucket] = term;
+            }
+        }
+        return topTerms;
+    }
+
+}

--- a/src/test/java/org/elasticsearch/common/util/StreamingTopKTests.java
+++ b/src/test/java/org/elasticsearch/common/util/StreamingTopKTests.java
@@ -1,0 +1,321 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.util;
+
+import com.carrotsearch.hppc.LongLongOpenHashMap;
+import org.apache.lucene.util.InPlaceMergeSorter;
+import org.elasticsearch.test.ElasticsearchTestCase;
+
+import java.util.Arrays;
+import java.util.Random;
+
+public class StreamingTopKTests extends ElasticsearchTestCase {
+
+    private static class TermAndCount {
+        public final long term;
+        public final long count;
+
+        TermAndCount(long term, long count) {
+            this.term = term;
+            this.count = count;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = 1;
+            result = 31 * result + (int) (count ^ (count >>> 32));
+            result = 31 * result + (int) (term ^ (term >>> 32));
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == null)
+                return false;
+            if (getClass() != obj.getClass())
+                return false;
+            TermAndCount other = (TermAndCount) obj;
+            if (count != other.count)
+                return false;
+            if (term != other.term)
+                return false;
+            return true;
+        }
+
+        @Override
+        public String toString() {
+            return "{" + term + ":" + count + "}";
+        }
+    }
+
+    // Base implementation of a counter
+    private static interface Counter {
+
+        public void add(long term);
+
+        public TermAndCount[] topTerms();
+
+    }
+
+    // Dummy implementation that computes all counts and shrinks in the end
+    private static class DummyTopTermCounter implements Counter {
+
+        private final boolean asc;
+        private final int size;
+        private final LongLongOpenHashMap counts;
+
+        public DummyTopTermCounter(boolean asc, int size) {
+            this.asc = asc;
+            this.size = size;
+            counts = new LongLongOpenHashMap();
+        }
+
+        @Override
+        public void add(long term) {
+            if (counts.containsKey(term)) {
+                counts.lset(counts.lget() + 1);
+            } else {
+                counts.put(term, 1);
+            }
+        }
+
+        @Override
+        public TermAndCount[] topTerms() {
+            final long[] terms = counts.keys().toArray();
+            new InPlaceMergeSorter() {
+                @Override
+                protected void swap(int i, int j) {
+                    final long tmp = terms[i];
+                    terms[i] = terms[j];
+                    terms[j] = tmp;
+                }
+
+                @Override
+                protected int compare(int i, int j) {
+                    return asc ? Long.compare(terms[i], terms[j]) : Long.compare(terms[j], terms[i]);
+                }
+            }.sort(0, terms.length);
+            TermAndCount[] topTerms = new TermAndCount[Math.min(size, terms.length)];
+            for (int i = 0; i < topTerms.length; ++i) {
+                topTerms[i] = new TermAndCount(terms[i], counts.get(terms[i]));
+            }
+            return topTerms;
+        }
+
+    }
+
+    private static class StreamingTopTermCounter implements Counter {
+
+        private final boolean asc;
+        private final StreamingTopK topK;
+        private final long[] counts;
+        private final StreamingTopK.Status status;
+
+        StreamingTopTermCounter(boolean asc, int size) {
+            this.asc = asc;
+            topK = new TermStreamingTopK(size, asc);
+            counts = new long[size];
+            status = new StreamingTopK.Status();
+        }
+
+        @Override
+        public void add(long term) {
+            topK.add(term, status);
+            if (status.bucket >= 0) {
+                if (status.recycled) {
+                    counts[status.bucket] = 1;
+                } else {
+                    counts[status.bucket] += 1;
+                }
+            }
+        }
+
+        @Override
+        public TermAndCount[] topTerms() {
+            final long[] terms = topK.topTerms();
+            final TermAndCount[] topTerms = new TermAndCount[terms.length];
+            for (int i = 0; i < terms.length; ++i) {
+                topTerms[i] = new TermAndCount(terms[i], counts[i]);
+            }
+            new InPlaceMergeSorter() {
+
+                @Override
+                protected void swap(int i, int j) {
+                    TermAndCount tmp = topTerms[i];
+                    topTerms[i] = topTerms[j];
+                    topTerms[j] = tmp;
+                }
+
+                @Override
+                protected int compare(int i, int j) {
+                    return asc ? Long.compare(topTerms[i].term, topTerms[j].term) : Long.compare(topTerms[j].term, topTerms[i].term);
+                }
+            }.sort(0, topTerms.length);
+            return topTerms;
+        }
+
+    }
+
+    // Dummy implementation that computes all counts and shrinks in the end
+    private static class DummyTopCountCounter implements Counter {
+
+        private final int size;
+        private final LongLongOpenHashMap counts;
+
+        public DummyTopCountCounter(int size) {
+            this.size = size;
+            counts = new LongLongOpenHashMap();
+        }
+
+        @Override
+        public void add(long term) {
+            if (counts.containsKey(term)) {
+                counts.lset(counts.lget() + 1);
+            } else {
+                counts.put(term, 1);
+            }
+        }
+
+        @Override
+        public TermAndCount[] topTerms() {
+            final long[] terms = counts.keys().toArray();
+            new InPlaceMergeSorter() {
+                @Override
+                protected void swap(int i, int j) {
+                    final long tmp = terms[i];
+                    terms[i] = terms[j];
+                    terms[j] = tmp;
+                }
+
+                @Override
+                protected int compare(int i, int j) {
+                    return Long.compare(counts.get(terms[j]), counts.get(terms[i]));
+                }
+            }.sort(0, terms.length);
+            TermAndCount[] topTerms = new TermAndCount[Math.min(size, terms.length)];
+            for (int i = 0; i < topTerms.length; ++i) {
+                topTerms[i] = new TermAndCount(terms[i], counts.get(terms[i]));
+            }
+            return topTerms;
+        }
+    }
+
+    private static class StreamingTopCountCounter implements Counter {
+
+        private final StreamingTopK topK;
+        private final long[] counts;
+        private final StreamingTopK.Status status;
+
+        StreamingTopCountCounter(int size) {
+            topK = new CountStreamingTopK(size);
+            counts = new long[size];
+            status = new StreamingTopK.Status();
+        }
+
+        @Override
+        public void add(long term) {
+            topK.add(term, status);
+            if (status.recycled) {
+                counts[status.bucket] = 1;
+            } else {
+                counts[status.bucket] += 1;
+            }
+        }
+
+        @Override
+        public TermAndCount[] topTerms() {
+            final long[] terms = topK.topTerms();
+            final TermAndCount[] topTerms = new TermAndCount[terms.length];
+            for (int i = 0; i < terms.length; ++i) {
+                topTerms[i] = new TermAndCount(terms[i], counts[i]);
+            }
+            new InPlaceMergeSorter() {
+                @Override
+                protected void swap(int i, int j) {
+                    TermAndCount tmp = topTerms[i];
+                    topTerms[i] = topTerms[j];
+                    topTerms[j] = tmp;
+                }
+
+                @Override
+                protected int compare(int i, int j) {
+                    return Long.compare(topTerms[j].count, topTerms[i].count);
+                }
+            }.sort(0, topTerms.length);
+            return topTerms;
+        }
+    }
+
+    public void testTerms() {
+        // we run a duel between our streaming impl and the dummy impl
+        for (boolean asc : new boolean[] { true, false }) {
+            final int numberOfUniqueValues = scaledRandomIntBetween(1, 100000);
+            final int iters = scaledRandomIntBetween(numberOfUniqueValues, Math.max(100000, numberOfUniqueValues * 3));
+            final int k = scaledRandomIntBetween(1, 1000);
+            final long[] terms = new long[numberOfUniqueValues];
+            for (int i = 0; i < terms.length; ++i) {
+                terms[i] = randomLong();
+            }
+
+            Counter counter1 = new DummyTopTermCounter(asc, k);
+            Counter counter2 = new StreamingTopTermCounter(asc, k);
+            for (int i = 0; i < iters; ++i) {
+                final long term = terms[randomInt(numberOfUniqueValues - 1)];
+                counter1.add(term);
+                counter2.add(term);
+            }
+            final TermAndCount[] topTerms1 = counter1.topTerms();
+            final TermAndCount[] topTerms2 = counter2.topTerms();
+            assertArrayEquals(topTerms1, topTerms2);
+        }
+    }
+
+    public void testCounts() {
+        // still a duel but this time the streaming impl is not accurate
+        final int numberOfUniqueValues = 1000;
+        final int iters = 1000000;
+        final long[] terms = new long[numberOfUniqueValues];
+        for (int i = 0; i < terms.length; ++i) {
+            terms[i] = randomLong();
+        }
+
+        for (int iter = 0; iter < 10; ++iter) {
+            final int k = scaledRandomIntBetween(100, 1100);
+            Counter counter1 = new DummyTopCountCounter(k);
+            Counter counter2 = new StreamingTopCountCounter(k);
+            // the streaming implementation is approximate by nature. If we used a random seed
+            // then we could sometimes hit a special sequence of numbers that would increase
+            // the error, this is why we test on a single seed
+            Random r = new Random(0);
+            for (int i = 0; i < iters; ++i) {
+                final int index = (int) (Math.pow(r.nextDouble(), 10) * numberOfUniqueValues); // force some terms to be much more frequent
+                final long term = terms[index];
+                counter1.add(term);
+                counter2.add(term);
+            }
+            final TermAndCount[] topTerms1 = counter1.topTerms();
+            final TermAndCount[] topTerms2 = counter2.topTerms();
+            assertEquals(topTerms1.length, topTerms2.length);
+            // only compare the top 5 elements, afterwards errors are expected
+            assertArrayEquals(Arrays.copyOf(topTerms1, 5), Arrays.copyOf(topTerms2, 5));
+        }
+    }
+
+}


### PR DESCRIPTION
This pull request is only a first building block for #6697. It doesn't change
anything and is not ready for review yet.

Utility classes to compute the top terms sorted either by term or count in a
streaming fashion. In both cases, we rely on priority queues.

Sorting by term produces accurate results. Sorting by count (only desc is
supported, not asc) is based on the space-saving algorithm:
https://icmi.cs.ucsb.edu/research/tech_reports/reports/2005-23.pdf
and is not fully accurate.
