### PR TITLE
In fixed bitset service fix order where the warmer listener is added.

### DIFF
--- a/src/main/java/org/elasticsearch/index/cache/fixedbitset/FixedBitSetFilterCache.java
+++ b/src/main/java/org/elasticsearch/index/cache/fixedbitset/FixedBitSetFilterCache.java
@@ -94,6 +94,10 @@ public class FixedBitSetFilterCache extends AbstractIndexComponent implements At
     @Inject(optional = true)
     public void setIndicesWarmer(IndicesWarmer indicesWarmer) {
         this.indicesWarmer = indicesWarmer;
+    }
+
+    public void setIndexService(InternalIndexService indexService) {
+        this.indexService = indexService;
         indicesWarmer.addListener(warmer);
     }
 
@@ -162,10 +166,6 @@ public class FixedBitSetFilterCache extends AbstractIndexComponent implements At
                 return value;
             }
         }).fixedBitSet;
-    }
-
-    public void setIndexService(InternalIndexService indexService) {
-        this.indexService = indexService;
     }
 
     @Override
@@ -283,10 +283,10 @@ public class FixedBitSetFilterCache extends AbstractIndexComponent implements At
                                 final long start = System.nanoTime();
                                 getAndLoadIfNotPresent(filterToWarm, ctx);
                                 if (indexShard.warmerService().logger().isTraceEnabled()) {
-                                    indexShard.warmerService().logger().trace("warmed random access for [{}], took [{}]", filterToWarm, TimeValue.timeValueNanos(System.nanoTime() - start));
+                                    indexShard.warmerService().logger().trace("warmed fixed bitset for [{}], took [{}]", filterToWarm, TimeValue.timeValueNanos(System.nanoTime() - start));
                                 }
                             } catch (Throwable t) {
-                                indexShard.warmerService().logger().warn("failed to load random access for [{}]", t, filterToWarm);
+                                indexShard.warmerService().logger().warn("failed to load fixed bitset for [{}]", t, filterToWarm);
                             } finally {
                                 latch.countDown();
                             }


### PR DESCRIPTION
Add warmer listener only when index service is set, in order to prevent possible NPE.

The IndicesWarmer gets set before the InternalIndexService gets set, which can lead to a small time window were InternalIndexService isn't set

Closes #8140
