### PR TITLE
Fixes description of thor commands in Readme

### DIFF
--- a/rest-api-spec/README.markdown
+++ b/rest-api-spec/README.markdown
@@ -50,8 +50,8 @@ it is the responsibility of the developer to use this information for a sensible
 
 The repository contains some utilities in the `utils` directory:
 
-* The `thor api:generate:spec` will generate the basic JSON specification from Java source code
-* The `thor api:generate:code` generates Ruby source code and tests from the specs, and can be extended
+* The `thor api:spec:generate` will generate the basic JSON specification from Java source code
+* The `thor api:code:generate` generates Ruby source code and tests from the specs, and can be extended
   to generate assets in another programming language
 
 Run `bundle install` and then `thor list` in the _utils_ folder.
@@ -59,6 +59,13 @@ Run `bundle install` and then `thor list` in the _utils_ folder.
 The full command to generate the api spec is:
 
     thor api:spec:generate --output=myfolder --elasticsearch=/path/to/es
+
+Then to generate ruby files for all JSON specifications:
+
+    thor api:code:generate --output=myfolder-test/ myfolder/*.json
+
+This generates a list of ruby files with tests in folder `myfolder-test`.
+
 
 ## License
 

--- a/rest-api-spec/utils/thor/generate_source.rb
+++ b/rest-api-spec/utils/thor/generate_source.rb
@@ -34,7 +34,7 @@ module Elasticsearch
       method_option :language,  default: 'ruby',                                          desc: 'Programming language'
       method_option :force,     type: :boolean, default: false,                           desc: 'Overwrite the output'
       method_option :verbose,   type: :boolean, default: false,                           desc: 'Output more information'
-      method_option :input,     default: File.expand_path('../../../api-spec', __FILE__), desc: 'Path to directory with JSON API specs'
+      method_option :input,     default: File.expand_path('../../../api', __FILE__), desc: 'Path to directory with JSON API specs'
       method_option :output,    default: File.expand_path('../../../tmp/out', __FILE__),        desc: 'Path to output directory'
 
       def generate(*files)


### PR DESCRIPTION
Fixes the description of how to generate JSON API files and matching ruby files.
- adjusts default option of `input` argument to match existing folder
- fixes description of thor usage.
