### PR TITLE
Fix handling of `dangling_timeout` set to 0 and `auto_import_dangled` true

### DIFF
--- a/src/main/java/org/elasticsearch/gateway/local/state/meta/LocalGatewayMetaState.java
+++ b/src/main/java/org/elasticsearch/gateway/local/state/meta/LocalGatewayMetaState.java
@@ -287,7 +287,10 @@ public class LocalGatewayMetaState extends AbstractComponent implements ClusterS
                             }
                             final IndexMetaData indexMetaData = loadIndexState(indexName);
                             if (indexMetaData != null) {
-                                if (danglingTimeout.millis() == 0) {
+                                if(autoImportDangled.shouldImport()){
+                                    logger.info("[{}] dangling index, exists on local file system, but not in cluster metadata, auto import to cluster state [{}]", indexName, autoImportDangled);
+                                    danglingIndices.put(indexName, new DanglingIndex(indexName, null));
+                                } else if (danglingTimeout.millis() == 0) {
                                     logger.info("[{}] dangling index, exists on local file system, but not in cluster metadata, timeout set to 0, deleting now", indexName);
                                     try {
                                         nodeEnv.deleteIndexDirectorySafe(new Index(indexName));

--- a/src/test/java/org/elasticsearch/gateway/local/LocalGatewayIndexStateTests.java
+++ b/src/test/java/org/elasticsearch/gateway/local/LocalGatewayIndexStateTests.java
@@ -339,6 +339,7 @@ public class LocalGatewayIndexStateTests extends ElasticsearchIntegrationTest {
     public void testDanglingIndicesAutoImportYes() throws Exception {
         Settings settings = settingsBuilder()
                 .put("gateway.type", "local").put("gateway.local.auto_import_dangled", "yes")
+                .put("gateway.local.dangling_timeout", randomIntBetween(0, 120))
                 .build();
         logger.info("--> starting two nodes");
 


### PR DESCRIPTION
was set to yes, dangling indices were deleted by mistake,
because a RemoveDanglingIndices runnable was added
to every dangling indices, without considering the auto_import_dangled
setting.
