### PR TITLE
Support binding on multiple host/port pairs

### DIFF
--- a/docs/reference/modules/transport.asciidoc
+++ b/docs/reference/modules/transport.asciidoc
@@ -48,6 +48,33 @@ between all nodes. Defaults to `false`.
 It also uses the common
 <<modules-network,network settings>>.
 
+==== TCP Transport Profiles
+
+Elasticsearch allows you to bind to multiple ports on different interfaces by the use of transport profiles. See this example configuration
+
+```
+transport.profiles.default.port: 9300-9400
+transport.profiles.default.bind_host: 10.0.0.1
+transport.profiles.client.port: 9500-9600
+transport.profiles.client.bind_host: 192.168.0.1
+transport.profiles.dmz.port: 9700-9800
+transport.profiles.dmz.bind_host: 172.16.1.2
+```
+
+The `default` profile is a special. It is used as fallback for any other profiles, if those do not have a specific configuration setting set.
+Note that the default profile is how other nodes in the cluster will connect to this node usually. In the future this feature will allow to enable node-to-node communication via multiple interfaces.
+
+The following parameters can be configured like that
+
+* `port`: The port to bind to
+* `bind_host`: The host to bind
+* `publish_host`: The host which is published in informational APIs
+* `tcp_no_delay`: Configures the `TCP_NO_DELAY` option for this socket
+* `tcp_keep_alive`: Configures the `SO_KEEPALIVE` option for this socket
+* `reuse_address`: Configures the `SO_REUSEADDR` option for this socket
+* `tcp_send_buffer_size`: Configures the send buffer size of the socket
+* `tcp_receive_buffer_size`: Configures the receive buffer size of the socket
+
 [float]
 === Local Transport
 

--- a/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
+++ b/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.common.util.concurrent;
 
+import com.google.common.base.Joiner;
 import org.elasticsearch.common.settings.Settings;
 
 import java.util.concurrent.*;
@@ -72,6 +73,10 @@ public class EsExecutors {
         return new EsThreadPoolExecutor(size, size, 0, TimeUnit.MILLISECONDS, queue, threadFactory, new EsAbortPolicy());
     }
 
