### PR TITLE
Client: Only fetch the node info during node sampling

### DIFF
--- a/src/main/java/org/elasticsearch/client/transport/TransportClientNodesService.java
+++ b/src/main/java/org/elasticsearch/client/transport/TransportClientNodesService.java
@@ -348,7 +348,7 @@ public class TransportClientNodesService extends AbstractComponent {
                 }
                 try {
                     NodesInfoResponse nodeInfo = transportService.submitRequest(listedNode, NodesInfoAction.NAME,
-                            headers.applyTo(Requests.nodesInfoRequest("_local")),
+                            headers.applyTo(Requests.nodesInfoRequest("_local").clear()),
                             TransportRequestOptions.options().withType(TransportRequestOptions.Type.STATE).withTimeout(pingTimeout),
                             new FutureTransportResponseHandler<NodesInfoResponse>() {
                                 @Override


### PR DESCRIPTION
Today we are fetching a lot of information that is unneeded
for the sampling phase. We only really need the DiscoveryNode
to ensure the node is still there.
This commit clears all flags to be false on the NodeInfo call.
