### PR TITLE
This adds ability to specify 'named' threadpool to searches.

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
+++ b/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.Version;
+import org.elasticsearch.common.Booleans;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -72,7 +73,7 @@ public class DiscoveryNode implements Streamable, Serializable {
 
     public static boolean clientNode(Settings settings) {
         String client = settings.get("node.client");
-        return client != null && client.equals("true");
+        return Booleans.isExplicitTrue(client);
     }
 
     public static boolean masterNode(Settings settings) {
@@ -80,7 +81,7 @@ public class DiscoveryNode implements Streamable, Serializable {
         if (master == null) {
             return !clientNode(settings);
         }
-        return master.equals("true");
+        return Booleans.isExplicitTrue(master);
     }
 
     public static boolean dataNode(Settings settings) {
@@ -88,7 +89,7 @@ public class DiscoveryNode implements Streamable, Serializable {
         if (data == null) {
             return !clientNode(settings);
         }
-        return data.equals("true");
+        return Booleans.isExplicitTrue(data);
     }
 
     public static final ImmutableList<DiscoveryNode> EMPTY_LIST = ImmutableList.of();
@@ -244,7 +245,7 @@ public class DiscoveryNode implements Streamable, Serializable {
         if (data == null) {
             return !clientNode();
         }
-        return data.equals("true");
+        return Booleans.parseBooleanExact(data);
     }
 
     /**
@@ -259,7 +260,7 @@ public class DiscoveryNode implements Streamable, Serializable {
      */
     public boolean clientNode() {
         String client = attributes.get("client");
-        return client != null && client.equals("true");
+        return client != null && Booleans.parseBooleanExact(client);
     }
 
     public boolean isClientNode() {
@@ -274,7 +275,7 @@ public class DiscoveryNode implements Streamable, Serializable {
         if (master == null) {
             return !clientNode();
         }
-        return master.equals("true");
+        return Booleans.parseBooleanExact(master);
     }
 
     /**

--- a/src/main/java/org/elasticsearch/common/Booleans.java
+++ b/src/main/java/org/elasticsearch/common/Booleans.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.common;
 
+import org.elasticsearch.ElasticsearchParseException;
+
 /**
  *
  */
@@ -76,6 +78,26 @@ public class Booleans {
             return (text[offset] == 'f' && text[offset + 1] == 'a' && text[offset + 2] == 'l' && text[offset + 3] == 's' && text[offset + 4] == 'e');
         }
         return false;
+    }
+
+    /***
+     *
+     * @param value
+     * @return true/false
+     * throws exception if string cannot be parsed to boolean
+     */
+    public static Boolean parseBooleanExact(String value){
+        if (value != null) {
+            boolean isFalse = (value.equals("false") || value.equals("0") || value.equals("off") || value.equals("no"));
+            if (isFalse) {
+                return false;
+            }
+            boolean isTrue = (value.equals("true") || value.equals("1") || value.equals("on") || value.equals("yes"));
+            if (isTrue) {
+                return true;
+            }
+        }
+        throw new ElasticsearchParseException("value cannot be parsed to boolean [ true/1/on/yes OR false/0/off/no ]  ");
     }
 
     public static Boolean parseBoolean(String value, Boolean defaultValue) {


### PR DESCRIPTION
Currently all searches uses SEARCH thread pool to run queries. However if we have programs using ES with different 'interests' and 'SLA's' -they can block each others queries.

Example:
- 'fred' indexes documents, but does some denormalization and needs to query ES for that purpose.
- 'barney' queries same ES cluster to serve website traffic.

fred's queries get queued in thread pool due to large amount of queries from barney at times ; fred is okay with 800 ms while barney needs query response by 200 ms.

Named threadpools need to be configured in yml explicitly, eg:

```
threadpool:
     fred:
        type: fixed
        size: 30
```

[ Here fred , named threadpool is configured with default size of 30]

SearchRequestBuilder and ScrollRequestBuilder takes threadpool name ,
but defaults to SEARCH. REST API accepts new http parameter 'threadpool'
which can take name of threadpool to run queries.

```
curl -XPUT "http://localhost:9200/movies/movie/1" -d'
> {
>     "title": "The Godfather",
>     "director": "Francis Ford Coppola",
>     "year": 1972,
>     "genres": ["Crime", "Drama"]
> }'
```
## Call with 'custom' threadpool

```
curl 'localhost:9200/_search?q=*&threadpool=fred'
```
## Invalid threadpool name

```
curl 'localhost:9200/_search?q=*&threadpool=barney

{"error":"SearchPhaseExecutionException[Failed to execute phase [query], all shards failed; shardFailures {[J8vv81u1SKK5BUizD5Yppw][movies][0]: ElasticsearchIllegalArgumentException[No executor found for [pollois]]}{[J8vv81u1SKK5BUizD5Yppw][movies][1]: ElasticsearchIllegalArgumentException[No executor found for [pollois]]}{[J8vv81u1SKK5BUizD5Yppw][movies][2]: ElasticsearchIllegalArgumentException[No executor found for [pollois]]}{[J8vv81u1SKK5BUizD5Yppw][movies][3]: ElasticsearchIllegalArgumentException[No executor found for [pollois]]}{[J8vv81u1SKK5BUizD5Yppw][movies][4]: ElasticsearchIllegalArgumentException[No executor found for [pollois]]}]","status":400}
```

Thanks to way original code is done - _stats shows new threadpool stats

Closes #8124
