### PR TITLE
Minor fixes to the `match` query

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/MatchQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MatchQueryParser.java
@@ -123,8 +123,6 @@ public class MatchQueryParser implements QueryParser {
                         }
                     } else if ("minimum_should_match".equals(currentFieldName) || "minimumShouldMatch".equals(currentFieldName)) {
                         minimumShouldMatch = parser.textOrNull();
-                    } else if ("rewrite".equals(currentFieldName)) {
-                        matchQuery.setRewriteMethod(QueryParsers.parseRewriteMethod(parseContext.parseFieldMatcher(), parser.textOrNull(), null));
                     } else if ("fuzzy_rewrite".equals(currentFieldName) || "fuzzyRewrite".equals(currentFieldName)) {
                         matchQuery.setFuzzyRewriteMethod(QueryParsers.parseRewriteMethod(parseContext.parseFieldMatcher(), parser.textOrNull(), null));
                     } else if ("fuzzy_transpositions".equals(currentFieldName)) {

--- a/core/src/main/java/org/elasticsearch/index/query/MultiMatchQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MultiMatchQueryParser.java
@@ -113,8 +113,6 @@ public class MultiMatchQueryParser implements QueryParser {
                     }
                 } else if ("minimum_should_match".equals(currentFieldName) || "minimumShouldMatch".equals(currentFieldName)) {
                     minimumShouldMatch = parser.textOrNull();
-                } else if ("rewrite".equals(currentFieldName)) {
-                    multiMatchQuery.setRewriteMethod(QueryParsers.parseRewriteMethod(parseContext.parseFieldMatcher(), parser.textOrNull(), null));
                 } else if ("fuzzy_rewrite".equals(currentFieldName) || "fuzzyRewrite".equals(currentFieldName)) {
                     multiMatchQuery.setFuzzyRewriteMethod(QueryParsers.parseRewriteMethod(parseContext.parseFieldMatcher(), parser.textOrNull(), null));
                 } else if ("use_dis_max".equals(currentFieldName) || "useDisMax".equals(currentFieldName)) {

--- a/core/src/main/java/org/elasticsearch/index/search/MatchQuery.java
+++ b/core/src/main/java/org/elasticsearch/index/search/MatchQuery.java
@@ -29,7 +29,6 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.lucene.search.MultiPhrasePrefixQuery;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.unit.Fuzziness;
-import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.query.QueryParseContext;
 import org.elasticsearch.index.query.support.QueryParsers;
@@ -67,8 +66,6 @@ public class MatchQuery {
     protected int maxExpansions = FuzzyQuery.defaultMaxExpansions;
 
     protected boolean transpositions = FuzzyQuery.defaultTranspositions;
-
-    protected MultiTermQuery.RewriteMethod rewriteMethod;
 
     protected MultiTermQuery.RewriteMethod fuzzyRewriteMethod;
 
@@ -116,10 +113,6 @@ public class MatchQuery {
 
     public void setTranspositions(boolean transpositions) {
         this.transpositions = transpositions;
-    }
-
-    public void setRewriteMethod(MultiTermQuery.RewriteMethod rewriteMethod) {
-        this.rewriteMethod = rewriteMethod;
     }
 
     public void setFuzzyRewriteMethod(MultiTermQuery.RewriteMethod fuzzyRewriteMethod) {
@@ -278,10 +271,11 @@ public class MatchQuery {
                 if (query instanceof FuzzyQuery) {
                     QueryParsers.setRewriteMethod((FuzzyQuery) query, fuzzyRewriteMethod);
                 }
+                return query;
             }
             int edits = fuzziness.asDistance(term.text());
             FuzzyQuery query = new FuzzyQuery(term, edits, fuzzyPrefixLength, maxExpansions, transpositions);
-            QueryParsers.setRewriteMethod(query, rewriteMethod);
+            QueryParsers.setRewriteMethod(query, fuzzyRewriteMethod);
             return query;
         }
         if (fieldType != null) {

--- a/docs/reference/query-dsl/match-query.asciidoc
+++ b/docs/reference/query-dsl/match-query.asciidoc
@@ -46,7 +46,7 @@ See <<fuzziness>> for allowed settings.
 
 The `prefix_length` and
 `max_expansions` can be set in this case to control the fuzzy process.
-If the fuzzy option is set the query will use `constant_score_rewrite`
+If the fuzzy option is set the query will use `top_terms_blended_freqs_${max_expansions}`
 as its <<query-dsl-multi-term-rewrite,rewrite
 method>> the `fuzzy_rewrite` parameter allows to control how the query will get
 rewritten.


### PR DESCRIPTION
Fixed documentation since the default rewrite method for fuzzy queries is to
select top terms, fixed usage of the fuzzy rewrite method, and removed unused
`rewrite` parameter.

Close #6932
