### PR TITLE
Switch to forbidden-apis 1.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1202,7 +1202,7 @@
             <plugin>
                 <groupId>de.thetaphi</groupId>
                 <artifactId>forbiddenapis</artifactId>
-                <version>1.6.1</version>
+                <version>1.7</version>
 
                 <executions>
                     <execution>


### PR DESCRIPTION
This pull request switches to forbidden-apis 1.7, see https://code.google.com/p/forbidden-apis/wiki/Changes for details. The main solved issue in addition to new Ant features and improved documentation is fixes in ignoring unresolvable signatures (like depecated Java 8 signatures did not work with Java 9, leading to errors in Lucene trunk)
