### PR TITLE
[STORE] Add dedicated method to write temporary files

### DIFF
--- a/src/main/java/org/elasticsearch/indices/recovery/RecoveryStatus.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoveryStatus.java
@@ -252,7 +252,7 @@ public class RecoveryStatus extends AbstractRefCounted {
         String tempFileName = getTempNameForFile(fileName);
         // add first, before it's created
         tempFileNames.add(tempFileName);
-        IndexOutput indexOutput = store.createVerifyingOutput(tempFileName, IOContext.DEFAULT, metaData);
+        IndexOutput indexOutput = store.createVerifyingOutput(store.createTempOutput(tempFileName, fileName, IOContext.DEFAULT), metaData);
         openIndexOutputs.put(fileName, indexOutput);
         return indexOutput;
     }

--- a/src/test/java/org/elasticsearch/indices/recovery/RecoveryStatusTests.java
+++ b/src/test/java/org/elasticsearch/indices/recovery/RecoveryStatusTests.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.indices.recovery;
+
+import com.google.common.collect.Sets;
+import org.apache.lucene.store.IndexOutput;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.transport.LocalTransportAddress;
+import org.elasticsearch.index.service.IndexService;
+import org.elasticsearch.index.shard.service.InternalIndexShard;
+import org.elasticsearch.index.store.StoreFileMetaData;
+import org.elasticsearch.test.ElasticsearchSingleNodeTest;
+
+import java.io.IOException;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ */
+public class RecoveryStatusTests extends ElasticsearchSingleNodeTest {
+    
+    public void testRenameTempFiles() throws IOException {
+        IndexService service = createIndex("foo");
+        RecoveryState state = new RecoveryState();
+
+        InternalIndexShard indexShard = (InternalIndexShard) service.shard(0);
+        DiscoveryNode node = new DiscoveryNode("foo", new LocalTransportAddress("bar"), Version.CURRENT);
+        RecoveryStatus status = new RecoveryStatus(indexShard, node, state, new RecoveryTarget.RecoveryListener() {
+            @Override
+            public void onRecoveryDone(RecoveryState state) {
+            }
+
+            @Override
+            public void onRecoveryFailure(RecoveryState state, RecoveryFailedException e, boolean sendShardFailure) {
+            }
+        });
+        try (IndexOutput indexOutput = status.openAndPutIndexOutput("foo.bar", new StoreFileMetaData("foo.bar", 8), status.store())) {
+            indexOutput.writeInt(1);
+            IndexOutput openIndexOutput = status.getOpenIndexOutput("foo.bar");
+            assertSame(openIndexOutput, indexOutput);
+            openIndexOutput.writeInt(1);
+        }
+        status.removeOpenIndexOutputs("foo.bar");
+        Set<String> strings = Sets.newHashSet(status.store().directory().listAll());
+        String expectedFile = null;
+        for (String file : strings) {
+            if (Pattern.compile("recovery[.]\\d+[.]foo[.]bar").matcher(file).matches()) {
+                expectedFile = file;
+                break;
+            }
+        }
+        assertNotNull(expectedFile);
+        status.renameAllTempFiles();
+        strings = Sets.newHashSet(status.store().directory().listAll());
+        assertTrue(strings.toString(), strings.contains("foo.bar"));
+        status.markAsDone();
+    }
+}


### PR DESCRIPTION
Recovery writes temporary files which might not end up in the
right distributor directories today. This commit adds a dedicated
API that allows specifying the target file name in order to create the
tempoary file in the correct directory.