+    public static String threadName(Settings settings, String ... names) {
+        return threadName(settings, "[" +  Joiner.on(".").skipNulls().join(names) + "]");
+    }
+
     public static String threadName(Settings settings, String namePrefix) {
         String name = settings.get("name");
         if (name == null) {
@@ -84,6 +89,10 @@ public class EsExecutors {
 
     public static ThreadFactory daemonThreadFactory(Settings settings, String namePrefix) {
         return daemonThreadFactory(threadName(settings, namePrefix));
+    }
+
+    public static ThreadFactory daemonThreadFactory(Settings settings, String ... names) {
+        return daemonThreadFactory(threadName(settings, names));
     }
 
     public static ThreadFactory daemonThreadFactory(String namePrefix) {

--- a/src/test/java/org/elasticsearch/test/transport/NettyTransportMultiPortIntegrationTests.java
+++ b/src/test/java/org/elasticsearch/test/transport/NettyTransportMultiPortIntegrationTests.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.test.transport;
+
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthStatus;
+import org.elasticsearch.client.transport.TransportClient;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.InetSocketTransportAddress;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.junit.annotations.Network;
+import org.elasticsearch.test.junit.annotations.TestLogging;
+import org.junit.Test;
+
+import java.util.Locale;
+
+import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.Scope;
+import static org.hamcrest.Matchers.is;
+
+/**
+ *
+ */
+@ClusterScope(scope = Scope.SUITE, numDataNodes = 1)
+public class NettyTransportMultiPortIntegrationTests extends ElasticsearchIntegrationTest {
+
+    private final int randomPort = randomIntBetween(1025, 65000);
+    private final String randomPortRange = String.format(Locale.ROOT, "%s-%s", randomPort, randomPort+100);
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return settingsBuilder()
+                .put(super.nodeSettings(nodeOrdinal))
+                .put("network.host", "127.0.0.1")
+                .put("node.mode", "network")
+                .put("transport.profiles.client1.port", randomPortRange)
+                .put("transport.profiles.client1.reuse_address", true)
+                .build();
+    }
+
+    @Test
+    @Network
+    @TestLogging("transport.netty:DEBUG")
+    public void testThatTransportClientCanConnect() throws Exception {
+        Settings settings = settingsBuilder().put("cluster.name", internalCluster().getClusterName()).build();
+        try (TransportClient transportClient = new TransportClient(settings)) {
+            transportClient.addTransportAddress(new InetSocketTransportAddress("localhost", randomPort));
+            ClusterHealthResponse response = transportClient.admin().cluster().prepareHealth().get();
+            assertThat(response.getStatus(), is(ClusterHealthStatus.GREEN));
+        }
+    }
+
+}

--- a/src/test/java/org/elasticsearch/test/transport/NettyTransportMultiPortTests.java
+++ b/src/test/java/org/elasticsearch/test/transport/NettyTransportMultiPortTests.java
@@ -1,0 +1,227 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.test.transport;
+
+import com.carrotsearch.hppc.IntOpenHashSet;
+import com.google.common.base.Charsets;
+import com.google.common.collect.Sets;
+import org.elasticsearch.Version;
+import org.elasticsearch.cache.recycler.PageCacheRecycler;
+import org.elasticsearch.cluster.metadata.BenchmarkMetaData;
+import org.elasticsearch.common.component.Lifecycle;
+import org.elasticsearch.common.network.NetworkService;
+import org.elasticsearch.common.network.NetworkUtils;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.InetSocketTransportAddress;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
+import org.elasticsearch.node.settings.NodeSettingsService;
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.test.cache.recycler.MockBigArrays;
+import org.elasticsearch.test.junit.annotations.Network;
+import org.elasticsearch.test.junit.annotations.TestLogging;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.netty.NettyTransport;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.util.Set;
+
+import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.Scope;
+import static org.hamcrest.Matchers.is;
+
+/**
+ *
+ */
+@ClusterScope(scope = Scope.TEST, numDataNodes = 1)
+public class NettyTransportMultiPortTests extends ElasticsearchTestCase {
+
+    private NettyTransport nettyTransport;
+    private ThreadPool threadPool;
+
+    @After
+    public void shutdownNettyTransport() {
+        if (nettyTransport != null) {
+            nettyTransport.stop();
+        }
+        if (threadPool != null) {
+            threadPool.shutdownNow();
+        }
+
+    }
+
+    @Test
+    @TestLogging("shield.transport.netty:DEBUG")
+    public void testThatNettyCanBindToMultiplePorts() throws Exception {
+        int[] ports = getRandomPorts(3);
+
+        Settings settings = settingsBuilder()
+                .put("network.host", "127.0.0.1")
+                .put("transport.tcp.port", ports[0])
+                .put("transport.profiles.default.port", ports[1])
+                .put("transport.profiles.client1.port", ports[2])
+                .build();
+
+        startNettyTransport(settings);
+
+        assertConnectionRefused(ports[0]);
+        assertPortIsBound(ports[1]);
+        assertPortIsBound(ports[2]);
+    }
+
+    @Test
+    @TestLogging("transport.netty:DEBUG")
+    public void testThatDefaultProfileInheritsFromStandardSettings() throws Exception {
+        int[] ports = getRandomPorts(2);
+
+        Settings settings = settingsBuilder()
+                .put("network.host", "127.0.0.1")
+                .put("transport.tcp.port", ports[0])
+                .put("transport.profiles.client1.port", ports[1])
+                .build();
+
+        startNettyTransport(settings);
+
+        assertPortIsBound(ports[0]);
+        assertPortIsBound(ports[1]);
+    }
+
+    @Test
+    @TestLogging("transport.netty:DEBUG")
+    public void testThatProfileWithoutPortSettingsFails() throws Exception {
+        int[] ports = getRandomPorts(1);
+
+        Settings settings = settingsBuilder()
+                .put("network.host", "127.0.0.1")
+                .put("transport.tcp.port", ports[0])
+                .put("transport.profiles.client1.whatever", "foo")
+                .build();
+
+        startNettyTransport(settings);
+
+        assertPortIsBound(ports[0]);
+    }
+
+    @Test
+    @TestLogging("transport.netty:DEBUG")
+    public void testThatDefaultProfilePortOverridesGeneralConfiguration() throws Exception {
+        int[] ports = getRandomPorts(3);
+
+        Settings settings = settingsBuilder()
+                .put("network.host", "127.0.0.1")
+                .put("transport.tcp.port", ports[0])
+                .put("transport.netty.port", ports[1])
+                .put("transport.profiles.default.port", ports[2])
+                .build();
+
+        startNettyTransport(settings);
+
+        assertConnectionRefused(ports[0]);
+        assertConnectionRefused(ports[1]);
+        assertPortIsBound(ports[2]);
+    }
+
+    @Test
+    @Network
+    public void testThatBindingOnDifferentHostsWorks() throws Exception {
+        int[] ports = getRandomPorts(2);
+        InetAddress firstNonLoopbackAddress = NetworkUtils.getFirstNonLoopbackAddress(NetworkUtils.StackType.IPv4);
+
+        Settings settings = settingsBuilder()
+                .put("network.host", "127.0.0.1")
+                .put("transport.tcp.port", ports[0])
+                .put("transport.profiles.default.bind_host", "127.0.0.1")
+                .put("transport.profiles.client1.bind_host", firstNonLoopbackAddress.getHostAddress())
+                .put("transport.profiles.client1.port", ports[1])
+                .build();
+
+        startNettyTransport(settings);
+
+        assertPortIsBound("127.0.0.1", ports[0]);
+        assertPortIsBound(firstNonLoopbackAddress.getHostAddress(), ports[1]);
+        assertConnectionRefused(ports[1]);
+    }
+
+    // TODO, make sure one can check more settings and that they are applied correctly
+
+    private int[] getRandomPorts(int numberOfPorts) {
+        IntOpenHashSet ports = new IntOpenHashSet();
+
+        for (int i = 0; i < numberOfPorts; i++) {
+            int port = randomIntBetween(1025, 65000);
+            while (ports.contains(port)) {
+                port = randomIntBetween(1025, 65000);
+            }
+            ports.add(port);
+        }
+
+        return ports.toArray();
+    }
+
+    private void startNettyTransport(Settings settings) {
+        threadPool = new ThreadPool("tst");
+        BigArrays bigArrays = new MockBigArrays(settings, new PageCacheRecycler(settings, threadPool), new NoneCircuitBreakerService());
+
+        nettyTransport = new NettyTransport(settings, threadPool, new NetworkService(settings), bigArrays, Version.CURRENT);
+        nettyTransport.start();
+
+        assertThat(nettyTransport.lifecycleState(), is(Lifecycle.State.STARTED));
+    }
+
+    private void assertConnectionRefused(int port) throws Exception {
+        try {
+            trySocketConnection(new InetSocketTransportAddress("localhost", port).address());
+            fail("Expected to get exception when connecting to port " + port);
+        } catch (IOException e) {
+            // expected
+            logger.info("Got expected connection message {}", e.getMessage());
+        }
+    }
+
+    private void assertPortIsBound(int port) throws Exception {
+        assertPortIsBound("localhost", port);
+    }
+
+    private void assertPortIsBound(String host, int port) throws Exception {
+        logger.info("Trying to connect to [{}]:[{}]", host, port);
+        trySocketConnection(new InetSocketTransportAddress(host, port).address());
+    }
+
+    private void trySocketConnection(InetSocketAddress address) throws Exception {
+        try (Socket socket = new Socket()) {
+            logger.info("Connecting to {}", address);
+            socket.connect(address, 500);
+
+            assertThat(socket.isConnected(), is(true));
+            try (OutputStream os = socket.getOutputStream()) {
+                os.write("foo".getBytes(Charsets.UTF_8));
+                os.flush();
+            }
+        }
+    }
+}

--- a/src/test/java/org/elasticsearch/test/transport/NettyTransportTests.java
+++ b/src/test/java/org/elasticsearch/test/transport/NettyTransportTests.java
@@ -90,16 +90,16 @@ public class NettyTransportTests extends ElasticsearchIntegrationTest {
         }
 
         @Override
-        public ChannelPipelineFactory configureServerChannelPipelineFactory() {
-            return new ErrorPipelineFactory(this);
+        public ChannelPipelineFactory configureServerChannelPipelineFactory(String name, Settings groupSettings) {
+            return new ErrorPipelineFactory(this, name, groupSettings);
         }
 
-        private static class ErrorPipelineFactory extends ServerChannelPipeFactory {
+        private static class ErrorPipelineFactory extends ServerChannelPipelineFactory {
 
             private final ESLogger logger;
 
-            public ErrorPipelineFactory(ExceptionThrowingNettyTransport exceptionThrowingNettyTransport) {
-                super(exceptionThrowingNettyTransport);
+            public ErrorPipelineFactory(ExceptionThrowingNettyTransport exceptionThrowingNettyTransport, String name, Settings groupSettings) {
+                super(exceptionThrowingNettyTransport, name, groupSettings);
                 this.logger = exceptionThrowingNettyTransport.logger;
             }
 


### PR DESCRIPTION
This PR allows to bind to more than host and port using the `bind_host` and `port` properties. You can basically create differrent profiles, which can also have different tcp and buffer settings.

TODO: Documentation, explain possible options
