### PR TITLE
Fix wrong error messages in MultiMatchQueryParser

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/MultiMatchQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MultiMatchQueryParser.java
@@ -34,7 +34,7 @@ import java.io.IOException;
 import java.util.Map;
 
 /**
- * Same ad {@link MatchQueryParser} but has support for multiple fields.
+ * Same as {@link MatchQueryParser} but has support for multiple fields.
  */
 public class MultiMatchQueryParser implements QueryParser {
 
@@ -142,11 +142,11 @@ public class MultiMatchQueryParser implements QueryParser {
         }
 
         if (value == null) {
-            throw new QueryParsingException(parseContext.index(), "No text specified for match_all query");
+            throw new QueryParsingException(parseContext.index(), "No text specified for multi_match query");
         }
 
         if (fieldNameWithBoosts.isEmpty()) {
-            throw new QueryParsingException(parseContext.index(), "No fields specified for match_all query");
+            throw new QueryParsingException(parseContext.index(), "No fields specified for multi_match query");
         }
         if (type == null) {
             type = MultiMatchQueryBuilder.Type.BEST_FIELDS;


### PR DESCRIPTION
There is an issue with the error messages of `multi_match`:

``` json
{
    "multi_match": {
        "query":    "full text search",
        "fields":   [ "title", "body" ]
    }
}
```

If I do not have any "title" or "body" fields in my mapping, it threw a parse error: `No fields specified for match_all query`. Which is wrong both ways:
- There are fields in my query
- my query is not a "match_all" :)

This PR fix this last issue and a small typo in the doc block.
