### PR TITLE
Return 0 instead of -1 for unknown/non-exposed ramBytesUsed()

### DIFF
--- a/src/main/java/org/elasticsearch/index/fielddata/plain/BinaryDVAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/BinaryDVAtomicFieldData.java
@@ -63,7 +63,7 @@ public class BinaryDVAtomicFieldData implements AtomicFieldData {
 
     @Override
     public long ramBytesUsed() {
-        return -1; // unknown
+        return 0; // unknown
     }
 
 }

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/BinaryDVNumericIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/BinaryDVNumericIndexFieldData.java
@@ -84,7 +84,7 @@ public class BinaryDVNumericIndexFieldData extends DocValuesIndexFieldData imple
 
                 };
             } else {
-                return new AtomicLongFieldData(-1) {
+                return new AtomicLongFieldData(0) {
 
                     @Override
                     public SortedNumericDocValues getLongValues() {

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/BytesBinaryDVAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/BytesBinaryDVAtomicFieldData.java
@@ -42,7 +42,7 @@ final class BytesBinaryDVAtomicFieldData implements AtomicFieldData {
 
     @Override
     public long ramBytesUsed() {
-        return -1; // not exposed by Lucene
+        return 0; // not exposed by Lucene
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointBinaryDVAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointBinaryDVAtomicFieldData.java
@@ -43,7 +43,7 @@ final class GeoPointBinaryDVAtomicFieldData extends AbstractAtomicGeoPointFieldD
 
     @Override
     public long ramBytesUsed() {
-        return -1; // not exposed by Lucene
+        return 0; // not exposed by Lucene
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/NumericDVIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/NumericDVIndexFieldData.java
@@ -42,7 +42,7 @@ public class NumericDVIndexFieldData extends DocValuesIndexFieldData implements 
     public AtomicLongFieldData load(AtomicReaderContext context) {
         final AtomicReader reader = context.reader();
         final String field = fieldNames.indexName();
-        return new AtomicLongFieldData(-1) {
+        return new AtomicLongFieldData(0) {
             @Override
             public SortedNumericDocValues getLongValues() {
                 try {

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/SortedNumericDVIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/SortedNumericDVIndexFieldData.java
@@ -103,7 +103,7 @@ public class SortedNumericDVIndexFieldData extends DocValuesIndexFieldData imple
         final String field;
 
         SortedNumericLongFieldData(AtomicReader reader, String field) {
-            super(-1L);
+            super(0L);
             this.reader = reader;
             this.field = field;
         }
@@ -140,7 +140,7 @@ public class SortedNumericDVIndexFieldData extends DocValuesIndexFieldData imple
         final String field;
         
         SortedNumericFloatFieldData(AtomicReader reader, String field) {
-            super(-1L);
+            super(0L);
             this.reader = reader;
             this.field = field;
         }
@@ -226,7 +226,7 @@ public class SortedNumericDVIndexFieldData extends DocValuesIndexFieldData imple
         final String field;
         
         SortedNumericDoubleFieldData(AtomicReader reader, String field) {
-            super(-1L);
+            super(0L);
             this.reader = reader;
             this.field = field;
         }

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/SortedSetDVBytesAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/SortedSetDVBytesAtomicFieldData.java
@@ -56,7 +56,7 @@ public final class SortedSetDVBytesAtomicFieldData extends AbstractAtomicOrdinal
 
     @Override
     public long ramBytesUsed() {
-        return -1; // unknown
+        return 0; // unknown
     }
 
 }


### PR DESCRIPTION
From @rmuir - "The accountable interface specifies that such values are illegal"

Fixes #8239
