### PR TITLE
[TEST] `Scope.SUITE` is not reproducible due to late cluster initialization

### DIFF
--- a/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
@@ -57,9 +57,6 @@ import org.elasticsearch.client.Requests;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
-import org.elasticsearch.cluster.routing.IndexRoutingTable;
-import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
-import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.allocation.decider.DiskThresholdDecider;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Priority;
@@ -300,9 +297,11 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
             switch (currentClusterScope) {
                 case GLOBAL:
                     clearClusters();
+                    assert GLOBAL_CLUSTER != null : "Scope.GLOBAL cluster must be initialied in a static context";
                     currentCluster = GLOBAL_CLUSTER;
                     break;
                 case SUITE:
+                    assert clusters.containsKey(this.getClass()) : "Scope.SUITE cluster must be initialized in a static context";
                     currentCluster = buildAndPutCluster(currentClusterScope, false);
                     break;
                 case TEST:
@@ -583,6 +582,8 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
         if (createIfExists || testCluster == null) {
             testCluster = buildTestCluster(currentClusterScope);
         } else {
+            // if we carry that cluster over ie. it was already there we remove it and then call clearClusters
+            // and put it back afterwards such that all pending leftover clusters are closed and disposed...
             clusters.remove(this.getClass());
         }
         clearClusters();
@@ -1527,7 +1528,7 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
         assertThat(clearResponse.isSucceeded(), equalTo(true));
     }
 
