### PR TITLE
Startup: Prevent potential loop in bin/elasticsearch

### DIFF
--- a/bin/elasticsearch
+++ b/bin/elasticsearch
@@ -164,8 +164,13 @@ do
       --*=*) properties="$properties -Des.${1#--}"
            shift 1
            ;;
-      --*) properties="$properties -Des.${1#--}=$2"
-           shift 2
+      --*) if [ $# -gt 1 ] ; then
+               properties="$properties -Des.${1#--}=$2"
+               shift 2
+           else
+               echo "Ignoring option without value $1"
+               shift 1
+           fi
            ;;
       *) ARGV="$ARGV $1" ; shift
     esac


### PR DESCRIPTION
If bin/elasticsearch is started with a single --long argument, it could
potentially be caught up in a loop on bash (dash handles this correctly).

This commit adds an additional check that prints out an error message

Closes #7104
