### PR TITLE
Harden recovery for old segments

### DIFF
--- a/src/main/java/org/elasticsearch/index/store/LegacyVerification.java
+++ b/src/main/java/org/elasticsearch/index/store/LegacyVerification.java
@@ -56,8 +56,8 @@ class LegacyVerification {
         final Checksum checksum = new BufferedChecksum(new Adler32());
         long written;
         
-        public Adler32VerifyingIndexOutput(IndexOutput in, String adler32, long length) {
-            super(in);
+        public Adler32VerifyingIndexOutput(IndexOutput out, String adler32, long length) {
+            super(out);
             this.adler32 = adler32;
             this.length = length;
         }
@@ -66,25 +66,25 @@ class LegacyVerification {
         public void verify() throws IOException {
             if (written != length) {
                 throw new CorruptIndexException("expected length=" + length + " != actual length: " + written + " : file truncated?" + 
-                                                " (resource=" + in + ")");
+                                                " (resource=" + out + ")");
             }
             final String actualChecksum = Store.digestToString(checksum.getValue());
             if (!adler32.equals(actualChecksum)) {
                 throw new CorruptIndexException("checksum failed (hardware problem?) : expected=" + adler32 +
-                                                " actual=" + actualChecksum + " resource=(" + in + ")");
+                                                " actual=" + actualChecksum + " resource=(" + out + ")");
             }
         }
 
         @Override
         public void writeByte(byte b) throws IOException {
-            in.writeByte(b);
+            out.writeByte(b);
             checksum.update(b);
             written++;
         }
 
         @Override
         public void writeBytes(byte[] bytes, int offset, int length) throws IOException {
-            in.writeBytes(bytes, offset, length);
+            out.writeBytes(bytes, offset, length);
             checksum.update(bytes, offset, length);
             written += length;
         }
@@ -97,8 +97,8 @@ class LegacyVerification {
         final long length;
         long written;
         
-        public LengthVerifyingIndexOutput(IndexOutput in, long length) {
-            super(in);
+        public LengthVerifyingIndexOutput(IndexOutput out, long length) {
+            super(out);
             this.length = length;
         }
 
@@ -106,19 +106,19 @@ class LegacyVerification {
         public void verify() throws IOException {
             if (written != length) {
                 throw new CorruptIndexException("expected length=" + length + " != actual length: " + written + " : file truncated?" + 
-                                                " (resource=" + in + ")");
+                                                " (resource=" + out + ")");
             }
         }
 
         @Override
         public void writeByte(byte b) throws IOException {
-            in.writeByte(b);
+            out.writeByte(b);
             written++;
         }
 
         @Override
         public void writeBytes(byte[] bytes, int offset, int length) throws IOException {
-            in.writeBytes(bytes, offset, length);
+            out.writeBytes(bytes, offset, length);
             written += length;
         }
     }

--- a/src/main/java/org/elasticsearch/index/store/LegacyVerification.java
+++ b/src/main/java/org/elasticsearch/index/store/LegacyVerification.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.store;
+
+import org.apache.lucene.index.CorruptIndexException;
+import org.apache.lucene.store.BufferedChecksum;
+import org.apache.lucene.store.IndexOutput;
+
+import java.io.IOException;
+import java.util.zip.Adler32;
+import java.util.zip.Checksum;
+
+/** 
+ * Implements verification checks to the best extent possible
+ * against legacy segments.
+ * <p>
+ * For files since ES 1.3, we have a lucene checksum, and
+ * we verify both CRC32 + length from that.
+ * For older segment files, we have an elasticsearch Adler32 checksum
+ * and a length, except for commit points.
+ * For older commit points, we only have the length in metadata,
+ * but lucene always wrote a CRC32 checksum we can verify in the future, too.
+ * For (Jurassic?) files, we dont have an Adler32 checksum at all,
+ * since its optional in the protocol. But we always know the length.
+ * @deprecated only to support old segments
+ */
+@Deprecated
+class LegacyVerification {
+    
+    // TODO: add a verifier for old lucene segments_N that also checks CRC.
+    // but for now, at least truncation is detected here (as length will be checked)
+    
+    /** 
+     * verifies Adler32 + length for index files before lucene 4.8
+     */
+    static class Adler32VerifyingIndexOutput extends VerifyingIndexOutput {
+        final IndexOutput delegate;
+        final String adler32;
+        final long length;
+        final Checksum checksum = new BufferedChecksum(new Adler32());
+        long written;
+        
+        public Adler32VerifyingIndexOutput(IndexOutput delegate, String adler32, long length) {
+            this.delegate = delegate;
+            this.adler32 = adler32;
+            this.length = length;
+        }
+
+        @Override
+        public void verify() throws IOException {
+            if (written != length) {
+                throw new CorruptIndexException("expected length=" + length + " != actual length: " + written + " : file truncated?" + 
+                                                " (resource=" + delegate + ")");
+            }
+            final String actualChecksum = Store.digestToString(checksum.getValue());
+            if (!adler32.equals(actualChecksum)) {
+                throw new CorruptIndexException("checksum failed (hardware problem?) : expected=" + adler32 +
+                                                " actual=" + actualChecksum + " resource=(" + delegate + ")");
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            delegate.close();
+        }
+
+        @Override
+        @Deprecated
+        public void flush() throws IOException {
+            delegate.flush(); // we dont buffer, but whatever
+        }
+
+        @Override
+        public long getChecksum() throws IOException {
+            return delegate.getChecksum();
+        }
+
+        @Override
+        public long getFilePointer() {
+            return delegate.getFilePointer();
+        }
+
+        @Override
+        public void writeByte(byte b) throws IOException {
+            delegate.writeByte(b);
+            checksum.update(b);
+            written++;
+        }
+
+        @Override
+        public void writeBytes(byte[] bytes, int offset, int length) throws IOException {
+            delegate.writeBytes(bytes, offset, length);
+            checksum.update(bytes, offset, length);
+            written += length;
+        }
+    }
+    
+    /** 
+     * verifies length for index files before lucene 4.8
+     */
+    static class LengthVerifyingIndexOutput extends VerifyingIndexOutput {
+        final IndexOutput delegate;
+        final long length;
+        long written;
+        
+        public LengthVerifyingIndexOutput(IndexOutput delegate, long length) {
+            this.delegate = delegate;
+            this.length = length;
+        }
+
+        @Override
+        public void verify() throws IOException {
+            if (written != length) {
+                throw new CorruptIndexException("expected length=" + length + " != actual length: " + written + " : file truncated?" + 
+                                                " (resource=" + delegate + ")");
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            delegate.close();
+        }
+
+        @Override
+        @Deprecated
+        public void flush() throws IOException {
+            delegate.flush(); // we dont buffer, but whatever
+        }
+
+        @Override
+        public long getChecksum() throws IOException {
+            return delegate.getChecksum();
+        }
+
+        @Override
+        public long getFilePointer() {
+            return delegate.getFilePointer();
+        }
+
+        @Override
+        public void writeByte(byte b) throws IOException {
+            delegate.writeByte(b);
+            written++;
+        }
+
+        @Override
+        public void writeBytes(byte[] bytes, int offset, int length) throws IOException {
+            delegate.writeBytes(bytes, offset, length);
+            written += length;
+        }
+    }
+}

--- a/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/src/main/java/org/elasticsearch/index/store/Store.java
@@ -889,8 +889,8 @@ public class Store extends AbstractIndexShardComponent implements CloseableIndex
         private final long checksumPosition;
         private String actualChecksum;
 
-        LuceneVerifyingIndexOutput(StoreFileMetaData metadata, IndexOutput in) {
-            super(in);
+        LuceneVerifyingIndexOutput(StoreFileMetaData metadata, IndexOutput out) {
+            super(out);
             this.metadata = metadata;
             checksumPosition = metadata.length() - 8; // the last 8 bytes are the checksum
         }
@@ -910,7 +910,7 @@ public class Store extends AbstractIndexShardComponent implements CloseableIndex
             if (writtenBytes++ == checksumPosition) {
                 readAndCompareChecksum();
             }
-            in.writeByte(b);
+            out.writeByte(b);
         }
 
         private void readAndCompareChecksum() throws IOException {
@@ -927,13 +927,13 @@ public class Store extends AbstractIndexShardComponent implements CloseableIndex
             if (writtenBytes + length > checksumPosition && actualChecksum == null) {
                 assert writtenBytes <= checksumPosition;
                 final int bytesToWrite = (int)(checksumPosition-writtenBytes);
-                in.writeBytes(b, offset, bytesToWrite);
+                out.writeBytes(b, offset, bytesToWrite);
                 readAndCompareChecksum();
                 offset += bytesToWrite;
                 length -= bytesToWrite;
                 writtenBytes += bytesToWrite;
             }
-            in.writeBytes(b, offset, length);
+            out.writeBytes(b, offset, length);
             writtenBytes += length;
         }
 

--- a/src/main/java/org/elasticsearch/index/store/VerifyingIndexOutput.java
+++ b/src/main/java/org/elasticsearch/index/store/VerifyingIndexOutput.java
@@ -29,11 +29,11 @@ import org.apache.lucene.store.IndexOutput;
  */
 // do NOT optimize this class for performance
 public abstract class VerifyingIndexOutput extends IndexOutput {
-    protected final IndexOutput in;
+    protected final IndexOutput out;
     
     /** Sole constructor */
-    VerifyingIndexOutput(IndexOutput in) {
-        this.in = in;
+    VerifyingIndexOutput(IndexOutput out) {
+        this.out = out;
     }
     
     /**
@@ -46,27 +46,27 @@ public abstract class VerifyingIndexOutput extends IndexOutput {
     
     @Override
     public final void close() throws IOException {
-        in.close();
+        out.close();
     }
 
     @Override
     @Deprecated
     public final void flush() throws IOException {
-        in.flush(); // we dont buffer, but whatever
+        out.flush(); // we dont buffer, but whatever
     }
 
     @Override
     public final long getChecksum() throws IOException {
-        return in.getChecksum();
+        return out.getChecksum();
     }
 
     @Override
     public final long getFilePointer() {
-        return in.getFilePointer();
+        return out.getFilePointer();
     }
     
     @Override
     public final long length() throws IOException {
-        return in.length();
+        return out.length();
     }
 }

--- a/src/main/java/org/elasticsearch/index/store/VerifyingIndexOutput.java
+++ b/src/main/java/org/elasticsearch/index/store/VerifyingIndexOutput.java
@@ -23,12 +23,50 @@ import java.io.IOException;
 
 import org.apache.lucene.store.IndexOutput;
 
-/** abstract class for verifying what was written */
+/** 
+ * abstract class for verifying what was written.
+ * subclasses override {@link #writeByte(byte)} and {@link #writeBytes(byte[], int, int)}
+ */
+// do NOT optimize this class for performance
 public abstract class VerifyingIndexOutput extends IndexOutput {
+    protected final IndexOutput in;
+    
+    /** Sole constructor */
+    VerifyingIndexOutput(IndexOutput in) {
+        this.in = in;
+    }
     
     /**
      * Verifies the checksum and compares the written length with the expected file length. This method should be
      * called after all data has been written to this output.
      */
     public abstract void verify() throws IOException;
+    
+    // default implementations... forwarding to delegate
+    
+    @Override
+    public final void close() throws IOException {
+        in.close();
+    }
+
+    @Override
+    @Deprecated
+    public final void flush() throws IOException {
+        in.flush(); // we dont buffer, but whatever
+    }
+
+    @Override
+    public final long getChecksum() throws IOException {
+        return in.getChecksum();
+    }
+
+    @Override
+    public final long getFilePointer() {
+        return in.getFilePointer();
+    }
+    
+    @Override
+    public final long length() throws IOException {
+        return in.length();
+    }
 }

--- a/src/main/java/org/elasticsearch/index/store/VerifyingIndexOutput.java
+++ b/src/main/java/org/elasticsearch/index/store/VerifyingIndexOutput.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.store;
+
+import java.io.IOException;
+
+import org.apache.lucene.store.IndexOutput;
+
+/** abstract class for verifying what was written */
+public abstract class VerifyingIndexOutput extends IndexOutput {
+    
+    /**
+     * Verifies the checksum and compares the written length with the expected file length. This method should be
+     * called after all data has been written to this output.
+     */
+    public abstract void verify() throws IOException;
+}

--- a/src/test/java/org/elasticsearch/index/store/StoreTest.java
+++ b/src/test/java/org/elasticsearch/index/store/StoreTest.java
@@ -113,7 +113,7 @@ public class StoreTest extends ElasticsearchLuceneTestCase {
         indexInput.seek(0);
         BytesRef ref = new BytesRef(scaledRandomIntBetween(1, 1024));
         long length = indexInput.length();
-        IndexOutput verifyingOutput = new Store.VerifyingIndexOutput(new StoreFileMetaData("foo1.bar", length, checksum, TEST_VERSION_CURRENT), dir.createOutput("foo1.bar", IOContext.DEFAULT));
+        IndexOutput verifyingOutput = new Store.LuceneVerifyingIndexOutput(new StoreFileMetaData("foo1.bar", length, checksum, TEST_VERSION_CURRENT), dir.createOutput("foo1.bar", IOContext.DEFAULT));
         while (length > 0) {
             if (random().nextInt(10) == 0) {
                 verifyingOutput.writeByte(indexInput.readByte());
@@ -140,7 +140,7 @@ public class StoreTest extends ElasticsearchLuceneTestCase {
     public void testVerifyingIndexOutputWithBogusInput() throws IOException {
         Directory dir = newDirectory();
         int length = scaledRandomIntBetween(10, 1024);
-        IndexOutput verifyingOutput = new Store.VerifyingIndexOutput(new StoreFileMetaData("foo1.bar", length, "", TEST_VERSION_CURRENT), dir.createOutput("foo1.bar", IOContext.DEFAULT));
+        IndexOutput verifyingOutput = new Store.LuceneVerifyingIndexOutput(new StoreFileMetaData("foo1.bar", length, "", TEST_VERSION_CURRENT), dir.createOutput("foo1.bar", IOContext.DEFAULT));
         try {
             while (length > 0) {
                 verifyingOutput.writeByte((byte) random().nextInt());

--- a/src/test/java/org/elasticsearch/index/store/TestLegacyVerification.java
+++ b/src/test/java/org/elasticsearch/index/store/TestLegacyVerification.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.store;
+
+import java.nio.charset.StandardCharsets;
+import java.util.zip.Adler32;
+
+import org.apache.lucene.index.CorruptIndexException;
+
+import org.apache.lucene.store.IndexOutput;
+
+import org.apache.lucene.store.IOContext;
+
+import org.apache.lucene.store.Directory;
+import org.elasticsearch.test.ElasticsearchLuceneTestCase;
+
+/** 
+ * Simple tests for LegacyVerification (old segments)
+ * @deprecated remove this test when support for lucene 4.x 
+ *             segments is not longer needed. 
+ */
+@Deprecated
+public class TestLegacyVerification extends ElasticsearchLuceneTestCase {
+    
+    public void testAdler32() throws Exception {
+        Adler32 expected = new Adler32();
+        byte bytes[] = "abcdefgh".getBytes(StandardCharsets.UTF_8);
+        expected.update(bytes);
+        String expectedString = Store.digestToString(expected.getValue());
+        
+        Directory dir = newDirectory();
+        
+        IndexOutput o = dir.createOutput("legacy", IOContext.DEFAULT);
+        VerifyingIndexOutput out = new LegacyVerification.Adler32VerifyingIndexOutput(o, expectedString, 8);
+        out.writeBytes(bytes, 0, bytes.length);
+        out.verify();
+        out.close();
+        out.verify();
+        
+        dir.close();
+    }
+    
+    public void testAdler32Corrupt() throws Exception {
+        Adler32 expected = new Adler32();
+        byte bytes[] = "abcdefgh".getBytes(StandardCharsets.UTF_8);
+        expected.update(bytes);
+        String expectedString = Store.digestToString(expected.getValue());
+        
+        byte corruptBytes[] = "abcdefch".getBytes(StandardCharsets.UTF_8);
+        Directory dir = newDirectory();
+        
+        IndexOutput o = dir.createOutput("legacy", IOContext.DEFAULT);
+        VerifyingIndexOutput out = new LegacyVerification.Adler32VerifyingIndexOutput(o, expectedString, 8);
+        out.writeBytes(corruptBytes, 0, bytes.length);
+        try {
+            out.verify();
+            fail();
+        } catch (CorruptIndexException e) {
+            // expected exception
+        }
+        out.close();
+        
+        try {
+            out.verify();
+            fail();
+        } catch (CorruptIndexException e) {
+            // expected exception
+        }
+        
+        dir.close();
+    }
+    
+    public void testLengthOnlyOneByte() throws Exception {
+        Directory dir = newDirectory();
+        
+        IndexOutput o = dir.createOutput("oneByte", IOContext.DEFAULT);
+        VerifyingIndexOutput out = new LegacyVerification.LengthVerifyingIndexOutput(o, 1);
+        out.writeByte((byte) 3);
+        out.verify();
+        out.close();
+        out.verify();
+        
+        dir.close();
+    }
+    
+    public void testLengthOnlyCorrupt() throws Exception {
+        Directory dir = newDirectory();
+        
+        IndexOutput o = dir.createOutput("oneByte", IOContext.DEFAULT);
+        VerifyingIndexOutput out = new LegacyVerification.LengthVerifyingIndexOutput(o, 2);
+        out.writeByte((byte) 3);
+        try {
+            out.verify();
+            fail();
+        } catch (CorruptIndexException expected) {
+            // expected exception
+        }
+        
+        out.close();
+        
+        try {
+            out.verify();
+            fail();
+        } catch (CorruptIndexException expected) {
+            // expected exception
+        }
+        
+        dir.close();
+    }
+}


### PR DESCRIPTION
When a lucene 4.8+ file is transferred, Store returns a VerifyingIndexOutput
that verifies both the CRC32 integrity and the length of the file.

However, for older files, problems can make it to the lucene level. This is not great
since older lucene files aren't especially strong as far as detecting issues here.

For example, if a network transfer is closed on the remote side, we might write a
truncated or corrupted file... which old lucene formats may or may not detect.

The idea here is to verify old files with their legacy Adler32 checksum, plus expected
length. If they don't have an Adler32 (segments_N, jurassic elasticsearch?, its optional
as far as the protocol goes), then at least check the length.

We could improve it for segments_N, its had an embedded CRC32 forever in lucene, but this
gets trickier. Long term, we should also try to also improve tests around here, especially
backwards compat testing, we should test that detected corruptions are handled properly.

I added unit tests for the two cases covered here. PR is against 1.x since thats what i'm working with,
but I can forward-port to master once we figure this out.
