### PR TITLE
Make template params take arrays

### DIFF
--- a/src/main/java/org/elasticsearch/action/search/SearchRequest.java
+++ b/src/main/java/org/elasticsearch/action/search/SearchRequest.java
@@ -74,7 +74,7 @@ public class SearchRequest extends ActionRequest<SearchRequest> implements Indic
     private boolean templateSourceUnsafe;
     private String templateName;
     private ScriptService.ScriptType templateType;
-    private Map<String, String> templateParams = Collections.emptyMap();
+    private Map<String, Object> templateParams = Collections.emptyMap();
 
     private BytesReference source;
     private boolean sourceUnsafe;
@@ -452,7 +452,7 @@ public class SearchRequest extends ActionRequest<SearchRequest> implements Indic
     /**
      * Template parameters used for rendering
      */
-    public void templateParams(Map<String, String> params) {
+    public void templateParams(Map<String, Object> params) {
         this.templateParams = params;
     }
 
@@ -473,7 +473,7 @@ public class SearchRequest extends ActionRequest<SearchRequest> implements Indic
     /**
      * Template parameters used for rendering
      */
-    public Map<String, String> templateParams() {
+    public Map<String, Object> templateParams() {
         return templateParams;
     }
 
@@ -579,7 +579,7 @@ public class SearchRequest extends ActionRequest<SearchRequest> implements Indic
                 templateType = ScriptService.ScriptType.readFrom(in);
             }
             if (in.readBoolean()) {
-                templateParams = (Map<String, String>) in.readGenericValue();
+                templateParams = (Map<String, Object>) in.readGenericValue();
             }
         }
 

--- a/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
@@ -958,7 +958,7 @@ public class SearchRequestBuilder extends ActionRequestBuilder<SearchRequest, Se
         return this;
     }
 
