### PR TITLE
Allow to cancel recovery sources when shards are closed

### DIFF
--- a/src/main/java/org/elasticsearch/common/util/concurrent/AbstractRunnable.java
+++ b/src/main/java/org/elasticsearch/common/util/concurrent/AbstractRunnable.java
@@ -39,7 +39,17 @@ public abstract class AbstractRunnable implements Runnable {
             onFailure(ex);
         } catch (Throwable t) {
             onFailure(t);
+        } finally {
+            onAfter();
         }
+    }
+
+    /**
+     * This method is called in a finally block after successful execution
+     * or on a rejection.
+     */
+    public void onAfter() {
+        // nothing by default
     }
 
     /**

--- a/src/main/java/org/elasticsearch/common/util/concurrent/EsThreadPoolExecutor.java
+++ b/src/main/java/org/elasticsearch/common/util/concurrent/EsThreadPoolExecutor.java
@@ -81,7 +81,12 @@ public class EsThreadPoolExecutor extends ThreadPoolExecutor {
             if (command instanceof AbstractRunnable) {
                 // If we are an abstract runnable we can handle the rejection
                 // directly and don't need to rethrow it.
-                ((AbstractRunnable)command).onRejection(ex);
+                try {
+                    ((AbstractRunnable) command).onRejection(ex);
+                } finally {
+                    ((AbstractRunnable) command).onAfter();
+
+                }
             } else {
                 throw ex;
             }


### PR DESCRIPTION
Today recovery sources are not cancled if a shard is closed. The recovery target
is already cancled when shards are closed but we should also cleanup and cancel
the sources side since it holds on to shard locks / references until it's closed.
