### PR TITLE
Don't write bad search requests into exception messages

### DIFF
--- a/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/src/main/java/org/elasticsearch/search/SearchService.java
@@ -686,7 +686,8 @@ public class SearchService extends AbstractLifecycleComponent<SearchService> {
             } catch (Throwable e1) {
                 // ignore
             }
-            throw new SearchParseException(context, "Failed to parse source [" + sSource + "]", e);
+            logger.error("Could not parse search source [{}]", sSource, e);
+            throw new SearchParseException(context, "Failed to parse source", e);
         } finally {
             if (parser != null) {
                 parser.close();


### PR DESCRIPTION
See issue #8370.

If a search requests's source doesn't parse, log the
source instead of putting it into an exception
message and propagating it. This prevents large
strings from being built up.

Ideally the source could be streamed to a log file
so that it never has to be rendered in-memory in
its entirety, but this is a good start.
