### PR TITLE
Transport/ Java API: Fix result transport and add api methods

### DIFF
--- a/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
@@ -33,8 +33,10 @@ import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.Scroll;
 import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.significant.heuristics.SignificanceHeuristicParserMapper;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.highlight.HighlightBuilder;
+import org.elasticsearch.search.reducers.bucket.slidingwindow.SlidingWindowBuilder;
 import org.elasticsearch.search.rescore.RescoreBuilder;
 import org.elasticsearch.search.sort.SortBuilder;
 import org.elasticsearch.search.sort.SortOrder;
@@ -1068,5 +1070,11 @@ public class SearchRequestBuilder extends ActionRequestBuilder<SearchRequest, Se
 
     private SuggestBuilder suggestBuilder() {
         return sourceBuilder().suggest();
+    }
+
+    public SearchRequestBuilder addReducer(SlidingWindowBuilder two_buckets) {
+        sourceBuilder().reducer(two_buckets);
+        return this;
+
     }
 }

--- a/src/main/java/org/elasticsearch/action/search/SearchResponse.java
+++ b/src/main/java/org/elasticsearch/action/search/SearchResponse.java
@@ -99,6 +99,10 @@ public class SearchResponse extends ActionResponse implements StatusToXContent {
         return internalResponse.aggregations();
     }
 
