### PR TITLE
Aggregations: Fail with a parse exception if `top_hits` agg is defined under a `nested` agg.

### DIFF
--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/ReverseNestedAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/ReverseNestedAggregator.java
@@ -45,6 +45,7 @@ import java.io.IOException;
 public class ReverseNestedAggregator extends SingleBucketAggregator implements ReaderContextAware {
 
     private final FixedBitSetFilter parentFilter;
+    private final String nestedPath;
     private DocIdSetIterator parentDocs;
 
     // TODO: Add LongIntPagedHashMap?
@@ -53,6 +54,7 @@ public class ReverseNestedAggregator extends SingleBucketAggregator implements R
 
     public ReverseNestedAggregator(String name, AggregatorFactories factories, String nestedPath, AggregationContext aggregationContext, Aggregator parent) {
         super(name, factories, aggregationContext, parent);
+        this.nestedPath = nestedPath;
 
         // Early validation
         NestedAggregator closestNestedAggregator = findClosestNestedAggregator(parent);
@@ -127,7 +129,7 @@ public class ReverseNestedAggregator extends SingleBucketAggregator implements R
         collectBucket(parentDoc, bucketOrd);
     }
 
-    private static NestedAggregator findClosestNestedAggregator(Aggregator parent) {
+    static NestedAggregator findClosestNestedAggregator(Aggregator parent) {
         for (; parent != null; parent = parent.parent()) {
             if (parent instanceof NestedAggregator) {
                 return (NestedAggregator) parent;
@@ -148,6 +150,10 @@ public class ReverseNestedAggregator extends SingleBucketAggregator implements R
 
     Filter getParentFilter() {
         return parentFilter;
+    }
+
+    public String getNestedPath() {
+        return nestedPath;
     }
 
     @Override


### PR DESCRIPTION
PR for #8668
