### PR TITLE
Add before/after indexDeleted callbacks to IndicesLifecycle

### DIFF
--- a/src/main/java/org/elasticsearch/indices/IndicesLifecycle.java
+++ b/src/main/java/org/elasticsearch/indices/IndicesLifecycle.java
@@ -146,6 +146,28 @@ public interface IndicesLifecycle {
         public void indexShardStateChanged(IndexShard indexShard, @Nullable IndexShardState previousState, IndexShardState currentState, @Nullable String reason) {
 
         }
+
+        /**
+         * Called after the index has been deleted.
+         * This listener method is invoked after {@link #afterIndexClosed(org.elasticsearch.index.Index)}
+         * when an index is deleted
+         *
+         * @param index The index
+         */
+        public void afterIndexDeleted(Index index) {
+
+        }
+
+        /**
+         * Called before the index gets deleted.
+         * This listener method is invoked after
+         * {@link #beforeIndexClosed(org.elasticsearch.index.service.IndexService)} when an index is deleted
+         *
+         * @param indexService The index service
+         */
+        public void beforeIndexDeleted(IndexService indexService) {
+
+        }
     }
 
 }

--- a/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -78,9 +78,24 @@ public interface IndicesService extends Iterable<IndexService>, LifecycleCompone
 
     IndexService createIndex(String index, Settings settings, String localNodeId) throws ElasticsearchException;
 
+    /**
+     * Removes the given index from this service and releases all associated resources. Persistent parts of the index
+     * like the shards files, state and transaction logs are kept around in the case of a disaster recovery.
+     * @param index the index to remove
+     * @param reason  the high level reason causing this removal
+     */
     void removeIndex(String index, String reason) throws ElasticsearchException;
 
