### PR TITLE
Fix Bloom filter ram usage calculation

### DIFF
--- a/src/main/java/org/elasticsearch/common/util/BloomFilter.java
+++ b/src/main/java/org/elasticsearch/common/util/BloomFilter.java
@@ -24,6 +24,7 @@ import org.apache.lucene.store.DataInput;
 import org.apache.lucene.store.DataOutput;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
@@ -262,7 +263,7 @@ public class BloomFilter {
     }
 
     public long getSizeInBytes() {
-        return bits.bitSize() + 8;
+        return bits.ramBytesUsed();
     }
 
     @Override
@@ -382,6 +383,10 @@ public class BloomFilter {
 
         @Override public int hashCode() {
             return Arrays.hashCode(data);
+        }
+
+        public long ramBytesUsed() {
+            return RamUsageEstimator.NUM_BYTES_LONG * data.length + RamUsageEstimator.NUM_BYTES_ARRAY_HEADER + 16;
         }
     }
 

--- a/src/test/java/org/elasticsearch/index/codec/postingformat/ElasticsearchPostingsFormatTest.java
+++ b/src/test/java/org/elasticsearch/index/codec/postingformat/ElasticsearchPostingsFormatTest.java
@@ -24,10 +24,13 @@ import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 import com.carrotsearch.randomizedtesting.annotations.TimeoutSuite;
 import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.PostingsFormat;
 import org.apache.lucene.index.BasePostingsFormatTestCase;
 import org.apache.lucene.util.LuceneTestCase;
 import org.apache.lucene.util.TestUtil;
 import org.apache.lucene.util.TimeUnits;
+import org.elasticsearch.common.util.BloomFilter;
+import org.elasticsearch.index.codec.postingsformat.BloomFilterPostingsFormat;
 import org.elasticsearch.index.codec.postingsformat.Elasticsearch090PostingsFormat;
 import org.elasticsearch.test.ElasticsearchThreadFilter;
 import org.elasticsearch.test.junit.listeners.ReproduceInfoPrinter;
@@ -44,7 +47,9 @@ public class ElasticsearchPostingsFormatTest extends BasePostingsFormatTestCase 
 
     @Override
     protected Codec getCodec() {
-        return TestUtil.alwaysPostingsFormat(new Elasticsearch090PostingsFormat());
+        return random().nextBoolean() ?
+                TestUtil.alwaysPostingsFormat(new Elasticsearch090PostingsFormat())
+                : TestUtil.alwaysPostingsFormat(new BloomFilterPostingsFormat(PostingsFormat.forName("Lucene50"), BloomFilter.Factory.DEFAULT));
     }
     
 }


### PR DESCRIPTION
BloomFilter actually returned the size of the bitset as the
size in bytes so off by factor 8 plus a constant :)

Closes #8564
