### PR TITLE
Fix serialization of PendingClusterTask.timeInQueue.

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/service/PendingClusterTask.java
+++ b/src/main/java/org/elasticsearch/cluster/service/PendingClusterTask.java
@@ -79,7 +79,11 @@ public class PendingClusterTask implements Streamable {
         insertOrder = in.readVLong();
         priority = Priority.readFrom(in);
         source = in.readText();
-        timeInQueue = in.readVLong();
+        if (in.getVersion().onOrAfter(Version.V_1_4_0)) {
+            timeInQueue = in.readLong();
+        } else {
+            timeInQueue = in.readVLong();
+        }
         if (in.getVersion().onOrAfter(Version.V_1_3_0)) {
             executing = in.readBoolean();
         }
@@ -90,7 +94,12 @@ public class PendingClusterTask implements Streamable {
         out.writeVLong(insertOrder);
         Priority.writeTo(priority, out);
         out.writeText(source);
-        out.writeVLong(timeInQueue);
+        if (out.getVersion().onOrAfter(Version.V_1_4_0)) {
+            // timeInQueue is set to -1 when unknown and can be negative if time goes backwards
+            out.writeLong(timeInQueue);
+        } else {
+            out.writeVLong(timeInQueue);
+        }
         if (out.getVersion().onOrAfter(Version.V_1_3_0)) {
             out.writeBoolean(executing);
         }


### PR DESCRIPTION
This parameter is serialized as a vLong while it could sometimes be negative.
