### PR TITLE
Fix example in logging daily rotate configuration

### DIFF
--- a/config/logging.yml
+++ b/config/logging.yml
@@ -43,12 +43,12 @@ appender:
   # For more information see https://logging.apache.org/log4j/extras/apidocs/org/apache/log4j/rolling/RollingFileAppender.html
   #file:
     #type: extrasRollingFile
-    #file: ${path.logs}/elasticsearch.log.gz
+    #file: ${path.logs}/${cluster.name}.log
     #rollingPolicy: timeBased
-    #rollingPolicy.FileNamePattern: ${path.logs}/${cluster.name}%d{yyyy-MM-dd}.log.gz
+    #rollingPolicy.FileNamePattern: ${path.logs}/${cluster.name}.log.%d{yyyy-MM-dd}.gz
     #layout:
       #type: pattern
-      #conversionPattern: "%d{ISO8601}"
+      #conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"
 
   index_search_slow_log_file:
     type: dailyRollingFile

--- a/src/main/java/org/elasticsearch/common/logging/log4j/LogConfigurator.java
+++ b/src/main/java/org/elasticsearch/common/logging/log4j/LogConfigurator.java
@@ -62,12 +62,13 @@ public class LogConfigurator {
             .put("null", "org.apache.log4j.NullAppender")
             .put("rollingFile", "org.apache.log4j.RollingFileAppender")
             .put("extrasRollingFile", "org.apache.log4j.rolling.RollingFileAppender")
-            .put("timeBased", "org.apache.log4j.rolling.TimeBasedRollingPolicy")
             .put("smtp", "org.apache.log4j.net.SMTPAppender")
             .put("socket", "org.apache.log4j.net.SocketAppender")
             .put("socketHub", "org.apache.log4j.net.SocketHubAppender")
             .put("syslog", "org.apache.log4j.net.SyslogAppender")
             .put("telnet", "org.apache.log4j.net.TelnetAppender")
+                    // policies
+            .put("timeBased", "org.apache.log4j.rolling.TimeBasedRollingPolicy")
                     // layouts
             .put("simple", "org.apache.log4j.SimpleLayout")
             .put("html", "org.apache.log4j.HTMLLayout")


### PR DESCRIPTION
PR #8464 come with a bug in the example provided.

First, the current log file is not compressed so it should not end with `.gz`.
Second, conversion pattern was removing all the log content but was printing only the log date.
Then, the current log filename was hardcoded to `elasticsearch` instead of the cluster name.
