### PR TITLE
Take into account `_default_ mapping` in index template when parsing alias filter in index templates.

### DIFF
--- a/src/main/java/org/elasticsearch/action/index/TransportIndexAction.java
+++ b/src/main/java/org/elasticsearch/action/index/TransportIndexAction.java
@@ -83,7 +83,12 @@ public class TransportIndexAction extends TransportShardReplicationOperationActi
         // if we don't have a master, we don't have metadata, that's fine, let it find a master using create index API
         if (autoCreateIndex.shouldAutoCreate(request.index(), clusterService.state())) {
             request.beforeLocalFork(); // we fork on another thread...
-            createIndexAction.execute(new CreateIndexRequest(request).index(request.index()).cause("auto(index api)").masterNodeTimeout(request.timeout()), new ActionListener<CreateIndexResponse>() {
+            CreateIndexRequest createIndexRequest = new CreateIndexRequest(request);
+            createIndexRequest.index(request.index());
+            createIndexRequest.mapping(request.type());
+            createIndexRequest.cause("auto(index api)");
+            createIndexRequest.masterNodeTimeout(request.timeout());
+            createIndexAction.execute(createIndexRequest, new ActionListener<CreateIndexResponse>() {
                 @Override
                 public void onResponse(CreateIndexResponse result) {
                     innerExecute(request, listener);

--- a/src/test/java/org/elasticsearch/indices/template/SimpleIndexTemplateTests.java
+++ b/src/test/java/org/elasticsearch/indices/template/SimpleIndexTemplateTests.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.action.admin.indices.alias.get.GetAliasesResponse;
@@ -45,6 +46,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
+import static org.elasticsearch.index.query.FilterBuilders.termFilter;
 import static org.elasticsearch.index.query.QueryBuilders.termQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.*;
 import static org.hamcrest.Matchers.*;
@@ -464,8 +466,8 @@ public class SimpleIndexTemplateTests extends ElasticsearchIntegrationTest {
     public void testDuplicateAlias() throws Exception {
         client().admin().indices().preparePutTemplate("template_1")
                 .setTemplate("te*")
-                .addAlias(new Alias("my_alias").filter(FilterBuilders.termFilter("field", "value1")))
-                .addAlias(new Alias("my_alias").filter(FilterBuilders.termFilter("field", "value2")))
+                .addAlias(new Alias("my_alias").filter(termFilter("field", "value1")))
+                .addAlias(new Alias("my_alias").filter(termFilter("field", "value2")))
                 .get();
 
         GetIndexTemplatesResponse response = client().admin().indices().prepareGetTemplates("template_1").get();
@@ -595,6 +597,45 @@ public class SimpleIndexTemplateTests extends ElasticsearchIntegrationTest {
                 assertThat(aliasMetaData.indexRouting(), nullValue());
                 assertThat(aliasMetaData.searchRouting(), equalTo("test-routing"));
             }
+        }
+    }
+
+    @Test
+    public void testStrictAliasParsingInIndicesCreatedViaTemplates() throws Exception {
+        // Indexing into a should succeed, because the field mapping for field 'field' is defined in the test mapping.
+        client().admin().indices().preparePutTemplate("template1")
+                .setTemplate("a")
+                .setOrder(0)
+                .addMapping("test", "field", "type=string")
+                .addAlias(new Alias("alias1").filter(termFilter("field", "value"))).get();
+        // Indexing into b should succeed, because the field mapping for field 'field' is defined in the _default_ mapping and the test type exists.
+        client().admin().indices().preparePutTemplate("template2")
+                .setTemplate("b")
+                .setOrder(0)
+                .addMapping("_default_", "field", "type=string")
+                .addMapping("test")
+                .addAlias(new Alias("alias2").filter(termFilter("field", "value"))).get();
+        // Indexing into c should succeed, because the field mapping for field 'field' is defined in the _default_ mapping.
+        client().admin().indices().preparePutTemplate("template3")
+                .setTemplate("c")
+                .setOrder(0)
+                .addMapping("_default_", "field", "type=string")
+                .addAlias(new Alias("alias3").filter(termFilter("field", "value"))).get();
+        // Indexing into d index should fail, since there is field with name 'field' in the mapping
+        client().admin().indices().preparePutTemplate("template4")
+                .setTemplate("d")
+                .setOrder(0)
+                .addAlias(new Alias("alias4").filter(termFilter("field", "value"))).get();
+
+        client().prepareIndex("a", "test", "test").setSource("{}").get();
+        client().prepareIndex("b", "test", "test").setSource("{}").get();
+        client().prepareIndex("c", "test", "test").setSource("{}").get();
+        try {
+            client().prepareIndex("d", "test", "test").setSource("{}").get();
+            fail();
+        } catch (Exception e) {
+            assertThat(ExceptionsHelper.unwrapCause(e), instanceOf(ElasticsearchIllegalArgumentException.class));
+            assertThat(e.getMessage(), containsString("failed to parse filter for alias [alias4]"));
         }
     }
 }


### PR DESCRIPTION
By also taking into account the type for an index request that indexes into index that doesn't exist in the automatic create index request, the mapping for the new type will take over the `_default_` mapping. Alias filters that then point to fields in the `_default_` mapping will then not fail. 

PR for #8473
