### PR TITLE
Indices API: Fix GET index API always running all features

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexRequest.java
@@ -19,7 +19,9 @@
 
 package org.elasticsearch.action.admin.indices.get;
 
+import com.google.common.collect.ObjectArrays;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.info.ClusterInfoRequest;
@@ -28,16 +30,82 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * A request to delete an index. Best created with {@link org.elasticsearch.client.Requests#deleteIndexRequest(String)}.
  */
 public class GetIndexRequest extends ClusterInfoRequest<GetIndexRequest> {
 
-    private String[] features = new String[] { "_settings", "_warmers", "_mappings", "_aliases" };
+    public static enum Feature {
+        ALIASES((byte) 0, "_aliases", "_alias"),
+        MAPPINGS((byte) 1, "_mappings", "_mapping"),
+        SETTINGS((byte) 2, "_settings"),
+        WARMERS((byte) 3, "_warmers", "_warmer");
+
+        private static final Feature[] FEATURES = new Feature[Feature.values().length];
+
+        static {
+            for (Feature feature : Feature.values()) {
+                assert feature.id() < FEATURES.length && feature.id() >= 0;
+                FEATURES[feature.id] = feature;
+            }
+        }
+
+        private final List<String> validNames;
+        private final String preferredName;
+        private final byte id;
+
+        private Feature(byte id, String... validNames) {
+            assert validNames != null && validNames.length > 0;
+            this.id = id;
+            this.validNames = Arrays.asList(validNames);
+            this.preferredName = validNames[0];
+        }
+
+        public byte id() {
+            return id;
+        }
+
+        public String preferredName() {
+            return preferredName;
+        }
+
+        public boolean validName(String name) {
+            return this.validNames.contains(name);
+        }
+
+        public static Feature fromName(String name) throws ElasticsearchIllegalArgumentException {
+            for (Feature feature : Feature.values()) {
+                if (feature.validName(name)) {
+                    return feature;
+                }
+            }
+            throw new ElasticsearchIllegalArgumentException("No feature for name [" + name + "]");
+        }
+
+        public static Feature fromId(byte id) throws ElasticsearchIllegalArgumentException {
+            if (id < 0 || id >= FEATURES.length) {
+                throw new ElasticsearchIllegalArgumentException("No mapping for id [" + id + "]");
+            }
+            return FEATURES[id];
+        }
+
+        public static Feature[] convertToFeatures(String... featureNames) {
+            Feature[] features = new Feature[featureNames.length];
+            for (int i = 0; i < featureNames.length; i++) {
+                features[i] = Feature.fromName(featureNames[i]);
+            }
+            return features;
+        }
+    }
+
+    private static final Feature[] DEFAULT_FEATURES = new Feature[] { Feature.ALIASES, Feature.MAPPINGS, Feature.SETTINGS, Feature.WARMERS };
+    private Feature[] features = DEFAULT_FEATURES;
     private boolean indicesOptionsSet = false;
 
-    public GetIndexRequest features(String[] features) {
+    public GetIndexRequest features(Feature... features) {
         if (features == null) {
             throw new ElasticsearchIllegalArgumentException("features cannot be null");
         } else {
@@ -46,7 +114,45 @@ public class GetIndexRequest extends ClusterInfoRequest<GetIndexRequest> {
         return this;
     }
 
+    /**
+     * @deprecated use {@link #features(Feature[])} instead
+     */
+    @Deprecated
+    public GetIndexRequest features(String[] featureNames) {
+        features(Feature.convertToFeatures(featureNames));
+        return this;
+    }
+
+    public GetIndexRequest addFeatures(Feature... features) {
+        if (this.features == DEFAULT_FEATURES) {
+            return features(features);
+        } else {
+            return features(ObjectArrays.concat(featuresAsEnums(), features, Feature.class));
+        }
+    }
+
+    /**
+     * @deprecated use {@link #addFeatures(Feature[])} instead
+     */
+    @Deprecated
+    public GetIndexRequest addFeatures(String[] featureNames) {
+        addFeatures(Feature.convertToFeatures(featureNames));
+        return this;
+    }
+
+    /**
+     * @deprecated use {@link #featuresAsEnums()} instead
+     */
+    @Deprecated
     public String[] features() {
+        String[] featureNames = new String[features.length];
+        for (int i = 0; i < features.length; i++) {
+            featureNames[i] = features[i].preferredName();
+        }
+        return featureNames;
+    }
+
+    public Feature[] featuresAsEnums() {
         return features;
     }
     
@@ -58,14 +164,33 @@ public class GetIndexRequest extends ClusterInfoRequest<GetIndexRequest> {
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        features = in.readStringArray();
+        if (in.getVersion().before(Version.V_1_4_1)) {
+            Feature.convertToFeatures(in.readStringArray());
+        } else {
+            int size = in.readVInt();
+            features = new Feature[size];
+            for (int i = 0; i < size; i++) {
+                features[i] = Feature.fromId(in.readByte());
+            }
+        }
         indicesOptionsSet = in.readBoolean();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeStringArray(features);
+        if (out.getVersion().before(Version.V_1_4_1)) {
+            String[] featureNames = new String[features.length];
+            for (int i = 0; i< features.length; i++) {
+                featureNames[i] = features[i].preferredName();
+            }
+            out.writeStringArray(featureNames);
+        } else {
+            out.writeVInt(features.length);
+            for (Feature feature : features) {
+                out.writeByte(feature.id);
+            }
+        }
         out.writeBoolean(indicesOptionsSet);
     }
 
@@ -88,7 +213,7 @@ public class GetIndexRequest extends ClusterInfoRequest<GetIndexRequest> {
         IndicesOptions defaultIndicesOptions = IndicesOptions.strictExpandOpen();
         String[] indices = indices();
         // This makes sure that the get aliases API behaves exactly like in previous versions wrt indices options iff only aliases are requested
-        if (features != null && features.length == 1 && features[0] != null && ("_alias".equals(features[0]) || "_aliases".equals(features[0]))) {
+        if (features != null && features.length == 1 && features[0] != null && Feature.ALIASES.equals(features[0])) {
             // If we are asking for all indices we need to return open and closed, if not we only expand to open
             if (MetaData.isAllIndices(indices)) {
                 defaultIndicesOptions = IndicesOptions.fromOptions(true, true, true, true);

--- a/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexRequestBuilder.java
@@ -19,8 +19,8 @@
 
 package org.elasticsearch.action.admin.indices.get;
 
-import com.google.common.collect.ObjectArrays;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.get.GetIndexRequest.Feature;
 import org.elasticsearch.action.support.master.info.ClusterInfoRequestBuilder;
 import org.elasticsearch.client.IndicesAdminClient;
 
@@ -33,13 +33,31 @@ public class GetIndexRequestBuilder extends ClusterInfoRequestBuilder<GetIndexRe
         super(client, new GetIndexRequest().indices(indices));
     }
 
-    public GetIndexRequestBuilder setFeatures(String... features) {
+    public GetIndexRequestBuilder setFeatures(Feature... features) {
         request.features(features);
         return this;
     }
 
-    public GetIndexRequestBuilder addFeatures(String... features) {
-        request.features(ObjectArrays.concat(request.features(), features, String.class));
+    public GetIndexRequestBuilder addFeatures(Feature... features) {
+        request.addFeatures(features);
+        return this;
+    }
+
+    /**
+     * @deprecated use {@link #setFeatures(Feature[])} instead
+     */
+    @Deprecated
+    public GetIndexRequestBuilder setFeatures(String... featureNames) {
+        request.features(featureNames);
+        return this;
+    }
+
+    /**
+     * @deprecated use {@link #addFeatures(Feature[])} instead
+     */
+    @Deprecated
+    public GetIndexRequestBuilder addFeatures(String... featureNames) {
+        request.addFeatures(featureNames);
         return this;
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexResponse.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.admin.indices.get;
 
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import com.google.common.collect.ImmutableList;
+
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.admin.indices.alias.get.GetAliasesResponse;
 import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsResponse;
@@ -57,10 +58,18 @@ public class GetIndexResponse extends ActionResponse {
             ImmutableOpenMap<String, ImmutableOpenMap<String, MappingMetaData>> mappings,
             ImmutableOpenMap<String, ImmutableList<AliasMetaData>> aliases, ImmutableOpenMap<String, Settings> settings) {
         this.indices = indices;
-        this.warmers = warmers;
-        this.mappings = mappings;
-        this.aliases = aliases;
-        this.settings = settings;
+        if (warmers != null) {
+            this.warmers = warmers;
+        }
+        if (mappings != null) {
+            this.mappings = mappings;
+        }
+        if (aliases != null) {
+            this.aliases = aliases;
+        }
+        if (settings != null) {
+            this.settings = settings;
+        }
     }
 
     GetIndexResponse() {

--- a/src/main/java/org/elasticsearch/action/admin/indices/get/TransportGetIndexAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/get/TransportGetIndexAction.java
@@ -20,9 +20,11 @@
 package org.elasticsearch.action.admin.indices.get;
 
 import com.google.common.collect.ImmutableList;
+
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchIllegalStateException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.get.GetIndexRequest.Feature;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.info.TransportClusterInfoAction;
 import org.elasticsearch.cluster.ClusterService;
@@ -78,35 +80,32 @@ public class TransportGetIndexAction extends TransportClusterInfoAction<GetIndex
         ImmutableOpenMap<String, ImmutableOpenMap<String, MappingMetaData>> mappingsResult = ImmutableOpenMap.of();
         ImmutableOpenMap<String, ImmutableList<AliasMetaData>> aliasesResult = ImmutableOpenMap.of();
         ImmutableOpenMap<String, Settings> settings = ImmutableOpenMap.of();
-        String[] features = request.features();
+        Feature[] features = request.featuresAsEnums();
         boolean doneAliases = false;
         boolean doneMappings = false;
         boolean doneSettings = false;
         boolean doneWarmers = false;
-        for (String feature : features) {
+        for (Feature feature : features) {
             switch (feature) {
-                case "_warmer":
-                case "_warmers":
+            case WARMERS:
                     if (!doneWarmers) {
                         warmersResult = state.metaData().findWarmers(concreteIndices, request.types(), Strings.EMPTY_ARRAY);
                         doneWarmers = true;
                     }
                     break;
-                case "_mapping":
-                case "_mappings":
+            case MAPPINGS:
                     if (!doneMappings) {
                         mappingsResult = state.metaData().findMappings(concreteIndices, request.types());
                         doneMappings = true;
                     }
                     break;
-                case "_alias":
-                case "_aliases":
+            case ALIASES:
                     if (!doneAliases) {
                         aliasesResult = state.metaData().findAliases(Strings.EMPTY_ARRAY, concreteIndices);
                         doneAliases = true;
                     }
                     break;
-                case "_settings":
+            case SETTINGS:
                     if (!doneSettings) {
                         ImmutableOpenMap.Builder<String, Settings> settingsMapBuilder = ImmutableOpenMap.builder();
                         for (String index : concreteIndices) {

--- a/src/test/java/org/elasticsearch/action/admin/indices/get/GetIndexTests.java
+++ b/src/test/java/org/elasticsearch/action/admin/indices/get/GetIndexTests.java
@@ -20,8 +20,10 @@
 package org.elasticsearch.action.admin.indices.get;
 
 import com.google.common.collect.ImmutableList;
-import org.elasticsearch.ElasticsearchIllegalStateException;
+
+import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.action.admin.indices.alias.Alias;
+import org.elasticsearch.action.admin.indices.get.GetIndexRequest.Feature;
 import org.elasticsearch.cluster.metadata.AliasMetaData;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
@@ -36,7 +38,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
 
 @ElasticsearchIntegrationTest.SuiteScopeTest
 public class GetIndexTests extends ElasticsearchIntegrationTest {
@@ -68,7 +72,7 @@ public class GetIndexTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testSimpleMapping() {
-        GetIndexResponse response = client().admin().indices().prepareGetIndex().addIndices("idx").setFeatures("_mapping").get();
+        GetIndexResponse response = runWithRandomFeatureMethod(client().admin().indices().prepareGetIndex().addIndices("idx"), "_mapping");
         String[] indices = response.indices();
         assertThat(indices, notNullValue());
         assertThat(indices.length, equalTo(1));
@@ -81,7 +85,7 @@ public class GetIndexTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testSimpleMappings() {
-        GetIndexResponse response = client().admin().indices().prepareGetIndex().addIndices("idx").setFeatures("_mappings").get();
+        GetIndexResponse response = runWithRandomFeatureMethod(client().admin().indices().prepareGetIndex().addIndices("idx"), "_mappings");
         String[] indices = response.indices();
         assertThat(indices, notNullValue());
         assertThat(indices.length, equalTo(1));
@@ -94,7 +98,7 @@ public class GetIndexTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testSimpleAlias() {
-        GetIndexResponse response = client().admin().indices().prepareGetIndex().addIndices("idx").setFeatures("_alias").get();
+        GetIndexResponse response = runWithRandomFeatureMethod(client().admin().indices().prepareGetIndex().addIndices("idx"), "_alias");
         String[] indices = response.indices();
         assertThat(indices, notNullValue());
         assertThat(indices.length, equalTo(1));
@@ -107,7 +111,7 @@ public class GetIndexTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testSimpleAliases() {
-        GetIndexResponse response = client().admin().indices().prepareGetIndex().addIndices("idx").setFeatures("_aliases").get();
+        GetIndexResponse response = runWithRandomFeatureMethod(client().admin().indices().prepareGetIndex().addIndices("idx"), "_aliases");
         String[] indices = response.indices();
         assertThat(indices, notNullValue());
         assertThat(indices.length, equalTo(1));
@@ -120,7 +124,7 @@ public class GetIndexTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testSimpleSettings() {
-        GetIndexResponse response = client().admin().indices().prepareGetIndex().addIndices("idx").setFeatures("_settings").get();
+        GetIndexResponse response = runWithRandomFeatureMethod(client().admin().indices().prepareGetIndex().addIndices("idx"), "_settings");
         String[] indices = response.indices();
         assertThat(indices, notNullValue());
         assertThat(indices.length, equalTo(1));
@@ -133,7 +137,7 @@ public class GetIndexTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testSimpleWarmer() {
-        GetIndexResponse response = client().admin().indices().prepareGetIndex().addIndices("idx").setFeatures("_warmer").get();
+        GetIndexResponse response = runWithRandomFeatureMethod(client().admin().indices().prepareGetIndex().addIndices("idx"), "_warmer");
         String[] indices = response.indices();
         assertThat(indices, notNullValue());
         assertThat(indices.length, equalTo(1));
@@ -146,7 +150,7 @@ public class GetIndexTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testSimpleWarmers() {
-        GetIndexResponse response = client().admin().indices().prepareGetIndex().addIndices("idx").setFeatures("_warmers").get();
+        GetIndexResponse response = runWithRandomFeatureMethod(client().admin().indices().prepareGetIndex().addIndices("idx"), "_warmers");
         String[] indices = response.indices();
         assertThat(indices, notNullValue());
         assertThat(indices.length, equalTo(1));
@@ -162,9 +166,9 @@ public class GetIndexTests extends ElasticsearchIntegrationTest {
         client().admin().indices().prepareGetIndex().addIndices("missing_idx").get();
     }
 
-    @Test(expected=ElasticsearchIllegalStateException.class)
+    @Test(expected = ElasticsearchIllegalArgumentException.class)
     public void testSimpleUnknownFeature() {
-        client().admin().indices().prepareGetIndex().addIndices("idx").setFeatures("_foo").get();
+        runWithRandomFeatureMethod(client().admin().indices().prepareGetIndex().addIndices("idx"), "_foo");
     }
 
     @Test
@@ -174,8 +178,8 @@ public class GetIndexTests extends ElasticsearchIntegrationTest {
         for (int i = 0; i < numFeatures; i++) {
             features.add(randomFrom(allFeatures));
         }
-        GetIndexResponse response = client().admin().indices().prepareGetIndex().addIndices("idx")
-                .setFeatures(features.toArray(new String[features.size()])).get();
+        GetIndexResponse response = runWithRandomFeatureMethod(client().admin().indices().prepareGetIndex().addIndices("idx"),
+                features.toArray(new String[features.size()]));
         String[] indices = response.indices();
         assertThat(indices, notNullValue());
         assertThat(indices.length, equalTo(1));
@@ -222,8 +226,8 @@ public class GetIndexTests extends ElasticsearchIntegrationTest {
         for (int i = 0; i < numFeatures; i++) {
             features.add(randomFrom(allFeatures));
         }
-        GetIndexResponse response = client().admin().indices().prepareGetIndex().addIndices("empty_idx")
-                .setFeatures(features.toArray(new String[features.size()])).get();
+        GetIndexResponse response = runWithRandomFeatureMethod(client().admin().indices().prepareGetIndex().addIndices("empty_idx"),
+                features.toArray(new String[features.size()]));
         String[] indices = response.indices();
         assertThat(indices, notNullValue());
         assertThat(indices.length, equalTo(1));
@@ -240,6 +244,141 @@ public class GetIndexTests extends ElasticsearchIntegrationTest {
             assertEmptySettings(response);
         }
         assertEmptyWarmers(response);
+    }
+
+    @Test
+    public void testSimpleMappingEnum() {
+        GetIndexResponse response = runWithRandomFeatureMethod(client().admin().indices().prepareGetIndex().addIndices("idx"),
+                Feature.MAPPINGS);
+        String[] indices = response.indices();
+        assertThat(indices, notNullValue());
+        assertThat(indices.length, equalTo(1));
+        assertThat(indices[0], equalTo("idx"));
+        assertMappings(response, "idx");
+        assertEmptyAliases(response);
+        assertEmptySettings(response);
+        assertEmptyWarmers(response);
+    }
+
+    @Test
+    public void testSimpleAliasEnum() {
+        GetIndexResponse response = runWithRandomFeatureMethod(client().admin().indices().prepareGetIndex().addIndices("idx"),
+                Feature.ALIASES);
+        String[] indices = response.indices();
+        assertThat(indices, notNullValue());
+        assertThat(indices.length, equalTo(1));
+        assertThat(indices[0], equalTo("idx"));
+        assertAliases(response, "idx");
+        assertEmptyMappings(response);
+        assertEmptySettings(response);
+        assertEmptyWarmers(response);
+    }
+
+    @Test
+    public void testSimpleSettingsEnum() {
+        GetIndexResponse response = runWithRandomFeatureMethod(client().admin().indices().prepareGetIndex().addIndices("idx"),
+                Feature.SETTINGS);
+        String[] indices = response.indices();
+        assertThat(indices, notNullValue());
+        assertThat(indices.length, equalTo(1));
+        assertThat(indices[0], equalTo("idx"));
+        assertSettings(response, "idx");
+        assertEmptyAliases(response);
+        assertEmptyMappings(response);
+        assertEmptyWarmers(response);
+    }
+
+    @Test
+    public void testSimpleWarmerEnum() {
+        GetIndexResponse response = runWithRandomFeatureMethod(client().admin().indices().prepareGetIndex().addIndices("idx"),
+                Feature.WARMERS);
+        String[] indices = response.indices();
+        assertThat(indices, notNullValue());
+        assertThat(indices.length, equalTo(1));
+        assertThat(indices[0], equalTo("idx"));
+        assertWarmers(response, "idx");
+        assertEmptyAliases(response);
+        assertEmptyMappings(response);
+        assertEmptySettings(response);
+    }
+
+    @Test
+    public void testSimpleMixedFeaturesEnum() {
+        int numFeatures = randomIntBetween(1, Feature.values().length);
+        List<Feature> features = new ArrayList<Feature>(numFeatures);
+        for (int i = 0; i < numFeatures; i++) {
+            features.add(randomFrom(Feature.values()));
+        }
+        GetIndexResponse response = runWithRandomFeatureMethod(client().admin().indices().prepareGetIndex().addIndices("idx"),
+                features.toArray(new Feature[features.size()]));
+        String[] indices = response.indices();
+        assertThat(indices, notNullValue());
+        assertThat(indices.length, equalTo(1));
+        assertThat(indices[0], equalTo("idx"));
+        if (features.contains(Feature.ALIASES)) {
+            assertAliases(response, "idx");
+        } else {
+            assertEmptyAliases(response);
+        }
+        if (features.contains(Feature.MAPPINGS)) {
+            assertMappings(response, "idx");
+        } else {
+            assertEmptyMappings(response);
+        }
+        if (features.contains(Feature.SETTINGS)) {
+            assertSettings(response, "idx");
+        } else {
+            assertEmptySettings(response);
+        }
+        if (features.contains(Feature.WARMERS)) {
+            assertWarmers(response, "idx");
+        } else {
+            assertEmptyWarmers(response);
+        }
+    }
+
+    @Test
+    public void testEmptyMixedFeaturesEnum() {
+        int numFeatures = randomIntBetween(1, Feature.values().length);
+        List<Feature> features = new ArrayList<Feature>(numFeatures);
+        for (int i = 0; i < numFeatures; i++) {
+            features.add(randomFrom(Feature.values()));
+        }
+        GetIndexResponse response = runWithRandomFeatureMethod(client().admin().indices().prepareGetIndex().addIndices("empty_idx"),
+                features.toArray(new Feature[features.size()]));
+        String[] indices = response.indices();
+        assertThat(indices, notNullValue());
+        assertThat(indices.length, equalTo(1));
+        assertThat(indices[0], equalTo("empty_idx"));
+        assertEmptyAliases(response);
+        if (features.contains(Feature.MAPPINGS)) {
+            assertEmptyOrOnlyDefaultMappings(response, "empty_idx");
+        } else {
+            assertEmptyMappings(response);
+        }
+        if (features.contains(Feature.SETTINGS)) {
+            assertNonEmptySettings(response, "empty_idx");
+        } else {
+            assertEmptySettings(response);
+        }
+        assertEmptyWarmers(response);
+    }
+
+    @Deprecated
+    private GetIndexResponse runWithRandomFeatureMethod(GetIndexRequestBuilder requestBuilder, String... features) {
+        if (randomBoolean()) {
+            return requestBuilder.addFeatures(features).get();
+        } else {
+            return requestBuilder.setFeatures(features).get();
+        }
+    }
+
+    private GetIndexResponse runWithRandomFeatureMethod(GetIndexRequestBuilder requestBuilder, Feature... features) {
+        if (randomBoolean()) {
+            return requestBuilder.addFeatures(features).get();
+        } else {
+            return requestBuilder.setFeatures(features).get();
+        }
     }
 
     @Test(expected=IndexMissingException.class)


### PR DESCRIPTION
Previous to this change all features (_alias,_mapping,_settings,_warmer) are run regardless of which features are actually requested. This change fixes the request object to resolve this bug.

This change is for 1.4 and a.x branches see https://github.com/elasticsearch/elasticsearch/pull/8392 for equivalent change in master
