### PR TITLE
Do not force the post-filter to be loaded into a BitSet.

### DIFF
--- a/src/main/java/org/elasticsearch/common/lucene/search/FilteredCollector.java
+++ b/src/main/java/org/elasticsearch/common/lucene/search/FilteredCollector.java
@@ -69,12 +69,21 @@ public class FilteredCollector implements XCollector {
         } else {
             iterator = set.iterator();
         }
+        if (iterator == null) {
+            return new FilterLeafCollector(in) {
+                @Override
+                public void collect(int doc) throws IOException {
+                    // no-op
+                }
+                @Override
+                public boolean acceptsDocsOutOfOrder() {
+                    return true;
+                }
+            };
+        }
         return new FilterLeafCollector(in) {
             @Override
             public void collect(int doc) throws IOException {
-                if (iterator == null) {
-                    return;
-                }
                 final int itDoc = iterator.docID();
                 if (itDoc > doc) {
                     return;

--- a/src/main/java/org/elasticsearch/common/lucene/search/FilteredCollector.java
+++ b/src/main/java/org/elasticsearch/common/lucene/search/FilteredCollector.java
@@ -28,13 +28,10 @@ import java.io.IOException;
 /**
  *
  */
-public class FilteredCollector extends SimpleCollector implements XCollector {
+public class FilteredCollector implements XCollector {
 
     private final Collector collector;
     private final Filter filter;
-
-    private Bits docSet;
-    private LeafCollector leafCollector;
 
     public FilteredCollector(Collector collector, Filter filter) {
         this.collector = collector;
@@ -49,25 +46,53 @@ public class FilteredCollector extends SimpleCollector implements XCollector {
     }
 
     @Override
-    public void setScorer(Scorer scorer) throws IOException {
-        leafCollector.setScorer(scorer);
-    }
+    public LeafCollector getLeafCollector(LeafReaderContext context) throws IOException {
+        final DocIdSet set = filter.getDocIdSet(context, null);
+        final LeafCollector in = collector.getLeafCollector(context);
+        final Bits bits = set == null ? null : set.bits();
 
-    @Override
-    public void collect(int doc) throws IOException {
-        if (docSet.get(doc)) {
-            leafCollector.collect(doc);
+        if (bits != null) {
+            // the filter supports random-access
+            return new FilterLeafCollector(in) {
+                public void collect(int doc) throws IOException {
+                    if (bits.get(doc)) {
+                        in.collect(doc);
+                    }
+                }
+            };
         }
+
+        // No random-access support, use the iterator and force in-order scoring
+        final DocIdSetIterator iterator;
+        if (DocIdSets.isEmpty(set)) {
+            iterator = null;
+        } else {
+            iterator = set.iterator();
+        }
+        return new FilterLeafCollector(in) {
+            @Override
+            public void collect(int doc) throws IOException {
+                if (iterator == null) {
+                    return;
+                }
+                final int itDoc = iterator.docID();
+                if (itDoc > doc) {
+                    return;
+                } else if (itDoc < doc) {
+                    if (iterator.advance(doc) == doc) {
+                        in.collect(doc);
+                    }
+                } else {
+                    in.collect(doc);
+                }
+            }
+
+            @Override
+            public boolean acceptsDocsOutOfOrder() {
+                // we only support iterating in order because the iterator can only advance
+                return false;
+            }
+        };
     }
 
-    @Override
-    public void doSetNextReader(LeafReaderContext context) throws IOException {
-        leafCollector = collector.getLeafCollector(context);
-        docSet = DocIdSets.toSafeBits(context.reader(), filter.getDocIdSet(context, null));
-    }
-
-    @Override
-    public boolean acceptsDocsOutOfOrder() {
-        return leafCollector.acceptsDocsOutOfOrder();
-    }
 }


### PR DESCRIPTION
If the filter does not support random-access, we should use the iterator instead of loading it into a BitSet.
