### PR TITLE
QueryBuilders cleanup (add and deprecate)

### DIFF
--- a/docs/java-api/query-dsl-queries.asciidoc
+++ b/docs/java-api/query-dsl-queries.asciidoc
@@ -275,7 +275,7 @@ See {ref}/query-dsl-query-string-query.html[QueryString Query]
 
 [source,java]
 --------------------------------------------------
-QueryBuilder qb = queryString("+kimchy -elasticsearch");    <1>
+QueryBuilder qb = queryStringQuery("+kimchy -elasticsearch");    <1>
 --------------------------------------------------
 <1> text
 

--- a/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
@@ -23,8 +23,10 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.geo.builders.ShapeBuilder;
 import org.elasticsearch.index.query.functionscore.FunctionScoreQueryBuilder;
 import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilder;
+import org.elasticsearch.script.ScriptService;
 
 import java.util.Collection;
+import java.util.Map;
 
 /**
  * A static factory for simple "import static" usage.
@@ -49,12 +51,21 @@ public abstract class QueryBuilders {
     }
 
     /**
+     * @deprecated by commonTermsQuery(String, Object)
+     * Will be removed in elasticsearch 2.0.0
+     */
+    @Deprecated
+    public static CommonTermsQueryBuilder commonTerms(String name, Object text) {
+        return commonTermsQuery(name, text);
+    }
+
+    /**
      * Creates a common query for the provided field name and text.
      *
      * @param name The field name.
      * @param text The query text (to be analyzed).
      */
