### PR TITLE
Cut over to Path API for file deletion

### DIFF
--- a/dev-tools/forbidden/all-signatures.txt
+++ b/dev-tools/forbidden/all-signatures.txt
@@ -1,3 +1,5 @@
 @defaultMessage Convert to URI
 java.net.URL#getPath()
 java.net.URL#getFile()
+
+java.io.File#delete() @ use Files.delete for real exception, IOUtils.deleteFilesIgnoringExceptions if you dont care

--- a/src/main/java/org/elasticsearch/common/blobstore/BlobContainer.java
+++ b/src/main/java/org/elasticsearch/common/blobstore/BlobContainer.java
@@ -51,7 +51,7 @@ public interface BlobContainer {
      */
     OutputStream createOutput(String blobName) throws IOException;
 
-    boolean deleteBlob(String blobName) throws IOException;
+    void deleteBlob(String blobName) throws IOException;
 
     void deleteBlobsByPrefix(String blobNamePrefix) throws IOException;
 

--- a/src/main/java/org/elasticsearch/common/blobstore/BlobStore.java
+++ b/src/main/java/org/elasticsearch/common/blobstore/BlobStore.java
@@ -18,6 +18,8 @@
  */
 package org.elasticsearch.common.blobstore;
 
+import java.io.IOException;
+
 /**
  *
  */
@@ -25,7 +27,7 @@ public interface BlobStore {
 
     BlobContainer blobContainer(BlobPath path);
 
-    void delete(BlobPath path);
+    void delete(BlobPath path) throws IOException;
 
     void close();
 }

--- a/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobContainer.java
+++ b/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobContainer.java
@@ -30,6 +30,8 @@ import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.io.FileSystemUtils;
 
 import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 /**
  *
@@ -65,8 +67,12 @@ public class FsBlobContainer extends AbstractBlobContainer {
         return builder.immutableMap();
     }
 
-    public boolean deleteBlob(String blobName) throws IOException {
-        return new File(path, blobName).delete();
+    @Override
+    public void deleteBlob(String blobName) throws IOException {
+        Path blobPath = new File(path, blobName).toPath();
+        if (Files.exists(blobPath)) {
+            Files.delete(blobPath);
+        }
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobStore.java
+++ b/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobStore.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.common.blobstore.fs;
 
+import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.common.blobstore.BlobContainer;
 import org.elasticsearch.common.blobstore.BlobPath;
 import org.elasticsearch.common.blobstore.BlobStore;
@@ -30,6 +31,7 @@ import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 
 import java.io.File;
+import java.io.IOException;
 
 /**
  *
@@ -74,8 +76,8 @@ public class FsBlobStore extends AbstractComponent implements BlobStore {
     }
 
     @Override
-    public void delete(BlobPath path) {
-        FileSystemUtils.deleteRecursively(buildPath(path));
+    public void delete(BlobPath path) throws IOException {
+        IOUtils.rm(buildPath(path).toPath());
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/common/blobstore/url/URLBlobContainer.java
+++ b/src/main/java/org/elasticsearch/common/blobstore/url/URLBlobContainer.java
@@ -73,7 +73,7 @@ public class URLBlobContainer extends AbstractBlobContainer {
      * This operation is not supported by URLBlobContainer
      */
     @Override
-    public boolean deleteBlob(String blobName) throws IOException {
+    public void deleteBlob(String blobName) throws IOException {
         throw new UnsupportedOperationException("URL repository is read only");
     }
 

--- a/src/main/java/org/elasticsearch/common/http/client/HttpDownloadHelper.java
+++ b/src/main/java/org/elasticsearch/common/http/client/HttpDownloadHelper.java
@@ -22,6 +22,7 @@ package org.elasticsearch.common.http.client;
 import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.io.FileSystemUtils;
 import org.elasticsearch.common.unit.TimeValue;
 
 import java.io.*;
@@ -346,7 +347,7 @@ public class HttpDownloadHelper {
                     // Try to delete the garbage we'd otherwise leave
                     // behind.
                     IOUtils.closeWhileHandlingException(os, is);
-                    dest.delete();
+                    FileSystemUtils.deleteFilesIgnoringExceptions(dest.toPath());
                 } else {
                     IOUtils.close(os, is);
                 }
@@ -385,7 +386,7 @@ public class HttpDownloadHelper {
             } else {
                 IOUtils.closeWhileHandlingException(is, os);
                 if (dest != null && dest.exists()) {
-                    dest.delete();
+                    FileSystemUtils.deleteFilesIgnoringExceptions(dest.toPath());
                 }
             }
         }

--- a/src/main/java/org/elasticsearch/gateway/local/LocalGateway.java
+++ b/src/main/java/org/elasticsearch/gateway/local/LocalGateway.java
@@ -22,6 +22,7 @@ package org.elasticsearch.gateway.local;
 import com.carrotsearch.hppc.ObjectFloatOpenHashMap;
 import com.carrotsearch.hppc.ObjectOpenHashSet;
 import com.carrotsearch.hppc.cursors.ObjectCursor;
+import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.cluster.*;
@@ -197,7 +198,11 @@ public class LocalGateway extends AbstractLifecycleComponent<Gateway> implements
 
     @Override
     public void reset() throws Exception {
-        FileSystemUtils.deleteRecursively(nodeEnv.nodeDataLocations());
+        try {
+            IOUtils.rm(FileSystemUtils.toPaths(nodeEnv.nodeDataLocations()));
+        } catch (Exception ex) {
+            logger.debug("failed to delete shard locations", ex);
+        }
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/gateway/local/state/meta/MetaDataStateFormat.java
+++ b/src/main/java/org/elasticsearch/gateway/local/state/meta/MetaDataStateFormat.java
@@ -208,7 +208,9 @@ public abstract class MetaDataStateFormat<T> {
                     if (file.getName().equals(fileName)) {
                         continue;
                     }
-                    Files.delete(file.toPath());
+                    if (Files.exists(file.toPath())) {
+                        Files.delete(file.toPath());
+                    }
                 }
             }
         }

