### PR TITLE
Take percentage watermarks into account for reroute listener

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/DiskUsage.java
+++ b/src/main/java/org/elasticsearch/cluster/DiskUsage.java
@@ -19,20 +19,25 @@
 
 package org.elasticsearch.cluster;
 
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.unit.ByteSizeValue;
+
 /**
  * Encapsulation class used to represent the amount of disk used on a node.
  */
 public class DiskUsage {
     final String nodeId;
+    final String nodeName;
     final long totalBytes;
     final long freeBytes;
 
-    public DiskUsage(String nodeId, long totalBytes, long freeBytes) {
+    public DiskUsage(String nodeId, String nodeName, long totalBytes, long freeBytes) {
         if ((totalBytes < freeBytes) || (totalBytes < 0)) {
             throw new IllegalStateException("Free bytes [" + freeBytes +
                     "] cannot be less than 0 or greater than total bytes [" + totalBytes + "]");
         }
         this.nodeId = nodeId;
+        this.nodeName = nodeName;
         this.totalBytes = totalBytes;
         this.freeBytes = freeBytes;
     }
@@ -55,6 +60,7 @@ public class DiskUsage {
     }
 
     public String toString() {
-        return "[" + nodeId + "] free: " + getFreeBytes() + "[" + getFreeDiskAsPercentage() + "%]";
+        return "[" + nodeId + "][" + nodeName + "] free: " + new ByteSizeValue(getFreeBytes()) +
+                "[" + Strings.format1Decimals(getFreeDiskAsPercentage(), "%") + "]";
     }
 }

--- a/src/main/java/org/elasticsearch/cluster/InternalClusterInfoService.java
+++ b/src/main/java/org/elasticsearch/cluster/InternalClusterInfoService.java
@@ -304,10 +304,11 @@ public class InternalClusterInfoService extends AbstractComponent implements Clu
                                 total += info.getTotal().bytes();
                             }
                             String nodeId = nodeStats.getNode().id();
+                            String nodeName = nodeStats.getNode().getName();
                             if (logger.isTraceEnabled()) {
                                 logger.trace("node: [{}], total disk: {}, available disk: {}", nodeId, total, available);
                             }
-                            newUsages.put(nodeId, new DiskUsage(nodeId, total, available));
+                            newUsages.put(nodeId, new DiskUsage(nodeId, nodeName, total, available));
                         }
                     }
                     usages = ImmutableMap.copyOf(newUsages);

