### PR TITLE
Set bloom default to false even when Directory doesn't have a codecService

### DIFF
--- a/src/main/java/org/elasticsearch/index/codec/postingsformat/BloomFilterPostingsFormat.java
+++ b/src/main/java/org/elasticsearch/index/codec/postingsformat/BloomFilterPostingsFormat.java
@@ -164,7 +164,7 @@ public final class BloomFilterPostingsFormat extends PostingsFormat {
                         .readString();
                 int numBlooms = bloomIn.readInt();
 
-                boolean load = true;
+                boolean load = false;
                 Store.StoreDirectory storeDir = DirectoryUtils.getStoreDirectory(state.directory);
                 if (storeDir != null && storeDir.codecService() != null) {
                     load = storeDir.codecService().isLoadBloomFilter();

--- a/src/test/java/org/elasticsearch/index/codec/postingformat/DefaultPostingsFormatTests.java
+++ b/src/test/java/org/elasticsearch/index/codec/postingformat/DefaultPostingsFormatTests.java
@@ -75,7 +75,7 @@ public class DefaultPostingsFormatTests extends ElasticsearchTestCase {
 
         assertThat(terms.size(), equalTo(1l));
         assertThat(terms, not(instanceOf(BloomFilterPostingsFormat.BloomFilteredTerms.class)));
-        assertThat(uidTerms, instanceOf(BloomFilterPostingsFormat.BloomFilteredTerms.class));
+        assertThat(uidTerms, not(instanceOf(BloomFilterPostingsFormat.BloomFilteredTerms.class)));
 
         reader.close();
         writer.close();


### PR DESCRIPTION
We disabled loading of bloom filters by default a while ago, but in the code we still default to true if the directory is not a StoreDirectory or doesn't have a codecService.  I don't know if this ever happens, but in a standalone test (using my own FSDirectory) I suddenly saw bloom filters being loaded so I want to defensively fix this.
