### PR TITLE
Remove `index.percolator.allow_unmapped_fields` setting.

### DIFF
--- a/src/main/java/org/elasticsearch/index/percolator/PercolatorQueriesRegistry.java
+++ b/src/main/java/org/elasticsearch/index/percolator/PercolatorQueriesRegistry.java
@@ -68,8 +68,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public class PercolatorQueriesRegistry extends AbstractIndexShardComponent {
 
-    public final static String ALLOW_UNMAPPED_FIELDS = "index.percolator.allow_unmapped_fields";
-
     // This is a shard level service, but these below are index level service:
     private final IndexQueryParserService queryParserService;
     private final MapperService mapperService;
@@ -85,7 +83,6 @@ public class PercolatorQueriesRegistry extends AbstractIndexShardComponent {
     private final RealTimePercolatorOperationListener realTimePercolatorOperationListener = new RealTimePercolatorOperationListener();
     private final PercolateTypeListener percolateTypeListener = new PercolateTypeListener();
     private final AtomicBoolean realTimePercolatorEnabled = new AtomicBoolean(false);
-    private final boolean allowUnmappedFields;
 
     private CloseableThreadLocal<QueryParseContext> cache = new CloseableThreadLocal<QueryParseContext>() {
         @Override
@@ -106,7 +103,6 @@ public class PercolatorQueriesRegistry extends AbstractIndexShardComponent {
         this.indexCache = indexCache;
         this.indexFieldDataService = indexFieldDataService;
         this.shardPercolateService = shardPercolateService;
-        this.allowUnmappedFields = indexSettings.getAsBoolean(ALLOW_UNMAPPED_FIELDS, false);
 
         indicesLifecycle.addListener(shardLifecycleListener);
         mapperService.addTypeListener(percolateTypeListener);
@@ -203,7 +199,16 @@ public class PercolatorQueriesRegistry extends AbstractIndexShardComponent {
         QueryParseContext context = cache.get();
         try {
             context.reset(parser);
-            context.setAllowUnmappedFields(allowUnmappedFields);
+            // This means that fields in the query need to exist in the mapping prior to registering this query
+            // The reason that this is required, is that if a field doesn't exist then the query assumes defaults, which may be undesired.
+            //
+            // Even worse when fields mentioned in percolator queries do go added to map after the queries have been registered
+            // then the percolator queries don't work as expected any more.
+            //
+            // Query parsing can't introduce new fields in mappings (which happens when registering a percolator query),
+            // because field type can't be inferred from queries (like document do) so the best option here is to disallow
+            // the usage of unmapped fields in percolator queries to avoid unexpected behaviour
+            context.setAllowUnmappedFields(false);
             return queryParserService.parseInnerQuery(context);
         } catch (IOException e) {
             throw new QueryParsingException(queryParserService.index(), "Failed to parse", e);


### PR DESCRIPTION
There should be no way to opt out from strict field resolution for percolator query parsing.