+    public Aggregations getReductions() {
+        return internalResponse.reductions();
+    }
+
 
     public Suggest getSuggest() {
         return internalResponse.suggest();

--- a/src/main/java/org/elasticsearch/search/aggregations/ReducerBuilders.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/ReducerBuilders.java
@@ -16,27 +16,15 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.elasticsearch.search;
 
-import com.google.common.collect.ImmutableList;
-import org.elasticsearch.common.inject.AbstractModule;
-import org.elasticsearch.common.inject.Module;
-import org.elasticsearch.common.inject.SpawnModules;
-import org.elasticsearch.search.aggregations.TransportAggregationModule;
-import org.elasticsearch.search.reducers.TransportReductionModule;
+package org.elasticsearch.search.aggregations;
 
-/**
- *
- */
-public class TransportSearchModule extends AbstractModule implements SpawnModules {
 
-    @Override
-    public Iterable<? extends Module> spawnModules() {
-        return ImmutableList.of(new TransportAggregationModule(), new TransportReductionModule());
-    }
+import org.elasticsearch.search.reducers.bucket.slidingwindow.SlidingWindowBuilder;
 
-    @Override
-    protected void configure() {
+public class ReducerBuilders {
 
+    public static SlidingWindowBuilder slidingWindowReducer(String name) {
+        return new SlidingWindowBuilder(name);
     }
 }

--- a/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
+++ b/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
@@ -41,6 +41,8 @@ import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
 import org.elasticsearch.search.fetch.source.FetchSourceContext;
 import org.elasticsearch.search.highlight.HighlightBuilder;
 import org.elasticsearch.search.internal.SearchContext;
+import org.elasticsearch.search.reducers.ReductionBuilder;
+import org.elasticsearch.search.reducers.bucket.slidingwindow.SlidingWindowBuilder;
 import org.elasticsearch.search.rescore.RescoreBuilder;
 import org.elasticsearch.search.sort.SortBuilder;
 import org.elasticsearch.search.sort.SortBuilders;
@@ -109,6 +111,7 @@ public class SearchSourceBuilder implements ToXContent {
     private List<AbstractAggregationBuilder> aggregations;
     private BytesReference aggregationsBinary;
 
+    private List<ReductionBuilder> reducers;
 
     private HighlightBuilder highlightBuilder;
 
@@ -844,6 +847,15 @@ public class SearchSourceBuilder implements ToXContent {
             builder.endObject();
         }
 
+        if (reducers != null) {
+            builder.field("reducers");
+            builder.startObject();
+            for (ReductionBuilder reducer : reducers) {
+                reducer.toXContent(builder, params);
+            }
+            builder.endObject();
+        }
+
         if (aggregationsBinary != null) {
             if (XContentFactory.xContentType(aggregationsBinary) == builder.contentType()) {
                 builder.rawField("aggregations", aggregationsBinary);
@@ -902,6 +914,13 @@ public class SearchSourceBuilder implements ToXContent {
 
         builder.endObject();
         return builder;
+    }
+
+    public void reducer(ReductionBuilder reducer) {
+        if (reducers == null) {
+            reducers = Lists.newArrayList();
+        }
+        reducers.add(reducer);
     }
 
     private static class ScriptField {

--- a/src/main/java/org/elasticsearch/search/reducers/ReducerParsers.java
+++ b/src/main/java/org/elasticsearch/search/reducers/ReducerParsers.java
@@ -81,12 +81,7 @@ public class ReducerParsers {
         ReducerFactories.Builder factories = new ReducerFactories.Builder();
 
         XContentParser.Token token = null;
-        while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
-            if (token != XContentParser.Token.START_OBJECT) {
-                throw new SearchParseException(context, "Unexpected token " + token + " in [reducers]: reductions array must contain reduction definition objects.");
-            }
-
-            token = parser.nextToken();
+        while ((token = parser.nextToken()) != Token.END_OBJECT) {
             if (token != XContentParser.Token.FIELD_NAME) {
                 throw new SearchParseException(context, "Unexpected token " + token + " in [reducers]: reductions definitions must start with the name of the reduction.");
             }
@@ -133,7 +128,6 @@ public class ReducerParsers {
                 }
             }
 
-            token = parser.nextToken();
             if (token != XContentParser.Token.END_OBJECT) {
                 throw new SearchParseException(context, "Unexpected token " + token + " in [reducers]: expected " + Token.END_OBJECT + ".");
             }

--- a/src/main/java/org/elasticsearch/search/reducers/bucket/InternalBucketReducerAggregation.java
+++ b/src/main/java/org/elasticsearch/search/reducers/bucket/InternalBucketReducerAggregation.java
@@ -40,7 +40,6 @@ import java.util.Map;
 
 public abstract class InternalBucketReducerAggregation extends InternalAggregation implements BucketReducerAggregation {
 
-    private String name;
     private List<InternalSelection> selections;
     private Map<String, Selection> selectionMap;
 
@@ -123,9 +122,11 @@ public abstract class InternalBucketReducerAggregation extends InternalAggregati
                 bucket.toXContent(builder, params);
             }
             builder.endArray();
-            builder.startObject("reductions");
-            aggregations.toXContentInternal(builder, params);
-            builder.endObject();
+            if (aggregations != null) {
+                builder.startObject("reductions");
+                aggregations.toXContentInternal(builder, params);
+                builder.endObject();
+            }
             builder.endObject();
             return builder;
         }

--- a/src/main/java/org/elasticsearch/search/reducers/bucket/slidingwindow/SlidingWindowBuilder.java
+++ b/src/main/java/org/elasticsearch/search/reducers/bucket/slidingwindow/SlidingWindowBuilder.java
@@ -29,16 +29,18 @@ public class SlidingWindowBuilder extends ReductionBuilder<SlidingWindowBuilder>
     private String path = null;
     private Integer windowSize = null;
 
-    protected SlidingWindowBuilder(String name) {
+    public SlidingWindowBuilder(String name) {
         super(name, InternalSlidingWindow.TYPE.name());
     }
 
-    public void path(String path) {
+    public SlidingWindowBuilder path(String path) {
         this.path = path;
+        return this;
     }
 
-    public void windowSize(int windowSize) {
+    public SlidingWindowBuilder windowSize(int windowSize) {
         this.windowSize = windowSize;
+        return this;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/reducers/metric/delta/DeltaReducer.java
+++ b/src/main/java/org/elasticsearch/search/reducers/metric/delta/DeltaReducer.java
@@ -25,6 +25,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.bucket.BucketStreamContext;
 import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
+import org.elasticsearch.search.aggregations.metrics.MetricsAggregator;
 import org.elasticsearch.search.reducers.*;
 
 import java.io.IOException;
@@ -51,6 +52,8 @@ public class DeltaReducer extends Reducer {
     @Override
     public InternalAggregation doReduce(MultiBucketsAggregation aggregation, BytesReference bucketType,
             BucketStreamContext bucketStreamContext) throws ReductionExecutionException {
+        //compute diff
+        MultiBucketsAggregation.Bucket bucket0 = aggregation.getBuckets().get(0);
         return null;
     }
 

--- a/src/test/java/org/elasticsearch/search/aggregations/reducers/SlidingWindowTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/reducers/SlidingWindowTests.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.reducers;
+
+
+import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.search.aggregations.Aggregation;
+import org.elasticsearch.search.aggregations.Aggregations;
+import org.elasticsearch.search.reducers.bucket.BucketReducerAggregation;
+import org.elasticsearch.search.reducers.bucket.slidingwindow.InternalSlidingWindow;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.histogram;
+import static org.elasticsearch.search.aggregations.ReducerBuilders.slidingWindowReducer;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
+import static org.hamcrest.core.Is.is;
+
+public class SlidingWindowTests extends ElasticsearchIntegrationTest {
+
+    @Test
+    public void testBasicSelection() throws IOException, ExecutionException, InterruptedException {
+        indexData();
+        SearchResponse searchResponse = client().prepareSearch("index").addAggregation(histogram("histo").field("hist_field").interval(10)).addReducer(slidingWindowReducer("two_buckets").path("histo").windowSize(5)).get();
+        assertSearchResponse(searchResponse);
+        Aggregations reductions = searchResponse.getReductions();
+        Aggregation slidingWindow = reductions.getAsMap().get("two_buckets");
+        assertNotNull(slidingWindow);
+        assertTrue(slidingWindow instanceof InternalSlidingWindow);
+        for (BucketReducerAggregation.Selection window : ((InternalSlidingWindow)slidingWindow).getSelections()) {
+            assertThat(window.getBuckets().size(), is(5));
+        }
+    }
+
+    private void indexData() throws IOException, ExecutionException, InterruptedException {
+        List<IndexRequestBuilder> indexRequests = new ArrayList<>();
+        for (int i = 0; i<100; i++ ) {
+            indexRequests.add(client().prepareIndex("index", "type").setSource(jsonBuilder()
+                    .startObject()
+                    .field("hist_field", i)
+                    .endObject()));
+        }
+        indexRandom(true, true, indexRequests);
+    }
+}


### PR DESCRIPTION
Also this commit changes request structure. "reducers" shoudl be given as object
and not as array to be consistent with aggregations.

```
"reducers": [
   "reducer1": {...
...
]
```

becomes

```
"reducers": {
   "reducer1": {...
...
}
```