-    public static CommonTermsQueryBuilder commonTerms(String name, Object text) {
+    public static CommonTermsQueryBuilder commonTermsQuery(String name, Object text) {
         return new CommonTermsQueryBuilder(name, text);
     }
 
@@ -74,6 +85,7 @@ public abstract class QueryBuilders {
      * @param name The field name.
      * @param text The query text (to be analyzed).
      * @deprecated use {@link #textPhraseQuery(String, Object)} instead
+     * Will be removed in elasticsearch 2.0.0
      */
     public static MatchQueryBuilder textPhrase(String name, Object text) {
         return textPhraseQuery(name, text);
@@ -106,6 +118,7 @@ public abstract class QueryBuilders {
      * @param name The field name.
      * @param text The query text (to be analyzed).
      * @deprecated use {@link #textPhrasePrefixQuery(String, Object)} instead
+     * Will be removed in elasticsearch 2.0.0
      */
     public static MatchQueryBuilder textPhrasePrefix(String name, Object text) {
         return textPhrasePrefixQuery(name, text);
@@ -117,6 +130,7 @@ public abstract class QueryBuilders {
      * @param name The field name.
      * @param text The query text (to be analyzed).
      * @deprecated Use {@link #matchPhrasePrefixQuery(String, Object)}
+     * Will be removed in elasticsearch 2.0.0
      */
     public static MatchQueryBuilder textPhrasePrefixQuery(String name, Object text) {
         return new MatchQueryBuilder(name, text).type(MatchQueryBuilder.Type.PHRASE_PREFIX);
@@ -286,6 +300,14 @@ public abstract class QueryBuilders {
     }
 
     /**
+     * @deprecated by queryStringQuery(String)
+     */
+    @Deprecated
+    public static QueryStringQueryBuilder queryString(String queryString) {
+        return queryStringQuery(queryString);
+    }
+
+    /**
      * A query that parses a query string and runs it. There are two modes that this operates. The first,
      * when no field is added (using {@link QueryStringQueryBuilder#field(String)}, will run the query once and non prefixed fields
      * will use the {@link QueryStringQueryBuilder#defaultField(String)} set. The second, when one or more fields are added
@@ -294,8 +316,16 @@ public abstract class QueryBuilders {
      *
      * @param queryString The query string to run
      */
-    public static QueryStringQueryBuilder queryString(String queryString) {
+    public static QueryStringQueryBuilder queryStringQuery(String queryString) {
         return new QueryStringQueryBuilder(queryString);
+    }
+
+    /**
+     * @deprecated by simpleQueryStringQuery(String)
+     */
+    @Deprecated
+    public static SimpleQueryStringBuilder simpleQueryString(String queryString) {
+        return simpleQueryStringQuery(queryString);
     }
 
     /**
@@ -304,7 +334,7 @@ public abstract class QueryBuilders {
      * {@link org.apache.lucene.queryparser.XSimpleQueryParser} for the full
      * supported syntax.
      */
-    public static SimpleQueryStringBuilder simpleQueryString(String queryString) {
+    public static SimpleQueryStringBuilder simpleQueryStringQuery(String queryString) {
         return new SimpleQueryStringBuilder(queryString);
     }
 
@@ -384,6 +414,7 @@ public abstract class QueryBuilders {
      * @param queryBuilder  The query to apply the filter to
      * @param filterBuilder The filter to apply on the query
      * @deprecated Use filteredQuery instead (rename)
+     * Will be removed in elasticsearch 2.0.0
      */
     public static FilteredQueryBuilder filtered(QueryBuilder queryBuilder, @Nullable FilterBuilder filterBuilder) {
         return new FilteredQueryBuilder(queryBuilder, filterBuilder);
@@ -632,6 +663,8 @@ public abstract class QueryBuilders {
      *
      * @param name   The field name
      * @param values The terms
+     * @deprecated not used
+     * Will be removed in elasticsearch 2.0.0
      */
     public static TermsQueryBuilder inQuery(String name, String... values) {
         return new TermsQueryBuilder(name, values);
@@ -642,6 +675,8 @@ public abstract class QueryBuilders {
      *
      * @param name   The field name
      * @param values The terms
+     * @deprecated not used
+     * Will be removed in elasticsearch 2.0.0
      */
     public static TermsQueryBuilder inQuery(String name, int... values) {
         return new TermsQueryBuilder(name, values);
@@ -652,6 +687,8 @@ public abstract class QueryBuilders {
      *
      * @param name   The field name
      * @param values The terms
+     * @deprecated not used
+     * Will be removed in elasticsearch 2.0.0
      */
     public static TermsQueryBuilder inQuery(String name, long... values) {
         return new TermsQueryBuilder(name, values);
@@ -662,6 +699,8 @@ public abstract class QueryBuilders {
      *
      * @param name   The field name
      * @param values The terms
+     * @deprecated not used
+     * Will be removed in elasticsearch 2.0.0
      */
     public static TermsQueryBuilder inQuery(String name, float... values) {
         return new TermsQueryBuilder(name, values);
@@ -672,6 +711,8 @@ public abstract class QueryBuilders {
      *
      * @param name   The field name
      * @param values The terms
+     * @deprecated not used
+     * Will be removed in elasticsearch 2.0.0
      */
     public static TermsQueryBuilder inQuery(String name, double... values) {
         return new TermsQueryBuilder(name, values);
@@ -682,6 +723,8 @@ public abstract class QueryBuilders {
      *
      * @param name   The field name
      * @param values The terms
+     * @deprecated not used
+     * Will be removed in elasticsearch 2.0.0
      */
     public static TermsQueryBuilder inQuery(String name, Object... values) {
         return new TermsQueryBuilder(name, values);
@@ -692,6 +735,8 @@ public abstract class QueryBuilders {
      *
      * @param name   The field name
      * @param values The terms
+     * @deprecated not used
+     * Will be removed in elasticsearch 2.0.0
      */
     public static TermsQueryBuilder inQuery(String name, Collection<?> values) {
         return new TermsQueryBuilder(name, values);
@@ -732,6 +777,20 @@ public abstract class QueryBuilders {
 
     public static GeoShapeQueryBuilder geoShapeQuery(String name, String indexedShapeId, String indexedShapeType) {
         return new GeoShapeQueryBuilder(name, indexedShapeId, indexedShapeType);
+    }
+
+    /**
+     * Facilitates creating template query requests using an inline script
+     */
+    public static TemplateQueryBuilder templateQuery(String template, Map<String, Object> vars) {
+        return new TemplateQueryBuilder(template, vars);
+    }
+
+    /**
+     * Facilitates creating template query requests
+     */
+    public static TemplateQueryBuilder templateQuery(String template, ScriptService.ScriptType templateType, Map<String, Object> vars) {
+        return new TemplateQueryBuilder(template, templateType, vars);
     }
 
     private QueryBuilders() {

--- a/src/main/java/org/elasticsearch/rest/action/explain/RestExplainAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/explain/RestExplainAction.java
@@ -70,7 +70,7 @@ public class RestExplainAction extends BaseRestHandler {
         } else if (sourceString != null) {
             explainRequest.source(new BytesArray(request.param("source")), false);
         } else if (queryString != null) {
-            QueryStringQueryBuilder queryStringBuilder = QueryBuilders.queryString(queryString);
+            QueryStringQueryBuilder queryStringBuilder = QueryBuilders.queryStringQuery(queryString);
             queryStringBuilder.defaultField(request.param("df"));
             queryStringBuilder.analyzer(request.param("analyzer"));
             queryStringBuilder.analyzeWildcard(request.paramAsBoolean("analyze_wildcard", false));

--- a/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
@@ -125,7 +125,7 @@ public class RestSearchAction extends BaseRestHandler {
         SearchSourceBuilder searchSourceBuilder = null;
         String queryString = request.param("q");
         if (queryString != null) {
-            QueryStringQueryBuilder queryBuilder = QueryBuilders.queryString(queryString);
+            QueryStringQueryBuilder queryBuilder = QueryBuilders.queryStringQuery(queryString);
             queryBuilder.defaultField(request.param("df"));
             queryBuilder.analyzer(request.param("analyzer"));
             queryBuilder.analyzeWildcard(request.paramAsBoolean("analyze_wildcard", false));

--- a/src/main/java/org/elasticsearch/rest/action/support/RestActions.java
+++ b/src/main/java/org/elasticsearch/rest/action/support/RestActions.java
@@ -89,7 +89,7 @@ public class RestActions {
         if (queryString == null) {
             return null;
         }
-        QueryStringQueryBuilder queryBuilder = QueryBuilders.queryString(queryString);
+        QueryStringQueryBuilder queryBuilder = QueryBuilders.queryStringQuery(queryString);
         queryBuilder.defaultField(request.param("df"));
         queryBuilder.analyzer(request.param("analyzer"));
         String defaultOperator = request.param("default_operator");

--- a/src/test/java/org/elasticsearch/action/bench/BenchmarkTestUtil.java
+++ b/src/test/java/org/elasticsearch/action/bench/BenchmarkTestUtil.java
@@ -90,8 +90,8 @@ public class BenchmarkTestUtil {
         QUERY_STRING {
             @Override
             QueryBuilder getQuery() {
-                return QueryBuilders.queryString(
-                            randomAsciiOfLengthBetween(1, 3));
+                return QueryBuilders.queryStringQuery(
+                        randomAsciiOfLengthBetween(1, 3));
             }
         },
         WILDCARD {

--- a/src/test/java/org/elasticsearch/bwcompat/BasicBackwardsCompatibilityTest.java
+++ b/src/test/java/org/elasticsearch/bwcompat/BasicBackwardsCompatibilityTest.java
@@ -432,7 +432,7 @@ public class BasicBackwardsCompatibilityTest extends ElasticsearchBackwardsCompa
             countResponse = client().prepareCount().setQuery(constantScoreQuery(existsFilter("field1"))).get();
             assertHitCount(countResponse, 2l);
 
-            countResponse = client().prepareCount().setQuery(queryString("_exists_:field1")).get();
+            countResponse = client().prepareCount().setQuery(queryStringQuery("_exists_:field1")).get();
             assertHitCount(countResponse, 2l);
 
             countResponse = client().prepareCount().setQuery(filteredQuery(matchAllQuery(), existsFilter("field2"))).get();
@@ -458,7 +458,7 @@ public class BasicBackwardsCompatibilityTest extends ElasticsearchBackwardsCompa
             countResponse = client().prepareCount().setQuery(constantScoreQuery(missingFilter("field1"))).get();
             assertHitCount(countResponse, 2l);
 
-            countResponse = client().prepareCount().setQuery(queryString("_missing_:field1")).get();
+            countResponse = client().prepareCount().setQuery(queryStringQuery("_missing_:field1")).get();
             assertHitCount(countResponse, 2l);
 
             // wildcard check

--- a/src/test/java/org/elasticsearch/count/query/SimpleQueryTests.java
+++ b/src/test/java/org/elasticsearch/count/query/SimpleQueryTests.java
@@ -88,33 +88,33 @@ public class SimpleQueryTests extends ElasticsearchIntegrationTest {
                 client().prepareIndex("test", "type1", "1").setSource("field1", "the quick brown fox"),
                 client().prepareIndex("test", "type1", "2").setSource("field1", "the quick lazy huge brown fox jumps over the tree") );
 
-        CountResponse countResponse = client().prepareCount().setQuery(QueryBuilders.commonTerms("field1", "the quick brown").cutoffFrequency(3).lowFreqOperator(Operator.OR)).get();
+        CountResponse countResponse = client().prepareCount().setQuery(QueryBuilders.commonTermsQuery("field1", "the quick brown").cutoffFrequency(3).lowFreqOperator(Operator.OR)).get();
         assertHitCount(countResponse, 3l);
 
-        countResponse = client().prepareCount().setQuery(QueryBuilders.commonTerms("field1", "the quick brown").cutoffFrequency(3).lowFreqOperator(Operator.AND)).get();
+        countResponse = client().prepareCount().setQuery(QueryBuilders.commonTermsQuery("field1", "the quick brown").cutoffFrequency(3).lowFreqOperator(Operator.AND)).get();
         assertHitCount(countResponse, 2l);
 
         // Default
-        countResponse = client().prepareCount().setQuery(QueryBuilders.commonTerms("field1", "the quick brown").cutoffFrequency(3)).get();
+        countResponse = client().prepareCount().setQuery(QueryBuilders.commonTermsQuery("field1", "the quick brown").cutoffFrequency(3)).get();
         assertHitCount(countResponse, 3l);
 
-        countResponse = client().prepareCount().setQuery(QueryBuilders.commonTerms("field1", "the huge fox").lowFreqMinimumShouldMatch("2")).get();
+        countResponse = client().prepareCount().setQuery(QueryBuilders.commonTermsQuery("field1", "the huge fox").lowFreqMinimumShouldMatch("2")).get();
         assertHitCount(countResponse, 1l);
 
-        countResponse = client().prepareCount().setQuery(QueryBuilders.commonTerms("field1", "the lazy fox brown").cutoffFrequency(1).highFreqMinimumShouldMatch("3")).get();
+        countResponse = client().prepareCount().setQuery(QueryBuilders.commonTermsQuery("field1", "the lazy fox brown").cutoffFrequency(1).highFreqMinimumShouldMatch("3")).get();
         assertHitCount(countResponse, 2l);
 
-        countResponse = client().prepareCount().setQuery(QueryBuilders.commonTerms("field1", "the lazy fox brown").cutoffFrequency(1).highFreqMinimumShouldMatch("4")).get();
+        countResponse = client().prepareCount().setQuery(QueryBuilders.commonTermsQuery("field1", "the lazy fox brown").cutoffFrequency(1).highFreqMinimumShouldMatch("4")).get();
         assertHitCount(countResponse, 1l);
 
         countResponse = client().prepareCount().setSource(new BytesArray("{ \"query\" : { \"common\" : { \"field1\" : { \"query\" : \"the lazy fox brown\", \"cutoff_frequency\" : 1, \"minimum_should_match\" : { \"high_freq\" : 4 } } } } }").array()).get();
         assertHitCount(countResponse, 1l);
 
         // Default
-        countResponse = client().prepareCount().setQuery(QueryBuilders.commonTerms("field1", "the lazy fox brown").cutoffFrequency(1)).get();
+        countResponse = client().prepareCount().setQuery(QueryBuilders.commonTermsQuery("field1", "the lazy fox brown").cutoffFrequency(1)).get();
         assertHitCount(countResponse, 1l);
 
-        countResponse = client().prepareCount().setQuery(QueryBuilders.commonTerms("field1", "the quick brown").cutoffFrequency(3).analyzer("standard")).get();
+        countResponse = client().prepareCount().setQuery(QueryBuilders.commonTermsQuery("field1", "the quick brown").cutoffFrequency(3).analyzer("standard")).get();
         assertHitCount(countResponse, 3l);
         // standard drops "the" since its a stopword
 
@@ -141,19 +141,19 @@ public class SimpleQueryTests extends ElasticsearchIntegrationTest {
         client().prepareIndex("test", "type1", "1").setSource("field1", "value_1", "field2", "value_2").get();
         refresh();
 
-        CountResponse countResponse = client().prepareCount().setQuery(queryString("value*").analyzeWildcard(true)).get();
+        CountResponse countResponse = client().prepareCount().setQuery(queryStringQuery("value*").analyzeWildcard(true)).get();
         assertHitCount(countResponse, 1l);
 
-        countResponse = client().prepareCount().setQuery(queryString("*ue*").analyzeWildcard(true)).get();
+        countResponse = client().prepareCount().setQuery(queryStringQuery("*ue*").analyzeWildcard(true)).get();
         assertHitCount(countResponse, 1l);
 
-        countResponse = client().prepareCount().setQuery(queryString("*ue_1").analyzeWildcard(true)).get();
+        countResponse = client().prepareCount().setQuery(queryStringQuery("*ue_1").analyzeWildcard(true)).get();
         assertHitCount(countResponse, 1l);
 
-        countResponse = client().prepareCount().setQuery(queryString("val*e_1").analyzeWildcard(true)).get();
+        countResponse = client().prepareCount().setQuery(queryStringQuery("val*e_1").analyzeWildcard(true)).get();
         assertHitCount(countResponse, 1l);
 
-        countResponse = client().prepareCount().setQuery(queryString("v?l*e?1").analyzeWildcard(true)).get();
+        countResponse = client().prepareCount().setQuery(queryStringQuery("v?l*e?1").analyzeWildcard(true)).get();
         assertHitCount(countResponse, 1l);
     }
 
@@ -164,17 +164,17 @@ public class SimpleQueryTests extends ElasticsearchIntegrationTest {
         client().prepareIndex("test", "type1", "1").setSource("field1", "value_1", "field2", "value_2").get();
         refresh();
 
-        CountResponse countResponse = client().prepareCount().setQuery(queryString("VALUE_3~1").lowercaseExpandedTerms(true)).get();
+        CountResponse countResponse = client().prepareCount().setQuery(queryStringQuery("VALUE_3~1").lowercaseExpandedTerms(true)).get();
         assertHitCount(countResponse, 1l);
-        countResponse = client().prepareCount().setQuery(queryString("VALUE_3~1").lowercaseExpandedTerms(false)).get();
+        countResponse = client().prepareCount().setQuery(queryStringQuery("VALUE_3~1").lowercaseExpandedTerms(false)).get();
         assertHitCount(countResponse, 0l);
-        countResponse = client().prepareCount().setQuery(queryString("ValUE_*").lowercaseExpandedTerms(true)).get();
+        countResponse = client().prepareCount().setQuery(queryStringQuery("ValUE_*").lowercaseExpandedTerms(true)).get();
         assertHitCount(countResponse, 1l);
-        countResponse = client().prepareCount().setQuery(queryString("vAl*E_1")).get();
+        countResponse = client().prepareCount().setQuery(queryStringQuery("vAl*E_1")).get();
         assertHitCount(countResponse, 1l);
-        countResponse = client().prepareCount().setQuery(queryString("[VALUE_1 TO VALUE_3]")).get();
+        countResponse = client().prepareCount().setQuery(queryStringQuery("[VALUE_1 TO VALUE_3]")).get();
         assertHitCount(countResponse, 1l);
-        countResponse = client().prepareCount().setQuery(queryString("[VALUE_1 TO VALUE_3]").lowercaseExpandedTerms(false)).get();
+        countResponse = client().prepareCount().setQuery(queryStringQuery("[VALUE_1 TO VALUE_3]").lowercaseExpandedTerms(false)).get();
         assertHitCount(countResponse, 0l);
     }
 
@@ -195,13 +195,13 @@ public class SimpleQueryTests extends ElasticsearchIntegrationTest {
         client().prepareIndex("test", "type", "1").setSource("past", aMonthAgo, "future", aMonthFromNow).get();
         refresh();
 
-        CountResponse countResponse = client().prepareCount().setQuery(queryString("past:[now-2M/d TO now/d]")).get();
+        CountResponse countResponse = client().prepareCount().setQuery(queryStringQuery("past:[now-2M/d TO now/d]")).get();
         assertHitCount(countResponse, 1l);
 
-        countResponse = client().prepareCount().setQuery(queryString("future:[now/d TO now+2M/d]").lowercaseExpandedTerms(false)).get();
+        countResponse = client().prepareCount().setQuery(queryStringQuery("future:[now/d TO now+2M/d]").lowercaseExpandedTerms(false)).get();
         assertHitCount(countResponse, 1l);
 
-        countResponse = client().prepareCount("test").setQuery(queryString("future:[now/D TO now+2M/d]").lowercaseExpandedTerms(false)).get();
+        countResponse = client().prepareCount("test").setQuery(queryStringQuery("future:[now/D TO now+2M/d]").lowercaseExpandedTerms(false)).get();
         //D is an unsupported unit in date math
         assertThat(countResponse.getSuccessfulShards(), equalTo(0));
         assertThat(countResponse.getFailedShards(), equalTo(test.numPrimaries));
@@ -316,7 +316,7 @@ public class SimpleQueryTests extends ElasticsearchIntegrationTest {
         countResponse = client().prepareCount().setQuery(constantScoreQuery(existsFilter("field1"))).get();
         assertHitCount(countResponse, 2l);
 
-        countResponse = client().prepareCount().setQuery(queryString("_exists_:field1")).get();
+        countResponse = client().prepareCount().setQuery(queryStringQuery("_exists_:field1")).get();
         assertHitCount(countResponse, 2l);
 
         countResponse = client().prepareCount().setQuery(filteredQuery(matchAllQuery(), existsFilter("field2"))).get();
@@ -342,7 +342,7 @@ public class SimpleQueryTests extends ElasticsearchIntegrationTest {
         countResponse = client().prepareCount().setQuery(constantScoreQuery(missingFilter("field1"))).get();
         assertHitCount(countResponse, 2l);
 
-        countResponse = client().prepareCount().setQuery(queryString("_missing_:field1")).get();
+        countResponse = client().prepareCount().setQuery(queryStringQuery("_missing_:field1")).get();
         assertHitCount(countResponse, 2l);
 
         // wildcard check
@@ -537,13 +537,13 @@ public class SimpleQueryTests extends ElasticsearchIntegrationTest {
         client().prepareIndex("test", "type1", "2").setSource("str", "shay", "date", "2012-02-05", "num", 20).get();
         refresh();
 
-        CountResponse countResponse = client().prepareCount().setQuery(queryString("str:kimcy~1")).get();
+        CountResponse countResponse = client().prepareCount().setQuery(queryStringQuery("str:kimcy~1")).get();
         assertHitCount(countResponse, 1l);
 
-        countResponse = client().prepareCount().setQuery(queryString("num:11~1")).get();
+        countResponse = client().prepareCount().setQuery(queryStringQuery("num:11~1")).get();
         assertHitCount(countResponse, 1l);
 
-        countResponse = client().prepareCount().setQuery(queryString("date:2012-02-02~1d")).get();
+        countResponse = client().prepareCount().setQuery(queryStringQuery("date:2012-02-02~1d")).get();
         assertHitCount(countResponse, 1l);
     }
 
@@ -554,25 +554,25 @@ public class SimpleQueryTests extends ElasticsearchIntegrationTest {
         client().prepareIndex("test", "type1", "2").setSource("str", "shay", "date", "2012-02-05", "num", 20).get();
         refresh();
 
-        CountResponse countResponse = client().prepareCount().setQuery(queryString("num:>19")).get();
+        CountResponse countResponse = client().prepareCount().setQuery(queryStringQuery("num:>19")).get();
         assertHitCount(countResponse, 1l);
 
-        countResponse = client().prepareCount().setQuery(queryString("num:>20")).get();
+        countResponse = client().prepareCount().setQuery(queryStringQuery("num:>20")).get();
         assertHitCount(countResponse, 0l);
 
-        countResponse = client().prepareCount().setQuery(queryString("num:>=20")).get();
+        countResponse = client().prepareCount().setQuery(queryStringQuery("num:>=20")).get();
         assertHitCount(countResponse, 1l);
 
-        countResponse = client().prepareCount().setQuery(queryString("num:>11")).get();
+        countResponse = client().prepareCount().setQuery(queryStringQuery("num:>11")).get();
         assertHitCount(countResponse, 2l);
 
-        countResponse = client().prepareCount().setQuery(queryString("num:<20")).get();
+        countResponse = client().prepareCount().setQuery(queryStringQuery("num:<20")).get();
         assertHitCount(countResponse, 1l);
 
-        countResponse = client().prepareCount().setQuery(queryString("num:<=20")).get();
+        countResponse = client().prepareCount().setQuery(queryStringQuery("num:<=20")).get();
         assertHitCount(countResponse, 2l);
 
-        countResponse = client().prepareCount().setQuery(queryString("+num:>11 +num:<20")).get();
+        countResponse = client().prepareCount().setQuery(queryStringQuery("+num:>11 +num:<20")).get();
         assertHitCount(countResponse, 1l);
     }
 

--- a/src/test/java/org/elasticsearch/count/simple/SimpleCountTests.java
+++ b/src/test/java/org/elasticsearch/count/simple/SimpleCountTests.java
@@ -93,14 +93,14 @@ public class SimpleCountTests extends ElasticsearchIntegrationTest {
         CountResponse countResponse = client().prepareCount().setQuery(QueryBuilders.termQuery("_id", "XXX1")).execute().actionGet();
         assertHitCount(countResponse, 1l);
 
-        countResponse = client().prepareCount().setQuery(QueryBuilders.queryString("_id:XXX1")).execute().actionGet();
+        countResponse = client().prepareCount().setQuery(QueryBuilders.queryStringQuery("_id:XXX1")).execute().actionGet();
         assertHitCount(countResponse, 1l);
 
         // id is not index, but we can automatically support prefix as well
         countResponse = client().prepareCount().setQuery(QueryBuilders.prefixQuery("_id", "XXX")).execute().actionGet();
         assertHitCount(countResponse, 1l);
 
-        countResponse = client().prepareCount().setQuery(QueryBuilders.queryString("_id:XXX*").lowercaseExpandedTerms(false)).execute().actionGet();
+        countResponse = client().prepareCount().setQuery(QueryBuilders.queryStringQuery("_id:XXX*").lowercaseExpandedTerms(false)).execute().actionGet();
         assertHitCount(countResponse, 1l);
     }
 
@@ -114,7 +114,7 @@ public class SimpleCountTests extends ElasticsearchIntegrationTest {
         CountResponse countResponse = client().prepareCount("test").setQuery(QueryBuilders.rangeQuery("field").gte("2010-01-03||+2d").lte("2010-01-04||+2d")).execute().actionGet();
         assertHitCount(countResponse, 2l);
 
-        countResponse = client().prepareCount("test").setQuery(QueryBuilders.queryString("field:[2010-01-03||+2d TO 2010-01-04||+2d]")).execute().actionGet();
+        countResponse = client().prepareCount("test").setQuery(QueryBuilders.queryStringQuery("field:[2010-01-03||+2d TO 2010-01-04||+2d]")).execute().actionGet();
         assertHitCount(countResponse, 2l);
     }
 

--- a/src/test/java/org/elasticsearch/exists/SimpleExistsTests.java
+++ b/src/test/java/org/elasticsearch/exists/SimpleExistsTests.java
@@ -89,13 +89,13 @@ public class SimpleExistsTests extends ElasticsearchIntegrationTest {
         ExistsResponse existsResponse = client().prepareExists().setQuery(QueryBuilders.termQuery("_id", "XXX1")).execute().actionGet();
         assertExists(existsResponse, true);
 
-        existsResponse = client().prepareExists().setQuery(QueryBuilders.queryString("_id:XXX1")).execute().actionGet();
+        existsResponse = client().prepareExists().setQuery(QueryBuilders.queryStringQuery("_id:XXX1")).execute().actionGet();
         assertExists(existsResponse, true);
 
         existsResponse = client().prepareExists().setQuery(QueryBuilders.prefixQuery("_id", "XXX")).execute().actionGet();
         assertExists(existsResponse, true);
 
-        existsResponse = client().prepareExists().setQuery(QueryBuilders.queryString("_id:XXX*").lowercaseExpandedTerms(false)).execute().actionGet();
+        existsResponse = client().prepareExists().setQuery(QueryBuilders.queryStringQuery("_id:XXX*").lowercaseExpandedTerms(false)).execute().actionGet();
         assertExists(existsResponse, true);
     }
 
@@ -109,7 +109,7 @@ public class SimpleExistsTests extends ElasticsearchIntegrationTest {
         ExistsResponse existsResponse = client().prepareExists("test").setQuery(QueryBuilders.rangeQuery("field").gte("2010-01-03||+2d").lte("2010-01-04||+2d")).execute().actionGet();
         assertExists(existsResponse, true);
 
-        existsResponse = client().prepareExists("test").setQuery(QueryBuilders.queryString("field:[2010-01-03||+2d TO 2010-01-04||+2d]")).execute().actionGet();
+        existsResponse = client().prepareExists("test").setQuery(QueryBuilders.queryStringQuery("field:[2010-01-03||+2d TO 2010-01-04||+2d]")).execute().actionGet();
         assertExists(existsResponse, true);
     }
 
@@ -124,7 +124,7 @@ public class SimpleExistsTests extends ElasticsearchIntegrationTest {
         ExistsResponse existsResponse = client().prepareExists("test").setQuery(QueryBuilders.rangeQuery("field").gte("2010-01-07||+2d").lte("2010-01-21||+2d")).execute().actionGet();
         assertExists(existsResponse, false);
 
-        existsResponse = client().prepareExists("test").setQuery(QueryBuilders.queryString("_id:XXY*").lowercaseExpandedTerms(false)).execute().actionGet();
+        existsResponse = client().prepareExists("test").setQuery(QueryBuilders.queryStringQuery("_id:XXY*").lowercaseExpandedTerms(false)).execute().actionGet();
         assertExists(existsResponse, false);
     }
 

--- a/src/test/java/org/elasticsearch/explain/ExplainActionTests.java
+++ b/src/test/java/org/elasticsearch/explain/ExplainActionTests.java
@@ -40,7 +40,7 @@ import java.io.ByteArrayOutputStream;
 import java.util.Map;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
-import static org.elasticsearch.index.query.QueryBuilders.queryString;
+import static org.elasticsearch.index.query.QueryBuilders.queryStringQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
@@ -262,7 +262,7 @@ public class ExplainActionTests extends ElasticsearchIntegrationTest {
 
         refresh();
 
-        ExplainResponse explainResponse = client().prepareExplain("test", "type", "1").setQuery(queryString("past:[now-2M/d TO now/d]")).get();
+        ExplainResponse explainResponse = client().prepareExplain("test", "type", "1").setQuery(queryStringQuery("past:[now-2M/d TO now/d]")).get();
         assertThat(explainResponse.isExists(), equalTo(true));
         assertThat(explainResponse.isMatch(), equalTo(true));
     }

--- a/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
+++ b/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
@@ -120,7 +120,7 @@ public class SimpleIndexQueryParserTests extends ElasticsearchSingleNodeTest {
     @Test
     public void testQueryStringBuilder() throws Exception {
         IndexQueryParserService queryParser = queryParser();
-        Query parsedQuery = queryParser.parse(queryString("test").defaultField("content").phraseSlop(1)).query();
+        Query parsedQuery = queryParser.parse(queryStringQuery("test").defaultField("content").phraseSlop(1)).query();
 
         assertThat(parsedQuery, instanceOf(TermQuery.class));
         TermQuery termQuery = (TermQuery) parsedQuery;
@@ -140,7 +140,7 @@ public class SimpleIndexQueryParserTests extends ElasticsearchSingleNodeTest {
     @Test
     public void testQueryStringBoostsBuilder() throws Exception {
         IndexQueryParserService queryParser = queryParser();
-        QueryStringQueryBuilder builder = queryString("field:boosted^2");
+        QueryStringQueryBuilder builder = queryStringQuery("field:boosted^2");
         Query parsedQuery = queryParser.parse(builder).query();
         assertThat(parsedQuery, instanceOf(TermQuery.class));
         assertThat(((TermQuery) parsedQuery).getTerm(), equalTo(new Term("field", "boosted")));
@@ -149,7 +149,7 @@ public class SimpleIndexQueryParserTests extends ElasticsearchSingleNodeTest {
         parsedQuery = queryParser.parse(builder).query();
         assertThat(parsedQuery.getBoost(), equalTo(4.0f));
 
-        builder = queryString("((field:boosted^2) AND (field:foo^1.5))^3");
+        builder = queryStringQuery("((field:boosted^2) AND (field:foo^1.5))^3");
         parsedQuery = queryParser.parse(builder).query();
         assertThat(parsedQuery, instanceOf(BooleanQuery.class));
         assertThat(assertBooleanSubQuery(parsedQuery, TermQuery.class, 0).getTerm(), equalTo(new Term("field", "boosted")));
@@ -165,7 +165,7 @@ public class SimpleIndexQueryParserTests extends ElasticsearchSingleNodeTest {
     @Test
     public void testQueryStringFields1Builder() throws Exception {
         IndexQueryParserService queryParser = queryParser();
-        Query parsedQuery = queryParser.parse(queryString("test").field("content").field("name").useDisMax(false)).query();
+        Query parsedQuery = queryParser.parse(queryStringQuery("test").field("content").field("name").useDisMax(false)).query();
         assertThat(parsedQuery, instanceOf(BooleanQuery.class));
         BooleanQuery bQuery = (BooleanQuery) parsedQuery;
         assertThat(bQuery.clauses().size(), equalTo(2));
@@ -201,7 +201,7 @@ public class SimpleIndexQueryParserTests extends ElasticsearchSingleNodeTest {
     @Test
     public void testQueryStringFields2Builder() throws Exception {
         IndexQueryParserService queryParser = queryParser();
-        Query parsedQuery = queryParser.parse(queryString("test").field("content").field("name").useDisMax(true)).query();
+        Query parsedQuery = queryParser.parse(queryStringQuery("test").field("content").field("name").useDisMax(true)).query();
         assertThat(parsedQuery, instanceOf(DisjunctionMaxQuery.class));
         DisjunctionMaxQuery disMaxQuery = (DisjunctionMaxQuery) parsedQuery;
         List<Query> disjuncts = disMaxQuery.getDisjuncts();
@@ -224,7 +224,7 @@ public class SimpleIndexQueryParserTests extends ElasticsearchSingleNodeTest {
     @Test
     public void testQueryStringFields3Builder() throws Exception {
         IndexQueryParserService queryParser = queryParser();
-        Query parsedQuery = queryParser.parse(queryString("test").field("content", 2.2f).field("name").useDisMax(true)).query();
+        Query parsedQuery = queryParser.parse(queryStringQuery("test").field("content", 2.2f).field("name").useDisMax(true)).query();
         assertThat(parsedQuery, instanceOf(DisjunctionMaxQuery.class));
         DisjunctionMaxQuery disMaxQuery = (DisjunctionMaxQuery) parsedQuery;
         List<Query> disjuncts = disMaxQuery.getDisjuncts();

--- a/src/test/java/org/elasticsearch/indices/leaks/IndicesLeaksTests.java
+++ b/src/test/java/org/elasticsearch/indices/leaks/IndicesLeaksTests.java
@@ -126,7 +126,7 @@ public class IndicesLeaksTests extends ElasticsearchIntegrationTest {
     private void performCommonOperations() {
         client().prepareIndex("test", "type", "1").setSource("field1", "value", "field2", 2, "field3", 3.0f).execute().actionGet();
         client().admin().indices().prepareRefresh().execute().actionGet();
-        client().prepareSearch("test").setQuery(QueryBuilders.queryString("field1:value")).execute().actionGet();
+        client().prepareSearch("test").setQuery(QueryBuilders.queryStringQuery("field1:value")).execute().actionGet();
         client().prepareSearch("test").setQuery(QueryBuilders.termQuery("field1", "value")).execute().actionGet();
     }
 }

--- a/src/test/java/org/elasticsearch/percolator/PercolatorTests.java
+++ b/src/test/java/org/elasticsearch/percolator/PercolatorTests.java
@@ -372,7 +372,7 @@ public class PercolatorTests extends ElasticsearchIntegrationTest {
         client().prepareIndex("test", PercolatorService.TYPE_NAME, "1")
                 .setSource(jsonBuilder().startObject()
                         .field("source", "productizer")
-                        .field("query", QueryBuilders.constantScoreQuery(QueryBuilders.queryString("filingcategory:s")))
+                        .field("query", QueryBuilders.constantScoreQuery(QueryBuilders.queryStringQuery("filingcategory:s")))
                         .endObject())
                 .setRefresh(true)
                 .execute().actionGet();
@@ -1654,7 +1654,7 @@ public class PercolatorTests extends ElasticsearchIntegrationTest {
         client().prepareIndex("test", PercolatorService.TYPE_NAME, "1")
                 .setSource(jsonBuilder().startObject()
                         .field("query", QueryBuilders.constantScoreQuery(FilterBuilders.andFilter(
-                                FilterBuilders.queryFilter(QueryBuilders.queryString("root")),
+                                FilterBuilders.queryFilter(QueryBuilders.queryStringQuery("root")),
                                 FilterBuilders.termFilter("message", "tree"))))
                         .endObject())
                 .setRefresh(true)
@@ -1729,7 +1729,7 @@ public class PercolatorTests extends ElasticsearchIntegrationTest {
 
         try {
         client().prepareIndex("idx", PercolatorService.TYPE_NAME, "1")
-                .setSource(jsonBuilder().startObject().field("query", QueryBuilders.queryString("color:red")).endObject())
+                .setSource(jsonBuilder().startObject().field("query", QueryBuilders.queryStringQuery("color:red")).endObject())
                 .get();
             fail();
         } catch (PercolatorException e) {
@@ -1747,10 +1747,10 @@ public class PercolatorTests extends ElasticsearchIntegrationTest {
         // The previous percolate request introduced the custom.color field, so now we register the query again
         // and the field name `color` will be resolved to `custom.color` field in mapping via smart field mapping resolving.
         client().prepareIndex("idx", PercolatorService.TYPE_NAME, "1")
-                .setSource(jsonBuilder().startObject().field("query", QueryBuilders.queryString("color:red")).endObject())
+                .setSource(jsonBuilder().startObject().field("query", QueryBuilders.queryStringQuery("color:red")).endObject())
                 .get();
         client().prepareIndex("idx", PercolatorService.TYPE_NAME, "2")
-                .setSource(jsonBuilder().startObject().field("query", QueryBuilders.queryString("color:blue")).field("type", "type").endObject())
+                .setSource(jsonBuilder().startObject().field("query", QueryBuilders.queryStringQuery("color:blue")).field("type", "type").endObject())
                 .get();
 
         // The second request will yield a match, since the query during the proper field during parsing.

--- a/src/test/java/org/elasticsearch/search/child/SimpleChildQuerySearchTests.java
+++ b/src/test/java/org/elasticsearch/search/child/SimpleChildQuerySearchTests.java
@@ -210,7 +210,7 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
         assertThat(searchResponse.getHits().getAt(1).id(), anyOf(equalTo("c1"), equalTo("c2")));
         assertThat(searchResponse.getHits().getAt(1).field("_parent").value().toString(), equalTo("p1"));
 
-        searchResponse = client().prepareSearch("test").setQuery(queryString("_parent:p1")).addFields("_parent").get();
+        searchResponse = client().prepareSearch("test").setQuery(queryStringQuery("_parent:p1")).addFields("_parent").get();
         assertNoFailures(searchResponse);
         assertThat(searchResponse.getHits().totalHits(), equalTo(2l));
         assertThat(searchResponse.getHits().getAt(0).id(), anyOf(equalTo("c1"), equalTo("c2")));
@@ -636,16 +636,16 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
         refresh();
 
         SearchResponse searchResponse = client().prepareSearch("test").setSearchType(SearchType.DFS_QUERY_THEN_FETCH)
-                .setQuery(boolQuery().mustNot(hasChildQuery("child", boolQuery().should(queryString("c_field:*"))))).get();
+                .setQuery(boolQuery().mustNot(hasChildQuery("child", boolQuery().should(queryStringQuery("c_field:*"))))).get();
         assertNoFailures(searchResponse);
 
         searchResponse = client().prepareSearch("test").setSearchType(SearchType.DFS_QUERY_THEN_FETCH)
-                .setQuery(boolQuery().mustNot(hasParentQuery("parent", boolQuery().should(queryString("p_field:*"))))).execute()
+                .setQuery(boolQuery().mustNot(hasParentQuery("parent", boolQuery().should(queryStringQuery("p_field:*"))))).execute()
                 .actionGet();
         assertNoFailures(searchResponse);
 
         searchResponse = client().prepareSearch("test").setSearchType(SearchType.DFS_QUERY_THEN_FETCH)
-                .setQuery(boolQuery().mustNot(topChildrenQuery("child", boolQuery().should(queryString("c_field:*"))))).execute()
+                .setQuery(boolQuery().mustNot(topChildrenQuery("child", boolQuery().should(queryStringQuery("c_field:*"))))).execute()
                 .actionGet();
         assertNoFailures(searchResponse);
     }
@@ -668,7 +668,7 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
         refresh();
 
         SearchResponse searchResponse = client().prepareSearch("test").setSearchType(SearchType.QUERY_THEN_FETCH)
-                .setQuery(boolQuery().mustNot(topChildrenQuery("child", boolQuery().should(queryString("c_field:*"))))).execute()
+                .setQuery(boolQuery().mustNot(topChildrenQuery("child", boolQuery().should(queryStringQuery("c_field:*"))))).execute()
                 .actionGet();
         assertNoFailures(searchResponse);
     }
@@ -1524,7 +1524,7 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
                                         hasChildQuery(
                                                 "child_type_one",
                                                 boolQuery().must(
-                                                        queryString("name:William*").analyzeWildcard(true)
+                                                        queryStringQuery("name:William*").analyzeWildcard(true)
                                                 )
                                         )
                                 )
@@ -1541,7 +1541,7 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
                                         hasChildQuery(
                                                 "child_type_two",
                                                 boolQuery().must(
-                                                        queryString("name:William*").analyzeWildcard(true)
+                                                        queryStringQuery("name:William*").analyzeWildcard(true)
                                                 )
                                         )
                                 )

--- a/src/test/java/org/elasticsearch/search/functionscore/FunctionScoreFieldValueTests.java
+++ b/src/test/java/org/elasticsearch/search/functionscore/FunctionScoreFieldValueTests.java
@@ -65,14 +65,14 @@ public class FunctionScoreFieldValueTests extends ElasticsearchIntegrationTest {
         // document 2 scores higher because 17 > 5
         SearchResponse response = client().prepareSearch("test")
                 .setExplain(randomBoolean())
-                .setQuery(functionScoreQuery(simpleQueryString("foo"), fieldValueFactorFunction("test")))
+                .setQuery(functionScoreQuery(simpleQueryStringQuery("foo"), fieldValueFactorFunction("test")))
                 .get();
         assertOrderedSearchHits(response, "2", "1");
 
         // document 1 scores higher because 1/5 > 1/17
         response = client().prepareSearch("test")
                 .setExplain(randomBoolean())
-                .setQuery(functionScoreQuery(simpleQueryString("foo"),
+                .setQuery(functionScoreQuery(simpleQueryStringQuery("foo"),
                         fieldValueFactorFunction("test").modifier(FieldValueFactorFunction.Modifier.RECIPROCAL)))
                 .get();
         assertOrderedSearchHits(response, "1", "2");
@@ -92,7 +92,7 @@ public class FunctionScoreFieldValueTests extends ElasticsearchIntegrationTest {
         try {
             response = client().prepareSearch("test")
                     .setExplain(randomBoolean())
-                    .setQuery(functionScoreQuery(simpleQueryString("foo"),
+                    .setQuery(functionScoreQuery(simpleQueryStringQuery("foo"),
                             fieldValueFactorFunction("test").modifier(FieldValueFactorFunction.Modifier.RECIPROCAL).factor(0)))
                     .get();
             assertFailures(response);

--- a/src/test/java/org/elasticsearch/search/matchedqueries/MatchedQueriesTests.java
+++ b/src/test/java/org/elasticsearch/search/matchedqueries/MatchedQueriesTests.java
@@ -223,8 +223,8 @@ public class MatchedQueriesTests extends ElasticsearchIntegrationTest {
                     .setQuery(
                             boolQuery()
                                     .minimumNumberShouldMatch(1)
-                                    .should(queryString("dolor").queryName("dolor"))
-                                    .should(queryString("elit").queryName("elit"))
+                                    .should(queryStringQuery("dolor").queryName("dolor"))
+                                    .should(queryStringQuery("elit").queryName("elit"))
                     )
                     .setPreference("_primary")
                     .get();

--- a/src/test/java/org/elasticsearch/search/query/SimpleQueryStringTests.java
+++ b/src/test/java/org/elasticsearch/search/query/SimpleQueryStringTests.java
@@ -34,8 +34,8 @@ import java.util.concurrent.ExecutionException;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
-import static org.elasticsearch.index.query.QueryBuilders.queryString;
-import static org.elasticsearch.index.query.QueryBuilders.simpleQueryString;
+import static org.elasticsearch.index.query.QueryBuilders.queryStringQuery;
+import static org.elasticsearch.index.query.QueryBuilders.simpleQueryStringQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.*;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchHits;
 import static org.hamcrest.Matchers.equalTo;
@@ -56,32 +56,32 @@ public class SimpleQueryStringTests extends ElasticsearchIntegrationTest {
                 client().prepareIndex("test", "type1", "5").setSource("body", "quux baz spaghetti"),
                 client().prepareIndex("test", "type1", "6").setSource("otherbody", "spaghetti"));
 
-        SearchResponse searchResponse = client().prepareSearch().setQuery(simpleQueryString("foo bar")).get();
+        SearchResponse searchResponse = client().prepareSearch().setQuery(simpleQueryStringQuery("foo bar")).get();
         assertHitCount(searchResponse, 3l);
         assertSearchHits(searchResponse, "1", "2", "3");
 
         searchResponse = client().prepareSearch().setQuery(
-                simpleQueryString("foo bar").defaultOperator(SimpleQueryStringBuilder.Operator.AND)).get();
+                simpleQueryStringQuery("foo bar").defaultOperator(SimpleQueryStringBuilder.Operator.AND)).get();
         assertHitCount(searchResponse, 1l);
         assertFirstHit(searchResponse, hasId("3"));
 
-        searchResponse = client().prepareSearch().setQuery(simpleQueryString("\"quux baz\" +(eggplant | spaghetti)")).get();
+        searchResponse = client().prepareSearch().setQuery(simpleQueryStringQuery("\"quux baz\" +(eggplant | spaghetti)")).get();
         assertHitCount(searchResponse, 2l);
         assertSearchHits(searchResponse, "4", "5");
 
         searchResponse = client().prepareSearch().setQuery(
-                simpleQueryString("eggplants").analyzer("snowball")).get();
+                simpleQueryStringQuery("eggplants").analyzer("snowball")).get();
         assertHitCount(searchResponse, 1l);
         assertFirstHit(searchResponse, hasId("4"));
 
         searchResponse = client().prepareSearch().setQuery(
-                simpleQueryString("spaghetti").field("body", 1000.0f).field("otherbody", 2.0f).queryName("myquery")).get();
+                simpleQueryStringQuery("spaghetti").field("body", 1000.0f).field("otherbody", 2.0f).queryName("myquery")).get();
         assertHitCount(searchResponse, 2l);
         assertFirstHit(searchResponse, hasId("5"));
         assertSearchHits(searchResponse, "5", "6");
         assertThat(searchResponse.getHits().getAt(0).getMatchedQueries()[0], equalTo("myquery"));
 
-        searchResponse = client().prepareSearch().setQuery(simpleQueryString("spaghetti").field("*body")).get();
+        searchResponse = client().prepareSearch().setQuery(simpleQueryStringQuery("spaghetti").field("*body")).get();
         assertHitCount(searchResponse, 2l);
         assertSearchHits(searchResponse, "5", "6");
 
@@ -97,21 +97,21 @@ public class SimpleQueryStringTests extends ElasticsearchIntegrationTest {
         client().prepareIndex("test", "type1", "1").setSource("body", "Professional").get();
         refresh();
 
-        SearchResponse searchResponse = client().prepareSearch().setQuery(simpleQueryString("Professio*")).get();
+        SearchResponse searchResponse = client().prepareSearch().setQuery(simpleQueryStringQuery("Professio*")).get();
         assertHitCount(searchResponse, 1l);
         assertSearchHits(searchResponse, "1");
 
         searchResponse = client().prepareSearch().setQuery(
-                simpleQueryString("Professio*").lowercaseExpandedTerms(false)).get();
+                simpleQueryStringQuery("Professio*").lowercaseExpandedTerms(false)).get();
         assertHitCount(searchResponse, 0l);
 
         searchResponse = client().prepareSearch().setQuery(
-                simpleQueryString("Professionan~1")).get();
+                simpleQueryStringQuery("Professionan~1")).get();
         assertHitCount(searchResponse, 1l);
         assertSearchHits(searchResponse, "1");
 
         searchResponse = client().prepareSearch().setQuery(
-                simpleQueryString("Professionan~1").lowercaseExpandedTerms(false)).get();
+                simpleQueryStringQuery("Professionan~1").lowercaseExpandedTerms(false)).get();
         assertHitCount(searchResponse, 0l);
     }
 
@@ -121,17 +121,17 @@ public class SimpleQueryStringTests extends ElasticsearchIntegrationTest {
         client().prepareIndex("test", "type1", "1").setSource("body", "bılly").get();
         refresh();
 
-        SearchResponse searchResponse = client().prepareSearch().setQuery(simpleQueryString("BILL*")).get();
+        SearchResponse searchResponse = client().prepareSearch().setQuery(simpleQueryStringQuery("BILL*")).get();
         assertHitCount(searchResponse, 0l);
-        searchResponse = client().prepareSearch().setQuery(queryString("body:BILL*")).get();
+        searchResponse = client().prepareSearch().setQuery(queryStringQuery("body:BILL*")).get();
         assertHitCount(searchResponse, 0l);
 
         searchResponse = client().prepareSearch().setQuery(
-                simpleQueryString("BILL*").locale(new Locale("tr", "TR"))).get();
+                simpleQueryStringQuery("BILL*").locale(new Locale("tr", "TR"))).get();
         assertHitCount(searchResponse, 1l);
         assertSearchHits(searchResponse, "1");
         searchResponse = client().prepareSearch().setQuery(
-                queryString("body:BILL*").locale(new Locale("tr", "TR"))).get();
+                queryStringQuery("body:BILL*").locale(new Locale("tr", "TR"))).get();
         assertHitCount(searchResponse, 1l);
         assertSearchHits(searchResponse, "1");
     }
@@ -156,22 +156,22 @@ public class SimpleQueryStringTests extends ElasticsearchIntegrationTest {
         refresh();
 
         SearchResponse searchResponse = client().prepareSearch().setQuery(
-                simpleQueryString("foo bar baz").field("body")).get();
+                simpleQueryStringQuery("foo bar baz").field("body")).get();
         assertHitCount(searchResponse, 1l);
         assertSearchHits(searchResponse, "1");
 
         searchResponse = client().prepareSearch().setQuery(
-                simpleQueryString("foo bar baz").field("type1.body")).get();
+                simpleQueryStringQuery("foo bar baz").field("type1.body")).get();
         assertHitCount(searchResponse, 1l);
         assertSearchHits(searchResponse, "1");
 
         searchResponse = client().prepareSearch().setQuery(
-                simpleQueryString("foo bar baz").field("body.sub")).get();
+                simpleQueryStringQuery("foo bar baz").field("body.sub")).get();
         assertHitCount(searchResponse, 1l);
         assertSearchHits(searchResponse, "1");
 
         searchResponse = client().prepareSearch().setQuery(
-                simpleQueryString("foo bar baz").field("type1.body.sub")).get();
+                simpleQueryStringQuery("foo bar baz").field("type1.body.sub")).get();
         assertHitCount(searchResponse, 1l);
         assertSearchHits(searchResponse, "1");
     }
@@ -188,7 +188,7 @@ public class SimpleQueryStringTests extends ElasticsearchIntegrationTest {
                 client().prepareIndex("test", "type1", "6").setSource("otherbody", "spaghetti"));
 
         SearchResponse searchResponse = client().prepareSearch().setQuery(
-                simpleQueryString("foo bar").flags(SimpleQueryStringFlag.ALL)).get();
+                simpleQueryStringQuery("foo bar").flags(SimpleQueryStringFlag.ALL)).get();
         assertHitCount(searchResponse, 3l);
         assertSearchHits(searchResponse, "1", "2", "3");
 
@@ -198,21 +198,21 @@ public class SimpleQueryStringTests extends ElasticsearchIntegrationTest {
         assertSearchHits(searchResponse, "1", "2", "3");
 
         searchResponse = client().prepareSearch().setQuery(
-                simpleQueryString("foo | bar")
+                simpleQueryStringQuery("foo | bar")
                         .defaultOperator(SimpleQueryStringBuilder.Operator.AND)
                         .flags(SimpleQueryStringFlag.OR)).get();
         assertHitCount(searchResponse, 3l);
         assertSearchHits(searchResponse, "1", "2", "3");
 
         searchResponse = client().prepareSearch().setQuery(
-                simpleQueryString("foo | bar")
+                simpleQueryStringQuery("foo | bar")
                         .defaultOperator(SimpleQueryStringBuilder.Operator.AND)
                         .flags(SimpleQueryStringFlag.NONE)).get();
         assertHitCount(searchResponse, 1l);
         assertFirstHit(searchResponse, hasId("3"));
 
         searchResponse = client().prepareSearch().setQuery(
-                simpleQueryString("baz | egg*")
+                simpleQueryStringQuery("baz | egg*")
                         .defaultOperator(SimpleQueryStringBuilder.Operator.AND)
                         .flags(SimpleQueryStringFlag.NONE)).get();
         assertHitCount(searchResponse, 0l);
@@ -229,7 +229,7 @@ public class SimpleQueryStringTests extends ElasticsearchIntegrationTest {
         assertHitCount(searchResponse, 1l);
 
         searchResponse = client().prepareSearch().setQuery(
-                simpleQueryString("baz | egg*")
+                simpleQueryStringQuery("baz | egg*")
                         .defaultOperator(SimpleQueryStringBuilder.Operator.AND)
                         .flags(SimpleQueryStringFlag.WHITESPACE, SimpleQueryStringFlag.PREFIX)).get();
         assertHitCount(searchResponse, 1l);
@@ -243,12 +243,12 @@ public class SimpleQueryStringTests extends ElasticsearchIntegrationTest {
                 client().prepareIndex("test2", "type1", "10").setSource("field", 5));
         refresh();
 
-        SearchResponse searchResponse = client().prepareSearch().setQuery(simpleQueryString("foo").field("field")).get();
+        SearchResponse searchResponse = client().prepareSearch().setQuery(simpleQueryStringQuery("foo").field("field")).get();
         assertFailures(searchResponse);
         assertHitCount(searchResponse, 1l);
         assertSearchHits(searchResponse, "1");
 
-        searchResponse = client().prepareSearch().setQuery(simpleQueryString("foo").field("field").lenient(true)).get();
+        searchResponse = client().prepareSearch().setQuery(simpleQueryStringQuery("foo").field("field").lenient(true)).get();
         assertNoFailures(searchResponse);
         assertHitCount(searchResponse, 1l);
         assertSearchHits(searchResponse, "1");
@@ -260,7 +260,7 @@ public class SimpleQueryStringTests extends ElasticsearchIntegrationTest {
                 client().prepareIndex("test", "doc", "1").setSource("num", 1, "body", "foo bar baz"),
                 client().prepareIndex("test", "doc", "2").setSource("num", 2, "body", "eggplant spaghetti lasagna"));
 
-        BoolQueryBuilder q = boolQuery().should(simpleQueryString("bar").field("num").field("body").lenient(true));
+        BoolQueryBuilder q = boolQuery().should(simpleQueryStringQuery("bar").field("num").field("body").lenient(true));
         SearchResponse resp = client().prepareSearch("test").setQuery(q).get();
         assertNoFailures(resp);
         // the bug is that this would be parsed into basically a match_all
@@ -288,7 +288,7 @@ public class SimpleQueryStringTests extends ElasticsearchIntegrationTest {
         indexRandom(true, client().prepareIndex("test1", "type1", "1").setSource("location", "Köln"));
         refresh();
 
-        SearchResponse searchResponse = client().prepareSearch().setQuery(simpleQueryString("Köln*").analyzeWildcard(true).field("location")).get();
+        SearchResponse searchResponse = client().prepareSearch().setQuery(simpleQueryStringQuery("Köln*").analyzeWildcard(true).field("location")).get();
         assertNoFailures(searchResponse);
         assertHitCount(searchResponse, 1l);
         assertSearchHits(searchResponse, "1");

--- a/src/test/java/org/elasticsearch/search/rescore/QueryRescorerTests.java
+++ b/src/test/java/org/elasticsearch/search/rescore/QueryRescorerTests.java
@@ -38,7 +38,6 @@ import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilders;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.rescore.RescoreBuilder.QueryRescorer;
-import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.junit.Test;
 
@@ -675,10 +674,10 @@ public class QueryRescorerTests extends ElasticsearchIntegrationTest {
 
         // Now use one rescore to drag the number we're looking for into the window of another
         QueryRescorer ninetyIsGood = RescoreBuilder.queryRescorer(
-                QueryBuilders.functionScoreQuery(QueryBuilders.queryString("*ninety*")).boostMode(CombineFunction.REPLACE)
+                QueryBuilders.functionScoreQuery(QueryBuilders.queryStringQuery("*ninety*")).boostMode(CombineFunction.REPLACE)
                 .add(ScoreFunctionBuilders.scriptFunction("1000.0f"))).setScoreMode("total");
         QueryRescorer oneToo = RescoreBuilder.queryRescorer(
-                QueryBuilders.functionScoreQuery(QueryBuilders.queryString("*one*")).boostMode(CombineFunction.REPLACE)
+                QueryBuilders.functionScoreQuery(QueryBuilders.queryStringQuery("*one*")).boostMode(CombineFunction.REPLACE)
                 .add(ScoreFunctionBuilders.scriptFunction("1000.0f"))).setScoreMode("total");
         request.clearRescorers().addRescorer(ninetyIsGood).addRescorer(oneToo, 10);
         response = request.setSize(2).get();

--- a/src/test/java/org/elasticsearch/search/scroll/SearchScrollTests.java
+++ b/src/test/java/org/elasticsearch/search/scroll/SearchScrollTests.java
@@ -193,7 +193,7 @@ public class SearchScrollTests extends ElasticsearchIntegrationTest {
         assertThat(client().prepareCount().setQuery(termQuery("message", "update")).execute().actionGet().getCount(), equalTo(0l));
 
         SearchResponse searchResponse = client().prepareSearch()
-                .setQuery(queryString("user:kimchy"))
+                .setQuery(queryStringQuery("user:kimchy"))
                 .setSize(35)
                 .setScroll(TimeValue.timeValueMinutes(2))
                 .addSort("postDate", SortOrder.ASC)

--- a/src/test/java/org/elasticsearch/search/simple/SimpleSearchTests.java
+++ b/src/test/java/org/elasticsearch/search/simple/SimpleSearchTests.java
@@ -114,14 +114,14 @@ public class SimpleSearchTests extends ElasticsearchIntegrationTest {
         SearchResponse searchResponse = client().prepareSearch().setQuery(QueryBuilders.termQuery("_id", "XXX1")).execute().actionGet();
         assertHitCount(searchResponse, 1l);
 
-        searchResponse = client().prepareSearch().setQuery(QueryBuilders.queryString("_id:XXX1")).execute().actionGet();
+        searchResponse = client().prepareSearch().setQuery(QueryBuilders.queryStringQuery("_id:XXX1")).execute().actionGet();
         assertHitCount(searchResponse, 1l);
 
         // id is not index, but we can automatically support prefix as well
         searchResponse = client().prepareSearch().setQuery(QueryBuilders.prefixQuery("_id", "XXX")).execute().actionGet();
         assertHitCount(searchResponse, 1l);
 
-        searchResponse = client().prepareSearch().setQuery(QueryBuilders.queryString("_id:XXX*").lowercaseExpandedTerms(false)).execute().actionGet();
+        searchResponse = client().prepareSearch().setQuery(QueryBuilders.queryStringQuery("_id:XXX*").lowercaseExpandedTerms(false)).execute().actionGet();
         assertHitCount(searchResponse, 1l);
     }
 
@@ -167,7 +167,7 @@ public class SimpleSearchTests extends ElasticsearchIntegrationTest {
         assertNoFailures(searchResponse);
         assertHitCount(searchResponse, 2l);
 
-        searchResponse = client().prepareSearch("test").setQuery(QueryBuilders.queryString("field:[2010-01-03||+2d TO 2010-01-04||+2d]")).execute().actionGet();
+        searchResponse = client().prepareSearch("test").setQuery(QueryBuilders.queryStringQuery("field:[2010-01-03||+2d TO 2010-01-04||+2d]")).execute().actionGet();
         assertHitCount(searchResponse, 2l);
     }
     

--- a/src/test/java/org/elasticsearch/validate/SimpleValidateQueryTests.java
+++ b/src/test/java/org/elasticsearch/validate/SimpleValidateQueryTests.java
@@ -41,7 +41,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 
-import static org.elasticsearch.index.query.QueryBuilders.queryString;
+import static org.elasticsearch.index.query.QueryBuilders.queryStringQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.*;
@@ -66,15 +66,15 @@ public class SimpleValidateQueryTests extends ElasticsearchIntegrationTest {
         refresh();
 
         assertThat(client().admin().indices().prepareValidateQuery("test").setSource("foo".getBytes(Charsets.UTF_8)).execute().actionGet().isValid(), equalTo(false));
-        assertThat(client().admin().indices().prepareValidateQuery("test").setQuery(QueryBuilders.queryString("_id:1")).execute().actionGet().isValid(), equalTo(true));
-        assertThat(client().admin().indices().prepareValidateQuery("test").setQuery(QueryBuilders.queryString("_i:d:1")).execute().actionGet().isValid(), equalTo(false));
+        assertThat(client().admin().indices().prepareValidateQuery("test").setQuery(QueryBuilders.queryStringQuery("_id:1")).execute().actionGet().isValid(), equalTo(true));
+        assertThat(client().admin().indices().prepareValidateQuery("test").setQuery(QueryBuilders.queryStringQuery("_i:d:1")).execute().actionGet().isValid(), equalTo(false));
 
-        assertThat(client().admin().indices().prepareValidateQuery("test").setQuery(QueryBuilders.queryString("foo:1")).execute().actionGet().isValid(), equalTo(true));
-        assertThat(client().admin().indices().prepareValidateQuery("test").setQuery(QueryBuilders.queryString("bar:hey")).execute().actionGet().isValid(), equalTo(false));
+        assertThat(client().admin().indices().prepareValidateQuery("test").setQuery(QueryBuilders.queryStringQuery("foo:1")).execute().actionGet().isValid(), equalTo(true));
+        assertThat(client().admin().indices().prepareValidateQuery("test").setQuery(QueryBuilders.queryStringQuery("bar:hey")).execute().actionGet().isValid(), equalTo(false));
 
-        assertThat(client().admin().indices().prepareValidateQuery("test").setQuery(QueryBuilders.queryString("nonexistent:hello")).execute().actionGet().isValid(), equalTo(true));
+        assertThat(client().admin().indices().prepareValidateQuery("test").setQuery(QueryBuilders.queryStringQuery("nonexistent:hello")).execute().actionGet().isValid(), equalTo(true));
 
-        assertThat(client().admin().indices().prepareValidateQuery("test").setQuery(QueryBuilders.queryString("foo:1 AND")).execute().actionGet().isValid(), equalTo(false));
+        assertThat(client().admin().indices().prepareValidateQuery("test").setQuery(QueryBuilders.queryStringQuery("foo:1 AND")).execute().actionGet().isValid(), equalTo(false));
     }
 
     private static String filter(String uncachedFilter) {
@@ -119,12 +119,12 @@ public class SimpleValidateQueryTests extends ElasticsearchIntegrationTest {
         assertThat(response.getQueryExplanation().get(0).getExplanation(), nullValue());
 
         final String typeFilter = filter("_type:type1");
-        assertExplanation(QueryBuilders.queryString("_id:1"), equalTo("filtered(ConstantScore(_uid:type1#1))->" + typeFilter));
+        assertExplanation(QueryBuilders.queryStringQuery("_id:1"), equalTo("filtered(ConstantScore(_uid:type1#1))->" + typeFilter));
 
         assertExplanation(QueryBuilders.idsQuery("type1").addIds("1").addIds("2"),
                 equalTo("filtered(ConstantScore(_uid:type1#1 _uid:type1#2))->" + typeFilter));
 
-        assertExplanation(QueryBuilders.queryString("foo"), equalTo("filtered(_all:foo)->" + typeFilter));
+        assertExplanation(QueryBuilders.queryStringQuery("foo"), equalTo("filtered(_all:foo)->" + typeFilter));
 
         assertExplanation(QueryBuilders.filteredQuery(
                 QueryBuilders.termQuery("foo", "1"),
@@ -229,7 +229,7 @@ public class SimpleValidateQueryTests extends ElasticsearchIntegrationTest {
 
         for (Client client : internalCluster()) {
                 ValidateQueryResponse response = client.admin().indices().prepareValidateQuery("test")
-                    .setQuery(QueryBuilders.queryString("foo"))
+                    .setQuery(QueryBuilders.queryStringQuery("foo"))
                     .setExplain(true)
                     .execute().actionGet();
             assertThat(response.isValid(), equalTo(true));
@@ -253,7 +253,7 @@ public class SimpleValidateQueryTests extends ElasticsearchIntegrationTest {
         refresh();
 
         ValidateQueryResponse response = client().admin().indices().prepareValidateQuery()
-                .setQuery(queryString("past:[now-2M/d TO now/d]")).setExplain(true).get();
+                .setQuery(queryStringQuery("past:[now-2M/d TO now/d]")).setExplain(true).get();
 
         assertNoFailures(response);
         assertThat(response.getQueryExplanation().size(), equalTo(1));


### PR DESCRIPTION
Some QueryBuilders are missing or have a different naming than the other ones.

This patch is applied to branch 1.x and master (elasticsearch 1.5 and 2.0):
## Added
- `templateQuery(...)`
- `commonTermsQuery(...)`
- `queryStringQuery(...)`
- `simpleQueryStringQuery(...)`
## Deprecated
- `commonTerms(...)`
- `queryString(...)`
- `simpleQueryString(...)`

Closes #8721
