### PR TITLE
Add all meta fields to the top level json document in search response

### DIFF
--- a/docs/reference/migration/migrate_2_0.asciidoc
+++ b/docs/reference/migration/migrate_2_0.asciidoc
@@ -647,3 +647,37 @@ created on or after clusters with version 2.0:
 * The `type` option on the `_parent` field can only point to a parent type that doesn't exist yet,
   so this means that an existing type/mapping can no longer become a parent type.
 * The `has_child` and `has_parent` queries can no longer be use in alias filters.
+
+=== Meta fields returned under the top-level json object
+
+When selecting meta fields such as `_routing` or `_timestamp`, the field values
+are now directly put as a top-level property of the json objet, instead of being
+put under `fields` like regular stored fields.
+
+[source,sh]
+---------------
+curl -XGET 'localhost:9200/test/_search?fields=_timestamp,foo'
+---------------
+
+[source,json]
+---------------
+{
+   [...]
+   "hits": {
+      "total": 1,
+      "max_score": 1,
+      "hits": [
+         {
+            "_index": "test",
+            "_type": "test",
+            "_id": "1",
+            "_score": 1,
+            "_timestamp": 10000000,
+            "fields": {
+              "foo" : [ "bar" ]
+            }
+         }
+      ]
+   }
+}
+---------------

--- a/rest-api-spec/test/README.asciidoc
+++ b/rest-api-spec/test/README.asciidoc
@@ -203,7 +203,7 @@ The specified key exists and has a true value (ie not `0`, `false`, `undefined`,
 or the empty string), eg:
 
 ....
-    - is_true:  fields._parent  # the _parent key exists in the fields hash and is "true"
+    - is_true:  fields.foo  # the foo key exists in the fields hash and is "true"
 ....
 
 === `is_false`
