### PR TITLE
Note empty query string parsing difference..

### DIFF
--- a/docs/reference/query-dsl/queries/simple-query-string-query.asciidoc
+++ b/docs/reference/query-dsl/queries/simple-query-string-query.asciidoc
@@ -110,3 +110,9 @@ should be enabled. It is specified as a `|`-delimited string with the
 
 The available flags are: `ALL`, `NONE`, `AND`, `OR`, `NOT`, `PREFIX`, `PHRASE`,
 `PRECEDENCE`, `ESCAPE`, `WHITESPACE`, `FUZZY`, `NEAR`, and `SLOP`.
+
+
+===== Empty Query
+
+Unlike a `query_string` query, a `simple_query_string` query will match all
+documents when the query string is empty, or contains only whitespace.


### PR DESCRIPTION
..between query_string and simple_query_string. I can't actually find
source code or docs to back up this paragraph, however it appears to be
the way things work.