--- a/src/main/java/org/elasticsearch/gateway/local/state/shards/LocalGatewayShardsState.java
+++ b/src/main/java/org/elasticsearch/gateway/local/state/shards/LocalGatewayShardsState.java
@@ -37,6 +37,7 @@ import org.elasticsearch.gateway.local.state.meta.MetaDataStateFormat;
 import org.elasticsearch.index.shard.ShardId;
 
 import java.io.*;
+import java.nio.file.Files;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
@@ -317,7 +318,12 @@ public class LocalGatewayShardsState extends AbstractComponent implements Cluste
                 if (!name.startsWith("shards-")) {
                     continue;
                 }
-                stateFile.delete();
+                try {
+                    Files.delete(stateFile.toPath());
+                } catch (Exception ex) {
+                    logger.debug("Failed to delete state file {}", ex, stateFile);
+                }
+
             }
         }
 

--- a/src/main/java/org/elasticsearch/index/gateway/local/LocalIndexShardGateway.java
+++ b/src/main/java/org/elasticsearch/index/gateway/local/LocalIndexShardGateway.java
@@ -51,6 +51,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import java.io.EOFException;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
@@ -290,7 +291,11 @@ public class LocalIndexShardGateway extends AbstractIndexShardComponent implemen
             }
             indexShard.performRecoveryFinalization(true);
 
