### PR TITLE
Handle failed request when auto create index is disabled

### DIFF
--- a/src/test/java/org/elasticsearch/action/bulk/BulkProcessorClusterSettingsTests.java
+++ b/src/test/java/org/elasticsearch/action/bulk/BulkProcessorClusterSettingsTests.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.bulk;
+
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
+import org.elasticsearch.test.ElasticsearchIntegrationTest.Scope;
+import org.junit.Test;
+
+@ClusterScope(scope = Scope.TEST, numDataNodes = 0)
+public class BulkProcessorClusterSettingsTests extends ElasticsearchIntegrationTest {
+
+    @Test
+    public void testBulkProcessorAutoCreateRestrictions() throws Exception {
+        // See issue #8125
+        Settings settings = ImmutableSettings.settingsBuilder().put("action.auto_create_index", false).build();
+
+        internalCluster().startNode(settings);
+
+        createIndex("willwork");
+        client().admin().cluster().prepareHealth("willwork").setWaitForGreenStatus().execute().actionGet();
+
+        BulkRequestBuilder bulkRequestBuilder = client().prepareBulk();
+        bulkRequestBuilder.add(client().prepareIndex("willwork", "type1", "1").setSource("{\"foo\":1}"));
+        bulkRequestBuilder.add(client().prepareIndex("wontwork", "type1", "2").setSource("{\"foo\":2}"));
+        bulkRequestBuilder.add(client().prepareIndex("willwork", "type1", "3").setSource("{\"foo\":3}"));
+        BulkResponse br = bulkRequestBuilder.get();
+        BulkItemResponse[] responses = br.getItems();
+        assertEquals(3, responses.length);
+        assertFalse("Operation on existing index should succeed", responses[0].isFailed());
+        assertTrue("Missing index should have been flagged", responses[1].isFailed());
+        assertEquals("IndexMissingException[[wontwork] missing]", responses[1].getFailureMessage());
+        assertFalse("Operation on existing index should succeed", responses[2].isFailed());
+    }
+}


### PR DESCRIPTION
If a bulk request contains a mix of indexing requests for an existing index and one that needs to be auto-created but a cluster configuration prevents the auto-create of the new index, the ingest process hangs. The exception for the failure to create an index was not caught or reported back properly. Added a Junit test to recreate the issue and the associated fix is in TransportBulkAction.

Closes #8125
