### PR TITLE
Testing: Added utility class to find free port

### DIFF
--- a/src/test/java/org/elasticsearch/test/transport/NettyTransportMultiPortIntegrationTests.java
+++ b/src/test/java/org/elasticsearch/test/transport/NettyTransportMultiPortIntegrationTests.java
@@ -40,10 +40,10 @@ import static org.hamcrest.Matchers.is;
 /**
  *
  */
-@ClusterScope(scope = Scope.SUITE, numDataNodes = 1, enableRandomBenchNodes = false)
+@ClusterScope(scope = Scope.SUITE, numDataNodes = 1, enableRandomBenchNodes = false, transportClientRatio = 1.0)
 public class NettyTransportMultiPortIntegrationTests extends ElasticsearchIntegrationTest {
 
-    private final int randomPort = randomIntBetween(1025, 65000);
+    private final int randomPort = SocketUtil.findFreeLocalPort();
     private final String randomPortRange = String.format(Locale.ROOT, "%s-%s", randomPort, randomPort+10);
 
     @Override

--- a/src/test/java/org/elasticsearch/test/transport/NettyTransportMultiPortTests.java
+++ b/src/test/java/org/elasticsearch/test/transport/NettyTransportMultiPortTests.java
@@ -18,12 +18,9 @@
  */
 package org.elasticsearch.test.transport;
 
-import com.carrotsearch.hppc.IntOpenHashSet;
 import com.google.common.base.Charsets;
-import com.google.common.collect.Sets;
 import org.elasticsearch.Version;
 import org.elasticsearch.cache.recycler.PageCacheRecycler;
-import org.elasticsearch.cluster.metadata.BenchmarkMetaData;
 import org.elasticsearch.common.component.Lifecycle;
 import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.network.NetworkUtils;
@@ -31,7 +28,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
-import org.elasticsearch.node.settings.NodeSettingsService;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.elasticsearch.test.cache.recycler.MockBigArrays;
 import org.elasticsearch.test.junit.annotations.Network;
@@ -39,16 +35,13 @@ import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.netty.NettyTransport;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
-import java.util.Set;
 
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 import static org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
@@ -72,13 +65,12 @@ public class NettyTransportMultiPortTests extends ElasticsearchTestCase {
         if (threadPool != null) {
             threadPool.shutdownNow();
         }
-
     }
 
     @Test
     @TestLogging("shield.transport.netty:DEBUG")
     public void testThatNettyCanBindToMultiplePorts() throws Exception {
-        int[] ports = getRandomPorts(3);
+        int[] ports = SocketUtil.findFreeLocalPorts(3);
 
         Settings settings = settingsBuilder()
                 .put("network.host", "127.0.0.1")
@@ -97,7 +89,7 @@ public class NettyTransportMultiPortTests extends ElasticsearchTestCase {
     @Test
     @TestLogging("transport.netty:DEBUG")
     public void testThatDefaultProfileInheritsFromStandardSettings() throws Exception {
-        int[] ports = getRandomPorts(2);
+        int[] ports = SocketUtil.findFreeLocalPorts(2);
 
         Settings settings = settingsBuilder()
                 .put("network.host", "127.0.0.1")
@@ -114,7 +106,7 @@ public class NettyTransportMultiPortTests extends ElasticsearchTestCase {
     @Test
     @TestLogging("transport.netty:DEBUG")
     public void testThatProfileWithoutPortSettingsFails() throws Exception {
-        int[] ports = getRandomPorts(1);
+        int[] ports = SocketUtil.findFreeLocalPorts(1);
 
         Settings settings = settingsBuilder()
                 .put("network.host", "127.0.0.1")
@@ -130,7 +122,7 @@ public class NettyTransportMultiPortTests extends ElasticsearchTestCase {
     @Test
     @TestLogging("transport.netty:DEBUG")
     public void testThatDefaultProfilePortOverridesGeneralConfiguration() throws Exception {
-        int[] ports = getRandomPorts(3);
+        int[] ports = SocketUtil.findFreeLocalPorts(3);
 
         Settings settings = settingsBuilder()
                 .put("network.host", "127.0.0.1")
@@ -149,7 +141,7 @@ public class NettyTransportMultiPortTests extends ElasticsearchTestCase {
     @Test
     @Network
     public void testThatBindingOnDifferentHostsWorks() throws Exception {
-        int[] ports = getRandomPorts(2);
+        int[] ports = SocketUtil.findFreeLocalPorts(2);
         InetAddress firstNonLoopbackAddress = NetworkUtils.getFirstNonLoopbackAddress(NetworkUtils.StackType.IPv4);
 
         Settings settings = settingsBuilder()
@@ -165,22 +157,6 @@ public class NettyTransportMultiPortTests extends ElasticsearchTestCase {
         assertPortIsBound("127.0.0.1", ports[0]);
         assertPortIsBound(firstNonLoopbackAddress.getHostAddress(), ports[1]);
         assertConnectionRefused(ports[1]);
-    }
-
-    // TODO, make sure one can check more settings and that they are applied correctly
-
-    private int[] getRandomPorts(int numberOfPorts) {
-        IntOpenHashSet ports = new IntOpenHashSet();
-
-        for (int i = 0; i < numberOfPorts; i++) {
-            int port = randomIntBetween(1025, 65000);
-            while (ports.contains(port)) {
-                port = randomIntBetween(1025, 65000);
-            }
-            ports.add(port);
-        }
-
-        return ports.toArray();
     }
 
     private void startNettyTransport(Settings settings) {

--- a/src/test/java/org/elasticsearch/test/transport/SocketUtil.java
+++ b/src/test/java/org/elasticsearch/test/transport/SocketUtil.java
@@ -100,6 +100,7 @@ public class SocketUtil {
         try {
             try(ServerSocket serverSocket = new ServerSocket()) {
                 SocketAddress sa = new InetSocketAddress(localAddress, port);
+                serverSocket.setReuseAddress(true);
                 serverSocket.bind(sa);
                 return true;
             }

--- a/src/test/java/org/elasticsearch/test/transport/SocketUtil.java
+++ b/src/test/java/org/elasticsearch/test/transport/SocketUtil.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.test.transport;
+
+import com.carrotsearch.hppc.IntOpenHashSet;
+import com.carrotsearch.randomizedtesting.RandomizedTest;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.network.NetworkUtils;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.SocketAddress;
+import java.util.Locale;
+
+import static org.elasticsearch.common.Preconditions.checkArgument;
+
+/**
+ * helper class to find a free port
+ */
+public class SocketUtil {
+
+    /**
+     * Find a number of free ports in the IANA ephemeral port range [49152-65535]
+     *
+     * @param numberOfPorts Number of ports to find
+     * @return an array of integer which are considered to be free when tested
+     */
+    public static int[] findFreeLocalPorts(int numberOfPorts) {
+        // IANA suggests to use these as "ephemeral ports" (short lived)
+        return findFreeLocalPorts(49152, 65535, numberOfPorts);
+    }
+
+    /**
+     * Find a single free port in the IANA ephemeral port range [49152-65535]
+     *
+     * @return An int representing a port which was considered to be free when tested
+     */
+    public static int findFreeLocalPort() {
+        // IANA suggests to use these as "ephemeral ports" (short lived)
+        return findFreeLocalPorts(49152, 65535, 1)[0];
+    }
+
+    /**
+     * Find a number of free ports in the configured port range
+     *
+     * @param low Lowest port in allowed range
+     * @param high Max port in allowed range
+     * @param numberOfPorts Number of ports to find
+     * @return an array of integer which are considered to be free when tested
+     */
+    public static int[] findFreeLocalPorts(int low, int high, int numberOfPorts) {
+        checkArgument(low < high, String.format(Locale.ROOT, "Expected %s < %s", low, high));
+        IntOpenHashSet ports = new IntOpenHashSet();
+
+        // create some exit condition vars
+        int runs = 0;
+        int maxRuns = numberOfPorts * 10;
+
+        while (ports.size() < numberOfPorts) {
+            int randomPort = RandomizedTest.randomIntBetween(low, high);
+            if (isFreeSocket(randomPort)) {
+                ports.add(randomPort);
+            }
+
+            if (++runs > maxRuns) {
+                throw new ElasticsearchException("Could not find free port in range[" + low + "-" + high + "] after " + runs + " runs");
+            }
+        }
+
+        return ports.toArray();
+    }
+
+    /**
+     * Try a socket bind and close to see if the port is free on the local interface
+     * @param port A an arbitrary port number
+     *
+     * @return true if the socket could be bound, false otherwise
+     */
+    private static boolean isFreeSocket(int port) {
+        InetAddress localAddress = NetworkUtils.getLocalAddress();
+
+        try {
+            try(ServerSocket serverSocket = new ServerSocket()) {
+                SocketAddress sa = new InetSocketAddress(localAddress, port);
+                serverSocket.bind(sa);
+                return true;
+            }
+        } catch (IOException e) {
+            // ignore and try to use the next port
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
The current netty tests heavily rely on finding a free port to bind to.

In order to simplify this, the first step is to bind only on so-called
ephemeral ports, which are considered to be high and short lived. This also
prevents binding on the heavily used 9xxx port range on testing systems.

The second step is to add a SocketUtil class, which returns a currently
unused port by trying to bind and unbind to it. This class check randomly
one of the ephemeral ports and also allows to return several ports at once.
