### PR TITLE
Enabled overriding the request headers in the clients

### DIFF
--- a/src/main/java/org/elasticsearch/client/support/Headers.java
+++ b/src/main/java/org/elasticsearch/client/support/Headers.java
@@ -48,7 +48,9 @@ public class Headers {
 
     public <M extends TransportMessage<?>> M applyTo(M message) {
         for (String key : headers.names()) {
-            message.putHeader(key, headers.get(key));
+            if (!message.hasHeader(key)) {
+                message.putHeader(key, headers.get(key));
+            }
         }
         return message;
     }

--- a/src/test/java/org/elasticsearch/client/AbstractClientHeadersTests.java
+++ b/src/test/java/org/elasticsearch/client/AbstractClientHeadersTests.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.client;
 
 import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableMap;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.GenericAction;
 import org.elasticsearch.action.admin.cluster.node.shutdown.NodesShutdownAction;
@@ -132,22 +133,45 @@ public abstract class AbstractClientHeadersTests extends ElasticsearchTestCase {
         client.admin().indices().prepareFlush().execute().addListener(new AssertingActionListener<FlushResponse>(FlushAction.NAME));
     }
 
-    protected static void assertHeaders(Map<String, Object> headers) {
+    @Test
+    public void testOverideHeader() throws Exception {
+        String key1Val = randomAsciiOfLength(5);
+        Map<String, Object> expected = ImmutableMap.<String, Object>builder()
+                .put("key1", key1Val)
+                .put("key2", "val 2")
+                .build();
+
+        client.prepareGet("idx", "type", "id")
+                .putHeader("key1", key1Val)
+                .execute().addListener(new AssertingActionListener<GetResponse>(GetAction.NAME, expected));
+
+        client.admin().cluster().prepareClusterStats()
+                .putHeader("key1", key1Val)
+                .execute().addListener(new AssertingActionListener<ClusterStatsResponse>(ClusterStatsAction.NAME, expected));
+
+        client.admin().indices().prepareCreate("idx")
+                .putHeader("key1", key1Val)
+                .execute().addListener(new AssertingActionListener<CreateIndexResponse>(CreateIndexAction.NAME, expected));
+    }
+
+    protected static void assertHeaders(Map<String, Object> headers, Map<String, Object> expected) {
         assertThat(headers, notNullValue());
-        assertThat(headers.size(), is(2));
-        assertThat(headers.get("key1"), notNullValue());
-        assertThat(headers.get("key1").toString(), equalTo("val1"));
-        assertThat(headers.get("key2"), notNullValue());
-        assertThat(headers.get("key2").toString(), equalTo("val 2"));
+        assertThat(headers.size(), is(expected.size()));
+        for (Map.Entry<String, Object> expectedEntry : expected.entrySet()) {
+            assertThat(headers.get(expectedEntry.getKey()), equalTo(expectedEntry.getValue()));
+        }
     }
 
     protected static void assertHeaders(TransportMessage<?> message) {
+        assertHeaders(message, HEADER_SETTINGS.getAsSettings(Headers.PREFIX).getAsStructuredMap());
+    }
+
+    protected static void assertHeaders(TransportMessage<?> message, Map<String, Object> expected) {
         assertThat(message.getHeaders(), notNullValue());
-        assertThat(message.getHeaders().size(), is(2));
-        assertThat(message.getHeader("key1"), notNullValue());
-        assertThat(message.getHeader("key1").toString(), equalTo("val1"));
-        assertThat(message.getHeader("key2"), notNullValue());
-        assertThat(message.getHeader("key2").toString(), equalTo("val 2"));
+        assertThat(message.getHeaders().size(), is(expected.size()));
+        for (Map.Entry<String, Object> expectedEntry : expected.entrySet()) {
+            assertThat(message.getHeader(expectedEntry.getKey()), equalTo(expectedEntry.getValue()));
+        }
     }
 
     protected static class InternalException extends Exception {
@@ -167,9 +191,15 @@ public abstract class AbstractClientHeadersTests extends ElasticsearchTestCase {
     protected static class AssertingActionListener<T> implements ActionListener<T> {
 
         private final String action;
+        private final Map<String, Object> expectedHeaders;
 
         public AssertingActionListener(String action) {
+            this(action, HEADER_SETTINGS.getAsSettings(Headers.PREFIX).getAsStructuredMap());
+        }
+
+       public AssertingActionListener(String action, Map<String, Object> expectedHeaders) {
             this.action = action;
+            this.expectedHeaders = expectedHeaders;
         }
 
         @Override
@@ -183,7 +213,7 @@ public abstract class AbstractClientHeadersTests extends ElasticsearchTestCase {
             assertThat("expected action [" + action + "] to throw an internal exception", e, notNullValue());
             assertThat(action, equalTo(((InternalException) e).action));
             Map<String, Object> headers = ((InternalException) e).headers;
-            assertHeaders(headers);
+            assertHeaders(headers, expectedHeaders);
         }
 
         public Throwable unwrap(Throwable t, Class<? extends Throwable> exceptionType) {

--- a/src/test/java/org/elasticsearch/client/transport/TransportClientHeadersTests.java
+++ b/src/test/java/org/elasticsearch/client/transport/TransportClientHeadersTests.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.client.transport;
 
-import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.GenericAction;
 import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;


### PR DESCRIPTION
One can set the headers sent with request by the clients by setting the `request.headers` setting. This commit enables overriding any such set headers directly on the requests.
