### PR TITLE
Adding setters or making them public in ActionRequests

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeRequest.java
@@ -48,8 +48,13 @@ public class AnalyzeRequest extends SingleCustomOperationRequest<AnalyzeRequest>
 
     private String field;
 
-    AnalyzeRequest() {
-
+    /**
+     * Constructs a new analyzer request.
+     * <p />
+     * {@link #text(String)} must be set.
+     */
+    public AnalyzeRequest() {
+        this(null);
     }
 
     /**
@@ -57,8 +62,8 @@ public class AnalyzeRequest extends SingleCustomOperationRequest<AnalyzeRequest>
      *
      * @param text The text to analyze
      */
-    public AnalyzeRequest(String text) {
-        this.text = text;
+    public AnalyzeRequest(@Nullable String text) {
+        this(null, text);
     }
 
     /**
@@ -67,9 +72,19 @@ public class AnalyzeRequest extends SingleCustomOperationRequest<AnalyzeRequest>
      * @param index The index name
      * @param text  The text to analyze
      */
-    public AnalyzeRequest(@Nullable String index, String text) {
+    public AnalyzeRequest(@Nullable String index, @Nullable String text) {
         this.index(index);
         this.text = text;
+    }
+
+    /**
+     * Set the text to analyze.
+     * @param text The text to analyze.
+     * @return Always {@code this}.
+     */
+    public AnalyzeRequest text(String text) {
+        this.text = text;
+        return this;
     }
 
     public String text() {

--- a/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeRequestBuilder.java
@@ -45,6 +45,16 @@ public class AnalyzeRequestBuilder extends SingleCustomOperationRequestBuilder<A
     }
 
     /**
+     * Sets the text to analyze.
+     * @param text The text to analyze.
+     * @return Always {@code this}.
+     */
+    public AnalyzeRequestBuilder setText(String text) {
+        request.text(text);
+        return this;
+    }
+
+    /**
      * Sets the analyzer name to use in order to analyze the text.
      *
      * @param analyzer The analyzer name.

--- a/src/main/java/org/elasticsearch/action/admin/indices/template/delete/DeleteIndexTemplateRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/template/delete/DeleteIndexTemplateRequest.java
@@ -34,7 +34,13 @@ public class DeleteIndexTemplateRequest extends MasterNodeOperationRequest<Delet
 
     private String name;
 
-    DeleteIndexTemplateRequest() {
+    /**
+     * Constructs a new delete index request.
+     * <p />
+     * {@link #name(String)} must be set.
+     */
+    public DeleteIndexTemplateRequest() {
+        this(null);
     }
 
     /**
@@ -51,6 +57,16 @@ public class DeleteIndexTemplateRequest extends MasterNodeOperationRequest<Delet
             validationException = addValidationError("name is missing", validationException);
         }
         return validationException;
+    }
+
+    /**
+     * Set the index template name to delete.
+     * @param name The name of the index template
+     * @return Always {@code this}.
+     */
+    public DeleteIndexTemplateRequest name(String name) {
+        this.name = name;
+        return this;
     }
 
     /**

--- a/src/main/java/org/elasticsearch/action/admin/indices/template/delete/DeleteIndexTemplateRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/template/delete/DeleteIndexTemplateRequestBuilder.java
@@ -35,6 +35,16 @@ public class DeleteIndexTemplateRequestBuilder extends MasterNodeOperationReques
         super(indicesClient, new DeleteIndexTemplateRequest(name));
     }
 
+    /**
+     * Sets the name of the index template to delete.
+     * @param name The name of the index template.
+     * @return Always {@code this}.
+     */
+    public DeleteIndexTemplateRequestBuilder setName(String name) {
+        request.name(name);
+        return this;
+    }
+
     @Override
     protected void doExecute(ActionListener<DeleteIndexTemplateResponse> listener) {
         client.deleteTemplate(request, listener);

--- a/src/main/java/org/elasticsearch/action/mlt/MoreLikeThisRequest.java
+++ b/src/main/java/org/elasticsearch/action/mlt/MoreLikeThisRequest.java
@@ -33,7 +33,6 @@ import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.search.Scroll;
@@ -47,9 +46,10 @@ import static org.elasticsearch.search.Scroll.readScroll;
 
 /**
  * A more like this request allowing to search for documents that a "like" the provided document. The document
- * to check against to fetched based on the index, type and id provided. Best created with {@link org.elasticsearch.client.Requests#moreLikeThisRequest(String)}.
+ * to check against to fetched based on the index, type and id provided. Best created with {@link
+ * Requests#moreLikeThisRequest(String)}.
  * <p/>
- * <p>Note, the {@link #index()}, {@link #type(String)} and {@link #id(String)} are required.
+ * <p>Note, the {@link #index(String)}, {@link #type(String)} and {@link #id(String)} are required.
  *
  * @see org.elasticsearch.client.Client#moreLikeThis(MoreLikeThisRequest)
  * @see org.elasticsearch.client.Requests#moreLikeThisRequest(String)
@@ -88,7 +88,12 @@ public class MoreLikeThisRequest extends ActionRequest<MoreLikeThisRequest> impl
     private BytesReference searchSource;
     private boolean searchSourceUnsafe;
 
-    MoreLikeThisRequest() {
+    /**
+     * Constructs a new more like this request for a document.
+     * Use {@link #index(String)}, {@link #type(String)}, and {@link #id(String)} to specify the document to load.
+     */
+    public MoreLikeThisRequest() {
+        this(null);
     }
 
     /**
@@ -107,14 +112,20 @@ public class MoreLikeThisRequest extends ActionRequest<MoreLikeThisRequest> impl
     }
 
     /**
+     * Set the index to load the document from, which the "like" query will run with.
+     * @param index The index name.
+     * @return Always {@code this}.
+     */
+    public MoreLikeThisRequest index(String index) {
+        this.index = index;
+        return this;
+    }
+
+    /**
      * The type of document to load from which the "like" query will run with.
      */
     public String type() {
         return type;
-    }
-
-    void index(String index) {
-        this.index = index;
     }
 
     public IndicesOptions indicesOptions() {
@@ -190,8 +201,14 @@ public class MoreLikeThisRequest extends ActionRequest<MoreLikeThisRequest> impl
         return routing;
     }
 
-    public void routing(String routing) {
+    /**
+     * Set the routing for this request.
+     * @param routing The routing for the request.
+     * @return Always {@code this}.
+     */
+    public MoreLikeThisRequest routing(String routing) {
         this.routing = routing;
+        return this;
     }
 
     /**

--- a/src/main/java/org/elasticsearch/action/mlt/MoreLikeThisRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/mlt/MoreLikeThisRequestBuilder.java
@@ -44,6 +44,30 @@ public class MoreLikeThisRequestBuilder extends ActionRequestBuilder<MoreLikeThi
     }
 
     /**
+     * The index of the document to use in order to find documents "like" this one.
+     */
+    public MoreLikeThisRequestBuilder setIndex(String index) {
+        request.index(index);
+        return this;
+    }
+
+    /**
+     * The type of the document to use in order to find documents "like" this one.
+     */
+    public MoreLikeThisRequestBuilder setType(String type) {
+        request.type(type);
+        return this;
+    }
+
+    /**
+     * The ID of the document to use in order to find documents "like" this one.
+     */
+    public MoreLikeThisRequestBuilder setId(String id) {
+        request.id(id);
+        return this;
+    }
+
+    /**
      * The fields of the document to use in order to find documents "like" this one. Defaults to run
      * against all the document fields.
      */


### PR DESCRIPTION
MoreLikeThisRequest, AnalyzeRequest, and DeleteIndexTemplateRequest (and associated builders) all prevented some fields from being set outside their constructor. This makes those fields _publically_ settable, which helps to simplify usage in other languages like Groovy.

Closes #8122
