### PR TITLE
Use 1 instead of 0 as filler version value for nested docs

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/internal/VersionFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/VersionFieldMapper.java
@@ -131,11 +131,11 @@ public class VersionFieldMapper extends AbstractFieldMapper<Long> implements Int
 
     @Override
     public void postParse(ParseContext context) throws IOException {
-        // In the case of nested docs, let's fill nested docs with version=0 so that Lucene doesn't write a Bitset for documents
-        // that don't have the field
+        // In the case of nested docs, let's fill nested docs with version=1 so that Lucene doesn't write a Bitset for documents
+        // that don't have the field. This is consistent with the default value for efficiency.
         for (int i = 1; i < context.docs().size(); i++) {
             final Document doc = context.docs().get(i);
-            doc.add(new NumericDocValuesField(NAME, 0L));
+            doc.add(new NumericDocValuesField(NAME, 1L));
         }
     }
 


### PR DESCRIPTION
This is consistent with the default value of version=1, which means if a user isnt using versioning, the lucene codec can potentially completely optimize all store for the version field away.
