### PR TITLE
Synchronize operations that modify file mappings on DistributorDirectory

### DIFF
--- a/src/test/java/org/elasticsearch/index/store/DistributorDirectoryTest.java
+++ b/src/test/java/org/elasticsearch/index/store/DistributorDirectoryTest.java
@@ -158,14 +158,15 @@ public class DistributorDirectoryTest extends BaseDirectoryTestCase {
             try (IndexOutput out = dd.createOutput("foo.bar", IOContext.DEFAULT)) {
                 out.writeInt(1);
             }
-            try {
-                dd.renameFile("foo.bar", file);
-                fail("target file already exists");
-            } catch (IOException ex) {
-                // target file already exists
+            assertNotNull(dd);
+            if (dd.getDirectory("foo.bar") != dd.getDirectory(file)) {
+                try {
+                    dd.renameFile("foo.bar", file);
+                    fail("target file already exists in a different directory");
+                } catch (IOException ex) {
+                    // target file already exists
+                }
             }
-
-            theDir.deleteFile(file);
             assertTrue(DistributorDirectory.assertConsistency(logger, dd));
             IOUtils.close(dd);
         }


### PR DESCRIPTION
The rename(String, String) method doesn't allow this implementation to use a simple
concurrent map. There is a race during a rename operation where files are not fully
renamed but already visible via #listAll(). This inconsistency can lead to problems
when opening commit points since the pending_segments_N as well as segments_N are visible
but not yet atomically renamed.

Yet, non of the methods that are synced are long running such that adding sychronization
doesn't introduce bottlenecks here. The Direcotry#sync(...) method is not synchronized since
it doesn't change any mapping nor does it depend on the mapping.
