### PR TITLE
Generate dynamic mappings for empty strings.

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/object/ObjectMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/object/ObjectMapper.java
@@ -739,11 +739,6 @@ public class ObjectMapper implements Mapper, AllFieldMapper.IncludeInAll {
                         }
                     }
 
-                    if (!resolved && context.parser().textLength() == 0) {
-                        // empty string with no mapping, treat it like null value
-                        return;
-                    }
-
                     if (!resolved && context.root().dateDetection()) {
                         String text = context.parser().text();
                         // a safe check since "1" gets parsed as well

--- a/src/test/java/org/elasticsearch/index/mapper/dynamic/DynamicMappingTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/dynamic/DynamicMappingTests.java
@@ -20,8 +20,10 @@ package org.elasticsearch.index.mapper.dynamic;
 
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.mapper.DocumentMapper;
+import org.elasticsearch.index.mapper.FieldMappers;
 import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.index.mapper.StrictDynamicMappingException;
+import org.elasticsearch.index.service.IndexService;
 import org.elasticsearch.test.ElasticsearchSingleNodeTest;
 import org.junit.Test;
 
@@ -146,5 +148,12 @@ public class DynamicMappingTests extends ElasticsearchSingleNodeTest {
         } catch (StrictDynamicMappingException e) {
             // all is well
         }
+    }
+
+    public void testDynamicMappingOnEmptyString() throws Exception {
+        IndexService service = createIndex("test");
+        client().prepareIndex("test", "type").setSource("empty_field", "").get();
+        FieldMappers mappers = service.mapperService().indexName("empty_field");
+        assertTrue(mappers != null && mappers.isEmpty() == false);
     }
 }


### PR DESCRIPTION
This will help the exists/missing filters behave as expected in presence of
empty strings, as well as when using a default analyzer that would generate
tokens for an empty string (uncommon).

Close #8198
