### PR TITLE
Expose `max_determinized_states` in regexp query, filter

### DIFF
--- a/docs/reference/query-dsl/filters/regexp-filter.asciidoc
+++ b/docs/reference/query-dsl/filters/regexp-filter.asciidoc
@@ -27,7 +27,14 @@ See <<regexp-syntax>> for details of the supported regular expression language.
 You can also select the cache name and use the same regexp flags in the
 filter as in the query.
 
-*Note*: You have to enable caching explicitly in order to have the
+Regular expressions are dangerous because it's easy to write one that
+requires an exponential number of internal determinized automaton
+states (and corresponding RAM and CPU) for Lucene to execute.  To
+prevent this, use the the `max_determinized_states` setting (defaults
+to 10000) to limit how many states may be executd.  If the regexp
+exceeds this count, an exception is thrown and the query will fail.
+
+You have to enable caching explicitly in order to have the
 `regexp` filter cached.
 
 [source,js]
@@ -41,7 +48,8 @@ filter as in the query.
             "regexp":{
                 "name.first" : {
                     "value" : "s.*y",
-                    "flags" : "INTERSECTION|COMPLEMENT|EMPTY"
+                    "flags" : "INTERSECTION|COMPLEMENT|EMPTY",
+		    "max_determinized_states": 20000
                 },
                 "_name":"test",
                 "_cache" : true,

--- a/docs/reference/query-dsl/queries/query-string-query.asciidoc
+++ b/docs/reference/query-dsl/queries/query-string-query.asciidoc
@@ -63,6 +63,10 @@ made to analyze those as well.
 
 |`auto_generate_phrase_queries` |Default to `false`.
 
+|`max_determinized_states` |Limit on how many automaton states regexp
+queries are allowed to create.  This protects against too-difficult
+(e.g. exponentially hard) regexps.  Default to 10000.
+
 |`minimum_should_match` |A value controlling how many "should" clauses
 in the resulting boolean query should match. It can be an absolute value
 (`2`), a percentage (`30%`) or a

--- a/docs/reference/query-dsl/queries/query-string-query.asciidoc
+++ b/docs/reference/query-dsl/queries/query-string-query.asciidoc
@@ -61,11 +61,11 @@ phrase matches are required. Default value is `0`.
 not analyzed. By setting this value to `true`, a best effort will be
 made to analyze those as well.
 
-|`auto_generate_phrase_queries` |Default to `false`.
+|`auto_generate_phrase_queries` |Defaults to `false`.
 
 |`max_determinized_states` |Limit on how many automaton states regexp
 queries are allowed to create.  This protects against too-difficult
-(e.g. exponentially hard) regexps.  Default to 10000.
+(e.g. exponentially hard) regexps.  Defaults to 10000.
 
 |`minimum_should_match` |A value controlling how many "should" clauses
 in the resulting boolean query should match. It can be an absolute value

--- a/docs/reference/query-dsl/queries/regexp-query.asciidoc
+++ b/docs/reference/query-dsl/queries/regexp-query.asciidoc
@@ -55,5 +55,25 @@ Possible flags are `ALL`, `ANYSTRING`, `AUTOMATON`, `COMPLEMENT`,
 http://lucene.apache.org/core/4_9_0/core/org/apache/lucene/util/automaton/RegExp.html[Lucene
 documentation] for their meaning
 
+Regular expressions are dangerous because it's easy to write one that
+requires an exponential number of internal determinized automaton
+states (and corresponding RAM and CPU) for Lucene to execute.  To
+prevent this, use the the `max_determinized_states` setting (defaults
+to 10000) to limit how many states may be executd.  If the regexp
+exceeds this count, an exception is thrown and the query will fail.
+
+[source,js]
+--------------------------------------------------
+{
+    "regexp":{
+        "name.first": {
+            "value": "s.*y",
+            "flags" : "INTERSECTION|COMPLEMENT|EMPTY",
+	    "max_determinized_states": 20000
+        }
+    }
+}
+--------------------------------------------------
+
 
 include::regexp-syntax.asciidoc[]

--- a/pom.xml
+++ b/pom.xml
@@ -31,8 +31,8 @@
     </parent>
 
     <properties>
-        <lucene.version>4.10.2</lucene.version>
-        <lucene.maven.version>4.10.2</lucene.maven.version>
+        <lucene.version>4.10.3</lucene.version>
+        <lucene.maven.version>4.10.3-snapshot-1637309</lucene.maven.version>
         <tests.jvms>auto</tests.jvms>
         <tests.shuffle>true</tests.shuffle>
         <tests.output>onerror</tests.output>
@@ -49,6 +49,10 @@
         <repository>
             <id>Codehaus Snapshots</id>
             <url>http://repository.codehaus.org/</url>
+        </repository>
+        <repository>
+            <id>Lucene snapshots</id>
+            <url>http://people.apache.org/~mikemccand/fake_staging_area/repo/</url> 
         </repository>
     </repositories>
 

