### PR TITLE
Add inner hits to nested and parent/child queries

### DIFF
--- a/docs/reference/search/request-body.asciidoc
+++ b/docs/reference/search/request-body.asciidoc
@@ -127,3 +127,5 @@ include::request/index-boost.asciidoc[]
 include::request/min-score.asciidoc[]
 
 include::request/named-queries-and-filters.asciidoc[]
+
+include::request/inner-hits.asciidoc[]

--- a/docs/reference/search/request/inner-hits.asciidoc
+++ b/docs/reference/search/request/inner-hits.asciidoc
@@ -1,0 +1,246 @@
+[[search-request-inner-hits]]
+=== Inner hits
+
+The <<mapping-parent-field, parent/child>> and <<mapping-nested-type, nested>> features allow to return documents that
+have matches in a different scope. In the parent/child case parent document are returned based on matches in child
+documents or child document are returned based on matches in parent documents. In the nested case documents are returned
+based on matches in nested inner objects.
+
+In both cases the actual matches in the different scopes that caused a document to be returned is hidden. In many cases
+it is very useful to know which inner nested objects in the case of nested or children or parent documents in the case
+of parent/child caused certain information to be returned. The inner hits feature can be used for this. This feature
+returns per search hit in the search response additional nested hits that caused a search hit to match in a different scope.
+
+The following snippet explains the basic structure of inner hits:
+
+[source,js]
+--------------------------------------------------
+"inner_hits" : {
+    "<inner_hits_name>" : {
+        "<path|type>" : {
+            "<path-to-nested-object-field|child-or-parent-type>" : {
+                <inner_hits_body>
+                [,"inner_hits" : { [<sub_inner_hits>]+ } ]?
+            }
+        }
+    }
+    [,"<inner_hits_name_2>" : { ... } ]*
+}
+--------------------------------------------------
+
+Inside the `inner_hits` definition, first the name if the inner hit is defined then whether the inner_hit
+is a nested by defining `path` or a parent/child based definition by defining `type`. The next object layer contains
+the name of the nested object field if the inner_hits is nested or the parent or child type if the inner_hit definition
+is parent/child based.
+
+Multiple inner hit definitions can be defined in a single request. In the `<inner_hits_body>` any option for features
+that `inner_hits` support can be defined. Optionally another `inner_hits` definition can be defined in the `<inner_hits_body>`.
+
+If `inner_hits` is defined each search will contain a `inner_hits` json object with the following structure:
+
+[source,js]
+--------------------------------------------------
+"hits": [
+     {
+        "_index": ...,
+        "_type": ...,
+        "_id": ...,
+        "inner_hits": {
+           "<inner_hits_name>": {
+              "hits": {
+                 "total": ...,
+                 "hits": [
+                    {
+                       "_type": ...,
+                       "_id": ...,
+                       ...
+                    },
+                    ...
+                 ]
+              }
+           }
+        },
+        ...
+     },
+     ...
+]
+--------------------------------------------------
+
+==== Options
+
+Inner hits support the following options:
+
+[horizontal]
+`path`:: Defines the nested scope where hits will be collected from.
+`type`:: Defines the parent or child type score where hits will be collected from.
+`query`:: Defines the query that will run in the defined nested, parent or child scope to collect and score hits. By default all document in the scope will be matched.
+`from`:: The offset from where the first hit to fetch for each `inner_hits` in the returned regular search hits.
+`size`:: The maximum number of hits to return per `inner_hits`. By default the top three matching hits are returned.
+`sort`:: How the inner hits should be sorted per `inner_hits`. By default the hits are sorted by the score.
+
+Either `path` or `type` must be defined. The `path` or `type` defines the scope from where hits are fetched and
+used as inner hits.
+
+Inner hits also supports the following per document features:
+
+* <<search-request-highlighting,Highlighting>>
+* <<search-request-explain,Explain>>
+* <<search-request-source-filtering,Source filtering>>
+* <<search-request-script-fields,Script fields>>
+* <<search-request-fielddata-fields,Fielddata fields>>
+* <<search-request-version,Include versions>>
+
+[[nested-inner-hits]]
+==== Nested inner hits
+
+The nested `inner_hits` can be used to include nested inner objects as inner hits to a search hit.
+
+The example below assumes that there is a nested object field defined with the name `comments`:
+
+[source,js]
+--------------------------------------------------
+{
+    "query" : {
+        "nested" : {
+            "path" : "comments",
+            "query" : {
+                "match" : {"comments.message" : "[actual query]"}
+            }
+        }
+    },
+    "inner_hits" : {
+        "comment" : {
+            "path" : { <1>
+                "comments" : { <2>
+                    "query" : {
+                        "match" : {"comments.message" : "[actual query]"}
+                    }
+                }
+            }
+        }
+    }
+}
+--------------------------------------------------
+
+<1> The inner hit definition is nested and requires the `path` option.
+<2> The path option refers to the nested object field `comments`
+
+In the above the query is repeated in both the query and the `comment` inner hit definition. At the moment there is
+no query referencing support, so in order to make sure that only inner nested objects are returned that contributed to
+the matching of the regular hits, the inner query in the `nested` query needs to also be defined on the inner hits definition.
+
+An example of a response snippet that could be generated from the above search request:
+
+[source,js]
+--------------------------------------------------
+...
+"hits": {
+  ...
+  "hits": [
+     {
+        "_index": "my-index",
+        "_type": "question",
+        "_id": "1",
+        "_source": ...,
+        "inner_hits": {
+           "comment": {
+              "hits": {
+                 "total": ...,
+                 "hits": [
+                    {
+                       "_type": "question",
+                       "_id": "1",
+                       "_nested": {
+                          "field": "comments",
+                          "offset": 2
+                       },
+                       "_source": ...
+                    },
+                    ...
+                 ]
+              }
+           }
+        }
+     },
+     ...
+--------------------------------------------------
+
+The `_nested` metadata is crucial in the above example, because it defines from what inner nested object this inner hit
+came from. The `field` defines the object array field the nested hit is from and the `offset` relative to its location
+in the `_source`. Due to sorting and scoring the actual location of the hit objects in the `inner_hits` is usually
+different than the location a nested inner object was defined.
+
+By default the `_source` is returned also for the hit objects in `inner_hits`, but this can be changed. Either via
+`_source` filtering feature part of the source can be returned or be disabled. If stored fields are defined on the
+nested level these can also be returned via the `fields` feature.
+
+An important default is that the `_source` returned in hits inside `inner_hits` is relative to the `_nested` metadata.
+So in the above example only the comment part is returned per nested hit and not the entire source of the top level
+document that contained the the comment.
+
+[[parent-child-inner-hits]]
+==== Parent/child inner hits
+
+The parent/child `inner_hits` can be used to include parent or child
+
+The examples below assumes that there is a `_parent` field mapping in the `comment` type:
+
+[source,js]
+--------------------------------------------------
+{
+    "query" : {
+        "has_child" : {
+            "type" : "comment",
+            "query" : {
+                "match" : {"message" : "[actual query]"}
+            }
+        }
+    },
+    "inner_hits" : {
+        "comment" : {
+            "type" : { <1>
+                "comment" : { <2>
+                    "query" : {
+                        "match" : {"message" : "[actual query]"}
+                    }
+                }
+            }
+        }
+    }
+}
+--------------------------------------------------
+
+<1> This is a parent/child inner hit definition and requires the `type` option.
+<2> Refers to the document type `comment`
+
+An example of a response snippet that could be generated from the above search request:
+
+[source,js]
+--------------------------------------------------
+...
+"hits": {
+  ...
+  "hits": [
+     {
+        "_index": "my-index",
+        "_type": "question",
+        "_id": "1",
+        "_source": ...,
+        "inner_hits": {
+           "comment": {
+              "hits": {
+                 "total": ...,
+                 "hits": [
+                    {
+                       "_type": "comment",
+                       "_id": "5",
+                       "_source": ...
+                    },
+                    ...
+                 ]
+              }
+           }
+        }
+     },
+     ...
+--------------------------------------------------

--- a/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
@@ -34,6 +34,7 @@ import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.Scroll;
 import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.search.fetch.innerhits.InnerHitsBuilder;
 import org.elasticsearch.search.highlight.HighlightBuilder;
 import org.elasticsearch.search.rescore.RescoreBuilder;
 import org.elasticsearch.search.sort.SortBuilder;
@@ -741,6 +742,11 @@ public class SearchRequestBuilder extends ActionRequestBuilder<SearchRequest, Se
         return this;
     }
 
+    public SearchRequestBuilder addInnerHit(String name, InnerHitsBuilder.InnerHit innerHit) {
+        innerHitsBuilder().addInnerHit(name, innerHit);
+        return this;
+    }
+
     /**
      * Delegates to {@link org.elasticsearch.search.suggest.SuggestBuilder#setText(String)}.
      */
@@ -1030,6 +1036,10 @@ public class SearchRequestBuilder extends ActionRequestBuilder<SearchRequest, Se
 
     private HighlightBuilder highlightBuilder() {
         return sourceBuilder().highlighter();
+    }
+
+    private InnerHitsBuilder innerHitsBuilder() {
+        return sourceBuilder().innerHitsBuilder();
     }
 
     private SuggestBuilder suggestBuilder() {

--- a/src/main/java/org/elasticsearch/index/query/NestedQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/NestedQueryParser.java
@@ -165,11 +165,13 @@ public class NestedQueryParser implements QueryParser {
         }
     }
 
-    static ThreadLocal<LateBindingParentFilter> parentFilterContext = new ThreadLocal<>();
+    // TODO: Change this mechanism in favour of how parent nested object type is resolved in nested and reverse_nested agg
+    // with this also proper validation can be performed on what is a valid nested child nested object type to be used
+    public static ThreadLocal<LateBindingParentFilter> parentFilterContext = new ThreadLocal<>();
 
-    static class LateBindingParentFilter extends BitDocIdSetFilter {
+    public static class LateBindingParentFilter extends BitDocIdSetFilter {
 
-        BitDocIdSetFilter filter;
+        public BitDocIdSetFilter filter;
 
         @Override
         public int hashCode() {
@@ -178,7 +180,8 @@ public class NestedQueryParser implements QueryParser {
 
         @Override
         public boolean equals(Object obj) {
-            return filter.equals(obj);
+            if (!(obj instanceof LateBindingParentFilter)) return false;
+            return filter.equals(((LateBindingParentFilter) obj).filter);
         }
 
         @Override

--- a/src/main/java/org/elasticsearch/percolator/PercolateContext.java
+++ b/src/main/java/org/elasticsearch/percolator/PercolateContext.java
@@ -55,6 +55,7 @@ import org.elasticsearch.search.dfs.DfsSearchResult;
 import org.elasticsearch.search.fetch.FetchSearchResult;
 import org.elasticsearch.search.fetch.FetchSubPhase;
 import org.elasticsearch.search.fetch.fielddata.FieldDataFieldsContext;
+import org.elasticsearch.search.fetch.innerhits.InnerHitsContext;
 import org.elasticsearch.search.fetch.script.ScriptFieldsContext;
 import org.elasticsearch.search.fetch.source.FetchSourceContext;
 import org.elasticsearch.search.highlight.SearchContextHighlight;
@@ -679,6 +680,16 @@ public class PercolateContext extends SearchContext {
 
     @Override
     public Counter timeEstimateCounter() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void innerHits(InnerHitsContext innerHitsContext) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public InnerHitsContext innerHits() {
         throw new UnsupportedOperationException();
     }
 }

--- a/src/main/java/org/elasticsearch/search/SearchHit.java
+++ b/src/main/java/org/elasticsearch/search/SearchHit.java
@@ -200,6 +200,11 @@ public interface SearchHit extends Streamable, ToXContent, Iterable<SearchHitFie
     SearchShardTarget getShard();
 
     /**
+     * @return Inner hits or <code>null</code> if there are none
+     */
+    Map<String, SearchHits> getInnerHits();
+
+    /**
      * Encapsulates the nested identity of a hit.
      */
     public interface NestedIdentity {

--- a/src/main/java/org/elasticsearch/search/SearchModule.java
+++ b/src/main/java/org/elasticsearch/search/SearchModule.java
@@ -32,6 +32,7 @@ import org.elasticsearch.search.dfs.DfsPhase;
 import org.elasticsearch.search.fetch.FetchPhase;
 import org.elasticsearch.search.fetch.explain.ExplainFetchSubPhase;
 import org.elasticsearch.search.fetch.fielddata.FieldDataFieldsFetchSubPhase;
+import org.elasticsearch.search.fetch.innerhits.InnerHitsFetchSubPhase;
 import org.elasticsearch.search.fetch.matchedqueries.MatchedQueriesFetchSubPhase;
 import org.elasticsearch.search.fetch.script.ScriptFieldsFetchSubPhase;
 import org.elasticsearch.search.fetch.source.FetchSourceSubPhase;
@@ -66,6 +67,7 @@ public class SearchModule extends AbstractModule implements SpawnModules {
         bind(VersionFetchSubPhase.class).asEagerSingleton();
         bind(MatchedQueriesFetchSubPhase.class).asEagerSingleton();
         bind(HighlightPhase.class).asEagerSingleton();
+        bind(InnerHitsFetchSubPhase.class).asEagerSingleton();
 
         bind(SearchServiceTransportAction.class).asEagerSingleton();
         bind(MoreLikeThisFetchService.class).asEagerSingleton();

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/TopHitsParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/TopHitsParser.java
@@ -30,6 +30,7 @@ import org.elasticsearch.search.fetch.script.ScriptFieldsParseElement;
 import org.elasticsearch.search.fetch.source.FetchSourceParseElement;
 import org.elasticsearch.search.highlight.HighlighterParseElement;
 import org.elasticsearch.search.internal.SearchContext;
+import org.elasticsearch.search.internal.SubSearchContext;
 import org.elasticsearch.search.sort.SortParseElement;
 
 import java.io.IOException;
@@ -63,7 +64,7 @@ public class TopHitsParser implements Aggregator.Parser {
 
     @Override
     public AggregatorFactory parse(String aggregationName, XContentParser parser, SearchContext context) throws IOException {
-        TopHitsContext topHitsContext = new TopHitsContext(context);
+        SubSearchContext subSearchContext = new SubSearchContext(context);
         XContentParser.Token token;
         String currentFieldName = null;
         try {
@@ -71,26 +72,26 @@ public class TopHitsParser implements Aggregator.Parser {
                 if (token == XContentParser.Token.FIELD_NAME) {
                     currentFieldName = parser.currentName();
                 } else if ("sort".equals(currentFieldName)) {
-                    sortParseElement.parse(parser, topHitsContext);
+                    sortParseElement.parse(parser, subSearchContext);
                 } else if ("_source".equals(currentFieldName)) {
-                    sourceParseElement.parse(parser, topHitsContext);
+                    sourceParseElement.parse(parser, subSearchContext);
                 } else if (token.isValue()) {
                     switch (currentFieldName) {
                         case "from":
-                            topHitsContext.from(parser.intValue());
+                            subSearchContext.from(parser.intValue());
                             break;
                         case "size":
-                            topHitsContext.size(parser.intValue());
+                            subSearchContext.size(parser.intValue());
                             break;
                         case "track_scores":
                         case "trackScores":
-                            topHitsContext.trackScores(parser.booleanValue());
+                            subSearchContext.trackScores(parser.booleanValue());
                             break;
                         case "version":
-                            topHitsContext.version(parser.booleanValue());
+                            subSearchContext.version(parser.booleanValue());
                             break;
                         case "explain":
-                            topHitsContext.explain(parser.booleanValue());
+                            subSearchContext.explain(parser.booleanValue());
                             break;
                         default:
                             throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
@@ -98,11 +99,11 @@ public class TopHitsParser implements Aggregator.Parser {
                 } else if (token == XContentParser.Token.START_OBJECT) {
                     switch (currentFieldName) {
                         case "highlight":
-                            highlighterParseElement.parse(parser, topHitsContext);
+                            highlighterParseElement.parse(parser, subSearchContext);
                             break;
                         case "scriptFields":
                         case "script_fields":
-                            scriptFieldsParseElement.parse(parser, topHitsContext);
+                            scriptFieldsParseElement.parse(parser, subSearchContext);
                             break;
                         default:
                             throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
@@ -111,7 +112,7 @@ public class TopHitsParser implements Aggregator.Parser {
                     switch (currentFieldName) {
                         case "fielddataFields":
                         case "fielddata_fields":
-                            fieldDataFieldsParseElement.parse(parser, topHitsContext);
+                            fieldDataFieldsParseElement.parse(parser, subSearchContext);
                             break;
                         default:
                             throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
@@ -123,7 +124,7 @@ public class TopHitsParser implements Aggregator.Parser {
         } catch (Exception e) {
             throw ExceptionsHelper.convertToElastic(e);
         }
-        return new TopHitsAggregator.Factory(aggregationName, fetchPhase, topHitsContext);
+        return new TopHitsAggregator.Factory(aggregationName, fetchPhase, subSearchContext);
     }
 
 }

--- a/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
+++ b/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
@@ -38,6 +38,7 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.query.FilterBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
+import org.elasticsearch.search.fetch.innerhits.InnerHitsBuilder;
 import org.elasticsearch.search.fetch.source.FetchSourceContext;
 import org.elasticsearch.search.highlight.HighlightBuilder;
 import org.elasticsearch.search.internal.SearchContext;
@@ -112,6 +113,8 @@ public class SearchSourceBuilder implements ToXContent {
     private HighlightBuilder highlightBuilder;
 
     private SuggestBuilder suggestBuilder;
+
+    private InnerHitsBuilder innerHitsBuilder;
 
     private List<RescoreBuilder> rescoreBuilders;
     private Integer defaultRescoreWindowSize;
@@ -434,6 +437,13 @@ public class SearchSourceBuilder implements ToXContent {
         return this;
     }
 
+    public InnerHitsBuilder innerHitsBuilder() {
+        if (innerHitsBuilder == null) {
+            innerHitsBuilder = new InnerHitsBuilder();
+        }
+        return innerHitsBuilder;
+    }
+
     public SuggestBuilder suggest() {
         if (suggestBuilder == null) {
             suggestBuilder = new SuggestBuilder("suggest");
@@ -642,7 +652,12 @@ public class SearchSourceBuilder implements ToXContent {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
+        innerToXContent(builder, params);
+        builder.endObject();
+        return builder;
+    }
 
+    public void innerToXContent(XContentBuilder builder, Params params) throws IOException{
         if (from != -1) {
             builder.field("from", from);
         }
@@ -792,6 +807,10 @@ public class SearchSourceBuilder implements ToXContent {
             highlightBuilder.toXContent(builder, params);
         }
 
+        if (innerHitsBuilder != null) {
+            innerHitsBuilder.toXContent(builder, params);
+        }
+
         if (suggestBuilder != null) {
             suggestBuilder.toXContent(builder, params);
         }
@@ -835,9 +854,6 @@ public class SearchSourceBuilder implements ToXContent {
             }
             builder.endArray();
         }
-
-        builder.endObject();
-        return builder;
     }
 
     private static class ScriptField {

--- a/src/main/java/org/elasticsearch/search/fetch/innerhits/InnerHitsBuilder.java
+++ b/src/main/java/org/elasticsearch/search/fetch/innerhits/InnerHitsBuilder.java
@@ -1,0 +1,442 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.fetch.innerhits;
+
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.search.highlight.HighlightBuilder;
+import org.elasticsearch.search.sort.SortBuilder;
+import org.elasticsearch.search.sort.SortOrder;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ */
+public class InnerHitsBuilder implements ToXContent {
+
+    private Map<String, InnerHit> innerHits = new HashMap<>();
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject("inner_hits");
+        for (Map.Entry<String, InnerHit> entry : innerHits.entrySet()) {
+            builder.startObject(entry.getKey());
+            entry.getValue().toXContent(builder, params);
+            builder.endObject();
+        }
+        return builder.endObject();
+    }
+
+    public void addInnerHit(String name, InnerHit innerHit) {
+        innerHits.put(name, innerHit);
+    }
+
+    public static class InnerHit implements ToXContent {
+
+        private String path;
+        private String type;
+
+        private SearchSourceBuilder sourceBuilder;
+
+        public InnerHit setQuery(QueryBuilder query) {
+            sourceBuilder().query(query);
+            return this;
+        }
+
+        public InnerHit setPath(String path) {
+            this.path = path;
+            return this;
+        }
+
+        public InnerHit setType(String type) {
+            this.type = type;
+            return this;
+        }
+
+        /**
+         * The index to start to return hits from. Defaults to <tt>0</tt>.
+         */
+        public InnerHit setFrom(int from) {
+            sourceBuilder().from(from);
+            return this;
+        }
+
+
+        /**
+         * The number of search hits to return. Defaults to <tt>10</tt>.
+         */
+        public InnerHit setSize(int size) {
+            sourceBuilder().size(size);
+            return this;
+        }
+
+        /**
+         * Applies when sorting, and controls if scores will be tracked as well. Defaults to
+         * <tt>false</tt>.
+         */
+        public InnerHit setTrackScores(boolean trackScores) {
+            sourceBuilder().trackScores(trackScores);
+            return this;
+        }
+
+        /**
+         * Should each {@link org.elasticsearch.search.SearchHit} be returned with an
+         * explanation of the hit (ranking).
+         */
+        public InnerHit setExplain(boolean explain) {
+            sourceBuilder().explain(explain);
+            return this;
+        }
+
+        /**
+         * Should each {@link org.elasticsearch.search.SearchHit} be returned with its
+         * version.
+         */
+        public InnerHit setVersion(boolean version) {
+            sourceBuilder().version(version);
+            return this;
+        }
+
+        /**
+         * Sets no fields to be loaded, resulting in only id and type to be returned per field.
+         */
+        public InnerHit setNoFields() {
+            sourceBuilder().noFields();
+            return this;
+        }
+
+        /**
+         * Indicates whether the response should contain the stored _source for every hit
+         */
+        public InnerHit setFetchSource(boolean fetch) {
+            sourceBuilder().fetchSource(fetch);
+            return this;
+        }
+
+        /**
+         * Indicate that _source should be returned with every hit, with an "include" and/or "exclude" set which can include simple wildcard
+         * elements.
+         *
+         * @param include An optional include (optionally wildcarded) pattern to filter the returned _source
+         * @param exclude An optional exclude (optionally wildcarded) pattern to filter the returned _source
+         */
+        public InnerHit setFetchSource(@Nullable String include, @Nullable String exclude) {
+            sourceBuilder().fetchSource(include, exclude);
+            return this;
+        }
+
+        /**
+         * Indicate that _source should be returned with every hit, with an "include" and/or "exclude" set which can include simple wildcard
+         * elements.
+         *
+         * @param includes An optional list of include (optionally wildcarded) pattern to filter the returned _source
+         * @param excludes An optional list of exclude (optionally wildcarded) pattern to filter the returned _source
+         */
+        public InnerHit setFetchSource(@Nullable String[] includes, @Nullable String[] excludes) {
+            sourceBuilder().fetchSource(includes, excludes);
+            return this;
+        }
+
+        /**
+         * Adds a field data based field to load and return. The field does not have to be stored,
+         * but its recommended to use non analyzed or numeric fields.
+         *
+         * @param name The field to get from the field data cache
+         */
+        public InnerHit addFieldDataField(String name) {
+            sourceBuilder().fieldDataField(name);
+            return this;
+        }
+
+        /**
+         * Adds a script based field to load and return. The field does not have to be stored,
+         * but its recommended to use non analyzed or numeric fields.
+         *
+         * @param name   The name that will represent this value in the return hit
+         * @param script The script to use
+         */
+        public InnerHit addScriptField(String name, String script) {
+            sourceBuilder().scriptField(name, script);
+            return this;
+        }
+
+        /**
+         * Adds a script based field to load and return. The field does not have to be stored,
+         * but its recommended to use non analyzed or numeric fields.
+         *
+         * @param name   The name that will represent this value in the return hit
+         * @param script The script to use
+         * @param params Parameters that the script can use.
+         */
+        public InnerHit addScriptField(String name, String script, Map<String, Object> params) {
+            sourceBuilder().scriptField(name, script, params);
+            return this;
+        }
+
+        /**
+         * Adds a script based field to load and return. The field does not have to be stored,
+         * but its recommended to use non analyzed or numeric fields.
+         *
+         * @param name   The name that will represent this value in the return hit
+         * @param lang   The language of the script
+         * @param script The script to use
+         * @param params Parameters that the script can use (can be <tt>null</tt>).
+         */
+        public InnerHit addScriptField(String name, String lang, String script, Map<String, Object> params) {
+            sourceBuilder().scriptField(name, lang, script, params);
+            return this;
+        }
+
+        /**
+         * Adds a sort against the given field name and the sort ordering.
+         *
+         * @param field The name of the field
+         * @param order The sort ordering
+         */
+        public InnerHit addSort(String field, SortOrder order) {
+            sourceBuilder().sort(field, order);
+            return this;
+        }
+
+        /**
+         * Adds a generic sort builder.
+         *
+         * @see org.elasticsearch.search.sort.SortBuilders
+         */
+        public InnerHit addSort(SortBuilder sort) {
+            sourceBuilder().sort(sort);
+            return this;
+        }
+
+        /**
+         * Adds a field to be highlighted with default fragment size of 100 characters, and
+         * default number of fragments of 5.
+         *
+         * @param name The field to highlight
+         */
+        public InnerHit addHighlightedField(String name) {
+            highlightBuilder().field(name);
+            return this;
+        }
+
+
+        /**
+         * Adds a field to be highlighted with a provided fragment size (in characters), and
+         * default number of fragments of 5.
+         *
+         * @param name         The field to highlight
+         * @param fragmentSize The size of a fragment in characters
+         */
+        public InnerHit addHighlightedField(String name, int fragmentSize) {
+            highlightBuilder().field(name, fragmentSize);
+            return this;
+        }
+
+        /**
+         * Adds a field to be highlighted with a provided fragment size (in characters), and
+         * a provided (maximum) number of fragments.
+         *
+         * @param name              The field to highlight
+         * @param fragmentSize      The size of a fragment in characters
+         * @param numberOfFragments The (maximum) number of fragments
+         */
+        public InnerHit addHighlightedField(String name, int fragmentSize, int numberOfFragments) {
+            highlightBuilder().field(name, fragmentSize, numberOfFragments);
+            return this;
+        }
+
+        /**
+         * Adds a field to be highlighted with a provided fragment size (in characters),
+         * a provided (maximum) number of fragments and an offset for the highlight.
+         *
+         * @param name              The field to highlight
+         * @param fragmentSize      The size of a fragment in characters
+         * @param numberOfFragments The (maximum) number of fragments
+         */
+        public InnerHit addHighlightedField(String name, int fragmentSize, int numberOfFragments,
+                                                    int fragmentOffset) {
+            highlightBuilder().field(name, fragmentSize, numberOfFragments, fragmentOffset);
+            return this;
+        }
+
+        /**
+         * Adds a highlighted field.
+         */
+        public InnerHit addHighlightedField(HighlightBuilder.Field field) {
+            highlightBuilder().field(field);
+            return this;
+        }
+
+        /**
+         * Set a tag scheme that encapsulates a built in pre and post tags. The allows schemes
+         * are <tt>styled</tt> and <tt>default</tt>.
+         *
+         * @param schemaName The tag scheme name
+         */
+        public InnerHit setHighlighterTagsSchema(String schemaName) {
+            highlightBuilder().tagsSchema(schemaName);
+            return this;
+        }
+
+        public InnerHit setHighlighterFragmentSize(Integer fragmentSize) {
+            highlightBuilder().fragmentSize(fragmentSize);
+            return this;
+        }
+
+        public InnerHit setHighlighterNumOfFragments(Integer numOfFragments) {
+            highlightBuilder().numOfFragments(numOfFragments);
+            return this;
+        }
+
+        public InnerHit setHighlighterFilter(Boolean highlightFilter) {
+            highlightBuilder().highlightFilter(highlightFilter);
+            return this;
+        }
+
+        /**
+         * The encoder to set for highlighting
+         */
+        public InnerHit setHighlighterEncoder(String encoder) {
+            highlightBuilder().encoder(encoder);
+            return this;
+        }
+
+        /**
+         * Explicitly set the pre tags that will be used for highlighting.
+         */
+        public InnerHit setHighlighterPreTags(String... preTags) {
+            highlightBuilder().preTags(preTags);
+            return this;
+        }
+
+        /**
+         * Explicitly set the post tags that will be used for highlighting.
+         */
+        public InnerHit setHighlighterPostTags(String... postTags) {
+            highlightBuilder().postTags(postTags);
+            return this;
+        }
+
+        /**
+         * The order of fragments per field. By default, ordered by the order in the
+         * highlighted text. Can be <tt>score</tt>, which then it will be ordered
+         * by score of the fragments.
+         */
+        public InnerHit setHighlighterOrder(String order) {
+            highlightBuilder().order(order);
+            return this;
+        }
+
+        public InnerHit setHighlighterRequireFieldMatch(boolean requireFieldMatch) {
+            highlightBuilder().requireFieldMatch(requireFieldMatch);
+            return this;
+        }
+
+        public InnerHit setHighlighterBoundaryMaxScan(Integer boundaryMaxScan) {
+            highlightBuilder().boundaryMaxScan(boundaryMaxScan);
+            return this;
+        }
+
+        public InnerHit setHighlighterBoundaryChars(char[] boundaryChars) {
+            highlightBuilder().boundaryChars(boundaryChars);
+            return this;
+        }
+
+        /**
+         * The highlighter type to use.
+         */
+        public InnerHit setHighlighterType(String type) {
+            highlightBuilder().highlighterType(type);
+            return this;
+        }
+
+        public InnerHit setHighlighterFragmenter(String fragmenter) {
+            highlightBuilder().fragmenter(fragmenter);
+            return this;
+        }
+
+        /**
+         * Sets a query to be used for highlighting all fields instead of the search query.
+         */
+        public InnerHit setHighlighterQuery(QueryBuilder highlightQuery) {
+            highlightBuilder().highlightQuery(highlightQuery);
+            return this;
+        }
+
+        /**
+         * Sets the size of the fragment to return from the beginning of the field if there are no matches to
+         * highlight and the field doesn't also define noMatchSize.
+         * @param noMatchSize integer to set or null to leave out of request.  default is null.
+         * @return this builder for chaining
+         */
+        public InnerHit setHighlighterNoMatchSize(Integer noMatchSize) {
+            highlightBuilder().noMatchSize(noMatchSize);
+            return this;
+        }
+
+        /**
+         * Sets the maximum number of phrases the fvh will consider if the field doesn't also define phraseLimit.
+         */
+        public InnerHit setHighlighterPhraseLimit(Integer phraseLimit) {
+            highlightBuilder().phraseLimit(phraseLimit);
+            return this;
+        }
+
+        public InnerHit setHighlighterOptions(Map<String, Object> options) {
+            highlightBuilder().options(options);
+            return this;
+        }
+
+        public InnerHit addInnerHit(String name, InnerHit innerHit) {
+            sourceBuilder().innerHitsBuilder().addInnerHit(name, innerHit);
+            return this;
+        }
+
+        private SearchSourceBuilder sourceBuilder() {
+            if (sourceBuilder == null) {
+                sourceBuilder = new SearchSourceBuilder();
+            }
+            return sourceBuilder;
+        }
+
+        public HighlightBuilder highlightBuilder() {
+            return sourceBuilder().highlighter();
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            if (path != null) {
+                builder.startObject("path").startObject(path);
+            } else {
+                builder.startObject("type").startObject(type);
+            }
+            if (sourceBuilder != null) {
+                sourceBuilder.innerToXContent(builder, params);
+            }
+            return builder.endObject().endObject();
+        }
+    }
+
+}

--- a/src/main/java/org/elasticsearch/search/fetch/innerhits/InnerHitsContext.java
+++ b/src/main/java/org/elasticsearch/search/fetch/innerhits/InnerHitsContext.java
@@ -1,0 +1,279 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.fetch.innerhits;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.queries.TermFilter;
+import org.apache.lucene.search.*;
+import org.apache.lucene.search.join.BitDocIdSetFilter;
+import org.apache.lucene.util.BitSet;
+import org.apache.lucene.util.Bits;
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.common.lucene.search.AndFilter;
+import org.elasticsearch.index.mapper.DocumentMapper;
+import org.elasticsearch.index.mapper.Uid;
+import org.elasticsearch.index.mapper.internal.ParentFieldMapper;
+import org.elasticsearch.index.mapper.internal.UidFieldMapper;
+import org.elasticsearch.index.mapper.object.ObjectMapper;
+import org.elasticsearch.index.query.ParsedQuery;
+import org.elasticsearch.index.search.nested.NonNestedDocsFilter;
+import org.elasticsearch.search.fetch.FetchSubPhase;
+import org.elasticsearch.search.internal.FilteredSearchContext;
+import org.elasticsearch.search.internal.SearchContext;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Map;
+
+/**
+ */
+public final class InnerHitsContext {
+
+    private Map<String, BaseInnerHits> innerHits;
+
+    public InnerHitsContext(Map<String, BaseInnerHits> innerHits) {
+        this.innerHits = innerHits;
+    }
+
+    public Map<String, BaseInnerHits> getInnerHits() {
+        return innerHits;
+    }
+
+    public static abstract class BaseInnerHits extends FilteredSearchContext {
+
+        protected final Query query;
+        private final InnerHitsContext childInnerHits;
+
+        protected BaseInnerHits(SearchContext context, Query query, Map<String, BaseInnerHits> childInnerHits) {
+            super(context);
+            this.query = query;
+            if (childInnerHits != null && !childInnerHits.isEmpty()) {
+                this.childInnerHits = new InnerHitsContext(childInnerHits);
+            } else {
+                this.childInnerHits = null;
+            }
+        }
+
+        @Override
+        public Query query() {
+            return query;
+        }
+
+        @Override
+        public ParsedQuery parsedQuery() {
+            return new ParsedQuery(query, ImmutableMap.<String, Filter>of());
+        }
+
+        public abstract TopDocs topDocs(SearchContext context, FetchSubPhase.HitContext hitContext);
+
+        @Override
+        public InnerHitsContext innerHits() {
+            return childInnerHits;
+        }
+
+    }
+
+    public static final class NestedInnerHits extends BaseInnerHits {
+
+        private final ObjectMapper parentObjectMapper;
+        private final ObjectMapper childObjectMapper;
+
+        public NestedInnerHits(SearchContext context, Query query, Map<String, BaseInnerHits> childInnerHits, ObjectMapper parentObjectMapper, ObjectMapper childObjectMapper) {
+            super(context, query, childInnerHits);
+            this.parentObjectMapper = parentObjectMapper;
+            this.childObjectMapper = childObjectMapper;
+        }
+
+        @Override
+        public TopDocs topDocs(SearchContext context, FetchSubPhase.HitContext hitContext) {
+            TopDocsCollector topDocsCollector;
+            int topN = from() + size();
+            if (sort() != null) {
+                try {
+                    topDocsCollector = TopFieldCollector.create(sort(), topN, true, trackScores(), trackScores(), true);
+                } catch (IOException e) {
+                    throw ExceptionsHelper.convertToElastic(e);
+                }
+            } else {
+                topDocsCollector = TopScoreDocCollector.create(topN, true);
+            }
+
+            Filter rawParentFilter;
+            if (parentObjectMapper == null) {
+                rawParentFilter = NonNestedDocsFilter.INSTANCE;
+            } else {
+                rawParentFilter = parentObjectMapper.nestedTypeFilter();
+            }
+            BitDocIdSetFilter parentFilter = context.bitsetFilterCache().getBitDocIdSetFilter(rawParentFilter);
+            Filter childFilter = context.filterCache().cache(childObjectMapper.nestedTypeFilter());
+            try {
+                Query q = new FilteredQuery(query, new NestedChildrenFilter(parentFilter, childFilter, hitContext));
+                context.searcher().search(q, topDocsCollector);
+            } catch (IOException e) {
+                throw ExceptionsHelper.convertToElastic(e);
+            }
+            return topDocsCollector.topDocs(from(), size());
+        }
+
+        // A filter that only emits the nested children docs of a specific nested parent doc
+        static class NestedChildrenFilter extends Filter {
+
+            private final BitDocIdSetFilter parentFilter;
+            private final Filter childFilter;
+            private final int docId;
+            private final LeafReader atomicReader;
+
+            NestedChildrenFilter(BitDocIdSetFilter parentFilter, Filter childFilter, FetchSubPhase.HitContext hitContext) {
+                this.parentFilter = parentFilter;
+                this.childFilter = childFilter;
+                this.docId = hitContext.docId();
+                this.atomicReader = hitContext.readerContext().reader();
+            }
+
+            @Override
+            public DocIdSet getDocIdSet(LeafReaderContext context, final Bits acceptDocs) throws IOException {
+                // Nested docs only reside in a single segment, so no need to evaluate all segments
+                if (!context.reader().getCoreCacheKey().equals(this.atomicReader.getCoreCacheKey())) {
+                    return null;
+                }
+
+                // If docId == 0 then we a parent doc doesn't have child docs, because child docs are stored
+                // before the parent doc and because parent doc is 0 we can safely assume that there are no child docs.
+                if (docId == 0) {
+                    return null;
+                }
+
+                final BitSet parents = parentFilter.getDocIdSet(context).bits();
+                final int firstChildDocId = parents.prevSetBit(docId - 1) + 1;
+                // A parent doc doesn't have child docs, so we can early exit here:
+                if (firstChildDocId == docId) {
+                    return null;
+                }
+
+                final DocIdSet children = childFilter.getDocIdSet(context, acceptDocs);
+                if (children == null) {
+                    return null;
+                }
+                final DocIdSetIterator childrenIterator = children.iterator();
+                if (childrenIterator == null) {
+                    return null;
+                }
+                return new DocIdSet() {
+
+                    @Override
+                    public long ramBytesUsed() {
+                        return parents.ramBytesUsed() + children.ramBytesUsed();
+                    }
+
+                    @Override
+                    public DocIdSetIterator iterator() throws IOException {
+                        return new DocIdSetIterator() {
+
+                            int currentDocId = -1;
+
+                            @Override
+                            public int docID() {
+                                return currentDocId;
+                            }
+
+                            @Override
+                            public int nextDoc() throws IOException {
+                                return advance(currentDocId + 1);
+                            }
+
+                            @Override
+                            public int advance(int target) throws IOException {
+                                target = Math.max(firstChildDocId, target);
+                                if (target >= docId) {
+                                    // We're outside the child nested scope, so it is done
+                                    return currentDocId = NO_MORE_DOCS;
+                                } else {
+                                    int advanced = childrenIterator.advance(target);
+                                    if (advanced >= docId) {
+                                        // We're outside the child nested scope, so it is done
+                                        return currentDocId = NO_MORE_DOCS;
+                                    } else {
+                                        return currentDocId = advanced;
+                                    }
+                                }
+                            }
+
+                            @Override
+                            public long cost() {
+                                return childrenIterator.cost();
+                            }
+                        };
+                    }
+                };
+            }
+        }
+
+    }
+
+    public static final class ParentChildInnerHits extends BaseInnerHits {
+
+        private final DocumentMapper documentMapper;
+
+        public ParentChildInnerHits(SearchContext context, Query query, Map<String, BaseInnerHits> childInnerHits, DocumentMapper documentMapper) {
+            super(context, query, childInnerHits);
+            this.documentMapper = documentMapper;
+        }
+
+        @Override
+        public TopDocs topDocs(SearchContext context, FetchSubPhase.HitContext hitContext) {
+            TopDocsCollector topDocsCollector;
+            int topN = from() + size();
+            if (sort() != null) {
+                try {
+                    topDocsCollector = TopFieldCollector.create(sort(), topN, true, trackScores(), trackScores(), false);
+                } catch (IOException e) {
+                    throw ExceptionsHelper.convertToElastic(e);
+                }
+            } else {
+                topDocsCollector = TopScoreDocCollector.create(topN, false);
+            }
+
+            String field;
+            ParentFieldMapper hitParentFieldMapper = documentMapper.parentFieldMapper();
+            if (hitParentFieldMapper.active()) {
+                // Hit has a active _parent field and it is a child doc, so we want a parent doc as inner hits.
+                field = ParentFieldMapper.NAME;
+            } else {
+                // Hit has no active _parent field and it is a parent doc, so we want children docs as inner hits.
+                field = UidFieldMapper.NAME;
+            }
+            String term = Uid.createUid(hitContext.hit().type(), hitContext.hit().id());
+            Filter filter = new TermFilter(new Term(field, term)); // Only include docs that have the current hit as parent
+            Filter typeFilter = documentMapper.typeFilter(); // Only include docs that have this inner hits type.
+            try {
+                context.searcher().search(
+                        new FilteredQuery(query, new AndFilter(Arrays.asList(filter, typeFilter))),
+                        topDocsCollector
+                );
+            } catch (IOException e) {
+                throw ExceptionsHelper.convertToElastic(e);
+            }
+            return topDocsCollector.topDocs(from(), size());
+        }
+    }
+}

--- a/src/main/java/org/elasticsearch/search/fetch/innerhits/InnerHitsFetchSubPhase.java
+++ b/src/main/java/org/elasticsearch/search/fetch/innerhits/InnerHitsFetchSubPhase.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.fetch.innerhits;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.lucene.search.FieldDoc;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.search.SearchParseElement;
+import org.elasticsearch.search.fetch.FetchPhase;
+import org.elasticsearch.search.fetch.FetchSearchResult;
+import org.elasticsearch.search.fetch.FetchSubPhase;
+import org.elasticsearch.search.fetch.fielddata.FieldDataFieldsParseElement;
+import org.elasticsearch.search.fetch.script.ScriptFieldsParseElement;
+import org.elasticsearch.search.fetch.source.FetchSourceParseElement;
+import org.elasticsearch.search.highlight.HighlighterParseElement;
+import org.elasticsearch.search.internal.InternalSearchHit;
+import org.elasticsearch.search.internal.InternalSearchHits;
+import org.elasticsearch.search.internal.SearchContext;
+import org.elasticsearch.search.sort.SortParseElement;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ */
+public class InnerHitsFetchSubPhase implements FetchSubPhase {
+
+    private final SortParseElement sortParseElement;
+    private final FetchSourceParseElement sourceParseElement;
+    private final HighlighterParseElement highlighterParseElement;
+    private final FieldDataFieldsParseElement fieldDataFieldsParseElement;
+    private final ScriptFieldsParseElement scriptFieldsParseElement;
+
+    private FetchPhase fetchPhase;
+
+    @Inject
+    public InnerHitsFetchSubPhase(SortParseElement sortParseElement, FetchSourceParseElement sourceParseElement, HighlighterParseElement highlighterParseElement, FieldDataFieldsParseElement fieldDataFieldsParseElement, ScriptFieldsParseElement scriptFieldsParseElement) {
+        this.sortParseElement = sortParseElement;
+        this.sourceParseElement = sourceParseElement;
+        this.highlighterParseElement = highlighterParseElement;
+        this.fieldDataFieldsParseElement = fieldDataFieldsParseElement;
+        this.scriptFieldsParseElement = scriptFieldsParseElement;
+    }
+
+    @Override
+    public Map<String, ? extends SearchParseElement> parseElements() {
+        return ImmutableMap.of("inner_hits", new InnerHitsParseElement(
+                sortParseElement, sourceParseElement, highlighterParseElement, fieldDataFieldsParseElement, scriptFieldsParseElement
+        ));
+    }
+
+    @Override
+    public boolean hitExecutionNeeded(SearchContext context) {
+        return context.innerHits() != null;
+    }
+
+    @Override
+    public void hitExecute(SearchContext context, HitContext hitContext) throws ElasticsearchException {
+        InnerHitsContext innerHitsContext = context.innerHits();
+        Map<String, InternalSearchHits> results = new HashMap<>();
+        Map<String, InnerHitsContext.BaseInnerHits> innerHitsByKey = innerHitsContext.getInnerHits();
+        for (Map.Entry<String, InnerHitsContext.BaseInnerHits> entry : innerHitsByKey.entrySet()) {
+            InnerHitsContext.BaseInnerHits innerHits = entry.getValue();
+            TopDocs topDocs = innerHits.topDocs(context, hitContext);
+            innerHits.queryResult().topDocs(topDocs);
+            int[] docIdsToLoad = new int[topDocs.scoreDocs.length];
+            for (int i = 0; i < topDocs.scoreDocs.length; i++) {
+                docIdsToLoad[i] = topDocs.scoreDocs[i].doc;
+            }
+            innerHits.docIdsToLoad(docIdsToLoad, 0, docIdsToLoad.length);
+            fetchPhase.execute(innerHits);
+            FetchSearchResult fetchResult = innerHits.fetchResult();
+            InternalSearchHit[] internalHits = fetchResult.fetchResult().hits().internalHits();
+            for (int i = 0; i < internalHits.length; i++) {
+                ScoreDoc scoreDoc = topDocs.scoreDocs[i];
+                InternalSearchHit searchHitFields = internalHits[i];
+                searchHitFields.shard(innerHits.shardTarget());
+                searchHitFields.score(scoreDoc.score);
+                if (scoreDoc instanceof FieldDoc) {
+                    FieldDoc fieldDoc = (FieldDoc) scoreDoc;
+                    searchHitFields.sortValues(fieldDoc.fields);
+                }
+            }
+            results.put(entry.getKey(), fetchResult.hits());
+        }
+        hitContext.hit().setInnerHits(results);
+    }
+
+    @Override
+    public boolean hitsExecutionNeeded(SearchContext context) {
+        return false;
+    }
+
+    @Override
+    public void hitsExecute(SearchContext context, InternalSearchHit[] hits) throws ElasticsearchException {
+    }
+
+    // To get around cyclic dependency issue
+    public void setFetchPhase(FetchPhase fetchPhase) {
+        this.fetchPhase = fetchPhase;
+    }
+}

--- a/src/main/java/org/elasticsearch/search/fetch/innerhits/InnerHitsParseElement.java
+++ b/src/main/java/org/elasticsearch/search/fetch/innerhits/InnerHitsParseElement.java
@@ -1,0 +1,252 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.fetch.innerhits;
+
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.Query;
+import org.elasticsearch.ElasticsearchIllegalArgumentException;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.mapper.DocumentMapper;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.object.ObjectMapper;
+import org.elasticsearch.index.query.NestedQueryParser;
+import org.elasticsearch.search.SearchParseElement;
+import org.elasticsearch.search.fetch.fielddata.FieldDataFieldsParseElement;
+import org.elasticsearch.search.fetch.script.ScriptFieldsParseElement;
+import org.elasticsearch.search.fetch.source.FetchSourceParseElement;
+import org.elasticsearch.search.highlight.HighlighterParseElement;
+import org.elasticsearch.search.internal.SearchContext;
+import org.elasticsearch.search.internal.SubSearchContext;
+import org.elasticsearch.search.sort.SortParseElement;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ */
+public class InnerHitsParseElement implements SearchParseElement {
+
+    private final SortParseElement sortParseElement;
+    private final FetchSourceParseElement sourceParseElement;
+    private final HighlighterParseElement highlighterParseElement;
+    private final FieldDataFieldsParseElement fieldDataFieldsParseElement;
+    private final ScriptFieldsParseElement scriptFieldsParseElement;
+
+    public InnerHitsParseElement(SortParseElement sortParseElement, FetchSourceParseElement sourceParseElement, HighlighterParseElement highlighterParseElement, FieldDataFieldsParseElement fieldDataFieldsParseElement, ScriptFieldsParseElement scriptFieldsParseElement) {
+        this.sortParseElement = sortParseElement;
+        this.sourceParseElement = sourceParseElement;
+        this.highlighterParseElement = highlighterParseElement;
+        this.fieldDataFieldsParseElement = fieldDataFieldsParseElement;
+        this.scriptFieldsParseElement = scriptFieldsParseElement;
+    }
+
+    @Override
+    public void parse(XContentParser parser, SearchContext context) throws Exception {
+        Map<String, InnerHitsContext.BaseInnerHits> innerHitsMap = parseInnerHits(parser, context);
+        if (innerHitsMap != null) {
+            context.innerHits(new InnerHitsContext(innerHitsMap));
+        }
+    }
+
+    private Map<String, InnerHitsContext.BaseInnerHits> parseInnerHits(XContentParser parser, SearchContext context) throws Exception {
+        XContentParser.Token token;
+        Map<String, InnerHitsContext.BaseInnerHits> innerHitsMap = null;
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token != XContentParser.Token.FIELD_NAME) {
+                throw new ElasticsearchIllegalArgumentException("Unexpected token " + token + " in [inner_hits]: aggregations definitions must start with the name of the aggregation.");
+            }
+            final String innerHitName = parser.currentName();
+            token = parser.nextToken();
+            if (token != XContentParser.Token.START_OBJECT) {
+                throw new ElasticsearchIllegalArgumentException("Inner hit definition for [" + innerHitName + " starts with a [" + token + "], expected a [" + XContentParser.Token.START_OBJECT + "].");
+            }
+            InnerHitsContext.BaseInnerHits innerHits = parseInnerHit(parser, context, innerHitName);
+            if (innerHitsMap == null) {
+                innerHitsMap = new HashMap<>();
+            }
+            innerHitsMap.put(innerHitName, innerHits);
+        }
+        return innerHitsMap;
+    }
+
+    private InnerHitsContext.BaseInnerHits parseInnerHit(XContentParser parser, SearchContext context, String innerHitName) throws Exception {
+        XContentParser.Token token = parser.nextToken();
+        if (token != XContentParser.Token.FIELD_NAME) {
+            throw new ElasticsearchIllegalArgumentException("Unexpected token " + token + " inside inner hit definition. Either specify [path] or [type] object");
+        }
+        String fieldName = parser.currentName();
+        token = parser.nextToken();
+        if (token != XContentParser.Token.START_OBJECT) {
+            throw new ElasticsearchIllegalArgumentException("Inner hit definition for [" + innerHitName + " starts with a [" + token + "], expected a [" + XContentParser.Token.START_OBJECT + "].");
+        }
+        final boolean nested;
+        switch (fieldName) {
+            case "path":
+                nested = true;
+                break;
+            case "type":
+                nested = false;
+                break;
+            default:
+                throw new ElasticsearchIllegalArgumentException("Either path or type object must be defined");
+        }
+        token = parser.nextToken();
+        if (token != XContentParser.Token.FIELD_NAME) {
+            throw new ElasticsearchIllegalArgumentException("Unexpected token " + token + " inside inner hit definition. Either specify [path] or [type] object");
+        }
+        fieldName = parser.currentName();
+        token = parser.nextToken();
+        if (token != XContentParser.Token.START_OBJECT) {
+            throw new ElasticsearchIllegalArgumentException("Inner hit definition for [" + innerHitName + " starts with a [" + token + "], expected a [" + XContentParser.Token.START_OBJECT + "].");
+        }
+
+        NestedQueryParser.LateBindingParentFilter parentFilter = null;
+        NestedQueryParser.LateBindingParentFilter currentFilter = null;
+
+
+        String nestedPath = null;
+        String type = null;
+        if (nested) {
+            nestedPath = fieldName;
+            currentFilter = new NestedQueryParser.LateBindingParentFilter();
+            parentFilter = NestedQueryParser.parentFilterContext.get();
+            NestedQueryParser.parentFilterContext.set(currentFilter);
+        } else {
+            type = fieldName;
+        }
+
+        Query query = null;
+        Map<String, InnerHitsContext.BaseInnerHits> childInnerHits = null;
+        SubSearchContext subSearchContext = new SubSearchContext(context);
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                fieldName = parser.currentName();
+            } else if ("sort".equals(fieldName)) {
+                sortParseElement.parse(parser, subSearchContext);
+            } else if ("_source".equals(fieldName)) {
+                sourceParseElement.parse(parser, subSearchContext);
+            } else if (token == XContentParser.Token.START_OBJECT) {
+                switch (fieldName) {
+                    case "highlight":
+                        highlighterParseElement.parse(parser, subSearchContext);
+                        break;
+                    case "scriptFields":
+                    case "script_fields":
+                        scriptFieldsParseElement.parse(parser, subSearchContext);
+                        break;
+                    case "inner_hits":
+                        childInnerHits = parseInnerHits(parser, subSearchContext);
+                        break;
+                    case "query":
+                        query = context.queryParserService().parse(parser).query();
+                        break;
+                    default:
+                        throw new ElasticsearchIllegalArgumentException("Unknown key for a " + token + " in [" + innerHitName + "]: [" + fieldName + "].");
+                }
+            } else if (token == XContentParser.Token.START_ARRAY) {
+                switch (fieldName) {
+                    case "fielddataFields":
+                    case "fielddata_fields":
+                        fieldDataFieldsParseElement.parse(parser, subSearchContext);
+                        break;
+                    default:
+                        throw new ElasticsearchIllegalArgumentException("Unknown key for a " + token + " in [" + innerHitName + "]: [" + fieldName + "].");
+                }
+            } else if (token.isValue()) {
+                switch (fieldName) {
+                    case "query" :
+                        query = context.queryParserService().parse(parser).query();
+                        break;
+                    case "from":
+                        subSearchContext.from(parser.intValue());
+                        break;
+                    case "size":
+                        subSearchContext.size(parser.intValue());
+                        break;
+                    case "track_scores":
+                    case "trackScores":
+                        subSearchContext.trackScores(parser.booleanValue());
+                        break;
+                    case "version":
+                        subSearchContext.version(parser.booleanValue());
+                        break;
+                    case "explain":
+                        subSearchContext.explain(parser.booleanValue());
+                        break;
+                    default:
+                        throw new ElasticsearchIllegalArgumentException("Unknown key for a " + token + " in [" + innerHitName + "]: [" + fieldName + "].");
+                }
+            } else {
+                throw new ElasticsearchIllegalArgumentException("Unexpected token " + token + " in [" + innerHitName + "].");
+            }
+        }
+
+        // Completely consume all json objects:
+        token = parser.nextToken();
+        if (token != XContentParser.Token.END_OBJECT) {
+            throw new ElasticsearchIllegalArgumentException("Expected [" + XContentParser.Token.END_OBJECT + "] token, but got a [" + token + "] token.");
+        }
+        token = parser.nextToken();
+        if (token != XContentParser.Token.END_OBJECT) {
+            throw new ElasticsearchIllegalArgumentException("Expected [" + XContentParser.Token.END_OBJECT + "] token, but got a [" + token + "] token.");
+        }
+
+        if (query == null) {
+            query = new MatchAllDocsQuery();
+        }
+
+        if (nestedPath != null && type != null) {
+            throw new ElasticsearchIllegalArgumentException("Either [path] or [type] can be defined not both");
+        } else if (nestedPath != null) {
+            MapperService.SmartNameObjectMapper smartNameObjectMapper = context.smartNameObjectMapper(nestedPath);
+            if (smartNameObjectMapper == null || !smartNameObjectMapper.hasMapper()) {
+                throw new ElasticsearchIllegalArgumentException("path [" + nestedPath +"] doesn't exist");
+            }
+            ObjectMapper childObjectMapper = smartNameObjectMapper.mapper();
+            if (!childObjectMapper.nested().isNested()) {
+                throw new ElasticsearchIllegalArgumentException("path [" + nestedPath +"] isn't nested");
+            }
+            DocumentMapper childDocumentMapper = smartNameObjectMapper.docMapper();
+            if (childDocumentMapper == null) {
+                for (DocumentMapper documentMapper : context.mapperService().docMappers(false)) {
+                    if (documentMapper.objectMappers().containsKey(nestedPath)) {
+                        childDocumentMapper = documentMapper;
+                        break;
+                    }
+                }
+            }
+            if (currentFilter != null && childDocumentMapper != null) {
+                currentFilter.filter = context.bitsetFilterCache().getBitDocIdSetFilter(childObjectMapper.nestedTypeFilter());
+                NestedQueryParser.parentFilterContext.set(parentFilter);
+            }
+
+            ObjectMapper parentObjectMapper = childDocumentMapper.findParentObjectMapper(childObjectMapper);
+            return new InnerHitsContext.NestedInnerHits(subSearchContext, query, childInnerHits, parentObjectMapper, childObjectMapper);
+        } else if (type != null) {
+            DocumentMapper documentMapper = context.mapperService().documentMapper(type);
+            if (documentMapper == null) {
+                throw new ElasticsearchIllegalArgumentException("type [" + type + "] doesn't exist");
+            }
+            return new InnerHitsContext.ParentChildInnerHits(subSearchContext, query, childInnerHits, documentMapper);
+        } else {
+            throw new ElasticsearchIllegalArgumentException("Either [path] or [type] must be defined");
+        }
+    }
+}

--- a/src/main/java/org/elasticsearch/search/internal/DefaultSearchContext.java
+++ b/src/main/java/org/elasticsearch/search/internal/DefaultSearchContext.java
@@ -59,6 +59,7 @@ import org.elasticsearch.search.aggregations.SearchContextAggregations;
 import org.elasticsearch.search.dfs.DfsSearchResult;
 import org.elasticsearch.search.fetch.FetchSearchResult;
 import org.elasticsearch.search.fetch.fielddata.FieldDataFieldsContext;
+import org.elasticsearch.search.fetch.innerhits.InnerHitsContext;
 import org.elasticsearch.search.fetch.script.ScriptFieldsContext;
 import org.elasticsearch.search.fetch.source.FetchSourceContext;
 import org.elasticsearch.search.highlight.SearchContextHighlight;
@@ -175,6 +176,8 @@ public class DefaultSearchContext extends SearchContext {
     private volatile long lastAccessTime = -1;
 
     private volatile boolean useSlowScroll;
+
+    private InnerHitsContext innerHitsContext;
 
     public DefaultSearchContext(long id, ShardSearchRequest request, SearchShardTarget shardTarget,
                          Engine.Searcher engineSearcher, IndexService indexService, IndexShard indexShard,
@@ -699,5 +702,15 @@ public class DefaultSearchContext extends SearchContext {
     @Override
     public Counter timeEstimateCounter() {
         return timeEstimateCounter;
+    }
+
+    @Override
+    public void innerHits(InnerHitsContext innerHitsContext) {
+        this.innerHitsContext = innerHitsContext;
+    }
+
+    @Override
+    public InnerHitsContext innerHits() {
+        return innerHitsContext;
     }
 }

--- a/src/main/java/org/elasticsearch/search/internal/FilteredSearchContext.java
+++ b/src/main/java/org/elasticsearch/search/internal/FilteredSearchContext.java
@@ -16,14 +16,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.elasticsearch.test;
+
+package org.elasticsearch.search.internal;
 
 import org.apache.lucene.search.Filter;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.util.Counter;
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.cache.recycler.PageCacheRecycler;
 import org.elasticsearch.common.util.BigArrays;
@@ -37,7 +37,6 @@ import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.IndexQueryParserService;
 import org.elasticsearch.index.query.ParsedFilter;
 import org.elasticsearch.index.query.ParsedQuery;
-import org.elasticsearch.index.service.IndexService;
 import org.elasticsearch.index.shard.service.IndexShard;
 import org.elasticsearch.index.similarity.SimilarityService;
 import org.elasticsearch.script.ScriptService;
@@ -51,556 +50,521 @@ import org.elasticsearch.search.fetch.innerhits.InnerHitsContext;
 import org.elasticsearch.search.fetch.script.ScriptFieldsContext;
 import org.elasticsearch.search.fetch.source.FetchSourceContext;
 import org.elasticsearch.search.highlight.SearchContextHighlight;
-import org.elasticsearch.search.internal.ContextIndexSearcher;
-import org.elasticsearch.search.internal.SearchContext;
-import org.elasticsearch.search.internal.ShardSearchRequest;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.search.query.QuerySearchResult;
 import org.elasticsearch.search.rescore.RescoreSearchContext;
 import org.elasticsearch.search.scan.ScanContext;
 import org.elasticsearch.search.suggest.SuggestionSearchContext;
-import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.List;
 
-public class TestSearchContext extends SearchContext {
+/**
+ */
+public abstract class FilteredSearchContext extends SearchContext {
 
-    final PageCacheRecycler pageCacheRecycler;
-    final BigArrays bigArrays;
-    final IndexService indexService;
-    final FilterCache filterCache;
-    final IndexFieldDataService indexFieldDataService;
-    final BitsetFilterCache fixedBitSetFilterCache;
-    final ThreadPool threadPool;
+    private final SearchContext in;
 
-    ContextIndexSearcher searcher;
-    int size;
-    private int terminateAfter = DEFAULT_TERMINATE_AFTER;
-    private String[] types;
-
-    public TestSearchContext(ThreadPool threadPool,PageCacheRecycler pageCacheRecycler, BigArrays bigArrays, IndexService indexService, FilterCache filterCache, IndexFieldDataService indexFieldDataService) {
-        this.pageCacheRecycler = pageCacheRecycler;
-        this.bigArrays = bigArrays.withCircuitBreaking();
-        this.indexService = indexService;
-        this.filterCache = indexService.cache().filter();
-        this.indexFieldDataService = indexService.fieldData();
-        this.fixedBitSetFilterCache = indexService.bitsetFilterCache();
-        this.threadPool = threadPool;
+    public FilteredSearchContext(SearchContext in) {
+        this.in = in;
     }
 
-    public TestSearchContext() {
-        this.pageCacheRecycler = null;
-        this.bigArrays = null;
-        this.indexService = null;
-        this.filterCache = null;
-        this.indexFieldDataService = null;
-        this.threadPool = null;
-        this.fixedBitSetFilterCache = null;
-    }
-
-    public void setTypes(String... types) {
-        this.types = types;
+    @Override
+    protected void doClose() {
+        in.doClose();
     }
 
     @Override
     public void preProcess() {
+        in.preProcess();
     }
 
     @Override
     public Filter searchFilter(String[] types) {
-        return null;
+        return in.searchFilter(types);
     }
 
     @Override
     public long id() {
-        return 0;
+        return in.id();
     }
 
     @Override
     public String source() {
-        return null;
+        return in.source();
     }
 
     @Override
     public ShardSearchRequest request() {
-        return null;
+        return in.request();
     }
 
     @Override
     public SearchType searchType() {
-        return null;
+        return in.searchType();
     }
 
     @Override
     public SearchContext searchType(SearchType searchType) {
-        return null;
+        return in.searchType(searchType);
     }
 
     @Override
     public SearchShardTarget shardTarget() {
-        return null;
+        return in.shardTarget();
     }
 
     @Override
     public int numberOfShards() {
-        return 0;
+        return in.numberOfShards();
     }
 
     @Override
     public boolean hasTypes() {
-        return false;
+        return in.hasTypes();
     }
 
     @Override
     public String[] types() {
-        return new String[0];
+        return in.types();
     }
 
     @Override
     public float queryBoost() {
-        return 0;
+        return in.queryBoost();
     }
 
     @Override
     public SearchContext queryBoost(float queryBoost) {
-        return null;
+        return in.queryBoost(queryBoost);
     }
 
     @Override
     protected long nowInMillisImpl() {
-        return 0;
+        return in.nowInMillisImpl();
     }
 
     @Override
     public Scroll scroll() {
-        return null;
+        return in.scroll();
     }
 
     @Override
     public SearchContext scroll(Scroll scroll) {
-        return null;
+        return in.scroll(scroll);
     }
 
     @Override
     public SearchContextAggregations aggregations() {
-        return null;
+        return in.aggregations();
     }
 
     @Override
     public SearchContext aggregations(SearchContextAggregations aggregations) {
-        return null;
+        return in.aggregations(aggregations);
     }
 
     @Override
     public SearchContextHighlight highlight() {
-        return null;
+        return in.highlight();
     }
 
     @Override
     public void highlight(SearchContextHighlight highlight) {
-    }
-
-    @Override
-    public SuggestionSearchContext suggest() {
-        return null;
-    }
-
-    @Override
-    public void suggest(SuggestionSearchContext suggest) {
-    }
-
-    @Override
-    public List<RescoreSearchContext> rescore() {
-        return null;
-    }
-
-    @Override
-    public void addRescore(RescoreSearchContext rescore) {
-    }
-
-    @Override
-    public boolean hasFieldDataFields() {
-        return false;
-    }
-
-    @Override
-    public FieldDataFieldsContext fieldDataFields() {
-        return null;
-    }
-
-    @Override
-    public boolean hasScriptFields() {
-        return false;
-    }
-
-    @Override
-    public ScriptFieldsContext scriptFields() {
-        return null;
-    }
-
-    @Override
-    public boolean sourceRequested() {
-        return false;
-    }
-
-    @Override
-    public boolean hasFetchSourceContext() {
-        return false;
-    }
-
-    @Override
-    public FetchSourceContext fetchSourceContext() {
-        return null;
-    }
-
-    @Override
-    public SearchContext fetchSourceContext(FetchSourceContext fetchSourceContext) {
-        return null;
-    }
-
-    @Override
-    public ContextIndexSearcher searcher() {
-        return searcher;
-    }
-
-    public void setSearcher(ContextIndexSearcher searcher) {
-        this.searcher = searcher;
-    }
-
-    @Override
-    public IndexShard indexShard() {
-        return null;
-    }
-
-    @Override
-    public MapperService mapperService() {
-        if (indexService != null) {
-            return indexService.mapperService();
-        }
-        return null;
-    }
-
-    @Override
-    public AnalysisService analysisService() {
-        return indexService.analysisService();
-    }
-
-    @Override
-    public IndexQueryParserService queryParserService() {
-        return indexService.queryParserService();
-    }
-
-    @Override
-    public SimilarityService similarityService() {
-        return null;
-    }
-
-    @Override
-    public ScriptService scriptService() {
-        return null;
-    }
-
-    @Override
-    public PageCacheRecycler pageCacheRecycler() {
-        return pageCacheRecycler;
-    }
-
-    @Override
-    public BigArrays bigArrays() {
-        return bigArrays;
-    }
-
-    @Override
-    public FilterCache filterCache() {
-        return filterCache;
-    }
-
-    @Override
-    public BitsetFilterCache bitsetFilterCache() {
-        return fixedBitSetFilterCache;
-    }
-
-    @Override
-    public IndexFieldDataService fieldData() {
-        return indexFieldDataService;
-    }
-
-    @Override
-    public long timeoutInMillis() {
-        return 0;
-    }
-
-    @Override
-    public void timeoutInMillis(long timeoutInMillis) {
-    }
-
-    @Override
-    public int terminateAfter() {
-        return terminateAfter;
-    }
-
-    @Override
-    public void terminateAfter(int terminateAfter) {
-        this.terminateAfter = terminateAfter;
-    }
-
-    @Override
-    public SearchContext minimumScore(float minimumScore) {
-        return null;
-    }
-
-    @Override
-    public Float minimumScore() {
-        return null;
-    }
-
-    @Override
-    public SearchContext sort(Sort sort) {
-        return null;
-    }
-
-    @Override
-    public Sort sort() {
-        return null;
-    }
-
-    @Override
-    public SearchContext trackScores(boolean trackScores) {
-        return null;
-    }
-
-    @Override
-    public boolean trackScores() {
-        return false;
-    }
-
-    @Override
-    public SearchContext parsedPostFilter(ParsedFilter postFilter) {
-        return null;
-    }
-
-    @Override
-    public ParsedFilter parsedPostFilter() {
-        return null;
-    }
-
-    @Override
-    public Filter aliasFilter() {
-        return null;
-    }
-
-    @Override
-    public SearchContext parsedQuery(ParsedQuery query) {
-        return null;
-    }
-
-    @Override
-    public ParsedQuery parsedQuery() {
-        return null;
-    }
-
-    @Override
-    public Query query() {
-        return null;
-    }
-
-    @Override
-    public boolean queryRewritten() {
-        return false;
-    }
-
-    @Override
-    public SearchContext updateRewriteQuery(Query rewriteQuery) {
-        return null;
-    }
-
-    @Override
-    public int from() {
-        return 0;
-    }
-
-    @Override
-    public SearchContext from(int from) {
-        return null;
-    }
-
-    @Override
-    public int size() {
-        return size;
-    }
-
-    public void setSize(int size) {
-        this.size = size;
-    }
-
-
-    @Override
-    public SearchContext size(int size) {
-        return null;
-    }
-
-    @Override
-    public boolean hasFieldNames() {
-        return false;
-    }
-
-    @Override
-    public List<String> fieldNames() {
-        return null;
-    }
-
-    @Override
-    public void emptyFieldNames() {
-    }
-
-    @Override
-    public boolean explain() {
-        return false;
-    }
-
-    @Override
-    public void explain(boolean explain) {
-    }
-
-    @Override
-    public List<String> groupStats() {
-        return null;
-    }
-
-    @Override
-    public void groupStats(List<String> groupStats) {
-    }
-
-    @Override
-    public boolean version() {
-        return false;
-    }
-
-    @Override
-    public void version(boolean version) {
-    }
-
-    @Override
-    public int[] docIdsToLoad() {
-        return new int[0];
-    }
-
-    @Override
-    public int docIdsToLoadFrom() {
-        return 0;
-    }
-
-    @Override
-    public int docIdsToLoadSize() {
-        return 0;
-    }
-
-    @Override
-    public SearchContext docIdsToLoad(int[] docIdsToLoad, int docsIdsToLoadFrom, int docsIdsToLoadSize) {
-        return null;
-    }
-
-    @Override
-    public void accessed(long accessTime) {
-    }
-
-    @Override
-    public long lastAccessTime() {
-        return 0;
-    }
-
-    @Override
-    public long keepAlive() {
-        return 0;
-    }
-
-    @Override
-    public void keepAlive(long keepAlive) {
-    }
-
-    @Override
-    public void lastEmittedDoc(ScoreDoc doc) {
-    }
-
-    @Override
-    public ScoreDoc lastEmittedDoc() {
-        return null;
-    }
-
-    @Override
-    public SearchLookup lookup() {
-        return null;
-    }
-
-    @Override
-    public DfsSearchResult dfsResult() {
-        return null;
-    }
-
-    @Override
-    public QuerySearchResult queryResult() {
-        return null;
-    }
-
-    @Override
-    public FetchSearchResult fetchResult() {
-        return null;
-    }
-
-    @Override
-    public ScanContext scanContext() {
-        return null;
-    }
-
-    @Override
-    public MapperService.SmartNameFieldMappers smartFieldMappers(String name) {
-        return null;
-    }
-
-    @Override
-    public FieldMappers smartNameFieldMappers(String name) {
-        return null;
-    }
-
-    @Override
-    public FieldMapper<?> smartNameFieldMapper(String name) {
-        if (mapperService() != null) {
-            return mapperService().smartNameFieldMapper(name, types());
-        }
-        return null;
-    }
-
-    @Override
-    public MapperService.SmartNameObjectMapper smartNameObjectMapper(String name) {
-        return null;
-    }
-
-    @Override
-    public void doClose() throws ElasticsearchException {
-    }
-
-    @Override
-    public boolean useSlowScroll() {
-        return false;
-    }
-
-    @Override
-    public SearchContext useSlowScroll(boolean useSlowScroll) {
-        return null;
-    }
-
-    @Override
-    public Counter timeEstimateCounter() {
-        throw new UnsupportedOperationException();
+        in.highlight(highlight);
     }
 
     @Override
     public void innerHits(InnerHitsContext innerHitsContext) {
-        throw new UnsupportedOperationException();
+        in.innerHits(innerHitsContext);
     }
 
     @Override
     public InnerHitsContext innerHits() {
-        throw new UnsupportedOperationException();
+        return in.innerHits();
+    }
+
+    @Override
+    public SuggestionSearchContext suggest() {
+        return in.suggest();
+    }
+
+    @Override
+    public void suggest(SuggestionSearchContext suggest) {
+        in.suggest(suggest);
+    }
+
+    @Override
+    public List<RescoreSearchContext> rescore() {
+        return in.rescore();
+    }
+
+    @Override
+    public void addRescore(RescoreSearchContext rescore) {
+        in.addRescore(rescore);
+    }
+
+    @Override
+    public boolean hasFieldDataFields() {
+        return in.hasFieldDataFields();
+    }
+
+    @Override
+    public FieldDataFieldsContext fieldDataFields() {
+        return in.fieldDataFields();
+    }
+
+    @Override
+    public boolean hasScriptFields() {
+        return in.hasScriptFields();
+    }
+
+    @Override
+    public ScriptFieldsContext scriptFields() {
+        return in.scriptFields();
+    }
+
+    @Override
+    public boolean sourceRequested() {
+        return in.sourceRequested();
+    }
+
+    @Override
+    public boolean hasFetchSourceContext() {
+        return in.hasFetchSourceContext();
+    }
+
+    @Override
+    public FetchSourceContext fetchSourceContext() {
+        return in.fetchSourceContext();
+    }
+
+    @Override
+    public SearchContext fetchSourceContext(FetchSourceContext fetchSourceContext) {
+        return in.fetchSourceContext(fetchSourceContext);
+    }
+
+    @Override
+    public ContextIndexSearcher searcher() {
+        return in.searcher();
+    }
+
+    @Override
+    public IndexShard indexShard() {
+        return in.indexShard();
+    }
+
+    @Override
+    public MapperService mapperService() {
+        return in.mapperService();
+    }
+
+    @Override
+    public AnalysisService analysisService() {
+        return in.analysisService();
+    }
+
+    @Override
+    public IndexQueryParserService queryParserService() {
+        return in.queryParserService();
+    }
+
+    @Override
+    public SimilarityService similarityService() {
+        return in.similarityService();
+    }
+
+    @Override
+    public ScriptService scriptService() {
+        return in.scriptService();
+    }
+
+    @Override
+    public PageCacheRecycler pageCacheRecycler() {
+        return in.pageCacheRecycler();
+    }
+
+    @Override
+    public BigArrays bigArrays() {
+        return in.bigArrays();
+    }
+
+    @Override
+    public FilterCache filterCache() {
+        return in.filterCache();
+    }
+
+    @Override
+    public BitsetFilterCache bitsetFilterCache() {
+        return in.bitsetFilterCache();
+    }
+
+    @Override
+    public IndexFieldDataService fieldData() {
+        return in.fieldData();
+    }
+
+    @Override
+    public long timeoutInMillis() {
+        return in.timeoutInMillis();
+    }
+
+    @Override
+    public void timeoutInMillis(long timeoutInMillis) {
+        in.timeoutInMillis(timeoutInMillis);
+    }
+
+    @Override
+    public int terminateAfter() {
+        return in.terminateAfter();
+    }
+
+    @Override
+    public void terminateAfter(int terminateAfter) {
+        in.terminateAfter(terminateAfter);
+    }
+
+    @Override
+    public SearchContext minimumScore(float minimumScore) {
+        return in.minimumScore(minimumScore);
+    }
+
+    @Override
+    public Float minimumScore() {
+        return in.minimumScore();
+    }
+
+    @Override
+    public SearchContext sort(Sort sort) {
+        return in.sort(sort);
+    }
+
+    @Override
+    public Sort sort() {
+        return in.sort();
+    }
+
+    @Override
+    public SearchContext trackScores(boolean trackScores) {
+        return in.trackScores(trackScores);
+    }
+
+    @Override
+    public boolean trackScores() {
+        return in.trackScores();
+    }
+
+    @Override
+    public SearchContext parsedPostFilter(ParsedFilter postFilter) {
+        return in.parsedPostFilter(postFilter);
+    }
+
+    @Override
+    public ParsedFilter parsedPostFilter() {
+        return in.parsedPostFilter();
+    }
+
+    @Override
+    public Filter aliasFilter() {
+        return in.aliasFilter();
+    }
+
+    @Override
+    public SearchContext parsedQuery(ParsedQuery query) {
+        return in.parsedQuery(query);
+    }
+
+    @Override
+    public ParsedQuery parsedQuery() {
+        return in.parsedQuery();
+    }
+
+    @Override
+    public Query query() {
+        return in.query();
+    }
+
+    @Override
+    public boolean queryRewritten() {
+        return in.queryRewritten();
+    }
+
+    @Override
+    public SearchContext updateRewriteQuery(Query rewriteQuery) {
+        return in.updateRewriteQuery(rewriteQuery);
+    }
+
+    @Override
+    public int from() {
+        return in.from();
+    }
+
+    @Override
+    public SearchContext from(int from) {
+        return in.from(from);
+    }
+
+    @Override
+    public int size() {
+        return in.size();
+    }
+
+    @Override
+    public SearchContext size(int size) {
+        return in.size(size);
+    }
+
+    @Override
+    public boolean hasFieldNames() {
+        return in.hasFieldNames();
+    }
+
+    @Override
+    public List<String> fieldNames() {
+        return in.fieldNames();
+    }
+
+    @Override
+    public void emptyFieldNames() {
+        in.emptyFieldNames();
+    }
+
+    @Override
+    public boolean explain() {
+        return in.explain();
+    }
+
+    @Override
+    public void explain(boolean explain) {
+        in.explain(explain);
+    }
+
+    @Override
+    public List<String> groupStats() {
+        return in.groupStats();
+    }
+
+    @Override
+    public void groupStats(List<String> groupStats) {
+        in.groupStats(groupStats);
+    }
+
+    @Override
+    public boolean version() {
+        return in.version();
+    }
+
+    @Override
+    public void version(boolean version) {
+        in.version(version);
+    }
+
+    @Override
+    public int[] docIdsToLoad() {
+        return in.docIdsToLoad();
+    }
+
+    @Override
+    public int docIdsToLoadFrom() {
+        return in.docIdsToLoadFrom();
+    }
+
+    @Override
+    public int docIdsToLoadSize() {
+        return in.docIdsToLoadSize();
+    }
+
+    @Override
+    public SearchContext docIdsToLoad(int[] docIdsToLoad, int docsIdsToLoadFrom, int docsIdsToLoadSize) {
+        return in.docIdsToLoad(docIdsToLoad, docsIdsToLoadFrom, docsIdsToLoadSize);
+    }
+
+    @Override
+    public void accessed(long accessTime) {
+        accessed(accessTime);
+    }
+
+    @Override
+    public long lastAccessTime() {
+        return in.lastAccessTime();
+    }
+
+    @Override
+    public long keepAlive() {
+        return in.keepAlive();
+    }
+
+    @Override
+    public void keepAlive(long keepAlive) {
+        in.keepAlive(keepAlive);
+    }
+
+    @Override
+    public void lastEmittedDoc(ScoreDoc doc) {
+        in.lastEmittedDoc(doc);
+    }
+
+    @Override
+    public ScoreDoc lastEmittedDoc() {
+        return in.lastEmittedDoc();
+    }
+
+    @Override
+    public SearchLookup lookup() {
+        return in.lookup();
+    }
+
+    @Override
+    public DfsSearchResult dfsResult() {
+        return in.dfsResult();
+    }
+
+    @Override
+    public QuerySearchResult queryResult() {
+        return in.queryResult();
+    }
+
+    @Override
+    public FetchSearchResult fetchResult() {
+        return in.fetchResult();
+    }
+
+    @Override
+    public ScanContext scanContext() {
+        return in.scanContext();
+    }
+
+    @Override
+    public MapperService.SmartNameFieldMappers smartFieldMappers(String name) {
+        return in.smartFieldMappers(name);
+    }
+
+    @Override
+    public FieldMappers smartNameFieldMappers(String name) {
+        return in.smartNameFieldMappers(name);
+    }
+
+    @Override
+    public FieldMapper smartNameFieldMapper(String name) {
+        return in.smartNameFieldMapper(name);
+    }
+
+    @Override
+    public MapperService.SmartNameObjectMapper smartNameObjectMapper(String name) {
+        return in.smartNameObjectMapper(name);
+    }
+
+    @Override
+    public boolean useSlowScroll() {
+        return in.useSlowScroll();
+    }
+
+    @Override
+    public SearchContext useSlowScroll(boolean useSlowScroll) {
+        return in.useSlowScroll(useSlowScroll);
+    }
+
+    @Override
+    public Counter timeEstimateCounter() {
+        return in.timeEstimateCounter();
     }
 }

--- a/src/main/java/org/elasticsearch/search/internal/InternalSearchHits.java
+++ b/src/main/java/org/elasticsearch/search/internal/InternalSearchHits.java
@@ -115,7 +115,7 @@ public class InternalSearchHits implements SearchHits {
 
     public void shardTarget(SearchShardTarget shardTarget) {
         for (InternalSearchHit hit : hits) {
-            hit.shardTarget(shardTarget);
+            hit.shard(shardTarget);
         }
     }
 

--- a/src/main/java/org/elasticsearch/search/internal/SearchContext.java
+++ b/src/main/java/org/elasticsearch/search/internal/SearchContext.java
@@ -52,6 +52,7 @@ import org.elasticsearch.search.aggregations.SearchContextAggregations;
 import org.elasticsearch.search.dfs.DfsSearchResult;
 import org.elasticsearch.search.fetch.FetchSearchResult;
 import org.elasticsearch.search.fetch.fielddata.FieldDataFieldsContext;
+import org.elasticsearch.search.fetch.innerhits.InnerHitsContext;
 import org.elasticsearch.search.fetch.script.ScriptFieldsContext;
 import org.elasticsearch.search.fetch.source.FetchSourceContext;
 import org.elasticsearch.search.highlight.SearchContextHighlight;
@@ -155,6 +156,10 @@ public abstract class SearchContext implements Releasable {
     public abstract SearchContextHighlight highlight();
 
     public abstract void highlight(SearchContextHighlight highlight);
+
+    public abstract void innerHits(InnerHitsContext innerHitsContext);
+
+    public abstract InnerHitsContext innerHits();
 
     public abstract SuggestionSearchContext suggest();
 

--- a/src/main/java/org/elasticsearch/search/internal/SubSearchContext.java
+++ b/src/main/java/org/elasticsearch/search/internal/SubSearchContext.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.elasticsearch.search.aggregations.metrics.tophits;
+package org.elasticsearch.search.internal;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -26,44 +26,25 @@ import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.util.Counter;
 import org.elasticsearch.action.search.SearchType;
-import org.elasticsearch.cache.recycler.PageCacheRecycler;
-import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.index.analysis.AnalysisService;
-import org.elasticsearch.index.cache.bitset.BitsetFilterCache;
-import org.elasticsearch.index.cache.filter.FilterCache;
-import org.elasticsearch.index.fielddata.IndexFieldDataService;
-import org.elasticsearch.index.mapper.FieldMapper;
-import org.elasticsearch.index.mapper.FieldMappers;
-import org.elasticsearch.index.mapper.MapperService;
-import org.elasticsearch.index.query.IndexQueryParserService;
 import org.elasticsearch.index.query.ParsedFilter;
-import org.elasticsearch.index.query.ParsedQuery;
-import org.elasticsearch.index.shard.service.IndexShard;
-import org.elasticsearch.index.similarity.SimilarityService;
-import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.Scroll;
-import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.search.aggregations.SearchContextAggregations;
-import org.elasticsearch.search.dfs.DfsSearchResult;
 import org.elasticsearch.search.fetch.FetchSearchResult;
 import org.elasticsearch.search.fetch.fielddata.FieldDataFieldsContext;
+import org.elasticsearch.search.fetch.innerhits.InnerHitsContext;
 import org.elasticsearch.search.fetch.script.ScriptFieldsContext;
 import org.elasticsearch.search.fetch.source.FetchSourceContext;
 import org.elasticsearch.search.highlight.SearchContextHighlight;
-import org.elasticsearch.search.internal.ContextIndexSearcher;
-import org.elasticsearch.search.internal.SearchContext;
-import org.elasticsearch.search.internal.ShardSearchRequest;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.search.query.QuerySearchResult;
 import org.elasticsearch.search.rescore.RescoreSearchContext;
-import org.elasticsearch.search.scan.ScanContext;
 import org.elasticsearch.search.suggest.SuggestionSearchContext;
 
 import java.util.List;
 
 /**
  */
-public class TopHitsContext extends SearchContext {
+public class SubSearchContext extends FilteredSearchContext {
 
     // By default return 3 hits per bucket. A higher default would make the response really large by default, since
     // the to hits are returned per bucket.
@@ -80,8 +61,6 @@ public class TopHitsContext extends SearchContext {
     private int docsIdsToLoadFrom;
     private int docsIdsToLoadSize;
 
-    private final SearchContext context;
-
     private List<String> fieldNames;
     private FieldDataFieldsContext fieldDataFields;
     private ScriptFieldsContext scriptFields;
@@ -92,10 +71,10 @@ public class TopHitsContext extends SearchContext {
     private boolean trackScores;
     private boolean version;
 
-    public TopHitsContext(SearchContext context) {
+    public SubSearchContext(SearchContext context) {
+        super(context);
         this.fetchSearchResult = new FetchSearchResult();
         this.querySearchResult = new QuerySearchResult();
-        this.context = context;
     }
 
     @Override
@@ -112,53 +91,8 @@ public class TopHitsContext extends SearchContext {
     }
 
     @Override
-    public long id() {
-        return context.id();
-    }
-
-    @Override
-    public String source() {
-        return context.source();
-    }
-
-    @Override
-    public ShardSearchRequest request() {
-        return context.request();
-    }
-
-    @Override
-    public SearchType searchType() {
-        return context.searchType();
-    }
-
-    @Override
     public SearchContext searchType(SearchType searchType) {
         throw new UnsupportedOperationException("this context should be read only");
-    }
-
-    @Override
-    public SearchShardTarget shardTarget() {
-        return context.shardTarget();
-    }
-
-    @Override
-    public int numberOfShards() {
-        return context.numberOfShards();
-    }
-
-    @Override
-    public boolean hasTypes() {
-        return context.hasTypes();
-    }
-
-    @Override
-    public String[] types() {
-        return context.types();
-    }
-
-    @Override
-    public float queryBoost() {
-        return context.queryBoost();
     }
 
     @Override
@@ -167,23 +101,8 @@ public class TopHitsContext extends SearchContext {
     }
 
     @Override
-    protected long nowInMillisImpl() {
-        return context.nowInMillis();
-    }
-
-    @Override
-    public Scroll scroll() {
-        return context.scroll();
-    }
-
-    @Override
     public SearchContext scroll(Scroll scroll) {
         throw new UnsupportedOperationException("Not supported");
-    }
-
-    @Override
-    public SearchContextAggregations aggregations() {
-        return context.aggregations();
     }
 
     @Override
@@ -200,18 +119,8 @@ public class TopHitsContext extends SearchContext {
     }
 
     @Override
-    public SuggestionSearchContext suggest() {
-        return context.suggest();
-    }
-
-    @Override
     public void suggest(SuggestionSearchContext suggest) {
         throw new UnsupportedOperationException("Not supported");
-    }
-
-    @Override
-    public List<RescoreSearchContext> rescore() {
-        return context.rescore();
     }
 
     @Override
@@ -267,78 +176,8 @@ public class TopHitsContext extends SearchContext {
     }
 
     @Override
-    public ContextIndexSearcher searcher() {
-        return context.searcher();
-    }
-
-    @Override
-    public IndexShard indexShard() {
-        return context.indexShard();
-    }
-
-    @Override
-    public MapperService mapperService() {
-        return context.mapperService();
-    }
-
-    @Override
-    public AnalysisService analysisService() {
-        return context.analysisService();
-    }
-
-    @Override
-    public IndexQueryParserService queryParserService() {
-        return context.queryParserService();
-    }
-
-    @Override
-    public SimilarityService similarityService() {
-        return context.similarityService();
-    }
-
-    @Override
-    public ScriptService scriptService() {
-        return context.scriptService();
-    }
-
-    @Override
-    public PageCacheRecycler pageCacheRecycler() {
-        return context.pageCacheRecycler();
-    }
-
-    @Override
-    public BigArrays bigArrays() {
-        return context.bigArrays();
-    }
-
-    @Override
-    public FilterCache filterCache() {
-        return context.filterCache();
-    }
-
-    @Override
-    public BitsetFilterCache bitsetFilterCache() {
-        return context.bitsetFilterCache();
-    }
-
-    @Override
-    public IndexFieldDataService fieldData() {
-        return context.fieldData();
-    }
-
-    @Override
-    public long timeoutInMillis() {
-        return context.timeoutInMillis();
-    }
-
-    @Override
     public void timeoutInMillis(long timeoutInMillis) {
         throw new UnsupportedOperationException("Not supported");
-    }
-
-    @Override
-    public int terminateAfter() {
-        return context.terminateAfter();
     }
 
     @Override
@@ -352,14 +191,9 @@ public class TopHitsContext extends SearchContext {
     }
 
     @Override
-    public Float minimumScore() {
-        return context.minimumScore();
-    }
-
-    @Override
     public SearchContext sort(Sort sort) {
         this.sort = sort;
-        return null;
+        return this;
     }
 
     @Override
@@ -381,36 +215,6 @@ public class TopHitsContext extends SearchContext {
     @Override
     public SearchContext parsedPostFilter(ParsedFilter postFilter) {
         throw new UnsupportedOperationException("Not supported");
-    }
-
-    @Override
-    public ParsedFilter parsedPostFilter() {
-        return context.parsedPostFilter();
-    }
-
-    @Override
-    public Filter aliasFilter() {
-        return context.aliasFilter();
-    }
-
-    @Override
-    public SearchContext parsedQuery(ParsedQuery query) {
-        return context.parsedQuery(query);
-    }
-
-    @Override
-    public ParsedQuery parsedQuery() {
-        return context.parsedQuery();
-    }
-
-    @Override
-    public Query query() {
-        return context.query();
-    }
-
-    @Override
-    public boolean queryRewritten() {
-        return context.queryRewritten();
     }
 
     @Override
@@ -469,11 +273,6 @@ public class TopHitsContext extends SearchContext {
     }
 
     @Override
-    public List<String> groupStats() {
-        return context.groupStats();
-    }
-
-    @Override
     public void groupStats(List<String> groupStats) {
         throw new UnsupportedOperationException("Not supported");
     }
@@ -517,16 +316,6 @@ public class TopHitsContext extends SearchContext {
     }
 
     @Override
-    public long lastAccessTime() {
-        return context.lastAccessTime();
-    }
-
-    @Override
-    public long keepAlive() {
-        return context.keepAlive();
-    }
-
-    @Override
     public void keepAlive(long keepAlive) {
         throw new UnsupportedOperationException("Not supported");
     }
@@ -534,21 +323,6 @@ public class TopHitsContext extends SearchContext {
     @Override
     public void lastEmittedDoc(ScoreDoc doc) {
         throw new UnsupportedOperationException("Not supported");
-    }
-
-    @Override
-    public ScoreDoc lastEmittedDoc() {
-        return context.lastEmittedDoc();
-    }
-
-    @Override
-    public SearchLookup lookup() {
-        return context.lookup();
-    }
-
-    @Override
-    public DfsSearchResult dfsResult() {
-        return context.dfsResult();
     }
 
     @Override
@@ -561,34 +335,14 @@ public class TopHitsContext extends SearchContext {
         return fetchSearchResult;
     }
 
-    @Override
-    public ScanContext scanContext() {
-        return context.scanContext();
-    }
+    private SearchLookup searchLookup;
 
     @Override
-    public MapperService.SmartNameFieldMappers smartFieldMappers(String name) {
-        return context.smartFieldMappers(name);
-    }
-
-    @Override
-    public FieldMappers smartNameFieldMappers(String name) {
-        return context.smartNameFieldMappers(name);
-    }
-
-    @Override
-    public FieldMapper smartNameFieldMapper(String name) {
-        return context.smartNameFieldMapper(name);
-    }
-
-    @Override
-    public MapperService.SmartNameObjectMapper smartNameObjectMapper(String name) {
-        return context.smartNameObjectMapper(name);
-    }
-
-    @Override
-    public boolean useSlowScroll() {
-        return context.useSlowScroll();
+    public SearchLookup lookup() {
+        if (searchLookup == null) {
+            searchLookup = new SearchLookup(mapperService(), fieldData(), request().types());
+        }
+        return searchLookup;
     }
 
     @Override
@@ -599,5 +353,17 @@ public class TopHitsContext extends SearchContext {
     @Override
     public Counter timeEstimateCounter() {
         throw new UnsupportedOperationException("Not supported");
+    }
+
+    private InnerHitsContext innerHitsContext;
+
+    @Override
+    public void innerHits(InnerHitsContext innerHitsContext) {
+        this.innerHitsContext = innerHitsContext;
+    }
+
+    @Override
+    public InnerHitsContext innerHits() {
+        return innerHitsContext;
     }
 }

--- a/src/main/java/org/elasticsearch/search/sort/SortParseElement.java
+++ b/src/main/java/org/elasticsearch/search/sort/SortParseElement.java
@@ -41,7 +41,7 @@ import org.elasticsearch.index.search.nested.NonNestedDocsFilter;
 import org.elasticsearch.search.MultiValueMode;
 import org.elasticsearch.search.SearchParseElement;
 import org.elasticsearch.search.SearchParseException;
-import org.elasticsearch.search.aggregations.metrics.tophits.TopHitsContext;
+import org.elasticsearch.search.internal.SubSearchContext;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.util.List;
@@ -244,7 +244,7 @@ public class SortParseElement implements SearchParseElement {
                 if (!objectMapper.nested().isNested()) {
                     throw new ElasticsearchIllegalArgumentException("mapping for explicit nested path is not mapped as nested: [" + nestedPath + "]");
                 }
-            } else if (!(context instanceof TopHitsContext)) {
+            } else if (!(context instanceof SubSearchContext)) {
                 // Only automatically resolve nested path when sort isn't defined for top_hits
                 objectMapper = context.mapperService().resolveClosestNestedObjectMapper(fieldName);
             }

--- a/src/test/java/org/elasticsearch/search/fetch/innerhits/NestedChildrenFilterTest.java
+++ b/src/test/java/org/elasticsearch/search/fetch/innerhits/NestedChildrenFilterTest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.fetch.innerhits;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.IntField;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.RandomIndexWriter;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.queries.TermFilter;
+import org.apache.lucene.search.*;
+import org.apache.lucene.search.join.BitDocIdSetCachingWrapperFilter;
+import org.apache.lucene.search.join.BitDocIdSetFilter;
+import org.apache.lucene.store.Directory;
+import org.elasticsearch.search.fetch.FetchSubPhase;
+import org.elasticsearch.search.fetch.innerhits.InnerHitsContext.NestedInnerHits.NestedChildrenFilter;
+import org.elasticsearch.test.ElasticsearchLuceneTestCase;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ */
+public class NestedChildrenFilterTest extends ElasticsearchLuceneTestCase {
+
+    @Test
+    public void testNestedChildrenFilter() throws Exception {
+        int numParentDocs = scaledRandomIntBetween(0, 32);
+        int maxChildDocsPerParent = scaledRandomIntBetween(8, 16);
+
+        Directory dir = newDirectory();
+        RandomIndexWriter writer = new RandomIndexWriter(random(), dir);
+        for (int i = 0; i < numParentDocs; i++) {
+            int numChildDocs = scaledRandomIntBetween(0, maxChildDocsPerParent);
+            List<Document> docs = new ArrayList<>(numChildDocs + 1);
+            for (int j = 0; j < numChildDocs; j++) {
+                Document childDoc = new Document();
+                childDoc.add(new StringField("type", "child", Field.Store.NO));
+                docs.add(childDoc);
+            }
+
+            Document parenDoc = new Document();
+            parenDoc.add(new StringField("type", "parent", Field.Store.NO));
+            parenDoc.add(new IntField("num_child_docs", numChildDocs, Field.Store.YES));
+            docs.add(parenDoc);
+            writer.addDocuments(docs);
+        }
+
+        IndexReader reader = writer.getReader();
+        writer.close();
+
+        IndexSearcher searcher = new IndexSearcher(reader);
+        FetchSubPhase.HitContext hitContext = new FetchSubPhase.HitContext();
+        BitDocIdSetFilter parentFilter = new BitDocIdSetCachingWrapperFilter(new TermFilter(new Term("type", "parent")));
+        Filter childFilter = new TermFilter(new Term("type", "child"));
+        int checkedParents = 0;
+        for (LeafReaderContext leaf : reader.leaves()) {
+            DocIdSetIterator parents = parentFilter.getDocIdSet(leaf).iterator();
+            for (int parentDoc = parents.nextDoc(); parentDoc != DocIdSetIterator.NO_MORE_DOCS ; parentDoc = parents.nextDoc()) {
+                int expectedChildDocs = leaf.reader().document(parentDoc).getField("num_child_docs").numericValue().intValue();
+                hitContext.reset(null, leaf, parentDoc, reader);
+                NestedChildrenFilter nestedChildrenFilter = new NestedChildrenFilter(parentFilter, childFilter, hitContext);
+                TotalHitCountCollector totalHitCountCollector = new TotalHitCountCollector();
+                searcher.search(new ConstantScoreQuery(nestedChildrenFilter), totalHitCountCollector);
+                assertThat(totalHitCountCollector.getTotalHits(), equalTo(expectedChildDocs));
+                checkedParents++;
+            }
+        }
+        assertThat(checkedParents, equalTo(numParentDocs));
+        reader.close();
+        dir.close();
+    }
+
+}

--- a/src/test/java/org/elasticsearch/search/innerhits/InnerHitsTests.java
+++ b/src/test/java/org/elasticsearch/search/innerhits/InnerHitsTests.java
@@ -1,0 +1,523 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.innerhits;
+
+import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchHits;
+import org.elasticsearch.search.fetch.innerhits.InnerHitsBuilder;
+import org.elasticsearch.search.sort.SortOrder;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.index.query.QueryBuilders.*;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.*;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+/**
+ */
+public class InnerHitsTests extends ElasticsearchIntegrationTest {
+
+    @Test
+    public void testSimpleNested() throws Exception {
+        assertAcked(prepareCreate("articles").addMapping("article", jsonBuilder().startObject().startObject("article").startObject("properties")
+                .startObject("comments")
+                    .field("type", "nested")
+                    .startObject("properties")
+                        .startObject("message")
+                            .field("type", "string")
+                        .endObject()
+                    .endObject()
+                .endObject()
+                .startObject("title")
+                    .field("type", "string")
+                .endObject()
+                .endObject().endObject().endObject()));
+
+        List<IndexRequestBuilder> requests = new ArrayList<>();
+        requests.add(client().prepareIndex("articles", "article", "1").setSource(jsonBuilder().startObject()
+                .field("title", "quick brown fox")
+                .startArray("comments")
+                .startObject().field("message", "fox eat quick").endObject()
+                .startObject().field("message", "fox ate rabbit x y z").endObject()
+                .startObject().field("message", "rabbit got away").endObject()
+                .endArray()
+                .endObject()));
+        requests.add(client().prepareIndex("articles", "article", "2").setSource(jsonBuilder().startObject()
+                .field("title", "big gray elephant")
+                .startArray("comments")
+                    .startObject().field("message", "elephant captured").endObject()
+                    .startObject().field("message", "mice squashed by elephant x").endObject()
+                    .startObject().field("message", "elephant scared by mice x y").endObject()
+                .endArray()
+                .endObject()));
+        indexRandom(true, requests);
+
+        SearchResponse response = client().prepareSearch("articles")
+                .setQuery(nestedQuery("comments", matchQuery("comments.message", "fox")))
+                .addInnerHit("comment", new InnerHitsBuilder.InnerHit().setPath("comments").setQuery(matchQuery("comments.message", "fox")))
+                .get();
+        assertNoFailures(response);
+        assertHitCount(response, 1);
+        assertSearchHit(response, 1, hasId("1"));
+        assertThat(response.getHits().getAt(0).getInnerHits().size(), equalTo(1));
+        SearchHits innerHits = response.getHits().getAt(0).getInnerHits().get("comment");
+        assertThat(innerHits.totalHits(), equalTo(2l));
+        assertThat(innerHits.getHits().length, equalTo(2));
+        assertThat(innerHits.getAt(0).getId(), equalTo("1"));
+        assertThat(innerHits.getAt(0).getNestedIdentity().getField().string(), equalTo("comments"));
+        assertThat(innerHits.getAt(0).getNestedIdentity().getOffset(), equalTo(0));
+        assertThat(innerHits.getAt(1).getId(), equalTo("1"));
+        assertThat(innerHits.getAt(1).getNestedIdentity().getField().string(), equalTo("comments"));
+        assertThat(innerHits.getAt(1).getNestedIdentity().getOffset(), equalTo(1));
+
+        response = client().prepareSearch("articles")
+                .setQuery(nestedQuery("comments", matchQuery("comments.message", "elephant")))
+                .addInnerHit("comment", new InnerHitsBuilder.InnerHit().setPath("comments").setQuery(matchQuery("comments.message", "elephant")))
+                .get();
+        assertNoFailures(response);
+        assertHitCount(response, 1);
+        assertSearchHit(response, 1, hasId("2"));
+        assertThat(response.getHits().getAt(0).getInnerHits().size(), equalTo(1));
+        innerHits = response.getHits().getAt(0).getInnerHits().get("comment");
+        assertThat(innerHits.totalHits(), equalTo(3l));
+        assertThat(innerHits.getHits().length, equalTo(3));
+        assertThat(innerHits.getAt(0).getId(), equalTo("2"));
+        assertThat(innerHits.getAt(0).getNestedIdentity().getField().string(), equalTo("comments"));
+        assertThat(innerHits.getAt(0).getNestedIdentity().getOffset(), equalTo(0));
+        assertThat(innerHits.getAt(1).getId(), equalTo("2"));
+        assertThat(innerHits.getAt(1).getNestedIdentity().getField().string(), equalTo("comments"));
+        assertThat(innerHits.getAt(1).getNestedIdentity().getOffset(), equalTo(1));
+        assertThat(innerHits.getAt(2).getId(), equalTo("2"));
+        assertThat(innerHits.getAt(2).getNestedIdentity().getField().string(), equalTo("comments"));
+        assertThat(innerHits.getAt(2).getNestedIdentity().getOffset(), equalTo(2));
+
+        response = client().prepareSearch("articles")
+                .setQuery(nestedQuery("comments", matchQuery("comments.message", "fox")))
+                .addInnerHit("comment", new InnerHitsBuilder.InnerHit().setPath("comments")
+                        .setQuery(matchQuery("comments.message", "fox"))
+                        .addHighlightedField("comments.message")
+                        .setExplain(true)
+                        .addFieldDataField("comments.message")
+                        .addScriptField("script", "doc['comments.message'].value")
+                        .setSize(1)
+                ).get();
+
+        assertNoFailures(response);
+        innerHits = response.getHits().getAt(0).getInnerHits().get("comment");
+        assertThat(innerHits.getHits().length, equalTo(1));
+        assertThat(innerHits.getAt(0).getHighlightFields().get("comments.message").getFragments()[0].string(), equalTo("<em>fox</em> eat quick"));
+        assertThat(innerHits.getAt(0).explanation().toString(), containsString("(MATCH) weight(comments.message:fox in"));
+        assertThat(innerHits.getAt(0).getFields().get("comments.message").getValue().toString(), equalTo("eat"));
+        assertThat(innerHits.getAt(0).getFields().get("script").getValue().toString(), equalTo("eat"));
+    }
+
+    @Test
+    public void testRandomNested() throws Exception {
+        assertAcked(prepareCreate("idx").addMapping("type", "field1", "type=nested", "field2", "type=nested"));
+        int numDocs = scaledRandomIntBetween(25, 100);
+        List<IndexRequestBuilder> requestBuilders = new ArrayList<>();
+
+        int[] field1InnerObjects = new int[numDocs];
+        int[] field2InnerObjects = new int[numDocs];
+        for (int i = 0; i < numDocs; i++) {
+            int numInnerObjects = field1InnerObjects[i] = scaledRandomIntBetween(0, numDocs);
+            XContentBuilder source = jsonBuilder().startObject().startArray("field1");
+            for (int j = 0; j < numInnerObjects; j++) {
+                source.startObject().field("x", "y").endObject();
+            }
+            numInnerObjects = field2InnerObjects[i] = scaledRandomIntBetween(0, numDocs);
+            source.endArray().startArray("field2");
+            for (int j = 0; j < numInnerObjects; j++) {
+                source.startObject().field("x", "y").endObject();
+            }
+            source.endArray().endObject();
+
+            requestBuilders.add(client().prepareIndex("idx", "type", String.format(Locale.ENGLISH, "%03d", i)).setSource(source));
+        }
+
+        indexRandom(true, requestBuilders);
+
+        SearchResponse searchResponse = client().prepareSearch("idx")
+                .setSize(numDocs)
+                .addSort("_uid", SortOrder.ASC)
+                .addInnerHit("a", new InnerHitsBuilder.InnerHit().setPath("field1").addSort("_doc", SortOrder.DESC).setSize(numDocs)) // Sort order is DESC, because we reverse the inner objects during indexing!
+                .addInnerHit("b", new InnerHitsBuilder.InnerHit().setPath("field2").addSort("_doc", SortOrder.DESC).setSize(numDocs))
+                .get();
+
+        assertHitCount(searchResponse, numDocs);
+        assertThat(searchResponse.getHits().getHits().length, equalTo(numDocs));
+        for (int i = 0; i < numDocs; i++) {
+            SearchHit searchHit = searchResponse.getHits().getAt(i);
+            SearchHits inner = searchHit.getInnerHits().get("a");
+            assertThat(inner.totalHits(), equalTo((long) field1InnerObjects[i]));
+            for (int j = 0; j < field1InnerObjects[i]; j++) {
+                SearchHit innerHit =  inner.getAt(j);
+                assertThat(innerHit.getNestedIdentity().getField().string(), equalTo("field1"));
+                assertThat(innerHit.getNestedIdentity().getOffset(), equalTo(j));
+                assertThat(innerHit.getNestedIdentity().getChild(), nullValue());
+            }
+
+            inner = searchHit.getInnerHits().get("b");
+            assertThat(inner.totalHits(), equalTo((long) field2InnerObjects[i]));
+            for (int j = 0; j < field2InnerObjects[i]; j++) {
+                SearchHit innerHit =  inner.getAt(j);
+                assertThat(innerHit.getNestedIdentity().getField().string(), equalTo("field2"));
+                assertThat(innerHit.getNestedIdentity().getOffset(), equalTo(j));
+                assertThat(innerHit.getNestedIdentity().getChild(), nullValue());
+            }
+        }
+    }
+
+    @Test
+    public void testSimpleParentChild() throws Exception {
+        assertAcked(prepareCreate("articles")
+                .addMapping("article", "title", "type=string")
+                .addMapping("comment", "_parent", "type=article", "message", "type=string")
+        );
+
+        List<IndexRequestBuilder> requests = new ArrayList<>();
+        requests.add(client().prepareIndex("articles", "article", "1").setSource("title", "quick brown fox"));
+        requests.add(client().prepareIndex("articles", "comment", "1").setParent("1").setSource("message", "fox eat quick"));
+        requests.add(client().prepareIndex("articles", "comment", "2").setParent("1").setSource("message", "fox ate rabbit x y z"));
+        requests.add(client().prepareIndex("articles", "comment", "3").setParent("1").setSource("message", "rabbit got away"));
+        requests.add(client().prepareIndex("articles", "article", "2").setSource("title", "big gray elephant"));
+        requests.add(client().prepareIndex("articles", "comment", "4").setParent("2").setSource("message", "elephant captured"));
+        requests.add(client().prepareIndex("articles", "comment", "5").setParent("2").setSource("message", "mice squashed by elephant x"));
+        requests.add(client().prepareIndex("articles", "comment", "6").setParent("2").setSource("message", "elephant scared by mice x y"));
+        indexRandom(true, requests);
+
+        SearchResponse response = client().prepareSearch("articles")
+                .setQuery(hasChildQuery("comment", matchQuery("message", "fox")))
+                .addInnerHit("comment", new InnerHitsBuilder.InnerHit().setType("comment").setQuery(matchQuery("message", "fox")))
+                .get();
+
+        assertNoFailures(response);
+        assertHitCount(response, 1);
+        assertSearchHit(response, 1, hasId("1"));
+
+        assertThat(response.getHits().getAt(0).getInnerHits().size(), equalTo(1));
+        SearchHits innerHits = response.getHits().getAt(0).getInnerHits().get("comment");
+        assertThat(innerHits.totalHits(), equalTo(2l));
+
+        assertThat(innerHits.getAt(0).getId(), equalTo("1"));
+        assertThat(innerHits.getAt(0).type(), equalTo("comment"));
+        assertThat(innerHits.getAt(1).getId(), equalTo("2"));
+        assertThat(innerHits.getAt(1).type(), equalTo("comment"));
+
+        response = client().prepareSearch("articles")
+                .setQuery(hasChildQuery("comment", matchQuery("message", "elephant")))
+                .addInnerHit("comment", new InnerHitsBuilder.InnerHit().setType("comment").setQuery(matchQuery("message", "elephant")))
+                .get();
+
+        assertNoFailures(response);
+        assertHitCount(response, 1);
+        assertSearchHit(response, 1, hasId("2"));
+
+        assertThat(response.getHits().getAt(0).getInnerHits().size(), equalTo(1));
+        innerHits = response.getHits().getAt(0).getInnerHits().get("comment");
+        assertThat(innerHits.totalHits(), equalTo(3l));
+
+        assertThat(innerHits.getAt(0).getId(), equalTo("4"));
+        assertThat(innerHits.getAt(0).type(), equalTo("comment"));
+        assertThat(innerHits.getAt(1).getId(), equalTo("5"));
+        assertThat(innerHits.getAt(1).type(), equalTo("comment"));
+        assertThat(innerHits.getAt(2).getId(), equalTo("6"));
+        assertThat(innerHits.getAt(2).type(), equalTo("comment"));
+
+        response = client().prepareSearch("articles")
+                .setQuery(hasChildQuery("comment", matchQuery("message", "fox")))
+                .addInnerHit("comment", new InnerHitsBuilder.InnerHit().setType("comment")
+                                .setQuery(matchQuery("message", "fox"))
+                                .addHighlightedField("message")
+                                .setExplain(true)
+                                .addFieldDataField("message")
+                                .addScriptField("script", "doc['message'].value")
+                                .setSize(1)
+                ).get();
+
+        assertNoFailures(response);
+        innerHits = response.getHits().getAt(0).getInnerHits().get("comment");
+        assertThat(innerHits.getHits().length, equalTo(1));
+        assertThat(innerHits.getAt(0).getHighlightFields().get("message").getFragments()[0].string(), equalTo("<em>fox</em> eat quick"));
+        assertThat(innerHits.getAt(0).explanation().toString(), containsString("(MATCH) weight(message:fox"));
+        assertThat(innerHits.getAt(0).getFields().get("message").getValue().toString(), equalTo("eat"));
+        assertThat(innerHits.getAt(0).getFields().get("script").getValue().toString(), equalTo("eat"));
+    }
+
+    @Test
+    public void testRandomParentChild() throws Exception {
+        assertAcked(prepareCreate("idx")
+                        .addMapping("parent")
+                        .addMapping("child1", "_parent", "type=parent")
+                        .addMapping("child2", "_parent", "type=parent")
+        );
+        int numDocs = scaledRandomIntBetween(5, 50);
+        List<IndexRequestBuilder> requestBuilders = new ArrayList<>();
+
+        int child1 = 0;
+        int child2 = 0;
+        int[] child1InnerObjects = new int[numDocs];
+        int[] child2InnerObjects = new int[numDocs];
+        for (int parent = 0; parent < numDocs; parent++) {
+            String parentId = String.format(Locale.ENGLISH, "%03d", parent);
+            requestBuilders.add(client().prepareIndex("idx", "parent", parentId).setSource("{}"));
+
+            int numChildDocs = child1InnerObjects[parent] = scaledRandomIntBetween(0, numDocs);
+            int limit = child1 + numChildDocs;
+            for (; child1 < limit; child1++) {
+                requestBuilders.add(client().prepareIndex("idx", "child1", String.format(Locale.ENGLISH, "%04d", child1)).setParent(parentId).setSource("{}"));
+            }
+            numChildDocs = child2InnerObjects[parent] = scaledRandomIntBetween(0, numDocs);
+            limit = child2 + numChildDocs;
+            for (; child2 < limit; child2++) {
+                requestBuilders.add(client().prepareIndex("idx", "child2", String.format(Locale.ENGLISH, "%04d", child2)).setParent(parentId).setSource("{}"));
+            }
+        }
+        indexRandom(true, requestBuilders);
+
+        SearchResponse searchResponse = client().prepareSearch("idx")
+                .setSize(numDocs)
+                .setTypes("parent")
+                .addSort("_uid", SortOrder.ASC)
+                .addInnerHit("a", new InnerHitsBuilder.InnerHit().setType("child1").addSort("_uid", SortOrder.ASC).setSize(numDocs))
+                .addInnerHit("b", new InnerHitsBuilder.InnerHit().setType("child2").addSort("_uid", SortOrder.ASC).setSize(numDocs))
+                .get();
+
+        assertHitCount(searchResponse, numDocs);
+        assertThat(searchResponse.getHits().getHits().length, equalTo(numDocs));
+
+        int offset1 = 0;
+        int offset2 = 0;
+        for (int parent = 0; parent < numDocs; parent++) {
+            SearchHit searchHit = searchResponse.getHits().getAt(parent);
+            assertThat(searchHit.getType(), equalTo("parent"));
+            assertThat(searchHit.getId(), equalTo(String.format(Locale.ENGLISH, "%03d", parent)));
+
+            SearchHits inner = searchHit.getInnerHits().get("a");
+            assertThat(inner.totalHits(), equalTo((long) child1InnerObjects[parent]));
+            for (int child = 0; child < child1InnerObjects[parent]; child++) {
+                SearchHit innerHit =  inner.getAt(child);
+                assertThat(innerHit.getType(), equalTo("child1"));
+                String childId = String.format(Locale.ENGLISH, "%04d", offset1 + child);
+                assertThat(innerHit.getId(), equalTo(childId));
+                assertThat(innerHit.getNestedIdentity(), nullValue());
+            }
+            offset1 += child1InnerObjects[parent];
+
+            inner = searchHit.getInnerHits().get("b");
+            assertThat(inner.totalHits(), equalTo((long) child2InnerObjects[parent]));
+            for (int child = 0; child < child2InnerObjects[parent]; child++) {
+                SearchHit innerHit = inner.getAt(child);
+                assertThat(innerHit.getType(), equalTo("child2"));
+                String childId = String.format(Locale.ENGLISH, "%04d", offset2 + child);
+                assertThat(innerHit.getId(), equalTo(childId));
+                assertThat(innerHit.getNestedIdentity(), nullValue());
+            }
+            offset2 += child2InnerObjects[parent];
+        }
+    }
+
+    @Test
+    public void testPathOrTypeMustBeDefined() {
+        createIndex("articles");
+        ensureGreen("articles");
+        try {
+            client().prepareSearch("articles")
+                    .addInnerHit("comment", new InnerHitsBuilder.InnerHit())
+                    .get();
+        } catch (Exception e) {
+            assertThat(e.getMessage(), containsString("Failed to build search source"));
+        }
+
+    }
+
+    @Test
+    public void testParentChildMultipleLayers() throws Exception {
+        assertAcked(prepareCreate("articles")
+                        .addMapping("article", "title", "type=string")
+                        .addMapping("comment", "_parent", "type=article", "message", "type=string")
+                        .addMapping("remark", "_parent", "type=comment", "message", "type=string")
+        );
+
+        List<IndexRequestBuilder> requests = new ArrayList<>();
+        requests.add(client().prepareIndex("articles", "article", "1").setSource("title", "quick brown fox"));
+        requests.add(client().prepareIndex("articles", "comment", "1").setParent("1").setSource("message", "fox eat quick"));
+        requests.add(client().prepareIndex("articles", "remark", "1").setParent("1").setRouting("1").setSource("message", "good"));
+        requests.add(client().prepareIndex("articles", "article", "2").setSource("title", "big gray elephant"));
+        requests.add(client().prepareIndex("articles", "comment", "2").setParent("2").setSource("message", "elephant captured"));
+        requests.add(client().prepareIndex("articles", "remark", "2").setParent("2").setRouting("2").setSource("message", "bad"));
+        indexRandom(true, requests);
+
+        SearchResponse response = client().prepareSearch("articles")
+                .setQuery(hasChildQuery("comment", hasChildQuery("remark", matchQuery("message", "good"))))
+                .addInnerHit("comment",
+                        new InnerHitsBuilder.InnerHit().setType("comment")
+                                .setQuery(hasChildQuery("remark", matchQuery("message", "good")))
+                                .addInnerHit("remark", new InnerHitsBuilder.InnerHit().setType("remark").setQuery(matchQuery("message", "good")))
+                )
+                .get();
+
+        assertNoFailures(response);
+        assertHitCount(response, 1);
+        assertSearchHit(response, 1, hasId("1"));
+
+        assertThat(response.getHits().getAt(0).getInnerHits().size(), equalTo(1));
+        SearchHits innerHits = response.getHits().getAt(0).getInnerHits().get("comment");
+        assertThat(innerHits.totalHits(), equalTo(1l));
+        assertThat(innerHits.getAt(0).getId(), equalTo("1"));
+        assertThat(innerHits.getAt(0).type(), equalTo("comment"));
+
+        innerHits = innerHits.getAt(0).getInnerHits().get("remark");
+        assertThat(innerHits.totalHits(), equalTo(1l));
+        assertThat(innerHits.getAt(0).getId(), equalTo("1"));
+        assertThat(innerHits.getAt(0).type(), equalTo("remark"));
+
+        response = client().prepareSearch("articles")
+                .setQuery(hasChildQuery("comment", hasChildQuery("remark", matchQuery("message", "bad"))))
+                .addInnerHit("comment",
+                        new InnerHitsBuilder.InnerHit().setType("comment")
+                                .setQuery(hasChildQuery("remark", matchQuery("message", "bad")))
+                                .addInnerHit("remark", new InnerHitsBuilder.InnerHit().setType("remark").setQuery(matchQuery("message", "bad")))
+                )
+                .get();
+
+        assertNoFailures(response);
+        assertHitCount(response, 1);
+        assertSearchHit(response, 1, hasId("2"));
+
+        assertThat(response.getHits().getAt(0).getInnerHits().size(), equalTo(1));
+        innerHits = response.getHits().getAt(0).getInnerHits().get("comment");
+        assertThat(innerHits.totalHits(), equalTo(1l));
+        assertThat(innerHits.getAt(0).getId(), equalTo("2"));
+        assertThat(innerHits.getAt(0).type(), equalTo("comment"));
+
+        innerHits = innerHits.getAt(0).getInnerHits().get("remark");
+        assertThat(innerHits.totalHits(), equalTo(1l));
+        assertThat(innerHits.getAt(0).getId(), equalTo("2"));
+        assertThat(innerHits.getAt(0).type(), equalTo("remark"));
+    }
+
+    @Test
+    public void testNestedMultipleLayers() throws Exception {
+        assertAcked(prepareCreate("articles").addMapping("article", jsonBuilder().startObject().startObject("article").startObject("properties")
+                .startObject("comments")
+                    .field("type", "nested")
+                    .startObject("properties")
+                        .startObject("message")
+                            .field("type", "string")
+                        .endObject()
+                        .startObject("remarks")
+                            .field("type", "nested")
+                            .startObject("properties")
+                                .startObject("message").field("type", "string").endObject()
+                            .endObject()
+                        .endObject()
+                    .endObject()
+                .endObject()
+                .startObject("title")
+                    .field("type", "string")
+                .endObject()
+                .endObject().endObject().endObject()));
+
+        List<IndexRequestBuilder> requests = new ArrayList<>();
+        requests.add(client().prepareIndex("articles", "article", "1").setSource(jsonBuilder().startObject()
+                .field("title", "quick brown fox")
+                .startArray("comments")
+                .startObject()
+                .field("message", "fox eat quick")
+                .startArray("remarks").startObject().field("message", "good").endObject().endArray()
+                .endObject()
+                .endArray()
+                .endObject()));
+        requests.add(client().prepareIndex("articles", "article", "2").setSource(jsonBuilder().startObject()
+                .field("title", "big gray elephant")
+                .startArray("comments")
+                    .startObject()
+                        .field("message", "elephant captured")
+                        .startArray("remarks").startObject().field("message", "bad").endObject().endArray()
+                    .endObject()
+                .endArray()
+                .endObject()));
+        indexRandom(true, requests);
+
+        SearchResponse response = client().prepareSearch("articles")
+                .setQuery(nestedQuery("comments", nestedQuery("comments.remarks", matchQuery("comments.remarks.message", "good"))))
+                .addInnerHit("comment", new InnerHitsBuilder.InnerHit()
+                                .setPath("comments")
+                                .setQuery(nestedQuery("comments.remarks", matchQuery("comments.remarks.message", "good")))
+                                .addInnerHit("remark", new InnerHitsBuilder.InnerHit().setPath("comments.remarks").setQuery(matchQuery("comments.remarks.message", "good")))
+                ).get();
+        assertNoFailures(response);
+        assertHitCount(response, 1);
+        assertSearchHit(response, 1, hasId("1"));
+        assertThat(response.getHits().getAt(0).getInnerHits().size(), equalTo(1));
+        SearchHits innerHits = response.getHits().getAt(0).getInnerHits().get("comment");
+        assertThat(innerHits.totalHits(), equalTo(1l));
+        assertThat(innerHits.getHits().length, equalTo(1));
+        assertThat(innerHits.getAt(0).getId(), equalTo("1"));
+        assertThat(innerHits.getAt(0).getNestedIdentity().getField().string(), equalTo("comments"));
+        assertThat(innerHits.getAt(0).getNestedIdentity().getOffset(), equalTo(0));
+        innerHits = innerHits.getAt(0).getInnerHits().get("remark");
+        assertThat(innerHits.totalHits(), equalTo(1l));
+        assertThat(innerHits.getHits().length, equalTo(1));
+        assertThat(innerHits.getAt(0).getId(), equalTo("1"));
+        assertThat(innerHits.getAt(0).getNestedIdentity().getField().string(), equalTo("comments"));
+        assertThat(innerHits.getAt(0).getNestedIdentity().getOffset(), equalTo(0));
+        assertThat(innerHits.getAt(0).getNestedIdentity().getChild().getField().string(), equalTo("remarks"));
+        assertThat(innerHits.getAt(0).getNestedIdentity().getChild().getOffset(), equalTo(0));
+
+        response = client().prepareSearch("articles")
+                .setQuery(nestedQuery("comments", nestedQuery("comments.remarks", matchQuery("comments.remarks.message", "bad"))))
+                .addInnerHit("comment", new InnerHitsBuilder.InnerHit()
+                                .setPath("comments")
+                                .setQuery(nestedQuery("comments.remarks", matchQuery("comments.remarks.message", "bad")))
+                                .addInnerHit("remark", new InnerHitsBuilder.InnerHit().setPath("comments.remarks").setQuery(matchQuery("comments.remarks.message", "bad")))
+                ).get();
+        assertNoFailures(response);
+        assertHitCount(response, 1);
+        assertSearchHit(response, 1, hasId("2"));
+        assertThat(response.getHits().getAt(0).getInnerHits().size(), equalTo(1));
+        innerHits = response.getHits().getAt(0).getInnerHits().get("comment");
+        assertThat(innerHits.totalHits(), equalTo(1l));
+        assertThat(innerHits.getHits().length, equalTo(1));
+        assertThat(innerHits.getAt(0).getId(), equalTo("2"));
+        assertThat(innerHits.getAt(0).getNestedIdentity().getField().string(), equalTo("comments"));
+        assertThat(innerHits.getAt(0).getNestedIdentity().getOffset(), equalTo(0));
+        innerHits = innerHits.getAt(0).getInnerHits().get("remark");
+        assertThat(innerHits.totalHits(), equalTo(1l));
+        assertThat(innerHits.getHits().length, equalTo(1));
+        assertThat(innerHits.getAt(0).getId(), equalTo("2"));
+        assertThat(innerHits.getAt(0).getNestedIdentity().getField().string(), equalTo("comments"));
+        assertThat(innerHits.getAt(0).getNestedIdentity().getOffset(), equalTo(0));
+        assertThat(innerHits.getAt(0).getNestedIdentity().getChild().getField().string(), equalTo("remarks"));
+        assertThat(innerHits.getAt(0).getNestedIdentity().getChild().getOffset(), equalTo(0));
+    }
+
+}


### PR DESCRIPTION
Inner hits allows to embed nested inner objects, children documents or the parent document that contributed to the matching of the returned search hit as inner hits, which would otherwise be hidden.

Example search request w/ nested query:

``` bash
curl -XGET "http://localhost:9200/stack/question/_search" -d'
{
  "query": {
    "nested": {
      "path": "comments",
      "query": {
        "match": {
          "comments.text": "elasticsearch"
        }
      }
    }
  },
  "_source": {
    "include": "title"
  },
  "inner_hits": {
    "comments": {
      "path": {
        "comments": {
          "_source": {
            "include": "text"
          },
          "query": {
            "match": {
              "comments.text": "elasticsearch"
            }
          }
        }
      }
    }
  }
}'
```

Example response:

``` json
{
   "took": 16,
   "timed_out": false,
   "_shards": {
      "total": 5,
      "successful": 5,
      "failed": 0
   },
   "hits": {
      "total": 3,
      "max_score": 2.1920953,
      "hits": [
         {
            "_index": "stack",
            "_type": "question",
            "_id": "485316",
            "_score": 2.1920953,
            "_source": {
               "title": "timestamp +5 hours logstash"
            },
            "inner_hits": {
               "comments": {
                  "hits": {
                     "total": 1,
                     "max_score": 2.1920953,
                     "hits": [
                        {
                           "_index": "stack",
                           "_type": "question",
                           "_id": "485316",
                           "_nested": {
                              "field": "comments",
                              "offset": 2
                           },
                           "_score": 2.1920953,
                           "_source": {
                              "text": "So my timezone is EST which shows in the log, but the agent stamps 2013-03-06T17:03:56.934Z before it sends to elasticsearch."
                           }
                        }
                     ]
                  }
               }
            }
         },
         {
            "_index": "stack",
            "_type": "question",
            "_id": "107518",
            "_score": 1.8563976,
            "_source": {
               "title": "Web based file search in the lan?"
            },
            "inner_hits": {
               "comments": {
                  "hits": {
                     "total": 1,
                     "max_score": 1.8563976,
                     "hits": [
                        {
                           "_index": "stack",
                           "_type": "question",
                           "_id": "107518",
                           "_nested": {
                              "field": "comments",
                              "offset": 2
                           },
                           "_score": 1.8563976,
                           "_source": {
                              "text": "Did you ever settle on something? I am looking for something similar. Does Solr work? that seems to be the most common suggestion. I tried elasticsearch but didn't know how to add a network path as an index to it."
                           }
                        }
                     ]
                  }
               }
            }
         },
         {
            "_index": "stack",
            "_type": "question",
            "_id": "419532",
            "_score": 1.2994784,
            "_source": {
               "title": "How to silently buffer tunnel traffic on network split, and automatically renew the connection when possible?"
            },
            "inner_hits": {
               "comments": {
                  "hits": {
                     "total": 1,
                     "max_score": 1.2994784,
                     "hits": [
                        {
                           "_index": "stack",
                           "_type": "question",
                           "_id": "419532",
                           "_nested": {
                              "field": "comments",
                              "offset": 4
                           },
                           "_score": 1.2994784,
                           "_source": {
                              "text": "Let me elaborate. I'm using ElasticSearch replication, when network disconnects, it puts all \"cluster\" into \"yellow\" state, means writes are postponed. I want to use \"localhost\" as replica nodes' host setting in config, both in China and in Germany. Under this there will be daemons acting as tcp proxy buffer and handling disconnections nicely. That's the outline of the idea, however maybe it would better to just leave it to ElasticSearch's protocol and handle yellow state in my app."
                           }
                        }
                     ]
                  }
               }
            }
         }
      ]
   }
}
```

For documentation and more examples check the: `inner-hits.asciidoc` file.

Closes #3022, #3152
