### PR TITLE
Change log level for mpercolate

### DIFF
--- a/src/main/java/org/elasticsearch/action/percolate/TransportMultiPercolateAction.java
+++ b/src/main/java/org/elasticsearch/action/percolate/TransportMultiPercolateAction.java
@@ -244,7 +244,7 @@ public class TransportMultiPercolateAction extends HandledTransportAction<MultiP
 
         @SuppressWarnings("unchecked")
         void onShardResponse(ShardId shardId, TransportShardMultiPercolateAction.Response response) {
-            logger.debug("{} Percolate shard response", shardId);
+            logger.trace("{} Percolate shard response", shardId);
             try {
                 for (TransportShardMultiPercolateAction.Response.Item item : response.items()) {
                     AtomicReferenceArray shardResults = responsesByItemAndShard.get(item.slot());


### PR DESCRIPTION
When using _mpercolate API we log by default a lot of DEBUG `Percolate shard response`.
They should be in TRACE level instead of DEBUG.
