### PR TITLE
Prefer recovering the state file that uses the latest format.

### DIFF
--- a/src/main/java/org/elasticsearch/gateway/local/state/meta/MetaDataStateFormat.java
+++ b/src/main/java/org/elasticsearch/gateway/local/state/meta/MetaDataStateFormat.java
@@ -22,15 +22,23 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.Collections2;
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.index.CorruptIndexException;
-import org.apache.lucene.store.*;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.OutputStreamIndexOutput;
+import org.apache.lucene.store.SimpleFSDirectory;
 import org.apache.lucene.util.IOUtils;
+import org.elasticsearch.ElasticsearchIllegalStateException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.Preconditions;
-import org.elasticsearch.common.io.FileSystemUtils;
 import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.lucene.store.InputStreamIndexInput;
-import org.elasticsearch.common.xcontent.*;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -226,6 +234,7 @@ public abstract class MetaDataStateFormat<T> {
     public static <T> T loadLatestState(ESLogger logger, MetaDataStateFormat<T> format, Pattern pattern, String stateType, File... dataLocations) {
         List<FileAndVersion> files = new ArrayList<>();
         long maxVersion = -1;
+        boolean maxVersionIsLegacy = true;
         if (dataLocations != null) { // select all eligable files first
             for (File dataLocation : dataLocations) {
                 File stateDir = new File(dataLocation, MetaDataStateFormat.STATE_DIR_NAME);
@@ -243,6 +252,7 @@ public abstract class MetaDataStateFormat<T> {
                         final long version = Long.parseLong(matcher.group(1));
                         maxVersion = Math.max(maxVersion, version);
                         final boolean legacy = MetaDataStateFormat.STATE_FILE_EXTENSION.equals(matcher.group(2)) == false;
+                        maxVersionIsLegacy &= legacy;
                         files.add(new FileAndVersion(stateFile, version, legacy));
                     }
                 }
@@ -251,8 +261,11 @@ public abstract class MetaDataStateFormat<T> {
         final List<Throwable> exceptions = new ArrayList<>();
         T state = null;
         // NOTE: we might have multiple version of the latest state if there are multiple data dirs.. for this case
-        //       we iterate only over the ones with the max version
-        for (FileAndVersion fileAndVersion : Collections2.filter(files, new VersionPredicate(maxVersion))) {
+        //       we iterate only over the ones with the max version. If we have at least one state file that uses the
+        //       new format (ie. legacy == false) then we know that the latest version state ought to use this new format.
+        //       In case the state file with the latest version does not use the new format while older state files do,
+        //       the list below will be empty and loading the state will fail
+        for (FileAndVersion fileAndVersion : Collections2.filter(files, new VersionAndLegacyPredicate(maxVersion, maxVersionIsLegacy))) {
             try {
                 final File stateFile = fileAndVersion.file;
                 final long version = fileAndVersion.version;
@@ -280,10 +293,10 @@ public abstract class MetaDataStateFormat<T> {
             }
         }
         // if we reach this something went wrong
-        if (files.size() > 0 || exceptions.size() > 0) {
-            // here we where not able to load the latest version from neither of the data dirs
-            // this case is exceptional and we should not continue
-            ExceptionsHelper.maybeThrowRuntimeAndSuppress(exceptions);
+        ExceptionsHelper.maybeThrowRuntimeAndSuppress(exceptions);
+        if (files.size() > 0) {
+            // We have some state files but none of them gave us a usable state
+            throw new ElasticsearchIllegalStateException("Could not find a state file to recover from among " + files);
         }
         return state;
     }
@@ -292,15 +305,18 @@ public abstract class MetaDataStateFormat<T> {
      * Filters out all {@link FileAndVersion} instances with a different version than
      * the given one.
      */
-    private static final class VersionPredicate implements Predicate<FileAndVersion> {
+    private static final class VersionAndLegacyPredicate implements Predicate<FileAndVersion> {
         private final long version;
+        private final boolean legacy;
 
-        VersionPredicate(long version) {
+        VersionAndLegacyPredicate(long version, boolean legacy) {
             this.version = version;
+            this.legacy = legacy;
         }
+
         @Override
         public boolean apply(FileAndVersion input) {
-            return input.version == version;
+            return input.version == version && input.legacy == legacy;
         }
     }
 
@@ -308,7 +324,7 @@ public abstract class MetaDataStateFormat<T> {
      * Internal struct-like class that holds the parsed state version, the file
      * and a flag if the file is a legacy state ie. pre 1.5
      */
-    private static class FileAndVersion implements Comparable<FileAndVersion>{
+    private static class FileAndVersion {
         final File file;
         final long version;
         final boolean legacy;
@@ -317,12 +333,6 @@ public abstract class MetaDataStateFormat<T> {
             this.file = file;
             this.version = version;
             this.legacy = legacy;
-        }
-
-        @Override
-        public int compareTo(FileAndVersion o) {
-            // highest first
-            return Long.compare(o.version, version);
         }
     }
 

--- a/src/test/java/org/elasticsearch/gateway/local/state/meta/MetaDataStateFormatTest.java
+++ b/src/test/java/org/elasticsearch/gateway/local/state/meta/MetaDataStateFormatTest.java
@@ -20,26 +20,52 @@ package org.elasticsearch.gateway.local.state.meta;
 
 import com.carrotsearch.randomizedtesting.LifecycleScope;
 import org.apache.lucene.codecs.CodecUtil;
-import org.apache.lucene.store.*;
+import org.apache.lucene.store.BaseDirectoryWrapper;
+import org.apache.lucene.store.ChecksumIndexInput;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.MockDirectoryWrapper;
+import org.apache.lucene.store.SimpleFSDirectory;
 import org.apache.lucene.util.TestRuleMarkFailure;
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.ElasticsearchIllegalStateException;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.logging.ESLogger;
-import org.elasticsearch.common.xcontent.*;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.io.*;
+import java.io.Closeable;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.RandomAccessFile;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.startsWith;
 
 public class MetaDataStateFormatTest extends ElasticsearchTestCase {
 
@@ -217,6 +243,70 @@ public class MetaDataStateFormatTest extends ElasticsearchTestCase {
         }
     }
 
+    // If the latest version doesn't use the legacy format while previous versions do, then fail hard
+    public void testLatestVersionDoesNotUseLegacy() throws IOException {
+        final ToXContent.Params params = ToXContent.EMPTY_PARAMS;
+        MetaDataStateFormat<MetaData> format = LocalGatewayMetaState.globalStateFormat(randomFrom(XContentType.values()), params, randomBoolean());
+        final File[] dirs = new File[2];
+        dirs[0] = newTempDir(LifecycleScope.TEST);
+        dirs[1] = newTempDir(LifecycleScope.TEST);
+        for (File dir : dirs) {
+            Files.createDirectories(new File(dir, MetaDataStateFormat.STATE_DIR_NAME).toPath());
+        }
+        final File dir1 = randomFrom(dirs);
+        final int v1 = randomInt(10);
+        // write a first state file in the new format
+        format.write(randomMeta(), LocalGatewayMetaState.GLOBAL_STATE_FILE_PREFIX, v1, dir1);
+
+        // write a second state file in the old format but with a newer version
+        final File dir2 = randomFrom(dirs);
+        final int v2 = v1 + 1 + randomInt(10);
+        try (XContentBuilder xcontentBuilder = XContentFactory.contentBuilder(format.format(), new FileOutputStream(new File(new File(dir2, MetaDataStateFormat.STATE_DIR_NAME), LocalGatewayMetaState.GLOBAL_STATE_FILE_PREFIX + v2)))) {
+            xcontentBuilder.startObject();
+            MetaData.Builder.toXContent(randomMeta(), xcontentBuilder, params);
+            xcontentBuilder.endObject();
+        }
+
+        try {
+            MetaDataStateFormat.loadLatestState(logger, format, LocalGatewayMetaState.GLOBAL_STATE_FILE_PATTERN, "foobar", dirs);
+            fail("latest version can not be read");
+        } catch (ElasticsearchIllegalStateException ex) {
+            assertThat(ex.getMessage(), startsWith("Could not find a state file to recover from among "));
+        }
+    }
+
+    // If both the legacy and the new format are available for the latest version, prefer the new format
+    public void testPrefersNewerFormat() throws IOException {
+        final ToXContent.Params params = ToXContent.EMPTY_PARAMS;
+        MetaDataStateFormat<MetaData> format = LocalGatewayMetaState.globalStateFormat(randomFrom(XContentType.values()), params, randomBoolean());
+        final File[] dirs = new File[2];
+        dirs[0] = newTempDir(LifecycleScope.TEST);
+        dirs[1] = newTempDir(LifecycleScope.TEST);
+        for (File dir : dirs) {
+            Files.createDirectories(new File(dir, MetaDataStateFormat.STATE_DIR_NAME).toPath());
+        }
+        final File dir1 = randomFrom(dirs);
+        final long v = randomInt(10);
+
+        MetaData meta = randomMeta();
+        String uuid = meta.uuid();
+
+        // write a first state file in the old format
+        final File dir2 = randomFrom(dirs);
+        MetaData meta2 = randomMeta();
+        assertFalse(meta2.uuid().equals(uuid));
+        try (XContentBuilder xcontentBuilder = XContentFactory.contentBuilder(format.format(), new FileOutputStream(new File(new File(dir2, MetaDataStateFormat.STATE_DIR_NAME), LocalGatewayMetaState.GLOBAL_STATE_FILE_PREFIX + v)))) {
+            xcontentBuilder.startObject();
+            MetaData.Builder.toXContent(randomMeta(), xcontentBuilder, params);
+            xcontentBuilder.endObject();
+        }
+
+        // write a second state file in the new format but with the same version
+        format.write(meta, LocalGatewayMetaState.GLOBAL_STATE_FILE_PREFIX, v, dir1);
+
+        MetaData state = MetaDataStateFormat.loadLatestState(logger, format, LocalGatewayMetaState.GLOBAL_STATE_FILE_PATTERN, "foobar", dirs);
+        assertThat(state.uuid(), equalTo(uuid));
+    }
 
     @Test
     public void testLoadState() throws IOException {


### PR DESCRIPTION
Currently MetaDataStateFormat loads the first available state file that has
the latest version. In case several files are available and some of them use
the new format while other ones use the legacy format, it should also prefer
the new format. This is typically useful when we upgrade the metadata when
recovering from the gateway: we might write the upgraded state with the new
format while the previous state used the legacy format, so we end up with
two files having the same version but using different formats.
