### PR TITLE
Add option for analyzing wildcard/prefix to simple_query_strinq

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
@@ -39,6 +39,7 @@ public class SimpleQueryStringBuilder extends BaseQueryBuilder {
     private int flags = -1;
     private Boolean lowercaseExpandedTerms;
     private Boolean lenient;
+    private Boolean analyzeWildcard;
     private Locale locale;
 
     /**
@@ -128,6 +129,11 @@ public class SimpleQueryStringBuilder extends BaseQueryBuilder {
         return this;
     }
 
+    public SimpleQueryStringBuilder analyzeWildcard(boolean analyzeWildcard) {
+        this.analyzeWildcard = analyzeWildcard;
+        return this;
+    }
+
     @Override
     public void doXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(SimpleQueryStringParser.NAME);
@@ -166,6 +172,10 @@ public class SimpleQueryStringBuilder extends BaseQueryBuilder {
 
         if (lenient != null) {
             builder.field("lenient", lenient);
+        }
+
+        if (analyzeWildcard != null) {
+            builder.field("analyze_wildcard", analyzeWildcard);
         }
 
         if (locale != null) {

--- a/src/main/java/org/elasticsearch/index/query/SimpleQueryStringParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SimpleQueryStringParser.java
@@ -178,6 +178,8 @@ public class SimpleQueryStringParser implements QueryParser {
                     sqsSettings.lowercaseExpandedTerms(parser.booleanValue());
                 } else if ("lenient".equals(currentFieldName)) {
                     sqsSettings.lenient(parser.booleanValue());
+                } else if ("analyze_wildcard".equals(currentFieldName)) {
+                    sqsSettings.analyzeWildcard(parser.booleanValue());
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {

--- a/src/test/java/org/elasticsearch/search/query/SimpleQueryStringTests.java
+++ b/src/test/java/org/elasticsearch/search/query/SimpleQueryStringTests.java
@@ -19,7 +19,9 @@
 
 package org.elasticsearch.search.query;
 
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.SimpleQueryStringBuilder;
 import org.elasticsearch.index.query.SimpleQueryStringFlag;
@@ -266,4 +268,30 @@ public class SimpleQueryStringTests extends ElasticsearchIntegrationTest {
         assertHitCount(resp, 1);
         assertSearchHits(resp, "1");
     }
+
+    @Test
+    public void testSimpleQueryStringAnalyzeWildcard() throws ExecutionException, InterruptedException, IOException {
+        String mapping = XContentFactory.jsonBuilder()
+                .startObject()
+                .startObject("type1")
+                .startObject("properties")
+                .startObject("location")
+                .field("type", "string")
+                .field("analyzer", "german")
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject().string();
+
+        CreateIndexRequestBuilder mappingRequest = client().admin().indices().prepareCreate("test1").addMapping("type1", mapping);
+        mappingRequest.execute().actionGet();
+        indexRandom(true, client().prepareIndex("test1", "type1", "1").setSource("location", "Köln"));
+        refresh();
+
+        SearchResponse searchResponse = client().prepareSearch().setQuery(simpleQueryString("Köln*").analyzeWildcard(true).field("location")).get();
+        assertNoFailures(searchResponse);
+        assertHitCount(searchResponse, 1l);
+        assertSearchHits(searchResponse, "1");
+    }
+
 }


### PR DESCRIPTION
The query_string query has an option for analyzing wildcard/prefix (#787) by a best effort approach.

This adds `analyze_wildcard` option also to simple_query_string.

The default is set to `false` so the existing behavior of simple_query_string is unchanged.
