### PR TITLE
GetIndexedScript call can deadlock

### DIFF
--- a/src/main/java/org/elasticsearch/action/indexedscripts/get/TransportGetIndexedScriptAction.java
+++ b/src/main/java/org/elasticsearch/action/indexedscripts/get/TransportGetIndexedScriptAction.java
@@ -49,8 +49,18 @@ public class TransportGetIndexedScriptAction extends HandledTransportAction<GetI
     }
 
     @Override
-    public void doExecute(GetIndexedScriptRequest request, ActionListener<GetIndexedScriptResponse> listener){
-        GetResponse scriptResponse = scriptService.queryScriptIndex(request);
-        listener.onResponse(new GetIndexedScriptResponse(scriptResponse));
+    public void doExecute(GetIndexedScriptRequest request, final ActionListener<GetIndexedScriptResponse> listener){
+        // forward the handling to the script service we are running on a network thread here...
+        scriptService.queryScriptIndex(request,new ActionListener<GetResponse>() {
+            @Override
+            public void onResponse(GetResponse getFields) {
+                listener.onResponse(new GetIndexedScriptResponse(getFields));
+            }
+
+            @Override
+            public void onFailure(Throwable e) {
+                listener.onFailure(e);
+            }
+        });
     }
 }

--- a/src/main/java/org/elasticsearch/script/ScriptService.java
+++ b/src/main/java/org/elasticsearch/script/ScriptService.java
@@ -354,12 +354,12 @@ public class ScriptService extends AbstractComponent {
         }
     }
 
-    public GetResponse queryScriptIndex(GetIndexedScriptRequest request) {
+    public void queryScriptIndex(GetIndexedScriptRequest request, final ActionListener<GetResponse> listener) {
         String scriptLang = validateScriptLanguage(request.scriptLang());
         GetRequest getRequest = new GetRequest(request, SCRIPT_INDEX).type(scriptLang).id(request.id())
                 .version(request.version()).versionType(request.versionType())
                 .operationThreaded(false).preference("_local"); //Set preference for no forking
-        return client.get(getRequest).actionGet();
+        client.get(getRequest, listener);
     }
 
     private String validateScriptLanguage(String scriptLang) {


### PR DESCRIPTION
GetIndexedScript can deadlock since they perform blocking operation
on the network thread. This commit moves the blocking to an async operation
