### PR TITLE
[GEO] Fix for geo_shape query with polygon from -180/90 to 180/-90

### DIFF
--- a/src/main/java/org/elasticsearch/common/geo/builders/BasePolygonBuilder.java
+++ b/src/main/java/org/elasticsearch/common/geo/builders/BasePolygonBuilder.java
@@ -396,7 +396,7 @@ public abstract class BasePolygonBuilder<E extends BasePolygonBuilder<E>> extend
                 holes[numHoles] = null;
             }
             // only connect edges if intersections are pairwise (per comment above)
-            if (e1.intersect != Edge.maxCoordinate() && e2.intersect != Edge.maxCoordinate()) {
+            if (e1.intersect != Edge.MAX_COORDINATE && e2.intersect != Edge.MAX_COORDINATE) {
                 connect(e1, e2);
             }
         }

--- a/src/main/java/org/elasticsearch/common/geo/builders/BasePolygonBuilder.java
+++ b/src/main/java/org/elasticsearch/common/geo/builders/BasePolygonBuilder.java
@@ -395,7 +395,15 @@ public abstract class BasePolygonBuilder<E extends BasePolygonBuilder<E>> extend
                 holes[e2.component-1] = holes[numHoles];
                 holes[numHoles] = null;
             }
-            // only connect edges if intersections are pairwise (per comment above)
+            // only connect edges if intersections are pairwise 
+            // per the comment above, the edge array is sorted by y-value of the intersection
+            // with the dateline.  Two edges have the same y intercept when they cross the 
+            // dateline thus they appear sequentially (pairwise) in the edge array. Two edges
+            // do not have the same y intercept when we're forming a multi-poly from a poly
+            // that wraps the dateline (but there are 2 ordered intercepts).  
+            // The connect method creates a new edge for these paired edges in the linked list. 
+            // For boundary conditions (e.g., intersect but not crossing) there is no sibling edge 
+            // to connect. Thus the following enforces the pairwise rule 
             if (e1.intersect != Edge.MAX_COORDINATE && e2.intersect != Edge.MAX_COORDINATE) {
                 connect(e1, e2);
             }

--- a/src/main/java/org/elasticsearch/common/geo/builders/BasePolygonBuilder.java
+++ b/src/main/java/org/elasticsearch/common/geo/builders/BasePolygonBuilder.java
@@ -395,7 +395,10 @@ public abstract class BasePolygonBuilder<E extends BasePolygonBuilder<E>> extend
                 holes[e2.component-1] = holes[numHoles];
                 holes[numHoles] = null;
             }
-            connect(e1, e2);
+            // only connect edges if intersections are pairwise (per comment above)
+            if (e1.intersect != Edge.maxCoordinate() && e2.intersect != Edge.maxCoordinate()) {
+                connect(e1, e2);
+            }
         }
         return numHoles;
     }

