### PR TITLE
[TEST] initialize SUITE | GLOBAL scope cluster in a private random context

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>com.carrotsearch.randomizedtesting</groupId>
             <artifactId>randomizedtesting-runner</artifactId>
-            <version>2.1.6</version>
+            <version>2.1.10</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/org/elasticsearch/test/CompositeTestCluster.java
+++ b/src/test/java/org/elasticsearch/test/CompositeTestCluster.java
@@ -57,6 +57,7 @@ public class CompositeTestCluster extends TestCluster {
     private static final String NODE_PREFIX = "external_";
 
     public CompositeTestCluster(InternalTestCluster cluster, int numExternalNodes, ExternalNode externalNode) throws IOException {
+        super(cluster.seed());
         this.cluster = cluster;
         this.externalNodes = new ExternalNode[numExternalNodes];
         for (int i = 0; i < externalNodes.length; i++) {

--- a/src/test/java/org/elasticsearch/test/ElasticsearchBackwardsCompatIntegrationTest.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchBackwardsCompatIntegrationTest.java
@@ -133,8 +133,8 @@ public abstract class ElasticsearchBackwardsCompatIntegrationTest extends Elasti
         return (CompositeTestCluster) cluster();
     }
 
-    protected TestCluster buildTestCluster(Scope scope) throws IOException {
-        TestCluster cluster = super.buildTestCluster(scope);
+    protected TestCluster buildTestCluster(Scope scope, long seed) throws IOException {
+        TestCluster cluster = super.buildTestCluster(scope, seed);
         ExternalNode externalNode = new ExternalNode(backwardsCompatibilityPath(), randomLong(), new SettingsSource() {
             @Override
             public Settings node(int nodeOrdinal) {

--- a/src/test/java/org/elasticsearch/test/ExternalTestCluster.java
+++ b/src/test/java/org/elasticsearch/test/ExternalTestCluster.java
@@ -67,7 +67,7 @@ public final class ExternalTestCluster extends TestCluster {
     private final int numBenchNodes;
 
     public ExternalTestCluster(TransportAddress... transportAddresses) {
-
+        super(0);
         Settings clientSettings = ImmutableSettings.settingsBuilder()
                 .put("config.ignore_system_properties", true) // prevents any settings to be replaced by system properties.
                 .put("client.transport.ignore_cluster_name", true)

--- a/src/test/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/src/test/java/org/elasticsearch/test/InternalTestCluster.java
@@ -201,6 +201,7 @@ public final class InternalTestCluster extends TestCluster {
                                int minNumDataNodes, int maxNumDataNodes, String clusterName, SettingsSource settingsSource, int numClientNodes,
                                boolean enableRandomBenchNodes,
                                int jvmOrdinal, String nodePrefix) {
+        super(clusterSeed);
         this.clusterName = clusterName;
 
         if (minNumDataNodes < 0 || maxNumDataNodes < 0) {

--- a/src/test/java/org/elasticsearch/test/TestCluster.java
+++ b/src/test/java/org/elasticsearch/test/TestCluster.java
@@ -44,10 +44,19 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.*;
 public abstract class TestCluster implements Iterable<Client>, Closeable {
 
     protected final ESLogger logger = Loggers.getLogger(getClass());
+    private final long seed;
 
     protected Random random;
 
     protected double transportClientRatio = 0.0;
+
+    public TestCluster(long seed) {
+        this.seed = seed;
+    }
+
+    public long seed() {
+        return seed;
+    }
 
     /**
      * This method should be executed before each test to reset the cluster to its initial state.

--- a/src/test/java/org/elasticsearch/test/test/GlobalScopeClusterTests.java
+++ b/src/test/java/org/elasticsearch/test/test/GlobalScopeClusterTests.java
@@ -34,27 +34,31 @@ import static org.hamcrest.Matchers.equalTo;
 public class GlobalScopeClusterTests extends ElasticsearchIntegrationTest {
     private static int ITER = 0;
     private static long[] SEQUENCE = new long[100];
+    private static Long CLUSTER_SEED = null;
 
     @Test
     @Repeat(iterations = 10, useConstantSeed = true)
-    public void testReproducible() {
+    public void testReproducible() throws IOException {
         if (ITER++ == 0) {
+            CLUSTER_SEED = cluster().seed();
             for (int i = 0; i < SEQUENCE.length; i++) {
                 SEQUENCE[i] = randomLong();
             }
         } else {
+            assertEquals(CLUSTER_SEED, new Long(cluster().seed()));
             for (int i = 0; i < SEQUENCE.length; i++) {
                 assertThat(SEQUENCE[i], equalTo(randomLong()));
             }
         }
     }
 
-    protected TestCluster buildTestCluster(Scope scope) throws IOException {
+    @Override
+    protected TestCluster buildTestCluster(Scope scope, long seed) throws IOException {
         // produce some randomness
         int iters = between(1, 100);
         for (int i = 0; i < iters; i++) {
             randomLong();
         }
-        return super.buildTestCluster(scope);
+        return super.buildTestCluster(scope, seed);
     }
 }

--- a/src/test/java/org/elasticsearch/test/test/SuiteScopeClusterTests.java
+++ b/src/test/java/org/elasticsearch/test/test/SuiteScopeClusterTests.java
@@ -35,27 +35,31 @@ import static org.hamcrest.Matchers.equalTo;
 public class SuiteScopeClusterTests extends ElasticsearchIntegrationTest {
     private static int ITER = 0;
     private static long[] SEQUENCE = new long[100];
+    private static Long CLUSTER_SEED = null;
 
     @Test
     @Repeat(iterations = 10, useConstantSeed = true)
-    public void testReproducible() {
+    public void testReproducible() throws IOException {
         if (ITER++ == 0) {
+            CLUSTER_SEED = cluster().seed();
             for (int i = 0; i < SEQUENCE.length; i++) {
                 SEQUENCE[i] = randomLong();
             }
         } else {
+            assertEquals(CLUSTER_SEED, new Long(cluster().seed()));
             for (int i = 0; i < SEQUENCE.length; i++) {
                 assertThat(SEQUENCE[i], equalTo(randomLong()));
             }
         }
     }
 
-    protected TestCluster buildTestCluster(Scope scope) throws IOException {
+    @Override
+    protected TestCluster buildTestCluster(Scope scope, long seed) throws IOException {
         // produce some randomness
         int iters = between(1, 100);
         for (int i = 0; i < iters; i++) {
             randomLong();
         }
-        return super.buildTestCluster(scope);
+        return super.buildTestCluster(scope, seed);
     }
 }

--- a/src/test/java/org/elasticsearch/test/test/TestScopeClusterTests.java
+++ b/src/test/java/org/elasticsearch/test/test/TestScopeClusterTests.java
@@ -35,27 +35,31 @@ import static org.hamcrest.Matchers.equalTo;
 public class TestScopeClusterTests extends ElasticsearchIntegrationTest {
     private static int ITER = 0;
     private static long[] SEQUENCE = new long[100];
+    private static Long CLUSTER_SEED = null;
 
     @Test
     @Repeat(iterations = 10, useConstantSeed = true)
-    public void testReproducible() {
+    public void testReproducible() throws IOException {
         if (ITER++ == 0) {
+            CLUSTER_SEED = cluster().seed();
             for (int i = 0; i < SEQUENCE.length; i++) {
                 SEQUENCE[i] = randomLong();
             }
         } else {
+            assertEquals(CLUSTER_SEED, new Long(cluster().seed()));
             for (int i = 0; i < SEQUENCE.length; i++) {
                 assertThat(SEQUENCE[i], equalTo(randomLong()));
             }
         }
     }
 
-    protected TestCluster buildTestCluster(Scope scope) throws IOException {
+    @Override
+    protected TestCluster buildTestCluster(Scope scope, long seed) throws IOException {
         // produce some randomness
         int iters = between(1, 100);
         for (int i = 0; i < iters; i++) {
             randomLong();
         }
-        return super.buildTestCluster(scope);
+        return super.buildTestCluster(scope, seed);
     }
 }


### PR DESCRIPTION
Today any call to the current randomized context modifies the random
sequence such that cluster initialization is context dependent. If due
to an error for instance a static util method is used like `randomLong`
inside the TestCluster instead of the provided Random instance all
reproducibility guarantees are gone. This commit adds a safe mechanism
to initialize these clusters even if a static helper is used. All none
test scope clusters are now initialized in a private randomized context.
