### PR TITLE
Use groovy-x.y.z-indy jar for better scripting performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -278,6 +278,7 @@
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
             <version>2.3.2</version>
+            <classifier>indy</classifier>
             <scope>compile</scope>
             <optional>true</optional>
         </dependency>


### PR DESCRIPTION
Using the Groovy jar with the indy (short for `invokedynamic`) classifier enables usage of the `invokedynamic` instruction available in Java 7+. Due to buggy JVMs, it should only be used with Java 7u60 or later.

Closes #8182 
