### PR TITLE
Fixing copy/paste mistake in SearchRequest.extraSource's exception message

### DIFF
--- a/src/main/java/org/elasticsearch/action/search/SearchRequest.java
+++ b/src/main/java/org/elasticsearch/action/search/SearchRequest.java
@@ -371,7 +371,7 @@ public class SearchRequest extends ActionRequest<SearchRequest> implements Indic
             builder.map(extraSource);
             return extraSource(builder);
         } catch (IOException e) {
-            throw new ElasticsearchGenerationException("Failed to generate [" + source + "]", e);
+            throw new ElasticsearchGenerationException("Failed to generate [" + extraSource + "]", e);
         }
     }
 


### PR DESCRIPTION
Uses the `extraSource` parameter for debug instead of the `source` field.

Closes #8117
