### PR TITLE
Adds ability to specify 'named' threadpool to searches.

### DIFF
--- a/src/main/java/org/elasticsearch/action/search/SearchRequest.java
+++ b/src/main/java/org/elasticsearch/action/search/SearchRequest.java
@@ -69,6 +69,8 @@ public class SearchRequest extends ActionRequest<SearchRequest> implements Indic
     private String routing;
     @Nullable
     private String preference;
+    @Nullable
+    private String threadPoolName;
 
     private BytesReference templateSource;
     private boolean templateSourceUnsafe;
@@ -228,6 +230,14 @@ public class SearchRequest extends ActionRequest<SearchRequest> implements Indic
     public SearchRequest routing(String routing) {
         this.routing = routing;
         return this;
+    }
+
+    /**
+     *  Name for custom search threadpool , no name or null default to SEARCH thread pool
+     */
+    public SearchRequest threadPool(String threadPoolName){
+        this.threadPoolName = threadPoolName;
+        return  this;
     }
 
     /**
@@ -491,6 +501,13 @@ public class SearchRequest extends ActionRequest<SearchRequest> implements Indic
         return searchType;
     }
 
+
+    /**
+     * returns thread pool name
+     */
+    public String threadPool() {
+        return threadPoolName;
+    }
     /**
      * The indices
      */

