### PR TITLE
Internal: Make version parsing more lenient

### DIFF
--- a/src/main/java/org/elasticsearch/common/lucene/Lucene.java
+++ b/src/main/java/org/elasticsearch/common/lucene/Lucene.java
@@ -427,10 +427,14 @@ public class Lucene {
                 try {
                     return Version.parseLeniently(toParse);
                 } catch (IllegalArgumentException e) {
-                    final String parsedMatchVersion = toParse
-                            .toUpperCase(Locale.ROOT)
-                            .replaceFirst("^(\\d+)\\.(\\d+)(.(\\d+))+$", "LUCENE_$1_$2");
-                    return Version.valueOf(parsedMatchVersion);
+                    try {
+                        final String parsedMatchVersion = toParse
+                                .toUpperCase(Locale.ROOT)
+                                .replaceFirst("^(\\d+)\\.(\\d+)(.(\\d+))+$", "LUCENE_$1_$2");
+                        return Version.valueOf(parsedMatchVersion);
+                    } catch (IllegalArgumentException ex) {
+                        // just move on and return the default
+                    }
                 }
             }
             return defaultValue;


### PR DESCRIPTION
Today we fall back to a beta/alpha version parsing if the first attemp
failed. Yet, if the second attemp failed we throw the exception rather
than returning the default value provided.

Note: this PR is only against `1.3` newer branches don't have this problem
