### PR TITLE
Fix GET index API always running all features

### DIFF
--- a/docs/reference/migration/migrate_2_0.asciidoc
+++ b/docs/reference/migration/migrate_2_0.asciidoc
@@ -11,6 +11,13 @@ if a requested index does not exist. This change brings the defaults for this AP
 line with the other Indices APIs. The <<multi-index>> options can be used on a request 
 to change this behavior
 
+`GetIndexRequest.features()` now returns an array of Feature Enums instrad of an array of String values.
+The following deprecated methods have been removed:
+* `GetIndexRequest.addFeatures(String[])` - Please use `GetIndexRequest.addFeatures(Feature[])` instead
+* `GetIndexRequest.features(String[])` - Please use `GetIndexRequest.features(Feature[])` instead
+* `GetIndexRequestBuilder.addFeatures(String[])` - Please use `GetIndexRequestBuilder.addFeatures(Feature[])` instead
+* `GetIndexRequestBuilder.setFeatures(String[])` - Please use `GetIndexRequestBuilder.setFeatures(Feature[])` instead
+
 === Partial fields
 
 Partial fields were deprecated since 1.0.0beta1 in favor of <<search-request-source-filtering,source filtering>>.

--- a/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexRequest.java
@@ -19,22 +19,91 @@
 
 package org.elasticsearch.action.admin.indices.get;
 
