### PR TITLE
Upgrade to current Lucene 5.0.0 snapshot

### DIFF
--- a/docs/reference/analysis/tokenfilters/normalization-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/normalization-tokenfilter.asciidoc
@@ -34,3 +34,7 @@ Scandinavian::
 http://lucene.apache.org/core/4_9_0/analyzers-common/org/apache/lucene/analysis/miscellaneous/ScandinavianNormalizationFilter.html[`scandinavian_normalization`],
 http://lucene.apache.org/core/4_9_0/analyzers-common/org/apache/lucene/analysis/miscellaneous/ScandinavianFoldingFilter.html[`scandinavian_folding`]
 
+Serbian::
+
+not-released-yet[`serbian_normalization`],
+

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <lucene.version>5.0.0</lucene.version>
-        <lucene.maven.version>5.0.0-snapshot-1637347</lucene.maven.version>
+        <lucene.maven.version>5.0.0-snapshot-1640808</lucene.maven.version>
         <tests.jvms>auto</tests.jvms>
         <tests.shuffle>true</tests.shuffle>
         <tests.output>onerror</tests.output>
@@ -55,6 +55,10 @@
         <repository>
             <id>Lucene snapshots</id>
             <url>https://download.elasticsearch.org/lucenesnapshots/1637347</url> 
+        </repository>
+        <repository>
+            <id>Lucene tmp snapshots</id>
+            <url>https://people.apache.org/~mikemccand/tmp500</url> 
         </repository>
     </repositories>
 

