### PR TITLE
Filter indices stats for translog

### DIFF
--- a/docs/reference/indices/stats.asciidoc
+++ b/docs/reference/indices/stats.asciidoc
@@ -47,6 +47,7 @@ specified as well in the URI. Those stats can be any of:
 `refresh`::     Refresh statistics.
 `suggest`::     Suggest statistics.
 `warmer`::      Warmer statistics.
+`translog`::    Translog statistics.
 
 Some statistics allow per field granularity which accepts a list
 comma-separated list of included fields. By default all fields are included:

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/stats/RestIndicesStatsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/stats/RestIndicesStatsAction.java
@@ -81,6 +81,7 @@ public class RestIndicesStatsAction extends BaseRestHandler {
             indicesStatsRequest.completion(metrics.contains("completion"));
             indicesStatsRequest.suggest(metrics.contains("suggest"));
             indicesStatsRequest.queryCache(metrics.contains("query_cache"));
+            indicesStatsRequest.translog(metrics.contains("translog"));
         }
 
         if (request.hasParam("groups")) {


### PR DESCRIPTION
A lot of the indices stats can be filtered (e.g. curl -XGET "http://localhost:9200/example/_stats/suggest"), all of them are documented in http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-stats.html. The same does not work for the translog information I would have expected at curl -XGET "http://localhost:9200/example/_stats/translog"

Added the missing call in the RestAction, closes #8262
