### PR TITLE
Don't catch FNF/NSF exception when reading metadata

### DIFF
--- a/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -67,10 +67,7 @@ import org.elasticsearch.indices.recovery.RecoveryState;
 import org.elasticsearch.indices.recovery.RecoveryTarget;
 import org.elasticsearch.threadpool.ThreadPool;
 
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -729,7 +726,6 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent<Indic
                 // For replicas: we are recovering a backup from a primary
                 RecoveryState.Type type = shardRouting.primary() ? RecoveryState.Type.RELOCATION : RecoveryState.Type.REPLICA;
                 recoveryTarget.startRecovery(indexShard, type, sourceNode, new PeerRecoveryListener(shardRouting, indexService, indexMetaData));
-
             } catch (Throwable e) {
                 indexShard.engine().failEngine("corrupted preexisting index", e);
                 handleRecoveryFailure(indexService, indexMetaData, shardRouting, true, e);

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.indices.recovery;
 
-import com.google.common.collect.ImmutableMap;
 import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.store.IndexOutput;
 import org.elasticsearch.ElasticsearchException;
@@ -155,7 +154,7 @@ public class RecoveryTarget extends AbstractComponent {
         logger.trace("collecting local files for {}", recoveryStatus);
         final Map<String, StoreFileMetaData> existingFiles;
         try {
-            existingFiles = recoveryStatus.store().getMetadata().asMap();
+            existingFiles = recoveryStatus.store().getMetadataOrEmpty().asMap();
         } catch (Exception e) {
             logger.debug("error while listing local files, recovery as if there are none", e);
             onGoingRecoveries.failRecovery(recoveryStatus.recoveryId(),

--- a/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetaData.java
+++ b/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetaData.java
@@ -50,10 +50,7 @@ import org.elasticsearch.transport.TransportService;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 
 /**
@@ -149,10 +146,10 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesOperatio
         if (indexService != null) {
             InternalIndexShard indexShard = (InternalIndexShard) indexService.shard(shardId.id());
             if (indexShard != null) {
-                Store store = indexShard.store();
+                final Store store = indexShard.store();
                 store.incRef();
                 try {
-                    return new StoreFilesMetaData(true, shardId, indexShard.store().getMetadata().asMap());
+                    return new StoreFilesMetaData(true, shardId, store.getMetadataOrEmpty().asMap());
                 } finally {
                     store.decRef();
                 }
@@ -182,8 +179,7 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesOperatio
         if (!exists) {
             return new StoreFilesMetaData(false, shardId, ImmutableMap.<String, StoreFileMetaData>of());
         }
-        final Store.MetadataSnapshot storeFileMetaDatas = Store.readMetadataSnapshot(shardIndexLocations, logger);
-        return new StoreFilesMetaData(false, shardId, storeFileMetaDatas.asMap());
+        return new StoreFilesMetaData(false, shardId, Store.readMetadataSnapshot(shardIndexLocations, logger).asMap());
     }
 
     @Override

--- a/src/test/java/org/elasticsearch/index/store/StoreTest.java
+++ b/src/test/java/org/elasticsearch/index/store/StoreTest.java
@@ -40,9 +40,7 @@ import java.io.IOException;
 import java.nio.file.NoSuchFileException;
 import java.util.*;
 
-import static com.carrotsearch.randomizedtesting.RandomizedTest.randomBoolean;
-import static com.carrotsearch.randomizedtesting.RandomizedTest.randomInt;
-import static com.carrotsearch.randomizedtesting.RandomizedTest.randomIntBetween;
+import static com.carrotsearch.randomizedtesting.RandomizedTest.*;
 import static org.hamcrest.Matchers.*;
 
 public class StoreTest extends ElasticsearchLuceneTestCase {
@@ -184,9 +182,15 @@ public class StoreTest extends ElasticsearchLuceneTestCase {
         if (random().nextBoolean()) {
             DirectoryReader.open(writer, random().nextBoolean()).close(); // flush
         }
+        Store.MetadataSnapshot metadata;
         // check before we committed
-        Store.MetadataSnapshot metadata = store.getMetadata();
-        assertThat(metadata.asMap().isEmpty(), is(true));   // nothing committed
+        try {
+            store.getMetadata();
+            fail("no index present - expected exception");
+        } catch (IndexNotFoundException ex) {
+            // expected
+        }
+        assertThat(store.getMetadataOrEmpty(), is(Store.MetadataSnapshot.EMPTY)); // nothing committed
 
         writer.close();
         Store.LegacyChecksums checksums = new Store.LegacyChecksums();
@@ -247,10 +251,15 @@ public class StoreTest extends ElasticsearchLuceneTestCase {
         if (random().nextBoolean()) {
             DirectoryReader.open(writer, random().nextBoolean()).close(); // flush
         }
+        Store.MetadataSnapshot metadata;
         // check before we committed
-        Store.MetadataSnapshot metadata = store.getMetadata();
-        assertThat(metadata.asMap().isEmpty(), is(true)); // nothing committed
-
+        try {
+            store.getMetadata();
+            fail("no index present - expected exception");
+        } catch (IndexNotFoundException ex) {
+            // expected
+        }
+        assertThat(store.getMetadataOrEmpty(), is(Store.MetadataSnapshot.EMPTY)); // nothing committed
         writer.commit();
         writer.close();
         metadata = store.getMetadata();
@@ -302,9 +311,15 @@ public class StoreTest extends ElasticsearchLuceneTestCase {
         if (random().nextBoolean()) {
             DirectoryReader.open(writer, random().nextBoolean()).close(); // flush
         }
+        Store.MetadataSnapshot metadata;
         // check before we committed
-        Store.MetadataSnapshot metadata = store.getMetadata();
-        assertThat(metadata.asMap().isEmpty(), is(true)); // nothing committed
+        try {
+            store.getMetadata();
+            fail("no index present - expected exception");
+        } catch (IndexNotFoundException ex) {
+            // expected
+        }
+        assertThat(store.getMetadataOrEmpty(), is(Store.MetadataSnapshot.EMPTY)); // nothing committed
         writer.commit();
         writer.close();
         Store.LegacyChecksums checksums = new Store.LegacyChecksums();
@@ -707,7 +722,4 @@ public class StoreTest extends ElasticsearchLuceneTestCase {
         store.deleteContent();
         IOUtils.close(store);
     }
-
-
-
 }


### PR DESCRIPTION
When reading metadata we do catch FileNotFound and NoSuchFileExceptions
today, log the even and return an empty metadata object. Yet, in some cases
this might be the wrong thing todo ie. if a commit point is provided these
situations are actually an error and should be rethrown. This commit
pushes the responsiblity to the caller to handle this exception.