--- a/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -84,8 +84,8 @@ public class NodeEnvironment extends AbstractComponent implements Closeable{
                 if (Files.exists(dir) == false) {
                     Files.createDirectories(dir);
                 }
-                Directory luceneDir = FSDirectory.open(dir);
-                try {
+                
+                try (Directory luceneDir = FSDirectory.open(dir)) {
                     logger.trace("obtaining node lock on {} ...", dir.toAbsolutePath());
                     Lock tmpLock = NativeFSLockFactory.INSTANCE.makeLock(luceneDir, "node.lock");
                     boolean obtained = tmpLock.obtain();
@@ -113,8 +113,6 @@ public class NodeEnvironment extends AbstractComponent implements Closeable{
                         locks[i] = null;
                     }
                     break;
-                } finally {
-                    luceneDir.close();
                 }
             }
             if (locks[0] != null) {

--- a/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -85,9 +85,9 @@ public class NodeEnvironment extends AbstractComponent implements Closeable{
                     Files.createDirectories(dir);
                 }
                 
-                try (Directory luceneDir = FSDirectory.open(dir)) {
+                try (Directory luceneDir = FSDirectory.open(dir, NativeFSLockFactory.INSTANCE)) {
                     logger.trace("obtaining node lock on {} ...", dir.toAbsolutePath());
-                    Lock tmpLock = NativeFSLockFactory.INSTANCE.makeLock(luceneDir, "node.lock");
+                    Lock tmpLock = luceneDir.makeLock("node.lock");
                     boolean obtained = tmpLock.obtain();
                     if (obtained) {
                         locks[dirIndex] = tmpLock;

--- a/src/main/java/org/elasticsearch/index/analysis/AnalysisModule.java
+++ b/src/main/java/org/elasticsearch/index/analysis/AnalysisModule.java
@@ -511,6 +511,7 @@ public class AnalysisModule extends AbstractModule {
             tokenFiltersBindings.processTokenFilter("persian_normalization", PersianNormalizationFilterFactory.class);
             tokenFiltersBindings.processTokenFilter("scandinavian_normalization", ScandinavianNormalizationFilterFactory.class);
             tokenFiltersBindings.processTokenFilter("scandinavian_folding", ScandinavianFoldingFilterFactory.class);
+            tokenFiltersBindings.processTokenFilter("serbian_normalization", SerbianNormalizationFilterFactory.class);
 
             tokenFiltersBindings.processTokenFilter("hunspell", HunspellTokenFilterFactory.class);
             tokenFiltersBindings.processTokenFilter("cjk_bigram", CJKBigramFilterFactory.class);

--- a/src/main/java/org/elasticsearch/index/analysis/SerbianNormalizationFilterFactory.java
+++ b/src/main/java/org/elasticsearch/index/analysis/SerbianNormalizationFilterFactory.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.analysis;
+
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.sr.SerbianNormalizationFilter;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.assistedinject.Assisted;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.settings.IndexSettings;
+/**
+ *
+ */
+public class SerbianNormalizationFilterFactory extends AbstractTokenFilterFactory {
+
+    @Inject
+    public SerbianNormalizationFilterFactory(Index index, @IndexSettings Settings indexSettings, @Assisted String name, @Assisted Settings settings) {
+        super(index, indexSettings, name, settings);
+    }
+
+    @Override
+    public TokenStream create(TokenStream tokenStream) {
+        return new SerbianNormalizationFilter(tokenStream);
+    }
+}

--- a/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
+++ b/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
@@ -1434,11 +1434,6 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
 
     private IndexWriter createWriter() throws IOException {
         try {
-            // release locks when started
-            if (IndexWriter.isLocked(store.directory())) {
-                logger.warn("shard is locked, releasing lock");
-                IndexWriter.unlock(store.directory());
-            }
             boolean create = !Lucene.indexExists(store.directory());
             IndexWriterConfig config = new IndexWriterConfig(analysisService.defaultIndexAnalyzer());
             config.setCommitOnClose(false); // we by default don't commit on close

--- a/src/main/java/org/elasticsearch/index/mapper/core/BinaryFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/BinaryFieldMapper.java
@@ -264,7 +264,7 @@ public class BinaryFieldMapper extends AbstractFieldMapper<BytesReference> {
 
         public static final FieldType TYPE = new FieldType();
         static {
-            TYPE.setDocValueType(DocValuesType.BINARY);
+            TYPE.setDocValuesType(DocValuesType.BINARY);
             TYPE.freeze();
         }
 

--- a/src/main/java/org/elasticsearch/index/mapper/core/DoubleFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/DoubleFieldMapper.java
@@ -404,7 +404,7 @@ public class DoubleFieldMapper extends NumberFieldMapper<Double> {
 
         public static final FieldType TYPE = new FieldType();
         static {
-          TYPE.setDocValueType(DocValuesType.BINARY);
+          TYPE.setDocValuesType(DocValuesType.BINARY);
           TYPE.freeze();
         }
 

--- a/src/main/java/org/elasticsearch/index/mapper/core/FloatFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/FloatFieldMapper.java
@@ -409,7 +409,7 @@ public class FloatFieldMapper extends NumberFieldMapper<Float> {
 
         public static final FieldType TYPE = new FieldType();
         static {
-          TYPE.setDocValueType(DocValuesType.BINARY);
+          TYPE.setDocValuesType(DocValuesType.BINARY);
           TYPE.freeze();
         }
 

--- a/src/main/java/org/elasticsearch/index/mapper/core/NumberFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/NumberFieldMapper.java
@@ -433,7 +433,7 @@ public abstract class NumberFieldMapper<T extends Number> extends AbstractFieldM
 
         public static final FieldType TYPE = new FieldType();
         static {
-          TYPE.setDocValueType(DocValuesType.BINARY);
+          TYPE.setDocValuesType(DocValuesType.BINARY);
           TYPE.freeze();
         }
 
@@ -484,7 +484,7 @@ public abstract class NumberFieldMapper<T extends Number> extends AbstractFieldM
 
         public static final FieldType TYPE = new FieldType();
         static {
-          TYPE.setDocValueType(DocValuesType.BINARY);
+          TYPE.setDocValuesType(DocValuesType.BINARY);
           TYPE.freeze();
         }
 

--- a/src/main/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapper.java
@@ -728,7 +728,7 @@ public class GeoPointFieldMapper extends AbstractFieldMapper<GeoPoint> implement
 
         public static final FieldType TYPE = new FieldType();
         static {
-          TYPE.setDocValueType(DocValuesType.BINARY);
+          TYPE.setDocValuesType(DocValuesType.BINARY);
           TYPE.freeze();
         }
 

--- a/src/main/java/org/elasticsearch/index/merge/scheduler/ConcurrentMergeSchedulerProvider.java
+++ b/src/main/java/org/elasticsearch/index/merge/scheduler/ConcurrentMergeSchedulerProvider.java
@@ -151,6 +151,11 @@ public class ConcurrentMergeSchedulerProvider extends MergeSchedulerProvider {
             super.afterMerge(merge);
             provider.afterMerge(merge);
         }
+
+        @Override
+        protected void maybeStall() {
+            // Don't stall here, because we do our own index throttling (in InternalEngine.IndexThrottle) when merges can't keep up
+        }
     }
 
     class ApplySettings implements IndexSettingsService.Listener {

--- a/src/main/java/org/elasticsearch/index/store/DistributorDirectory.java
+++ b/src/main/java/org/elasticsearch/index/store/DistributorDirectory.java
@@ -162,14 +162,6 @@ public final class DistributorDirectory extends Directory {
         return directory;
     }
 
-    /** Called by makeLock's wrapped lock, to record the lock file. */
-    synchronized void addNameDirMapping(String name, Directory dir) {
-        assert nameDirMapping.containsKey(name) == false || nameDirMapping.get(name) == dir;
-        if (nameDirMapping.get(name) == null) {
-            nameDirMapping.put(name, dir);
-        }
-    }
-
     @Override
     public synchronized String toString() {
         return distributor.toString();
@@ -218,7 +210,12 @@ public final class DistributorDirectory extends Directory {
                 @Override
                 public boolean obtain() throws IOException {
                     if (delegateLock.obtain()) {
-                        addNameDirMapping(lockName, primary);
+                        synchronized(DistributorDirectory.this) {
+                            assert nameDirMapping.containsKey(lockName) == false || nameDirMapping.get(lockName) == primary;
+                            if (nameDirMapping.get(lockName) == null) {
+                                nameDirMapping.put(lockName, primary);
+                            }
+                        }
                         return true;
                     } else {
                         return false;

--- a/src/main/java/org/elasticsearch/index/store/fs/FsDirectoryService.java
+++ b/src/main/java/org/elasticsearch/index/store/fs/FsDirectoryService.java
@@ -65,7 +65,7 @@ public abstract class FsDirectoryService extends DirectoryService implements Sto
         } else if (fsLock.equals("simple")) {
             lockFactory = SimpleFSLockFactory.INSTANCE;
         } else {
-            throw new StoreException(shardId, "unrecognized fs_lock \"" + fsLock + "\": must be native, simple or none");
+            throw new StoreException(shardId, "unrecognized fs_lock \"" + fsLock + "\": must be native or simple");
         }
         return lockFactory;
     }

--- a/src/main/java/org/elasticsearch/index/store/fs/FsDirectoryService.java
+++ b/src/main/java/org/elasticsearch/index/store/fs/FsDirectoryService.java
@@ -59,13 +59,11 @@ public abstract class FsDirectoryService extends DirectoryService implements Sto
 
     protected final LockFactory buildLockFactory() throws IOException {
         String fsLock = componentSettings.get("lock", componentSettings.get("fs_lock", "native"));
-        LockFactory lockFactory = NoLockFactory.INSTANCE;
+        LockFactory lockFactory;
         if (fsLock.equals("native")) {
             lockFactory = NativeFSLockFactory.INSTANCE;
         } else if (fsLock.equals("simple")) {
             lockFactory = SimpleFSLockFactory.INSTANCE;
-        } else if (fsLock.equals("none")) {
-            lockFactory = NoLockFactory.INSTANCE;
         } else {
             throw new StoreException(shardId, "unrecognized fs_lock \"" + fsLock + "\": must be native, simple or none");
         }

--- a/src/main/java/org/elasticsearch/search/suggest/context/GeolocationContextMapping.java
+++ b/src/main/java/org/elasticsearch/search/suggest/context/GeolocationContextMapping.java
@@ -632,9 +632,9 @@ public class GeolocationContextMapping extends ContextMapping {
                             for (int i = 0 ; i < lonFields.length ; i++) {
                                 IndexableField lonField = lonFields[i];
                                 IndexableField latField = latFields[i];
-                                assert lonField.fieldType().docValueType() == latField.fieldType().docValueType();
+                                assert lonField.fieldType().docValuesType() == latField.fieldType().docValuesType();
                                 // we write doc values fields differently: one field for all values, so we need to only care about indexed fields
-                                if (lonField.fieldType().docValueType() == DocValuesType.NONE) {
+                                if (lonField.fieldType().docValuesType() == DocValuesType.NONE) {
                                     spare.reset(latField.numericValue().doubleValue(), lonField.numericValue().doubleValue());
                                     geohashes.add(spare.geohash());
                                 }

--- a/src/test/java/org/elasticsearch/index/analysis/AnalysisFactoryTests.java
+++ b/src/test/java/org/elasticsearch/index/analysis/AnalysisFactoryTests.java
@@ -134,6 +134,7 @@ public class AnalysisFactoryTests extends ElasticsearchTestCase {
         put("russianlightstem",          StemmerTokenFilterFactory.class);
         put("scandinavianfolding",       ScandinavianFoldingFilterFactory.class);
         put("scandinaviannormalization", ScandinavianNormalizationFilterFactory.class);
+        put("serbiannormalization",      SerbianNormalizationFilterFactory.class);
         put("shingle",                   ShingleTokenFilterFactory.class);
         put("snowballporter",            SnowballTokenFilterFactory.class);
         put("soraninormalization",       SoraniNormalizationFilterFactory.class);

--- a/src/test/java/org/elasticsearch/index/engine/internal/InternalEngineTests.java
+++ b/src/test/java/org/elasticsearch/index/engine/internal/InternalEngineTests.java
@@ -348,6 +348,9 @@ public class InternalEngineTests extends ElasticsearchTestCase {
     }
 
     public void testStartAndAcquireConcurrently() {
+        // Close engine from setUp (we create our own):
+        engine.close();
+
         ConcurrentMergeSchedulerProvider mergeSchedulerProvider = new ConcurrentMergeSchedulerProvider(shardId, EMPTY_SETTINGS, threadPool, new IndexSettingsService(shardId.index(), EMPTY_SETTINGS));
         final Engine engine = createEngine(engineSettingsService, store, createTranslog(), mergeSchedulerProvider);
         final AtomicBoolean startPending = new AtomicBoolean(true);
@@ -377,6 +380,9 @@ public class InternalEngineTests extends ElasticsearchTestCase {
 
     @Test
     public void testSegmentsWithMergeFlag() throws Exception {
+        // Close engine from setUp (we create our own):
+        engine.close();
+
         ConcurrentMergeSchedulerProvider mergeSchedulerProvider = new ConcurrentMergeSchedulerProvider(shardId, EMPTY_SETTINGS, threadPool, new IndexSettingsService(shardId.index(), EMPTY_SETTINGS));
         final AtomicReference<CountDownLatch> waitTillMerge = new AtomicReference<>();
         final AtomicReference<CountDownLatch> waitForMerge = new AtomicReference<>();
@@ -1306,6 +1312,9 @@ public class InternalEngineTests extends ElasticsearchTestCase {
     @Slow
     @Test
     public void testEnableGcDeletes() throws Exception {
+
+        // Close engine from setUp (we create our own):
+        engine.close();
 
         // Make sure enableGCDeletes == false works:
         Settings settings = ImmutableSettings.builder()

--- a/src/test/java/org/elasticsearch/index/mapper/string/SimpleStringMappingTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/string/SimpleStringMappingTests.java
@@ -107,7 +107,7 @@ public class SimpleStringMappingTests extends ElasticsearchSingleNodeTest {
         assertEquals(ft1.omitNorms(), ft2.omitNorms());
         assertEquals(ft1.indexOptions(), ft2.indexOptions());
         assertEquals(ft1.storeTermVectors(), ft2.storeTermVectors());
-        assertEquals(ft1.docValueType(), ft2.docValueType());
+        assertEquals(ft1.docValuesType(), ft2.docValuesType());
     }
 
     private void assertParseIdemPotent(IndexableFieldType expected, DocumentMapper mapper) throws Exception {
@@ -327,8 +327,8 @@ public class SimpleStringMappingTests extends ElasticsearchSingleNodeTest {
 
     public static DocValuesType docValuesType(Document document, String fieldName) {
         for (IndexableField field : document.getFields(fieldName)) {
-            if (field.fieldType().docValueType() != DocValuesType.NONE) {
-                return field.fieldType().docValueType();
+            if (field.fieldType().docValuesType() != DocValuesType.NONE) {
+                return field.fieldType().docValuesType();
             }
         }
         return DocValuesType.NONE;

--- a/src/test/java/org/elasticsearch/index/store/distributor/DistributorTests.java
+++ b/src/test/java/org/elasticsearch/index/store/distributor/DistributorTests.java
@@ -164,7 +164,7 @@ public class DistributorTests extends ElasticsearchTestCase {
 
 
         public FakeFsDirectory(String path, long usableSpace) throws IOException {
-            super(Paths.get(path), NoLockFactory.getNoLockFactory());
+            super(Paths.get(path), NoLockFactory.INSTANCE);
             allocationCount = 0;
             this.useableSpace = usableSpace;
         }


### PR DESCRIPTION
A few recent lucene changes to fold in:

We've removed IndexWriter.unLock in Lucene, so I also removed "clear
lock on startup" in Elasticsearch.  A couple test cases were missing
engine.close() before opening a new engine.

I exposed the new SerbianNormalizationFilterFactory.

I noticed that we silently use NoLockFactory if you have a typo in
your index.store.fs.fs_lock; I changed this to throw
StoreException instead.  I think it's scary to be lenient
here?

The trickiest change was DistributorDirectory, and how it tracks the
file created by the lock factory.  For the writeFiles boolean, I had
to remove the check that "lockFactory instanceof FSLockFactory"; maybe
we could use reflection to get this, if it's really necessary?  (Do we
really support using NoLockFactory w/ FSDirectory?).  Or maybe instead
we could check if the class name of the lock/factory is NoLock, but
MockDirWrapper wraps in AssertingLock...

I added some harmless "synchronized" to methods (all callers of these
private methods are already sync'd) just to make it clear on quick
look that all access/changes to nameDirMapping are in fact sync'd.

I also fixed ConcurrentMergeSchedulerProvider to disable Lucene's CMS
stalling (override w/ an empty maybeStall method).  We can simplify
things here: remove EnableMergeScheduler, the separate MERGE thread
pool, let IndexWriter launch merges when they are needed (not
separately, once every second), etc., since Lucene won't stall
indexing threads anymore ... I'll open a separate issue for this.