@@ -238,7 +238,7 @@ Supports also regular expressions with flag X for more readability (accepts whit
 Compares two numeric values, eg:
 
 ....
-    - lt: { fields._ttl: 10000 }  # the `_ttl` value is less than 10,000
+    - lt: { _ttl: 10000 }  # the `_ttl` value is less than 10,000
 ....
 
 === `lte` and `gte`
@@ -246,7 +246,7 @@ Compares two numeric values, eg:
 Compares two numeric values, eg:
 
 ....
-    - lte: { fields._ttl: 10000 }  # the `_ttl` value is less than or equal to 10,000
+    - lte: { _ttl: 10000 }  # the `_ttl` value is less than or equal to 10,000
 ....
 
 === `length`

--- a/rest-api-spec/test/create/40_routing.yaml
+++ b/rest-api-spec/test/create/40_routing.yaml
@@ -31,7 +31,7 @@
           fields:  [_routing]
 
  - match:   { _id:              "1"}
- - match:   { fields._routing:  "5"}
+ - match:   { _routing:  "5"}
 
  - do:
       catch: missing

--- a/rest-api-spec/test/create/50_parent.yaml
+++ b/rest-api-spec/test/create/50_parent.yaml
@@ -38,6 +38,6 @@
           fields:  [_parent, _routing]
 
  - match:   { _id:      "1"}
- - match:   { fields._parent: "5"}
- - match:   { fields._routing: "5"}
+ - match:   { _parent: "5"}
+ - match:   { _routing: "5"}
 

--- a/rest-api-spec/test/create/55_parent_with_routing.yaml
+++ b/rest-api-spec/test/create/55_parent_with_routing.yaml
@@ -35,8 +35,8 @@
           fields:  [_parent, _routing]
 
  - match:   { _id:      "1"}
- - match:   { fields._parent: "5"}
- - match:   { fields._routing: "4"}
+ - match:   { _parent: "5"}
+ - match:   { _routing: "4"}
 
  - do:
       catch: missing

--- a/rest-api-spec/test/create/70_timestamp.yaml
+++ b/rest-api-spec/test/create/70_timestamp.yaml
@@ -28,7 +28,7 @@
           id:      1
           fields:  _timestamp
 
- - is_true:    fields._timestamp
+ - is_true:    _timestamp
 
 # milliseconds since epoch
 
@@ -52,7 +52,7 @@
           id:      1
           fields:  _timestamp
 
- - match: { fields._timestamp: 1372011280000 }
+ - match: { _timestamp: 1372011280000 }
 
 # date format
 
@@ -76,5 +76,5 @@
           id:      1
           fields:  _timestamp
 
- - match: { fields._timestamp: 1372011280000 }
+ - match: { _timestamp: 1372011280000 }
 

--- a/rest-api-spec/test/create/75_ttl.yaml
+++ b/rest-api-spec/test/create/75_ttl.yaml
@@ -29,8 +29,8 @@
           id:      1
           fields:  _ttl
 
- - lte:   { fields._ttl: 10000}
- - gt:    { fields._ttl: 0}
+ - lte:   { _ttl: 10000}
+ - gt:    { _ttl: 0}
 
 # milliseconds
 
@@ -53,8 +53,8 @@
           id:      1
           fields:  _ttl
 
- - lte:   { fields._ttl: 100000}
- - gt:    { fields._ttl: 10000}
+ - lte:   { _ttl: 100000}
+ - gt:    { _ttl: 10000}
 
 # duration
 
@@ -78,8 +78,8 @@
           id:      1
           fields:  _ttl
 
- - lte:   { fields._ttl: 20000}
- - gt:    { fields._ttl: 10000}
+ - lte:   { _ttl: 20000}
+ - gt:    { _ttl: 10000}
 
 # with timestamp
 

--- a/rest-api-spec/test/get/30_parent.yaml
+++ b/rest-api-spec/test/get/30_parent.yaml
@@ -31,8 +31,8 @@ setup:
           fields:  [_parent, _routing]
 
  - match:   { _id:      "1"}
- - match:   { fields._parent: 中文 }
- - match:   { fields._routing: 中文}
+ - match:   { _parent: 中文 }
+ - match:   { _routing: 中文}
 
 ---
 "Parent omitted":

--- a/rest-api-spec/test/get/40_routing.yaml
+++ b/rest-api-spec/test/get/40_routing.yaml
@@ -31,7 +31,7 @@
           fields:  [_routing]
 
  - match:   { _id:              "1"}
- - match:   { fields._routing:  "5"}
+ - match:   { _routing:  "5"}
 
  - do:
       catch: missing

--- a/rest-api-spec/test/get/55_parent_with_routing.yaml
+++ b/rest-api-spec/test/get/55_parent_with_routing.yaml
@@ -35,8 +35,8 @@
           fields:  [_parent, _routing]
 
  - match:   { _id:      "1"}
- - match:   { fields._parent: "5"}
- - match:   { fields._routing: "4"}
+ - match:   { _parent: "5"}
+ - match:   { _routing: "4"}
 
  - do:
       catch: missing

--- a/rest-api-spec/test/index/40_routing.yaml
+++ b/rest-api-spec/test/index/40_routing.yaml
@@ -30,8 +30,8 @@
           routing: 5
           fields:  [_routing]
 
- - match:   { _id:              "1"}
- - match:   { fields._routing:  "5"}
+ - match:   { _id:       "1"}
+ - match:   { _routing:  "5"}
 
  - do:
       catch: missing

--- a/rest-api-spec/test/index/50_parent.yaml
+++ b/rest-api-spec/test/index/50_parent.yaml
@@ -37,6 +37,6 @@
           fields:  [_parent, _routing]
 
  - match:   { _id:      "1"}
- - match:   { fields._parent: "5"}
- - match:   { fields._routing: "5"}
+ - match:   { _parent: "5"}
+ - match:   { _routing: "5"}
 

--- a/rest-api-spec/test/index/55_parent_with_routing.yaml
+++ b/rest-api-spec/test/index/55_parent_with_routing.yaml
@@ -35,8 +35,8 @@
           fields:  [_parent, _routing]
 
  - match:   { _id:      "1"}
- - match:   { fields._parent: "5"}
- - match:   { fields._routing: "4"}
+ - match:   { _parent: "5"}
+ - match:   { _routing: "4"}
 
  - do:
       catch: missing

--- a/rest-api-spec/test/index/70_timestamp.yaml
+++ b/rest-api-spec/test/index/70_timestamp.yaml
@@ -29,7 +29,7 @@
           id:      1
           fields:  _timestamp
 
- - is_true: fields._timestamp
+ - is_true: _timestamp
 
 # milliseconds since epoch
 
@@ -48,7 +48,7 @@
           id:      1
           fields:  _timestamp
 
- - match: { fields._timestamp: 1372011280000 }
+ - match: { _timestamp: 1372011280000 }
 
 # date format
 
@@ -67,5 +67,5 @@
           id:      1
           fields:  _timestamp
 
- - match: { fields._timestamp: 1372011280000 }
+ - match: { _timestamp: 1372011280000 }
 

--- a/rest-api-spec/test/index/75_ttl.yaml
+++ b/rest-api-spec/test/index/75_ttl.yaml
@@ -29,8 +29,8 @@
           id:      1
           fields:  _ttl
 
- - lte:   { fields._ttl: 10000}
- - gt:    { fields._ttl: 0}
+ - lte:   { _ttl: 10000}
+ - gt:    { _ttl: 0}
 
 # milliseconds
 
@@ -48,8 +48,8 @@
           id:      1
           fields:  _ttl
 
- - lte:   { fields._ttl: 100000}
- - gt:    { fields._ttl: 10000}
+ - lte:   { _ttl: 100000}
+ - gt:    { _ttl: 10000}
 
 # duration
 
@@ -68,8 +68,8 @@
           id:      1
           fields:  _ttl
 
- - lte:   { fields._ttl: 20000}
- - gt:    { fields._ttl: 10000}
+ - lte:   { _ttl: 20000}
+ - gt:    { _ttl: 10000}
 
 # with timestamp
 

--- a/rest-api-spec/test/mget/30_parent.yaml
+++ b/rest-api-spec/test/mget/30_parent.yaml
@@ -45,15 +45,15 @@
  - is_false:  docs.1.found
 
  - is_true:   docs.2.found
- - match:   { docs.2._index:          test_1 }
- - match:   { docs.2._type:           test   }
- - match:   { docs.2._id:             "1"    }
- - match:   { docs.2.fields._parent:  "4"    }
- - match:   { docs.2.fields._routing: "4"    }
+ - match:   { docs.2._index:   test_1 }
+ - match:   { docs.2._type:    test   }
+ - match:   { docs.2._id:      "1"    }
+ - match:   { docs.2._parent:  "4"    }
+ - match:   { docs.2._routing: "4"    }
 
  - is_true:   docs.3.found
- - match:   { docs.3._index:          test_1 }
- - match:   { docs.3._type:           test   }
- - match:   { docs.3._id:             "2"    }
- - match:   { docs.3.fields._parent:  "5"    }
- - match:   { docs.3.fields._routing: "5"    }
+ - match:   { docs.3._index:   test_1 }
+ - match:   { docs.3._type:    test   }
+ - match:   { docs.3._id:      "2"    }
+ - match:   { docs.3._parent:  "5"    }
+ - match:   { docs.3._routing: "5"    }

--- a/rest-api-spec/test/mget/40_routing.yaml
+++ b/rest-api-spec/test/mget/40_routing.yaml
@@ -37,7 +37,7 @@
  - is_false:  docs.1.found
 
  - is_true:   docs.2.found
- - match:   { docs.2._index:          test_1 }
- - match:   { docs.2._type:           test   }
- - match:   { docs.2._id:             "1"    }
- - match:   { docs.2.fields._routing: "5"    }
+ - match:   { docs.2._index:   test_1 }
+ - match:   { docs.2._type:    test   }
+ - match:   { docs.2._id:      "1"    }
+ - match:   { docs.2._routing: "5"    }

--- a/rest-api-spec/test/mget/55_parent_with_routing.yaml
+++ b/rest-api-spec/test/mget/55_parent_with_routing.yaml
@@ -40,8 +40,8 @@
  - is_false:  docs.1.found
 
  - is_true:   docs.2.found
- - match:   { docs.2._index:          test_1 }
- - match:   { docs.2._type:           test   }
- - match:   { docs.2._id:             "1"    }
- - match:   { docs.2.fields._parent:  "4"    }
- - match:   { docs.2.fields._routing: "5"    }
+ - match:   { docs.2._index:   test_1 }
+ - match:   { docs.2._type:    test   }
+ - match:   { docs.2._id:      "1"    }
+ - match:   { docs.2._parent:  "4"    }
+ - match:   { docs.2._routing: "5"    }

--- a/rest-api-spec/test/update/40_routing.yaml
+++ b/rest-api-spec/test/update/40_routing.yaml
@@ -32,7 +32,7 @@
           routing: 5
           fields:  _routing
 
- - match: { fields._routing:  "5"}
+ - match: { _routing:  "5"}
 
  - do:
       catch:      missing

--- a/rest-api-spec/test/update/50_parent.yaml
+++ b/rest-api-spec/test/update/50_parent.yaml
@@ -42,8 +42,8 @@ setup:
           parent:  5
           fields:  [_parent, _routing]
 
- - match: { fields._parent:  "5"}
- - match: { fields._routing: "5"}
+ - match: { _parent:  "5"}
+ - match: { _routing: "5"}
 
  - do:
       update:

--- a/rest-api-spec/test/update/55_parent_with_routing.yaml
+++ b/rest-api-spec/test/update/55_parent_with_routing.yaml
@@ -36,8 +36,8 @@
           parent:  5
           fields:  [_parent, _routing]
 
- - match: { fields._parent:  "5"}
- - match: { fields._routing: "4"}
+ - match: { _parent:  "5"}
+ - match: { _routing: "4"}
 
  - do:
       catch:      missing

--- a/rest-api-spec/test/update/70_timestamp.yaml
+++ b/rest-api-spec/test/update/70_timestamp.yaml
@@ -30,7 +30,7 @@
           id:      1
           fields:  _timestamp
 
- - is_true: fields._timestamp
+ - is_true: _timestamp
 
 # milliseconds since epoch
 
@@ -51,7 +51,7 @@
           id:      1
           fields:  _timestamp
 
- - match: { fields._timestamp: 1372011280000 }
+ - match: { _timestamp: 1372011280000 }
 
 # date format
 
@@ -72,5 +72,5 @@
           id:      1
           fields:  _timestamp
 
- - match: { fields._timestamp: 1372011280000 }
+ - match: { _timestamp: 1372011280000 }
 

--- a/rest-api-spec/test/update/75_ttl.yaml
+++ b/rest-api-spec/test/update/75_ttl.yaml
@@ -31,8 +31,8 @@
           id:      1
           fields:  _ttl
 
- - lte:   { fields._ttl: 10000}
- - gt:    { fields._ttl: 0}
+ - lte:   { _ttl: 10000}
+ - gt:    { _ttl: 0}
 
 # milliseconds
 
@@ -53,8 +53,8 @@
           id:      1
           fields:  _ttl
 
- - lte:   { fields._ttl: 100000}
- - gt:    { fields._ttl: 10000}
+ - lte:   { _ttl: 100000}
+ - gt:    { _ttl: 10000}
 
 # duration
 
@@ -75,8 +75,8 @@
           id:      1
           fields:  _ttl
 
- - lte:   { fields._ttl: 20000}
- - gt:    { fields._ttl: 10000}
+ - lte:   { _ttl: 20000}
+ - gt:    { _ttl: 10000}
 
 # with timestamp
 

--- a/rest-api-spec/test/update/85_fields_meta.yaml
+++ b/rest-api-spec/test/update/85_fields_meta.yaml
@@ -33,10 +33,10 @@
             doc:    { foo: baz }
             upsert: { foo: bar }
 
-  - match:   { get.fields._parent:  "5" }
-  - match:   { get.fields._routing: "5" }
-  - is_true:   get.fields._timestamp
-  - is_true:   get.fields._ttl
+  - match:   { get._parent:  "5" }
+  - match:   { get._routing: "5" }
+  - is_true:   get._timestamp
+  - is_true:   get._ttl
 
   - do:
       get:


### PR DESCRIPTION
Some of our meta fields (such as _id, _version, ...) are returned as top-level
properties of the json document, while other properties (_timestamp, _routing,
...) are returned under `fields`. This commit makes all meta fields returned
as top-level properties.

So eg. `GET test/test/1?fields=_timestamp,foo` would now return

``` json
{
   "_index": "test",
   "_type": "test",
   "_id": "1",
   "_version": 1,
   "_timestamp": 10000000,
   "found": true,
   "fields": {
     "foo": [ "bar" ]
   }
}
```

while it used to return

``` json
{
   "_index": "test",
   "_type": "test",
   "_id": "1",
   "_version": 1,
   "found": true,
   "fields": {
     "_timestamp": 10000000,
     "foo": [ "bar" ]
   }
}
```
