### PR TITLE
Tests: Force test locale to en_US, just like start scripts do.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -523,6 +523,7 @@
                                 <tests.heap.size>${tests.heap.size}</tests.heap.size>
                                 <tests.filter>${tests.filter}</tests.filter>
                                 <tests.version>${project.version}</tests.version>
+                                <tests.locale>en_US</tests.locale>
                                 <es.node.local>${env.ES_TEST_LOCAL}</es.node.local>
                                 <es.node.mode>${es.node.mode}</es.node.mode>
                                 <es.logger.level>${es.logger.level}</es.logger.level>


### PR DESCRIPTION
In May the elasticsearch start scripts were changed to always pass a locale of `en_US`.  However, the tests currently use the default behavior of the carrotsearch runner, which is to randomize the locale.  We should instead always run tests with the same locale as we will in a real system. 
