### PR TITLE
function_score: use query and filter together

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
@@ -474,6 +474,26 @@ public abstract class QueryBuilders {
     }
 
     /**
+     * A query that allows to define a custom scoring function.
+     *
+     * @param queryBuilder  The query to custom score
+     * @param filterBuilder The filterBuilder to custom score
+     */
+    public static FunctionScoreQueryBuilder functionScoreQuery(QueryBuilder queryBuilder, FilterBuilder filterBuilder) {
+        return new FunctionScoreQueryBuilder(queryBuilder, filterBuilder);
+    }
+
+    /**
+     * A query that allows to define a custom scoring function.
+     *
+     * @param queryBuilder  The query to custom score
+     * @param filterBuilder The filterBuilder to custom score
+     */
+    public static FunctionScoreQueryBuilder functionScoreQuery(QueryBuilder queryBuilder, FilterBuilder filterBuilder, ScoreFunctionBuilder function) {
+        return (new FunctionScoreQueryBuilder(queryBuilder, filterBuilder)).add(function);
+    }
+
+    /**
      * A more like this query that finds documents that are "like" the provided {@link MoreLikeThisQueryBuilder#likeText(String)}
      * which is checked against the fields the query is constructed with.
      *

--- a/src/main/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilder.java
@@ -51,16 +51,35 @@ public class FunctionScoreQueryBuilder extends BaseQueryBuilder implements Boost
     private ArrayList<FilterBuilder> filters = new ArrayList<>();
     private ArrayList<ScoreFunctionBuilder> scoreFunctions = new ArrayList<>();
 
+    /**
+     * Creates a function_score query that executes on documents that match query a query.
+     * Query and filter will be wrapped into a filtered_query.
+     *
+     * @param queryBuilder the query that defines which documents the function_score query will be executed on.
+     */
     public FunctionScoreQueryBuilder(QueryBuilder queryBuilder) {
         this.queryBuilder = queryBuilder;
         this.filterBuilder = null;
     }
 
+    /**
+     * Creates a function_score query that executes on documents that match query a query.
+     * Query and filter will be wrapped into a filtered_query.
+     *
+     * @param filterBuilder the filter that defines which documents the function_score query will be executed on.
+     */
     public FunctionScoreQueryBuilder(FilterBuilder filterBuilder) {
         this.filterBuilder = filterBuilder;
         this.queryBuilder = null;
     }
 
+    /**
+     * Creates a function_score query that executes on documents that match query and filter.
+     * Query and filter will be wrapped into a filtered_query.
+     *
+     * @param queryBuilder a query that will; be wrapped in a filtered query.
+     * @param filterBuilder the filter for the filtered query.
+     */
     public FunctionScoreQueryBuilder(QueryBuilder queryBuilder, FilterBuilder filterBuilder) {
         this.filterBuilder = filterBuilder;
         this.queryBuilder = queryBuilder;
@@ -71,6 +90,11 @@ public class FunctionScoreQueryBuilder extends BaseQueryBuilder implements Boost
         this.queryBuilder = null;
     }
 
