### PR TITLE
Internal: Don't pass acceptdocs down to nonNestedDocsFilter in ParentsFilter

### DIFF
--- a/src/main/java/org/elasticsearch/index/search/child/ParentIdsFilter.java
+++ b/src/main/java/org/elasticsearch/index/search/child/ParentIdsFilter.java
@@ -141,7 +141,7 @@ final class ParentIdsFilter extends Filter {
 
         FixedBitSet nonNestedDocs = null;
         if (nonNestedDocsFilter != null) {
-            nonNestedDocs = (FixedBitSet) nonNestedDocsFilter.getDocIdSet(context, acceptDocs);
+            nonNestedDocs = (FixedBitSet) nonNestedDocsFilter.getDocIdSet(context, null);
         }
 
         DocsEnum docsEnum = null;

--- a/src/test/java/org/elasticsearch/index/search/child/ChildrenConstantScoreQueryTests.java
+++ b/src/test/java/org/elasticsearch/index/search/child/ChildrenConstantScoreQueryTests.java
@@ -27,6 +27,7 @@ import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.*;
 import org.apache.lucene.queries.TermFilter;
 import org.apache.lucene.search.*;
+import org.apache.lucene.search.join.FixedBitSetCachingWrapperFilter;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.FixedBitSet;
 import org.apache.lucene.util.LuceneTestCase;
@@ -277,7 +278,7 @@ public class ChildrenConstantScoreQueryTests extends ElasticsearchLuceneTestCase
             String childValue = childValues[random().nextInt(numUniqueChildValues)];
             TermQuery childQuery = new TermQuery(new Term("field1", childValue));
             int shortCircuitParentDocSet = random().nextInt(numParentDocs);
-            Filter nonNestedDocsFilter = random().nextBoolean() ? SearchContext.current().filterCache().cache(NonNestedDocsFilter.INSTANCE) : null;
+            Filter nonNestedDocsFilter = random().nextBoolean() ? new FixedBitSetCachingWrapperFilter(SearchContext.current().filterCache().cache(NonNestedDocsFilter.INSTANCE)) : null;
             Query query;
             if (random().nextBoolean()) {
                 // Usage in HasChildQueryParser

--- a/src/test/java/org/elasticsearch/index/search/child/ChildrenQueryTests.java
+++ b/src/test/java/org/elasticsearch/index/search/child/ChildrenQueryTests.java
@@ -29,6 +29,7 @@ import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.*;
 import org.apache.lucene.queries.TermFilter;
 import org.apache.lucene.search.*;
+import org.apache.lucene.search.join.FixedBitSetCachingWrapperFilter;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.FixedBitSet;
 import org.apache.lucene.util.LuceneTestCase;
@@ -224,7 +225,7 @@ public class ChildrenQueryTests extends ElasticsearchLuceneTestCase {
             Query childQuery = new ConstantScoreQuery(new TermQuery(new Term("field1", childValue)));
             int shortCircuitParentDocSet = random().nextInt(numParentDocs);
             ScoreType scoreType = ScoreType.values()[random().nextInt(ScoreType.values().length)];
-            Filter nonNestedDocsFilter = random().nextBoolean() ? SearchContext.current().filterCache().cache(NonNestedDocsFilter.INSTANCE) : null;
+            Filter nonNestedDocsFilter = random().nextBoolean() ? new FixedBitSetCachingWrapperFilter(SearchContext.current().filterCache().cache(NonNestedDocsFilter.INSTANCE)) : null;
 
             // leave min/max set to 0 half the time
             int minChildren = random().nextInt(2) * scaledRandomIntBetween(0, 110);


### PR DESCRIPTION
PR for #8461. The bug can only occur in 1.3.5, but should be backported to the other branches as well.

The PR is against 1.3 branch
