### PR TITLE
Free pending search contexts if index is closed

### DIFF
--- a/src/main/java/org/elasticsearch/index/shard/service/IndexShard.java
+++ b/src/main/java/org/elasticsearch/index/shard/service/IndexShard.java
@@ -51,10 +51,7 @@ import org.elasticsearch.index.refresh.RefreshStats;
 import org.elasticsearch.index.search.stats.SearchStats;
 import org.elasticsearch.index.search.stats.ShardSearchService;
 import org.elasticsearch.index.service.IndexService;
-import org.elasticsearch.index.shard.DocsStats;
-import org.elasticsearch.index.shard.IllegalIndexShardStateException;
-import org.elasticsearch.index.shard.IndexShardComponent;
-import org.elasticsearch.index.shard.IndexShardState;
+import org.elasticsearch.index.shard.*;
 import org.elasticsearch.index.store.StoreStats;
 import org.elasticsearch.index.suggest.stats.ShardSuggestService;
 import org.elasticsearch.index.suggest.stats.SuggestStats;
@@ -182,6 +179,8 @@ public interface IndexShard extends IndexShardComponent {
     void readAllowed() throws IllegalIndexShardStateException;
 
     void readAllowed(Mode mode) throws IllegalIndexShardStateException;
+
+    ShardId shardId();
 
     public enum Mode {
         READ,

--- a/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/src/main/java/org/elasticsearch/search/SearchService.java
@@ -51,6 +51,7 @@ import org.elasticsearch.common.util.concurrent.FutureUtils;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.Index;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.fielddata.FieldDataType;
 import org.elasticsearch.index.fielddata.IndexFieldData;
@@ -145,6 +146,15 @@ public class SearchService extends AbstractLifecycleComponent<SearchService> {
         this.threadPool = threadPool;
         this.clusterService = clusterService;
         this.indicesService = indicesService;
+        indicesService.indicesLifecycle().addListener(new IndicesLifecycle.Listener() {
+
+            @Override
+            public void afterIndexClosed(Index index) {
+                // once an index is closed we can just clean up all the pending search context information
+                // to release memory and let references to the filesystem go etc.
+                freeAllContextForIndex(index);
+            }
+        });
         this.indicesWarmer = indicesWarmer;
         this.scriptService = scriptService;
         this.pageCacheRecycler = pageCacheRecycler;
@@ -562,6 +572,16 @@ public class SearchService extends AbstractLifecycleComponent<SearchService> {
 
         return context;
     }
+
+    private void freeAllContextForIndex(Index index) {
+        assert index != null;
+        for (SearchContext ctx : activeContexts.values()) {
+            if (index.equals(ctx.indexShard().shardId().index())) {
+                freeContext(ctx.id());
+            }
+        }
+    }
+
 
     public boolean freeContext(long id) {
         final SearchContext context = activeContexts.remove(id);


### PR DESCRIPTION
Today we hold on to search context reference if they are not cleaned
up for a while until a reaper thread trashes them if they timed out.
This commit removes all pending contexts once the index is closed to release
resources and filehandles immediatly once the index is closed.
