### PR TITLE
Throw exception if `index` is null or missing when creating an alias

### DIFF
--- a/docs/reference/indices/aliases.asciidoc
+++ b/docs/reference/indices/aliases.asciidoc
@@ -185,7 +185,7 @@ An alias can also be added with the endpoint
 where
 
 [horizontal]
-`index`::   The index the alias refers to. Can be any of `blank | * | _all | glob pattern | name1, name2, …`
+`index`::   The index the alias refers to. Can be any of `* | _all | glob pattern | name1, name2, …`
 `name`::   The name of the alias. This is a required option.
 `routing`:: An optional routing that can be associated with an alias.
 `filter`::  An optional filter that can be associated with an alias.

--- a/rest-api-spec/test/indices.delete_alias/all_path_options.yaml
+++ b/rest-api-spec/test/indices.delete_alias/all_path_options.yaml
@@ -16,11 +16,17 @@ setup:
   - do:
       indices.put_alias:
         name:  alias1
+        index:
+          - test_index1
+          - foo
         body:
           routing: "routing value"
   - do:
       indices.put_alias:
         name:  alias2
+        index:
+          - test_index2
+          - foo
         body:
           routing: "routing value"
 
@@ -31,14 +37,12 @@ setup:
         name: alias1
 
   - match: {test_index1.aliases.alias1.search_routing: "routing value"}
-  - match: {test_index2.aliases.alias1.search_routing: "routing value"}
   - match: {foo.aliases.alias1.search_routing: "routing value"}
 
   - do:
       indices.get_alias:
         name: alias2
 
-  - match: {test_index1.aliases.alias2.search_routing: "routing value"}
   - match: {test_index2.aliases.alias2.search_routing: "routing value"}
   - match: {foo.aliases.alias2.search_routing: "routing value"}
 
@@ -57,7 +61,6 @@ setup:
       indices.get_alias:
         name: alias2
 
-  - match: {test_index1.aliases.alias2.search_routing: "routing value"}
   - match: {test_index2.aliases.alias2.search_routing: "routing value"}
   - match: {foo.aliases.alias2.search_routing: "routing value"}
 
@@ -76,7 +79,6 @@ setup:
       indices.get_alias:
         name: alias2
 
-  - match: {test_index1.aliases.alias2.search_routing: "routing value"}
   - match: {test_index2.aliases.alias2.search_routing: "routing value"}
   - match: {foo.aliases.alias2.search_routing: "routing value"}
 
@@ -99,7 +101,6 @@ setup:
       indices.get_alias:
         name: alias2
 
-  - match: {test_index1.aliases.alias2.search_routing: "routing value"}
   - match: {test_index2.aliases.alias2.search_routing: "routing value"}
   - match: {foo.aliases.alias2.search_routing: "routing value"}
 
@@ -122,7 +123,6 @@ setup:
       indices.get_alias:
         name: alias2
 
-  - match: {test_index1.aliases.alias2.search_routing: "routing value"}
   - match: {test_index2.aliases.alias2.search_routing: "routing value"}
   - match: {foo.aliases.alias2.search_routing: "routing value"}
 
@@ -192,7 +192,6 @@ setup:
       indices.get_alias:
         name:  alias2
 
-  - match: {test_index1.aliases.alias2.search_routing: "routing value"}
   - match: {test_index2.aliases.alias2.search_routing: "routing value"}
   - match: {foo.aliases.alias2.search_routing: "routing value"}
 

--- a/rest-api-spec/test/indices.put_alias/all_path_options.yaml
+++ b/rest-api-spec/test/indices.put_alias/all_path_options.yaml
@@ -106,16 +106,10 @@ setup:
 
 
   - do:
+      catch: param
       indices.put_alias:
         name: alias
 
-  - do:
-      indices.get_alias:
-        name: alias
-
-  - match: {test_index1.aliases.alias: {}}
-  - match: {test_index2.aliases.alias: {}}
-  - match: {foo.aliases.alias: {}}
 
 ---
 "put alias with missing name":

--- a/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequest.java
@@ -304,7 +304,7 @@ public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesReq
                 }
             } else {
                 validationException = addValidationError("Alias action [" + aliasAction.actionType().name().toLowerCase(Locale.ENGLISH)
-                        + "]: [index] may not be null", validationException);
+                        + "]: Property [index] was either missing or null", validationException);
             }
         }
         return validationException;

