### PR TITLE
Fixes documentation URLs in spec files

### DIFF
--- a/rest-api-spec/api/cat.aliases.json
+++ b/rest-api-spec/api/cat.aliases.json
@@ -1,6 +1,6 @@
 {
   "cat.aliases": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-aliases.html",
+    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-alias.html",
     "methods": ["GET"],
     "url": {
       "path": "/_cat/aliases",

--- a/rest-api-spec/api/indices.get_settings.json
+++ b/rest-api-spec/api/indices.get_settings.json
@@ -1,6 +1,6 @@
 {
   "indices.get_settings": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-get-mapping.html",
+    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-get-settings.html",
     "methods": ["GET"],
     "url": {
       "path": "/_settings",

--- a/rest-api-spec/api/search_exists.json
+++ b/rest-api-spec/api/search_exists.json
@@ -1,6 +1,6 @@
 {
   "search_exists": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/exists.html",
+    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html",
     "methods": ["POST", "GET"],
     "url": {
       "path": "/_search/exists",

--- a/rest-api-spec/api/suggest.json
+++ b/rest-api-spec/api/suggest.json
@@ -1,6 +1,6 @@
 {
   "suggest": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-search.html",
+    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-suggesters.html",
     "methods": ["POST", "GET"],
     "url": {
       "path": "/_suggest",


### PR DESCRIPTION
This PR fixes a couple of documentation URLs in the JSON spec files that point either to a `404` page or the wrong documentation page.
