### PR TITLE
Tab characters in YAML should throw an exception

### DIFF
--- a/src/main/java/org/elasticsearch/common/settings/loader/YamlSettingsLoader.java
+++ b/src/main/java/org/elasticsearch/common/settings/loader/YamlSettingsLoader.java
@@ -37,12 +37,7 @@ public class YamlSettingsLoader extends XContentSettingsLoader {
 
     @Override
     public Map<String, String> load(String source) throws IOException {
-        /*
-         * #8259: Better handling of tabs vs spaces in elasticsearch.yml
-         */
-        if(source.indexOf("\t") > -1) {
-            throw new IOException("Tabs are illegal in YAML.  Did you mean to use whitespace character instead?");
-        }
+        // replace tabs with whitespace (yaml does not accept tabs, but many users might use it still...)
         return super.load(source.replace("\t", "  "));
     }
 }

--- a/src/main/java/org/elasticsearch/common/settings/loader/YamlSettingsLoader.java
+++ b/src/main/java/org/elasticsearch/common/settings/loader/YamlSettingsLoader.java
@@ -37,7 +37,12 @@ public class YamlSettingsLoader extends XContentSettingsLoader {
 
     @Override
     public Map<String, String> load(String source) throws IOException {
-        // replace tabs with whitespace (yaml does not accept tabs, but many users might use it still...)
-        return super.load(source.replace("\t", "  "));
+        /*
+         * #8259: Better handling of tabs vs spaces in elasticsearch.yml
+         */
+        if(source.indexOf("\t") > -1) {
+            throw new IOException("Tabs are illegal in YAML.  Did you mean to use whitespace character instead?");
+        }
+        return super.load(source);
     }
 }

--- a/src/main/java/org/elasticsearch/common/settings/loader/YamlSettingsLoader.java
+++ b/src/main/java/org/elasticsearch/common/settings/loader/YamlSettingsLoader.java
@@ -37,7 +37,12 @@ public class YamlSettingsLoader extends XContentSettingsLoader {
 
     @Override
     public Map<String, String> load(String source) throws IOException {
-        // replace tabs with whitespace (yaml does not accept tabs, but many users might use it still...)
+        /*
+         * #8259: Better handling of tabs vs spaces in elasticsearch.yml
+         */
+        if(source.indexOf("\t") > -1) {
+            throw new IOException("Tabs are illegal in YAML.  Did you mean to use whitespace character instead?");
+        }
         return super.load(source.replace("\t", "  "));
     }
 }


### PR DESCRIPTION
Better handling of tabs vs spaces in elasticsearch.yml
- Throw an exception if there is a 'tab' character in the elasticsearch.yml file

Closes #8259
