### PR TITLE
Aggregations: new “Sampler” provides a filter for top-scoring docs

### DIFF
--- a/docs/reference/search/aggregations/bucket.asciidoc
+++ b/docs/reference/search/aggregations/bucket.asciidoc
@@ -18,6 +18,8 @@ include::bucket/terms-aggregation.asciidoc[]
 
 include::bucket/significantterms-aggregation.asciidoc[]
 
+include::bucket/sampler-aggregation.asciidoc[]
+
 include::bucket/range-aggregation.asciidoc[]
 
 include::bucket/daterange-aggregation.asciidoc[]

--- a/docs/reference/search/aggregations/bucket/sampler-aggregation.asciidoc
+++ b/docs/reference/search/aggregations/bucket/sampler-aggregation.asciidoc
@@ -1,0 +1,87 @@
+[[search-aggregations-bucket-sampler-aggregation]]
+=== Sampler Aggregation
+
+An aggregation that filters the analysis of documents to a subset of the top-matching results.
+
+.The factors we want to control when we sample are: 
+* Quantity - some combinations of queries, datasets and aggregations can be expensive to run so we can cap the numbers of documents considered on each shard
+* Quality - some of the "fuzzier" searches can have a long-tail of low-quality results which we want to ignore
+
+
+==== Example usage
+
+An example problem that might require sampling is in a product recommendation scenario where we might want to use some example movie IDs to query 
+an index of user profiles which list their favourite viewings.
+This sort of query can match a large number of user profiles, some of which may have extensive lists of their favourite movies to be considered.
+We don't need to look at all user profiles to make useful recommendations and so we can use the `sampler` aggregation to to cap the processing time.
+
+Example:
+
+[source,js]
+--------------------------------------------------
+{
+    "query": {
+        "terms": {
+            "liked_movie_id": [
+                46970,
+                3726
+            ]
+        },
+        "aggregations": {
+            "sample": {
+                "sampler": {
+                    "shard_size": 1000
+                },
+                "aggregations": {
+                    "recommendations": {
+                        "significant_terms": {
+                            "field": "liked_movie_id"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+--------------------------------------------------
+
+Response:
+
+[source,js]
+--------------------------------------------------
+{
+	...
+    "aggregations": {
+        "sample": {
+            "doc_count": 2000,
+            "recommendations": {
+                "doc_count": 2000,
+                "buckets": [
+                    {
+                        "key": "31289",
+                        "doc_count": 1340,
+                        "score": 2.371,
+                        "bg_count": 66799
+                    }
+                    ...
+                ]
+            }
+        }
+    }
+}
+--------------------------------------------------
+Note the final doc_count in our sample is 2,000 - this is because the requested limit of 1,000 is per-shard
+and so we have 2 shards in this example.
+
+==== Options
+
+[horizontal]
+shard_size::    Optional. The maximum number of documents sampled on each shard. 
+				Defaults to 100
+
+random_sample::    Optional. Set to true to take a random sample of documents rather than top-scoring documents. 
+				Defaults to false
+
+
+
+

--- a/src/main/java/org/elasticsearch/search/aggregations/AggregationBuilders.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/AggregationBuilders.java
@@ -46,6 +46,8 @@ import org.elasticsearch.search.aggregations.bucket.range.geodistance.GeoDistanc
 import org.elasticsearch.search.aggregations.bucket.range.geodistance.GeoDistanceBuilder;
 import org.elasticsearch.search.aggregations.bucket.range.ipv4.IPv4Range;
 import org.elasticsearch.search.aggregations.bucket.range.ipv4.IPv4RangeBuilder;
+import org.elasticsearch.search.aggregations.bucket.sampler.SamplerAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.sampler.SamplerAggregator;
 import org.elasticsearch.search.aggregations.bucket.significant.SignificantTerms;
 import org.elasticsearch.search.aggregations.bucket.significant.SignificantTermsBuilder;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
@@ -202,6 +204,13 @@ public class AggregationBuilders {
      */
     public static GeoHashGridBuilder geohashGrid(String name) {
         return new GeoHashGridBuilder(name);
+    }
+
+    /**
+     * Create a new {@link SamplerAggregator} aggregation with the given name.
+     */
+    public static SamplerAggregationBuilder sampler(String name) {
+        return new SamplerAggregationBuilder(name);
     }
 
     /**

--- a/src/main/java/org/elasticsearch/search/aggregations/AggregationModule.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/AggregationModule.java
@@ -38,6 +38,7 @@ import org.elasticsearch.search.aggregations.bucket.range.RangeParser;
 import org.elasticsearch.search.aggregations.bucket.range.date.DateRangeParser;
 import org.elasticsearch.search.aggregations.bucket.range.geodistance.GeoDistanceParser;
 import org.elasticsearch.search.aggregations.bucket.range.ipv4.IpRangeParser;
+import org.elasticsearch.search.aggregations.bucket.sampler.SamplerParser;
 import org.elasticsearch.search.aggregations.bucket.significant.SignificantTermsParser;
 import org.elasticsearch.search.aggregations.bucket.significant.heuristics.SignificantTermsHeuristicModule;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsParser;
@@ -82,6 +83,7 @@ public class AggregationModule extends AbstractModule implements SpawnModules{
         parsers.add(FiltersParser.class);
         parsers.add(TermsParser.class);
         parsers.add(SignificantTermsParser.class);
+        parsers.add(SamplerParser.class);
         parsers.add(RangeParser.class);
         parsers.add(DateRangeParser.class);
         parsers.add(IpRangeParser.class);

--- a/src/main/java/org/elasticsearch/search/aggregations/TransportAggregationModule.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/TransportAggregationModule.java
@@ -36,6 +36,7 @@ import org.elasticsearch.search.aggregations.bucket.range.InternalRange;
 import org.elasticsearch.search.aggregations.bucket.range.date.InternalDateRange;
 import org.elasticsearch.search.aggregations.bucket.range.geodistance.InternalGeoDistance;
 import org.elasticsearch.search.aggregations.bucket.range.ipv4.InternalIPv4Range;
+import org.elasticsearch.search.aggregations.bucket.sampler.InternalSampler;
 import org.elasticsearch.search.aggregations.bucket.significant.SignificantLongTerms;
 import org.elasticsearch.search.aggregations.bucket.significant.SignificantStringTerms;
 import org.elasticsearch.search.aggregations.bucket.significant.UnmappedSignificantTerms;
@@ -103,6 +104,7 @@ public class TransportAggregationModule extends AbstractModule implements SpawnM
         InternalTopHits.registerStreams();
         InternalGeoBounds.registerStream();
         InternalChildren.registerStream();
+        InternalSampler.registerStreams();
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/BestBucketsDeferringCollector.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/BestBucketsDeferringCollector.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.bucket;
+
+import org.apache.lucene.index.AtomicReaderContext;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.lease.Releasables;
+import org.elasticsearch.search.aggregations.Aggregator;
+import org.elasticsearch.search.aggregations.BucketCollector;
+import org.elasticsearch.search.aggregations.FilteringBucketCollector;
+import org.elasticsearch.search.aggregations.RecordingBucketCollector;
+import org.elasticsearch.search.aggregations.RecordingPerReaderBucketCollector;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
+import org.elasticsearch.search.query.QueryPhaseExecutionException;
+
+import java.io.IOException;
+
+/**
+ * Buffers the matches in a collect stream and can replay a subset of the collected buckets
+ * to a deferred set of collectors.
+ * The rationale for not bundling all this logic into {@link RecordingBucketCollector} is to allow
+ * the possibility of alternative recorder impl choices while keeping the logic in here for
+ * setting {@link AggregationContext}'s setNextReader method and preparing the appropriate choice 
+ * of filtering logic for stream replay. These felt like agg-specific functions that should be kept away
+ * from the {@link RecordingBucketCollector} impl which is concentrated on efficient storage of doc and bucket IDs  
+ */
+public class BestBucketsDeferringCollector extends DeferringBucketCollector {
+    
+    private final RecordingBucketCollector recording;
+    private FilteringBucketCollector filteredCollector;
+
+
+    public BestBucketsDeferringCollector (BucketCollector deferred, AggregationContext context) {
+        this(deferred, context, new RecordingPerReaderBucketCollector(context));
+    }
+
+    protected BestBucketsDeferringCollector(BucketCollector deferred, AggregationContext context, RecordingBucketCollector recording) {
+        super(deferred, context);
+        this.recording = recording;
+
+    }
+
+    @Override
+    public void setNextReader(AtomicReaderContext reader) {
+        recording.setNextReader(reader);
+    }
+
+    @Override
+    public void collect(int docId, long bucketOrdinal) throws IOException {
+        recording.collect(docId, bucketOrdinal);
+    }
+
+    @Override
+    public void postCollection() throws IOException {
+        recording.postCollection();
+    }
+    
+    /**
+     * Plays a selection of the data cached from previous collect calls to the
+     * deferred collector.
+     * 
+     * @param survivingBucketOrds
+     *            the valid bucket ords for which deferred collection should be
+     *            attempted
+     */
+    public void prepareSelectedBuckets(long... survivingBucketOrds) {
+        context.setScorer(Aggregator.unavailableScorer);
+        
+        BucketCollector subs = new BucketCollector() {
+            @Override
+            public void setNextReader(AtomicReaderContext reader) {
+                // Need to set AggregationContext otherwise ValueSources in aggs
+                // don't read any values
+              context.setNextReader(reader);
+              deferred.setNextReader(reader);
+            }
+
+            @Override
+            public void collect(int docId, long bucketOrdinal) throws IOException {
+                deferred.collect(docId, bucketOrdinal);
+            }
+
+            @Override
+            public void postCollection() throws IOException {
+                deferred.postCollection();
+            }
+
+            @Override
+            public void gatherAnalysis(BucketAnalysisCollector results, long bucketOrdinal) {
+                deferred.gatherAnalysis(results, bucketOrdinal);
+            }
+        };
+
+        filteredCollector = new FilteringBucketCollector(survivingBucketOrds, subs, context.bigArrays());
+        try {
+            recording.replayCollection(filteredCollector);
+        } catch (IOException e) {
+            throw new QueryPhaseExecutionException(context.searchContext(), "Failed to replay deferred set of matching docIDs", e);
+        }
+    }
+
+    
+
+    @Override
+    public void close() throws ElasticsearchException {
+        Releasables.close(recording, filteredCollector);
+    }
+
+    @Override
+    public void gatherAnalysis(BucketAnalysisCollector analysisCollector, long bucketOrdinal)  {
+        filteredCollector.gatherAnalysis(analysisCollector, bucketOrdinal);
+    }
+
+}

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/BestDocsDeferringCollector.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/BestDocsDeferringCollector.java
@@ -1,0 +1,218 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.bucket;
+
+import org.apache.lucene.index.AtomicReaderContext;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TopDocsCollector;
+import org.apache.lucene.search.TopScoreDocCollector;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.ElasticsearchIllegalArgumentException;
+import org.elasticsearch.common.lucene.ScorerAware;
+import org.elasticsearch.search.aggregations.BucketCollector;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * A {@link DeferringBucketCollector} that identifies the top-scoring documents
+ * in search results and then passes only these on to nested collectors. This
+ * implementation is only for use with a single bucket aggregation.
+ * "Top-scoring" means the Lucene score but subclasses can provide an
+ * alternative {@link TopDocsCollector} that uses other criteria.
+ */
+public class BestDocsDeferringCollector extends DeferringBucketCollector implements ScorerAware {
+
+    protected TopDocsCollector<? extends ScoreDoc> topDocsCollector;
+    private final List<PerSegmentCollects> perSegmentCollections = new ArrayList<>();
+    private PerSegmentCollects currentCollection;
+    protected Scorer currentScorer;
+    private boolean collectCompleted;
+    private int matchedDocCount = 0;
+
+    public BestDocsDeferringCollector(BucketCollector deferred, AggregationContext context, int shardSize) {
+        super(deferred, context);
+        topDocsCollector = createTopDocsCollector(shardSize);
+        currentScorer = context.currentScorer();
+        // Keep abreast of scorer changes
+        context.registerScorerAware(this);
+    }
+
+    // Designed to be overridden by subclasses that may score docs by criteria
+    // other than Lucene score
+    protected TopDocsCollector<? extends ScoreDoc> createTopDocsCollector(int size) {
+        return TopScoreDocCollector.create(size, context.scoreDocsInOrder());
+    }
+
+    class PerSegmentCollects extends Scorer {
+        private AtomicReaderContext readerContext;
+        int maxDocId = Integer.MIN_VALUE;
+        private float currentScore;
+        private int currentDocId = -1;
+
+        PerSegmentCollects(AtomicReaderContext readerContext) {
+            // The publisher behaviour for Reader/Scorer listeners triggers a
+            // call to this constructor with a null scorer so we can't call
+            // scorer.getWeight() and pass the Weight to our base class.
+            // However, passing null seems to have no adverse effects here...
+            super(null);
+            this.readerContext = readerContext;
+        }
+
+        public void replayRelatedMatches(ScoreDoc[] sd) throws IOException {
+            // Need to set AggregationContext otherwise ValueSources in aggs
+            // don't read any values
+            context.setNextReader(readerContext);
+            deferred.setNextReader(readerContext);
+            currentScore = 0;
+            currentDocId = -1;
+            context.setScorer(this);
+            if (maxDocId < 0) {
+                return;
+            }
+            for (ScoreDoc scoreDoc : sd) {
+                // Doc ids from TopDocCollector are root-level Reader so
+                // need rebasing
+                int rebased = scoreDoc.doc - readerContext.docBase;
+                if ((rebased >= 0) && (rebased <= maxDocId)) {
+                    currentScore = scoreDoc.score;
+                    currentDocId = rebased;
+                    deferred.collect(rebased, 0);
+                }
+            }
+
+        }
+
+        @Override
+        public float score() throws IOException {
+            return currentScore;
+        }
+
+        @Override
+        public int freq() throws IOException {
+            throw new ElasticsearchException("This caching scorer implementation only implements score() and docID()");
+        }
+
+        @Override
+        public int docID() {
+            return currentDocId;
+        }
+
+        @Override
+        public int nextDoc() throws IOException {
+            throw new ElasticsearchException("This caching scorer implementation only implements score() and docID()");
+        }
+
+        @Override
+        public int advance(int target) throws IOException {
+            throw new ElasticsearchException("This caching scorer implementation only implements score() and docID()");
+        }
+
+        @Override
+        public long cost() {
+            throw new ElasticsearchException("This caching scorer implementation only implements score() and docID()");
+        }
+
+        public void collect(int docId) throws IOException {
+            topDocsCollector.collect(docId);
+            maxDocId = Math.max(maxDocId, docId);
+        }
+    }
+
+    @Override
+    public void setNextReader(AtomicReaderContext reader) {
+        if (collectCompleted) {
+            return;
+        }
+        currentCollection = new PerSegmentCollects(reader);
+        perSegmentCollections.add(currentCollection);
+        try {
+            topDocsCollector.setNextReader(reader);
+        } catch (IOException e) {
+            throw new ElasticsearchException("IOException collecting best scoring results", e);
+        }
+    }
+
+    @Override
+    public void collect(int docId, long bucketOrdinal) throws IOException {
+        if (bucketOrdinal != 0) {
+            throw new ElasticsearchIllegalArgumentException("Bucket ordinals must all be zero, received " + bucketOrdinal);
+        }
+        currentCollection.collect(docId);
+    }
+
+    @Override
+    public void postCollection() throws IOException {
+        collectCompleted = true;
+    }
+
+    @Override
+    public void close() throws ElasticsearchException {
+    }
+
+    @Override
+    public void prepareSelectedBuckets(long... survivingBucketOrds) {
+        TopDocs topDocs = topDocsCollector.topDocs();
+        ScoreDoc[] sd = topDocs.scoreDocs;
+        matchedDocCount = sd.length;
+        // Sort the top matches by docID for the benefit of deferred collector
+        Arrays.sort(sd, new Comparator<ScoreDoc>() {
+            @Override
+            public int compare(ScoreDoc o1, ScoreDoc o2) {
+                return o1.doc - o2.doc;
+            }
+        });
+        try {
+            for (PerSegmentCollects perSegDocs : perSegmentCollections) {
+                perSegDocs.replayRelatedMatches(sd);
+            }
+            deferred.postCollection();
+        } catch (IOException e) {
+            throw new ElasticsearchException("IOException collecting best scoring results", e);
+        }
+    }
+
+    @Override
+    public void gatherAnalysis(BucketAnalysisCollector analysisCollector, long bucketOrdinal) {
+        deferred.gatherAnalysis(analysisCollector, bucketOrdinal);
+    }
+
+    @Override
+    public void setScorer(Scorer scorer) {
+        try {
+            currentScorer = scorer;
+            topDocsCollector.setScorer(scorer);
+        } catch (IOException e) {
+            throw new ElasticsearchException("IO error setting scorer", e);
+        }
+
+    }
+
+    public long getDocCount() {
+        return matchedDocCount;
+    }
+
+}

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/RandomDocsSampleDeferringCollector.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/RandomDocsSampleDeferringCollector.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.bucket;
+
+import org.apache.lucene.index.AtomicReaderContext;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TopDocsCollector;
+import org.apache.lucene.util.PriorityQueue;
+import org.elasticsearch.search.aggregations.BucketCollector;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
+
+import java.io.IOException;
+
+/**
+ * A {@link DeferringBucketCollector} that first identifies a random sample of
+ * documents in search results and then passes only these on to nested
+ * collectors. This implementation is only for use with a single bucket
+ * aggregation.
+ */
+public class RandomDocsSampleDeferringCollector extends BestDocsDeferringCollector {
+
+    public RandomDocsSampleDeferringCollector(BucketCollector deferred, AggregationContext context, int shardSize) {
+        super(deferred, context, shardSize);
+    }
+
+    @Override
+    protected TopDocsCollector<RandomSampleScoreDoc> createTopDocsCollector(int size) {
+        return new RandomDocSampleCollector(size);
+    }
+
+    static class RandomDocSampleCollector extends TopDocsCollector<RandomSampleScoreDoc> {
+        RandomSampleScoreDoc pqTop;
+        int docBase = 0;
+        Scorer scorer;
+
+
+        public RandomDocSampleCollector(int numHits) {
+            super(new SampledHitQueue(numHits, true));
+            // SampledHitQueue implements getSentinelObject to return a
+            // ScoreDoc, so we
+            // know that at this point top() is already initialized.
+            pqTop = pq.top();
+        }
+
+        @Override
+        protected TopDocs newTopDocs(ScoreDoc[] results, int start) {
+            if (results == null) {
+                return EMPTY_TOPDOCS;
+            }
+
+            // We need to compute maxScore in order to set it in TopDocs. If
+            // start == 0, it means the largest element is already in results,
+            // use its
+            // score as maxScore. Otherwise pop everything else, until the
+            // largest element is extracted and use its score as maxScore.
+            float maxScore = Float.NaN;
+            if (start == 0) {
+                maxScore = ((RandomSampleScoreDoc) results[0]).randomizer;
+            } else {
+                for (int i = pq.size(); i > 1; i--) {
+                    pq.pop();
+                }
+                maxScore = ((RandomSampleScoreDoc) pq.pop()).randomizer;
+            }
+
+            return new TopDocs(totalHits, results, maxScore);
+        }
+
+        @Override
+        public void setNextReader(AtomicReaderContext context) {
+            docBase = context.docBase;
+        }
+
+        @Override
+        public void setScorer(Scorer scorer) throws IOException {
+            this.scorer = scorer;
+        }
+
+        @Override
+        public void collect(int doc) throws IOException {
+            float random = (float) Math.random();
+            float realScore = scorer.score();
+
+            // This collector cannot handle NaN
+            assert !Float.isNaN(random);
+
+            totalHits++;
+            if (random < pqTop.randomizer) {
+                // Doesn't compete w/ bottom entry in queue
+                return;
+            }
+            doc += docBase;
+            if (random == pqTop.randomizer && doc > pqTop.doc) {
+                // Break tie in score by doc ID:
+                return;
+            }
+            pqTop.doc = doc;
+            pqTop.score = realScore;
+            pqTop.randomizer = random;
+            pqTop = pq.updateTop();
+        }
+
+        @Override
+        public boolean acceptsDocsOutOfOrder() {
+            return false;
+        }
+
+        static class SampledHitQueue extends PriorityQueue<RandomSampleScoreDoc> {
+
+            SampledHitQueue(int size, boolean prePopulate) {
+                super(size, prePopulate);
+            }
+
+            @Override
+            protected RandomSampleScoreDoc getSentinelObject() {
+                // Always set the doc Id to MAX_VALUE so that it won't be
+                // favored by lessThan.
+                return new RandomSampleScoreDoc(Integer.MAX_VALUE, Float.NEGATIVE_INFINITY, Float.NEGATIVE_INFINITY);
+            }
+
+            @Override
+            protected final boolean lessThan(RandomSampleScoreDoc hitA, RandomSampleScoreDoc hitB) {
+                if (hitA.randomizer == hitB.randomizer)
+                    return hitA.doc > hitB.doc;
+                else
+                    return hitA.randomizer < hitB.randomizer;
+            }
+        }
+    }
+
+    static class RandomSampleScoreDoc extends ScoreDoc {
+        float randomizer;
+
+        public RandomSampleScoreDoc(int doc, float score) {
+            super(doc, score);
+            randomizer = (float) Math.random();
+        }
+
+        // Constructor used for sentinel object
+        protected RandomSampleScoreDoc(int doc, float score, float randomizer) {
+            super(doc, score);
+            this.randomizer = randomizer;
+        }
+    }
+
+}

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/InternalSampler.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/InternalSampler.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.search.aggregations.bucket.sampler;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.search.aggregations.AggregationStreams;
+import org.elasticsearch.search.aggregations.InternalAggregations;
+import org.elasticsearch.search.aggregations.bucket.InternalSingleBucketAggregation;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+*
+*/
+public class InternalSampler extends InternalSingleBucketAggregation implements Sampler {
+
+    public final static Type TYPE = new Type("sampler");
+
+    public final static AggregationStreams.Stream STREAM = new AggregationStreams.Stream() {
+        @Override
+        public InternalSampler readResult(StreamInput in) throws IOException {
+            InternalSampler result = new InternalSampler();
+            result.readFrom(in);
+            return result;
+        }
+    };
+
+    public static void registerStreams() {
+        AggregationStreams.registerStream(STREAM, TYPE.stream());
+    }
+
+    InternalSampler() {} // for serialization
+
+    InternalSampler(String name, long docCount, InternalAggregations subAggregations, Map<String, Object> metaData) {
+        super(name, docCount, subAggregations, metaData);
+    }
+
+    @Override
+    public Type type() {
+        return TYPE;
+    }
+
+    @Override
+    protected InternalSingleBucketAggregation newAggregation(String name, long docCount, InternalAggregations subAggregations) {
+        return new InternalSampler(name, docCount, subAggregations, metaData);
+    }
+}

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/Sampler.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/Sampler.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.search.aggregations.bucket.sampler;
+
+import org.elasticsearch.search.aggregations.bucket.SingleBucketAggregation;
+
+/**
+ * A {@code filter} aggregation that defines a single bucket to hold a sample of
+ * top-matching documents. Computation of child aggregations is deferred until
+ * the top-matching documents on a shard have been determined.
+ */
+public interface Sampler extends SingleBucketAggregation {
+}

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/SamplerAggregationBuilder.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/SamplerAggregationBuilder.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.bucket.sampler;
+
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.search.aggregations.AggregationBuilder;
+
+import java.io.IOException;
+
+/**
+ * Builder for the {@link Sampler} aggregation.
+ */
+public class SamplerAggregationBuilder extends AggregationBuilder<SamplerAggregationBuilder> {
+
+
+    private int shardSize = SamplerParser.DEFAULT_SHARD_SAMPLE_SIZE;
+    private boolean useRandomSample = SamplerParser.DEFAULT_USE_RANDOM_SAMPLE;
+
+    /**
+     * Sole constructor.
+     */
+    public SamplerAggregationBuilder(String name) {
+        super(name, InternalSampler.TYPE.name());
+    }
+
+    /**
+     * Set the max num docs to be returned from each shard.
+     */
+    public SamplerAggregationBuilder shardSize(int shardSize) {
+        this.shardSize = shardSize;
+        return this;
+    }
+
+    /**
+     * Set to true if the sample should be based on a random sample, false to
+     * sample based on the top-scoring documents. Default is false.
+     */
+    public SamplerAggregationBuilder useRandomSample(boolean useRandomSample) {
+        this.useRandomSample = useRandomSample;
+        return this;
+    }
+
+    @Override
+    protected XContentBuilder internalXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        if (shardSize != SamplerParser.DEFAULT_SHARD_SAMPLE_SIZE) {
+            builder.field(SamplerParser.SHARD_SIZE_FIELD.getPreferredName(), shardSize);
+        }
+
+        if (useRandomSample != SamplerParser.DEFAULT_USE_RANDOM_SAMPLE) {
+            builder.field(SamplerParser.RANDOM_SAMPLE_FIELD.getPreferredName(), useRandomSample);
+        }
+
+        return builder.endObject();
+    }
+}

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/SamplerAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/SamplerAggregator.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.search.aggregations.bucket.sampler;
+
+import org.apache.lucene.index.AtomicReaderContext;
+import org.elasticsearch.search.aggregations.Aggregator;
+import org.elasticsearch.search.aggregations.AggregatorFactories;
+import org.elasticsearch.search.aggregations.AggregatorFactory;
+import org.elasticsearch.search.aggregations.BucketCollector;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.bucket.BestDocsDeferringCollector;
+import org.elasticsearch.search.aggregations.bucket.BucketsAggregator;
+import org.elasticsearch.search.aggregations.bucket.DeferringBucketCollector;
+import org.elasticsearch.search.aggregations.bucket.RandomDocsSampleDeferringCollector;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Aggregate on only the top-scoring docs on a shard
+ */
+public class SamplerAggregator extends BucketsAggregator {
+
+    private final int shardSize;
+    private BestDocsDeferringCollector bdd;
+    private boolean useRandomSample;
+
+    public SamplerAggregator(String name, int shardSize, boolean useRandomSample, AggregatorFactories factories,
+            AggregationContext aggregationContext, Aggregator parent, Map<String, Object> metaData) {
+        super(name, BucketAggregationMode.PER_BUCKET, factories, 1, aggregationContext, parent, metaData);
+        this.shardSize = shardSize;
+        this.useRandomSample = useRandomSample;
+    }
+
+    @Override
+    protected DeferringBucketCollector createDeferrerImpl(BucketCollector deferred, AggregationContext context) {
+        if (useRandomSample) {
+            bdd = new RandomDocsSampleDeferringCollector(deferred, context, shardSize);
+        } else {
+            bdd = new BestDocsDeferringCollector(deferred, context, shardSize);
+        }
+        return bdd;
+    }
+
+    @Override
+    public void setNextReader(AtomicReaderContext reader) {
+    }
+
+    @Override
+    public void collect(int doc, long owningBucketOrdinal) throws IOException {
+        collectBucket(doc, 0);
+    }
+
+    @Override
+    protected boolean shouldDefer(Aggregator aggregator) {
+        return true;
+    }
+
+    @Override
+    public InternalAggregation buildAggregation(long owningBucketOrdinal) {
+        runDeferredCollections(0);
+        return new InternalSampler(name, bdd == null ? 0 : bdd.getDocCount(), bucketAggregations(owningBucketOrdinal), getMetaData());
+    }
+
+    @Override
+    public InternalAggregation buildEmptyAggregation() {
+        return new InternalSampler(name, 0, buildEmptySubAggregations(), getMetaData());
+    }
+
+    public static class Factory extends AggregatorFactory {
+
+        private int shardSize;
+        private boolean useRandomSample;
+
+        public Factory(String name, int shardSize, boolean useRandomSample) {
+            super(name, InternalSampler.TYPE.name());
+            this.shardSize = shardSize;
+            this.useRandomSample = useRandomSample;
+        }
+
+        @Override
+        protected Aggregator createInternal(AggregationContext context, Aggregator parent, long expectedBucketsCount,
+                Map<String, Object> metaData) {
+            return new SamplerAggregator(name, shardSize, useRandomSample, factories, context, parent, metaData);
+        }
+
+    }
+    @Override
+    public boolean shouldCollect() {
+        return true;
+    }
+}
+
+

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/SamplerParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/SamplerParser.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.search.aggregations.bucket.sampler;
+
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.search.SearchParseException;
+import org.elasticsearch.search.aggregations.Aggregator;
+import org.elasticsearch.search.aggregations.AggregatorFactory;
+import org.elasticsearch.search.internal.SearchContext;
+
+import java.io.IOException;
+
+/**
+ *
+ */
+public class SamplerParser implements Aggregator.Parser {
+
+    public static final int DEFAULT_SHARD_SAMPLE_SIZE = 100;
+    public static final ParseField SHARD_SIZE_FIELD = new ParseField("shard_size");
+    public static final ParseField RANDOM_SAMPLE_FIELD = new ParseField("random_sample");
+    public static final boolean DEFAULT_USE_RANDOM_SAMPLE = false;
+
+    @Override
+    public String type() {
+        return InternalSampler.TYPE.name();
+    }
+
+    @Override
+    public AggregatorFactory parse(String aggregationName, XContentParser parser, SearchContext context) throws IOException {
+        XContentParser.Token token;
+        String currentFieldName = null;
+        boolean useRandomSample = DEFAULT_USE_RANDOM_SAMPLE;
+        int shardSize = DEFAULT_SHARD_SAMPLE_SIZE;
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                currentFieldName = parser.currentName();
+            } else if (token == XContentParser.Token.VALUE_NUMBER) {
+                if (SHARD_SIZE_FIELD.match(currentFieldName)) {
+                    shardSize = parser.intValue();
+                } else {
+                    throw new SearchParseException(context, "Unsupported property \"" + currentFieldName + "\" for aggregation \""
+                            + aggregationName);
+                }
+            } else if (token == XContentParser.Token.VALUE_BOOLEAN) {
+                if (RANDOM_SAMPLE_FIELD.match(currentFieldName)) {
+                    useRandomSample = parser.booleanValue();
+                } else {
+                    throw new SearchParseException(context, "Unsupported property \"" + currentFieldName + "\" for aggregation \""
+                            + aggregationName);
+                }
+            } else {
+                throw new SearchParseException(context, "Unsupported property \"" + currentFieldName + "\" for aggregation \""
+                        + aggregationName);
+            }
+        }
+        return new SamplerAggregator.Factory(aggregationName, shardSize, useRandomSample);
+    }
+
+}

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/SamplerTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/SamplerTests.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.search.aggregations.bucket;
+
+import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.aggregations.AggregationBuilders;
+import org.elasticsearch.search.aggregations.Aggregations;
+import org.elasticsearch.search.aggregations.bucket.sampler.Sampler;
+import org.elasticsearch.search.aggregations.bucket.terms.Terms;
+import org.elasticsearch.search.aggregations.bucket.terms.Terms.Bucket;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.core.IsNull.notNullValue;
+
+@ElasticsearchIntegrationTest.SuiteScopeTest
+
+public class SamplerTests extends ElasticsearchIntegrationTest {
+    
+
+    @Override
+    public Settings indexSettings() {
+        return ImmutableSettings.builder()
+        // Need to have consistent number of shards for scoring logic
+                .put("index.number_of_shards", 2)
+                .put("index.number_of_replicas", between(0, 1))
+                .build();
+    }    
+
+    @Override
+    public void setupSuiteScopeCluster() throws Exception {
+        createIndex("idx");
+        // Here we give a subset of docs a "bonus" field to introduce scoring
+        // differences for later quality tests
+        List<IndexRequestBuilder> builders = new ArrayList<>();
+        for (int i = 0; i < 100; i++) {
+            int num = (int) (Math.random() * 5);
+            builders.add(client().prepareIndex("idx", "type").setSource(
+                    jsonBuilder().startObject().field("num", num).field("tag", num % 2 == 0 ? "even" : "odd")
+                            .field("bonus", num == 4 ? "highScore highScore highScore" : "")
+                    .endObject()));
+        }
+        indexRandom(true, builders);
+        createIndex("idx_unmapped");
+        ensureSearchable();
+    }
+    
+    
+
+    @Test
+    public void testBestQualitySample() throws Exception {
+        int maxPerShardSize = 5;
+        SearchResponse response = client().prepareSearch("idx").setQuery(QueryBuilders.matchQuery("num", 1))
+                .addAggregation(
+                        AggregationBuilders.sampler("sample").shardSize(maxPerShardSize)
+                                .subAggregation(AggregationBuilders.terms("terms").field("tag").size(10))).execute().actionGet();
+        assertSearchResponse(response);
+
+        Sampler sample = response.getAggregations().get("sample");
+        assertThat(sample.getDocCount(), lessThanOrEqualTo((long) getNumShards("idx").numPrimaries * maxPerShardSize));
+        Terms terms = sample.getAggregations().get("terms");
+        assertThat(terms, notNullValue());
+        assertThat(terms.getName(), equalTo("terms"));
+        Bucket odds = terms.getBucketByKey("odd");
+        assertNotNull(odds);
+        Bucket evens = terms.getBucketByKey("even");
+        assertNull(evens);
+    }
+
+    @Test
+    public void testRandomSample() throws Exception {
+        // Runs an agg on a random sample of results.
+        int maxPerShardSize = 5;
+        SearchResponse response = client()
+                .prepareSearch("idx")
+                .setQuery(QueryBuilders.matchQuery("_all", "even highScore"))
+                .addAggregation(
+                        AggregationBuilders.sampler("sample").shardSize(maxPerShardSize).useRandomSample(true)
+                                .subAggregation(AggregationBuilders.terms("terms").field("num").size(10))).execute().actionGet();
+        assertSearchResponse(response);
+
+        Sampler sample = response.getAggregations().get("sample");
+        assertThat(sample.getDocCount(), lessThanOrEqualTo((long) getNumShards("idx").numPrimaries * maxPerShardSize));
+        Terms terms = sample.getAggregations().get("terms");
+        assertThat(terms, notNullValue());
+        assertThat(terms.getName(), equalTo("terms"));
+
+        String[] nonExpecteds = { "one", "three", "five" };
+        for (String nonExpectedNum : nonExpecteds) {
+            assertNull(terms.getBucketByKey(nonExpectedNum));
+        }
+        // We expect diversity in our results which is missing if we purely rely
+        // on Lucene-ranked selections
+        assertTrue("A random sample should include lower-ranked results (this test may fail in VERY rare cases)",
+                terms.getBuckets().size() > 1);
+    }
+
+
+    @Test
+    public void testNestedSample() throws Exception {
+        int maxPerShardSize = 500;
+        SearchResponse response = client()
+                .prepareSearch("idx")
+                .setQuery(QueryBuilders.matchQuery("_all", "even odd"))
+                .addAggregation(
+                        AggregationBuilders
+                                .terms("tags")
+                                .field("tag")
+                                .subAggregation(
+                                        AggregationBuilders.sampler("sample").shardSize(maxPerShardSize)
+                                                .subAggregation(AggregationBuilders.terms("nums").field("num").size(10)))).execute()
+                .actionGet();
+        assertSearchResponse(response);
+
+        Terms tags = response.getAggregations().get("tags");
+        List<Bucket> tagsList = tags.getBuckets();
+        assertThat(tagsList.size(), equalTo(2));
+        checkSamples(maxPerShardSize, tags.getBucketByKey("odd").getAggregations(), 1);
+        checkSamples(maxPerShardSize, tags.getBucketByKey("even").getAggregations(), 0);
+    }
+
+    private void checkSamples(int maxPerShardSize, Aggregations oddEvenBucket, int expectedModulo) {
+        Sampler sample = oddEvenBucket.get("sample");
+        assertThat(sample.getDocCount(), lessThanOrEqualTo((long) getNumShards("idx").numPrimaries * maxPerShardSize));
+        Terms nums = sample.getAggregations().get("nums");
+        assertThat(nums, notNullValue());
+        List<Bucket> numBuckets = nums.getBuckets();
+        for (Bucket bucket : numBuckets) {
+            int key = Integer.parseInt(bucket.getKey());
+            assertThat(key % 2, equalTo(expectedModulo));
+        }
+    }
+
+}


### PR DESCRIPTION
Used to limit processing in child aggregations.

The existing Aggregator base class support for deferring computation of child aggs is modified (DeferringBucketCollector is refactored to be abstract and the logic it had for “best bucket” trimming is pushed down into a new BestBucketsDeferringCollector while the new logic for trimming based on doc score quality is in subclass BestDocsDeferringCollector).
Closes #8108