--- a/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
@@ -154,6 +154,14 @@ public class SearchRequestBuilder extends ActionRequestBuilder<SearchRequest, Se
     }
 
     /**
+     * This sets the custom search_thread pool to be used to run queries, defaults to SEARCH
+     */
+    public SearchRequestBuilder setThreadPoolName(String threadPoolName){
+        request.threadPool(threadPoolName);
+        return this;
+    }
+
+    /**
      * Sets the preference to execute the search. Defaults to randomize across shards. Can be set to
      * <tt>_local</tt> to prefer local shards, <tt>_primary</tt> to execute only on primary shards, or
      * a custom value, which guarantees that the same order will be used across different requests.

--- a/src/main/java/org/elasticsearch/action/search/SearchScrollRequest.java
+++ b/src/main/java/org/elasticsearch/action/search/SearchScrollRequest.java
@@ -39,6 +39,7 @@ public class SearchScrollRequest extends ActionRequest<SearchScrollRequest> {
 
     private String scrollId;
     private Scroll scroll;
+    private String threadPoolName;
 
     public SearchScrollRequest() {
     }
@@ -63,6 +64,13 @@ public class SearchScrollRequest extends ActionRequest<SearchScrollRequest> {
         return scrollId;
     }
 
+    /**
+     * returns thread pool name if specified in scroll request
+     */
+    public String threadPoolName(){
+        return this.threadPoolName;
+    }
+
     public SearchScrollRequest scrollId(String scrollId) {
         this.scrollId = scrollId;
         return this;
@@ -80,6 +88,11 @@ public class SearchScrollRequest extends ActionRequest<SearchScrollRequest> {
      */
     public SearchScrollRequest scroll(Scroll scroll) {
         this.scroll = scroll;
+        return this;
+    }
+
+    public SearchScrollRequest threadPool(String threadPoolName){
+        this.threadPoolName = threadPoolName;
         return this;
     }
 

--- a/src/main/java/org/elasticsearch/action/search/SearchScrollRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/search/SearchScrollRequestBuilder.java
@@ -78,6 +78,11 @@ public class SearchScrollRequestBuilder extends ActionRequestBuilder<SearchScrol
         return this;
     }
 
+    public SearchScrollRequestBuilder setThreadPoolName(String threadPoolName){
+        request.threadPool(threadPoolName);
+        return this;
+    }
+
     @Override
     protected void doExecute(ActionListener<SearchResponse> listener) {
         client.searchScroll(request, listener);

--- a/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
@@ -83,7 +83,12 @@ public class RestSearchAction extends BaseRestHandler {
 
     public static SearchRequest parseSearchRequest(RestRequest request) {
         String[] indices = Strings.splitStringByCommaToArray(request.param("index"));
+        String threadPool = request.param("threadpool");
+
         SearchRequest searchRequest = new SearchRequest(indices);
+        if (searchRequest != null ){
+            searchRequest.threadPool(threadPool);
+        }
         // get the content, and put it in the body
         // add content/source as template if template flag is set
         boolean isTemplateRequest = request.path().endsWith("/template");

--- a/src/main/java/org/elasticsearch/rest/action/search/RestSearchScrollAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/search/RestSearchScrollAction.java
@@ -51,10 +51,16 @@ public class RestSearchScrollAction extends BaseRestHandler {
     @Override
     public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         String scrollId = request.param("scroll_id");
+        String threadPool = request.param("threadpool");
+
         if (scrollId == null) {
             scrollId = RestActions.getRestContent(request).toUtf8();
         }
+
         SearchScrollRequest searchScrollRequest = new SearchScrollRequest(scrollId);
+        if ( threadPool != null ){
+            searchScrollRequest.threadPool(threadPool);
+        }
         searchScrollRequest.listenerThreaded(false);
         String scroll = request.param("scroll");
         if (scroll != null) {

--- a/src/main/java/org/elasticsearch/search/action/SearchServiceTransportAction.java
+++ b/src/main/java/org/elasticsearch/search/action/SearchServiceTransportAction.java
@@ -196,7 +196,7 @@ public class SearchServiceTransportAction extends AbstractComponent {
                 public DfsSearchResult call() throws Exception {
                     return searchService.executeDfsPhase(request);
                 }
-            }, listener);
+            }, listener,request.threadPoolName());
         } else {
             transportService.sendRequest(node, DFS_ACTION_NAME, request, new BaseTransportResponseHandler<DfsSearchResult>() {
 
@@ -230,7 +230,7 @@ public class SearchServiceTransportAction extends AbstractComponent {
                 public QuerySearchResultProvider call() throws Exception {
                     return searchService.executeQueryPhase(request);
                 }
-            }, listener);
+            }, listener,request.threadPoolName());
         } else {
             transportService.sendRequest(node, QUERY_ACTION_NAME, request, new BaseTransportResponseHandler<QuerySearchResultProvider>() {
 
@@ -264,7 +264,7 @@ public class SearchServiceTransportAction extends AbstractComponent {
                 public QuerySearchResult call() throws Exception {
                     return searchService.executeQueryPhase(request);
                 }
-            }, listener);
+            }, listener,request.threadPoolName());
         } else {
             transportService.sendRequest(node, QUERY_ID_ACTION_NAME, request, new BaseTransportResponseHandler<QuerySearchResult>() {
 
@@ -298,7 +298,7 @@ public class SearchServiceTransportAction extends AbstractComponent {
                 public QuerySearchResult call() throws Exception {
                     return searchService.executeQueryPhase(request).queryResult();
                 }
-            }, listener);
+            }, listener,request.threadPoolName());
         } else {
             transportService.sendRequest(node, QUERY_SCROLL_ACTION_NAME, request, new BaseTransportResponseHandler<ScrollQuerySearchResult>() {
 
@@ -332,7 +332,7 @@ public class SearchServiceTransportAction extends AbstractComponent {
                 public QueryFetchSearchResult call() throws Exception {
                     return searchService.executeFetchPhase(request);
                 }
-            }, listener);
+            }, listener,request.threadPoolName());
         } else {
             transportService.sendRequest(node, QUERY_FETCH_ACTION_NAME, request, new BaseTransportResponseHandler<QueryFetchSearchResult>() {
 
@@ -366,7 +366,7 @@ public class SearchServiceTransportAction extends AbstractComponent {
                 public QueryFetchSearchResult call() throws Exception {
                     return searchService.executeFetchPhase(request);
                 }
-            }, listener);
+            }, listener,request.threadPoolName());
         } else {
             transportService.sendRequest(node, QUERY_QUERY_FETCH_ACTION_NAME, request, new BaseTransportResponseHandler<QueryFetchSearchResult>() {
 
@@ -400,7 +400,7 @@ public class SearchServiceTransportAction extends AbstractComponent {
                 public QueryFetchSearchResult call() throws Exception {
                     return searchService.executeFetchPhase(request).result();
                 }
-            }, listener);
+            }, listener,request.threadPoolName());
         } else {
             transportService.sendRequest(node, QUERY_FETCH_SCROLL_ACTION_NAME, request, new BaseTransportResponseHandler<ScrollQueryFetchSearchResult>() {
 
@@ -451,7 +451,7 @@ public class SearchServiceTransportAction extends AbstractComponent {
                 public FetchSearchResult call() throws Exception {
                     return searchService.executeFetchPhase(request);
                 }
-            }, listener);
+            }, listener,request.threadPoolName());
         } else {
             transportService.sendRequest(node, action, request, new BaseTransportResponseHandler<FetchSearchResult>() {
 
@@ -485,7 +485,7 @@ public class SearchServiceTransportAction extends AbstractComponent {
                 public QuerySearchResult call() throws Exception {
                     return searchService.executeScan(request);
                 }
-            }, listener);
+            }, listener,request.threadPoolName());
         } else {
             transportService.sendRequest(node, SCAN_ACTION_NAME, request, new BaseTransportResponseHandler<QuerySearchResult>() {
 
@@ -519,7 +519,7 @@ public class SearchServiceTransportAction extends AbstractComponent {
                 public QueryFetchSearchResult call() throws Exception {
                     return searchService.executeScan(request).result();
                 }
-            }, listener);
+            }, listener,request.threadPoolName());
         } else {
             transportService.sendRequest(node, SCAN_SCROLL_ACTION_NAME, request, new BaseTransportResponseHandler<ScrollQueryFetchSearchResult>() {
 
@@ -546,9 +546,12 @@ public class SearchServiceTransportAction extends AbstractComponent {
         }
     }
 
-    private <T> void execute(final Callable<? extends T> callable, final SearchServiceListener<T> listener) {
+    private <T> void execute(final Callable<? extends T> callable, final SearchServiceListener<T> listener,String threadPoolName) {
+        if (threadPoolName == null) {
+            threadPoolName = ThreadPool.Names.SEARCH;
+        }
         try {
-            threadPool.executor(ThreadPool.Names.SEARCH).execute(new Runnable() {
+            threadPool.executor(threadPoolName).execute(new Runnable() {
                 @Override
                 public void run() {
                     // Listeners typically do counting on errors and successes, and the decision to move to second phase, etc. is based on

--- a/src/main/java/org/elasticsearch/search/fetch/ShardFetchRequest.java
+++ b/src/main/java/org/elasticsearch/search/fetch/ShardFetchRequest.java
@@ -44,6 +44,8 @@ public class ShardFetchRequest extends TransportRequest {
 
     private int size;
 
+    private String threadPoolName;
+
     private ScoreDoc lastEmittedDoc;
 
     public ShardFetchRequest() {
@@ -55,6 +57,7 @@ public class ShardFetchRequest extends TransportRequest {
         this.docIds = list.buffer;
         this.size = list.size();
         this.lastEmittedDoc = lastEmittedDoc;
+        this.threadPoolName = request.threadPoolName();
     }
 
     protected ShardFetchRequest(TransportRequest originalRequest, long id, IntArrayList list, ScoreDoc lastEmittedDoc) {
@@ -67,6 +70,10 @@ public class ShardFetchRequest extends TransportRequest {
 
     public long id() {
         return id;
+    }
+
+    public String threadPoolName(){
+        return threadPoolName;
     }
 
     public int[] docIds() {

--- a/src/main/java/org/elasticsearch/search/internal/InternalScrollSearchRequest.java
+++ b/src/main/java/org/elasticsearch/search/internal/InternalScrollSearchRequest.java
@@ -35,7 +35,7 @@ import static org.elasticsearch.search.Scroll.readScroll;
 public class InternalScrollSearchRequest extends TransportRequest {
 
     private long id;
-
+    private String threadPoolName;
     private Scroll scroll;
 
     public InternalScrollSearchRequest() {
@@ -44,6 +44,7 @@ public class InternalScrollSearchRequest extends TransportRequest {
     public InternalScrollSearchRequest(SearchScrollRequest request, long id) {
         super(request);
         this.id = id;
+        this.threadPoolName = request.threadPoolName();
         this.scroll = request.scroll();
     }
 
@@ -53,6 +54,10 @@ public class InternalScrollSearchRequest extends TransportRequest {
 
     public Scroll scroll() {
         return scroll;
+    }
+
+    public String threadPoolName(){
+        return this.threadPoolName;
     }
 
     public InternalScrollSearchRequest scroll(Scroll scroll) {

--- a/src/main/java/org/elasticsearch/search/internal/ShardSearchLocalRequest.java
+++ b/src/main/java/org/elasticsearch/search/internal/ShardSearchLocalRequest.java
@@ -67,6 +67,8 @@ public class ShardSearchLocalRequest implements ShardSearchRequest {
 
     private int numberOfShards;
 
+    private String threadPoolName;
+
     private SearchType searchType;
 
     private Scroll scroll;
@@ -100,6 +102,7 @@ public class ShardSearchLocalRequest implements ShardSearchRequest {
         this.templateName = searchRequest.templateName();
         this.templateType = searchRequest.templateType();
         this.templateParams = searchRequest.templateParams();
+        this.threadPoolName = searchRequest.threadPool();
         this.scroll = searchRequest.scroll();
         this.useSlowScroll = useSlowScroll;
         this.filteringAliases = filteringAliases;
@@ -165,6 +168,11 @@ public class ShardSearchLocalRequest implements ShardSearchRequest {
     @Override
     public SearchType searchType() {
         return searchType;
+    }
+
+    @Override
+    public String threadPoolName() {
+        return this.threadPoolName;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/internal/ShardSearchRequest.java
+++ b/src/main/java/org/elasticsearch/search/internal/ShardSearchRequest.java
@@ -50,6 +50,8 @@ public interface ShardSearchRequest {
 
     SearchType searchType();
 
+    String threadPoolName();
+
     String[] filteringAliases();
 
     long nowInMillis();

--- a/src/main/java/org/elasticsearch/search/internal/ShardSearchTransportRequest.java
+++ b/src/main/java/org/elasticsearch/search/internal/ShardSearchTransportRequest.java
@@ -46,6 +46,7 @@ public class ShardSearchTransportRequest extends TransportRequest implements Sha
     private OriginalIndices originalIndices;
 
     private ShardSearchLocalRequest shardSearchLocalRequest;
+    private String threadPoolName;
 
     public ShardSearchTransportRequest(){
     }
@@ -56,6 +57,7 @@ public class ShardSearchTransportRequest extends TransportRequest implements Sha
         this.shardSearchLocalRequest = new ShardSearchLocalRequest(searchRequest, shardRouting, numberOfShards,
                 useSlowScroll, filteringAliases, nowInMillis);
         this.originalIndices = new OriginalIndices(searchRequest);
+        this.threadPoolName = searchRequest.threadPool();
     }
 
     @Override
@@ -74,6 +76,10 @@ public class ShardSearchTransportRequest extends TransportRequest implements Sha
         return originalIndices.indicesOptions();
     }
 
+    @Override
+    public String threadPoolName(){
+        return shardSearchLocalRequest.threadPoolName();
+    }
     @Override
     public String index() {
         return shardSearchLocalRequest.index();

--- a/src/main/java/org/elasticsearch/search/query/QuerySearchRequest.java
+++ b/src/main/java/org/elasticsearch/search/query/QuerySearchRequest.java
@@ -43,6 +43,8 @@ public class QuerySearchRequest extends TransportRequest implements IndicesReque
 
     private OriginalIndices originalIndices;
 
+    private String thredPoolName;
+
     public QuerySearchRequest() {
     }
 
@@ -51,6 +53,7 @@ public class QuerySearchRequest extends TransportRequest implements IndicesReque
         this.id = id;
         this.dfs = dfs;
         this.originalIndices = new OriginalIndices(request);
+        this.thredPoolName = request.threadPool();
     }
 
     public long id() {
@@ -59,6 +62,11 @@ public class QuerySearchRequest extends TransportRequest implements IndicesReque
 
     public AggregatedDfs dfs() {
         return dfs;
+    }
+
+    public String threadPoolName()
+    {
+        return thredPoolName;
     }
 
     @Override


### PR DESCRIPTION
Named threadpools needs to be configured in yml explicitly .

For eg:

threadpool:
     fred:
        type: fixed
        size: 30

[ Here fred , named threadpool is configured with default size of 30]

SearchRequestBuilder and ScrollRequestBuilder takes threadpool name ,
but defaults to SEARCH. REST API accepts new http parameter 'threadpool'
which can take name of threadpool to run queries.

curl -XPUT "http://localhost:9200/movies/movie/1" -d'

> {
>     "title": "The Godfather",
>     "director": "Francis Ford Coppola",
>     "year": 1972,
>     "genres": ["Crime", "Drama"]
> }'

Call with 'custom' threadpool
++

curl 'localhost:9200/_search?q=*&threadpool=fred'
{"took":3,"timed_out":false,"_shards":{"total":5,"successful":5,"failed":0},"hits":{"total":1,"max_score":1.0,"hits":[{"_index":"movies","_type":"movie","_id":"1","_score":1.0,"_source":
{
    "title": "The Godfather",
    "director": "Francis Ford Coppola",
    "year": 1972,
    "genres": ["Crime", "Drama"]
}

Invalid threadpool name
++

 curl 'localhost:9200/_search?q=*&threadpool=pollois
'
{"error":"SearchPhaseExecutionException[Failed to execute phase [query],
all shards failed; shardFailures {[J8vv81u1SKK5BUizD5Yppw][movies][0]:
ElasticsearchIllegalArgumentException[No executor found for
[pollois]]}{[J8vv81u1SKK5BUizD5Yppw][movies][1]:
ElasticsearchIllegalArgumentException[No executor found for
[pollois]]}{[J8vv81u1SKK5BUizD5Yppw][movies][2]:
ElasticsearchIllegalArgumentException[No executor found for
[pollois]]}{[J8vv81u1SKK5BUizD5Yppw][movies][3]:
ElasticsearchIllegalArgumentException[No executor found for
[pollois]]}{[J8vv81u1SKK5BUizD5Yppw][movies][4]:
ElasticsearchIllegalArgumentException[No executor found for
[pollois]]}]","status":400}

default call
++

curl 'localhost:9200/_search?q=*'
{"took":3,"timed_out":false,"_shards":{"total":5,"successful":5,"failed":0},"hits":{"total":1,"max_score":1.0,"hits":[{"_index":"movies","_type":"movie","_id":"1","_score":1.0,"_source":
{
    "title": "The Godfather",
    "director": "Francis Ford Coppola",
    "year": 1972,
    "genres": ["Crime", "Drama"]

}

Thanks to way original code is done - _stats shows new threadpool stats