-    public SearchRequestBuilder setTemplateParams(Map<String,String> templateParams) {
+    public SearchRequestBuilder setTemplateParams(Map<String,Object> templateParams) {
         request.templateParams(templateParams);
         return this;
     }

--- a/src/main/java/org/elasticsearch/search/internal/ShardSearchLocalRequest.java
+++ b/src/main/java/org/elasticsearch/search/internal/ShardSearchLocalRequest.java
@@ -80,7 +80,7 @@ public class ShardSearchLocalRequest implements ShardSearchRequest {
     private BytesReference templateSource;
     private String templateName;
     private ScriptService.ScriptType templateType;
-    private Map<String, String> templateParams;
+    private Map<String, Object> templateParams;
     private Boolean queryCache;
 
     private long nowInMillis;
@@ -188,7 +188,7 @@ public class ShardSearchLocalRequest implements ShardSearchRequest {
     }
 
     @Override
-    public Map<String, String> templateParams() {
+    public Map<String, Object> templateParams() {
         return templateParams;
     }
 
@@ -236,7 +236,7 @@ public class ShardSearchLocalRequest implements ShardSearchRequest {
                 templateType = ScriptService.ScriptType.readFrom(in);
             }
             if (in.readBoolean()) {
-                templateParams = (Map<String, String>) in.readGenericValue();
+                templateParams = (Map<String, Object>) in.readGenericValue();
             }
         }
         if (in.getVersion().onOrAfter(ParsedScrollId.SCROLL_SEARCH_AFTER_MINIMUM_VERSION)) {
@@ -302,4 +302,3 @@ public class ShardSearchLocalRequest implements ShardSearchRequest {
         return out.bytes().copyBytesArray();
     }
 }
-

--- a/src/main/java/org/elasticsearch/search/internal/ShardSearchRequest.java
+++ b/src/main/java/org/elasticsearch/search/internal/ShardSearchRequest.java
@@ -58,7 +58,7 @@ public interface ShardSearchRequest {
 
     ScriptService.ScriptType templateType();
 
-    Map<String, String> templateParams();
+    Map<String, Object> templateParams();
 
     BytesReference templateSource();
 

--- a/src/main/java/org/elasticsearch/search/internal/ShardSearchTransportRequest.java
+++ b/src/main/java/org/elasticsearch/search/internal/ShardSearchTransportRequest.java
@@ -135,7 +135,7 @@ public class ShardSearchTransportRequest extends TransportRequest implements Sha
     }
 
     @Override
-    public Map<String, String> templateParams() {
+    public Map<String, Object> templateParams() {
         return shardSearchLocalRequest.templateParams();
     }
 

--- a/src/test/java/org/elasticsearch/index/query/TemplateQueryTest.java
+++ b/src/test/java/org/elasticsearch/index/query/TemplateQueryTest.java
@@ -205,7 +205,7 @@ public class TemplateQueryTest extends ElasticsearchIntegrationTest {
         index("test", "type", "5", jsonBuilder().startObject().field("otherField", "foo").endObject());
         refresh();
 
-        Map<String, String> templateParams = Maps.newHashMap();
+        Map<String, Object> templateParams = Maps.newHashMap();
         templateParams.put("mySize", "2");
         templateParams.put("myField", "theField");
         templateParams.put("myValue", "foo");
@@ -260,7 +260,7 @@ public class TemplateQueryTest extends ElasticsearchIntegrationTest {
 
         indexRandom(true,builders);
 
-        Map<String, String> templateParams = Maps.newHashMap();
+        Map<String, Object> templateParams = Maps.newHashMap();
         templateParams.put("fieldParam", "foo");
 
         SearchResponse searchResponse = client().prepareSearch("test").setTypes("type").
@@ -306,7 +306,6 @@ public class TemplateQueryTest extends ElasticsearchIntegrationTest {
                 "       }" +
                 "}"));
 
-
         indexRandom(true, builders);
 
         builders.clear();
@@ -319,7 +318,7 @@ public class TemplateQueryTest extends ElasticsearchIntegrationTest {
 
         indexRandom(true,builders);
 
-        Map<String, String> templateParams = Maps.newHashMap();
+        Map<String, Object> templateParams = Maps.newHashMap();
         templateParams.put("fieldParam", "foo");
 
         SearchResponse searchResponse = client().prepareSearch("test").setTypes("type").
@@ -368,4 +367,36 @@ public class TemplateQueryTest extends ElasticsearchIntegrationTest {
         sr = client().prepareSearch().setQuery(query).get();
         assertHitCount(sr, 4);
     }
+
+    @Test
+    public void testIndexedTemplateWithArray() throws Exception {
+      createIndex(ScriptService.SCRIPT_INDEX);
+      ensureGreen(ScriptService.SCRIPT_INDEX);
+      List<IndexRequestBuilder> builders = new ArrayList<>();
+
+      String multiQuery = "{\"query\":{\"terms\":{\"theField\":[\"{{#fieldParam}}\",\"{{.}}\",\"{{/fieldParam}}\"]}}}";
+
+      builders.add(client().prepareIndex(ScriptService.SCRIPT_INDEX, "mustache", "4").setSource(jsonBuilder().startObject().field("template", multiQuery).endObject()));
+
+      indexRandom(true,builders);
+
+      builders.clear();
+
+      builders.add(client().prepareIndex("test", "type", "1").setSource("{\"theField\":\"foo\"}"));
+      builders.add(client().prepareIndex("test", "type", "2").setSource("{\"theField\":\"foo 2\"}"));
+      builders.add(client().prepareIndex("test", "type", "3").setSource("{\"theField\":\"foo 3\"}"));
+      builders.add(client().prepareIndex("test", "type", "4").setSource("{\"theField\":\"foo 4\"}"));
+      builders.add(client().prepareIndex("test", "type", "5").setSource("{\"theField\":\"bar\"}"));
+
+      indexRandom(true,builders);
+
+      Map<String, Object> arrayTemplateParams = new HashMap<>();
+      String[] fieldParams = {"foo","bar"};
+      arrayTemplateParams.put("fieldParam", fieldParams);
+
+      SearchResponse searchResponse = client().prepareSearch("test").setTypes("type").
+              setTemplateName("/mustache/4").setTemplateType(ScriptService.ScriptType.INDEXED).setTemplateParams(arrayTemplateParams).get();
+      assertHitCount(searchResponse, 5);
+    }
+
 }


### PR DESCRIPTION
Currently the templateParams in SearchRequest is a `Map<String, String>` - this means that it could not take Arrays as part of the parameters, which is not the case when accessing it through the REST api, and also as documented in the docs for this feature.

This changes it to `Map<String, Object>` so that it can take other data-types.
