### PR TITLE
Deprecation: MLT Field Query

### DIFF
--- a/docs/reference/migration/migrate_1_4.asciidoc
+++ b/docs/reference/migration/migrate_1_4.asciidoc
@@ -77,3 +77,9 @@ On versions before `1.4.0.Beta1` all operations are rejected when a node loses i
 only write operations will be rejected by default. Read operations will still be served based on the information available
 to the node, which may result in being partial and possibly also stale. If the default is undesired then the
 pre `1.4.0.Beta1` behaviour can be enabled, see: <<modules-discovery-zen,no-master-block>>
+
+[float]
+==== More Like This Field
+
+The More Like This Field query has been deprecated in favor of the <<query-dsl-mlt-query, More Like This Query>>
+restrained set to a specific `field`. It will be removed in 2.0.

--- a/docs/reference/query-dsl/queries/mlt-field-query.asciidoc
+++ b/docs/reference/query-dsl/queries/mlt-field-query.asciidoc
@@ -1,6 +1,8 @@
 [[query-dsl-mlt-field-query]]
 === More Like This Field Query
 
+deprecated[1.4.0,Replaced by <<query-dsl-mlt-query>> set to a specific `field`]
+
 The `more_like_this_field` query is the same as the `more_like_this`
 query, except it runs against a single field. It provides nicer query
 DSL over the generic `more_like_this` query, and support typed fields

--- a/src/main/java/org/elasticsearch/action/mlt/TransportMoreLikeThisAction.java
+++ b/src/main/java/org/elasticsearch/action/mlt/TransportMoreLikeThisAction.java
@@ -46,7 +46,7 @@ import org.elasticsearch.index.get.GetField;
 import org.elasticsearch.index.mapper.*;
 import org.elasticsearch.index.mapper.internal.SourceFieldMapper;
 import org.elasticsearch.index.query.BoolQueryBuilder;
-import org.elasticsearch.index.query.MoreLikeThisFieldQueryBuilder;
+import org.elasticsearch.index.query.MoreLikeThisQueryBuilder;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -321,14 +321,14 @@ public class TransportMoreLikeThisAction extends HandledTransportAction<MoreLike
     }
 
     private void addMoreLikeThis(MoreLikeThisRequest request, BoolQueryBuilder boolBuilder, String fieldName, String likeText, boolean failOnUnsupportedField) {
-        MoreLikeThisFieldQueryBuilder mlt = moreLikeThisFieldQuery(fieldName)
+        MoreLikeThisQueryBuilder mlt = moreLikeThisQuery(fieldName)
                 .likeText(likeText)
                 .minimumShouldMatch(request.minimumShouldMatch())
                 .boostTerms(request.boostTerms())
                 .minDocFreq(request.minDocFreq())
                 .maxDocFreq(request.maxDocFreq())
                 .minWordLength(request.minWordLength())
-                .maxWordLen(request.maxWordLength())
+                .maxWordLength(request.maxWordLength())
                 .minTermFreq(request.minTermFreq())
                 .maxQueryTerms(request.maxQueryTerms())
                 .stopWords(request.stopWords())

--- a/src/main/java/org/elasticsearch/index/query/MoreLikeThisFieldQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/MoreLikeThisFieldQueryBuilder.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 /**
  * A more like this query that runs against a specific field.
  */
+@Deprecated
 public class MoreLikeThisFieldQueryBuilder extends BaseQueryBuilder implements BoostableQueryBuilder<MoreLikeThisFieldQueryBuilder> {
 
     private final String name;

--- a/src/main/java/org/elasticsearch/index/query/MoreLikeThisFieldQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MoreLikeThisFieldQueryParser.java
@@ -38,6 +38,7 @@ import static org.elasticsearch.index.query.support.QueryParsers.wrapSmartNameQu
 /**
  *
  */
+@Deprecated
 public class MoreLikeThisFieldQueryParser implements QueryParser {
 
     public static final String NAME = "mlt_field";


### PR DESCRIPTION
The MLT field query is simply replaced by a MLT query set to specific field.
To simplify code maintenance we should deprecate it in 1.4 and remove it in
2.0.
