### PR TITLE
[TEST] make sure rest tests info is printed for any @Rest annotated test

### DIFF
--- a/src/test/java/org/elasticsearch/test/junit/listeners/ReproduceInfoPrinter.java
+++ b/src/test/java/org/elasticsearch/test/junit/listeners/ReproduceInfoPrinter.java
@@ -27,7 +27,6 @@ import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.elasticsearch.test.InternalTestCluster;
-import org.elasticsearch.test.rest.ElasticsearchRestTests;
 import org.junit.internal.AssumptionViolatedException;
 import org.junit.runner.Description;
 import org.junit.runner.notification.Failure;
@@ -36,13 +35,9 @@ import org.junit.runner.notification.RunListener;
 import java.util.Locale;
 import java.util.TimeZone;
 
-import static com.carrotsearch.randomizedtesting.SysGlobals.SYSPROP_ITERATIONS;
-import static com.carrotsearch.randomizedtesting.SysGlobals.SYSPROP_PREFIX;
-import static com.carrotsearch.randomizedtesting.SysGlobals.SYSPROP_TESTMETHOD;
+import static com.carrotsearch.randomizedtesting.SysGlobals.*;
 import static org.elasticsearch.test.ElasticsearchIntegrationTest.TESTS_CLUSTER;
-import static org.elasticsearch.test.rest.ElasticsearchRestTests.REST_TESTS_BLACKLIST;
-import static org.elasticsearch.test.rest.ElasticsearchRestTests.REST_TESTS_SPEC;
-import static org.elasticsearch.test.rest.ElasticsearchRestTests.REST_TESTS_SUITE;
+import static org.elasticsearch.test.rest.ElasticsearchRestTests.*;
 
 /**
  * A {@link RunListener} that emits to {@link System#err} a string with command
@@ -76,8 +71,8 @@ public class ReproduceInfoPrinter extends RunListener {
         MavenMessageBuilder mavenMessageBuilder = new MavenMessageBuilder(b);
         mavenMessageBuilder.appendAllOpts(failure.getDescription());
 
-        //ElasticsearchRestTests is a special case as it allows for additional parameters
-        if (ElasticsearchRestTests.class.isAssignableFrom(failure.getDescription().getTestClass())) {
+        //Rest tests are a special case as they allow for additional parameters
+        if (failure.getDescription().getTestClass().isAnnotationPresent(Rest.class)) {
             mavenMessageBuilder.appendRestTestsProperties();
         }
 


### PR DESCRIPTION
We introduced the @Rest annotation a while ago for REST tests (see #7795), we have then to make sure that relevant info to reproduce failures gets printed out for any test that is marked with such annotation, not only for ElasticsearchRestTests