+import com.google.common.collect.ObjectArrays;
+
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.master.info.ClusterInfoRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * A request to delete an index. Best created with {@link org.elasticsearch.client.Requests#deleteIndexRequest(String)}.
  */
 public class GetIndexRequest extends ClusterInfoRequest<GetIndexRequest> {
 
-    private String[] features = new String[] { "_settings", "_warmers", "_mappings", "_aliases" };
+    public static enum Feature {
+        ALIASES((byte) 0, "_aliases", "_alias"),
+        MAPPINGS((byte) 1, "_mappings", "_mapping"),
+        SETTINGS((byte) 2, "_settings"),
+        WARMERS((byte) 3, "_warmers", "_warmer");
 
-    public GetIndexRequest features(String[] features) {
+        private static final Feature[] FEATURES = new Feature[Feature.values().length];
+
+        static {
+            for (Feature feature : Feature.values()) {
+                assert feature.id() < FEATURES.length && feature.id() >= 0;
+                FEATURES[feature.id] = feature;
+            }
+        }
+
+        private final List<String> validNames;
+        private final String preferredName;
+        private final byte id;
+
+        private Feature(byte id, String... validNames) {
+            assert validNames != null && validNames.length > 0;
+            this.id = id;
+            this.validNames = Arrays.asList(validNames);
+            this.preferredName = validNames[0];
+        }
+
+        public byte id() {
+            return id;
+        }
+
+        public String preferredName() {
+            return preferredName;
+        }
+
+        public boolean validName(String name) {
+            return this.validNames.contains(name);
+        }
+
+        public static Feature fromName(String name) throws ElasticsearchIllegalArgumentException {
+            for (Feature feature : Feature.values()) {
+                if (feature.validName(name)) {
+                    return feature;
+                }
+            }
+            throw new ElasticsearchIllegalArgumentException("No feature for name [" + name + "]");
+        }
+
+        public static Feature fromId(byte id) throws ElasticsearchIllegalArgumentException {
+            if (id < 0 || id >= FEATURES.length) {
+                throw new ElasticsearchIllegalArgumentException("No mapping for id [" + id + "]");
+            }
+            return FEATURES[id];
+        }
+
+        public static Feature[] convertToFeatures(String... featureNames) {
+            Feature[] features = new Feature[featureNames.length];
+            for (int i = 0; i < featureNames.length; i++) {
+                features[i] = Feature.fromName(featureNames[i]);
+            }
+            return features;
+        }
+    }
+
+    private static final Feature[] DEFAULT_FEATURES = new Feature[] { Feature.ALIASES, Feature.MAPPINGS, Feature.SETTINGS, Feature.WARMERS };
+    private Feature[] features = DEFAULT_FEATURES;
+
+    public GetIndexRequest features(Feature... features) {
         if (features == null) {
             throw new ElasticsearchIllegalArgumentException("features cannot be null");
         } else {
@@ -43,8 +112,24 @@ public class GetIndexRequest extends ClusterInfoRequest<GetIndexRequest> {
         return this;
     }
 
-    public String[] features() {
+    public GetIndexRequest addFeatures(Feature... features) {
+        if (this.features == DEFAULT_FEATURES) {
+            return features(features);
+        } else {
+            return features(ObjectArrays.concat(featuresAsEnums(), features, Feature.class));
+        }
+    }
+
+    public Feature[] features() {
         return features;
+    }
+
+    /**
+     * @deprecated use {@link #features()} instead
+     */
+    @Deprecated
+    public Feature[] featuresAsEnums() {
+        return features();
     }
     
     @Override
@@ -55,13 +140,32 @@ public class GetIndexRequest extends ClusterInfoRequest<GetIndexRequest> {
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        features = in.readStringArray();
+        if (in.getVersion().before(Version.V_1_4_1)) {
+            Feature.convertToFeatures(in.readStringArray());
+        } else {
+            int size = in.readVInt();
+            features = new Feature[size];
+            for (int i = 0; i < size; i++) {
+                features[i] = Feature.fromId(in.readByte());
+            }
+        }
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeStringArray(features);
+        if (out.getVersion().before(Version.V_1_4_1)) {
+            String[] featureNames = new String[features.length];
+            for (int i = 0; i< features.length; i++) {
+                featureNames[i] = features[i].preferredName();
+            }
+            out.writeStringArray(featureNames);
+        } else {
+            out.writeVInt(features.length);
+            for (Feature feature : features) {
+                out.writeByte(feature.id);
+            }
+        }
     }
 
 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexRequestBuilder.java
@@ -19,8 +19,8 @@
 
 package org.elasticsearch.action.admin.indices.get;
 
-import com.google.common.collect.ObjectArrays;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.get.GetIndexRequest.Feature;
 import org.elasticsearch.action.support.master.info.ClusterInfoRequestBuilder;
 import org.elasticsearch.client.IndicesAdminClient;
 
@@ -33,13 +33,13 @@ public class GetIndexRequestBuilder extends ClusterInfoRequestBuilder<GetIndexRe
         super(client, new GetIndexRequest().indices(indices));
     }
 
-    public GetIndexRequestBuilder setFeatures(String... features) {
+    public GetIndexRequestBuilder setFeatures(Feature... features) {
         request.features(features);
         return this;
     }
 
-    public GetIndexRequestBuilder addFeatures(String... features) {
-        request.features(ObjectArrays.concat(request.features(), features, String.class));
+    public GetIndexRequestBuilder addFeatures(Feature... features) {
+        request.addFeatures(features);
         return this;
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexResponse.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.admin.indices.get;
 
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import com.google.common.collect.ImmutableList;
+
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.cluster.metadata.AliasMetaData;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
@@ -48,10 +49,18 @@ public class GetIndexResponse extends ActionResponse {
             ImmutableOpenMap<String, ImmutableOpenMap<String, MappingMetaData>> mappings,
             ImmutableOpenMap<String, ImmutableList<AliasMetaData>> aliases, ImmutableOpenMap<String, Settings> settings) {
         this.indices = indices;
-        this.warmers = warmers;
-        this.mappings = mappings;
-        this.aliases = aliases;
-        this.settings = settings;
+        if (warmers != null) {
+            this.warmers = warmers;
+        }
+        if (mappings != null) {
+            this.mappings = mappings;
+        }
+        if (aliases != null) {
+            this.aliases = aliases;
+        }
+        if (settings != null) {
+            this.settings = settings;
+        }
     }
 
     GetIndexResponse() {

--- a/src/main/java/org/elasticsearch/action/admin/indices/get/TransportGetIndexAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/get/TransportGetIndexAction.java
@@ -20,9 +20,11 @@
 package org.elasticsearch.action.admin.indices.get;
 
 import com.google.common.collect.ImmutableList;
+
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchIllegalStateException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.get.GetIndexRequest.Feature;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.info.TransportClusterInfoAction;
 import org.elasticsearch.cluster.ClusterService;
@@ -78,35 +80,32 @@ public class TransportGetIndexAction extends TransportClusterInfoAction<GetIndex
         ImmutableOpenMap<String, ImmutableOpenMap<String, MappingMetaData>> mappingsResult = ImmutableOpenMap.of();
         ImmutableOpenMap<String, ImmutableList<AliasMetaData>> aliasesResult = ImmutableOpenMap.of();
         ImmutableOpenMap<String, Settings> settings = ImmutableOpenMap.of();
-        String[] features = request.features();
+        Feature[] features = request.featuresAsEnums();
         boolean doneAliases = false;
         boolean doneMappings = false;
         boolean doneSettings = false;
         boolean doneWarmers = false;
-        for (String feature : features) {
+        for (Feature feature : features) {
             switch (feature) {
-                case "_warmer":
-                case "_warmers":
+            case WARMERS:
                     if (!doneWarmers) {
                         warmersResult = state.metaData().findWarmers(concreteIndices, request.types(), Strings.EMPTY_ARRAY);
                         doneWarmers = true;
                     }
                     break;
-                case "_mapping":
-                case "_mappings":
+            case MAPPINGS:
                     if (!doneMappings) {
                         mappingsResult = state.metaData().findMappings(concreteIndices, request.types());
                         doneMappings = true;
                     }
                     break;
-                case "_alias":
-                case "_aliases":
+            case ALIASES:
                     if (!doneAliases) {
                         aliasesResult = state.metaData().findAliases(Strings.EMPTY_ARRAY, concreteIndices);
                         doneAliases = true;
                     }
                     break;
-                case "_settings":
+            case SETTINGS:
                     if (!doneSettings) {
                         ImmutableOpenMap.Builder<String, Settings> settingsMapBuilder = ImmutableOpenMap.builder();
                         for (String index : concreteIndices) {

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/get/RestGetIndicesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/get/RestGetIndicesAction.java
@@ -20,8 +20,10 @@ package org.elasticsearch.rest.action.admin.indices.get;
 
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import com.google.common.collect.ImmutableList;
+
 import org.elasticsearch.ElasticsearchIllegalStateException;
 import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
+import org.elasticsearch.action.admin.indices.get.GetIndexRequest.Feature;
 import org.elasticsearch.action.admin.indices.get.GetIndexResponse;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.Client;
@@ -34,7 +36,12 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ToXContent.Params;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentBuilderString;
-import org.elasticsearch.rest.*;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.BytesRestResponse;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.RestResponse;
 import org.elasticsearch.rest.action.support.RestBuilderListener;
 import org.elasticsearch.search.warmer.IndexWarmersMetaData;
 
@@ -58,15 +65,16 @@ public class RestGetIndicesAction extends BaseRestHandler {
     @Override
     public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         String[] indices = Strings.splitStringByCommaToArray(request.param("index"));
-        String[] features = request.paramAsStringArray("type", null);
+        String[] featureParams = request.paramAsStringArray("type", null);
         // Work out if the indices is a list of features
-        if (features == null && indices.length > 0 && indices[0] != null && indices[0].startsWith("_") && !"_all".equals(indices[0])) {
-            features = indices;
+        if (featureParams == null && indices.length > 0 && indices[0] != null && indices[0].startsWith("_") && !"_all".equals(indices[0])) {
+            featureParams = indices;
             indices = new String[] {"_all"};
         }
         final GetIndexRequest getIndexRequest = new GetIndexRequest();
         getIndexRequest.indices(indices);
-        if (features != null) {
+        if (featureParams != null) {
+            Feature[] features = Feature.convertToFeatures(featureParams);
             getIndexRequest.features(features);
         }
         getIndexRequest.indicesOptions(IndicesOptions.fromRequest(request, getIndexRequest.indicesOptions()));
@@ -76,27 +84,24 @@ public class RestGetIndicesAction extends BaseRestHandler {
             @Override
             public RestResponse buildResponse(GetIndexResponse response, XContentBuilder builder) throws Exception {
 
-                String[] features = getIndexRequest.features();
+                Feature[] features = getIndexRequest.featuresAsEnums();
                 String[] indices = response.indices();
 
                 builder.startObject();
                 for (String index : indices) {
                     builder.startObject(index);
-                    for (String feature : features) {
+                    for (Feature feature : features) {
                         switch (feature) {
-                        case "_alias":
-                        case "_aliases":
+                        case ALIASES:
                             writeAliases(response.aliases().get(index), builder, request);
                             break;
-                        case "_mapping":
-                        case "_mappings":
+                        case MAPPINGS:
                             writeMappings(response.mappings().get(index), builder, request);
                             break;
-                        case "_settings":
+                        case SETTINGS:
                             writeSettings(response.settings().get(index), builder, request);
                             break;
-                        case "_warmer":
-                        case "_warmers":
+                        case WARMERS:
                             writeWarmers(response.warmers().get(index), builder, request);
                             break;
                         default:

--- a/src/test/java/org/elasticsearch/action/admin/indices/get/GetIndexTests.java
+++ b/src/test/java/org/elasticsearch/action/admin/indices/get/GetIndexTests.java
@@ -20,8 +20,9 @@
 package org.elasticsearch.action.admin.indices.get;
 
 import com.google.common.collect.ImmutableList;
-import org.elasticsearch.ElasticsearchIllegalStateException;
+
 import org.elasticsearch.action.admin.indices.alias.Alias;
+import org.elasticsearch.action.admin.indices.get.GetIndexRequest.Feature;
 import org.elasticsearch.cluster.metadata.AliasMetaData;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
@@ -36,7 +37,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
 
 @ElasticsearchIntegrationTest.SuiteScopeTest
 public class GetIndexTests extends ElasticsearchIntegrationTest {
@@ -66,140 +69,9 @@ public class GetIndexTests extends ElasticsearchIntegrationTest {
         assertWarmers(response, "idx");
     }
 
-    @Test
-    public void testSimpleMapping() {
-        GetIndexResponse response = client().admin().indices().prepareGetIndex().addIndices("idx").setFeatures("_mapping").get();
-        String[] indices = response.indices();
-        assertThat(indices, notNullValue());
-        assertThat(indices.length, equalTo(1));
-        assertThat(indices[0], equalTo("idx"));
-        assertMappings(response, "idx");
-        assertEmptyAliases(response);
-        assertEmptySettings(response);
-        assertEmptyWarmers(response);
-    }
-
-    @Test
-    public void testSimpleMappings() {
-        GetIndexResponse response = client().admin().indices().prepareGetIndex().addIndices("idx").setFeatures("_mappings").get();
-        String[] indices = response.indices();
-        assertThat(indices, notNullValue());
-        assertThat(indices.length, equalTo(1));
-        assertThat(indices[0], equalTo("idx"));
-        assertMappings(response, "idx");
-        assertEmptyAliases(response);
-        assertEmptySettings(response);
-        assertEmptyWarmers(response);
-    }
-
-    @Test
-    public void testSimpleAlias() {
-        GetIndexResponse response = client().admin().indices().prepareGetIndex().addIndices("idx").setFeatures("_alias").get();
-        String[] indices = response.indices();
-        assertThat(indices, notNullValue());
-        assertThat(indices.length, equalTo(1));
-        assertThat(indices[0], equalTo("idx"));
-        assertAliases(response, "idx");
-        assertEmptyMappings(response);
-        assertEmptySettings(response);
-        assertEmptyWarmers(response);
-    }
-
-    @Test
-    public void testSimpleAliases() {
-        GetIndexResponse response = client().admin().indices().prepareGetIndex().addIndices("idx").setFeatures("_aliases").get();
-        String[] indices = response.indices();
-        assertThat(indices, notNullValue());
-        assertThat(indices.length, equalTo(1));
-        assertThat(indices[0], equalTo("idx"));
-        assertAliases(response, "idx");
-        assertEmptyMappings(response);
-        assertEmptySettings(response);
-        assertEmptyWarmers(response);
-    }
-
-    @Test
-    public void testSimpleSettings() {
-        GetIndexResponse response = client().admin().indices().prepareGetIndex().addIndices("idx").setFeatures("_settings").get();
-        String[] indices = response.indices();
-        assertThat(indices, notNullValue());
-        assertThat(indices.length, equalTo(1));
-        assertThat(indices[0], equalTo("idx"));
-        assertSettings(response, "idx");
-        assertEmptyAliases(response);
-        assertEmptyMappings(response);
-        assertEmptyWarmers(response);
-    }
-
-    @Test
-    public void testSimpleWarmer() {
-        GetIndexResponse response = client().admin().indices().prepareGetIndex().addIndices("idx").setFeatures("_warmer").get();
-        String[] indices = response.indices();
-        assertThat(indices, notNullValue());
-        assertThat(indices.length, equalTo(1));
-        assertThat(indices[0], equalTo("idx"));
-        assertWarmers(response, "idx");
-        assertEmptyAliases(response);
-        assertEmptyMappings(response);
-        assertEmptySettings(response);
-    }
-
-    @Test
-    public void testSimpleWarmers() {
-        GetIndexResponse response = client().admin().indices().prepareGetIndex().addIndices("idx").setFeatures("_warmers").get();
-        String[] indices = response.indices();
-        assertThat(indices, notNullValue());
-        assertThat(indices.length, equalTo(1));
-        assertThat(indices[0], equalTo("idx"));
-        assertWarmers(response, "idx");
-        assertEmptyAliases(response);
-        assertEmptyMappings(response);
-        assertEmptySettings(response);
-    }
-
     @Test(expected=IndexMissingException.class)
     public void testSimpleUnknownIndex() {
         client().admin().indices().prepareGetIndex().addIndices("missing_idx").get();
-    }
-
-    @Test(expected=ElasticsearchIllegalStateException.class)
-    public void testSimpleUnknownFeature() {
-        client().admin().indices().prepareGetIndex().addIndices("idx").setFeatures("_foo").get();
-    }
-
-    @Test
-    public void testSimpleMixedFeatures() {
-        int numFeatures = randomIntBetween(1, allFeatures.length);
-        List<String> features = new ArrayList<String>(numFeatures);
-        for (int i = 0; i < numFeatures; i++) {
-            features.add(randomFrom(allFeatures));
-        }
-        GetIndexResponse response = client().admin().indices().prepareGetIndex().addIndices("idx")
-                .setFeatures(features.toArray(new String[features.size()])).get();
-        String[] indices = response.indices();
-        assertThat(indices, notNullValue());
-        assertThat(indices.length, equalTo(1));
-        assertThat(indices[0], equalTo("idx"));
-        if (features.contains("_alias") || features.contains("_aliases")) {
-            assertAliases(response, "idx");
-        } else {
-            assertEmptyAliases(response);
-        }
-        if (features.contains("_mapping") || features.contains("_mappings")) {
-            assertMappings(response, "idx");
-        } else {
-            assertEmptyMappings(response);
-        }
-        if (features.contains("_settings")) {
-            assertSettings(response, "idx");
-        } else {
-            assertEmptySettings(response);
-        }
-        if (features.contains("_warmer") || features.contains("_warmers")) {
-            assertWarmers(response, "idx");
-        } else {
-            assertEmptyWarmers(response);
-        }
     }
 
     @Test
@@ -216,30 +88,129 @@ public class GetIndexTests extends ElasticsearchIntegrationTest {
     }
 
     @Test
-    public void testEmptyMixedFeatures() {
-        int numFeatures = randomIntBetween(1, allFeatures.length);
-        List<String> features = new ArrayList<String>(numFeatures);
+    public void testSimpleMapping() {
+        GetIndexResponse response = runWithRandomFeatureMethod(client().admin().indices().prepareGetIndex().addIndices("idx"),
+                Feature.MAPPINGS);
+        String[] indices = response.indices();
+        assertThat(indices, notNullValue());
+        assertThat(indices.length, equalTo(1));
+        assertThat(indices[0], equalTo("idx"));
+        assertMappings(response, "idx");
+        assertEmptyAliases(response);
+        assertEmptySettings(response);
+        assertEmptyWarmers(response);
+    }
+
+    @Test
+    public void testSimpleAlias() {
+        GetIndexResponse response = runWithRandomFeatureMethod(client().admin().indices().prepareGetIndex().addIndices("idx"),
+                Feature.ALIASES);
+        String[] indices = response.indices();
+        assertThat(indices, notNullValue());
+        assertThat(indices.length, equalTo(1));
+        assertThat(indices[0], equalTo("idx"));
+        assertAliases(response, "idx");
+        assertEmptyMappings(response);
+        assertEmptySettings(response);
+        assertEmptyWarmers(response);
+    }
+
+    @Test
+    public void testSimpleSettings() {
+        GetIndexResponse response = runWithRandomFeatureMethod(client().admin().indices().prepareGetIndex().addIndices("idx"),
+                Feature.SETTINGS);
+        String[] indices = response.indices();
+        assertThat(indices, notNullValue());
+        assertThat(indices.length, equalTo(1));
+        assertThat(indices[0], equalTo("idx"));
+        assertSettings(response, "idx");
+        assertEmptyAliases(response);
+        assertEmptyMappings(response);
+        assertEmptyWarmers(response);
+    }
+
+    @Test
+    public void testSimpleWarmer() {
+        GetIndexResponse response = runWithRandomFeatureMethod(client().admin().indices().prepareGetIndex().addIndices("idx"),
+                Feature.WARMERS);
+        String[] indices = response.indices();
+        assertThat(indices, notNullValue());
+        assertThat(indices.length, equalTo(1));
+        assertThat(indices[0], equalTo("idx"));
+        assertWarmers(response, "idx");
+        assertEmptyAliases(response);
+        assertEmptyMappings(response);
+        assertEmptySettings(response);
+    }
+
+    @Test
+    public void testSimpleMixedFeatures() {
+        int numFeatures = randomIntBetween(1, Feature.values().length);
+        List<Feature> features = new ArrayList<Feature>(numFeatures);
         for (int i = 0; i < numFeatures; i++) {
-            features.add(randomFrom(allFeatures));
+            features.add(randomFrom(Feature.values()));
         }
-        GetIndexResponse response = client().admin().indices().prepareGetIndex().addIndices("empty_idx")
-                .setFeatures(features.toArray(new String[features.size()])).get();
+        GetIndexResponse response = runWithRandomFeatureMethod(client().admin().indices().prepareGetIndex().addIndices("idx"),
+                features.toArray(new Feature[features.size()]));
+        String[] indices = response.indices();
+        assertThat(indices, notNullValue());
+        assertThat(indices.length, equalTo(1));
+        assertThat(indices[0], equalTo("idx"));
+        if (features.contains(Feature.ALIASES)) {
+            assertAliases(response, "idx");
+        } else {
+            assertEmptyAliases(response);
+        }
+        if (features.contains(Feature.MAPPINGS)) {
+            assertMappings(response, "idx");
+        } else {
+            assertEmptyMappings(response);
+        }
+        if (features.contains(Feature.SETTINGS)) {
+            assertSettings(response, "idx");
+        } else {
+            assertEmptySettings(response);
+        }
+        if (features.contains(Feature.WARMERS)) {
+            assertWarmers(response, "idx");
+        } else {
+            assertEmptyWarmers(response);
+        }
+    }
+
+    @Test
+    public void testEmptyMixedFeatures() {
+        int numFeatures = randomIntBetween(1, Feature.values().length);
+        List<Feature> features = new ArrayList<Feature>(numFeatures);
+        for (int i = 0; i < numFeatures; i++) {
+            features.add(randomFrom(Feature.values()));
+        }
+        GetIndexResponse response = runWithRandomFeatureMethod(client().admin().indices().prepareGetIndex().addIndices("empty_idx"),
+                features.toArray(new Feature[features.size()]));
         String[] indices = response.indices();
         assertThat(indices, notNullValue());
         assertThat(indices.length, equalTo(1));
         assertThat(indices[0], equalTo("empty_idx"));
         assertEmptyAliases(response);
-        if (features.contains("_mapping") || features.contains("_mappings")) {
+        if (features.contains(Feature.MAPPINGS)) {
             assertEmptyOrOnlyDefaultMappings(response, "empty_idx");
         } else {
             assertEmptyMappings(response);
         }
-        if (features.contains("_settings")) {
+        if (features.contains(Feature.SETTINGS)) {
             assertNonEmptySettings(response, "empty_idx");
         } else {
             assertEmptySettings(response);
         }
         assertEmptyWarmers(response);
+    }
+
+    private GetIndexResponse runWithRandomFeatureMethod(GetIndexRequestBuilder requestBuilder, Feature... features) {
+        if (randomBoolean()) {
+            return requestBuilder.addFeatures(features).get();
+        } else {
+            return requestBuilder.setFeatures(features).get();
+        }
     }
 
     private void assertWarmers(GetIndexResponse response, String indexName) {

--- a/src/test/java/org/elasticsearch/bwcompat/GetIndexBackwardsCompatibilityTests.java
+++ b/src/test/java/org/elasticsearch/bwcompat/GetIndexBackwardsCompatibilityTests.java
@@ -20,8 +20,10 @@
 package org.elasticsearch.bwcompat;
 
 import com.google.common.collect.ImmutableList;
+
 import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
+import org.elasticsearch.action.admin.indices.get.GetIndexRequest.Feature;
 import org.elasticsearch.action.admin.indices.get.GetIndexResponse;
 import org.elasticsearch.cluster.metadata.AliasMetaData;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
@@ -33,7 +35,9 @@ import org.elasticsearch.test.ElasticsearchBackwardsCompatIntegrationTest;
 import org.junit.Test;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
 
 public class GetIndexBackwardsCompatibilityTests extends ElasticsearchBackwardsCompatIntegrationTest {
 
@@ -41,7 +45,7 @@ public class GetIndexBackwardsCompatibilityTests extends ElasticsearchBackwardsC
     public void testGetAliases() throws Exception {
         CreateIndexResponse createIndexResponse = prepareCreate("test").addAlias(new Alias("testAlias")).execute().actionGet();
         assertAcked(createIndexResponse);
-        GetIndexResponse getIndexResponse = client().admin().indices().prepareGetIndex().addIndices("test").addFeatures("_aliases")
+        GetIndexResponse getIndexResponse = client().admin().indices().prepareGetIndex().addIndices("test").addFeatures(Feature.ALIASES)
                 .execute().actionGet();
         ImmutableOpenMap<String, ImmutableList<AliasMetaData>> aliasesMap = getIndexResponse.aliases();
         assertThat(aliasesMap, notNullValue());
@@ -58,7 +62,7 @@ public class GetIndexBackwardsCompatibilityTests extends ElasticsearchBackwardsC
     public void testGetMappings() throws Exception {
         CreateIndexResponse createIndexResponse = prepareCreate("test").addMapping("type1", "{\"type1\":{}}").execute().actionGet();
         assertAcked(createIndexResponse);
-        GetIndexResponse getIndexResponse = client().admin().indices().prepareGetIndex().addIndices("test").addFeatures("_mappings")
+        GetIndexResponse getIndexResponse = client().admin().indices().prepareGetIndex().addIndices("test").addFeatures(Feature.MAPPINGS)
                 .execute().actionGet();
         ImmutableOpenMap<String, ImmutableOpenMap<String, MappingMetaData>> mappings = getIndexResponse.mappings();
         assertThat(mappings, notNullValue());
@@ -79,7 +83,7 @@ public class GetIndexBackwardsCompatibilityTests extends ElasticsearchBackwardsC
     public void testGetSettings() throws Exception {
         CreateIndexResponse createIndexResponse = prepareCreate("test").setSettings(ImmutableSettings.builder().put("number_of_shards", 1)).execute().actionGet();
         assertAcked(createIndexResponse);
-        GetIndexResponse getIndexResponse = client().admin().indices().prepareGetIndex().addIndices("test").addFeatures("_settings")
+        GetIndexResponse getIndexResponse = client().admin().indices().prepareGetIndex().addIndices("test").addFeatures(Feature.SETTINGS)
                 .execute().actionGet();
         ImmutableOpenMap<String, Settings> settingsMap = getIndexResponse.settings();
         assertThat(settingsMap, notNullValue());
@@ -95,7 +99,7 @@ public class GetIndexBackwardsCompatibilityTests extends ElasticsearchBackwardsC
         ensureSearchable("test");
         assertAcked(client().admin().indices().preparePutWarmer("warmer1").setSearchRequest(client().prepareSearch("test")).get());
         ensureSearchable("test");
-        GetIndexResponse getIndexResponse = client().admin().indices().prepareGetIndex().addIndices("test").addFeatures("_warmers")
+        GetIndexResponse getIndexResponse = client().admin().indices().prepareGetIndex().addIndices("test").addFeatures(Feature.WARMERS)
                 .execute().actionGet();
         ImmutableOpenMap<String, ImmutableList<Entry>> warmersMap = getIndexResponse.warmers();
         assertThat(warmersMap, notNullValue());


### PR DESCRIPTION
Previous to this change all features (_alias,_mapping,_settings,_warmer) are run regardless of which features are actually requested. This change fixes the request object to resolve this bug
