### PR TITLE
Adds documentation for indices.exists_template

### DIFF
--- a/docs/reference/indices/templates.asciidoc
+++ b/docs/reference/indices/templates.asciidoc
@@ -95,6 +95,21 @@ curl -XGET localhost:9200/_template/
 
 
 [float]
+[[exists]]
+=== Templates exists
+
+Used to check if the template exists or not. For example:
+
+[source,js]
+-----------------------------------------------
+curl -XHEAD localhost:9200/_template/template_1
+-----------------------------------------------
+
+The HTTP status code indicates if the template with the given name
+exists or not. A status code `200` means it exists, a `404` it does not.
+
+
+[float]
 [[multiple-templates]]
 === Multiple Template Matching
 


### PR DESCRIPTION
Adds a small section about how to check if a template exists to the `indices-templates` page.

The documentation was built and checked with the [docs](https://github.com/elasticsearch/docs) project.