-    private ClusterScope getAnnotation(Class<?> clazz) {
+    private static ClusterScope getAnnotation(Class<?> clazz) {
         if (clazz == Object.class || clazz == ElasticsearchIntegrationTest.class) {
             return null;
         }
@@ -1539,7 +1540,11 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
     }
 
     private Scope getCurrentClusterScope() {
-        ClusterScope annotation = getAnnotation(this.getClass());
+        return getCurrentClusterScope(this.getClass());
+    }
+
+    private static Scope getCurrentClusterScope(Class<?> clazz) {
+        ClusterScope annotation = getAnnotation(clazz);
         // if we are not annotated assume global!
         return annotation == null ? Scope.GLOBAL : annotation.scope();
     }
@@ -1764,8 +1769,20 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
 
     private static void initializeSuiteScope() throws Exception {
         Class<?> targetClass = getContext().getTargetClass();
+        /**
+         * Note we create these test class instance via reflection
+         * since JUnit creates a new instance per test and that is also
+         * the reason why INSTANCE is static since this entire method
+         * must be executed in a static context.
+         */
         assert INSTANCE == null;
-        if (isSuiteScope(targetClass)) {
+        if (getCurrentClusterScope(targetClass) == Scope.SUITE) {
+            final ElasticsearchIntegrationTest instance = (ElasticsearchIntegrationTest) targetClass.newInstance();
+            // if we have suite scoped cluster here we need to initialize the
+            // cluster before the first test starts for reproducibility
+            instance.buildAndPutCluster(Scope.SUITE, false);
+        }
+        if (isSuiteScopedTest(targetClass)) {
             // note we need to do this this way to make sure this is reproducible
             INSTANCE = (ElasticsearchIntegrationTest) targetClass.newInstance();
             boolean success = false;
@@ -1792,7 +1809,7 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
     protected void setupSuiteScopeCluster() throws Exception {
     }
 
-    private static boolean isSuiteScope(Class<?> clazz) {
+    private static boolean isSuiteScopedTest(Class<?> clazz) {
         if (clazz == Object.class || clazz == ElasticsearchIntegrationTest.class) {
             return false;
         }
@@ -1800,7 +1817,18 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
         if (annotation != null) {
             return true;
         }
-        return isSuiteScope(clazz.getSuperclass());
+        return isSuiteScopedTest(clazz.getSuperclass());
+    }
+
+    private static boolean isSuiteScopeCluster(Class<?> clazz) {
+        if (clazz == Object.class || clazz == ElasticsearchIntegrationTest.class) {
+            return false;
+        }
+        SuiteScopeTest annotation = clazz.getAnnotation(SuiteScopeTest.class);
+        if (annotation != null) {
+            return true;
+        }
+        return isSuiteScopedTest(clazz.getSuperclass());
     }
 
     /**

--- a/src/test/java/org/elasticsearch/test/test/GlobalScopeClusterTests.java
+++ b/src/test/java/org/elasticsearch/test/test/GlobalScopeClusterTests.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.test.test;
+
+import com.carrotsearch.randomizedtesting.annotations.Repeat;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.TestCluster;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * This test ensures that the cluster initializion for GLOBAL scope is not influencing
+ * the tests random sequence due to initializtion using the same random instance.
+ */
+public class GlobalScopeClusterTests extends ElasticsearchIntegrationTest {
+    private static int ITER = 0;
+    private static long[] SEQUENCE = new long[100];
+
+    @Test
+    @Repeat(iterations = 10, useConstantSeed = true)
+    public void testReproducible() {
+        if (ITER++ == 0) {
+            for (int i = 0; i < SEQUENCE.length; i++) {
+                SEQUENCE[i] = randomLong();
+            }
+        } else {
+            for (int i = 0; i < SEQUENCE.length; i++) {
+                assertThat(SEQUENCE[i], equalTo(randomLong()));
+            }
+        }
+    }
+
+    protected TestCluster buildTestCluster(Scope scope) throws IOException {
+        // produce some randomness
+        int iters = between(1, 100);
+        for (int i = 0; i < iters; i++) {
+            randomLong();
+        }
+        return super.buildTestCluster(scope);
+    }
+}

--- a/src/test/java/org/elasticsearch/test/test/SuiteScopeClusterTests.java
+++ b/src/test/java/org/elasticsearch/test/test/SuiteScopeClusterTests.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.test.test;
+
+import com.carrotsearch.randomizedtesting.annotations.Repeat;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.TestCluster;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * This test ensures that the cluster initializion for suite scope is not influencing
+ * the tests random sequence due to initializtion using the same random instance.
+ */
+@ElasticsearchIntegrationTest.ClusterScope(scope = ElasticsearchIntegrationTest.Scope.SUITE)
+public class SuiteScopeClusterTests extends ElasticsearchIntegrationTest {
+    private static int ITER = 0;
+    private static long[] SEQUENCE = new long[100];
+
+    @Test
+    @Repeat(iterations = 10, useConstantSeed = true)
+    public void testReproducible() {
+        if (ITER++ == 0) {
+            for (int i = 0; i < SEQUENCE.length; i++) {
+                SEQUENCE[i] = randomLong();
+            }
+        } else {
+            for (int i = 0; i < SEQUENCE.length; i++) {
+                assertThat(SEQUENCE[i], equalTo(randomLong()));
+            }
+        }
+    }
+
+    protected TestCluster buildTestCluster(Scope scope) throws IOException {
+        // produce some randomness
+        int iters = between(1, 100);
+        for (int i = 0; i < iters; i++) {
+            randomLong();
+        }
+        return super.buildTestCluster(scope);
+    }
+}

--- a/src/test/java/org/elasticsearch/test/test/TestScopeClusterTests.java
+++ b/src/test/java/org/elasticsearch/test/test/TestScopeClusterTests.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.test.test;
+
+import com.carrotsearch.randomizedtesting.annotations.Repeat;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.TestCluster;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * This test ensures that the cluster initializion for TEST scope is not influencing
+ * the tests random sequence due to initializtion using the same random instance.
+ */
+@ElasticsearchIntegrationTest.ClusterScope(scope = ElasticsearchIntegrationTest.Scope.TEST)
+public class TestScopeClusterTests extends ElasticsearchIntegrationTest {
+    private static int ITER = 0;
+    private static long[] SEQUENCE = new long[100];
+
+    @Test
+    @Repeat(iterations = 10, useConstantSeed = true)
+    public void testReproducible() {
+        if (ITER++ == 0) {
+            for (int i = 0; i < SEQUENCE.length; i++) {
+                SEQUENCE[i] = randomLong();
+            }
+        } else {
+            for (int i = 0; i < SEQUENCE.length; i++) {
+                assertThat(SEQUENCE[i], equalTo(randomLong()));
+            }
+        }
+    }
+
+    protected TestCluster buildTestCluster(Scope scope) throws IOException {
+        // produce some randomness
+        int iters = between(1, 100);
+        for (int i = 0; i < iters; i++) {
+            randomLong();
+        }
+        return super.buildTestCluster(scope);
+    }
+}


### PR DESCRIPTION
The cluster for `Scope.SUITE` tests must be initialize in a static manner
before the first test runs otherwise the random context used to initialize
the cluster is taken from tests randomness rather than the suites randomness.
This means test clusters will have different setups if only a single test is
executed or even the test might have a entirely different random sequence.
