### PR TITLE
Tests: Pass through locale and timezone to test runner, and print in repro command line.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,8 @@
         <tests.output>onerror</tests.output>
         <tests.client.ratio></tests.client.ratio>
         <tests.bwc.path>${project.basedir}/backwards</tests.bwc.path>
+        <tests.locale>random</tests.locale>
+        <tests.timezone>random</tests.timezone>
         <es.logger.level>INFO</es.logger.level>
         <tests.heap.size>512m</tests.heap.size>
         <tests.heapdump.path>${basedir}/logs/</tests.heapdump.path>
@@ -523,6 +525,8 @@
                                 <tests.heap.size>${tests.heap.size}</tests.heap.size>
                                 <tests.filter>${tests.filter}</tests.filter>
                                 <tests.version>${project.version}</tests.version>
+                                <tests.locale>${tests.locale}</tests.locale>
+                                <tests.timezone>${tests.timezone}</tests.timezone>
                                 <es.node.local>${env.ES_TEST_LOCAL}</es.node.local>
                                 <es.node.mode>${es.node.mode}</es.node.mode>
                                 <es.logger.level>${es.logger.level}</es.logger.level>

--- a/src/test/java/org/elasticsearch/test/junit/listeners/ReproduceInfoPrinter.java
+++ b/src/test/java/org/elasticsearch/test/junit/listeners/ReproduceInfoPrinter.java
@@ -33,13 +33,16 @@ import org.junit.runner.Description;
 import org.junit.runner.notification.Failure;
 import org.junit.runner.notification.RunListener;
 
+import java.util.Locale;
+import java.util.TimeZone;
+
 import static com.carrotsearch.randomizedtesting.SysGlobals.SYSPROP_ITERATIONS;
+import static com.carrotsearch.randomizedtesting.SysGlobals.SYSPROP_PREFIX;
 import static com.carrotsearch.randomizedtesting.SysGlobals.SYSPROP_TESTMETHOD;
 import static org.elasticsearch.test.ElasticsearchIntegrationTest.TESTS_CLUSTER;
 import static org.elasticsearch.test.rest.ElasticsearchRestTests.REST_TESTS_BLACKLIST;
 import static org.elasticsearch.test.rest.ElasticsearchRestTests.REST_TESTS_SPEC;
 import static org.elasticsearch.test.rest.ElasticsearchRestTests.REST_TESTS_SUITE;
-
 
 /**
  * A {@link RunListener} that emits to {@link System#err} a string with command
@@ -115,6 +118,12 @@ public class ReproduceInfoPrinter extends RunListener {
             return appendESProperties();
         }
 
+        @Override
+        public ReproduceErrorMessageBuilder appendEnvironmentSettings() {
+            // we handle our own environment settings
+            return this;
+        }
+
         /**
          * Append a single VM option.
          */
@@ -126,6 +135,10 @@ public class ReproduceInfoPrinter extends RunListener {
             if (sysPropName.equals(SYSPROP_TESTMETHOD())) {
                 //don't print out the test method, we print it ourselves in appendAllOpts
                 //without filtering out the parameters (needed for REST tests)
+                return this;
+            }
+            if (sysPropName.equals(SYSPROP_PREFIX())) {
+                // we always use the default prefix
                 return this;
             }
             if (Strings.hasLength(value)) {
@@ -141,6 +154,8 @@ public class ReproduceInfoPrinter extends RunListener {
             if (System.getProperty("tests.jvm.argline") != null && !System.getProperty("tests.jvm.argline").isEmpty()) {
                 appendOpt("tests.jvm.argline", "\"" + System.getProperty("tests.jvm.argline") + "\"");
             }
+            appendOpt("tests.locale", Locale.getDefault().toString());
+            appendOpt("tests.timezone", TimeZone.getDefault().getID());
             appendOpt(AbstractRandomizedTest.SYSPROP_PROCESSORS, Integer.toString(AbstractRandomizedTest.TESTS_PROCESSORS));
             return this;
         }


### PR DESCRIPTION
The carrot runner currently randomizes both locale and timezone, but
these are not set in the maven reproduce line.  Since they aren't
even printed, we have no idea what locale/timezone the tests
actually ran with.