-            recoveringTranslogFile.delete();
+            try {
+                Files.delete(recoveringTranslogFile.toPath());
+            } catch (Exception ex) {
+                logger.debug("Failed to delete recovering translog file {}", ex, recoveringTranslogFile);
+            }
 
             for (final String type : typesToUpdate) {
                 final CountDownLatch latch = new CountDownLatch(1);

--- a/src/main/java/org/elasticsearch/index/store/fs/FsIndexStore.java
+++ b/src/main/java/org/elasticsearch/index/store/fs/FsIndexStore.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.store.fs;
 
+import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.ElasticsearchIllegalStateException;
 import org.elasticsearch.common.io.FileSystemUtils;
 import org.elasticsearch.common.settings.Settings;
@@ -81,7 +82,11 @@ public abstract class FsIndexStore extends AbstractIndexStore {
         if (indexService.hasShard(shardId.id())) {
             throw new ElasticsearchIllegalStateException(shardId + " allocated, can't be deleted");
         }
-        FileSystemUtils.deleteRecursively(shardLocations(shardId));
+        try {
+            IOUtils.rm(FileSystemUtils.toPaths(shardLocations(shardId)));
+        } catch (Exception ex) {
+            logger.debug("failed to delete shard locations", ex);
+        }
     }
 
     public File[] shardLocations(ShardId shardId) {

--- a/src/main/java/org/elasticsearch/index/translog/fs/FsTranslog.java
+++ b/src/main/java/org/elasticsearch/index/translog/fs/FsTranslog.java
@@ -41,6 +41,7 @@ import org.elasticsearch.index.translog.*;
 import java.io.File;
 import java.io.IOException;
 import java.nio.channels.ClosedChannelException;
+import java.nio.file.Files;
 import java.util.Collections;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -215,9 +216,9 @@ public class FsTranslog extends AbstractIndexShardComponent implements Translog 
                             continue;
                         }
                         try {
-                            file.delete();
-                        } catch (Exception e) {
-                            // ignore
+                            Files.delete(file.toPath());
+                        } catch (Exception ex) {
+                            logger.debug("failed to delete " + file, ex);
                         }
                     }
                 }

--- a/src/main/java/org/elasticsearch/index/translog/fs/RafReference.java
+++ b/src/main/java/org/elasticsearch/index/translog/fs/RafReference.java
@@ -19,11 +19,15 @@
 
 package org.elasticsearch.index.translog.fs;
 
+import org.apache.lucene.util.IOUtils;
+import org.elasticsearch.common.io.FileSystemUtils;
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.channels.FileChannel;
+import java.nio.file.Files;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -70,12 +74,14 @@ public class RafReference {
         if (refCount.decrementAndGet() <= 0) {
             try {
                 raf.close();
-                if (delete) {
-                    file.delete();
-                }
             } catch (IOException e) {
                 // ignore
+            } finally {
+                if (delete) {
+                    FileSystemUtils.deleteFilesIgnoringExceptions(file.toPath());
+                }
             }
+
         }
     }
 }

--- a/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
+++ b/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.indices.store;
 
 import org.apache.lucene.store.StoreRateLimiting;
