### PR TITLE
Improve the lifecycle management of the join control thread in zen discovery.

### DIFF
--- a/src/main/java/org/elasticsearch/ExceptionsHelper.java
+++ b/src/main/java/org/elasticsearch/ExceptionsHelper.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch;
 
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.rest.RestStatus;
@@ -183,5 +184,19 @@ public final class ExceptionsHelper {
                         && t.getMessage().contains("OutOfMemoryError")
                         )
                     );
+    }
+
+    /**
+     * Throws the specified exception. If null if specified then <code>true</code> is returned.
+     */
+    public static boolean reThrowIfNotNull(@Nullable Throwable e) {
+        if (e != null) {
+            if (e instanceof RuntimeException) {
+                throw (RuntimeException) e;
+            } else {
+                throw new RuntimeException(e);
+            }
+        }
+        return true;
     }
 }

--- a/src/main/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPing.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPing.java
@@ -201,44 +201,49 @@ public class UnicastZenPing extends AbstractLifecycleComponent<ZenPing> implemen
     @Override
     public void ping(final PingListener listener, final TimeValue timeout) throws ElasticsearchException {
         final SendPingsHandler sendPingsHandler = new SendPingsHandler(pingHandlerIdGenerator.incrementAndGet());
-        receivedResponses.put(sendPingsHandler.id(), sendPingsHandler);
         try {
-            sendPings(timeout, null, sendPingsHandler);
-        } catch (RejectedExecutionException e) {
-            logger.debug("Ping execution rejected", e);
-            // The RejectedExecutionException can come from the fact unicastConnectExecutor is at its max down in sendPings
-            // But don't bail here, we can retry later on after the send ping has been scheduled.
-        }
-        threadPool.schedule(TimeValue.timeValueMillis(timeout.millis() / 2), ThreadPool.Names.GENERIC, new AbstractRunnable() {
-            @Override
-            protected void doRun() {
+            receivedResponses.put(sendPingsHandler.id(), sendPingsHandler);
+            try {
                 sendPings(timeout, null, sendPingsHandler);
-                threadPool.schedule(TimeValue.timeValueMillis(timeout.millis() / 2), ThreadPool.Names.GENERIC, new AbstractRunnable() {
-                    @Override
-                    protected void doRun() throws Exception {
-                        sendPings(timeout, TimeValue.timeValueMillis(timeout.millis() / 2), sendPingsHandler);
-                        sendPingsHandler.close();
-                        for (DiscoveryNode node : sendPingsHandler.nodeToDisconnect) {
-                            logger.trace("[{}] disconnecting from {}", sendPingsHandler.id(), node);
-                            transportService.disconnectFromNode(node);
+            } catch (RejectedExecutionException e) {
+                logger.debug("Ping execution rejected", e);
+                // The RejectedExecutionException can come from the fact unicastConnectExecutor is at its max down in sendPings
+                // But don't bail here, we can retry later on after the send ping has been scheduled.
+            }
+            threadPool.schedule(TimeValue.timeValueMillis(timeout.millis() / 2), ThreadPool.Names.GENERIC, new AbstractRunnable() {
+                @Override
+                protected void doRun() {
+                    sendPings(timeout, null, sendPingsHandler);
+                    threadPool.schedule(TimeValue.timeValueMillis(timeout.millis() / 2), ThreadPool.Names.GENERIC, new AbstractRunnable() {
+                        @Override
+                        protected void doRun() throws Exception {
+                            sendPings(timeout, TimeValue.timeValueMillis(timeout.millis() / 2), sendPingsHandler);
+                            sendPingsHandler.close();
+                            for (DiscoveryNode node : sendPingsHandler.nodeToDisconnect) {
+                                logger.trace("[{}] disconnecting from {}", sendPingsHandler.id(), node);
+                                transportService.disconnectFromNode(node);
+                            }
+                            listener.onPing(sendPingsHandler.pingCollection().toArray());
                         }
-                        listener.onPing(sendPingsHandler.pingCollection().toArray());
-                    }
 
-                    @Override
-                    public void onFailure(Throwable t) {
-                        logger.debug("Ping execution failed", t);
-                        sendPingsHandler.close();
-                    }
-                });
-            }
+                        @Override
+                        public void onFailure(Throwable t) {
+                            logger.debug("Ping execution failed", t);
+                            sendPingsHandler.close();
+                        }
+                    });
+                }
 
-            @Override
-            public void onFailure(Throwable t) {
-                logger.debug("Ping execution failed", t);
-                sendPingsHandler.close();
-            }
-        });
+                @Override
+                public void onFailure(Throwable t) {
+                    logger.debug("Ping execution failed", t);
+                    sendPingsHandler.close();
+                }
+            });
+        } catch (Exception e) {
+            sendPingsHandler.close();
+            throw new ElasticsearchException("Ping execution failed", e);
+        }
     }
 
     class SendPingsHandler implements Closeable {


### PR DESCRIPTION
This PR also includes:
- Better exception handling in UnicastZenPing#ping
- In the join thread that runs the innerJoinCluster loop, remember the last known exception and throw that when assertions are enabled. We loop until inner join has successfully completed and if continues exceptions are thrown we should fail the test, because the exception shouldn't occur in production (at least not too often).
