### PR TITLE
Update DiskThresholdDecider javadoc

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDecider.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDecider.java
@@ -50,13 +50,13 @@ import static org.elasticsearch.cluster.InternalClusterInfoService.shardIdentifi
  * <code>cluster.routing.allocation.disk.watermark.low</code> is the low disk
  * watermark. New shards will not allocated to a node with usage higher than this,
  * although this watermark may be passed by allocating a shard. It defaults to
- * 0.70 (70.0%).
+ * 0.85 (85.0%).
  *
  * <code>cluster.routing.allocation.disk.watermark.high</code> is the high disk
  * watermark. If a node has usage higher than this, shards are not allowed to
  * remain on the node. In addition, if allocating a shard to a node causes the
  * node to pass this watermark, it will not be allowed. It defaults to
- * 0.85 (85.0%).
+ * 0.90 (90.0%).
  *
  * Both watermark settings are expressed in terms of used disk percentage, or
  * exact byte values for free space (like "500mb")


### PR DESCRIPTION
Since v1.3.0, and issue #6201, the default values in code and documentation have been updated to 85% and 90% for low and high watermarks. However, the related javadoc still contains the initial values : this commit fix this.