+import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.*;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -323,7 +324,11 @@ public class IndicesStore extends AbstractComponent implements ClusterStateListe
                             File[] shardLocations = nodeEnv.shardLocations(shardId);
                             if (FileSystemUtils.exists(shardLocations)) {
                                 logger.debug("{} deleting shard that is no longer used", shardId);
-                                FileSystemUtils.deleteRecursively(shardLocations);
+                                try {
+                                    IOUtils.rm(FileSystemUtils.toPaths(shardLocations));
+                                } catch (Exception ex) {
+                                    logger.debug("failed to delete shard locations", ex);
+                                }
                             }
                         }
                     } else {

--- a/src/test/java/org/elasticsearch/benchmark/fs/FsAppendBenchmark.java
+++ b/src/test/java/org/elasticsearch/benchmark/fs/FsAppendBenchmark.java
@@ -18,13 +18,16 @@
  */
 package org.elasticsearch.benchmark.fs;
 
+import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.common.StopWatch;
+import org.elasticsearch.common.io.FileSystemUtils;
 import org.elasticsearch.common.unit.ByteSizeValue;
 
 import java.io.File;
 import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
+import java.nio.file.Paths;
 import java.util.Random;
 
 /**
@@ -33,7 +36,7 @@ import java.util.Random;
 public class FsAppendBenchmark {
 
     public static void main(String[] args) throws Exception {
-        new File("work/test.log").delete();
+        FileSystemUtils.deleteFilesIgnoringExceptions(Paths.get("work/test.log"));
         RandomAccessFile raf = new RandomAccessFile("work/test.log", "rw");
         raf.setLength(0);
 

--- a/src/test/java/org/elasticsearch/cluster/allocation/ClusterRerouteTests.java
+++ b/src/test/java/org/elasticsearch/cluster/allocation/ClusterRerouteTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.cluster.allocation;
 
+import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.action.admin.cluster.reroute.ClusterRerouteResponse;
@@ -196,7 +197,7 @@ public class ClusterRerouteTests extends ElasticsearchIntegrationTest {
 
         logger.info("--> deleting the shard data [{}] ", Arrays.toString(shardLocation));
         assertThat(FileSystemUtils.exists(shardLocation), equalTo(true)); // verify again after cluster was shut down
-        assertThat(FileSystemUtils.deleteRecursively(shardLocation), equalTo(true));
+        IOUtils.rm(FileSystemUtils.toPaths(shardLocation));
 
         logger.info("--> starting nodes back, will not allocate the shard since it has no data, but the index will be there");
         node_1 = internalCluster().startNode(commonSettings);

--- a/src/test/java/org/elasticsearch/index/mapper/FileBasedMappingsTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/FileBasedMappingsTests.java
@@ -21,6 +21,7 @@ package org.elasticsearch.index.mapper;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.Files;
+import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsResponse;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
@@ -98,7 +99,7 @@ public class FileBasedMappingsTests extends ElasticsearchTestCase {
                 assertEquals(ImmutableSet.of("f", "g", "h"), properties.keySet());
             }
         } finally {
-            FileSystemUtils.deleteRecursively(configDir);
+            IOUtils.rm(configDir.toPath());
         }
     }
 

--- a/src/test/java/org/elasticsearch/index/translog/fs/FsBufferedTranslogTests.java
+++ b/src/test/java/org/elasticsearch/index/translog/fs/FsBufferedTranslogTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.translog.fs;
 
+import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.common.io.FileSystemUtils;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.index.translog.AbstractSimpleTranslogTests;
@@ -26,6 +27,8 @@ import org.elasticsearch.index.translog.Translog;
 import org.junit.AfterClass;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
 
 /**
  *
@@ -49,7 +52,7 @@ public class FsBufferedTranslogTests extends AbstractSimpleTranslogTests {
     }
 
     @AfterClass
-    public static void cleanup() {
-        FileSystemUtils.deleteRecursively(new File("data/fs-buf-translog"), true);
+    public static void cleanup() throws IOException {
+        IOUtils.rm(Paths.get("data/fs-buf-translog"));
     }
 }

--- a/src/test/java/org/elasticsearch/index/translog/fs/FsSimpleTranslogTests.java
+++ b/src/test/java/org/elasticsearch/index/translog/fs/FsSimpleTranslogTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.translog.fs;
 
+import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.common.io.FileSystemUtils;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.index.translog.AbstractSimpleTranslogTests;
@@ -26,6 +27,8 @@ import org.elasticsearch.index.translog.Translog;
 import org.junit.AfterClass;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
 
 /**
  *
@@ -45,7 +48,7 @@ public class FsSimpleTranslogTests extends AbstractSimpleTranslogTests {
     }
 
     @AfterClass
-    public static void cleanup() {
-        FileSystemUtils.deleteRecursively(new File("data/fs-simple-translog"), true);
+    public static void cleanup() throws IOException {
+        IOUtils.rm(Paths.get("data/fs-simple-translog"));
     }
 }

--- a/src/test/java/org/elasticsearch/plugins/PluginManagerTests.java
+++ b/src/test/java/org/elasticsearch/plugins/PluginManagerTests.java
@@ -20,6 +20,7 @@ package org.elasticsearch.plugins;
 
 import com.google.common.base.Predicate;
 import org.apache.http.impl.client.HttpClients;
+import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.ElasticsearchTimeoutException;
@@ -46,6 +47,7 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Paths;
 import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.common.io.FileSystemUtilsTests.assertFileContent;
@@ -65,12 +67,12 @@ public class PluginManagerTests extends ElasticsearchIntegrationTest {
     private static final String PLUGIN_DIR = "plugins";
 
     @After
-    public void afterTest() {
+    public void afterTest() throws IOException {
         deletePluginsFolder();
     }
 
     @Before
-    public void beforeTest() {
+    public void beforeTest() throws IOException {
         deletePluginsFolder();
     }
 
@@ -123,8 +125,7 @@ public class PluginManagerTests extends ElasticsearchIntegrationTest {
             assertThat(toolFile.canExecute(), is(true));
         } finally {
             // we need to clean up the copied dirs
-            FileSystemUtils.deleteRecursively(pluginBinDir);
-            FileSystemUtils.deleteRecursively(pluginConfigDir);
+            IOUtils.rm(pluginBinDir.toPath(), pluginConfigDir.toPath());
         }
     }
 
@@ -206,7 +207,7 @@ public class PluginManagerTests extends ElasticsearchIntegrationTest {
             assertFileContent(pluginConfigDir, "dir/subdir/testsubdir.txt.new", "version2\n");
         } finally {
             // we need to clean up the copied dirs
-            FileSystemUtils.deleteRecursively(pluginConfigDir);
+            IOUtils.rm(pluginConfigDir.toPath());
         }
     }
 
@@ -230,7 +231,7 @@ public class PluginManagerTests extends ElasticsearchIntegrationTest {
             assertDirectoryExists(pluginBinDir);
         } finally {
             // we need to clean up the copied dirs
-            FileSystemUtils.deleteRecursively(pluginBinDir);
+            IOUtils.rm(pluginBinDir.toPath());
         }
     }
 
@@ -463,8 +464,8 @@ public class PluginManagerTests extends ElasticsearchIntegrationTest {
         return false;
     }
 
-    private void deletePluginsFolder() {
-        FileSystemUtils.deleteRecursively(new File(PLUGIN_DIR));
+    private void deletePluginsFolder() throws IOException {
+        IOUtils.rm(Paths.get(PLUGIN_DIR));
     }
 
     @Test

--- a/src/test/java/org/elasticsearch/script/ScriptServiceTests.java
+++ b/src/test/java/org/elasticsearch/script/ScriptServiceTests.java
@@ -31,6 +31,7 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Map;
 
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
@@ -73,8 +74,8 @@ public class ScriptServiceTests extends ElasticsearchTestCase {
         assertThat(compiledScript.compiled(), equalTo((Object) "compiled_test_file"));
 
         logger.info("--> delete both files");
-        assertThat(testFileNoExt.delete(), equalTo(true));
-        assertThat(testFileWithExt.delete(), equalTo(true));
+        Files.delete(testFileNoExt.toPath());
+        Files.delete(testFileWithExt.toPath());
         resourceWatcherService.notifyNow();
 
         logger.info("--> verify that file with extension was correctly removed");

--- a/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreTests.java
+++ b/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreTests.java
@@ -22,6 +22,7 @@ package org.elasticsearch.snapshots;
 import com.carrotsearch.randomizedtesting.LifecycleScope;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
+import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.LuceneTestCase.Slow;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ListenableActionFuture;
@@ -45,6 +46,7 @@ import org.elasticsearch.cluster.metadata.MappingMetaData;
 import org.elasticsearch.cluster.metadata.SnapshotMetaData;
 import org.elasticsearch.cluster.routing.allocation.decider.FilterAllocationDecider;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.elasticsearch.common.io.FileSystemUtils;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.store.support.AbstractIndexStore;
@@ -55,6 +57,7 @@ import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.junit.Test;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -732,8 +735,8 @@ public class SharedClusterSnapshotRestoreTests extends AbstractSnapshotTests {
         File testIndex1 = new File(indices, "test-idx-1");
         File testIndex2 = new File(indices, "test-idx-2");
         File testIndex2Shard0 = new File(testIndex2, "0");
-        new File(testIndex1, "snapshot-test-snap-1").delete();
-        new File(testIndex2Shard0, "snapshot-test-snap-1").delete();
+        FileSystemUtils.deleteFilesIgnoringExceptions(new File(testIndex1, "snapshot-test-snap-1").toPath());
+        FileSystemUtils.deleteFilesIgnoringExceptions(new File(testIndex2Shard0, "snapshot-test-snap-1").toPath());
 
         logger.info("--> delete snapshot");
         client.admin().cluster().prepareDeleteSnapshot("test-repo", "test-snap-1").get();
@@ -768,7 +771,7 @@ public class SharedClusterSnapshotRestoreTests extends AbstractSnapshotTests {
 
         logger.info("--> delete index metadata and shard metadata");
         File metadata = new File(repo, "metadata-test-snap-1");
-        assertThat(metadata.delete(), equalTo(true));
+        Files.delete(metadata.toPath());
 
         logger.info("--> delete snapshot");
         client.admin().cluster().prepareDeleteSnapshot("test-repo", "test-snap-1").get();

--- a/src/test/java/org/elasticsearch/snapshots/mockstore/BlobContainerWrapper.java
+++ b/src/test/java/org/elasticsearch/snapshots/mockstore/BlobContainerWrapper.java
@@ -58,8 +58,8 @@ public class BlobContainerWrapper implements BlobContainer {
     }
 
     @Override
-    public boolean deleteBlob(String blobName) throws IOException {
-        return delegate.deleteBlob(blobName);
+    public void deleteBlob(String blobName) throws IOException {
+        delegate.deleteBlob(blobName);
     }
 
     @Override

--- a/src/test/java/org/elasticsearch/snapshots/mockstore/BlobStoreWrapper.java
+++ b/src/test/java/org/elasticsearch/snapshots/mockstore/BlobStoreWrapper.java
@@ -22,6 +22,8 @@ import org.elasticsearch.common.blobstore.BlobContainer;
 import org.elasticsearch.common.blobstore.BlobPath;
 import org.elasticsearch.common.blobstore.BlobStore;
 
+import java.io.IOException;
+
 /**
  *
  */
@@ -39,7 +41,7 @@ public class BlobStoreWrapper implements BlobStore {
     }
 
     @Override
-    public void delete(BlobPath path) {
+    public void delete(BlobPath path) throws IOException {
         delegate.delete(path);
     }
 

--- a/src/test/java/org/elasticsearch/snapshots/mockstore/MockRepository.java
+++ b/src/test/java/org/elasticsearch/snapshots/mockstore/MockRepository.java
@@ -262,9 +262,9 @@ public class MockRepository extends FsRepository {
             }
 
             @Override
-            public boolean deleteBlob(String blobName) throws IOException {
+            public void deleteBlob(String blobName) throws IOException {
                 maybeIOExceptionOrBlock(blobName);
-                return super.deleteBlob(blobName);
+                super.deleteBlob(blobName);
             }
 
             @Override

--- a/src/test/java/org/elasticsearch/stresstest/fullrestart/FullRestartStressTest.java
+++ b/src/test/java/org/elasticsearch/stresstest/fullrestart/FullRestartStressTest.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.stresstest.fullrestart;
 
+import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.count.CountResponse;
@@ -200,7 +201,11 @@ public class FullRestartStressTest {
                 File[] nodeDatas = ((InternalNode) node).injector().getInstance(NodeEnvironment.class).nodeDataLocations();
                 node.close();
                 if (clearNodeWork && !settings.get("gateway.type").equals("local")) {
-                    FileSystemUtils.deleteRecursively(nodeDatas);
+                    try {
+                        IOUtils.rm(FileSystemUtils.toPaths(nodeDatas));
+                    } catch (Exception ex) {
+                        logger.debug("failed to remove node data locations", ex);
+                    }
                 }
             }
 

--- a/src/test/java/org/elasticsearch/stresstest/rollingrestart/RollingRestartStressTest.java
+++ b/src/test/java/org/elasticsearch/stresstest/rollingrestart/RollingRestartStressTest.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.stresstest.rollingrestart;
 
+import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.count.CountResponse;
 import org.elasticsearch.action.get.GetResponse;
@@ -170,7 +171,12 @@ public class RollingRestartStressTest {
             File[] nodeData = ((InternalNode) nodes[nodeIndex]).injector().getInstance(NodeEnvironment.class).nodeDataLocations();
             nodes[nodeIndex].close();
             if (clearNodeData) {
-                FileSystemUtils.deleteRecursively(nodeData);
+                try {
+                    IOUtils.rm(FileSystemUtils.toPaths(nodeData));
+                } catch (Exception ex) {
+                     logger.debug("Failed to delete node data directories", ex);
+
+                }
             }
 
             try {


### PR DESCRIPTION
Today we use the File API for file deletion as well as recursive
directory deletions. This API returns a boolean if operations
are successful while hiding the actual reason why they failed.
The Path API throws and actual exception that might provide better
insights and debug information.
