### PR TITLE
Add support for distributed frequencies

### DIFF
--- a/docs/reference/docs/termvectors.asciidoc
+++ b/docs/reference/docs/termvectors.asciidoc
@@ -77,15 +77,22 @@ omit :
    each term in this field)
 
 [float]
+==== Distributed frequencies coming[1.5.0]
+
+Setting `dfs` to `true` (default is `false`) will return the term statistics
+or the field statistics of the entire index, and not just at the shard. Use it
+with caution as distributed frequencies can have a serious performance impact.
+
+[float]
 === Behaviour
 
 The term and field statistics are not accurate. Deleted documents
 are not taken into account. The information is only retrieved for the
-shard the requested document resides in. The term and field statistics
-are therefore only useful as relative measures whereas the absolute
-numbers have no meaning in this context. By default, when requesting
-term vectors of artificial documents, a shard to get the statistics from
-is randomly selected. Use `routing` only to hit a particular shard.
+shard the requested document resides in, unless `dfs` is set to `true`.
+The term and field statistics are therefore only useful as relative measures
+whereas the absolute numbers have no meaning in this context. By default,
+when requesting term vectors of artificial documents, a shard to get the statistics
+from is randomly selected. Use `routing` only to hit a particular shard.
 
 [float]
 === Example 1

--- a/rest-api-spec/api/termvector.json
+++ b/rest-api-spec/api/termvector.json
@@ -35,6 +35,12 @@
            "default" : true,
            "required" : false
         },
