### PR TITLE
Search Template - parse template if it is provided as a single escaped string.

### DIFF
--- a/src/test/java/org/elasticsearch/index/query/TemplateQueryTest.java
+++ b/src/test/java/org/elasticsearch/index/query/TemplateQueryTest.java
@@ -196,6 +196,84 @@ public class TemplateQueryTest extends ElasticsearchIntegrationTest {
         assertThat(searchResponse.getHits().hits().length, equalTo(1));
     }
 
+
+    @Test
+    public void testSearchTemplateQueryFromFile() throws Exception {
+        SearchRequest searchRequest = new SearchRequest();
+        searchRequest.indices("_all");
+        String templateString = "{" +
+                "  \"template\" : { \"file\": \"full-query-template\" }," +
+                "  \"params\":{" +
+                "    \"mySize\": 2," +
+                "    \"myField\": \"text\"," +
+                "    \"myValue\": \"value1\"" +
+                "  }" +
+                "}";
+        BytesReference bytesRef = new BytesArray(templateString);
+        searchRequest.templateSource(bytesRef, false);
+        SearchResponse searchResponse = client().search(searchRequest).get();
+        assertThat(searchResponse.getHits().hits().length, equalTo(1));
+    }
+
+    /**
+     * Test that template can be expressed as a single escaped string.
+     */
+    @Test
+    public void testTemplateQueryAsEscapedString() throws Exception {
+        SearchRequest searchRequest = new SearchRequest();
+        searchRequest.indices("_all");
+        String templateString = "{" +
+                "  \"template\" : \"{ \\\"size\\\": \\\"{{size}}\\\", \\\"query\\\":{\\\"match_all\\\":{}}}\"," +
+                "  \"params\":{" +
+                "    \"size\": 1" +
+                "  }" +
+                "}";
+        BytesReference bytesRef = new BytesArray(templateString);
+        searchRequest.templateSource(bytesRef, false);
+        SearchResponse searchResponse = client().search(searchRequest).get();
+        assertThat(searchResponse.getHits().hits().length, equalTo(1));
+    }
+
+    /**
+     * Test that template can contain conditional clause. In this case it is at the beginning of the string.
+     */
+    @Test
+    public void testTemplateQueryAsEscapedStringStartingWithConditionalClause() throws Exception {
+        SearchRequest searchRequest = new SearchRequest();
+        searchRequest.indices("_all");
+        String templateString = "{" +
+                "  \"template\" : \"{ {{#use_size}} \\\"size\\\": \\\"{{size}}\\\", {{/use_size}} \\\"query\\\":{\\\"match_all\\\":{}}}\"," +
+                "  \"params\":{" +
+                "    \"size\": 1," +
+                "    \"use_size\": true" +
+                "  }" +
+                "}";
+        BytesReference bytesRef = new BytesArray(templateString);
+        searchRequest.templateSource(bytesRef, false);
+        SearchResponse searchResponse = client().search(searchRequest).get();
+        assertThat(searchResponse.getHits().hits().length, equalTo(1));
+    }
+
+    /**
+     * Test that template can contain conditional clause. In this case it is at the end of the string.
+     */
+    @Test
+    public void testTemplateQueryAsEscapedStringWithConditionalClauseAtEnd() throws Exception {
+        SearchRequest searchRequest = new SearchRequest();
+        searchRequest.indices("_all");
+        String templateString = "{" +
+                "  \"template\" : \"{ \\\"query\\\":{\\\"match_all\\\":{}} {{#use_size}}, \\\"size\\\": \\\"{{size}}\\\" {{/use_size}} }\"," +
+                "  \"params\":{" +
+                "    \"size\": 1," +
+                "    \"use_size\": true" +
+                "  }" +
+                "}";
+        BytesReference bytesRef = new BytesArray(templateString);
+        searchRequest.templateSource(bytesRef, false);
+        SearchResponse searchResponse = client().search(searchRequest).get();
+        assertThat(searchResponse.getHits().hits().length, equalTo(1));
+    }
+
     @Test
     public void testThatParametersCanBeSet() throws Exception {
         index("test", "type", "1", jsonBuilder().startObject().field("theField", "foo").endObject());


### PR DESCRIPTION
I was trying to implement fix for #8308

I think I nailed it down. It seems it is combination of two related issues:

1) The `TemplateQueryParser.java` was not correctly parsing the request when the `template` contained a single `VALUE_STRING` token. I think this could not have been working before (obviously there were no tests for this use case). I improved the main `parse` method to detect string token. **Please review** namely the complex `if` conditions - I am sure there is a way how to express them in more elegant way.

2) The second issue is with `SearchService.java` in `parseTemplate` method where it tries to parse the template for second time. When I commented this part out then all the tests that I added to `TemplateQueryTest.java` started to pass. **Please review** validity of commenting this out. I did not notice any tests that would be broken due to this but the chance is that there were no tests covering the logic behind second parsing pass.

Looking for the feedback.
