### PR TITLE
Drop pre 0.90 compression BWC

### DIFF
--- a/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/src/main/java/org/elasticsearch/index/store/Store.java
@@ -501,27 +501,6 @@ public class Store extends AbstractIndexShardComponent implements CloseableIndex
         }
 
         @Override
-        public IndexInput openInput(String name, IOContext context) throws IOException {
-            IndexInput in = super.openInput(name, context);
-            boolean success = false;
-            try {
-                // Only for backward comp. since we now use Lucene codec compression
-                if (name.endsWith(".fdt") || name.endsWith(".tvf")) {
-                    Compressor compressor = CompressorFactory.compressor(in);
-                    if (compressor != null) {
-                        in = compressor.indexInput(in);
-                    }
-                }
-                success = true;
-            } finally {
-                if (!success) {
-                    IOUtils.closeWhileHandlingException(in);
-                }
-            }
-            return in;
-        }
-
-        @Override
         public void close() throws IOException {
             assert false : "Nobody should close this directory except of the Store itself";
         }


### PR DESCRIPTION
Pre 0.90 indices need to be upgraded to run with 2.0
we can drop the stored field compression BWC.