--- a/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequest.java
@@ -306,6 +306,9 @@ public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesReq
                                 + "]: [index] may not be empty string", validationException);
                     }
                 }
+            } else {
+                validationException = addValidationError("Alias action [" + aliasAction.actionType().name().toLowerCase(Locale.ENGLISH)
+                        + "]: [index] may not be null", validationException);
             }
         }
         return validationException;

--- a/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequest.java
@@ -294,10 +294,6 @@ public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesReq
                                 + "]: [alias] may not be empty string", validationException);
                     }
                 }
-                if (CollectionUtils.isEmpty(aliasAction.indices)) {
-                    validationException = addValidationError("Alias action [" + aliasAction.actionType().name().toLowerCase(Locale.ENGLISH)
-                            + "]: indices may not be empty", validationException);
-                }
             }
             if (!CollectionUtils.isEmpty(aliasAction.indices)) {
                 for (String index : aliasAction.indices) {

--- a/src/test/java/org/elasticsearch/aliases/IndexAliasesTests.java
+++ b/src/test/java/org/elasticsearch/aliases/IndexAliasesTests.java
@@ -744,9 +744,31 @@ public class IndexAliasesTests extends ElasticsearchIntegrationTest {
         assertThat(existsResponse.exists(), equalTo(false));
     }
 
-    @Test(expected = IndexMissingException.class)
-    public void testAddAliasNullIndex() {
-        admin().indices().prepareAliases().addAliasAction(AliasAction.newAddAliasAction(null, "alias1")).get();
+    @Test
+    public void testAddAliasNullWithoutExistingIndices() {
+        try {
+            assertAcked(admin().indices().prepareAliases().addAliasAction(AliasAction.newAddAliasAction(null, "alias1")));
+            fail("create alias should have failed due to null index");
+        } catch (ElasticsearchIllegalArgumentException e) {
+            assertThat(e.getMessage(), equalTo("Validation Failed: 1: Alias action [add]: [index] may not be null;"));
+        }
+
+    }
+
+    @Test
+    public void testAddAliasNullWithExistingIndices() throws Exception {
+        logger.info("--> creating index [test]");
+        createIndex("test");
+        ensureGreen();
+
+        logger.info("--> aliasing index [null] with [empty-alias]");
+
+        try {
+            assertAcked(admin().indices().prepareAliases().addAlias((String) null, "empty-alias"));
+            fail("create alias should have failed due to null index");
+        } catch (ElasticsearchIllegalArgumentException e) {
+            assertThat(e.getMessage(), equalTo("Validation Failed: 1: Alias action [add]: [index] may not be null;"));
+        }
     }
 
     @Test(expected = ActionRequestValidationException.class)
@@ -771,7 +793,7 @@ public class IndexAliasesTests extends ElasticsearchIntegrationTest {
             assertTrue("Should throw " + ActionRequestValidationException.class.getSimpleName(), false);
         } catch (ActionRequestValidationException e) {
             assertThat(e.validationErrors(), notNullValue());
-            assertThat(e.validationErrors().size(), equalTo(1));
+            assertThat(e.validationErrors().size(), equalTo(2));
         }
     }
 
@@ -927,22 +949,6 @@ public class IndexAliasesTests extends ElasticsearchIntegrationTest {
         client().admin().indices().prepareAliases()
                 .addAlias("test", "a", FilterBuilders.matchAllFilter()) // <-- no fail, b/c no field mentioned
                 .get();
-    }
-
-    @Test
-    public void testNullIndexOnAlias() throws Exception {
-        logger.info("--> creating index [test]");
-        createIndex("test");
-        ensureGreen();
-
-        logger.info("--> aliasing index [null] with [empty-alias]");
-
-        try {
-            assertAcked(admin().indices().prepareAliases().addAlias((String) null, "empty-alias"));
-            fail("create alias should have failed due to null index");
-        } catch (ElasticsearchIllegalArgumentException e) {
-            assertThat(e.getMessage(), equalTo("Validation Failed: 1: Alias action [add]: [index] may not be null;"));
-        }
     }
     
     private void checkAliases() {

--- a/src/test/java/org/elasticsearch/aliases/IndexAliasesTests.java
+++ b/src/test/java/org/elasticsearch/aliases/IndexAliasesTests.java
@@ -750,7 +750,7 @@ public class IndexAliasesTests extends ElasticsearchIntegrationTest {
             assertAcked(admin().indices().prepareAliases().addAliasAction(AliasAction.newAddAliasAction(null, "alias1")));
             fail("create alias should have failed due to null index");
         } catch (ElasticsearchIllegalArgumentException e) {
-            assertThat(e.getMessage(), equalTo("Validation Failed: 1: Alias action [add]: [index] may not be null;"));
+            assertThat(e.getMessage(), equalTo("Validation Failed: 1: Alias action [add]: Property [index] was either missing or null;"));
         }
 
     }
@@ -767,7 +767,7 @@ public class IndexAliasesTests extends ElasticsearchIntegrationTest {
             assertAcked(admin().indices().prepareAliases().addAlias((String) null, "empty-alias"));
             fail("create alias should have failed due to null index");
         } catch (ElasticsearchIllegalArgumentException e) {
-            assertThat(e.getMessage(), equalTo("Validation Failed: 1: Alias action [add]: [index] may not be null;"));
+            assertThat(e.getMessage(), equalTo("Validation Failed: 1: Alias action [add]: Property [index] was either missing or null;"));
         }
     }
 

--- a/src/test/java/org/elasticsearch/aliases/IndexAliasesTests.java
+++ b/src/test/java/org/elasticsearch/aliases/IndexAliasesTests.java
@@ -929,6 +929,22 @@ public class IndexAliasesTests extends ElasticsearchIntegrationTest {
                 .get();
     }
 
+    @Test
+    public void testNullIndexOnAlias() throws Exception {
+        logger.info("--> creating index [test]");
+        createIndex("test");
+        ensureGreen();
+
+        logger.info("--> aliasing index [null] with [empty-alias]");
+
+        try {
+            assertAcked(admin().indices().prepareAliases().addAlias((String) null, "empty-alias"));
+            fail("create alias should have failed due to null index");
+        } catch (ElasticsearchIllegalArgumentException e) {
+            assertThat(e.getMessage(), equalTo("Validation Failed: 1: Alias action [add]: [index] may not be null;"));
+        }
+    }
+    
     private void checkAliases() {
         GetAliasesResponse getAliasesResponse = admin().indices().prepareGetAliases("alias1").get();
         assertThat(getAliasesResponse.getAliases().get("test").size(), equalTo(1));

--- a/src/test/java/org/elasticsearch/aliases/IndexAliasesTests.java
+++ b/src/test/java/org/elasticsearch/aliases/IndexAliasesTests.java
@@ -750,7 +750,9 @@ public class IndexAliasesTests extends ElasticsearchIntegrationTest {
             assertAcked(admin().indices().prepareAliases().addAliasAction(AliasAction.newAddAliasAction(null, "alias1")));
             fail("create alias should have failed due to null index");
         } catch (ElasticsearchIllegalArgumentException e) {
-            assertThat(e.getMessage(), equalTo("Validation Failed: 1: Alias action [add]: Property [index] was either missing or null;"));
+            assertThat("Exception text does not contain \"Property [index] was either missing or null\"",
+                    e.getMessage().contains("Property [index] was either missing or null"),
+                    equalTo(true));
         }
 
     }
@@ -767,7 +769,9 @@ public class IndexAliasesTests extends ElasticsearchIntegrationTest {
             assertAcked(admin().indices().prepareAliases().addAlias((String) null, "empty-alias"));
             fail("create alias should have failed due to null index");
         } catch (ElasticsearchIllegalArgumentException e) {
-            assertThat(e.getMessage(), equalTo("Validation Failed: 1: Alias action [add]: Property [index] was either missing or null;"));
+            assertThat("Exception text does not contain \"Property [index] was either missing or null\"",
+                    e.getMessage().contains("Property [index] was either missing or null"),
+                    equalTo(true));
         }
     }
 


### PR DESCRIPTION
Fixes a bug where alias creation would allow `null` for index name, which thereby applied the alias to _all_ indices.  This patch makes the validator throw an exception if the index is null.

Java integration tests and YAML REST tests had to be modified, since they were testing this bug as if it were a real feature.

This is a **breaking** change, if someone was accidentally relying on this bug.

Fixes #7863, related to old PR #7976

``` bash
POST /_aliases
{
   "actions": [
      {
         "add": {
            "alias": "empty-alias",
            "index": null
         }
      }
   ]
}
```

``` json
{
   "error": "ActionRequestValidationException[Validation Failed: 1: Alias action [add]: [index] may not be null;]",
   "status": 400
}
```
