### PR TITLE
Fix error in documentation

### DIFF
--- a/docs/reference/mapping/fields/timestamp-field.asciidoc
+++ b/docs/reference/mapping/fields/timestamp-field.asciidoc
@@ -122,5 +122,5 @@ You can also set the default value to any date respecting <<mapping-timestamp-fi
 }
 --------------------------------------------------
 
-If you don't provide any timestamp value, indexation will fail.
+If you don't provide any timestamp value, _timestamp will be set to this default value.
 


### PR DESCRIPTION
Indexation does not fail if no timestamp provided when there is a default value defined in mapping.
