### PR TITLE
Clear the GroovyClassLoader cache before compiling

### DIFF
--- a/src/main/java/org/elasticsearch/script/NativeScriptEngineService.java
+++ b/src/main/java/org/elasticsearch/script/NativeScriptEngineService.java
@@ -93,4 +93,9 @@ public class NativeScriptEngineService extends AbstractComponent implements Scri
     @Override
     public void close() {
     }
+
+    @Override
+    public void scriptRemoved(CompiledScript script) {
+        // Nothing to do here
+    }
 }

--- a/src/main/java/org/elasticsearch/script/ScriptEngineService.java
+++ b/src/main/java/org/elasticsearch/script/ScriptEngineService.java
@@ -46,4 +46,11 @@ public interface ScriptEngineService {
     Object unwrap(Object value);
 
     void close();
+
+    /**
+     * Handler method called when a script is removed from the Guava cache.
+     *
+     * The passed script may be null if it has already been garbage collected.
+     * */
+    void scriptRemoved(@Nullable CompiledScript script);
 }

--- a/src/main/java/org/elasticsearch/script/expression/ExpressionScriptEngineService.java
+++ b/src/main/java/org/elasticsearch/script/expression/ExpressionScriptEngineService.java
@@ -33,6 +33,7 @@ import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.core.NumberFieldMapper;
+import org.elasticsearch.script.CompiledScript;
 import org.elasticsearch.script.ExecutableScript;
 import org.elasticsearch.script.ScriptEngineService;
 import org.elasticsearch.script.SearchScript;
@@ -154,4 +155,9 @@ public class ExpressionScriptEngineService extends AbstractComponent implements 
 
     @Override
     public void close() {}
+
+    @Override
+    public void scriptRemoved(CompiledScript script) {
+        // Nothing to do
+    }
 }

--- a/src/main/java/org/elasticsearch/script/groovy/GroovyScriptEngineService.java
+++ b/src/main/java/org/elasticsearch/script/groovy/GroovyScriptEngineService.java
@@ -43,7 +43,6 @@ import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.script.*;
 import org.elasticsearch.search.lookup.SearchLookup;
-import org.elasticsearch.search.suggest.term.TermSuggestion;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -86,6 +85,16 @@ public class GroovyScriptEngineService extends AbstractComponent implements Scri
             loader.close();
         } catch (IOException e) {
             logger.warn("Unable to close Groovy loader", e);
+        }
+    }
+
+    @Override
+    public void scriptRemoved(@Nullable CompiledScript script) {
+        // script could be null, meaning the script has already been garbage collected
+        if (script == null || "groovy".equals(script.lang())) {
+            // Clear the cache, this removes old script versions from the
+            // cache to prevent running out of PermGen space
+            loader.clearCache();
         }
     }
 

--- a/src/main/java/org/elasticsearch/script/mustache/MustacheScriptEngineService.java
+++ b/src/main/java/org/elasticsearch/script/mustache/MustacheScriptEngineService.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.io.FastStringReader;
 import org.elasticsearch.common.io.UTF8StreamWriter;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.script.CompiledScript;
 import org.elasticsearch.script.ExecutableScript;
 import org.elasticsearch.script.ScriptEngineService;
 import org.elasticsearch.script.SearchScript;
@@ -145,6 +146,11 @@ public class MustacheScriptEngineService extends AbstractComponent implements Sc
 
     @Override
     public void close() {
+        // Nothing to do here
+    }
+
+    @Override
+    public void scriptRemoved(CompiledScript script) {
         // Nothing to do here
     }
 

--- a/src/test/java/org/elasticsearch/script/ScriptServiceTests.java
+++ b/src/test/java/org/elasticsearch/script/ScriptServiceTests.java
@@ -132,6 +132,11 @@ public class ScriptServiceTests extends ElasticsearchTestCase {
         public void close() {
 
         }
+
+        @Override
+        public void scriptRemoved(CompiledScript script) {
+            // Nothing to do here
+        }
     }
 
 }


### PR DESCRIPTION
Since we don't use the cache, it's okay to clear it entirely if needed,
Elasticsearch maintains its own cache for compiled scripts.

Fixes #7658
Fixes #8073
