### PR TITLE
Use Lucene checksums if segment version is >= 4.9.0

### DIFF
--- a/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/src/main/java/org/elasticsearch/index/store/Store.java
@@ -603,6 +603,9 @@ public class Store extends AbstractIndexShardComponent implements CloseableIndex
      */
     public final static class MetadataSnapshot implements Iterable<StoreFileMetaData> {
         private static final ESLogger logger = Loggers.getLogger(MetadataSnapshot.class);
+        private static final Version FIRST_LUCENE_CHECKSUM_VERSION = Version.LUCENE_48;
+        // we stopped writing legacy checksums in 1.3.0 so all segments here must use the new CRC32 version
+        private static final Version FIRST_ES_CRC32_VERSION = org.elasticsearch.Version.V_1_3_0.luceneVersion;
 
         private final Map<String, StoreFileMetaData> metadata;
 
@@ -620,6 +623,11 @@ public class Store extends AbstractIndexShardComponent implements CloseableIndex
             metadata = buildMetadata(commit, directory, logger);
         }
 
+        private static final boolean useLuceneChecksum(Version version, boolean hasLegacyChecksum) {
+            return (version.onOrAfter(FIRST_LUCENE_CHECKSUM_VERSION) && hasLegacyChecksum == false) // no legacy checksum and a guarantee that lucene has checksums
+                    || version.onOrAfter(FIRST_ES_CRC32_VERSION); // OR we know that we didn't even write legacy checksums anymore when this segment was written.
+        }
+
         ImmutableMap<String, StoreFileMetaData> buildMetadata(IndexCommit commit, Directory directory, ESLogger logger) throws IOException {
             ImmutableMap.Builder<String, StoreFileMetaData> builder = ImmutableMap.builder();
             Map<String, String> checksumMap = readLegacyChecksums(directory).v1();
@@ -633,7 +641,7 @@ public class Store extends AbstractIndexShardComponent implements CloseableIndex
                     }
                     for (String file : info.files()) {
                         String legacyChecksum = checksumMap.get(file);
-                        if (version.onOrAfter(Version.LUCENE_4_8) && legacyChecksum == null) {
+                        if (useLuceneChecksum(version, legacyChecksum != null)) {
                             checksumFromLuceneFile(directory, file, builder, logger, version, Lucene46SegmentInfoFormat.SI_EXTENSION.equals(IndexFileNames.getExtension(file)));
                         } else {
                             builder.put(file, new StoreFileMetaData(file, directory.fileLength(file), legacyChecksum, null));
@@ -642,7 +650,7 @@ public class Store extends AbstractIndexShardComponent implements CloseableIndex
                 }
                 final String segmentsFile = segmentCommitInfos.getSegmentsFileName();
                 String legacyChecksum = checksumMap.get(segmentsFile);
-                if (maxVersion.onOrAfter(Version.LUCENE_4_8) && legacyChecksum == null) {
+                if (useLuceneChecksum(maxVersion, legacyChecksum != null)) {
                     checksumFromLuceneFile(directory, segmentsFile, builder, logger, maxVersion, true);
                 } else {
                     builder.put(segmentsFile, new StoreFileMetaData(segmentsFile, directory.fileLength(segmentsFile), legacyChecksum, null));

--- a/src/test/java/org/elasticsearch/index/store/StoreTest.java
+++ b/src/test/java/org/elasticsearch/index/store/StoreTest.java
@@ -19,14 +19,12 @@
 package org.elasticsearch.index.store;
 
 import org.apache.lucene.analysis.MockAnalyzer;
-import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.codecs.*;
+import org.apache.lucene.codecs.lucene45.Lucene45RWCodec;
 import org.apache.lucene.document.*;
 import org.apache.lucene.index.*;
 import org.apache.lucene.store.*;
-import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.IOUtils;
-import org.apache.lucene.util.TestUtil;
-import org.apache.lucene.util.Version;
+import org.apache.lucene.util.*;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.env.ShardLock;
 import org.elasticsearch.index.Index;
@@ -36,6 +34,8 @@ import org.elasticsearch.index.store.distributor.LeastUsedDistributor;
 import org.elasticsearch.index.store.distributor.RandomWeightedDistributor;
 import org.elasticsearch.test.DummyShardLock;
 import org.elasticsearch.test.ElasticsearchLuceneTestCase;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.FileNotFoundException;
@@ -49,6 +49,16 @@ import static com.carrotsearch.randomizedtesting.RandomizedTest.*;
 import static org.hamcrest.Matchers.*;
 
 public class StoreTest extends ElasticsearchLuceneTestCase {
+
+    @BeforeClass
+    public static void before() {
+        LuceneTestCase.OLD_FORMAT_IMPERSONATION_IS_ACTIVE = true;
+    }
+
+    @AfterClass
+    public static void after() {
+        LuceneTestCase.OLD_FORMAT_IMPERSONATION_IS_ACTIVE = false;
+    }
 
     @Test
     public void testRefCount() throws IOException {
@@ -188,13 +198,40 @@ public class StoreTest extends ElasticsearchLuceneTestCase {
         IOUtils.close(verifyingOutput, dir);
     }
 
+    private static final class OldSIMockingCodec extends Lucene45RWCodec {
+
+        @Override
+        public SegmentInfoFormat segmentInfoFormat() {
+            final SegmentInfoFormat segmentInfoFormat = super.segmentInfoFormat();
+            return new SegmentInfoFormat() {
+                @Override
+                public SegmentInfoReader getSegmentInfoReader() {
+                    return segmentInfoFormat.getSegmentInfoReader();
+                }
+
+                @Override
+                public SegmentInfoWriter getSegmentInfoWriter() {
+                    final SegmentInfoWriter segmentInfoWriter = segmentInfoFormat.getSegmentInfoWriter();
+                    return new SegmentInfoWriter() {
+                        @Override
+                        public void write(Directory dir, SegmentInfo info, FieldInfos fis, IOContext ioContext) throws IOException {
+                            info.setVersion(Version.LUCENE_45); // maybe lucene should do this too...
+                            segmentInfoWriter.write(dir, info, fis, ioContext);
+                        }
+                    };
+                }
+            };
+        }
+    }
+
     @Test
     public void testWriteLegacyChecksums() throws IOException {
         final ShardId shardId = new ShardId(new Index("index"), 1);
         DirectoryService directoryService = new LuceneManagedDirectoryService(random());
         Store store = new Store(shardId, ImmutableSettings.EMPTY, null, directoryService, randomDistributor(directoryService), new DummyShardLock(shardId));
         // set default codec - all segments need checksums
-        IndexWriter writer = new IndexWriter(store.directory(), newIndexWriterConfig(random(), TEST_VERSION_CURRENT, new MockAnalyzer(random())).setCodec(actualDefaultCodec()));
+        final boolean usesOldCodec = randomBoolean();
+        IndexWriter writer = new IndexWriter(store.directory(), newIndexWriterConfig(random(), TEST_VERSION_CURRENT, new MockAnalyzer(random())).setCodec(usesOldCodec ? new OldSIMockingCodec() : actualDefaultCodec()));
         int docs = 1 + random().nextInt(100);
 
         for (int i = 0; i < docs; i++) {
@@ -234,23 +271,34 @@ public class StoreTest extends ElasticsearchLuceneTestCase {
             if (file.equals("write.lock") || file.equals(IndexFileNames.SEGMENTS_GEN)) {
                 continue;
             }
-            try (IndexInput input = store.directory().openInput(file, IOContext.READONCE)) {
-                String checksum = Store.digestToString(CodecUtil.retrieveChecksum(input));
-                StoreFileMetaData storeFileMetaData = new StoreFileMetaData(file, store.directory().fileLength(file), checksum, null);
-                legacyMeta.put(file, storeFileMetaData);
-                checksums.add(storeFileMetaData);
-
-            }
-
+            StoreFileMetaData storeFileMetaData = new StoreFileMetaData(file, store.directory().fileLength(file), file + "checksum", null);
+            legacyMeta.put(file, storeFileMetaData);
+            checksums.add(storeFileMetaData);
         }
         checksums.write(store);
 
         metadata = store.getMetadata();
         Map<String, StoreFileMetaData> stringStoreFileMetaDataMap = metadata.asMap();
         assertThat(legacyMeta.size(), equalTo(stringStoreFileMetaDataMap.size()));
-        for (StoreFileMetaData meta : legacyMeta.values()) {
-            assertTrue(stringStoreFileMetaDataMap.containsKey(meta.name()));
-            assertTrue(stringStoreFileMetaDataMap.get(meta.name()).isSame(meta));
+        if (usesOldCodec) {
+            for (StoreFileMetaData meta : legacyMeta.values()) {
+                assertTrue(meta.toString(), stringStoreFileMetaDataMap.containsKey(meta.name()));
+                assertEquals(meta.name() + "checksum", meta.checksum());
+                assertTrue(meta + " vs. " + stringStoreFileMetaDataMap.get(meta.name()), stringStoreFileMetaDataMap.get(meta.name()).isSame(meta));
+            }
+        } else {
+
+            // even if we have a legacy checksum - if we use a new codec we should reuse
+            for (StoreFileMetaData meta : legacyMeta.values()) {
+                assertTrue(meta.toString(), stringStoreFileMetaDataMap.containsKey(meta.name()));
+                assertFalse(meta + " vs. " + stringStoreFileMetaDataMap.get(meta.name()), stringStoreFileMetaDataMap.get(meta.name()).isSame(meta));
+                StoreFileMetaData storeFileMetaData = metadata.get(meta.name());
+                try (IndexInput input = store.openVerifyingInput(meta.name(), IOContext.DEFAULT, storeFileMetaData)) {
+                    assertTrue(storeFileMetaData.toString(), input instanceof Store.VerifyingIndexInput);
+                    input.seek(meta.length());
+                    Store.verify(input);
+                }
+            }
         }
         assertDeleteContent(store, directoryService);
         IOUtils.close(store);


### PR DESCRIPTION
We started to use the lucene CRC32 checksums instead of the legacy Adler32
in `v1.3.0` which was the first version using lucene `4.9.0`. We can safely
assume that if the segment was written with this version that checksums
from lucene can be used even if the legacy checksum claims that it has a Adler32
for a given file / segment.

Closes #8587 

NOTE: this PR is against 1.x but will apply to master too but since it needs to pass BWC tests opened it against 1.x
