### PR TITLE
MLT Query: use ParseField#withAllDeprecated for percent_terms_to_match

### DIFF
--- a/docs/reference/query-dsl/queries/mlt-field-query.asciidoc
+++ b/docs/reference/query-dsl/queries/mlt-field-query.asciidoc
@@ -29,9 +29,13 @@ The `more_like_this_field` top level parameters include:
 |Parameter |Description
 |`like_text` |The text to find documents like it, *required*.
 
-|`minimum_should_match`| From the generated query, the number of terms that
+|`minimum_should_match`| coming[1.5.0] From the generated query, the number of terms that
 must match following the <<query-dsl-minimum-should-match,minimum should
 syntax>>. (Defaults to `"30%"`).
+
+|`percent_terms_to_match` | deprecated[1.5.0,Replaced by `minimum_should_match`]
+From the generated query, the percentage of terms that must match (float value
+between 0 and 1). Defaults to `0.3` (30 percent).
 
 |`min_term_freq` |The frequency below which terms will be ignored in the
 source doc. The default frequency is `2`.

--- a/docs/reference/query-dsl/queries/mlt-query.asciidoc
+++ b/docs/reference/query-dsl/queries/mlt-query.asciidoc
@@ -86,7 +86,7 @@ interesting terms extracted from some provided text. The interesting terms are
 selected with respect to their tf-idf scores. These are controlled by
 `min_term_freq`, `min_doc_freq`, and `max_doc_freq`. The number of interesting
 terms is controlled by `max_query_terms`. While the minimum number of clauses
-that must be satisfied is controlled by `percent_terms_to_match`. The terms
+that must be satisfied is controlled by `minimum_should_match`. The terms
 are extracted from the text in `like` and analyzed by the analyzer associated
 with the field, unless specified by `analyzer`. There are other parameters,
 such as `min_word_length`, `max_word_length` or `stop_words`, to control what
@@ -132,9 +132,13 @@ The text is analyzed by the default analyzer at the field, unless specified by t
 |`include` |When using `like` with document requests, specifies whether the documents should be
 included from the search. Defaults to `false`.
 
-|`minimum_should_match`| From the generated query, the number of terms that
+|`minimum_should_match`| coming[1.5.0] From the generated query, the number of terms that
 must match following the <<query-dsl-minimum-should-match,minimum should
 syntax>>. (Defaults to `"30%"`).
+
+|`percent_terms_to_match` | deprecated[1.5.0,Replaced by `minimum_should_match`]
+From the generated query, the percentage of terms that must match (float value
+between 0 and 1). Defaults to `0.3` (30 percent).
 
 |`min_term_freq` |The frequency below which terms will be ignored in the
 source doc. The default frequency is `2`.

--- a/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryParser.java
@@ -65,7 +65,7 @@ public class MoreLikeThisQueryParser implements QueryParser {
         public static final ParseField MAX_DOC_FREQ = new ParseField("max_doc_freq");
         public static final ParseField BOOST_TERMS = new ParseField("boost_terms");
         public static final ParseField MINIMUM_SHOULD_MATCH = new ParseField("minimum_should_match");
-        public static final ParseField PERCENT_TERMS_TO_MATCH = new ParseField("percent_terms_to_match");
+        public static final ParseField PERCENT_TERMS_TO_MATCH = new ParseField("percent_terms_to_match").withAllDeprecated("minimum_should_match");
         public static final ParseField FAIL_ON_UNSUPPORTED_FIELD = new ParseField("fail_on_unsupported_field");
         public static final ParseField STOP_WORDS = new ParseField("stop_words");
         public static final ParseField DOCUMENT_IDS = new ParseField("ids").withAllDeprecated("like");


### PR DESCRIPTION
Also the parameter was deprecated but not removed so we keep it in the doc and
mark it as deprecated ...
