### PR TITLE
Ensure shards are deleted under lock on close

### DIFF
--- a/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/src/main/java/org/elasticsearch/index/store/Store.java
@@ -364,15 +364,13 @@ public class Store extends AbstractIndexShardComponent implements CloseableIndex
             logger.debug("failed to close directory", e);
         } finally {
             try {
-                IOUtils.closeWhileHandlingException(shardLock);
-            } finally {
-                try {
-                    if (listener != null) {
-                        listener.onClose(shardId);
-                    }
-                } catch (Exception ex){
-                    logger.debug("OnCloseListener threw an exception", ex);
+                if (listener != null) {
+                    listener.onClose(shardId);
                 }
+            } catch (Exception ex){
+                logger.debug("OnCloseListener threw an exception", ex);
+            } finally {
+                IOUtils.closeWhileHandlingException(shardLock);
             }
 
 

--- a/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -113,7 +113,9 @@ public interface IndicesService extends Iterable<IndexService>, LifecycleCompone
         public void onAllShardsClosed(Index index, List<Throwable> failures);
 
         /**
-         * Invoked once the last resource using the given shard ID is released
+         * Invoked once the last resource using the given shard ID is released.
+         * Yet, this method is called while still holding the shards lock such that
+         * operations on the shards data can safely be executed in this callback.
          */
         public void onShardClosed(ShardId shardId);
 

--- a/src/main/java/org/elasticsearch/indices/InternalIndicesService.java
+++ b/src/main/java/org/elasticsearch/indices/InternalIndicesService.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.indices;
 
 import com.google.common.collect.*;
+import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchIllegalStateException;
 import org.elasticsearch.action.admin.indices.stats.CommonStats;
@@ -357,7 +358,8 @@ public class InternalIndicesService extends AbstractLifecycleComponent<IndicesSe
             @Override
             public void onShardClosed(ShardId shardId) {
                 try {
-                    nodeEnv.deleteShardDirectorySafe(shardId);
+                    // this is called under the shard lock - we can safely delete it
+                    IOUtils.rm(nodeEnv.shardPaths(shardId));
                     logger.debug("deleted shard [{}] from filesystem", shardId);
                 } catch (IOException e) {
                     logger.warn("Can't delete shard {} ", e, shardId);


### PR DESCRIPTION
Today there is a race condition between the actual deletion of
the shard and the release of the lock in the store. This race can cause
rare imports of dangeling indices if the cluster state update loop
tires to import the dangeling index in that particular windonw. This commit
adds more safety to the import of dangeling indices and removes the race
condition by holding on to the lock on store closing while the listener
is notified.
