### PR TITLE
[SPEC] Fixes a few locations of the params object in JSON specification

### DIFF
--- a/rest-api-spec/api/delete_template.json
+++ b/rest-api-spec/api/delete_template.json
@@ -10,17 +10,17 @@
           "type" : "string",
           "description" : "Template ID"
         }
-      }
-    },
-    "params" : {
-      "version": {
-        "type": "number",
-        "description": "Explicit version number for concurrency control"
       },
-      "version_type": {
-        "type": "enum",
-        "options": ["internal", "external", "external_gte", "force"],
-        "description": "Specific version type"
+      "params" : {
+        "version": {
+          "type": "number",
+          "description": "Explicit version number for concurrency control"
+        },
+        "version_type": {
+          "type": "enum",
+          "options": ["internal", "external", "external_gte", "force"],
+          "description": "Specific version type"
+        }
       }
     },
     "body": null

--- a/rest-api-spec/api/indices.get.json
+++ b/rest-api-spec/api/indices.get.json
@@ -34,6 +34,7 @@
           "description":"Whether wildcard expressions should get expanded to open or closed indices (default: open)"
         }
       }
-    }
+    },
+    "body": null
   }
 }

--- a/rest-api-spec/api/put_template.json
+++ b/rest-api-spec/api/put_template.json
@@ -11,23 +11,23 @@
           "description" : "Template ID",
           "required" : true
         }
-      }
-    },
-    "params" : {
-      "op_type": {
-        "type" : "enum",
-        "options" : ["index", "create"],
-        "default" : "index",
-        "description" : "Explicit operation type"
       },
-      "version": {
-        "type": "number",
-        "description": "Explicit version number for concurrency control"
-      },
-      "version_type": {
-        "type": "enum",
-        "options": ["internal", "external", "external_gte", "force"],
-        "description": "Specific version type"
+      "params" : {
+        "op_type": {
+          "type" : "enum",
+          "options" : ["index", "create"],
+          "default" : "index",
+          "description" : "Explicit operation type"
+        },
+        "version": {
+          "type": "number",
+          "description": "Explicit version number for concurrency control"
+        },
+        "version_type": {
+          "type": "enum",
+          "options": ["internal", "external", "external_gte", "force"],
+          "description": "Specific version type"
+        }
       }
     },
     "body": {


### PR DESCRIPTION
Moves the `params` block in a couple of JSON specification files, they were not located in the `url` block.