--- a/src/main/java/org/elasticsearch/common/geo/builders/ShapeBuilder.java
+++ b/src/main/java/org/elasticsearch/common/geo/builders/ShapeBuilder.java
@@ -297,7 +297,7 @@ public abstract class ShapeBuilder implements ToXContent {
             Coordinate p1 = edges[i].coordinate;
             Coordinate p2 = edges[i].next.coordinate;
             assert !Double.isNaN(p2.x) && !Double.isNaN(p1.x);  
-            edges[i].intersect = IntersectionOrder.SENTINEL;
+            edges[i].intersect = Edge.MAX_COORDINATE;
 
             double position = intersection(p1, p2, dateline);
             if (!Double.isNaN(position)) {
@@ -366,6 +366,7 @@ public abstract class ShapeBuilder implements ToXContent {
         Edge next; // next segment
         Coordinate intersect; // potential intersection with dateline
         int component = -1; // id of the component this edge belongs to
+        public static final Coordinate MAX_COORDINATE = new Coordinate(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY);
 
         protected Edge(Coordinate coordinate, Edge next, Coordinate intersection) {
             this.coordinate = coordinate;
@@ -377,7 +378,7 @@ public abstract class ShapeBuilder implements ToXContent {
         }
 
         protected Edge(Coordinate coordinate, Edge next) {
-            this(coordinate, next, IntersectionOrder.SENTINEL);
+            this(coordinate, next, Edge.MAX_COORDINATE);
         }
 
         private static final int top(Coordinate[] points, int offset, int length) {
@@ -486,10 +487,6 @@ public abstract class ShapeBuilder implements ToXContent {
             }
         }
 
-        public static Coordinate maxCoordinate() {
-            return IntersectionOrder.SENTINEL;
-        }
-
         @Override
         public String toString() {
             return "Edge[Component=" + component + "; start=" + coordinate + " " + "; intersection=" + intersect + "]";
@@ -499,8 +496,6 @@ public abstract class ShapeBuilder implements ToXContent {
     protected static final IntersectionOrder INTERSECTION_ORDER = new IntersectionOrder();
 
     private static final class IntersectionOrder implements Comparator<Edge> {
-        private static final Coordinate SENTINEL = new Coordinate(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY);
-        
         @Override
         public int compare(Edge o1, Edge o2) {
             return Double.compare(o1.intersect.y, o2.intersect.y);

--- a/src/main/java/org/elasticsearch/common/geo/builders/ShapeBuilder.java
+++ b/src/main/java/org/elasticsearch/common/geo/builders/ShapeBuilder.java
@@ -486,6 +486,10 @@ public abstract class ShapeBuilder implements ToXContent {
             }
         }
 
+        public static Coordinate maxCoordinate() {
+            return IntersectionOrder.SENTINEL;
+        }
+
         @Override
         public String toString() {
             return "Edge[Component=" + component + "; start=" + coordinate + " " + "; intersection=" + intersect + "]";

--- a/src/test/java/org/elasticsearch/common/geo/ShapeBuilderTests.java
+++ b/src/test/java/org/elasticsearch/common/geo/ShapeBuilderTests.java
@@ -394,6 +394,7 @@ public class ShapeBuilderTests extends ElasticsearchTestCase {
 
     @Test
     public void testShapeWithEdgeAlongDateline() {
+        // test case 1: test the positive side of the dateline
         PolygonBuilder builder = ShapeBuilder.newPolygon()
                 .point(180, 0)
                 .point(176, 4)
@@ -401,9 +402,34 @@ public class ShapeBuilderTests extends ElasticsearchTestCase {
                 .point(180, 0);
 
         Shape shape = builder.close().build();
+        assertPolygon(shape);
 
-         assertPolygon(shape);
+        // test case 2: test the negative side of the dateline
+        builder = ShapeBuilder.newPolygon()
+                .point(-180, 0)
+                .point(-176, 4)
+                .point(-180, -4)
+                .point(-180, 0);
+
+        shape = builder.close().build();
+        assertPolygon(shape);
      }
+
+    /**
+     * Test an enveloping polygon around the max mercator bounds
+     */
+    @Test
+    public void testBoundaryShape() {
+        PolygonBuilder builder = ShapeBuilder.newPolygon()
+                .point(-180, 90)
+                .point(180, 90)
+                .point(180, -90)
+                .point(-180, -90);
+
+        Shape shape = builder.close().build();
+
+        assertPolygon(shape);
+    }
 
     @Test
     public void testShapeWithEdgeAcrossDateline() {


### PR DESCRIPTION
This fix adds a simple consistency check that intersection edges appear pairwise. Polygonal boundary tests were passing (false positive) on the Eastern side of the dateline simply due to the initial order (edge direction) of the intersection edges.  Polygons in the Eastern hemispehere (which were not being tested) were correctly failing inside of JTS due to an attempt to connect incorrect intersection edges (that is, edges that were not even intersections). While this patch fixes issue/8467 (and adds broader test coverage) it is not intented as a long term solution.  The mid term fix (in work) will refactor all geospatial computational geometry to use ENU / ECF coordinate systems for higher accuracy and eliminate brute force mercator checks and conversions.

Closes #8467
