### PR TITLE
Log how long IW.rollback took, and when MockFSDir starts its check index

### DIFF
--- a/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
+++ b/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
@@ -1327,10 +1327,15 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
                     }
                     // no need to commit in this case!, we snapshot before we close the shard, so translog and all sync'ed
                     if (indexWriter != null) {
+                        long t0 = System.nanoTime();
                         try {
                             indexWriter.rollback();
                         } catch (AlreadyClosedException e) {
                             // ignore
+                        }
+                        long t1 = System.nanoTime();
+                        if (logger.isDebugEnabled()) {
+                            logger.debug("indexWriter.rollback took {} nanoseconds", t1-t0);
                         }
                     }
                 } catch (Throwable e) {

--- a/src/test/java/org/elasticsearch/test/store/MockFSDirectoryService.java
+++ b/src/test/java/org/elasticsearch/test/store/MockFSDirectoryService.java
@@ -120,6 +120,7 @@ public class MockFSDirectoryService extends FsDirectoryService {
 
     public void checkIndex(Store store, ShardId shardId) throws IndexShardException {
         if (store.tryIncRef()) {
+            logger.info("start check index");
             try {
                 Directory dir = store.directory();
                 if (!Lucene.indexExists(dir)) {


### PR DESCRIPTION
A trivial PR that logs how long IndexWriter.rollback took.
