### PR TITLE
Tests: Skip bwc analysis tests if using turkish or azuri locale.

### DIFF
--- a/src/test/java/org/elasticsearch/bwcompat/BasicAnalysisBackwardCompatibilityTests.java
+++ b/src/test/java/org/elasticsearch/bwcompat/BasicAnalysisBackwardCompatibilityTests.java
@@ -50,8 +50,11 @@ public class BasicAnalysisBackwardCompatibilityTests extends ElasticsearchBackwa
      */
     @Test
     public void testAnalyzerTokensAfterUpgrade() throws IOException, ExecutionException, InterruptedException {
+        // certain analyzers, namely PatternAnalyzer, have had issues with turkish and azuri
+        assumeFalse("Do not use turkish and azuri locales",
+                    Locale.getDefault().getLanguage().equals("tr") || Locale.getDefault().getLanguage().equals("az"));
+        
         int numFields = randomIntBetween(PreBuiltAnalyzers.values().length, PreBuiltAnalyzers.values().length * 10);
-        StringBuilder builder = new StringBuilder();
         String[] fields = new String[numFields * 2];
         int fieldId = 0;
         for (int i = 0; i < fields.length; i++) {


### PR DESCRIPTION
On 1.x, the pre built pattern analyzer has issues with turkish and azuri
locales.  We should just skip the test if using these locales.  On
master, the issue is fixed by only using the Elasticsearch version,
which avoids the default locale issue lucene's PatternAnalyzer is
susceptable to.
