### PR TITLE
Validates bool values in yaml for node settings

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
+++ b/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.Version;
+import org.elasticsearch.common.Booleans;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -72,7 +73,7 @@ public class DiscoveryNode implements Streamable, Serializable {
 
     public static boolean clientNode(Settings settings) {
         String client = settings.get("node.client");
-        return client != null && client.equals("true");
+        return Booleans.isExplicitTrue(client);
     }
 
     public static boolean masterNode(Settings settings) {
@@ -80,7 +81,7 @@ public class DiscoveryNode implements Streamable, Serializable {
         if (master == null) {
             return !clientNode(settings);
         }
-        return master.equals("true");
+        return Booleans.isExplicitTrue(master);
     }
 
     public static boolean dataNode(Settings settings) {
@@ -88,7 +89,7 @@ public class DiscoveryNode implements Streamable, Serializable {
         if (data == null) {
             return !clientNode(settings);
         }
-        return data.equals("true");
+        return Booleans.isExplicitTrue(data);
     }
 
     public static final ImmutableList<DiscoveryNode> EMPTY_LIST = ImmutableList.of();
@@ -244,7 +245,7 @@ public class DiscoveryNode implements Streamable, Serializable {
         if (data == null) {
             return !clientNode();
         }
-        return data.equals("true");
+        return Booleans.parseBooleanExact(data);
     }
 
     /**
@@ -259,7 +260,7 @@ public class DiscoveryNode implements Streamable, Serializable {
      */
     public boolean clientNode() {
         String client = attributes.get("client");
-        return client != null && client.equals("true");
+        return client != null && Booleans.parseBooleanExact(client);
     }
 
     public boolean isClientNode() {
@@ -274,7 +275,7 @@ public class DiscoveryNode implements Streamable, Serializable {
         if (master == null) {
             return !clientNode();
         }
-        return master.equals("true");
+        return Booleans.parseBooleanExact(master);
     }
 
     /**

--- a/src/main/java/org/elasticsearch/common/Booleans.java
+++ b/src/main/java/org/elasticsearch/common/Booleans.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.common;
 
+import org.elasticsearch.ElasticsearchIllegalArgumentException;
 /**
  *
  */
@@ -76,6 +77,26 @@ public class Booleans {
             return (text[offset] == 'f' && text[offset + 1] == 'a' && text[offset + 2] == 'l' && text[offset + 3] == 's' && text[offset + 4] == 'e');
         }
         return false;
+    }
+
+    /***
+     *
+     * @param value
+     * @return true/false
+     * throws exception if string cannot be parsed to boolean
+     */
+    public static Boolean parseBooleanExact(String value){
+
+        boolean isFalse = isExplicitFalse(value);
+        if (isFalse) {
+            return false;
+        }
+        boolean isTrue = isExplicitTrue(value);
+        if (isTrue) {
+            return true;
+        }
+
+        throw new ElasticsearchIllegalArgumentException("value cannot be parsed to boolean [ true/1/on/yes OR false/0/off/no ]  ");
     }
 
     public static Boolean parseBoolean(String value, Boolean defaultValue) {

--- a/src/test/java/org/elasticsearch/common/BooleansTests.java
+++ b/src/test/java/org/elasticsearch/common/BooleansTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.common;
 
+import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -67,6 +68,18 @@ public class BooleansTests extends ElasticsearchTestCase {
         assertThat(Booleans.parseBoolean(chars,0, chars.length, randomBoolean()), is(false));
         chars = randomFrom("true", "on", "yes").toUpperCase(Locale.ROOT).toCharArray();
         assertThat(Booleans.parseBoolean(chars,0, chars.length, randomBoolean()), is(true));
+    }
+
+    @Test
+    public void parseBooleanExact() {
+        assertThat(Booleans.parseBooleanExact(randomFrom("true", "on", "yes", "1")), is(true));
+        assertThat(Booleans.parseBooleanExact(randomFrom("false", "off", "no", "0")), is(false));
+        try {
+            Booleans.parseBooleanExact(randomFrom(null, "fred", "foo", "barney"));
+            fail("Expected exception while parsing invalid boolean value ");
+        } catch (Exception ex) {
+            assertTrue(ex instanceof ElasticsearchIllegalArgumentException);
+        }
     }
 
     public void testIsExplict() {


### PR DESCRIPTION
- Added parseBooleanExact in booleans which throws exception in case of
  parse failure
- Used ParseExact in static's to make it consistent

Closes #8097 
