### PR TITLE
Only schedule another refresh if `refresh_interval` is positive

### DIFF
--- a/src/main/java/org/elasticsearch/index/shard/service/InternalIndexShard.java
+++ b/src/main/java/org/elasticsearch/index/shard/service/InternalIndexShard.java
@@ -929,6 +929,9 @@ public class InternalIndexShard extends AbstractIndexShardComponent implements I
                 if (!refreshInterval.equals(InternalIndexShard.this.refreshInterval)) {
                     logger.info("updating refresh_interval from [{}] to [{}]", InternalIndexShard.this.refreshInterval, refreshInterval);
                     if (refreshScheduledFuture != null) {
+                        // NOTE: we pass false here so we do NOT attempt Thread.interrupt if EngineRefresher.run is currently running.  This is
+                        // very important, because doing so can cause files to suddenly be closed if they were doing IO when the interrupt
+                        // hit.  See https://issues.apache.org/jira/browse/LUCENE-2239
                         refreshScheduledFuture.cancel(false);
                         refreshScheduledFuture = null;
                     }

--- a/src/main/java/org/elasticsearch/index/shard/service/InternalIndexShard.java
+++ b/src/main/java/org/elasticsearch/index/shard/service/InternalIndexShard.java
@@ -946,11 +946,7 @@ public class InternalIndexShard extends AbstractIndexShardComponent implements I
         public void run() {
             // we check before if a refresh is needed, if not, we reschedule, otherwise, we fork, refresh, and then reschedule
             if (!engine().refreshNeeded()) {
-                synchronized (mutex) {
-                    if (state != IndexShardState.CLOSED) {
-                        refreshScheduledFuture = threadPool.schedule(refreshInterval, ThreadPool.Names.SAME, this);
-                    }
-                }
+                reschedule();
                 return;
             }
             threadPool.executor(ThreadPool.Names.REFRESH).execute(new Runnable() {
@@ -979,13 +975,19 @@ public class InternalIndexShard extends AbstractIndexShardComponent implements I
                             logger.warn("Failed to perform scheduled engine refresh", e);
                         }
                     }
-                    synchronized (mutex) {
-                        if (state != IndexShardState.CLOSED) {
-                            refreshScheduledFuture = threadPool.schedule(refreshInterval, ThreadPool.Names.SAME, EngineRefresher.this);
-                        }
-                    }
+
+                    reschedule();
                 }
             });
+        }
+
+        /** Schedules another (future) refresh, if refresh_interval is still enabled. */
+        private void reschedule() {
+            synchronized (mutex) {
+                if (state != IndexShardState.CLOSED && refreshInterval.millis() > 0) {
+                    refreshScheduledFuture = threadPool.schedule(refreshInterval, ThreadPool.Names.SAME, this);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
If a EngingRefresher.run was already running when the refresh_interval is
dynamically updated down to a non-positive value (0, -1, etc.), then
it's was possible for the refresh thread to go into while (true)
refresh() loop.

Closes #8085