--- a/src/test/java/org/elasticsearch/cluster/DiskUsageTests.java
+++ b/src/test/java/org/elasticsearch/cluster/DiskUsageTests.java
@@ -28,7 +28,7 @@ public class DiskUsageTests extends ElasticsearchTestCase {
 
     @Test
     public void diskUsageCalcTest() {
-        DiskUsage du = new DiskUsage("node1", 100, 40);
+        DiskUsage du = new DiskUsage("node1", "n1", 100, 40);
         assertThat(du.getFreeDiskAsPercentage(), equalTo(40.0));
         assertThat(du.getFreeBytes(), equalTo(40L));
         assertThat(du.getUsedBytes(), equalTo(60L));
@@ -44,12 +44,12 @@ public class DiskUsageTests extends ElasticsearchTestCase {
             long free = between(Integer.MIN_VALUE, Integer.MAX_VALUE);
             if (free > total || total <= 0) {
                 try {
-                    new DiskUsage("random", total, free);
+                    new DiskUsage("random", "random", total, free);
                     fail("should never reach this");
                 } catch (IllegalStateException e) {
                 }
             } else {
-                DiskUsage du = new DiskUsage("random", total, free);
+                DiskUsage du = new DiskUsage("random", "random", total, free);
                 assertThat(du.getFreeBytes(), equalTo(free));
                 assertThat(du.getTotalBytes(), equalTo(total));
                 assertThat(du.getUsedBytes(), equalTo(total - free));

--- a/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderTests.java
+++ b/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderTests.java
@@ -62,10 +62,10 @@ public class DiskThresholdDeciderTests extends ElasticsearchAllocationTestCase {
                 .put(DiskThresholdDecider.CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK, 0.8).build();
 
         Map<String, DiskUsage> usages = new HashMap<>();
-        usages.put("node1", new DiskUsage("node1", 100, 10)); // 90% used
-        usages.put("node2", new DiskUsage("node2", 100, 35)); // 65% used
-        usages.put("node3", new DiskUsage("node3", 100, 60)); // 40% used
-        usages.put("node4", new DiskUsage("node4", 100, 80)); // 20% used
+        usages.put("node1", new DiskUsage("node1", "node1", 100, 10)); // 90% used
+        usages.put("node2", new DiskUsage("node2", "node2", 100, 35)); // 65% used
+        usages.put("node3", new DiskUsage("node3", "node3", 100, 60)); // 40% used
+        usages.put("node4", new DiskUsage("node4", "node4", 100, 80)); // 20% used
 
         Map<String, Long> shardSizes = new HashMap<>();
         shardSizes.put("[test][0][p]", 10L); // 10 bytes
@@ -257,11 +257,11 @@ public class DiskThresholdDeciderTests extends ElasticsearchAllocationTestCase {
                 .put(DiskThresholdDecider.CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK, "9b").build();
 
         Map<String, DiskUsage> usages = new HashMap<>();
-        usages.put("node1", new DiskUsage("node1", 100, 10)); // 90% used
-        usages.put("node2", new DiskUsage("node2", 100, 10)); // 90% used
-        usages.put("node3", new DiskUsage("node3", 100, 60)); // 40% used
-        usages.put("node4", new DiskUsage("node4", 100, 80)); // 20% used
-        usages.put("node5", new DiskUsage("node5", 100, 85)); // 15% used
+        usages.put("node1", new DiskUsage("node1", "n1", 100, 10)); // 90% used
+        usages.put("node2", new DiskUsage("node2", "n2", 100, 10)); // 90% used
+        usages.put("node3", new DiskUsage("node3", "n3", 100, 60)); // 40% used
+        usages.put("node4", new DiskUsage("node4", "n4", 100, 80)); // 20% used
+        usages.put("node5", new DiskUsage("node5", "n5", 100, 85)); // 15% used
 
         Map<String, Long> shardSizes = new HashMap<>();
         shardSizes.put("[test][0][p]", 10L); // 10 bytes
@@ -327,7 +327,7 @@ public class DiskThresholdDeciderTests extends ElasticsearchAllocationTestCase {
         logger.info("--> nodeWithoutPrimary: {}", nodeWithoutPrimary);
 
         // Make node without the primary now habitable to replicas
-        usages.put(nodeWithoutPrimary, new DiskUsage(nodeWithoutPrimary, 100, 35)); // 65% used
+        usages.put(nodeWithoutPrimary, new DiskUsage(nodeWithoutPrimary, "", 100, 35)); // 65% used
         final ClusterInfo clusterInfo2 = new ClusterInfo(ImmutableMap.copyOf(usages), ImmutableMap.copyOf(shardSizes));
         cis = new ClusterInfoService() {
             @Override
@@ -522,8 +522,8 @@ public class DiskThresholdDeciderTests extends ElasticsearchAllocationTestCase {
                 .put(DiskThresholdDecider.CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK, "71%").build();
 
         Map<String, DiskUsage> usages = new HashMap<>();
-        usages.put("node1", new DiskUsage("node1", 100, 31)); // 69% used
-        usages.put("node2", new DiskUsage("node2", 100, 1));  // 99% used
+        usages.put("node1", new DiskUsage("node1", "n1", 100, 31)); // 69% used
+        usages.put("node2", new DiskUsage("node2", "n2", 100, 1));  // 99% used
 
         Map<String, Long> shardSizes = new HashMap<>();
         shardSizes.put("[test][0][p]", 10L); // 10 bytes
@@ -588,8 +588,8 @@ public class DiskThresholdDeciderTests extends ElasticsearchAllocationTestCase {
                 .put(DiskThresholdDecider.CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK, 0.85).build();
 
         Map<String, DiskUsage> usages = new HashMap<>();
-        usages.put("node2", new DiskUsage("node2", 100, 50)); // 50% used
-        usages.put("node3", new DiskUsage("node3", 100, 0));  // 100% used
+        usages.put("node2", new DiskUsage("node2", "node2", 100, 50)); // 50% used
+        usages.put("node3", new DiskUsage("node3", "node3", 100, 0));  // 100% used
 
         Map<String, Long> shardSizes = new HashMap<>();
         shardSizes.put("[test][0][p]", 10L); // 10 bytes
@@ -659,8 +659,8 @@ public class DiskThresholdDeciderTests extends ElasticsearchAllocationTestCase {
         DiskThresholdDecider decider = new DiskThresholdDecider(ImmutableSettings.EMPTY);
 
         Map<String, DiskUsage> usages = new HashMap<>();
-        usages.put("node2", new DiskUsage("node2", 100, 50)); // 50% used
-        usages.put("node3", new DiskUsage("node3", 100, 0));  // 100% used
+        usages.put("node2", new DiskUsage("node2", "n2", 100, 50)); // 50% used
+        usages.put("node3", new DiskUsage("node3", "n3", 100, 0));  // 100% used
 
         DiskUsage node1Usage = decider.averageUsage(rn, usages);
         assertThat(node1Usage.getTotalBytes(), equalTo(100L));
@@ -673,10 +673,10 @@ public class DiskThresholdDeciderTests extends ElasticsearchAllocationTestCase {
         DiskThresholdDecider decider = new DiskThresholdDecider(ImmutableSettings.EMPTY);
 
         Map<String, DiskUsage> usages = new HashMap<>();
-        usages.put("node2", new DiskUsage("node2", 100, 50)); // 50% used
-        usages.put("node3", new DiskUsage("node3", 100, 0));  // 100% used
+        usages.put("node2", new DiskUsage("node2", "n2", 100, 50)); // 50% used
+        usages.put("node3", new DiskUsage("node3", "n3", 100, 0));  // 100% used
 
-        Double after = decider.freeDiskPercentageAfterShardAssigned(new DiskUsage("node2", 100, 30), 11L);
+        Double after = decider.freeDiskPercentageAfterShardAssigned(new DiskUsage("node2", "n2", 100, 30), 11L);
         assertThat(after, equalTo(19.0));
     }
 
@@ -689,9 +689,9 @@ public class DiskThresholdDeciderTests extends ElasticsearchAllocationTestCase {
                 .put(DiskThresholdDecider.CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK, 0.8).build();
 
         Map<String, DiskUsage> usages = new HashMap<>();
-        usages.put("node1", new DiskUsage("node1", 100, 40)); // 60% used
-        usages.put("node2", new DiskUsage("node2", 100, 40)); // 60% used
-        usages.put("node2", new DiskUsage("node3", 100, 40)); // 60% used
+        usages.put("node1", new DiskUsage("node1", "n1", 100, 40)); // 60% used
+        usages.put("node2", new DiskUsage("node2", "n2", 100, 40)); // 60% used
+        usages.put("node2", new DiskUsage("node3", "n3", 100, 40)); // 60% used
 
         Map<String, Long> shardSizes = new HashMap<>();
         shardSizes.put("[test][0][p]", 14L); // 14 bytes

--- a/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/MockDiskUsagesTests.java
+++ b/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/MockDiskUsagesTests.java
@@ -81,13 +81,13 @@ public class MockDiskUsagesTests extends ElasticsearchIntegrationTest {
         // Start with all nodes at 50% usage
         final MockInternalClusterInfoService cis = (MockInternalClusterInfoService)
                 internalCluster().getInstance(ClusterInfoService.class, internalCluster().getMasterName());
-        cis.setN1Usage(nodes.get(0), new DiskUsage(nodes.get(0), 100, 50));
-        cis.setN2Usage(nodes.get(1), new DiskUsage(nodes.get(1), 100, 50));
-        cis.setN3Usage(nodes.get(2), new DiskUsage(nodes.get(2), 100, 50));
+        cis.setN1Usage(nodes.get(0), new DiskUsage(nodes.get(0), "n1", 100, 50));
+        cis.setN2Usage(nodes.get(1), new DiskUsage(nodes.get(1), "n2", 100, 50));
+        cis.setN3Usage(nodes.get(2), new DiskUsage(nodes.get(2), "n3", 100, 50));
 
         client().admin().cluster().prepareUpdateSettings().setTransientSettings(settingsBuilder()
-                .put(DiskThresholdDecider.CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK, "20b")
-                .put(DiskThresholdDecider.CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK, "10b")
+                .put(DiskThresholdDecider.CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK, randomFrom("20b", "80%"))
+                .put(DiskThresholdDecider.CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK, randomFrom("10b", "90%"))
                 .put(DiskThresholdDecider.CLUSTER_ROUTING_ALLOCATION_REROUTE_INTERVAL, "1s")).get();
 
         // Create an index with 10 shards so we can check allocation for it
@@ -118,9 +118,9 @@ public class MockDiskUsagesTests extends ElasticsearchIntegrationTest {
         }
 
         // Update the disk usages so one node has now passed the high watermark
-        cis.setN1Usage(realNodeNames.get(0), new DiskUsage(nodes.get(0), 100, 50));
-        cis.setN2Usage(realNodeNames.get(1), new DiskUsage(nodes.get(1), 100, 50));
-        cis.setN3Usage(realNodeNames.get(2), new DiskUsage(nodes.get(2), 100, 0)); // nothing free on node3
+        cis.setN1Usage(realNodeNames.get(0), new DiskUsage(nodes.get(0), "n1", 100, 50));
+        cis.setN2Usage(realNodeNames.get(1), new DiskUsage(nodes.get(1), "n2", 100, 50));
+        cis.setN3Usage(realNodeNames.get(2), new DiskUsage(nodes.get(2), "n3", 100, 0)); // nothing free on node3
 
         // Cluster info gathering interval is 2 seconds, give reroute 2 seconds to kick in
         Thread.sleep(4000);
@@ -170,9 +170,9 @@ public class MockDiskUsagesTests extends ElasticsearchIntegrationTest {
                                               ClusterService clusterService, ThreadPool threadPool) {
             super(settings, nodeSettingsService, transportNodesStatsAction, transportIndicesStatsAction, clusterService, threadPool);
             this.clusterName = ClusterName.clusterNameFromSettings(settings);
-            stats[0] = makeStats("node_t1", new DiskUsage("node_t1", 100, 100));
-            stats[1] = makeStats("node_t2", new DiskUsage("node_t2", 100, 100));
-            stats[2] = makeStats("node_t3", new DiskUsage("node_t3", 100, 100));
+            stats[0] = makeStats("node_t1", new DiskUsage("node_t1", "n1", 100, 100));
+            stats[1] = makeStats("node_t2", new DiskUsage("node_t2", "n2", 100, 100));
+            stats[2] = makeStats("node_t3", new DiskUsage("node_t3", "n3", 100, 100));
         }
 
         public void setN1Usage(String nodeName, DiskUsage newUsage) {


### PR DESCRIPTION
Fixes an issue where only absolute bytes were taken into account when
kicking off an automatic reroute due to disk usage. Also randomized the
tests to use either an absolute value or a percentage so this is tested.

Also adds logging for each node over the high and low watermark every
time a new cluster info usage is gathered (defaults to every 30
seconds).

Related to #8368
Fixes #8367