+        "dfs" : {
+           "type" : "boolean",
+           "description" : "Specifies if distributed frequencies should be returned instead shard frequencies.",
+           "default" : false,
+           "required" : false
+        },
         "fields" : {
           "type" : "list",
           "description" : "A comma-separated list of fields to return.",

--- a/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -160,6 +160,7 @@ import org.elasticsearch.action.support.ActionFilter;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.action.termvector.*;
+import org.elasticsearch.action.termvector.dfs.TransportDfsOnlyAction;
 import org.elasticsearch.action.update.TransportUpdateAction;
 import org.elasticsearch.action.update.UpdateAction;
 import org.elasticsearch.common.inject.AbstractModule;
@@ -280,7 +281,8 @@ public class ActionModule extends AbstractModule {
 
         registerAction(IndexAction.INSTANCE, TransportIndexAction.class);
         registerAction(GetAction.INSTANCE, TransportGetAction.class);
-        registerAction(TermVectorAction.INSTANCE, TransportSingleShardTermVectorAction.class);
+        registerAction(TermVectorAction.INSTANCE, TransportSingleShardTermVectorAction.class,
+                TransportDfsOnlyAction.class);
         registerAction(MultiTermVectorsAction.INSTANCE, TransportMultiTermVectorsAction.class,
                 TransportSingleShardMultiTermsVectorAction.class);
         registerAction(DeleteAction.INSTANCE, TransportDeleteAction.class,

--- a/src/main/java/org/elasticsearch/action/termvector/TermVectorRequest.java
+++ b/src/main/java/org/elasticsearch/action/termvector/TermVectorRequest.java
@@ -325,24 +325,30 @@ public class TermVectorRequest extends SingleShardOperationRequest<TermVectorReq
         return this;
     }
 
+    /**
+     * Return whether term vectors should be generated real-time (default to true).
+     */
     public boolean realtime() {
         return this.realtime == null ? true : this.realtime;
     }
 
+    /**
+     * Choose whether term vectors be generated real-time.
+     */
     public TermVectorRequest realtime(Boolean realtime) {
         this.realtime = realtime;
         return this;
     }
 
     /**
-     * Return the overridden analyzers at each field
+     * Return the overridden analyzers at each field.
      */
     public Map<String, String> perFieldAnalyzer() {
         return perFieldAnalyzer;
     }
 
     /**
-     * Override the analyzer used at each field when generating term vectors
+     * Override the analyzer used at each field when generating term vectors.
      */
     public TermVectorRequest perFieldAnalyzer(Map<String, String> perFieldAnalyzer) {
         this.perFieldAnalyzer = perFieldAnalyzer != null && perFieldAnalyzer.size() != 0 ? Maps.newHashMap(perFieldAnalyzer) : null;

--- a/src/main/java/org/elasticsearch/action/termvector/TermVectorRequest.java
+++ b/src/main/java/org/elasticsearch/action/termvector/TermVectorRequest.java
@@ -293,6 +293,22 @@ public class TermVectorRequest extends SingleShardOperationRequest<TermVectorReq
     }
 
     /**
+     * @return <code>true</code> if distributed frequencies should be returned. Otherwise
+     * <code>false</code>
+     */
+    public boolean dfs() {
+        return flagsEnum.contains(Flag.Dfs);
+    }
+
+    /**
+     * Use distributed frequencies instead of shard statistics.
+     */
+    public TermVectorRequest dfs(boolean dfs) {
+        setFlag(Flag.Dfs, dfs);
+        return this;
+    }
+
+    /**
      * Return only term vectors for special selected fields. Returns for term
      * vectors for all fields if selectedFields == null
      */
@@ -444,7 +460,7 @@ public class TermVectorRequest extends SingleShardOperationRequest<TermVectorReq
     public static enum Flag {
         // Do not change the order of these flags we use
         // the ordinal for encoding! Only append to the end!
-        Positions, Offsets, Payloads, FieldStatistics, TermStatistics
+        Positions, Offsets, Payloads, FieldStatistics, TermStatistics, Dfs
     }
 
     /**
@@ -477,6 +493,8 @@ public class TermVectorRequest extends SingleShardOperationRequest<TermVectorReq
                     termVectorRequest.termStatistics(parser.booleanValue());
                 } else if (currentFieldName.equals("field_statistics") || currentFieldName.equals("fieldStatistics")) {
                     termVectorRequest.fieldStatistics(parser.booleanValue());
+                } else if (currentFieldName.equals("dfs")) {
+                    termVectorRequest.dfs(parser.booleanValue());
                 } else if (currentFieldName.equals("per_field_analyzer") || currentFieldName.equals("perFieldAnalyzer")) {
                     termVectorRequest.perFieldAnalyzer(readPerFieldAnalyzer(parser.map()));
                 } else if ("_index".equals(currentFieldName)) { // the following is important for multi request parsing.

--- a/src/main/java/org/elasticsearch/action/termvector/TermVectorRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/termvector/TermVectorRequestBuilder.java
@@ -27,6 +27,11 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import java.util.Map;
 
 /**
+ * The builder class for a term vector request.
+ * Returns the term vector (doc frequency, positions, offsets) for a document.
+ * <p/>
+ * Note, the {@code index}, {@code type} and {@code id} are
+ * required.
  */
 public class TermVectorRequestBuilder extends ActionRequestBuilder<TermVectorRequest, TermVectorResponse, TermVectorRequestBuilder, Client> {
 
@@ -34,6 +39,11 @@ public class TermVectorRequestBuilder extends ActionRequestBuilder<TermVectorReq
         super(client, new TermVectorRequest());
     }
 
+    /**
+     * Constructs a new term vector request builder for a document that will be fetch
+     * from the provided index. Use {@code index}, {@code type} and
+     * {@code id} to specify the document to load.
+     */
     public TermVectorRequestBuilder(Client client, String index, String type, String id) {
         super(client, new TermVectorRequest(index, type, id));
     }
@@ -92,52 +102,81 @@ public class TermVectorRequestBuilder extends ActionRequestBuilder<TermVectorReq
      * <tt>_local</tt> to prefer local shards, <tt>_primary</tt> to execute only on primary shards, or
      * a custom value, which guarantees that the same order will be used across different requests.
      */
-    
     public TermVectorRequestBuilder setPreference(String preference) {
         request.preference(preference);
         return this;
     }
-    
+
+    /**
+     * Sets whether to return the start and stop offsets for each term if they were stored or
+     * skip offsets.
+     */
     public TermVectorRequestBuilder setOffsets(boolean offsets) {
         request.offsets(offsets);
         return this;
     }
 
+
+    /**
+     * Sets whether to return the positions for each term if stored or skip.
+     */
     public TermVectorRequestBuilder setPositions(boolean positions) {
         request.positions(positions);
         return this;
     }
 
+    /**
+     * Sets whether to return the payloads for each term or skip.
+     */
     public TermVectorRequestBuilder setPayloads(boolean payloads) {
         request.payloads(payloads);
         return this;
     }
 
+    /**
+     * Sets whether to return the term statistics for each term in the shard or skip.
+     */
     public TermVectorRequestBuilder setTermStatistics(boolean termStatistics) {
         request.termStatistics(termStatistics);
         return this;
     }
 
+    /**
+     * Sets whether to return the field statistics for each term in the shard or skip.
+     */
     public TermVectorRequestBuilder setFieldStatistics(boolean fieldStatistics) {
         request.fieldStatistics(fieldStatistics);
         return this;
     }
 
+    /**
+     * Sets whether to use distributed frequencies instead of shard statistics.
+     */
     public TermVectorRequestBuilder setDfs(boolean dfs) {
         request.dfs(dfs);
         return this;
     }
 
+    /**
+     * Sets whether to return only term vectors for special selected fields. Returns the term
+     * vectors for all fields if selectedFields == null
+     */
     public TermVectorRequestBuilder setSelectedFields(String... fields) {
         request.selectedFields(fields);
         return this;
     }
 
+    /**
+     * Sets whether term vectors are generated real-time.
+     */
     public TermVectorRequestBuilder setRealtime(Boolean realtime) {
         request.realtime(realtime);
         return this;
     }
 
+    /**
+     * Sets the analyzer used at each field when generating term vectors.
+     */
     public TermVectorRequestBuilder setPerFieldAnalyzer(Map<String, String> perFieldAnalyzer) {
         request.perFieldAnalyzer(perFieldAnalyzer);
         return this;

--- a/src/main/java/org/elasticsearch/action/termvector/TermVectorRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/termvector/TermVectorRequestBuilder.java
@@ -123,6 +123,11 @@ public class TermVectorRequestBuilder extends ActionRequestBuilder<TermVectorReq
         return this;
     }
 
+    public TermVectorRequestBuilder setDfs(boolean dfs) {
+        request.dfs(dfs);
+        return this;
+    }
+
     public TermVectorRequestBuilder setSelectedFields(String... fields) {
         request.selectedFields(fields);
         return this;

--- a/src/main/java/org/elasticsearch/action/termvector/TermVectorResponse.java
+++ b/src/main/java/org/elasticsearch/action/termvector/TermVectorResponse.java
@@ -30,6 +30,7 @@ import org.apache.lucene.util.CharsRefBuilder;
 import org.elasticsearch.ElasticsearchIllegalStateException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.termvector.TermVectorRequest.Flag;
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
@@ -38,6 +39,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentBuilderString;
+import org.elasticsearch.search.dfs.AggregatedDfs;
 
 import java.io.IOException;
 import java.util.EnumSet;
@@ -320,10 +322,14 @@ public class TermVectorResponse extends ActionResponse implements ToXContent {
     }
 
     public void setFields(Fields termVectorsByField, Set<String> selectedFields, EnumSet<Flag> flags, Fields topLevelFields) throws IOException {
+        setFields(termVectorsByField, selectedFields, flags, topLevelFields, null);
+    }
+
+    public void setFields(Fields termVectorsByField, Set<String> selectedFields, EnumSet<Flag> flags, Fields topLevelFields, @Nullable AggregatedDfs dfs) throws IOException {
         TermVectorWriter tvw = new TermVectorWriter(this);
 
         if (termVectorsByField != null) {
-            tvw.setFields(termVectorsByField, selectedFields, flags, topLevelFields);
+            tvw.setFields(termVectorsByField, selectedFields, flags, topLevelFields, dfs);
         }
 
     }

--- a/src/main/java/org/elasticsearch/action/termvector/dfs/DfsOnlyRequest.java
+++ b/src/main/java/org/elasticsearch/action/termvector/dfs/DfsOnlyRequest.java
@@ -111,7 +111,7 @@ public class DfsOnlyRequest extends BroadcastOperationRequest<DfsOnlyRequest> {
         String sSource = "_na_";
         try {
             sSource = XContentHelper.convertToJson(searchRequest.source(), false);
-        } catch (Exception e) {
+        } catch (IOException e) {
             // ignore
         }
         return "[" + Arrays.toString(indices) + "]" + Arrays.toString(types()) + ", source[" + sSource + "]";

--- a/src/main/java/org/elasticsearch/action/termvector/dfs/DfsOnlyRequest.java
+++ b/src/main/java/org/elasticsearch/action/termvector/dfs/DfsOnlyRequest.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.termvector.dfs;
+
+import org.apache.lucene.index.Fields;
+import org.apache.lucene.index.Terms;
+import org.apache.lucene.index.TermsEnum;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.support.broadcast.BroadcastOperationRequest;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Set;
+
+import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
+
+public class DfsOnlyRequest extends BroadcastOperationRequest<DfsOnlyRequest> {
+
+    private SearchRequest searchRequest;
+
+    long nowInMillis;
+
+    DfsOnlyRequest() {
+    }
+
+    public DfsOnlyRequest(Fields termVectorFields, String[] indices, String[] types, Set<String> selectedFields, Client client) throws IOException {
+        super(indices);
+
+        // build a search request with a query of all the terms
+        final BoolQueryBuilder boolBuilder = boolQuery();
+        TermsEnum iterator = null;
+        for (String fieldName : termVectorFields) {
+            if ((selectedFields != null) && (!selectedFields.contains(fieldName))) {
+                continue;
+            }
+            Terms terms = termVectorFields.terms(fieldName);
+            iterator = terms.iterator(iterator);
+            while (iterator.next() != null) {
+                String text = iterator.term().utf8ToString();
+                boolBuilder.should(QueryBuilders.termQuery(fieldName, text));
+            }
+        }
+        // wrap a search request object
+        this.searchRequest = client.prepareSearch(indices).setTypes(types).setQuery(boolBuilder).request();
+    }
+
+    public SearchRequest getSearchRequest() {
+        return searchRequest;
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        return searchRequest.validate();
+    }
+
+    @Override
+    protected void beforeStart() {
+        searchRequest.beforeStart();
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+        this.searchRequest.readFrom(in);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        this.searchRequest.writeTo(out);
+    }
+
+    public String[] types() {
+        return this.searchRequest.types();
+    }
+
+    public String routing() {
+        return this.searchRequest.routing();
+    }
+
+    public String preference() {
+        return this.searchRequest.preference();
+    }
+
+    @Override
+    public String toString() {
+        String sSource = "_na_";
+        try {
+            sSource = XContentHelper.convertToJson(searchRequest.source(), false);
+        } catch (Exception e) {
+            // ignore
+        }
+        return "[" + Arrays.toString(indices) + "]" + Arrays.toString(types()) + ", source[" + sSource + "]";
+    }
+
+}

--- a/src/main/java/org/elasticsearch/action/termvector/dfs/DfsOnlyRequest.java
+++ b/src/main/java/org/elasticsearch/action/termvector/dfs/DfsOnlyRequest.java
@@ -25,12 +25,12 @@ import org.apache.lucene.index.TermsEnum;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.support.broadcast.BroadcastOperationRequest;
-import org.elasticsearch.client.Client;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -40,14 +40,15 @@ import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
 
 public class DfsOnlyRequest extends BroadcastOperationRequest<DfsOnlyRequest> {
 
-    private SearchRequest searchRequest;
+    private SearchRequest searchRequest = new SearchRequest();
 
     long nowInMillis;
 
     DfsOnlyRequest() {
+
     }
 
-    public DfsOnlyRequest(Fields termVectorFields, String[] indices, String[] types, Set<String> selectedFields, Client client) throws IOException {
+    public DfsOnlyRequest(Fields termVectorFields, String[] indices, String[] types, Set<String> selectedFields) throws IOException {
         super(indices);
 
         // build a search request with a query of all the terms
@@ -65,7 +66,7 @@ public class DfsOnlyRequest extends BroadcastOperationRequest<DfsOnlyRequest> {
             }
         }
         // wrap a search request object
-        this.searchRequest = client.prepareSearch(indices).setTypes(types).setQuery(boolBuilder).request();
+        this.searchRequest = new SearchRequest(indices).types(types).source(new SearchSourceBuilder().query(boolBuilder));
     }
 
     public SearchRequest getSearchRequest() {

--- a/src/main/java/org/elasticsearch/action/termvector/dfs/DfsOnlyResponse.java
+++ b/src/main/java/org/elasticsearch/action/termvector/dfs/DfsOnlyResponse.java
@@ -37,10 +37,6 @@ public class DfsOnlyResponse extends BroadcastOperationResponse {
     private AggregatedDfs dfs;
     private long tookInMillis;
 
-    DfsOnlyResponse() {
-
-    }
-
     DfsOnlyResponse(AggregatedDfs dfs, int totalShards, int successfulShards, int failedShards,
                     List<ShardOperationFailedException> shardFailures, long tookInMillis) {
         super(totalShards, successfulShards, failedShards, shardFailures);

--- a/src/main/java/org/elasticsearch/action/termvector/dfs/DfsOnlyResponse.java
+++ b/src/main/java/org/elasticsearch/action/termvector/dfs/DfsOnlyResponse.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.termvector.dfs;
+
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.ShardSearchFailure;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.StatusToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.search.dfs.AggregatedDfs;
+
+import java.io.IOException;
+
+/**
+ * A response of a dfs only request.
+ */
+public class DfsOnlyResponse extends SearchResponse implements StatusToXContent {
+
+    private AggregatedDfs dfs;
+
+    private ShardSearchFailure[] shardFailures;
+
+    private long tookInMillis;
+
+    public DfsOnlyResponse(AggregatedDfs dfs, long tookInMillis, ShardSearchFailure[] shardFailures) {
+        this.dfs = dfs;
+        this.tookInMillis = tookInMillis;
+        this.shardFailures = shardFailures;
+    }
+
+    public AggregatedDfs getDfs() {
+        return dfs;
+    }
+
+    /**
+     * How long the dfs request took.
+     */
+    public TimeValue getTook() {
+        return new TimeValue(tookInMillis);
+    }
+
+    /**
+     * How long the dfs request took in milliseconds.
+     */
+    public long getTookInMillis() {
+        return tookInMillis;
+    }
+
+    /**
+     * The failed number of shards the search was executed on.
+     */
+    public int getFailedShards() {
+        // we don't return totalShards - successfulShards, we don't count "no shards available" as a failed shard, just don't
+        // count it in the successful counter
+        return shardFailures.length;
+    }
+
+    /**
+     * The failures that occurred during the search.
+     */
+    public ShardSearchFailure[] getShardFailures() {
+        return this.shardFailures;
+    }
+
+    @Override
+    public RestStatus status() {
+        return null;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        return null;
+    }
+}

--- a/src/main/java/org/elasticsearch/action/termvector/dfs/ShardDfsOnlyResponse.java
+++ b/src/main/java/org/elasticsearch/action/termvector/dfs/ShardDfsOnlyResponse.java
@@ -19,59 +19,44 @@
 
 package org.elasticsearch.action.termvector.dfs;
 
-import org.elasticsearch.action.ShardOperationFailedException;
-import org.elasticsearch.action.support.broadcast.BroadcastOperationResponse;
+import org.elasticsearch.action.support.broadcast.BroadcastShardOperationResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.search.dfs.AggregatedDfs;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.search.dfs.DfsSearchResult;
 
 import java.io.IOException;
-import java.util.List;
 
 /**
- * A response of a dfs only request.
+ *
  */
-public class DfsOnlyResponse extends BroadcastOperationResponse {
+class ShardDfsOnlyResponse extends BroadcastShardOperationResponse {
 
-    private AggregatedDfs dfs;
-    private long tookInMillis;
+    private DfsSearchResult dfsSearchResult = new DfsSearchResult();
 
-    DfsOnlyResponse() {
+    ShardDfsOnlyResponse() {
 
     }
 
-    DfsOnlyResponse(AggregatedDfs dfs, int totalShards, int successfulShards, int failedShards,
-                    List<ShardOperationFailedException> shardFailures, long tookInMillis) {
-        super(totalShards, successfulShards, failedShards, shardFailures);
-        this.dfs = dfs;
-        this.tookInMillis = tookInMillis;
+    ShardDfsOnlyResponse(ShardId shardId, DfsSearchResult dfsSearchResult) {
+        super(shardId);
+        this.dfsSearchResult = dfsSearchResult;
     }
 
-    public AggregatedDfs getDfs() {
-        return dfs;
-    }
-
-    public TimeValue getTook() {
-        return new TimeValue(tookInMillis);
-    }
-
-    public long getTookInMillis() {
-        return tookInMillis;
+    public DfsSearchResult getDfsSearchResult() {
+        return dfsSearchResult;
     }
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        AggregatedDfs.readAggregatedDfs(in);
-        tookInMillis = in.readVLong();
+        dfsSearchResult.readFrom(in);
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        dfs.writeTo(out);
-        out.writeVLong(tookInMillis);
+        dfsSearchResult.writeTo(out);
     }
 
 }

--- a/src/main/java/org/elasticsearch/action/termvector/dfs/TransportDfsOnlyAction.java
+++ b/src/main/java/org/elasticsearch/action/termvector/dfs/TransportDfsOnlyAction.java
@@ -54,7 +54,7 @@ import static com.google.common.collect.Lists.newArrayList;
  */
 public class TransportDfsOnlyAction extends TransportBroadcastOperationAction<DfsOnlyRequest, DfsOnlyResponse, ShardDfsOnlyRequest, ShardDfsOnlyResponse> {
 
-    public static final String NAME = "internal:data/read/dfs";
+    public static final String NAME = "internal:index/termvectors/dfs";
 
     private final SearchService searchService;
 

--- a/src/main/java/org/elasticsearch/action/termvector/dfs/TransportDfsOnlyAction.java
+++ b/src/main/java/org/elasticsearch/action/termvector/dfs/TransportDfsOnlyAction.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.termvector.dfs;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRunnable;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.type.TransportSearchTypeAction;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.AtomicArray;
+import org.elasticsearch.search.action.SearchServiceListener;
+import org.elasticsearch.search.action.SearchServiceTransportAction;
+import org.elasticsearch.search.controller.SearchPhaseController;
+import org.elasticsearch.search.dfs.AggregatedDfs;
+import org.elasticsearch.search.dfs.DfsSearchResult;
+import org.elasticsearch.search.internal.ShardSearchTransportRequest;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import java.io.IOException;
+
+/**
+ *
+ */
+public class TransportDfsOnlyAction extends TransportSearchTypeAction {
+
+    @Inject
+    public TransportDfsOnlyAction(Settings settings, ThreadPool threadPool, ClusterService clusterService,
+                                  SearchServiceTransportAction searchService, SearchPhaseController searchPhaseController, ActionFilters actionFilters) {
+        super(settings, threadPool, clusterService, searchService, searchPhaseController, actionFilters);
+    }
+
+    @Override
+    protected void doExecute(SearchRequest searchRequest, ActionListener<SearchResponse> listener) {
+        new AsyncAction(searchRequest, listener).start();
+    }
+
+    private class AsyncAction extends BaseAsyncAction<DfsSearchResult> {
+
+        private AggregatedDfs dfs;
+
+        private AsyncAction(SearchRequest request, ActionListener<SearchResponse> listener) {
+            super(request, listener);
+        }
+
+        @Override
+        protected String firstPhaseName() {
+            return "dfs_only";
+        }
+
+        @Override
+        protected void sendExecuteFirstPhase(DiscoveryNode node, ShardSearchTransportRequest request, SearchServiceListener<DfsSearchResult> listener) {
+            searchService.sendExecuteDfs(node, request, listener);
+        }
+
+        @Override
+        protected void moveToSecondPhase() {
+            this.dfs = searchPhaseController.aggregateDfs(firstResults);
+            sendFreeContext();
+            finishHim();
+        }
+
+        private void sendFreeContext() {
+            for (AtomicArray.Entry<DfsSearchResult> entry : firstResults.asList()) {
+                try {
+                    DiscoveryNode node = nodes.get(entry.value.shardTarget().nodeId());
+                    if (node != null) { // should not happen (==null) but safeguard anyhow
+                        searchService.sendFreeContext(node, entry.value.id(), request);
+                    }
+                } catch (Throwable t1) {
+                    logger.trace("failed to release context", t1);
+                }
+            }
+        }
+
+        private void finishHim() {
+            threadPool.executor(ThreadPool.Names.SEARCH).execute(new ActionRunnable(listener) {
+                @Override
+                public void doRun() throws IOException {
+                    listener.onResponse(new DfsOnlyResponse(dfs, buildTookInMillis(), buildShardFailures()));
+                }
+
+                @Override
+                public void onFailure(Throwable t) {
+                    ElasticsearchException failure = new ElasticsearchException("Exception during dfs phase", t);
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("failed to perform dfs", failure);
+                    }
+                    super.onFailure(t);
+                }
+            });
+        }
+    }
+
+}

--- a/src/main/java/org/elasticsearch/action/termvector/dfs/TransportDfsOnlyAction.java
+++ b/src/main/java/org/elasticsearch/action/termvector/dfs/TransportDfsOnlyAction.java
@@ -149,7 +149,7 @@ public class TransportDfsOnlyAction extends TransportBroadcastOperationAction<Df
     }
 
     /**
-     * Builds how long it took to execute the search.
+     * Builds how long it took to execute the dfs request.
      */
     protected final long buildTookInMillis(DfsOnlyRequest request) {
         // protect ourselves against time going backwards

--- a/src/main/java/org/elasticsearch/action/termvector/dfs/package-info.java
+++ b/src/main/java/org/elasticsearch/action/termvector/dfs/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Distributed frequencies.
+ */
+package org.elasticsearch.action.termvector.dfs;

--- a/src/main/java/org/elasticsearch/rest/action/termvector/RestTermVectorAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/termvector/RestTermVectorAction.java
@@ -84,6 +84,7 @@ public class RestTermVectorAction extends BaseRestHandler {
         termVectorRequest.termStatistics(request.paramAsBoolean("term_statistics", termVectorRequest.termStatistics()));
         termVectorRequest.fieldStatistics(request.paramAsBoolean("fieldStatistics", termVectorRequest.fieldStatistics()));
         termVectorRequest.fieldStatistics(request.paramAsBoolean("field_statistics", termVectorRequest.fieldStatistics()));
+        termVectorRequest.dfs(request.paramAsBoolean("dfs", termVectorRequest.dfs()));
     }
 
     static public void addFieldStringsFromParameter(TermVectorRequest termVectorRequest, String fields) {

--- a/src/test/java/org/elasticsearch/action/termvector/GetTermVectorTests.java
+++ b/src/test/java/org/elasticsearch/action/termvector/GetTermVectorTests.java
@@ -1031,9 +1031,7 @@ public class GetTermVectorTests extends AbstractTermVectorTests {
                 .addMapping("type1", "text", "type=string"));
         ensureGreen();
 
-        // get the number of shards assigned
-        GetSettingsResponse getSettingsResponse = client().admin().indices().prepareGetSettings("test").get();
-        int numberShards = Integer.parseInt(getSettingsResponse.getSetting("test", "index.number_of_shards"));
+        int numberShards = getNumShards("test").numPrimaries;
 
         logger.info("Index 'cat' in each shard out of {} shards ...", numberShards);
         List<IndexRequestBuilder> builders = new ArrayList<>();

--- a/src/test/java/org/elasticsearch/action/termvector/GetTermVectorTests.java
+++ b/src/test/java/org/elasticsearch/action/termvector/GetTermVectorTests.java
@@ -27,7 +27,6 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.admin.indices.alias.Alias;
-import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.ImmutableSettings;
@@ -35,6 +34,7 @@ import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.mapper.core.AbstractFieldMapper;
+import org.hamcrest.Matcher;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -1025,74 +1025,57 @@ public class GetTermVectorTests extends AbstractTermVectorTests {
         logger.info("Setting up the index ...");
         ImmutableSettings.Builder settings = settingsBuilder()
                 .put(indexSettings())
-                .put("index.analysis.analyzer", "standard");
+                .put("index.analysis.analyzer", "standard")
+                .put("index.number_of_shards", randomIntBetween(2, 10)); // we need at least 2 shards
         assertAcked(prepareCreate("test")
                 .setSettings(settings)
                 .addMapping("type1", "text", "type=string"));
         ensureGreen();
 
-        int numberShards = getNumShards("test").numPrimaries;
-
-        logger.info("Index 'cat' in each shard out of {} shards ...", numberShards);
+        int numDocs = scaledRandomIntBetween(25, 100);
+        logger.info("Indexing {} documents...", numDocs);
         List<IndexRequestBuilder> builders = new ArrayList<>();
-        for (int i = 0; i < numberShards; i++) {
-            builders.add(client().prepareIndex("test", "type1", i + "")
-                    .setRouting(i + "")
-                    .setSource("text", "cat"));
+        for (int i = 0; i < numDocs; i++) {
+            builders.add(client().prepareIndex("test", "type1", i + "").setSource("text", "cat"));
         }
         indexRandom(true, builders);
 
-        logger.info("Without dfs 'cat' should appear only once.");
-        TermVectorResponse response = client().prepareTermVector("test", "type1", randomIntBetween(0, numberShards - 1) + "")
+        XContentBuilder expectedStats = jsonBuilder()
+                .startObject()
+                .startObject("text")
+                    .startObject("field_statistics")
+                    .field("sum_doc_freq", numDocs)
+                    .field("doc_count", numDocs)
+                    .field("sum_ttf", numDocs)
+                .endObject()
+                    .startObject("terms")
+                        .startObject("cat")
+                        .field("doc_freq", numDocs)
+                        .field("ttf", numDocs)
+                        .endObject()
+                    .endObject()
+                .endObject()
+                .endObject();
+
+        logger.info("Without dfs 'cat' should appear strictly less than {} times.", numDocs);
+        TermVectorResponse response = client().prepareTermVector("test", "type1", randomIntBetween(0, numDocs - 1) + "")
                 .setSelectedFields("text")
                 .setFieldStatistics(true)
                 .setTermStatistics(true)
                 .get();
+        checkStats(response.getFields(), expectedStats, false);
 
-        checkStats(response.getFields(), jsonBuilder()
-                .startObject()
-                .startObject("text")
-                    .startObject("field_statistics")
-                    .field("sum_doc_freq", 1)
-                    .field("doc_count", 1)
-                    .field("sum_ttf", 1)
-                    .endObject()
-                    .startObject("terms")
-                        .startObject("cat")
-                        .field("doc_freq", 1)
-                        .field("ttf", 1)
-                        .endObject()
-                    .endObject()
-                .endObject()
-                .endObject());
-
-        logger.info("With dfs 'cat' should appear number {} times.", numberShards);
-        response = client().prepareTermVector("test", "type1", randomIntBetween(0, numberShards - 1) + "")
+        logger.info("With dfs 'cat' should appear exactly {} times.", numDocs);
+        response = client().prepareTermVector("test", "type1", randomIntBetween(0, numDocs - 1) + "")
                 .setSelectedFields("text")
                 .setFieldStatistics(true)
                 .setTermStatistics(true)
                 .setDfs(true)
                 .get();
+        checkStats(response.getFields(), expectedStats, true);
+    }
 
-        checkStats(response.getFields(), jsonBuilder()
-                .startObject()
-                .startObject("text")
-                    .startObject("field_statistics")
-                    .field("sum_doc_freq", numberShards)
-                    .field("doc_count", numberShards)
-                    .field("sum_ttf", numberShards)
-                    .endObject()
-                    .startObject("terms")
-                        .startObject("cat")
-                        .field("doc_freq", numberShards)
-                        .field("ttf", numberShards)
-                        .endObject()
-                    .endObject()
-                .endObject()
-                .endObject());
-        }
-
-    private void checkStats(Fields fields, XContentBuilder xContentBuilder) throws IOException {
+    private void checkStats(Fields fields, XContentBuilder xContentBuilder, boolean isEqual) throws IOException {
         Map<String, Object> stats = JsonXContent.jsonXContent.createParser(xContentBuilder.bytes()).map();
         assertThat("number of fields expected:", fields.size(), equalTo(stats.size()));
         for (String fieldName : fields) {
@@ -1101,14 +1084,14 @@ public class GetTermVectorTests extends AbstractTermVectorTests {
             Map<String, Integer> fieldStatistics = getFieldStatistics(stats, fieldName);
             String msg = "field: " + fieldName + " ";
             assertThat(msg + "sum_doc_freq:",
-                    terms.getSumDocFreq(),
-                    equalTo(fieldStatistics.get("sum_doc_freq").longValue()));
+                    (int) terms.getSumDocFreq(),
+                    equalOrLessThanTo(fieldStatistics.get("sum_doc_freq"), isEqual));
             assertThat(msg + "doc_count:",
                     terms.getDocCount(),
-                    equalTo(fieldStatistics.get("doc_count")));
+                    equalOrLessThanTo(fieldStatistics.get("doc_count"), isEqual));
             assertThat(msg + "sum_ttf:",
-                    terms.getSumTotalTermFreq(),
-                    equalTo(fieldStatistics.get("sum_ttf").longValue()));
+                    (int) terms.getSumTotalTermFreq(),
+                    equalOrLessThanTo(fieldStatistics.get("sum_ttf"), isEqual));
 
             final TermsEnum termsEnum = terms.iterator(null);
             BytesRef text;
@@ -1119,10 +1102,10 @@ public class GetTermVectorTests extends AbstractTermVectorTests {
                 msg = "term: (" + fieldName + "," + term + ") ";
                 assertThat(msg + "doc_freq:",
                         termsEnum.docFreq(),
-                        equalTo(termStatistics.get("doc_freq")));
+                        equalOrLessThanTo(termStatistics.get("doc_freq"), isEqual));
                 assertThat(msg + "ttf:",
-                        termsEnum.totalTermFreq(),
-                        equalTo(termStatistics.get("ttf").longValue()));
+                        (int) termsEnum.totalTermFreq(),
+                        equalOrLessThanTo(termStatistics.get("ttf"), isEqual));
             }
         }
     }
@@ -1134,4 +1117,12 @@ public class GetTermVectorTests extends AbstractTermVectorTests {
     private Map<String, Integer> getTermStatistics(Map<String, Object> stats, String fieldName, String term) {
         return (Map<String, Integer>) ((Map<String, Object>) ((Map<String, Object>) stats.get(fieldName)).get("terms")).get(term);
     }
+
+    private Matcher<Integer> equalOrLessThanTo(Integer value, boolean isEqual) {
+        if (isEqual) {
+            return equalTo(value);
+        }
+        return lessThan(value);
+    }
+
 }

--- a/src/test/java/org/elasticsearch/action/termvector/GetTermVectorTests.java
+++ b/src/test/java/org/elasticsearch/action/termvector/GetTermVectorTests.java
@@ -27,11 +27,13 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.admin.indices.alias.Alias;
+import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.mapper.core.AbstractFieldMapper;
 import org.junit.Test;
 
@@ -403,7 +405,6 @@ public class GetTermVectorTests extends AbstractTermVectorTests {
 
     @Test
     public void testRandomPayloadWithDelimitedPayloadTokenFilter() throws ElasticsearchException, IOException {
-
         //create the test document
         int encoding = randomIntBetween(0, 2);
         String encodingString = "";
@@ -1017,5 +1018,122 @@ public class GetTermVectorTests extends AbstractTermVectorTests {
 
     private static String indexOrAlias() {
         return randomBoolean() ? "test" : "alias";
+    }
+
+    @Test
+    public void testDfs() throws ElasticsearchException, ExecutionException, InterruptedException, IOException {
+        logger.info("Setting up the index ...");
+        ImmutableSettings.Builder settings = settingsBuilder()
+                .put(indexSettings())
+                .put("index.analysis.analyzer", "standard");
+        assertAcked(prepareCreate("test")
+                .setSettings(settings)
+                .addMapping("type1", "text", "type=string"));
+        ensureGreen();
+
+        // get the number of shards assigned
+        GetSettingsResponse getSettingsResponse = client().admin().indices().prepareGetSettings("test").get();
+        int numberShards = Integer.parseInt(getSettingsResponse.getSetting("test", "index.number_of_shards"));
+
+        logger.info("Index 'cat' in each shard out of {} shards ...", numberShards);
+        List<IndexRequestBuilder> builders = new ArrayList<>();
+        for (int i = 0; i < numberShards; i++) {
+            builders.add(client().prepareIndex("test", "type1", i + "")
+                    .setRouting(i + "")
+                    .setSource("text", "cat"));
+        }
+        indexRandom(true, builders);
+
+        logger.info("Without dfs 'cat' should appear only once.");
+        TermVectorResponse response = client().prepareTermVector("test", "type1", randomIntBetween(0, numberShards - 1) + "")
+                .setSelectedFields("text")
+                .setFieldStatistics(true)
+                .setTermStatistics(true)
+                .get();
+
+        checkStats(response.getFields(), jsonBuilder()
+                .startObject()
+                .startObject("text")
+                    .startObject("field_statistics")
+                    .field("sum_doc_freq", 1)
+                    .field("doc_count", 1)
+                    .field("sum_ttf", 1)
+                    .endObject()
+                    .startObject("terms")
+                        .startObject("cat")
+                        .field("doc_freq", 1)
+                        .field("ttf", 1)
+                        .endObject()
+                    .endObject()
+                .endObject()
+                .endObject());
+
+        logger.info("With dfs 'cat' should appear number {} times.", numberShards);
+        response = client().prepareTermVector("test", "type1", randomIntBetween(0, numberShards - 1) + "")
+                .setSelectedFields("text")
+                .setFieldStatistics(true)
+                .setTermStatistics(true)
+                .setDfs(true)
+                .get();
+
+        checkStats(response.getFields(), jsonBuilder()
+                .startObject()
+                .startObject("text")
+                    .startObject("field_statistics")
+                    .field("sum_doc_freq", numberShards)
+                    .field("doc_count", numberShards)
+                    .field("sum_ttf", numberShards)
+                    .endObject()
+                    .startObject("terms")
+                        .startObject("cat")
+                        .field("doc_freq", numberShards)
+                        .field("ttf", numberShards)
+                        .endObject()
+                    .endObject()
+                .endObject()
+                .endObject());
+        }
+
+    private void checkStats(Fields fields, XContentBuilder xContentBuilder) throws IOException {
+        Map<String, Object> stats = JsonXContent.jsonXContent.createParser(xContentBuilder.bytes()).map();
+        assertThat("number of fields expected:", fields.size(), equalTo(stats.size()));
+        for (String fieldName : fields) {
+            logger.info("Checking field statistics for field: {}", fieldName);
+            Terms terms = fields.terms(fieldName);
+            Map<String, Integer> fieldStatistics = getFieldStatistics(stats, fieldName);
+            String msg = "field: " + fieldName + " ";
+            assertThat(msg + "sum_doc_freq:",
+                    terms.getSumDocFreq(),
+                    equalTo(fieldStatistics.get("sum_doc_freq").longValue()));
+            assertThat(msg + "doc_count:",
+                    terms.getDocCount(),
+                    equalTo(fieldStatistics.get("doc_count")));
+            assertThat(msg + "sum_ttf:",
+                    terms.getSumTotalTermFreq(),
+                    equalTo(fieldStatistics.get("sum_ttf").longValue()));
+
+            final TermsEnum termsEnum = terms.iterator(null);
+            BytesRef text;
+            while((text = termsEnum.next()) != null) {
+                String term = text.utf8ToString();
+                logger.info("Checking term statistics for term: ({}, {})", fieldName, term);
+                Map<String, Integer> termStatistics = getTermStatistics(stats, fieldName, term);
+                msg = "term: (" + fieldName + "," + term + ") ";
+                assertThat(msg + "doc_freq:",
+                        termsEnum.docFreq(),
+                        equalTo(termStatistics.get("doc_freq")));
+                assertThat(msg + "ttf:",
+                        termsEnum.totalTermFreq(),
+                        equalTo(termStatistics.get("ttf").longValue()));
+            }
+        }
+    }
+
+    private Map<String, Integer> getFieldStatistics(Map<String, Object> stats, String fieldName) throws IOException {
+        return (Map<String, Integer>) ((Map<String, Object>) stats.get(fieldName)).get("field_statistics");
+    }
+
+    private Map<String, Integer> getTermStatistics(Map<String, Object> stats, String fieldName, String term) {
+        return (Map<String, Integer>) ((Map<String, Object>) ((Map<String, Object>) stats.get(fieldName)).get("terms")).get(term);
     }
 }

--- a/src/test/java/org/elasticsearch/transport/ActionNamesTests.java
+++ b/src/test/java/org/elasticsearch/transport/ActionNamesTests.java
@@ -28,6 +28,7 @@ import org.elasticsearch.action.bench.BenchmarkAction;
 import org.elasticsearch.action.bench.BenchmarkService;
 import org.elasticsearch.action.bench.BenchmarkStatusAction;
 import org.elasticsearch.action.exists.ExistsAction;
+import org.elasticsearch.action.termvector.dfs.TransportDfsOnlyAction;
 import org.elasticsearch.search.action.SearchServiceTransportAction;
 import org.elasticsearch.repositories.VerifyNodeRepositoryAction;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
@@ -146,5 +147,7 @@ public class ActionNamesTests extends ElasticsearchIntegrationTest {
         post_1_4_actions.add(SearchServiceTransportAction.FETCH_ID_SCROLL_ACTION_NAME);
         post_1_4_actions.add(VerifyRepositoryAction.NAME);
         post_1_4_actions.add(VerifyNodeRepositoryAction.ACTION_NAME);
+        post_1_4_actions.add(TransportDfsOnlyAction.NAME);
+        post_1_4_actions.add(TransportDfsOnlyAction.NAME + "[s]");
     }
 }


### PR DESCRIPTION
Adds distributed frequencies support for the Term Vectors API. A new parameter
called `dfs` is introduced which defaults to `false`.
