### PR TITLE
Immediately remove filter cache entries on cache clear

### DIFF
--- a/src/main/java/org/elasticsearch/indices/cache/filter/IndicesFilterCache.java
+++ b/src/main/java/org/elasticsearch/indices/cache/filter/IndicesFilterCache.java
@@ -202,12 +202,13 @@ public class IndicesFilterCache extends AbstractComponent implements RemovalList
                             }
                         }
                         cache.cleanUp();
-                        schedule();
                         keys.clear();
                     }
                 });
             } catch (EsRejectedExecutionException ex) {
                 logger.debug("Can not run ReaderCleaner - execution rejected", ex);
+            } finally {
+                schedule();
             }
         }
 


### PR DESCRIPTION
Previously we had a more complex listing where we added each reader key to the list of keys cleaned intermittently by `IndicesFilterCache.ReaderCleaner.run()`, but because every entry is being invalidated due to the cache clear, we should immediately clear them and clean up the cache.

This also moves the periodic cleaning rescheduling into a finally block so an exception does not prevent the cleanup from being rescheduled.

Fixes #8285
