### PR TITLE
Enable indy (invokedynamic) compile flag for Groovy scripts by default

### DIFF
--- a/core/src/main/java/org/elasticsearch/bootstrap/ESPolicy.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/ESPolicy.java
@@ -37,19 +37,19 @@ final class ESPolicy extends Policy {
     
     /** template policy file, the one used in tests */
     static final String POLICY_RESOURCE = "security.policy";
+    /** limited policy for groovy scripts */
+    static final String GROOVY_RESOURCE = "groovy.policy";
     
     final Policy template;
+    final Policy groovy;
     final PermissionCollection dynamic;
-    final PermissionCollection groovy;
 
     public ESPolicy(PermissionCollection dynamic) throws Exception {
-        URI uri = getClass().getResource(POLICY_RESOURCE).toURI();
-        this.template = Policy.getInstance("JavaPolicy", new URIParameter(uri));
+        URI policyUri = getClass().getResource(POLICY_RESOURCE).toURI();
+        URI groovyUri = getClass().getResource(GROOVY_RESOURCE).toURI();
+        this.template = Policy.getInstance("JavaPolicy", new URIParameter(policyUri));
+        this.groovy = Policy.getInstance("JavaPolicy", new URIParameter(groovyUri));
         this.dynamic = dynamic;
-        this.groovy = new Permissions();
-        // groovy IndyInterface bootstrap requires this property
-        groovy.add(new PropertyPermission("groovy.indy.logging", "read"));
-        groovy.setReadOnly();
     }
 
     @Override @SuppressForbidden(reason = "fast equals check is desired")
@@ -63,7 +63,7 @@ final class ESPolicy extends Policy {
             if (location != null) {
                 // run groovy scripts with no permissions (except logging property)
                 if ("/groovy/script".equals(location.getFile())) {
-                    return groovy.implies(permission);
+                    return groovy.implies(domain, permission);
                 }
             }
         }

--- a/core/src/main/java/org/elasticsearch/bootstrap/ESPolicy.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/ESPolicy.java
@@ -49,6 +49,7 @@ final class ESPolicy extends Policy {
         this.groovy = new Permissions();
         // groovy IndyInterface bootstrap requires this property
         groovy.add(new PropertyPermission("groovy.indy.logging", "read"));
+        groovy.setReadOnly();
     }
 
     @Override @SuppressForbidden(reason = "fast equals check is desired")

--- a/core/src/main/java/org/elasticsearch/script/groovy/GroovyScriptEngineService.java
+++ b/core/src/main/java/org/elasticsearch/script/groovy/GroovyScriptEngineService.java
@@ -64,10 +64,6 @@ public class GroovyScriptEngineService extends AbstractComponent implements Scri
     /**
      * The setting to enable or disable <code>invokedynamic</code> instruction support in Java 7+.
      * <p>
-     * This should only be used with Java 7u60 or later because of issues related to the instruction.
-     * The <code>invokedynamic</code> instruction allows near-Java performance from many of Groovy's
-     * dynamic features, which is why it is enabled by default.
-     * <p>
      * Note: If this is disabled because <code>invokedynamic</code> is causing issues, then the Groovy
      * <code>indy</code> jar needs to be replaced by the non-<code>indy</code> variant of it on the classpath (e.g.,
      * <code>groovy-all-2.4.4-indy.jar</code> should be replaced by <code>groovy-all-2.4.4.jar</code>).

--- a/core/src/main/resources/org/elasticsearch/bootstrap/groovy.policy
+++ b/core/src/main/resources/org/elasticsearch/bootstrap/groovy.policy
@@ -1,0 +1,31 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+ 
+/*
+ * Limited security policy for groovy scripts.
+ * This is what is needed for its invokeDynamic functionality to work.
+ */
+grant {
+  
+  // groovy IndyInterface bootstrap requires this property for indy logging
+  permission java.util.PropertyPermission "groovy.indy.logging", "read";
+  
+  // needed IndyInterface selectMethod (setCallSiteTarget)
+  permission java.lang.RuntimePermission "getClassLoader";
+};


### PR DESCRIPTION
With Java 7 and the `groovy-all-x.y.z-indy` jar, Groovy scripts can be compiled with `invokedynamic` instruction support. Even with the "indy" jar, Groovy does not enable this by default so that Groovy code compiled with these features are compatible with JVMs prior to Java 7.

With this commit, it is turned on by default because Elasticsearch requires Java 7. However, Java 7's invokedynamic support was buggy until Java 7u60 (and later), which means that users of this should update their JVMs to at least that version.

This does provide an unadvertised property (`"script.groovy.indy"`) to disable the feature in the unlikely event that user's do not want it enabled (e.g., future, non-existent JVM bug). Set it to `false` to disable this feature. If disabled, the assumption is that users _must_ replace the jar file with the non-indy variant as well, which is why this is not advertised or dynamically settable.

Closes #8184