--- a/src/main/java/org/apache/lucene/queryparser/classic/MapperQueryParser.java
+++ b/src/main/java/org/apache/lucene/queryparser/classic/MapperQueryParser.java
@@ -119,6 +119,7 @@ public class MapperQueryParser extends QueryParser {
         setMultiTermRewriteMethod(settings.rewriteMethod());
         setEnablePositionIncrements(settings.enablePositionIncrements());
         setAutoGeneratePhraseQueries(settings.autoGeneratePhraseQueries());
+        setMaxDeterminizedStates(settings.maxDeterminizedStates());
         setAllowLeadingWildcard(settings.allowLeadingWildcard());
         setLowercaseExpandedTerms(settings.lowercaseExpandedTerms());
         setPhraseSlop(settings.phraseSlop());
@@ -807,12 +808,12 @@ public class MapperQueryParser extends QueryParser {
                         if (fieldMappers.explicitTypeInNameWithDocMapper()) {
                             String[] previousTypes = QueryParseContext.setTypesWithPrevious(new String[]{fieldMappers.docMapper().type()});
                             try {
-                                query = currentMapper.regexpQuery(termStr, RegExp.ALL, multiTermRewriteMethod, parseContext);
+                                query = currentMapper.regexpQuery(termStr, RegExp.ALL, maxDeterminizedStates, multiTermRewriteMethod, parseContext);
                             } finally {
                                 QueryParseContext.setTypes(previousTypes);
                             }
                         } else {
-                            query = currentMapper.regexpQuery(termStr, RegExp.ALL, multiTermRewriteMethod, parseContext);
+                            query = currentMapper.regexpQuery(termStr, RegExp.ALL, maxDeterminizedStates, multiTermRewriteMethod, parseContext);
                         }
                     }
                     if (query == null) {

--- a/src/main/java/org/apache/lucene/queryparser/classic/QueryParserSettings.java
+++ b/src/main/java/org/apache/lucene/queryparser/classic/QueryParserSettings.java
@@ -23,6 +23,7 @@ import com.carrotsearch.hppc.ObjectFloatOpenHashMap;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.search.FuzzyQuery;
 import org.apache.lucene.search.MultiTermQuery;
+import org.apache.lucene.util.automaton.Operations;
 
 import java.util.Collection;
 import java.util.List;
@@ -49,6 +50,7 @@ public class QueryParserSettings {
     private float fuzzyMinSim = FuzzyQuery.defaultMinSimilarity;
     private int fuzzyPrefixLength = FuzzyQuery.defaultPrefixLength;
     private int fuzzyMaxExpansions = FuzzyQuery.defaultMaxExpansions;
+    private int maxDeterminizedStates = Operations.DEFAULT_MAX_DETERMINIZED_STATES;
     private MultiTermQuery.RewriteMethod fuzzyRewriteMethod = null;
     private boolean analyzeWildcard = DEFAULT_ANALYZE_WILDCARD;
     private boolean escape = false;
@@ -112,6 +114,14 @@ public class QueryParserSettings {
 
     public void autoGeneratePhraseQueries(boolean autoGeneratePhraseQueries) {
         this.autoGeneratePhraseQueries = autoGeneratePhraseQueries;
+    }
+
+    public int maxDeterminizedStates() {
+        return maxDeterminizedStates;
+    }
+
+    public void maxDeterminizedStates(int maxDeterminizedStates) {
+        this.maxDeterminizedStates = maxDeterminizedStates;
     }
 
     public boolean allowLeadingWildcard() {
@@ -314,6 +324,7 @@ public class QueryParserSettings {
         QueryParserSettings that = (QueryParserSettings) o;
 
         if (autoGeneratePhraseQueries != that.autoGeneratePhraseQueries()) return false;
+        if (maxDeterminizedStates != that.maxDeterminizedStates()) return false;
         if (allowLeadingWildcard != that.allowLeadingWildcard) return false;
         if (Float.compare(that.boost, boost) != 0) return false;
         if (enablePositionIncrements != that.enablePositionIncrements) return false;
@@ -366,6 +377,7 @@ public class QueryParserSettings {
         result = 31 * result + (boost != +0.0f ? Float.floatToIntBits(boost) : 0);
         result = 31 * result + (defaultOperator != null ? defaultOperator.hashCode() : 0);
         result = 31 * result + (autoGeneratePhraseQueries ? 1 : 0);
+        result = 31 * result + maxDeterminizedStates;
         result = 31 * result + (allowLeadingWildcard ? 1 : 0);
         result = 31 * result + (lowercaseExpandedTerms ? 1 : 0);
         result = 31 * result + (enablePositionIncrements ? 1 : 0);

--- a/src/main/java/org/apache/lucene/search/suggest/analyzing/XAnalyzingSuggester.java
+++ b/src/main/java/org/apache/lucene/search/suggest/analyzing/XAnalyzingSuggester.java
@@ -311,7 +311,8 @@ public class XAnalyzingSuggester extends Lookup {
   protected Automaton convertAutomaton(Automaton a) {
     if (queryPrefix != null) {
       a = Operations.concatenate(Arrays.asList(queryPrefix, a));
-      a = Operations.determinize(a);
+      // This automaton should not blow up during determinize:
+      a = Operations.determinize(a, Integer.MAX_VALUE);
     }
     return a;
   }
@@ -952,14 +953,16 @@ public class XAnalyzingSuggester extends Lookup {
       try {
           automaton = getTokenStreamToAutomaton().toAutomaton(ts);
       } finally {
-        IOUtils.closeWhileHandlingException(ts);
+          IOUtils.closeWhileHandlingException(ts);
       }
 
       automaton = replaceSep(automaton);
 
       // TODO: we can optimize this somewhat by determinizing
       // while we convert
-      automaton = Operations.determinize(automaton);
+
+      // This automaton should not blow up during determinize:
+      automaton = Operations.determinize(automaton, Integer.MAX_VALUE);
       return automaton;
   }
   

--- a/src/main/java/org/apache/lucene/search/suggest/analyzing/XFuzzySuggester.java
+++ b/src/main/java/org/apache/lucene/search/suggest/analyzing/XFuzzySuggester.java
@@ -205,7 +205,8 @@ public final class XFuzzySuggester extends XAnalyzingSuggester {
       if (unicodeAware) {
         // FLORIAN EDIT: get converted Automaton from superclass
         Automaton utf8automaton = new UTF32ToUTF8().convert(super.convertAutomaton(a));
-        utf8automaton = Operations.determinize(utf8automaton);
+        // This automaton should not blow up during determinize:
+        utf8automaton = Operations.determinize(utf8automaton, Integer.MAX_VALUE);
         return utf8automaton;
       } else {
         return super.convertAutomaton(a);
@@ -253,7 +254,9 @@ public final class XFuzzySuggester extends XAnalyzingSuggester {
           Automaton a = Operations.union(Arrays.asList(subs));
           // TODO: we could call toLevenshteinAutomata() before det? 
           // this only happens if you have multiple paths anyway (e.g. synonyms)
-          return Operations.determinize(a);
+
+          // This automaton should not blow up during determinize:
+          return Operations.determinize(a, Integer.MAX_VALUE);
         }
       }
 }

--- a/src/main/java/org/elasticsearch/Version.java
+++ b/src/main/java/org/elasticsearch/Version.java
@@ -207,7 +207,7 @@ public class Version implements Serializable {
     public static final int V_1_4_0_ID = /*00*/1040099;
     public static final Version V_1_4_0 = new Version(V_1_4_0_ID, false, org.apache.lucene.util.Version.LUCENE_4_10_2);
     public static final int V_1_4_1_ID = /*00*/1040199;
-    public static final Version V_1_4_1 = new Version(V_1_4_1_ID, true, org.apache.lucene.util.Version.LUCENE_4_10_2);
+    public static final Version V_1_4_1 = new Version(V_1_4_1_ID, true, org.apache.lucene.util.Version.LUCENE_4_10_3);
 
 
     public static final Version CURRENT = V_1_4_1;

--- a/src/main/java/org/elasticsearch/common/lucene/search/RegexpFilter.java
+++ b/src/main/java/org/elasticsearch/common/lucene/search/RegexpFilter.java
@@ -18,6 +18,8 @@
  */
 package org.elasticsearch.common.lucene.search;
 
+import java.io.IOException;
+
 import org.apache.lucene.index.AtomicReaderContext;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.DocIdSet;
@@ -25,9 +27,8 @@ import org.apache.lucene.search.Filter;
 import org.apache.lucene.search.MultiTermQueryWrapperFilter;
 import org.apache.lucene.search.RegexpQuery;
 import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.automaton.Operations;
 import org.apache.lucene.util.automaton.RegExp;
-
-import java.io.IOException;
 
 /**
  * A lazy regexp filter which only builds the automaton on the first call to {@link #getDocIdSet(AtomicReaderContext, Bits)}.
@@ -47,7 +48,11 @@ public class RegexpFilter extends Filter {
     }
 
     public RegexpFilter(Term term, int flags) {
-        filter = new InternalFilter(term, flags);
+        this(term, flags, Operations.DEFAULT_MAX_DETERMINIZED_STATES);
+    }
+
+    public RegexpFilter(Term term, int flags, int maxDeterminizedStates) {
+        filter = new InternalFilter(term, flags, maxDeterminizedStates);
         this.term = term;
         this.flags = flags;
     }
@@ -97,12 +102,8 @@ public class RegexpFilter extends Filter {
 
     static class InternalFilter extends MultiTermQueryWrapperFilter<RegexpQuery> {
 
-        public InternalFilter(Term term) {
-            super(new RegexpQuery(term));
-        }
-
-        public InternalFilter(Term term, int flags) {
-            super(new RegexpQuery(term, flags));
+        public InternalFilter(Term term, int flags, int maxDeterminizedStates) {
+            super(new RegexpQuery(term, flags, maxDeterminizedStates));
         }
     }
 

--- a/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -260,9 +260,9 @@ public interface FieldMapper<T> extends Mapper {
 
     Filter prefixFilter(Object value, @Nullable QueryParseContext context);
 
-    Query regexpQuery(Object value, int flags, @Nullable MultiTermQuery.RewriteMethod method, @Nullable QueryParseContext context);
+    Query regexpQuery(Object value, int flags, int maxDeterminizedStates, @Nullable MultiTermQuery.RewriteMethod method, @Nullable QueryParseContext context);
 
-    Filter regexpFilter(Object value, int flags, @Nullable QueryParseContext parseContext);
+    Filter regexpFilter(Object value, int flags, int maxDeterminizedStates, @Nullable QueryParseContext parseContext);
 
     /**
      * A term query to use when parsing a query string. Can return <tt>null</tt>.

--- a/src/main/java/org/elasticsearch/index/mapper/core/AbstractFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/AbstractFieldMapper.java
@@ -535,8 +535,8 @@ public abstract class AbstractFieldMapper<T> implements FieldMapper<T> {
     }
 
     @Override
-    public Query regexpQuery(Object value, int flags, @Nullable MultiTermQuery.RewriteMethod method, @Nullable QueryParseContext context) {
-        RegexpQuery query = new RegexpQuery(names().createIndexNameTerm(indexedValueForSearch(value)), flags);
+    public Query regexpQuery(Object value, int flags, int maxDeterminizedStates, @Nullable MultiTermQuery.RewriteMethod method, @Nullable QueryParseContext context) {
+        RegexpQuery query = new RegexpQuery(names().createIndexNameTerm(indexedValueForSearch(value)), flags, maxDeterminizedStates);
         if (method != null) {
             query.setRewriteMethod(method);
         }
@@ -544,8 +544,8 @@ public abstract class AbstractFieldMapper<T> implements FieldMapper<T> {
     }
 
     @Override
-    public Filter regexpFilter(Object value, int flags, @Nullable QueryParseContext parseContext) {
-        return new RegexpFilter(names().createIndexNameTerm(indexedValueForSearch(value)), flags);
+    public Filter regexpFilter(Object value, int flags, int maxDeterminizedStates, @Nullable QueryParseContext parseContext) {
+        return new RegexpFilter(names().createIndexNameTerm(indexedValueForSearch(value)), flags, maxDeterminizedStates);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/mapper/internal/IdFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/IdFieldMapper.java
@@ -232,13 +232,14 @@ public class IdFieldMapper extends AbstractFieldMapper<String> implements Intern
     }
 
     @Override
-    public Query regexpQuery(Object value, int flags, @Nullable MultiTermQuery.RewriteMethod method, @Nullable QueryParseContext context) {
+    public Query regexpQuery(Object value, int flags, int maxDeterminizedStates, @Nullable MultiTermQuery.RewriteMethod method, @Nullable QueryParseContext context) {
         if (fieldType.indexed() || context == null) {
-            return super.regexpQuery(value, flags, method, context);
+            return super.regexpQuery(value, flags, maxDeterminizedStates, method, context);
         }
         Collection<String> queryTypes = context.queryTypes();
         if (queryTypes.size() == 1) {
-            RegexpQuery regexpQuery = new RegexpQuery(new Term(UidFieldMapper.NAME, Uid.createUidAsBytes(Iterables.getFirst(queryTypes, null), BytesRefs.toBytesRef(value))), flags);
+            RegexpQuery regexpQuery = new RegexpQuery(new Term(UidFieldMapper.NAME, Uid.createUidAsBytes(Iterables.getFirst(queryTypes, null), BytesRefs.toBytesRef(value))),
+                                                      flags, maxDeterminizedStates);
             if (method != null) {
                 regexpQuery.setRewriteMethod(method);
             }
@@ -246,7 +247,7 @@ public class IdFieldMapper extends AbstractFieldMapper<String> implements Intern
         }
         BooleanQuery query = new BooleanQuery();
         for (String queryType : queryTypes) {
-            RegexpQuery regexpQuery = new RegexpQuery(new Term(UidFieldMapper.NAME, Uid.createUidAsBytes(queryType, BytesRefs.toBytesRef(value))), flags);
+            RegexpQuery regexpQuery = new RegexpQuery(new Term(UidFieldMapper.NAME, Uid.createUidAsBytes(queryType, BytesRefs.toBytesRef(value))), flags, maxDeterminizedStates);
             if (method != null) {
                 regexpQuery.setRewriteMethod(method);
             }
@@ -255,17 +256,17 @@ public class IdFieldMapper extends AbstractFieldMapper<String> implements Intern
         return query;
     }
 
-    public Filter regexpFilter(Object value, int flags, @Nullable QueryParseContext context) {
+    public Filter regexpFilter(Object value, int flags, int maxDeterminizedStates, @Nullable QueryParseContext context) {
         if (fieldType.indexed() || context == null) {
-            return super.regexpFilter(value, flags, context);
+            return super.regexpFilter(value, flags, maxDeterminizedStates, context);
         }
         Collection<String> queryTypes = context.queryTypes();
         if (queryTypes.size() == 1) {
-            return new RegexpFilter(new Term(UidFieldMapper.NAME, Uid.createUidAsBytes(Iterables.getFirst(queryTypes, null), BytesRefs.toBytesRef(value))), flags);
+            return new RegexpFilter(new Term(UidFieldMapper.NAME, Uid.createUidAsBytes(Iterables.getFirst(queryTypes, null), BytesRefs.toBytesRef(value))), flags, maxDeterminizedStates);
         }
         XBooleanFilter filter = new XBooleanFilter();
         for (String queryType : queryTypes) {
-            filter.add(new RegexpFilter(new Term(UidFieldMapper.NAME, Uid.createUidAsBytes(queryType, BytesRefs.toBytesRef(value))), flags), BooleanClause.Occur.SHOULD);
+            filter.add(new RegexpFilter(new Term(UidFieldMapper.NAME, Uid.createUidAsBytes(queryType, BytesRefs.toBytesRef(value))), flags, maxDeterminizedStates), BooleanClause.Occur.SHOULD);
         }
         return filter;
     }

--- a/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
@@ -19,13 +19,14 @@
 
 package org.elasticsearch.index.query;
 
-import com.carrotsearch.hppc.ObjectFloatOpenHashMap;
-import org.elasticsearch.common.unit.Fuzziness;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-
 import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
+
+import org.apache.lucene.util.automaton.Operations;
+import org.elasticsearch.common.unit.Fuzziness;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import com.carrotsearch.hppc.ObjectFloatOpenHashMap;
 
 import static com.google.common.collect.Lists.newArrayList;
 
@@ -92,6 +93,9 @@ public class QueryStringQueryBuilder extends BaseQueryBuilder implements Boostab
     private Boolean lenient;
 
     private String queryName;
+
+    /** To limit effort spent determinizing regexp queries. */
+    private Integer maxDeterminizedStates;
 
     public QueryStringQueryBuilder(String queryString) {
         this.queryString = queryString;
@@ -195,6 +199,14 @@ public class QueryStringQueryBuilder extends BaseQueryBuilder implements Boostab
      */
     public QueryStringQueryBuilder autoGeneratePhraseQueries(boolean autoGeneratePhraseQueries) {
         this.autoGeneratePhraseQueries = autoGeneratePhraseQueries;
+        return this;
+    }
+
+    /**
+     * Protects against too-difficult regular expression queries.
+     */
+    public QueryStringQueryBuilder maxDeterminizedStates(int maxDeterminizedStates) {
+        this.maxDeterminizedStates = maxDeterminizedStates;
         return this;
     }
 
@@ -353,6 +365,9 @@ public class QueryStringQueryBuilder extends BaseQueryBuilder implements Boostab
         }
         if (autoGeneratePhraseQueries != null) {
             builder.field("auto_generate_phrase_queries", autoGeneratePhraseQueries);
+        }
+        if (maxDeterminizedStates != null) {
+            builder.field("max_determinized_states", maxDeterminizedStates);
         }
         if (allowLeadingWildcard != null) {
             builder.field("allow_leading_wildcard", allowLeadingWildcard);

--- a/src/main/java/org/elasticsearch/index/query/QueryStringQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryStringQueryParser.java
@@ -156,6 +156,8 @@ public class QueryStringQueryParser implements QueryParser {
                     qpSettings.allowLeadingWildcard(parser.booleanValue());
                 } else if ("auto_generate_phrase_queries".equals(currentFieldName) || "autoGeneratePhraseQueries".equals(currentFieldName)) {
                     qpSettings.autoGeneratePhraseQueries(parser.booleanValue());
+                } else if ("max_determinized_states".equals(currentFieldName) || "maxDeterminizedStates".equals(currentFieldName)) {
+                    qpSettings.maxDeterminizedStates(parser.intValue());
                 } else if ("lowercase_expanded_terms".equals(currentFieldName) || "lowercaseExpandedTerms".equals(currentFieldName)) {
                     qpSettings.lowercaseExpandedTerms(parser.booleanValue());
                 } else if ("enable_position_increments".equals(currentFieldName) || "enablePositionIncrements".equals(currentFieldName)) {

--- a/src/main/java/org/elasticsearch/index/query/RegexpFilterBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/RegexpFilterBuilder.java
@@ -19,9 +19,10 @@
 
 package org.elasticsearch.index.query;
 
-import org.elasticsearch.common.xcontent.XContentBuilder;
-
 import java.io.IOException;
+
+import org.apache.lucene.util.automaton.Operations;
+import org.elasticsearch.common.xcontent.XContentBuilder;
 
 /**
  * A filter that restricts search results to values that have a matching regular expression in a given
@@ -34,6 +35,8 @@ public class RegexpFilterBuilder extends BaseFilterBuilder {
     private final String name;
     private final String regexp;
     private int flags = -1;
+    private int maxDeterminizedStates = Operations.DEFAULT_MAX_DETERMINIZED_STATES;
+    private boolean maxDetermizedStatesSet;
 
     private Boolean cache;
     private String cacheKey;
@@ -76,6 +79,15 @@ public class RegexpFilterBuilder extends BaseFilterBuilder {
     }
 
     /**
+     * Sets the regexp maxDeterminizedStates.
+     */
+    public RegexpFilterBuilder maxDeterminizedStates(int value) {
+        this.maxDeterminizedStates = value;
+        this.maxDetermizedStatesSet = true;
+        return this;
+    }
+
+    /**
      * Should the filter be cached or not. Defaults to <tt>false</tt>.
      */
     public RegexpFilterBuilder cache(boolean cache) {
@@ -96,8 +108,11 @@ public class RegexpFilterBuilder extends BaseFilterBuilder {
         } else {
             builder.startObject(name)
                     .field("value", regexp)
-                    .field("flags_value", flags)
-                    .endObject();
+                    .field("flags_value", flags);
+            if (maxDetermizedStatesSet) {
+                builder.field("max_determinized_states", maxDeterminizedStates);
+            }
+            builder.endObject();
         }
 
         if (filterName != null) {

--- a/src/main/java/org/elasticsearch/index/query/RegexpFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/RegexpFilterParser.java
@@ -19,16 +19,17 @@
 
 package org.elasticsearch.index.query;
 
+import java.io.IOException;
+
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.Filter;
+import org.apache.lucene.util.automaton.Operations;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.lucene.search.RegexpFilter;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.cache.filter.support.CacheKeyFilter;
 import org.elasticsearch.index.mapper.MapperService;
-
-import java.io.IOException;
 
 import static org.elasticsearch.index.query.support.QueryParsers.wrapSmartNameFilter;
 
@@ -62,6 +63,7 @@ public class RegexpFilterParser implements FilterParser {
 
         String filterName = null;
         String currentFieldName = null;
+        int maxDeterminizedStates = Operations.DEFAULT_MAX_DETERMINIZED_STATES;
         XContentParser.Token token;
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
             if (token == XContentParser.Token.FIELD_NAME) {
@@ -77,6 +79,8 @@ public class RegexpFilterParser implements FilterParser {
                         } else if ("flags".equals(currentFieldName)) {
                             String flags = parser.textOrNull();
                             flagsValue = RegexpFlag.resolveValue(flags);
+                        } else if ("max_determinized_states".equals(currentFieldName)) {
+                            maxDeterminizedStates = parser.intValue();
                         } else if ("flags_value".equals(currentFieldName)) {
                             flagsValue = parser.intValue();
                         } else {
@@ -114,16 +118,16 @@ public class RegexpFilterParser implements FilterParser {
             if (smartNameFieldMappers.explicitTypeInNameWithDocMapper()) {
                 String[] previousTypes = QueryParseContext.setTypesWithPrevious(new String[]{smartNameFieldMappers.docMapper().type()});
                 try {
-                    filter = smartNameFieldMappers.mapper().regexpFilter(value, flagsValue, parseContext);
+                    filter = smartNameFieldMappers.mapper().regexpFilter(value, flagsValue, maxDeterminizedStates, parseContext);
                 } finally {
                     QueryParseContext.setTypes(previousTypes);
                 }
             } else {
-                filter = smartNameFieldMappers.mapper().regexpFilter(value, flagsValue, parseContext);
+                filter = smartNameFieldMappers.mapper().regexpFilter(value, flagsValue, maxDeterminizedStates, parseContext);
             }
         }
         if (filter == null) {
-            filter = new RegexpFilter(new Term(fieldName, BytesRefs.toBytesRef(value)), flagsValue);
+            filter = new RegexpFilter(new Term(fieldName, BytesRefs.toBytesRef(value)), flagsValue, maxDeterminizedStates);
         }
 
         if (cache) {

--- a/src/main/java/org/elasticsearch/index/query/RegexpQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/RegexpQueryBuilder.java
@@ -19,9 +19,10 @@
 
 package org.elasticsearch.index.query;
 
-import org.elasticsearch.common.xcontent.XContentBuilder;
-
 import java.io.IOException;
+
+import org.apache.lucene.util.automaton.Operations;
+import org.elasticsearch.common.xcontent.XContentBuilder;
 
 /**
  * A Query that does fuzzy matching for a specific value.
@@ -37,6 +38,8 @@ public class RegexpQueryBuilder extends BaseQueryBuilder implements BoostableQue
     private float boost = -1;
     private String rewrite;
     private String queryName;
+    private int maxDeterminizedStates = Operations.DEFAULT_MAX_DETERMINIZED_STATES;
+    private boolean maxDetermizedStatesSet;
 
     /**
      * Constructs a new term query.
@@ -71,6 +74,15 @@ public class RegexpQueryBuilder extends BaseQueryBuilder implements BoostableQue
         return this;
     }
 
+    /**
+     * Sets the regexp maxDeterminizedStates.
+     */
+    public RegexpQueryBuilder maxDeterminizedStates(int value) {
+        this.maxDeterminizedStates = value;
+        this.maxDetermizedStatesSet = true;
+        return this;
+    }
+
     public RegexpQueryBuilder rewrite(String rewrite) {
         this.rewrite = rewrite;
         return this;
@@ -94,6 +106,9 @@ public class RegexpQueryBuilder extends BaseQueryBuilder implements BoostableQue
             builder.field("value", regexp);
             if (flags != -1) {
                 builder.field("flags_value", flags);
+            }
+            if (maxDetermizedStatesSet) {
+                builder.field("max_determinized_states", maxDeterminizedStates);
             }
             if (boost != -1) {
                 builder.field("boost", boost);

--- a/src/main/java/org/elasticsearch/index/query/RegexpQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/RegexpQueryParser.java
@@ -19,18 +19,19 @@
 
 package org.elasticsearch.index.query;
 
+import java.io.IOException;
+
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.MultiTermQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.RegexpQuery;
+import org.apache.lucene.util.automaton.Operations;
 import org.apache.lucene.util.automaton.RegExp;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.support.QueryParsers;
-
-import java.io.IOException;
 
 import static org.elasticsearch.index.query.support.QueryParsers.wrapSmartNameQuery;
 
@@ -64,6 +65,7 @@ public class RegexpQueryParser implements QueryParser {
         Object value = null;
         float boost = 1.0f;
         int flagsValue = -1;
+        int maxDeterminizedStates = Operations.DEFAULT_MAX_DETERMINIZED_STATES;
         String queryName = null;
         token = parser.nextToken();
         if (token == XContentParser.Token.START_OBJECT) {
@@ -86,6 +88,8 @@ public class RegexpQueryParser implements QueryParser {
                         if (flagsValue < 0) {
                             flagsValue = RegExp.ALL;
                         }
+                    } else if ("maxDeterminizedStates".equals(currentFieldName)) {
+                        maxDeterminizedStates = parser.intValue();
                     } else if ("_name".equals(currentFieldName)) {
                         queryName = parser.text();
                     }
@@ -111,16 +115,16 @@ public class RegexpQueryParser implements QueryParser {
             if (smartNameFieldMappers.explicitTypeInNameWithDocMapper()) {
                 String[] previousTypes = QueryParseContext.setTypesWithPrevious(new String[]{smartNameFieldMappers.docMapper().type()});
                 try {
-                    query = smartNameFieldMappers.mapper().regexpQuery(value, flagsValue, method, parseContext);
+                    query = smartNameFieldMappers.mapper().regexpQuery(value, flagsValue, maxDeterminizedStates, method, parseContext);
                 } finally {
                     QueryParseContext.setTypes(previousTypes);
                 }
             } else {
-                query = smartNameFieldMappers.mapper().regexpQuery(value, flagsValue, method, parseContext);
+                query = smartNameFieldMappers.mapper().regexpQuery(value, flagsValue, maxDeterminizedStates, method, parseContext);
             }
         }
         if (query == null) {
-            RegexpQuery regexpQuery = new RegexpQuery(new Term(fieldName, BytesRefs.toBytesRef(value)), flagsValue);
+            RegexpQuery regexpQuery = new RegexpQuery(new Term(fieldName, BytesRefs.toBytesRef(value)), flagsValue, maxDeterminizedStates);
             if (method != null) {
                 regexpQuery.setRewriteMethod(method);
             }

--- a/src/main/java/org/elasticsearch/search/suggest/context/ContextMapping.java
+++ b/src/main/java/org/elasticsearch/search/suggest/context/ContextMapping.java
@@ -259,7 +259,10 @@ public abstract class ContextMapping implements ToXContent {
             for (ContextQuery query : queries) {
                 a = Operations.concatenate(Arrays.asList(query.toAutomaton(), gap, a));
             }
-            return Operations.determinize(a);
+
+            // TODO: should we limit this?  Do any of our ContextQuery impls really create exponential regexps?  GeoQuery looks safe (union
+            // of strings).
+            return Operations.determinize(a, Integer.MAX_VALUE);
         }
 
         /**

--- a/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
+++ b/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
@@ -33,6 +33,7 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
 import org.apache.lucene.util.CharsRefBuilder;
 import org.apache.lucene.util.NumericUtils;
+import org.apache.lucene.util.automaton.TooComplexToDeterminizeException;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.action.get.MultiGetRequest;
@@ -244,6 +245,29 @@ public class SimpleIndexQueryParserTests extends ElasticsearchSingleNodeTest {
         assertThat((double) disjuncts.get(0).getBoost(), closeTo(2.2, 0.01));
         assertThat(((TermQuery) disjuncts.get(1)).getTerm(), equalTo(new Term("name", "test")));
         assertThat((double) disjuncts.get(1).getBoost(), closeTo(1, 0.01));
+    }
+
+    @Test
+    public void testQueryStringRegexp() throws Exception {
+        IndexQueryParserService queryParser = queryParser();
+        String query = copyToStringFromClasspath("/org/elasticsearch/index/query/query-regexp-max-determinized-states.json");
+        Query parsedQuery = queryParser.parse(query).query();
+        assertThat(parsedQuery, instanceOf(RegexpQuery.class));
+        RegexpQuery regexpQuery = (RegexpQuery) parsedQuery;
+        assertTrue(regexpQuery.toString().contains("/foo*bar/"));
+    }
+
+    @Test
+    public void testQueryStringRegexpTooManyDeterminizedStates() throws Exception {
+        IndexQueryParserService queryParser = queryParser();
+        String query = copyToStringFromClasspath("/org/elasticsearch/index/query/query-regexp-too-many-determinized-states.json");
+        try {
+            queryParser.parse(query).query();
+            fail("did not hit exception");
+        } catch (QueryParsingException qpe) {
+            // expected
+            assertTrue(qpe.getCause() instanceof TooComplexToDeterminizeException);
+        }
     }
 
     @Test
@@ -577,9 +601,32 @@ public class SimpleIndexQueryParserTests extends ElasticsearchSingleNodeTest {
     }
 
     @Test
+    public void testRegexpQueryWithMaxDeterminizedStates() throws IOException {
+        IndexQueryParserService queryParser = queryParser();
+        String query = copyToStringFromClasspath("/org/elasticsearch/index/query/regexp-max-determinized-states.json");
+        Query parsedQuery = queryParser.parse(query).query();
+        assertThat(parsedQuery, instanceOf(RegexpQuery.class));
+        RegexpQuery regexpQuery = (RegexpQuery) parsedQuery;
+        assertThat(regexpQuery.getField(), equalTo("name.first"));
+    }
+
+    @Test
     public void testRegexpFilteredQuery() throws IOException {
         IndexQueryParserService queryParser = queryParser();
         String query = copyToStringFromClasspath("/org/elasticsearch/index/query/regexp-filter.json");
+        Query parsedQuery = queryParser.parse(query).query();
+        assertThat(parsedQuery, instanceOf(XFilteredQuery.class));
+        Filter filter = ((XFilteredQuery) parsedQuery).getFilter();
+        assertThat(filter, instanceOf(RegexpFilter.class));
+        RegexpFilter regexpFilter = (RegexpFilter) filter;
+        assertThat(regexpFilter.field(), equalTo("name.first"));
+        assertThat(regexpFilter.regexp(), equalTo("s.*y"));
+    }
+
+    @Test
+    public void testRegexpFilteredQueryWithMaxDeterminizedStates() throws IOException {
+        IndexQueryParserService queryParser = queryParser();
+        String query = copyToStringFromClasspath("/org/elasticsearch/index/query/regexp-filter-max-determinized-states.json");
         Query parsedQuery = queryParser.parse(query).query();
         assertThat(parsedQuery, instanceOf(XFilteredQuery.class));
         Filter filter = ((XFilteredQuery) parsedQuery).getFilter();

--- a/src/test/java/org/elasticsearch/index/query/query-regexp-max-determinized-states.json
+++ b/src/test/java/org/elasticsearch/index/query/query-regexp-max-determinized-states.json
@@ -1,0 +1,7 @@
+{
+    query_string: {
+        default_field: "content",
+        query:"/foo*bar/",
+	max_determinized_states: 5000
+    }
+}

--- a/src/test/java/org/elasticsearch/index/query/query-regexp-too-many-determinized-states.json
+++ b/src/test/java/org/elasticsearch/index/query/query-regexp-too-many-determinized-states.json
@@ -1,0 +1,6 @@
+{
+    query_string: {
+        default_field: "content",
+        query: "/[ac]*a[ac]{50,200}/"
+    }
+}

--- a/src/test/java/org/elasticsearch/index/query/regexp-filter-max-determinized-states.json
+++ b/src/test/java/org/elasticsearch/index/query/regexp-filter-max-determinized-states.json
@@ -1,0 +1,17 @@
+{
+    "filtered": {
+        "query": {
+            "term": {
+                "name.first": "shay"
+            }
+        },
+        "filter": {
+            "regexp": {
+                "name.first": {
+		    "value": "s.*y",
+		    "max_determinized_states": 6000
+		}
+            }
+        }
+    }
+}

--- a/src/test/java/org/elasticsearch/index/query/regexp-max-determinized-states.json
+++ b/src/test/java/org/elasticsearch/index/query/regexp-max-determinized-states.json
@@ -1,0 +1,6 @@
+{
+    "regexp": {
+        "name.first": "s.*y",
+	"max_determinized_states": 5000
+    }
+}


### PR DESCRIPTION
This PR applies to 1.4.x, and it includes a Lucene snapshot upgrade (so we can't release 1.4.1 until Lucene also releases 4.10.3).

I just plumbed the max_determinized_states through to regexp query, filter and query_string, leaving the default at Lucene's default (10000 states).

Closes #8357
