### PR TITLE
Update pathhierarchy-tokenizer.asciidoc

### DIFF
--- a/docs/reference/analysis/tokenizers/pathhierarchy-tokenizer.asciidoc
+++ b/docs/reference/analysis/tokenizers/pathhierarchy-tokenizer.asciidoc
@@ -1,7 +1,7 @@
 [[analysis-pathhierarchy-tokenizer]]
 === Path Hierarchy Tokenizer
 
-The `path_hierarchy` tokenizer takes something like this:
+The `PathHierarchy` tokenizer takes something like this:
 
 -------------------------
 /something/something/else


### PR DESCRIPTION
The docs seem to contain a bug regarding the type of the path hierarchy tokenizer.
