### PR TITLE
Core: SerialMergeScheduler never triggers index throttling

### DIFF
--- a/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
+++ b/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
@@ -1279,9 +1279,7 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
 
     @Override
     public void close() throws ElasticsearchException {
-        logger.debug("close now acquire writeLock");
         try (InternalLock _ = writeLock.acquire()) {
-            logger.debug("close acquired writeLock");
             if (!closed) {
                 try {
                     closed = true;

--- a/src/main/java/org/elasticsearch/index/merge/scheduler/SerialMergeSchedulerProvider.java
+++ b/src/main/java/org/elasticsearch/index/merge/scheduler/SerialMergeSchedulerProvider.java
@@ -56,7 +56,7 @@ public class SerialMergeSchedulerProvider extends MergeSchedulerProvider {
 
     @Override
     public int getMaxMerges() {
-        return 2;
+        return 1;
     }
 
     @Override
@@ -90,7 +90,7 @@ public class SerialMergeSchedulerProvider extends MergeSchedulerProvider {
 
     }
 
-    /** NOTE: subclasses TrackingCONCURRENTMergeScheduler, but we set max_merge_count = max_thread_count = 1 above */
+    /** NOTE: subclasses TrackingCONCURRENTMergeScheduler, but we set max_merge_count = 2 and max_thread_count = 1, above */
     public static class CustomSerialMergeScheduler extends TrackingConcurrentMergeScheduler {
 
         private final ShardId shardId;

--- a/src/test/java/org/elasticsearch/indices/stats/IndexStatsTests.java
+++ b/src/test/java/org/elasticsearch/indices/stats/IndexStatsTests.java
@@ -358,12 +358,8 @@ public class IndexStatsTests extends ElasticsearchIntegrationTest {
             //nodesStats = client().admin().cluster().prepareNodesStats().setIndices(true).get();
             done = stats.getPrimaries().getIndexing().getTotal().getThrottleTimeInMillis() > 0;
             if (System.currentTimeMillis() - start > 300*1000) { //Wait 5 minutes for throttling to kick in
-                break;
+                fail("index throttling didn't kick in after 5 minutes of intense merging");
             }
-        }
-        stats = client().admin().indices().prepareStats().execute().actionGet();
-        if (done) {
-            assertThat(stats.getPrimaries().getIndexing().getTotal().getThrottleTimeInMillis(), greaterThan(0l));
         }
     }
 


### PR DESCRIPTION
This is a deprecated merge scheduler (already removed in master), but is still available in 1.3, 1.4, 1.5.

When you pick this merged scheduler, there is a bug that causes index throttling to not kick in, which means it's possible to accumulate way too many segments in the index.

Furthermore, this can then cause Elasticsearch to take a long time (> 30 seconds default timeout for e.g. a delete index request, resulting in a "Delete Index failed - not acked" from ElasticsearchIntegrationTest) to close the index, since it has a merge thread holding InternalEngine.readLock, stuck in IndexWriter.maybeMerge.  I'll address this issue separately; fixing SMS (here) should fix most of the false test failures.

I also fixed IndexStatsTests.throttleTests to fail if it never saw index throttling kick in after up to 5 minutes of crazy merges.
