### PR TITLE
Passing `fielddata_fields` as a non array causes OOM

### DIFF
--- a/src/main/java/org/elasticsearch/search/fetch/fielddata/FieldDataFieldsParseElement.java
+++ b/src/main/java/org/elasticsearch/search/fetch/fielddata/FieldDataFieldsParseElement.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.search.fetch.fielddata;
 
+import org.elasticsearch.ElasticsearchIllegalStateException;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.search.SearchParseElement;
 import org.elasticsearch.search.internal.SearchContext;
@@ -36,10 +37,17 @@ import org.elasticsearch.search.internal.SearchContext;
 public class FieldDataFieldsParseElement implements SearchParseElement {
     @Override
     public void parse(XContentParser parser, SearchContext context) throws Exception {
-        XContentParser.Token token;
-        while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
+        XContentParser.Token token = parser.currentToken();
+        if (token == XContentParser.Token.START_ARRAY) {
+            while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
+                String fieldName = parser.text();
+                context.fieldDataFields().add(new FieldDataFieldsContext.FieldDataField(fieldName));
+            }
+        } else if (token == XContentParser.Token.VALUE_STRING) {
             String fieldName = parser.text();
             context.fieldDataFields().add(new FieldDataFieldsContext.FieldDataField(fieldName));
+        }  else {
+            throw new ElasticsearchIllegalStateException("Expected either a VALUE_STRING or an START_ARRAY but got " + token);
         }
     }
 }


### PR DESCRIPTION
If `fielddata_fields` are passed as a simple value instead of an array
we end up in an infinite loop createing parsed elements with null
values.
This commit validates the incoming token
