### PR TITLE
Docs: Added new elasticsearch-river-kafka plugin to the documentation (u...

### DIFF
--- a/docs/reference/modules/plugins.asciidoc
+++ b/docs/reference/modules/plugins.asciidoc
@@ -235,6 +235,7 @@ You can disable that check using `plugins.check_lucene: false`.
 * https://github.com/jprante/elasticsearch-river-jdbc[JDBC River Plugin] (by Jörg Prante)
 * https://github.com/qotho/elasticsearch-river-jms[JMS River Plugin] (by Steve Sarandos)
 * https://github.com/endgameinc/elasticsearch-river-kafka[Kafka River Plugin] (by Endgame Inc.)
+* https://github.com/mariamhakobyan/elasticsearch-river-kafka[Kafka River Plugin 2] (by Mariam Hakobyan)
 * https://github.com/tlrx/elasticsearch-river-ldap[LDAP River Plugin] (by Tanguy Leroux)
 * https://github.com/richardwilly98/elasticsearch-river-mongodb/[MongoDB River Plugin] (by Richard Louapre)
 * https://github.com/sksamuel/elasticsearch-river-neo4j[Neo4j River Plugin] (by Steve Samuel)


### PR DESCRIPTION
...ses latest version of Kafka, EL Bulk API, and supports concurrent requests)

The differences between existing and this new plugin:
- uses Kafka 0.8.1.1 (latest version)
- uses Elasticsearch 1.4.0 (latest version)
- makes use of Bulk API (to have better performance)
- can be executed in concurrent requests
- abstracts the consuming mechanism (can consume Kafka messages from multiple brokers and partitions)

@clintongormley please review (a follow up on the closed PL - https://github.com/elasticsearch/elasticsearch/pull/8443)