+    /**
+     * Creates a function_score query that will execute the function scoreFunctionBuilder on all documents.
+     *
+     * @param scoreFunctionBuilder score function that is executed
+     */
     public FunctionScoreQueryBuilder(ScoreFunctionBuilder scoreFunctionBuilder) {
         if (scoreFunctionBuilder == null) {
             throw new ElasticsearchIllegalArgumentException("function_score: function must not be null");
@@ -81,6 +105,12 @@ public class FunctionScoreQueryBuilder extends BaseQueryBuilder implements Boost
         this.scoreFunctions.add(scoreFunctionBuilder);
     }
 
+    /**
+     * Adds a score function that will will execute the function scoreFunctionBuilder on all documents matching the filter.
+     *
+     * @param filter the filter that defines which documents the function_score query will be executed on.
+     * @param scoreFunctionBuilder score function that is executed
+     */
     public FunctionScoreQueryBuilder add(FilterBuilder filter, ScoreFunctionBuilder scoreFunctionBuilder) {
         if (scoreFunctionBuilder == null) {
             throw new ElasticsearchIllegalArgumentException("function_score: function must not be null");
@@ -90,6 +120,11 @@ public class FunctionScoreQueryBuilder extends BaseQueryBuilder implements Boost
         return this;
     }
 
+    /**
+     * Adds a score function that will will execute the function scoreFunctionBuilder on all documents.
+     *
+     * @param scoreFunctionBuilder score function that is executed
+     */
     public FunctionScoreQueryBuilder add(ScoreFunctionBuilder scoreFunctionBuilder) {
         if (scoreFunctionBuilder == null) {
             throw new ElasticsearchIllegalArgumentException("function_score: function must not be null");
@@ -99,21 +134,35 @@ public class FunctionScoreQueryBuilder extends BaseQueryBuilder implements Boost
         return this;
     }
 
+    /**
+     * Score mode defines how results of individual score functions will be aggregated.
+     * Can be first, avg, max, sum, min, multiply
+     */
     public FunctionScoreQueryBuilder scoreMode(String scoreMode) {
         this.scoreMode = scoreMode;
         return this;
     }
 
+    /**
+     * Score mode defines how the combined result of score functions will influence the final score together with the sub query score.
+     * Can be replace, avg, max, sum, min, multiply
+     */
     public FunctionScoreQueryBuilder boostMode(String boostMode) {
         this.boostMode = boostMode;
         return this;
     }
 
+    /**
+     * Score mode defines how the combined result of score functions will influence the final score together with the sub query score.
+     */
     public FunctionScoreQueryBuilder boostMode(CombineFunction combineFunction) {
         this.boostMode = combineFunction.getName();
         return this;
     }
 
+    /**
+     * Tha maximum boost that will be applied by function score.
+     */
     public FunctionScoreQueryBuilder maxBoost(float maxBoost) {
         this.maxBoost = maxBoost;
         return this;

--- a/src/main/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilder.java
@@ -61,6 +61,11 @@ public class FunctionScoreQueryBuilder extends BaseQueryBuilder implements Boost
         this.queryBuilder = null;
     }
 
+    public FunctionScoreQueryBuilder(QueryBuilder queryBuilder, FilterBuilder filterBuilder) {
+        this.filterBuilder = filterBuilder;
+        this.queryBuilder = queryBuilder;
+    }
+
     public FunctionScoreQueryBuilder() {
         this.filterBuilder = null;
         this.queryBuilder = null;
@@ -130,7 +135,8 @@ public class FunctionScoreQueryBuilder extends BaseQueryBuilder implements Boost
         if (queryBuilder != null) {
             builder.field("query");
             queryBuilder.toXContent(builder, params);
-        } else if (filterBuilder != null) {
+        }
+        if (filterBuilder != null) {
             builder.field("filter");
             filterBuilder.toXContent(builder, params);
         }

--- a/src/main/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryParser.java
@@ -148,11 +148,9 @@ public class FunctionScoreQueryParser implements QueryParser {
         }
         if (query == null && filter == null) {
             query = Queries.newMatchAllQuery();
-        }
-        if (query == null && filter != null) {
+        } else if (query == null && filter != null) {
             query = new ConstantScoreQuery(filter);
-        }
-        if (query != null && filter != null) {
+        } else if (query != null && filter != null) {
             query = new FilteredQuery(query, filter);
         }
         // if all filter elements returned null, just use the query

--- a/src/test/java/org/elasticsearch/search/functionscore/FunctionScoreTests.java
+++ b/src/test/java/org/elasticsearch/search/functionscore/FunctionScoreTests.java
@@ -20,6 +20,9 @@
 package org.elasticsearch.search.functionscore;
 
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsRequest;
+import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsResponse;
+import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.common.geo.GeoPoint;
@@ -28,11 +31,14 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.query.functionscore.FunctionScoreQueryBuilder;
 import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilder;
 import org.elasticsearch.index.query.functionscore.weight.WeightBuilder;
+import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 
 import static org.elasticsearch.client.Requests.searchRequest;
@@ -432,6 +438,41 @@ public class FunctionScoreTests extends ElasticsearchIntegrationTest {
         assertThat(response.getHits().getAt(0).score(), equalTo(1.0f));
         assertThat(((Terms) response.getAggregations().asMap().get("score_agg")).getBuckets().get(0).getKeyAsNumber().floatValue(), is(1f));
         assertThat(((Terms) response.getAggregations().asMap().get("score_agg")).getBuckets().get(0).getDocCount(), is(1l));
+    }
+
+    @Test
+    public void testFilterAndQueryGiven() throws IOException, ExecutionException, InterruptedException {
+        assertAcked(prepareCreate("test").addMapping(
+                "type",
+                jsonBuilder().startObject().startObject("type").startObject("properties")
+                        .startObject("filter_field").field("type", "string").endObject()
+                        .startObject("query_field").field("type", "string").endObject()
+                        .startObject("num").field("type", "float").endObject().endObject().endObject().endObject()));
+        ensureYellow();
+
+        List<IndexRequestBuilder> indexRequests = new ArrayList<>();
+        for (int i = 0; i < 20; i++) {
+            indexRequests.add(
+                    client().prepareIndex()
+                            .setType("type")
+                            .setId(Integer.toString(i))
+                            .setIndex("test")
+                            .setSource(
+                                    jsonBuilder().startObject().field("query_field", Integer.toString(i % 3)).field("filter_field", Integer.toString(i % 2)).field("num", i).endObject()));
+        }
+
+        indexRandom(true, true, indexRequests);
+
+        SearchResponse response = client().search(
+                searchRequest().source(
+                        searchSource().query(
+                                functionScoreQuery(termQuery("query_field", "0"), termFilter("filter_field", "0"), scriptFunction("doc['num'].value")).boostMode("replace")))).get();
+
+        assertSearchResponse(response);
+        assertThat(response.getHits().totalHits(), equalTo(4l));
+        for (SearchHit hit : response.getHits().getHits()) {
+            assertThat(Float.parseFloat(hit.getId()), equalTo(hit.getScore()));
+        }
     }
 }
 


### PR DESCRIPTION
Before, if filter and query was defined for function_score, then the
filter was silently ignored. Now, if both is defined then function score
query wraps this in a filtered_query.

closes #8638