-    void removeIndex(String index, String reason, @Nullable IndexCloseListener listener) throws ElasticsearchException;
+    /**
+     * Deletes the given index. Persistent parts of the index
+     * like the shards files, state and transaction logs are removed once all resources are released.
+     *
+     * Equivalent to {@link #removeIndex(String, String)} but fires
+     * different lifecycle events to ensure pending resources of this index are immediately removed.
+     * @param index the index to delete
+     * @param reason the high level reason causing this delete
+     */
+    void deleteIndex(String index, String reason) throws ElasticsearchException;
 
     /**
      * A listener interface that can be used to get notification once a shard or all shards

--- a/src/main/java/org/elasticsearch/indices/InternalIndicesLifecycle.java
+++ b/src/main/java/org/elasticsearch/indices/InternalIndicesLifecycle.java
@@ -132,6 +132,26 @@ public class InternalIndicesLifecycle extends AbstractComponent implements Indic
         }
     }
 
+    public void beforeIndexDeleted(IndexService indexService) {
+        for (Listener listener : listeners) {
+            try {
+                listener.beforeIndexDeleted(indexService);
+            } catch (Throwable t) {
+                logger.warn("[{}] failed to invoke before index deleted callback", t, indexService.index().name());
+            }
+        }
+    }
+
+    public void afterIndexDeleted(Index index) {
+        for (Listener listener : listeners) {
+            try {
+                listener.afterIndexDeleted(index);
+            } catch (Throwable t) {
+                logger.warn("[{}] failed to invoke after index deleted callback", t, index.name());
+            }
+        }
+    }
+
     public void afterIndexClosed(Index index) {
         for (Listener listener : listeners) {
             try {

--- a/src/test/java/org/elasticsearch/indices/IndicesLifecycleListenerSingleNodeTests.java
+++ b/src/test/java/org/elasticsearch/indices/IndicesLifecycleListenerSingleNodeTests.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.indices;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.Maps;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.service.IndexService;
+import org.elasticsearch.index.shard.IndexShardState;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.shard.service.IndexShard;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.ElasticsearchSingleNodeTest;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_REPLICAS;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
+import static org.elasticsearch.cluster.routing.allocation.decider.DisableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_DISABLE_ALLOCATION;
+import static org.elasticsearch.common.settings.ImmutableSettings.builder;
+import static org.elasticsearch.index.shard.IndexShardState.*;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.Scope;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+
+public class IndicesLifecycleListenerSingleNodeTests extends ElasticsearchSingleNodeTest {
+
+    @Override
+    protected boolean resetNodeAfterTest() {
+        return true;
+    }
+
+    @Test
+    public void testCloseDeleteCallback() throws Throwable {
+
+        final AtomicInteger counter = new AtomicInteger(1);
+        assertAcked(client().admin().indices().prepareCreate("test")
+                .setSettings(SETTING_NUMBER_OF_SHARDS, 1, SETTING_NUMBER_OF_REPLICAS, 0));
+        ensureGreen();
+        getInstanceFromNode(IndicesLifecycle.class).addListener(new IndicesLifecycle.Listener() {
+            @Override
+            public void afterIndexClosed(Index index) {
+                assertEquals(counter.get(), 3);
+                counter.incrementAndGet();
+            }
+
+            @Override
+            public void beforeIndexClosed(IndexService indexService) {
+                assertEquals(counter.get(), 1);
+                counter.incrementAndGet();
+            }
+
+            @Override
+            public void afterIndexDeleted(Index index) {
+                assertEquals(counter.get(), 4);
+                counter.incrementAndGet();
+            }
+
+            @Override
+            public void beforeIndexDeleted(IndexService indexService) {
+                assertEquals(counter.get(), 2);
+                counter.incrementAndGet();
+            }
+        });
+        assertAcked(client().admin().indices().prepareDelete("test").get());
+        assertEquals(5, counter.get());
+    }
+
+}

--- a/src/test/java/org/elasticsearch/test/ElasticsearchSingleNodeTest.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchSingleNodeTest.java
@@ -31,6 +31,7 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -204,5 +205,35 @@ public abstract class ElasticsearchSingleNodeTest extends ElasticsearchTestCase 
         PageCacheRecycler pageCacheRecycler = indexService.injector().getInstance(PageCacheRecycler.class);
         return new TestSearchContext(threadPool, pageCacheRecycler, bigArrays, indexService, indexService.cache().filter(), indexService.fieldData());
     }
+
+    /**
+     * Ensures the cluster has a green state via the cluster health API. This method will also wait for relocations.
+     * It is useful to ensure that all action on the cluster have finished and all shards that were currently relocating
+     * are now allocated and started.
+     */
+    public ClusterHealthStatus  ensureGreen(String... indices) {
+        return ensureGreen(TimeValue.timeValueSeconds(30), indices);
+    }
+
+
+    /**
+     * Ensures the cluster has a green state via the cluster health API. This method will also wait for relocations.
+     * It is useful to ensure that all action on the cluster have finished and all shards that were currently relocating
+     * are now allocated and started.
+     *
+     * @param timeout time out value to set on {@link org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest}
+     */
+    public ClusterHealthStatus ensureGreen(TimeValue timeout, String... indices) {
+        ClusterHealthResponse actionGet = client().admin().cluster()
+                .health(Requests.clusterHealthRequest(indices).timeout(timeout).waitForGreenStatus().waitForEvents(Priority.LANGUID).waitForRelocatingShards(0)).actionGet();
+        if (actionGet.isTimedOut()) {
+            logger.info("ensureGreen timed out, cluster state:\n{}\n{}", client().admin().cluster().prepareState().get().getState().prettyPrint(), client().admin().cluster().preparePendingClusterTasks().get().prettyPrint());
+            assertThat("timed out waiting for green state", actionGet.isTimedOut(), equalTo(false));
+        }
+        assertThat(actionGet.getStatus(), equalTo(ClusterHealthStatus.GREEN));
+        logger.debug("indices {} are green", indices.length == 0 ? "[_all]" : indices);
+        return actionGet.getStatus();
+    }
+
 
 }


### PR DESCRIPTION
In order to implement #8551 correctly without causing problems of relocating
shards we need to be informed if an index is actually deleted. This commit adds
more callbacks to the listener and makes deleteIndex a dedicated method on IndicesService
