### PR TITLE
Don't accept a dynamic update to `min_master_nodes` which is larger then current master node count

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/settings/ClusterDynamicSettingsModule.java
+++ b/src/main/java/org/elasticsearch/cluster/settings/ClusterDynamicSettingsModule.java
@@ -58,7 +58,6 @@ public class ClusterDynamicSettingsModule extends AbstractModule {
         clusterDynamicSettings.addDynamicSetting(DisableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_DISABLE_NEW_ALLOCATION);
         clusterDynamicSettings.addDynamicSetting(DisableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_DISABLE_ALLOCATION);
         clusterDynamicSettings.addDynamicSetting(DisableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_DISABLE_REPLICA_ALLOCATION);
-        clusterDynamicSettings.addDynamicSetting(ElectMasterService.DISCOVERY_ZEN_MINIMUM_MASTER_NODES, Validator.INTEGER);
         clusterDynamicSettings.addDynamicSetting(ZenDiscovery.SETTING_REJOIN_ON_MASTER_GONE, Validator.BOOLEAN);
         clusterDynamicSettings.addDynamicSetting(DiscoverySettings.NO_MASTER_BLOCK);
         clusterDynamicSettings.addDynamicSetting(FilterAllocationDecider.CLUSTER_ROUTING_INCLUDE_GROUP + "*");

--- a/src/test/java/org/elasticsearch/cluster/ClusterServiceTests.java
+++ b/src/test/java/org/elasticsearch/cluster/ClusterServiceTests.java
@@ -608,7 +608,7 @@ public class ClusterServiceTests extends ElasticsearchIntegrationTest {
                 .put("plugin.types", TestPlugin.class.getName())
                 .build();
 
-        internalCluster().startNode(settings);
+        String node_0 = internalCluster().startNode(settings);
         ClusterService clusterService = internalCluster().getInstance(ClusterService.class);
         MasterAwareService testService = internalCluster().getInstance(MasterAwareService.class);
 
@@ -635,14 +635,21 @@ public class ClusterServiceTests extends ElasticsearchIntegrationTest {
         clusterHealth = client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForNodes("1").get();
         assertThat(clusterHealth.isTimedOut(), equalTo(false));
 
-        // now that node1 is closed, node2 should be elected as master
+        // now that node0 is closed, node1 should be elected as master
         assertThat(clusterService1.state().nodes().localNodeMaster(), is(true));
         assertThat(testService1.master(), is(true));
+
+        // start another node and set min_master_node
+        internalCluster().startNode(ImmutableSettings.builder().put(settings));
+        assertFalse(client().admin().cluster().prepareHealth().setWaitForNodes("2").get().isTimedOut());
 
         Settings transientSettings = settingsBuilder()
                 .put("discovery.zen.minimum_master_nodes", 2)
                 .build();
         client().admin().cluster().prepareUpdateSettings().setTransientSettings(transientSettings).get();
+
+        // and shutdown the second node
+        internalCluster().stopRandomNonMasterNode();
 
         // there should not be any master as the minimum number of required eligible masters is not met
         awaitBusy(new Predicate<Object>() {
@@ -652,7 +659,7 @@ public class ClusterServiceTests extends ElasticsearchIntegrationTest {
         });
         assertThat(testService1.master(), is(false));
 
-
+        // bring the node back up
         String node_2 = internalCluster().startNode(ImmutableSettings.builder().put(settings).put(transientSettings));
         ClusterService clusterService2 = internalCluster().getInstance(ClusterService.class, node_2);
         MasterAwareService testService2 = internalCluster().getInstance(MasterAwareService.class, node_2);


### PR DESCRIPTION
The discovery.zen.minimum_master_nodes setting can be updated dynamically. Settings it to a value higher then the current number of master nodes will cause the current master to step down. This is dangerous because if done by mistake (typo) there is no way to restore the settings (this requires an active master).
