### PR TITLE
Cleanup non nested filter to not flip the FixedBitSet returned by the wrapped filter.

### DIFF
--- a/src/main/java/org/elasticsearch/index/search/nested/NestedDocsFilter.java
+++ b/src/main/java/org/elasticsearch/index/search/nested/NestedDocsFilter.java
@@ -30,16 +30,19 @@ import org.elasticsearch.index.mapper.internal.TypeFieldMapper;
 
 import java.io.IOException;
 
+/**
+ * Filter that returns all nested documents.
+ * A nested document is a sub documents that belong to a root document.
+ * Nested documents share the unique id and type and optionally the _source with root documents.
+ */
 public class NestedDocsFilter extends Filter {
 
     public static final NestedDocsFilter INSTANCE = new NestedDocsFilter();
 
-    private final PrefixFilter filter = new PrefixFilter(new Term(TypeFieldMapper.NAME, new BytesRef("__")));
-
+    private final Filter filter = nestedFilter();
     private final int hashCode = filter.hashCode();
 
     private NestedDocsFilter() {
-
     }
 
     @Override
@@ -56,4 +59,9 @@ public class NestedDocsFilter extends Filter {
     public boolean equals(Object obj) {
         return obj == INSTANCE;
     }
+
+    static Filter nestedFilter() {
+        return new PrefixFilter(new Term(TypeFieldMapper.NAME, new BytesRef("__")));
+    }
+
 }

--- a/src/main/java/org/elasticsearch/index/search/nested/NonNestedDocsFilter.java
+++ b/src/main/java/org/elasticsearch/index/search/nested/NonNestedDocsFilter.java
@@ -20,40 +20,30 @@
 package org.elasticsearch.index.search.nested;
 
 import org.apache.lucene.index.AtomicReaderContext;
-import org.apache.lucene.index.Term;
 import org.apache.lucene.search.DocIdSet;
 import org.apache.lucene.search.Filter;
-import org.apache.lucene.search.PrefixFilter;
 import org.apache.lucene.util.Bits;
-import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.FixedBitSet;
-import org.elasticsearch.common.lucene.docset.DocIdSets;
-import org.elasticsearch.index.mapper.internal.TypeFieldMapper;
+import org.elasticsearch.common.lucene.search.NotFilter;
 
 import java.io.IOException;
 
+/**
+ * A filter that returns all root (non nested) documents.
+ * Root documents have an unique id, a type and optionally have a _source and other indexed and stored fields.
+ */
 public class NonNestedDocsFilter extends Filter {
 
     public static final NonNestedDocsFilter INSTANCE = new NonNestedDocsFilter();
 
-    private final PrefixFilter filter = new PrefixFilter(new Term(TypeFieldMapper.NAME, new BytesRef("__")));
-
+    private final Filter filter = new NotFilter(NestedDocsFilter.nestedFilter());
     private final int hashCode = filter.hashCode();
 
     private NonNestedDocsFilter() {
-
     }
 
     @Override
     public DocIdSet getDocIdSet(AtomicReaderContext context, Bits acceptDocs) throws IOException {
-        DocIdSet docSet = filter.getDocIdSet(context, acceptDocs);
-        if (DocIdSets.isEmpty(docSet)) {
-            // will almost never happen, and we need an OpenBitSet for the parent filter in
-            // BlockJoinQuery, we cache it anyhow...
-            docSet = new FixedBitSet(context.reader().maxDoc());
-        }
-        ((FixedBitSet) docSet).flip(0, context.reader().maxDoc());
-        return docSet;
+        return filter.getDocIdSet(context, acceptDocs);
     }
 
     @Override


### PR DESCRIPTION
If the filter producing the FBS were to be cached then it would flip bits each time the NonNestedDocsFilter was executed.

In our case we cached the NonNestedDocsFilter itself so flipping bits each time NonNestedDocsFilter was used  didn't happen. However the hashcode of NonNestedDocsFilter and NestedDocsFilter was the same, since NonNestedDocsFilter directly used NestedDocsFilter#hashCode()

PR for #8227
