### PR TITLE
Added getProperty method to Aggregations

### DIFF
--- a/src/main/java/org/elasticsearch/search/aggregations/Aggregation.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/Aggregation.java
@@ -31,6 +31,15 @@ public interface Aggregation {
     String getName();
 
     /**
+     * Get the value of specified path in the aggregation.
+     * 
+     * @param path
+     *            the path to the property in the aggregation tree
+     * @return the value of the property
+     */
+    Object getProperty(String path);
+
+    /**
      * Get the optional byte array metadata that was set on the aggregation
      */
     Map<String, Object> getMetaData();

--- a/src/main/java/org/elasticsearch/search/aggregations/Aggregations.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/Aggregations.java
@@ -46,4 +46,13 @@ public interface Aggregations extends Iterable<Aggregation> {
      */
     <A extends Aggregation> A get(String name);
 
+    /**
+     * Get the value of specified path in the aggregation.
+     * 
+     * @param path
+     *            the path to the property in the aggregation tree
+     * @return the value of the property
+     */
+    Object getProperty(String path);
+
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/InternalAggregation.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/InternalAggregation.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentBuilderString;
 import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.search.aggregations.support.AggregationPath;
 
 import java.io.IOException;
 import java.util.List;
@@ -146,6 +147,13 @@ public abstract class InternalAggregation implements Aggregation, ToXContent, St
      * construction.
      */
     public abstract InternalAggregation reduce(ReduceContext reduceContext);
+
+    public Object getProperty(String path) {
+        AggregationPath aggPath = AggregationPath.parse(path);
+        return getProperty(aggPath.getPathElementsAsStringList());
+    }
+
+    public abstract Object getProperty(List<String> path);
 
     /**
      * Read a size under the assumption that a value of 0 means unlimited.

--- a/src/main/java/org/elasticsearch/search/aggregations/InternalAggregations.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/InternalAggregations.java
@@ -19,7 +19,13 @@
 package org.elasticsearch.search.aggregations;
 
 import com.google.common.base.Function;
-import com.google.common.collect.*;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -28,9 +34,14 @@ import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentBuilderString;
 import org.elasticsearch.search.aggregations.InternalAggregation.ReduceContext;
+import org.elasticsearch.search.aggregations.support.AggregationPath;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 
 import static com.google.common.collect.Maps.newHashMap;
 
@@ -104,6 +115,23 @@ public class InternalAggregations implements Aggregations, ToXContent, Streamabl
     @Override
     public <A extends Aggregation> A get(String name) {
         return (A) asMap().get(name);
+    }
+
+    public Object getProperty(String path) {
+        AggregationPath aggPath = AggregationPath.parse(path);
+        return getProperty(aggPath.getPathElementsAsStringList());
+    }
+
+    public Object getProperty(List<String> path) {
+        if (path.isEmpty()) {
+            return this;
+        }
+        String aggName = path.get(0);
+        InternalAggregation aggregation = get(aggName);
+        if (aggregation == null) {
+            throw new ElasticsearchIllegalArgumentException("Cannot find an aggregation named [" + aggName + "]");
+        }
+        return aggregation.getProperty(path.subList(1, path.size()));
     }
 
     /**

--- a/src/main/java/org/elasticsearch/search/aggregations/InternalMultiBucketAggregation.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/InternalMultiBucketAggregation.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations;
+
+import org.elasticsearch.ElasticsearchIllegalArgumentException;
+import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
+
+import java.util.List;
+import java.util.Map;
+
+public abstract class InternalMultiBucketAggregation extends InternalAggregation implements MultiBucketsAggregation {
+
+    public InternalMultiBucketAggregation() {
+    }
+
+    public InternalMultiBucketAggregation(String name, Map<String, Object> metaData) {
+        super(name, metaData);
+    }
+
+    @Override
+    public Object getProperty(List<String> path) {
+        if (path.isEmpty()) {
+            return this;
+        } else {
+            List<? extends Bucket> buckets = getBuckets();
+            Object[] propertyArray = new Object[buckets.size()];
+            for (int i = 0; i < buckets.size(); i++) {
+                propertyArray[i] = buckets.get(i).getProperty(getName(), path);
+            }
+            return propertyArray;
+        }
+    }
+
+    public static abstract class InternalBucket implements Bucket {
+        public Object getProperty(String containingAggName, List<String> path) {
+            if (path.isEmpty()) {
+                return this;
+            }
+            Aggregations aggregations = getAggregations();
+            String aggName = path.get(0);
+            if (aggName.equals("_count")) {
+                if (path.size() > 1) {
+                    throw new ElasticsearchIllegalArgumentException("_count must be the last element in the path");
+                }
+                return getDocCount();
+            } else if (aggName.equals("_key")) {
+                if (path.size() > 1) {
+                    throw new ElasticsearchIllegalArgumentException("_key must be the last element in the path");
+                }
+                return getKey();
+            }
+            InternalAggregation aggregation = aggregations.get(aggName);
+            if (aggregation == null) {
+                throw new ElasticsearchIllegalArgumentException("Cannot find an aggregation named [" + aggName + "] in [" + containingAggName + "]");
+            }
+            return aggregation.getProperty(path.subList(1, path.size()));
+        }
+    }
+}

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/MultiBucketsAggregation.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/MultiBucketsAggregation.java
@@ -26,7 +26,7 @@ import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.HasAggregations;
-import org.elasticsearch.search.aggregations.support.OrderPath;
+import org.elasticsearch.search.aggregations.support.AggregationPath;
 
 import java.util.Collection;
 import java.util.List;
@@ -63,21 +63,23 @@ public interface MultiBucketsAggregation extends Aggregation {
          */
         Aggregations getAggregations();
 
+        Object getProperty(String containingAggName, List<String> path);
+
         static class SubAggregationComparator<B extends Bucket> implements java.util.Comparator<B> {
 
-            private final OrderPath path;
+            private final AggregationPath path;
             private final boolean asc;
 
             public SubAggregationComparator(String expression, boolean asc) {
                 this.asc = asc;
-                this.path = OrderPath.parse(expression);
+                this.path = AggregationPath.parse(expression);
             }
 
             public boolean asc() {
                 return asc;
             }
 
-            public OrderPath path() {
+            public AggregationPath path() {
                 return path;
             }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/filters/InternalFilters.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/filters/InternalFilters.java
@@ -25,10 +25,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.text.StringText;
 import org.elasticsearch.common.text.Text;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.search.aggregations.AggregationStreams;
-import org.elasticsearch.search.aggregations.Aggregations;
-import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.InternalAggregations;
+import org.elasticsearch.search.aggregations.*;
 import org.elasticsearch.search.aggregations.bucket.BucketStreamContext;
 import org.elasticsearch.search.aggregations.bucket.BucketStreams;
 
@@ -41,7 +38,7 @@ import java.util.Map;
 /**
  *
  */
-public class InternalFilters extends InternalAggregation implements Filters {
+public class InternalFilters extends InternalMultiBucketAggregation implements Filters {
 
     public final static Type TYPE = new Type("filters");
 
@@ -75,7 +72,7 @@ public class InternalFilters extends InternalAggregation implements Filters {
         BucketStreams.registerStream(BUCKET_STREAM, TYPE.stream());
     }
 
-    public static class Bucket implements Filters.Bucket {
+    public static class Bucket extends InternalBucket implements Filters.Bucket {
 
         private final boolean keyed;
         private String key;

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/InternalGeoHashGrid.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/InternalGeoHashGrid.java
@@ -27,10 +27,7 @@ import org.elasticsearch.common.text.StringText;
 import org.elasticsearch.common.text.Text;
 import org.elasticsearch.common.util.LongObjectPagedHashMap;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.search.aggregations.AggregationStreams;
-import org.elasticsearch.search.aggregations.Aggregations;
-import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.InternalAggregations;
+import org.elasticsearch.search.aggregations.*;
 import org.elasticsearch.search.aggregations.bucket.BucketStreamContext;
 import org.elasticsearch.search.aggregations.bucket.BucketStreams;
 
@@ -42,7 +39,7 @@ import java.util.*;
  * All geohashes in a grid are of the same precision and held internally as a single long
  * for efficiency's sake.
  */
-public class InternalGeoHashGrid extends InternalAggregation implements GeoHashGrid {
+public class InternalGeoHashGrid extends InternalMultiBucketAggregation implements GeoHashGrid {
 
     public static final Type TYPE = new Type("geohash_grid", "ghcells");
 
@@ -77,7 +74,7 @@ public class InternalGeoHashGrid extends InternalAggregation implements GeoHashG
     }
 
 
-    static class Bucket implements GeoHashGrid.Bucket, Comparable<Bucket> {
+    static class Bucket extends InternalMultiBucketAggregation.InternalBucket implements GeoHashGrid.Bucket, Comparable<Bucket> {
 
         protected long geohashAsLong;
         protected long docCount;

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalHistogram.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalHistogram.java
@@ -30,10 +30,7 @@ import org.elasticsearch.common.text.StringText;
 import org.elasticsearch.common.text.Text;
 import org.elasticsearch.common.util.LongObjectPagedHashMap;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.search.aggregations.AggregationStreams;
-import org.elasticsearch.search.aggregations.Aggregations;
-import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.InternalAggregations;
+import org.elasticsearch.search.aggregations.*;
 import org.elasticsearch.search.aggregations.bucket.BucketStreamContext;
 import org.elasticsearch.search.aggregations.bucket.BucketStreams;
 import org.elasticsearch.search.aggregations.support.format.ValueFormatter;
@@ -48,7 +45,7 @@ import java.util.Map;
 /**
  * TODO should be renamed to InternalNumericHistogram (see comment on {@link Histogram})?
  */
-public class InternalHistogram<B extends InternalHistogram.Bucket> extends InternalAggregation implements Histogram {
+public class InternalHistogram<B extends InternalHistogram.Bucket> extends InternalMultiBucketAggregation implements Histogram {
 
     final static Type TYPE = new Type("histogram", "histo");
     final static Factory FACTORY = new Factory();
@@ -85,7 +82,7 @@ public class InternalHistogram<B extends InternalHistogram.Bucket> extends Inter
         BucketStreams.registerStream(BUCKET_STREAM, TYPE.stream());
     }
 
-    public static class Bucket implements Histogram.Bucket {
+    public static class Bucket extends InternalMultiBucketAggregation.InternalBucket implements Histogram.Bucket {
 
         long key;
         long docCount;

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalRange.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalRange.java
@@ -25,10 +25,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.text.StringText;
 import org.elasticsearch.common.text.Text;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.search.aggregations.AggregationStreams;
-import org.elasticsearch.search.aggregations.Aggregations;
-import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.InternalAggregations;
+import org.elasticsearch.search.aggregations.*;
 import org.elasticsearch.search.aggregations.bucket.BucketStreamContext;
 import org.elasticsearch.search.aggregations.bucket.BucketStreams;
 import org.elasticsearch.search.aggregations.support.format.ValueFormatter;
@@ -43,7 +40,7 @@ import java.util.Map;
 /**
  *
  */
-public class InternalRange<B extends InternalRange.Bucket> extends InternalAggregation implements Range {
+public class InternalRange<B extends InternalRange.Bucket> extends InternalMultiBucketAggregation implements Range {
 
     static final Factory FACTORY = new Factory();
 
@@ -80,7 +77,7 @@ public class InternalRange<B extends InternalRange.Bucket> extends InternalAggre
         BucketStreams.registerStream(BUCKET_STREAM, TYPE.stream());
     }
 
-    public static class Bucket implements Range.Bucket {
+    public static class Bucket extends InternalMultiBucketAggregation.InternalBucket implements Range.Bucket {
 
         protected transient final boolean keyed;
         protected transient final ValueFormatter formatter;

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/InternalSignificantTerms.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/InternalSignificantTerms.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
+import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
 import org.elasticsearch.search.aggregations.bucket.significant.heuristics.SignificanceHeuristic;
 
 import java.util.*;
@@ -31,7 +32,7 @@ import java.util.*;
 /**
  *
  */
-public abstract class InternalSignificantTerms extends InternalAggregation implements SignificantTerms, ToXContent, Streamable {
+public abstract class InternalSignificantTerms extends InternalMultiBucketAggregation implements SignificantTerms, ToXContent, Streamable {
 
     protected SignificanceHeuristic significanceHeuristic;
     protected int requiredSize;

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTerms.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTerms.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.search.aggregations.bucket.significant;
 
+import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
 import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
 
 import java.util.List;
@@ -28,7 +29,7 @@ import java.util.List;
 public interface SignificantTerms extends MultiBucketsAggregation, Iterable<SignificantTerms.Bucket> {
 
 
-    static abstract class Bucket implements MultiBucketsAggregation.Bucket {
+    static abstract class Bucket extends InternalMultiBucketAggregation.InternalBucket {
 
         long subsetDf;
         long subsetSize;

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalOrder.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalOrder.java
@@ -30,10 +30,15 @@ import org.elasticsearch.search.aggregations.bucket.SingleBucketAggregator;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms.Bucket;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms.Order;
 import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregator;
-import org.elasticsearch.search.aggregations.support.OrderPath;
+import org.elasticsearch.search.aggregations.support.AggregationPath;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
 
 /**
  *
@@ -136,7 +141,7 @@ class InternalOrder extends Terms.Order {
         } else if (!(order instanceof Aggregation)) {
             return order;
         }
-        OrderPath path = ((Aggregation) order).path();
+        AggregationPath path = ((Aggregation) order).path();
         path.validate(termsAggregator);
         return order;
     }
@@ -149,7 +154,7 @@ class InternalOrder extends Terms.Order {
             super(ID, key, asc, new MultiBucketsAggregation.Bucket.SubAggregationComparator<Terms.Bucket>(key, asc));
         }
 
-        OrderPath path() {
+        AggregationPath path() {
             return ((MultiBucketsAggregation.Bucket.SubAggregationComparator) comparator).path();
         }
 
@@ -167,9 +172,9 @@ class InternalOrder extends Terms.Order {
             // sub aggregation values directly from the sub aggregators bypassing bucket creation. Note that the comparator
             // attached to the order will still be used in the reduce phase of the Aggregation.
 
-            OrderPath path = path();
+            AggregationPath path = path();
             final Aggregator aggregator = path.resolveAggregator(termsAggregator);
-            final String key = path.tokens[path.tokens.length - 1].key;
+            final String key = path.lastPathElement().key;
 
             if (aggregator instanceof SingleBucketAggregator) {
                 assert key == null : "this should be picked up before the aggregation is executed - on validate";
@@ -286,12 +291,12 @@ class InternalOrder extends Terms.Order {
                 out.writeByte(order.id());
                 Aggregation aggregationOrder = (Aggregation) order;
                 out.writeBoolean(((MultiBucketsAggregation.Bucket.SubAggregationComparator) aggregationOrder.comparator).asc());
-                OrderPath path = ((Aggregation) order).path();
+                AggregationPath path = ((Aggregation) order).path();
                 if (out.getVersion().onOrAfter(Version.V_1_1_0)) {
                     out.writeString(path.toString());
                 } else {
                     // prev versions only supported sorting on a single level -> a single token;
-                    OrderPath.Token token = path.lastToken();
+                    AggregationPath.PathElement token = path.lastPathElement();
                     out.writeString(token.name);
                     boolean hasValueName = token.key != null;
                     out.writeBoolean(hasValueName);

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalTerms.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalTerms.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
+import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
 import org.elasticsearch.search.aggregations.bucket.terms.support.BucketPriorityQueue;
 import org.elasticsearch.search.aggregations.support.format.ValueFormatter;
 
@@ -36,7 +37,7 @@ import java.util.*;
 /**
  *
  */
-public abstract class InternalTerms extends InternalAggregation implements Terms, ToXContent, Streamable {
+public abstract class InternalTerms extends InternalMultiBucketAggregation implements Terms, ToXContent, Streamable {
 
     protected static final String DOC_COUNT_ERROR_UPPER_BOUND_FIELD_NAME = "doc_count_error_upper_bound";
     protected static final String SUM_OF_OTHER_DOC_COUNTS = "sum_other_doc_count";

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/Terms.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/Terms.java
@@ -20,6 +20,7 @@ package org.elasticsearch.search.aggregations.bucket.terms;
 
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.search.aggregations.Aggregator;
+import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
 import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
 
 import java.util.Arrays;
@@ -61,7 +62,7 @@ public interface Terms extends MultiBucketsAggregation {
     /**
      * A bucket that is associated with a single term
      */
-    static abstract class Bucket implements MultiBucketsAggregation.Bucket {
+    static abstract class Bucket extends InternalMultiBucketAggregation.InternalBucket {
 
         public abstract Number getKeyAsNumber();
 

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregator.java
@@ -29,7 +29,7 @@ import org.elasticsearch.search.aggregations.bucket.BucketsAggregator;
 import org.elasticsearch.search.aggregations.bucket.terms.InternalOrder.Aggregation;
 import org.elasticsearch.search.aggregations.bucket.terms.InternalOrder.CompoundOrder;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
-import org.elasticsearch.search.aggregations.support.OrderPath;
+import org.elasticsearch.search.aggregations.support.AggregationPath;
 
 import java.io.IOException;
 import java.util.HashSet;
@@ -142,13 +142,13 @@ public abstract class TermsAggregator extends BucketsAggregator {
         this.subAggCollectMode = subAggCollectMode;
         // Don't defer any child agg if we are dependent on it for pruning results
         if (order instanceof Aggregation){
-            OrderPath path = ((Aggregation) order).path();
+            AggregationPath path = ((Aggregation) order).path();
             aggsUsedForSorting.add(path.resolveTopmostAggregator(this));
         } else if (order instanceof CompoundOrder) {
             CompoundOrder compoundOrder = (CompoundOrder) order;
             for (Terms.Order orderElement : compoundOrder.orderElements()) {
                 if (orderElement instanceof Aggregation) {
-                    OrderPath path = ((Aggregation) orderElement).path();
+                    AggregationPath path = ((Aggregation) orderElement).path();
                     aggsUsedForSorting.add(path.resolveTopmostAggregator(this));
                 }
             }

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalNumericMetricsAggregation.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalNumericMetricsAggregation.java
@@ -18,8 +18,10 @@
  */
 package org.elasticsearch.search.aggregations.metrics;
 
+import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.search.aggregations.support.format.ValueFormatter;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -38,6 +40,18 @@ public abstract class InternalNumericMetricsAggregation extends InternalMetricsA
         }
 
         public abstract double value();
+
+        @Override
+        public Object getProperty(List<String> path) {
+            if (path.isEmpty()) {
+                return this;
+            } else if (path.size() == 1 && "value".equals(path.get(0))) {
+                return value();
+            } else {
+                throw new ElasticsearchIllegalArgumentException("path not supported for [" + getName() + "]: " + path);
+            }
+        }
+
     }
 
     public static abstract class MultiValue extends InternalNumericMetricsAggregation {
@@ -50,6 +64,16 @@ public abstract class InternalNumericMetricsAggregation extends InternalMetricsA
 
         public abstract double value(String name);
 
+        @Override
+        public Object getProperty(List<String> path) {
+            if (path.isEmpty()) {
+                return this;
+            } else if (path.size() == 1) {
+                return value(path.get(0));
+            } else {
+                throw new ElasticsearchIllegalArgumentException("path not supported for [" + getName() + "]: " + path);
+            }
+        }
     }
 
     private InternalNumericMetricsAggregation() {} // for serialization

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/geobounds/InternalGeoBounds.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/geobounds/InternalGeoBounds.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.search.aggregations.metrics.geobounds;
 
+import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -28,6 +29,7 @@ import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.metrics.InternalMetricsAggregation;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 
 public class InternalGeoBounds extends InternalMetricsAggregation implements GeoBounds {
@@ -103,7 +105,54 @@ public class InternalGeoBounds extends InternalMetricsAggregation implements Geo
         }
         return new InternalGeoBounds(name, top, bottom, posLeft, posRight, negLeft, negRight, wrapLongitude, getMetaData());
     }
-    
+
+    @Override
+    public Object getProperty(List<String> path) {
+        if (path.isEmpty()) {
+            return this;
+        } else if (path.size() == 1) {
+            BoundingBox boundingBox = resolveBoundingBox();
+            String bBoxSide = path.get(0);
+            switch (bBoxSide) {
+            case "top":
+                return boundingBox.topLeft.lat();
+            case "left":
+                return boundingBox.topLeft.lon();
+            case "bottom":
+                return boundingBox.bottomRight.lat();
+            case "right":
+                return boundingBox.bottomRight.lon();
+            default:
+                throw new ElasticsearchIllegalArgumentException("Found unknown path element [" + bBoxSide + "] in [" + getName() + "]");
+            }
+        } else if (path.size() == 2) {
+            BoundingBox boundingBox = resolveBoundingBox();
+            GeoPoint cornerPoint = null;
+            String cornerString = path.get(0);
+            switch (cornerString) {
+            case "top_left":
+                cornerPoint = boundingBox.topLeft;
+                break;
+            case "bottom_right":
+                cornerPoint = boundingBox.bottomRight;
+                break;
+            default:
+                throw new ElasticsearchIllegalArgumentException("Found unknown path element [" + cornerString + "] in [" + getName() + "]");
+            }
+            String latLonString = path.get(1);
+            switch (latLonString) {
+            case "lat":
+                return cornerPoint.lat();
+            case "lon":
+                return cornerPoint.lon();
+            default:
+                throw new ElasticsearchIllegalArgumentException("Found unknown path element [" + latLonString + "] in [" + getName() + "]");
+            }
+        } else {
+            throw new ElasticsearchIllegalArgumentException("path not supported for [" + getName() + "]: " + path);
+        }
+    }
+
     @Override
     public XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
         GeoPoint topLeft = topLeft();

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/scripted/InternalScriptedMetric.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/scripted/InternalScriptedMetric.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.search.aggregations.metrics.scripted;
 
+import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -110,6 +111,16 @@ public class InternalScriptedMetric extends InternalMetricsAggregation implement
     @Override
     public Type type() {
         return TYPE;
+    }
+
+    public Object getProperty(List<String> path) {
+        if (path.isEmpty()) {
+            return this;
+        } else if (path.size() == 1 && "value".equals(path.get(0))) {
+            return aggregation;
+        } else {
+            throw new ElasticsearchIllegalArgumentException("path not supported for [" + getName() + "]: " + path);
+        }
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/InternalTopHits.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/InternalTopHits.java
@@ -18,10 +18,14 @@
  */
 package org.elasticsearch.search.aggregations.metrics.tophits;
 
+import java.io.IOException;
+import java.util.List;
+
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TopFieldDocs;
+import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -33,10 +37,6 @@ import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.metrics.InternalMetricsAggregation;
 import org.elasticsearch.search.internal.InternalSearchHit;
 import org.elasticsearch.search.internal.InternalSearchHits;
-
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
 
 /**
  */
@@ -126,6 +126,15 @@ public class InternalTopHits extends InternalMetricsAggregation implements TopHi
             return new InternalTopHits(name, new InternalSearchHits(hits, reducedTopDocs.totalHits, reducedTopDocs.getMaxScore()));
         } catch (IOException e) {
             throw ExceptionsHelper.convertToElastic(e);
+        }
+    }
+
+    @Override
+    public Object getProperty(List<String> path) {
+        if (path.isEmpty()) {
+            return this;
+        } else {
+            throw new ElasticsearchIllegalArgumentException("path not supported for [" + getName() + "]: " + path);
         }
     }
 

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/ChildrenTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/ChildrenTests.java
@@ -18,6 +18,13 @@
  */
 package org.elasticsearch.search.aggregations.bucket;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.update.UpdateResponse;
@@ -30,16 +37,18 @@ import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.junit.Test;
 
-import java.util.*;
-
 import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
-import static org.elasticsearch.search.aggregations.AggregationBuilders.*;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.children;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.topHits;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
 
 /**
  */
@@ -138,8 +147,10 @@ public class ChildrenTests extends ElasticsearchIntegrationTest {
             Children childrenBucket = categoryBucket.getAggregations().get("to_comment");
             assertThat(childrenBucket.getName(), equalTo("to_comment"));
             assertThat(childrenBucket.getDocCount(), equalTo((long) entry1.getValue().commentIds.size()));
+            assertThat((long) childrenBucket.getProperty("_count"), equalTo((long) entry1.getValue().commentIds.size()));
 
             Terms commentersTerms = childrenBucket.getAggregations().get("commenters");
+            assertThat((Terms) childrenBucket.getProperty("commenters"), sameInstance(commentersTerms));
             assertThat(commentersTerms.getBuckets().size(), equalTo(entry1.getValue().commenterToCommentId.size()));
             for (Map.Entry<String, Set<String>> entry2 : entry1.getValue().commenterToCommentId.entrySet()) {
                 Terms.Bucket commentBucket = commentersTerms.getBucketByKey(entry2.getKey());

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/DateHistogramTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/DateHistogramTests.java
@@ -46,7 +46,11 @@ import java.util.List;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
-import static org.elasticsearch.search.aggregations.AggregationBuilders.*;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.dateHistogram;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.histogram;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.max;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.stats;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -349,6 +353,9 @@ public class DateHistogramTests extends ElasticsearchIntegrationTest {
         assertThat(histo, notNullValue());
         assertThat(histo.getName(), equalTo("histo"));
         assertThat(histo.getBuckets().size(), equalTo(3));
+        Object[] propertiesKeys = (Object[]) histo.getProperty("_key");
+        Object[] propertiesDocCounts = (Object[]) histo.getProperty("_count");
+        Object[] propertiesCounts = (Object[]) histo.getProperty("sum.value");
 
         long key = new DateTime(2012, 1, 1, 0, 0, DateTimeZone.UTC).getMillis();
         DateHistogram.Bucket bucket = histo.getBucketByKey(key);
@@ -358,6 +365,9 @@ public class DateHistogramTests extends ElasticsearchIntegrationTest {
         Sum sum = bucket.getAggregations().get("sum");
         assertThat(sum, notNullValue());
         assertThat(sum.getValue(), equalTo(1.0));
+        assertThat((String) propertiesKeys[0], equalTo("2012-01-01T00:00:00.000Z"));
+        assertThat((long) propertiesDocCounts[0], equalTo(1l));
+        assertThat((double) propertiesCounts[0], equalTo(1.0));
 
         key = new DateTime(2012, 2, 1, 0, 0, DateTimeZone.UTC).getMillis();
         bucket = histo.getBucketByKey(key);
@@ -367,6 +377,9 @@ public class DateHistogramTests extends ElasticsearchIntegrationTest {
         sum = bucket.getAggregations().get("sum");
         assertThat(sum, notNullValue());
         assertThat(sum.getValue(), equalTo(5.0));
+        assertThat((String) propertiesKeys[1], equalTo("2012-02-01T00:00:00.000Z"));
+        assertThat((long) propertiesDocCounts[1], equalTo(2l));
+        assertThat((double) propertiesCounts[1], equalTo(5.0));
 
         key = new DateTime(2012, 3, 1, 0, 0, DateTimeZone.UTC).getMillis();
         bucket = histo.getBucketByKey(key);
@@ -376,6 +389,9 @@ public class DateHistogramTests extends ElasticsearchIntegrationTest {
         sum = bucket.getAggregations().get("sum");
         assertThat(sum, notNullValue());
         assertThat(sum.getValue(), equalTo(15.0));
+        assertThat((String) propertiesKeys[2], equalTo("2012-03-01T00:00:00.000Z"));
+        assertThat((long) propertiesDocCounts[2], equalTo(3l));
+        assertThat((double) propertiesCounts[2], equalTo(15.0));
     }
 
     @Test

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/DateRangeTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/DateRangeTests.java
@@ -38,7 +38,11 @@ import java.util.List;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
-import static org.elasticsearch.search.aggregations.AggregationBuilders.*;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.dateRange;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.histogram;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.max;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.min;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.equalTo;
@@ -392,6 +396,9 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(range, notNullValue());
         assertThat(range.getName(), equalTo("range"));
         assertThat(range.getBuckets().size(), equalTo(3));
+        Object[] propertiesKeys = (Object[]) range.getProperty("_key");
+        Object[] propertiesDocCounts = (Object[]) range.getProperty("_count");
+        Object[] propertiesCounts = (Object[]) range.getProperty("sum.value");
 
         DateRange.Bucket bucket = range.getBucketByKey("r1");
         assertThat(bucket, notNullValue());
@@ -404,6 +411,9 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         Sum sum = bucket.getAggregations().get("sum");
         assertThat(sum, notNullValue());
         assertThat(sum.getValue(), equalTo((double) 1 + 2));
+        assertThat((String) propertiesKeys[0], equalTo("r1"));
+        assertThat((long) propertiesDocCounts[0], equalTo(2l));
+        assertThat((double) propertiesCounts[0], equalTo((double) 1 + 2));
 
         bucket = range.getBucketByKey("r2");
         assertThat(bucket, notNullValue());
@@ -416,6 +426,9 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         sum = bucket.getAggregations().get("sum");
         assertThat(sum, notNullValue());
         assertThat(sum.getValue(), equalTo((double) 3 + 4));
+        assertThat((String) propertiesKeys[1], equalTo("r2"));
+        assertThat((long) propertiesDocCounts[1], equalTo(2l));
+        assertThat((double) propertiesCounts[1], equalTo((double) 3 + 4));
 
         bucket = range.getBucketByKey("r3");
         assertThat(bucket, notNullValue());
@@ -427,6 +440,8 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getDocCount(), equalTo(numDocs - 4l));
         sum = bucket.getAggregations().get("sum");
         assertThat(sum, notNullValue());
+        assertThat((String) propertiesKeys[2], equalTo("r3"));
+        assertThat((long) propertiesDocCounts[2], equalTo(numDocs - 4l));
     }
 
     @Test

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/DoubleTermsTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/DoubleTermsTests.java
@@ -37,12 +37,23 @@ import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.functionScoreQuery;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
-import static org.elasticsearch.search.aggregations.AggregationBuilders.*;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.avg;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.extendedStats;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.filter;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.histogram;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.max;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.stats;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.equalTo;
@@ -382,6 +393,9 @@ public class DoubleTermsTests extends AbstractTermsTests {
         assertThat(terms, notNullValue());
         assertThat(terms.getName(), equalTo("terms"));
         assertThat(terms.getBuckets().size(), equalTo(5));
+        Object[] propertiesKeys = (Object[]) terms.getProperty("_key");
+        Object[] propertiesDocCounts = (Object[]) terms.getProperty("_count");
+        Object[] propertiesCounts = (Object[]) terms.getProperty("sum.value");
 
         for (int i = 0; i < 5; i++) {
             Terms.Bucket bucket = terms.getBucketByKey("" + (double) i);
@@ -392,6 +406,9 @@ public class DoubleTermsTests extends AbstractTermsTests {
             Sum sum = bucket.getAggregations().get("sum");
             assertThat(sum, notNullValue());
             assertThat((long) sum.getValue(), equalTo(i+i+1l));
+            assertThat((String) propertiesKeys[i], equalTo(String.valueOf((double) i)));
+            assertThat((long) propertiesDocCounts[i], equalTo(1l));
+            assertThat((double) propertiesCounts[i], equalTo((double) i + i + 1l));
         }
     }
 

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/FilterTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/FilterTests.java
@@ -136,6 +136,7 @@ public class FilterTests extends ElasticsearchIntegrationTest {
         assertThat(filter, notNullValue());
         assertThat(filter.getName(), equalTo("tag1"));
         assertThat(filter.getDocCount(), equalTo((long) numTag1Docs));
+        assertThat((long) filter.getProperty("_count"), equalTo((long) numTag1Docs));
 
         long sum = 0;
         for (int i = 0; i < numTag1Docs; ++i) {
@@ -146,6 +147,7 @@ public class FilterTests extends ElasticsearchIntegrationTest {
         assertThat(avgValue, notNullValue());
         assertThat(avgValue.getName(), equalTo("avg_value"));
         assertThat(avgValue.getValue(), equalTo((double) sum / numTag1Docs));
+        assertThat((double) filter.getProperty("avg_value.value"), equalTo((double) sum / numTag1Docs));
     }
 
     @Test

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/FiltersTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/FiltersTests.java
@@ -164,6 +164,9 @@ public class FiltersTests extends ElasticsearchIntegrationTest {
         assertThat(filters.getName(), equalTo("tags"));
 
         assertThat(filters.getBuckets().size(), equalTo(2));
+        Object[] propertiesKeys = (Object[]) filters.getProperty("_key");
+        Object[] propertiesDocCounts = (Object[]) filters.getProperty("_count");
+        Object[] propertiesCounts = (Object[]) filters.getProperty("avg_value.value");
 
         Filters.Bucket bucket = filters.getBucketByKey("tag1");
         assertThat(bucket, Matchers.notNullValue());
@@ -177,6 +180,9 @@ public class FiltersTests extends ElasticsearchIntegrationTest {
         assertThat(avgValue, notNullValue());
         assertThat(avgValue.getName(), equalTo("avg_value"));
         assertThat(avgValue.getValue(), equalTo((double) sum / numTag1Docs));
+        assertThat((String) propertiesKeys[0], equalTo("tag1"));
+        assertThat((long) propertiesDocCounts[0], equalTo((long) numTag1Docs));
+        assertThat((double) propertiesCounts[0], equalTo((double) sum / numTag1Docs));
 
         bucket = filters.getBucketByKey("tag2");
         assertThat(bucket, Matchers.notNullValue());
@@ -190,6 +196,9 @@ public class FiltersTests extends ElasticsearchIntegrationTest {
         assertThat(avgValue, notNullValue());
         assertThat(avgValue.getName(), equalTo("avg_value"));
         assertThat(avgValue.getValue(), equalTo((double) sum / numTag2Docs));
+        assertThat((String) propertiesKeys[1], equalTo("tag2"));
+        assertThat((long) propertiesDocCounts[1], equalTo((long) numTag2Docs));
+        assertThat((double) propertiesCounts[1], equalTo((double) sum / numTag2Docs));
     }
 
     @Test

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoDistanceTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoDistanceTests.java
@@ -18,7 +18,13 @@
  */
 package org.elasticsearch.search.aggregations.bucket;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
 import com.google.common.collect.Sets;
+
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.unit.DistanceUnit;
@@ -31,17 +37,15 @@ import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Set;
-
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
-import static org.elasticsearch.search.aggregations.AggregationBuilders.*;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.geoDistance;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.histogram;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.core.IsNull.notNullValue;
 
 /**
@@ -309,6 +313,9 @@ public class GeoDistanceTests extends ElasticsearchIntegrationTest {
         assertThat(geoDist, notNullValue());
         assertThat(geoDist.getName(), equalTo("amsterdam_rings"));
         assertThat(geoDist.getBuckets().size(), equalTo(3));
+        Object[] propertiesKeys = (Object[]) geoDist.getProperty("_key");
+        Object[] propertiesDocCounts = (Object[]) geoDist.getProperty("_count");
+        Object[] propertiesCities = (Object[]) geoDist.getProperty("cities");
 
         GeoDistance.Bucket bucket = geoDist.getBucketByKey("*-500.0");
         assertThat(bucket, notNullValue());
@@ -324,6 +331,9 @@ public class GeoDistanceTests extends ElasticsearchIntegrationTest {
             names.add(city.getKey());
         }
         assertThat(names.contains("utrecht") && names.contains("haarlem"), is(true));
+        assertThat((String) propertiesKeys[0], equalTo("*-500.0"));
+        assertThat((long) propertiesDocCounts[0], equalTo(2l));
+        assertThat((Terms) propertiesCities[0], sameInstance(cities));
 
         bucket = geoDist.getBucketByKey("500.0-1000.0");
         assertThat(bucket, notNullValue());
@@ -339,6 +349,9 @@ public class GeoDistanceTests extends ElasticsearchIntegrationTest {
             names.add(city.getKey());
         }
         assertThat(names.contains("berlin") && names.contains("prague"), is(true));
+        assertThat((String) propertiesKeys[1], equalTo("500.0-1000.0"));
+        assertThat((long) propertiesDocCounts[1], equalTo(2l));
+        assertThat((Terms) propertiesCities[1], sameInstance(cities));
 
         bucket = geoDist.getBucketByKey("1000.0-*");
         assertThat(bucket, notNullValue());
@@ -354,6 +367,9 @@ public class GeoDistanceTests extends ElasticsearchIntegrationTest {
             names.add(city.getKey());
         }
         assertThat(names.contains("tel-aviv"), is(true));
+        assertThat((String) propertiesKeys[2], equalTo("1000.0-*"));
+        assertThat((long) propertiesDocCounts[2], equalTo(1l));
+        assertThat((Terms) propertiesCities[2], sameInstance(cities));
     }
 
     @Test

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoHashGridTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoHashGridTests.java
@@ -21,6 +21,7 @@ package org.elasticsearch.search.aggregations.bucket;
 import com.carrotsearch.hppc.ObjectIntMap;
 import com.carrotsearch.hppc.ObjectIntOpenHashMap;
 import com.carrotsearch.hppc.cursors.ObjectIntCursor;
+
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.geo.GeoHashUtils;
@@ -29,6 +30,7 @@ import org.elasticsearch.index.query.GeoBoundingBoxFilterBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.bucket.filter.Filter;
 import org.elasticsearch.search.aggregations.bucket.geogrid.GeoHashGrid;
+import org.elasticsearch.search.aggregations.bucket.geogrid.GeoHashGrid.Bucket;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.junit.Test;
 
@@ -141,7 +143,11 @@ public class GeoHashGridTests extends ElasticsearchIntegrationTest {
             assertSearchResponse(response);
 
             GeoHashGrid geoGrid = response.getAggregations().get("geohashgrid");
-            for (GeoHashGrid.Bucket cell : geoGrid.getBuckets()) {
+            List<Bucket> buckets = geoGrid.getBuckets();
+            Object[] propertiesKeys = (Object[]) geoGrid.getProperty("_key");
+            Object[] propertiesDocCounts = (Object[]) geoGrid.getProperty("_count");
+            for (int i = 0; i < buckets.size(); i++) {
+                GeoHashGrid.Bucket cell = buckets.get(i);
                 String geohash = cell.getKey();
 
                 long bucketCount = cell.getDocCount();
@@ -149,6 +155,8 @@ public class GeoHashGridTests extends ElasticsearchIntegrationTest {
                 assertNotSame(bucketCount, 0);
                 assertEquals("Geohash " + geohash + " has wrong doc count ",
                         expectedBucketCount, bucketCount);
+                assertThat((String) propertiesKeys[i], equalTo(geohash));
+                assertThat((long) propertiesDocCounts[i], equalTo(bucketCount));
             }
         }
     }

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/GlobalTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/GlobalTests.java
@@ -18,6 +18,9 @@
  */
 package org.elasticsearch.search.aggregations.bucket;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
@@ -27,15 +30,13 @@ import org.elasticsearch.search.aggregations.metrics.stats.Stats;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.junit.Test;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.global;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.stats;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.core.IsNull.notNullValue;
 
 /**
@@ -86,9 +87,11 @@ public class GlobalTests extends ElasticsearchIntegrationTest {
         assertThat(global, notNullValue());
         assertThat(global.getName(), equalTo("global"));
         assertThat(global.getDocCount(), equalTo((long) numDocs));
+        assertThat((long) global.getProperty("_count"), equalTo((long) numDocs));
         assertThat(global.getAggregations().asList().isEmpty(), is(false));
 
         Stats stats = global.getAggregations().get("value_stats");
+        assertThat((Stats) global.getProperty("value_stats"), sameInstance(stats));
         assertThat(stats, notNullValue());
         assertThat(stats.getName(), equalTo("value_stats"));
         long sum = 0;

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/HistogramTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/HistogramTests.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.search.aggregations.bucket;
 
 import com.carrotsearch.hppc.LongOpenHashSet;
+
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.search.aggregations.Aggregator.SubAggCollectionMode;
@@ -39,10 +40,18 @@ import java.util.List;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.FilterBuilders.matchAllFilter;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
-import static org.elasticsearch.search.aggregations.AggregationBuilders.*;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.filter;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.histogram;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.max;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.stats;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.core.IsNull.notNullValue;
 
 /**
@@ -293,6 +302,9 @@ public class HistogramTests extends ElasticsearchIntegrationTest {
         assertThat(histo, notNullValue());
         assertThat(histo.getName(), equalTo("histo"));
         assertThat(histo.getBuckets().size(), equalTo(numValueBuckets));
+        Object[] propertiesKeys = (Object[]) histo.getProperty("_key");
+        Object[] propertiesDocCounts = (Object[]) histo.getProperty("_count");
+        Object[] propertiesCounts = (Object[]) histo.getProperty("sum.value");
 
         List<Histogram.Bucket> buckets = new ArrayList<>(histo.getBuckets());
         for (int i = 0; i < numValueBuckets; ++i) {
@@ -310,6 +322,9 @@ public class HistogramTests extends ElasticsearchIntegrationTest {
                 }
             }
             assertThat(sum.getValue(), equalTo((double) s));
+            assertThat((String) propertiesKeys[i], equalTo(String.valueOf((long) i * interval)));
+            assertThat((long) propertiesDocCounts[i], equalTo(valueCounts[i]));
+            assertThat((double) propertiesCounts[i], equalTo((double) s));
         }
     }
 

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/LongTermsTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/LongTermsTests.java
@@ -36,11 +36,22 @@ import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
-import static org.elasticsearch.search.aggregations.AggregationBuilders.*;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.avg;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.extendedStats;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.filter;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.histogram;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.max;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.stats;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.equalTo;
@@ -382,6 +393,9 @@ public class LongTermsTests extends AbstractTermsTests {
         assertThat(terms, notNullValue());
         assertThat(terms.getName(), equalTo("terms"));
         assertThat(terms.getBuckets().size(), equalTo(5));
+        Object[] propertiesKeys = (Object[]) terms.getProperty("_key");
+        Object[] propertiesDocCounts = (Object[]) terms.getProperty("_count");
+        Object[] propertiesCounts = (Object[]) terms.getProperty("sum.value");
 
         for (int i = 0; i < 5; i++) {
             Terms.Bucket bucket = terms.getBucketByKey("" + i);
@@ -392,6 +406,9 @@ public class LongTermsTests extends AbstractTermsTests {
             Sum sum = bucket.getAggregations().get("sum");
             assertThat(sum, notNullValue());
             assertThat((long) sum.getValue(), equalTo(i+i+1l));
+            assertThat((String) propertiesKeys[i], equalTo(String.valueOf(i)));
+            assertThat((long) propertiesDocCounts[i], equalTo(1l));
+            assertThat((double) propertiesCounts[i], equalTo((double) i + i + 1l));
         }
     }
 

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/MissingTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/MissingTests.java
@@ -32,7 +32,9 @@ import java.util.List;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
-import static org.elasticsearch.search.aggregations.AggregationBuilders.*;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.avg;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.histogram;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.missing;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -146,6 +148,7 @@ public class MissingTests extends ElasticsearchIntegrationTest {
         assertThat(missing, notNullValue());
         assertThat(missing.getName(), equalTo("missing_tag"));
         assertThat(missing.getDocCount(), equalTo((long) numDocsMissing + numDocsUnmapped));
+        assertThat((long) missing.getProperty("_count"), equalTo((long) numDocsMissing + numDocsUnmapped));
         assertThat(missing.getAggregations().asList().isEmpty(), is(false));
 
         long sum = 0;
@@ -159,6 +162,7 @@ public class MissingTests extends ElasticsearchIntegrationTest {
         assertThat(avgValue, notNullValue());
         assertThat(avgValue.getName(), equalTo("avg_value"));
         assertThat(avgValue.getValue(), equalTo((double) sum / (numDocsMissing + numDocsUnmapped)));
+        assertThat((double) missing.getProperty("avg_value.value"), equalTo((double) sum / (numDocsMissing + numDocsUnmapped)));
     }
 
     @Test

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/NestedTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/NestedTests.java
@@ -18,6 +18,9 @@
  */
 package org.elasticsearch.search.aggregations.bucket;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
@@ -36,16 +39,19 @@ import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
-import static org.elasticsearch.search.aggregations.AggregationBuilders.*;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.histogram;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.max;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.nested;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.stats;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.core.IsNull.notNullValue;
 
 /**
@@ -232,6 +238,7 @@ public class NestedTests extends ElasticsearchIntegrationTest {
         assertThat(nested, notNullValue());
         assertThat(nested.getName(), equalTo("nested"));
         assertThat(nested.getDocCount(), equalTo(docCount));
+        assertThat((long) nested.getProperty("_count"), equalTo(docCount));
         assertThat(nested.getAggregations().asList().isEmpty(), is(false));
 
         LongTerms values = nested.getAggregations().get("values");
@@ -249,6 +256,7 @@ public class NestedTests extends ElasticsearchIntegrationTest {
                 assertEquals(counts[i], bucket.getDocCount());
             }
         }
+        assertThat((LongTerms) nested.getProperty("values"), sameInstance(values));
     }
 
     @Test

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/RangeTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/RangeTests.java
@@ -35,7 +35,11 @@ import java.util.List;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
-import static org.elasticsearch.search.aggregations.AggregationBuilders.*;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.avg;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.histogram;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.range;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -268,6 +272,9 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         assertThat(range, notNullValue());
         assertThat(range.getName(), equalTo("range"));
         assertThat(range.getBuckets().size(), equalTo(3));
+        Object[] propertiesKeys = (Object[]) range.getProperty("_key");
+        Object[] propertiesDocCounts = (Object[]) range.getProperty("_count");
+        Object[] propertiesCounts = (Object[]) range.getProperty("sum.value");
 
         Range.Bucket bucket = range.getBucketByKey("*-3.0");
         assertThat(bucket, notNullValue());
@@ -278,6 +285,9 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         Sum sum = bucket.getAggregations().get("sum");
         assertThat(sum, notNullValue());
         assertThat(sum.getValue(), equalTo(3.0)); // 1 + 2
+        assertThat((String) propertiesKeys[0], equalTo("*-3.0"));
+        assertThat((long) propertiesDocCounts[0], equalTo(2l));
+        assertThat((double) propertiesCounts[0], equalTo(3.0));
 
         bucket = range.getBucketByKey("3.0-6.0");
         assertThat(bucket, notNullValue());
@@ -288,6 +298,9 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         sum = bucket.getAggregations().get("sum");
         assertThat(sum, notNullValue());
         assertThat(sum.getValue(), equalTo(12.0)); // 3 + 4 + 5
+        assertThat((String) propertiesKeys[1], equalTo("3.0-6.0"));
+        assertThat((long) propertiesDocCounts[1], equalTo(3l));
+        assertThat((double) propertiesCounts[1], equalTo(12.0));
 
         bucket = range.getBucketByKey("6.0-*");
         assertThat(bucket, notNullValue());
@@ -302,6 +315,9 @@ public class RangeTests extends ElasticsearchIntegrationTest {
             total += i + 1;
         }
         assertThat(sum.getValue(), equalTo((double) total));
+        assertThat((String) propertiesKeys[2], equalTo("6.0-*"));
+        assertThat((long) propertiesDocCounts[2], equalTo(numDocs - 5l));
+        assertThat((double) propertiesCounts[2], equalTo((double) total));
     }
 
     @Test

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/ReverseNestedTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/ReverseNestedTests.java
@@ -18,6 +18,10 @@
  */
 package org.elasticsearch.search.aggregations.bucket;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -28,16 +32,15 @@ import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.junit.Test;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
-import static org.elasticsearch.search.aggregations.AggregationBuilders.*;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.nested;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.reverseNested;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.core.IsNull.notNullValue;
 
 /**
@@ -155,7 +158,9 @@ public class ReverseNestedTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("1"));
         assertThat(bucket.getDocCount(), equalTo(6l));
         ReverseNested reverseNested = bucket.getAggregations().get("nested1_to_field1");
+        assertThat((long) reverseNested.getProperty("_count"), equalTo(5l));
         Terms tags = reverseNested.getAggregations().get("field1");
+        assertThat((Terms) reverseNested.getProperty("field1"), sameInstance(tags));
         List<Terms.Bucket> tagsBuckets = new ArrayList<>(tags.getBuckets());
         assertThat(tagsBuckets.size(), equalTo(6));
         assertThat(tagsBuckets.get(0).getKey(), equalTo("c"));

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/StringTermsTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/StringTermsTests.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.search.aggregations.bucket;
 
 import com.google.common.base.Strings;
+
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
@@ -41,13 +42,25 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.text.NumberFormat;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.FilterBuilders.termFilter;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
-import static org.elasticsearch.search.aggregations.AggregationBuilders.*;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.avg;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.count;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.extendedStats;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.filter;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.histogram;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.stats;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -250,12 +263,16 @@ public class StringTermsTests extends AbstractTermsTests {
         assertThat(terms, notNullValue());
         assertThat(terms.getName(), equalTo("terms"));
         assertThat(terms.getBuckets().size(), equalTo(5));
+        Object[] propertiesKeys = (Object[]) terms.getProperty("_key");
+        Object[] propertiesDocCounts = (Object[]) terms.getProperty("_count");
 
         for (int i = 0; i < 5; i++) {
             Terms.Bucket bucket = terms.getBucketByKey("val" + i);
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("val" + i));
             assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat((String) propertiesKeys[i], equalTo("val" + i));
+            assertThat((long) propertiesDocCounts[i], equalTo(1l));
         }
     }
 
@@ -631,6 +648,9 @@ public class StringTermsTests extends AbstractTermsTests {
         assertThat(terms, notNullValue());
         assertThat(terms.getName(), equalTo("terms"));
         assertThat(terms.getBuckets().size(), equalTo(5));
+        Object[] propertiesKeys = (Object[]) terms.getProperty("_key");
+        Object[] propertiesDocCounts = (Object[]) terms.getProperty("_count");
+        Object[] propertiesCounts = (Object[]) terms.getProperty("count.value");
 
         for (int i = 0; i < 5; i++) {
             Terms.Bucket bucket = terms.getBucketByKey("val" + i);
@@ -640,6 +660,9 @@ public class StringTermsTests extends AbstractTermsTests {
             ValueCount valueCount = bucket.getAggregations().get("count");
             assertThat(valueCount, notNullValue());
             assertThat(valueCount.getValue(), equalTo(2l));
+            assertThat((String) propertiesKeys[i], equalTo("val" + i));
+            assertThat((long) propertiesDocCounts[i], equalTo(1l));
+            assertThat((double) propertiesCounts[i], equalTo(2.0));
         }
     }
 

--- a/src/test/java/org/elasticsearch/search/aggregations/metrics/AbstractNumericTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/metrics/AbstractNumericTests.java
@@ -77,6 +77,8 @@ public abstract class AbstractNumericTests extends ElasticsearchIntegrationTest 
 
     public abstract void testSingleValuedField() throws Exception;
 
+    public abstract void testSingleValuedField_getProperty() throws Exception;
+
     public abstract void testSingleValuedField_PartiallyUnmapped() throws Exception;
 
     public abstract void testSingleValuedField_WithValueScript() throws Exception;

--- a/src/test/java/org/elasticsearch/search/aggregations/metrics/AvgTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/metrics/AvgTests.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.search.aggregations.metrics;
 
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.search.aggregations.bucket.global.Global;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.metrics.avg.Avg;
 import org.elasticsearch.test.junit.annotations.TestLogging;
@@ -26,8 +27,11 @@ import org.junit.Test;
 
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.avg;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.global;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.histogram;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 
 /**
  *
@@ -82,6 +86,31 @@ public class AvgTests extends AbstractNumericTests {
         assertThat(avg, notNullValue());
         assertThat(avg.getName(), equalTo("avg"));
         assertThat(avg.getValue(), equalTo((double) (1+2+3+4+5+6+7+8+9+10) / 10));
+    }
+
+    @Test
+    public void testSingleValuedField_getProperty() throws Exception {
+
+        SearchResponse searchResponse = client().prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(global("global").subAggregation(avg("avg").field("value"))).execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        Global global = searchResponse.getAggregations().get("global");
+        assertThat(global, notNullValue());
+        assertThat(global.getName(), equalTo("global"));
+        assertThat(global.getDocCount(), equalTo(10l));
+        assertThat(global.getAggregations(), notNullValue());
+        assertThat(global.getAggregations().asMap().size(), equalTo(1));
+
+        Avg avg = global.getAggregations().get("avg");
+        assertThat(avg, notNullValue());
+        assertThat(avg.getName(), equalTo("avg"));
+        double expectedAvgValue = (double) (1+2+3+4+5+6+7+8+9+10) / 10;
+        assertThat(avg.getValue(), equalTo(expectedAvgValue));
+        assertThat((Avg) global.getProperty("avg"), equalTo(avg));
+        assertThat((double) global.getProperty("avg.value"), equalTo(expectedAvgValue));
+        assertThat((double) avg.getProperty("value"), equalTo(expectedAvgValue));
     }
 
     @Override

--- a/src/test/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsTests.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHitField;
+import org.elasticsearch.search.aggregations.bucket.global.Global;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms.Bucket;
 import org.elasticsearch.search.aggregations.metrics.geobounds.GeoBounds;
@@ -45,11 +46,13 @@ import java.util.List;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.geoBounds;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.global;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.core.IsNull.notNullValue;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.sameInstance;
 
 /**
  *
@@ -217,6 +220,40 @@ public class GeoBoundsTests extends ElasticsearchIntegrationTest {
         assertThat(topLeft.lon(), equalTo(singleTopLeft.lon()));
         assertThat(bottomRight.lat(), equalTo(singleBottomRight.lat()));
         assertThat(bottomRight.lon(), equalTo(singleBottomRight.lon()));
+    }
+
+    @Test
+    public void testSingleValuedField_getProperty() throws Exception {
+        SearchResponse searchResponse = client()
+                .prepareSearch("idx")
+                .setQuery(matchAllQuery())
+                .addAggregation(
+                        global("global").subAggregation(geoBounds("geoBounds").field(SINGLE_VALUED_FIELD_NAME).wrapLongitude(false)))
+                .execute().actionGet();
+
+        assertSearchResponse(searchResponse);
+
+        Global global = searchResponse.getAggregations().get("global");
+        assertThat(global, notNullValue());
+        assertThat(global.getName(), equalTo("global"));
+        assertThat(global.getDocCount(), equalTo((long) numDocs));
+        assertThat(global.getAggregations(), notNullValue());
+        assertThat(global.getAggregations().asMap().size(), equalTo(1));
+
+        GeoBounds geobounds = global.getAggregations().get("geoBounds");
+        assertThat(geobounds, notNullValue());
+        assertThat(geobounds.getName(), equalTo("geoBounds"));
+        assertThat((GeoBounds) global.getProperty("geoBounds"), sameInstance(geobounds));
+        GeoPoint topLeft = geobounds.topLeft();
+        GeoPoint bottomRight = geobounds.bottomRight();
+        assertThat(topLeft.lat(), equalTo(singleTopLeft.lat()));
+        assertThat(topLeft.lon(), equalTo(singleTopLeft.lon()));
+        assertThat(bottomRight.lat(), equalTo(singleBottomRight.lat()));
+        assertThat(bottomRight.lon(), equalTo(singleBottomRight.lon()));
+        assertThat((double) global.getProperty("geoBounds.top"), equalTo(singleTopLeft.lat()));
+        assertThat((double) global.getProperty("geoBounds.left"), equalTo(singleTopLeft.lon()));
+        assertThat((double) global.getProperty("geoBounds.bottom"), equalTo(singleBottomRight.lat()));
+        assertThat((double) global.getProperty("geoBounds.right"), equalTo(singleBottomRight.lon()));
     }
 
     @Test

--- a/src/test/java/org/elasticsearch/search/aggregations/metrics/MinTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/metrics/MinTests.java
@@ -19,11 +19,13 @@
 package org.elasticsearch.search.aggregations.metrics;
 
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.search.aggregations.bucket.global.Global;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.metrics.min.Min;
 import org.junit.Test;
 
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.global;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.histogram;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.min;
 import static org.hamcrest.Matchers.equalTo;
@@ -82,6 +84,31 @@ public class MinTests extends AbstractNumericTests {
         assertThat(min, notNullValue());
         assertThat(min.getName(), equalTo("min"));
         assertThat(min.getValue(), equalTo(1.0));
+    }
+
+    @Test
+    public void testSingleValuedField_getProperty() throws Exception {
+
+        SearchResponse searchResponse = client().prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(global("global").subAggregation(min("min").field("value"))).execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        Global global = searchResponse.getAggregations().get("global");
+        assertThat(global, notNullValue());
+        assertThat(global.getName(), equalTo("global"));
+        assertThat(global.getDocCount(), equalTo(10l));
+        assertThat(global.getAggregations(), notNullValue());
+        assertThat(global.getAggregations().asMap().size(), equalTo(1));
+
+        Min min = global.getAggregations().get("min");
+        assertThat(min, notNullValue());
+        assertThat(min.getName(), equalTo("min"));
+        double expectedMinValue = 1.0;
+        assertThat(min.getValue(), equalTo(expectedMinValue));
+        assertThat((Min) global.getProperty("min"), equalTo(min));
+        assertThat((double) global.getProperty("min.value"), equalTo(expectedMinValue));
+        assertThat((double) min.getProperty("value"), equalTo(expectedMinValue));
     }
 
     @Test

--- a/src/test/java/org/elasticsearch/search/aggregations/metrics/PercentileRanksTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/metrics/PercentileRanksTests.java
@@ -21,6 +21,7 @@ package org.elasticsearch.search.aggregations.metrics;
 import com.google.common.collect.Lists;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.search.aggregations.bucket.global.Global;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram.Order;
 import org.elasticsearch.search.aggregations.metrics.percentiles.Percentile;
@@ -32,9 +33,14 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.global;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.histogram;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.percentileRanks;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.sameInstance;
 
 /**
  *
@@ -149,6 +155,33 @@ public class PercentileRanksTests extends AbstractNumericTests {
 
         final PercentileRanks percentiles = searchResponse.getAggregations().get("percentile_ranks");
         assertConsistent(pcts, percentiles, minValue, maxValue);
+    }
+
+    @Test
+    public void testSingleValuedField_getProperty() throws Exception {
+        final double[] pcts = randomPercents(minValue, maxValue);
+        SearchResponse searchResponse = client()
+                .prepareSearch("idx")
+                .setQuery(matchAllQuery())
+                .addAggregation(
+                        global("global").subAggregation(
+                                randomCompression(percentileRanks("percentile_ranks")).field("value").percentiles(pcts))).execute()
+                .actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        Global global = searchResponse.getAggregations().get("global");
+        assertThat(global, notNullValue());
+        assertThat(global.getName(), equalTo("global"));
+        assertThat(global.getDocCount(), equalTo(10l));
+        assertThat(global.getAggregations(), notNullValue());
+        assertThat(global.getAggregations().asMap().size(), equalTo(1));
+
+        PercentileRanks percentiles = global.getAggregations().get("percentile_ranks");
+        assertThat(percentiles, notNullValue());
+        assertThat(percentiles.getName(), equalTo("percentile_ranks"));
+        assertThat((PercentileRanks) global.getProperty("percentile_ranks"), sameInstance(percentiles));
+
     }
 
     @Test

--- a/src/test/java/org/elasticsearch/search/aggregations/metrics/PercentilesTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/metrics/PercentilesTests.java
@@ -21,6 +21,7 @@ package org.elasticsearch.search.aggregations.metrics;
 import com.google.common.collect.Lists;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.search.aggregations.bucket.global.Global;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram.Order;
 import org.elasticsearch.search.aggregations.metrics.percentiles.Percentile;
@@ -32,9 +33,14 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.global;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.histogram;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.percentiles;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.sameInstance;
 
 /**
  *
@@ -75,14 +81,15 @@ public class PercentilesTests extends AbstractNumericTests {
         for (int i = 0; i < pcts.length; ++i) {
             final Percentile percentile = percentileList.get(i);
             assertThat(percentile.getPercent(), equalTo(pcts[i]));
-            assertThat(percentile.getValue(), greaterThanOrEqualTo((double) minValue));
-            assertThat(percentile.getValue(), lessThanOrEqualTo((double) maxValue));
+            double value = percentile.getValue();
+            assertThat(value, greaterThanOrEqualTo((double) minValue));
+            assertThat(value, lessThanOrEqualTo((double) maxValue));
 
             if (percentile.getPercent() == 0) {
-                assertThat(percentile.getValue(), equalTo((double) minValue));
+                assertThat(value, equalTo((double) minValue));
             }
             if (percentile.getPercent() == 100) {
-                assertThat(percentile.getValue(), equalTo((double) maxValue));
+                assertThat(value, equalTo((double) maxValue));
             }
         }
 
@@ -148,6 +155,32 @@ public class PercentilesTests extends AbstractNumericTests {
 
         final Percentiles percentiles = searchResponse.getAggregations().get("percentiles");
         assertConsistent(pcts, percentiles, minValue, maxValue);
+    }
+
+    @Test
+    public void testSingleValuedField_getProperty() throws Exception {
+        final double[] pcts = randomPercentiles();
+        SearchResponse searchResponse = client()
+                .prepareSearch("idx")
+                .setQuery(matchAllQuery())
+                .addAggregation(
+                        global("global").subAggregation(randomCompression(percentiles("percentiles")).field("value").percentiles(pcts)))
+                .execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        Global global = searchResponse.getAggregations().get("global");
+        assertThat(global, notNullValue());
+        assertThat(global.getName(), equalTo("global"));
+        assertThat(global.getDocCount(), equalTo(10l));
+        assertThat(global.getAggregations(), notNullValue());
+        assertThat(global.getAggregations().asMap().size(), equalTo(1));
+
+        Percentiles percentiles = global.getAggregations().get("percentiles");
+        assertThat(percentiles, notNullValue());
+        assertThat(percentiles.getName(), equalTo("percentiles"));
+        assertThat((Percentiles) global.getProperty("percentiles"), sameInstance(percentiles));
+
     }
 
     @Test

--- a/src/test/java/org/elasticsearch/search/aggregations/metrics/StatsTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/metrics/StatsTests.java
@@ -20,15 +20,20 @@ package org.elasticsearch.search.aggregations.metrics;
 
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.ShardSearchFailure;
+import org.elasticsearch.search.aggregations.bucket.global.Global;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.metrics.stats.Stats;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.junit.Test;
 
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.global;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.histogram;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.stats;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.sameInstance;
 
 /**
  *
@@ -101,6 +106,44 @@ public class StatsTests extends AbstractNumericTests {
         assertThat(stats.getMax(), equalTo(10.0));
         assertThat(stats.getSum(), equalTo((double) 1+2+3+4+5+6+7+8+9+10));
         assertThat(stats.getCount(), equalTo(10l));
+    }
+
+    @Test
+    public void testSingleValuedField_getProperty() throws Exception {
+
+        SearchResponse searchResponse = client().prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(global("global").subAggregation(stats("stats").field("value"))).execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        Global global = searchResponse.getAggregations().get("global");
+        assertThat(global, notNullValue());
+        assertThat(global.getName(), equalTo("global"));
+        assertThat(global.getDocCount(), equalTo(10l));
+        assertThat(global.getAggregations(), notNullValue());
+        assertThat(global.getAggregations().asMap().size(), equalTo(1));
+
+        Stats stats = global.getAggregations().get("stats");
+        assertThat(stats, notNullValue());
+        assertThat(stats.getName(), equalTo("stats"));
+        Stats statsFromProperty = (Stats) global.getProperty("stats");
+        assertThat(statsFromProperty, notNullValue());
+        assertThat(statsFromProperty, sameInstance(stats));
+        double expectedAvgValue = (double) (1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10) / 10;
+        assertThat(stats.getAvg(), equalTo(expectedAvgValue));
+        assertThat((double) global.getProperty("stats.avg"), equalTo(expectedAvgValue));
+        double expectedMinValue = 1.0;
+        assertThat(stats.getMin(), equalTo(expectedMinValue));
+        assertThat((double) global.getProperty("stats.min"), equalTo(expectedMinValue));
+        double expectedMaxValue = 10.0;
+        assertThat(stats.getMax(), equalTo(expectedMaxValue));
+        assertThat((double) global.getProperty("stats.max"), equalTo(expectedMaxValue));
+        double expectedSumValue = (double) (1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10);
+        assertThat(stats.getSum(), equalTo(expectedSumValue));
+        assertThat((double) global.getProperty("stats.sum"), equalTo(expectedSumValue));
+        long expectedCountValue = 10;
+        assertThat(stats.getCount(), equalTo(expectedCountValue));
+        assertThat((double) global.getProperty("stats.count"), equalTo((double) expectedCountValue));
     }
 
     @Test

--- a/src/test/java/org/elasticsearch/search/aggregations/support/PathTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/support/PathTests.java
@@ -58,7 +58,7 @@ public class PathTests extends ElasticsearchTestCase {
 
     private void assertInvalidPath(String path, String reason) {
         try {
-            OrderPath.parse(path);
+            AggregationPath.parse(path);
             fail("Expected parsing path [" + path + "] to fail - " + reason);
         } catch (AggregationExecutionException aee) {
             // expected
@@ -66,12 +66,12 @@ public class PathTests extends ElasticsearchTestCase {
     }
 
     private void assertValidPath(String path, Tokens tokenz) {
-        OrderPath.Token[] tokens = tokenz.toArray();
-        OrderPath p = OrderPath.parse(path);
-        assertThat(p.tokens.length, equalTo(tokens.length));
-        for (int i = 0; i < p.tokens.length; i++) {
-            OrderPath.Token t1 = p.tokens[i];
-            OrderPath.Token t2 = tokens[i];
+        AggregationPath.PathElement[] tokens = tokenz.toArray();
+        AggregationPath p = AggregationPath.parse(path);
+        assertThat(p.getPathElements().size(), equalTo(tokens.length));
+        for (int i = 0; i < p.getPathElements().size(); i++) {
+            AggregationPath.PathElement t1 = p.getPathElements().get(i);
+            AggregationPath.PathElement t2 = tokens[i];
             assertThat(t1, equalTo(t2));
         }
     }
@@ -82,24 +82,24 @@ public class PathTests extends ElasticsearchTestCase {
 
     private static class Tokens {
 
-        private List<OrderPath.Token> tokens = new ArrayList<>();
+        private List<AggregationPath.PathElement> tokens = new ArrayList<>();
 
         Tokens add(String name) {
-            tokens.add(new OrderPath.Token(name, name, null));
+            tokens.add(new AggregationPath.PathElement(name, name, null));
             return this;
         }
 
         Tokens add(String name, String key) {
             if (Math.random() > 0.5) {
-                tokens.add(new OrderPath.Token(name + "." + key, name, key));
+                tokens.add(new AggregationPath.PathElement(name + "." + key, name, key));
             } else {
-                tokens.add(new OrderPath.Token(name + "[" + key + "]", name, key));
+                tokens.add(new AggregationPath.PathElement(name + "[" + key + "]", name, key));
             }
             return this;
         }
 
-        OrderPath.Token[] toArray() {
-            return tokens.toArray(new OrderPath.Token[tokens.size()]);
+        AggregationPath.PathElement[] toArray() {
+            return tokens.toArray(new AggregationPath.PathElement[tokens.size()]);
         }
 
 


### PR DESCRIPTION
This allows arbitrary properties to be retrieved from an aggregation tree. The property is specified using the same syntax as the
order parameter in the terms aggregation. If a property path contians a multi-bucket aggregation the property values from each bucket will be returned in an array.
