### PR TITLE
Use RoaringDocIdSet instead of FixedBitset for caching.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1429,6 +1429,7 @@
                                 <exclude>src/main/java/org/elasticsearch/common/geo/GeoHashUtils.java</exclude>
                                 <exclude>src/main/java/org/elasticsearch/common/lucene/search/XBooleanFilter.java</exclude>
                                 <exclude>src/main/java/org/elasticsearch/common/lucene/search/XFilteredQuery.java</exclude>
+                                <exclude>src/main/java/org/elasticsearch/common/lucene/docset/RoaringDocIdSet.java</exclude>
                                 <exclude>src/main/java/org/apache/lucene/queryparser/XSimpleQueryParser.java</exclude>
                                 <exclude>src/main/java/org/apache/lucene/**/X*.java</exclude>
                                 <!-- t-digest -->

--- a/src/main/java/org/elasticsearch/common/lucene/docset/DocIdSets.java
+++ b/src/main/java/org/elasticsearch/common/lucene/docset/DocIdSets.java
@@ -77,13 +77,13 @@ public class DocIdSets {
         if (set instanceof FixedBitSet) {
             return set;
         }
-        // TODO: should we use WAH8DocIdSet like Lucene?
-        FixedBitSet fixedBitSet = new FixedBitSet(reader.maxDoc());
-        do {
-            fixedBitSet.set(doc);
+
+        RoaringDocIdSet.Builder builder = new RoaringDocIdSet.Builder(reader.maxDoc());
+        do{
+            builder.add(doc);
             doc = it.nextDoc();
         } while (doc != DocIdSetIterator.NO_MORE_DOCS);
-        return fixedBitSet;
+        return builder.build();
     }
 
     /**

--- a/src/main/java/org/elasticsearch/common/lucene/docset/RoaringDocIdSet.java
+++ b/src/main/java/org/elasticsearch/common/lucene/docset/RoaringDocIdSet.java
@@ -1,0 +1,345 @@
+package org.elasticsearch.common.lucene.docset;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.apache.lucene.search.DocIdSet;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.util.FixedBitSet;
+import org.apache.lucene.util.RamUsageEstimator;
+
+/**
+ * {@link DocIdSet} implementation inspired from http://roaringbitmap.org/
+ *
+ * The space is divided into blocks of 2^16 bits and each block is encoded
+ * independently. In each block, if less than 2^12 bits are set, then
+ * documents are simply stored in a short[]. If more than 2^16-2^12 bits are
+ * set, then the inverse of the set is encoded in a simple short[]. Otherwise
+ * a {@link FixedBitSet} is used.
+ *
+ * @lucene.internal
+ */
+public class RoaringDocIdSet extends DocIdSet {
+
+    // Number of documents in a block
+    private static final int BLOCK_SIZE = 1 << 16;
+    // The maximum length for an array, beyond that point we switch to a bitset
+    private static final int MAX_ARRAY_LENGTH = 1 << 12;
+    private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(RoaringDocIdSet.class);
+
+    /** A builder of {@link RoaringDocIdSet}s. */
+    public static class Builder {
+
+        private final int maxDoc;
+        private final DocIdSet[] sets;
+
+        private int cardinality;
+        private int lastDocId;
+        private int currentBlock;
+        private int currentBlockCardinality;
+
+        // We start by filling the buffer and when it's full we copy the content of
+        // the buffer to the FixedBitSet and put further documents in that bitset
+        private final short[] buffer;
+        private FixedBitSet denseBuffer;
+
+        /** Sole constructor. */
+        public Builder(int maxDoc) {
+            this.maxDoc = maxDoc;
+            sets = new DocIdSet[(maxDoc + (1 << 16) - 1) >>> 16];
+            lastDocId = -1;
+            currentBlock = -1;
+            buffer = new short[MAX_ARRAY_LENGTH];
+        }
+
+        private void flush() {
+            assert currentBlockCardinality <= BLOCK_SIZE;
+            if (currentBlockCardinality <= MAX_ARRAY_LENGTH) {
+                // Use sparse encoding
+                assert denseBuffer == null;
+                if (currentBlockCardinality > 0) {
+                    sets[currentBlock] = new ShortArrayDocIdSet(Arrays.copyOf(buffer, currentBlockCardinality));
+                }
+            } else {
+                assert denseBuffer != null;
+                assert denseBuffer.cardinality() == currentBlockCardinality;
+                if (denseBuffer.length() == BLOCK_SIZE && BLOCK_SIZE - currentBlockCardinality < MAX_ARRAY_LENGTH) {
+                    // Doc ids are very dense, inverse the encoding
+                    final short[] excludedDocs = new short[BLOCK_SIZE - currentBlockCardinality];
+                    denseBuffer.flip(0, denseBuffer.length());
+                    int excludedDoc = -1;
+                    for (int i = 0; i < excludedDocs.length; ++i) {
+                        excludedDoc = denseBuffer.nextSetBit(excludedDoc + 1);
+                        assert excludedDoc != DocIdSetIterator.NO_MORE_DOCS;
+                        excludedDocs[i] = (short) excludedDoc;
+                    }
+                    assert excludedDoc + 1 == denseBuffer.length() || denseBuffer.nextSetBit(excludedDoc + 1) == DocIdSetIterator.NO_MORE_DOCS;
+                    sets[currentBlock] = new NotDocIdSet(new ShortArrayDocIdSet(excludedDocs), BLOCK_SIZE);
+                } else {
+                    // Neither sparse nor super dense, use a fixed bit set
+                    sets[currentBlock] = new FixedBitSet(denseBuffer.getBits(), denseBuffer.length());
+                }
+                denseBuffer = null;
+            }
+
+            cardinality += currentBlockCardinality;
+            denseBuffer = null;
+            currentBlockCardinality = 0;
+        }
+
+        /**
+         * Add a new doc-id to this builder.
+         * NOTE: doc ids must be added in order.
+         */
+        public Builder add(int docId) {
+            if (docId <= lastDocId) {
+                throw new IllegalArgumentException("Doc ids must be added in-order, got " + docId + " which is <= lastDocID=" + lastDocId);
+            }
+            final int block = docId >>> 16;
+            if (block != currentBlock) {
+                // we went to a different block, let's flush what we buffered and start from fresh
+                flush();
+                currentBlock = block;
+            }
+
+            if (currentBlockCardinality < MAX_ARRAY_LENGTH) {
+                buffer[currentBlockCardinality] = (short) docId;
+            } else {
+                if (denseBuffer == null) {
+                    // the buffer is full, let's move to a fixed bit set
+                    final int numBits = Math.min(1 << 16, maxDoc - (block << 16));
+                    denseBuffer = new FixedBitSet(numBits);
+                    for (short doc : buffer) {
+                        denseBuffer.set(doc & 0xFFFF);
+                    }
+                }
+                denseBuffer.set(docId & 0xFFFF);
+            }
+
+            lastDocId = docId;
+            currentBlockCardinality += 1;
+            return this;
+        }
+
+        /** Add the content of the provided {@link DocIdSetIterator}. */
+        public Builder add(DocIdSetIterator disi) throws IOException {
+            for (int doc = disi.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = disi.nextDoc()) {
+                add(doc);
+            }
+            return this;
+        }
+
+        /** Build an instance. */
+        public RoaringDocIdSet build() {
+            flush();
+            return new RoaringDocIdSet(sets, cardinality);
+        }
+
+    }
+
+    /**
+     * {@link DocIdSet} implementation that can store documents up to 2^16-1 in a short[].
+     */
+    private static class ShortArrayDocIdSet extends DocIdSet {
+
+        private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(ShortArrayDocIdSet.class);
+
+        private final short[] docIDs;
+
+        private ShortArrayDocIdSet(short[] docIDs) {
+            this.docIDs = docIDs;
+        }
+
+        @Override
+        public long ramBytesUsed() {
+            return BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(docIDs);
+        }
+
+        @Override
+        public DocIdSetIterator iterator() throws IOException {
+            return new DocIdSetIterator() {
+
+                int i = -1; // this is the index of the current document in the array
+                int doc = -1;
+
+                private int docId(int i) {
+                    return docIDs[i] & 0xFFFF;
+                }
+
+                @Override
+                public int nextDoc() throws IOException {
+                    if (++i >= docIDs.length) {
+                        return doc = NO_MORE_DOCS;
+                    }
+                    return doc = docId(i);
+                }
+
+                @Override
+                public int docID() {
+                    return doc;
+                }
+
+                @Override
+                public long cost() {
+                    return docIDs.length;
+                }
+
+                @Override
+                public int advance(int target) throws IOException {
+                    // binary search
+                    int lo = i + 1;
+                    int hi = docIDs.length - 1;
+                    while (lo <= hi) {
+                        final int mid = (lo + hi) >>> 1;
+                        final int midDoc = docId(mid);
+                        if (midDoc < target) {
+                            lo = mid + 1;
+                        } else {
+                            hi = mid - 1;
+                        }
+                    }
+                    if (lo == docIDs.length) {
+                        i = docIDs.length;
+                        return doc = NO_MORE_DOCS;
+                    } else {
+                        i = lo;
+                        return doc = docId(i);
+                    }
+                }
+            };
+        }
+
+    }
+
+    private final DocIdSet[] docIdSets;
+    private final int cardinality;
+    private final long ramBytesUsed;
+
+    private RoaringDocIdSet(DocIdSet[] docIdSets, int cardinality) {
+        this.docIdSets = docIdSets;
+        long ramBytesUsed = BASE_RAM_BYTES_USED + RamUsageEstimator.shallowSizeOf(docIdSets);
+        for (DocIdSet set : this.docIdSets) {
+            if (set != null) {
+                ramBytesUsed += set.ramBytesUsed();
+            }
+        }
+        this.ramBytesUsed = ramBytesUsed;
+        this.cardinality = cardinality;
+    }
+
+    @Override
+    public boolean isCacheable() {
+        return true;
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        return ramBytesUsed;
+    }
+
+    @Override
+    public DocIdSetIterator iterator() throws IOException {
+        if (cardinality == 0) {
+            return null;
+        }
+        return new Iterator();
+    }
+
+    private class Iterator extends DocIdSetIterator {
+
+        int block;
+        DocIdSetIterator sub = null;
+        int doc;
+
+        Iterator() throws IOException {
+            doc = -1;
+            block = 0;
+            while (docIdSets[block] == null) {
+                block += 1;
+            }
+            sub = docIdSets[block].iterator();
+        }
+
+        @Override
+        public int docID() {
+            return doc;
+        }
+
+        @Override
+        public int nextDoc() throws IOException {
+            if(sub == null){
+                return NO_MORE_DOCS;
+            }
+            final int subNext = sub.nextDoc();
+            if (subNext == NO_MORE_DOCS) {
+                return firstDocFromNextBlock();
+            }
+            return doc = (block << 16) | subNext;
+        }
+
+        @Override
+        public int advance(int target) throws IOException {
+            final int targetBlock = target >>> 16;
+            if (targetBlock != block) {
+                block = targetBlock;
+                if (block >= docIdSets.length) {
+                    sub = null;
+                    return doc = NO_MORE_DOCS;
+                }
+                if (docIdSets[block] == null) {
+                    return firstDocFromNextBlock();
+                }
+                sub = docIdSets[block].iterator();
+            }
+            final int subNext = sub.advance(target & 0xFFFF);
+            if (subNext == NO_MORE_DOCS) {
+                return firstDocFromNextBlock();
+            }
+            return doc = (block << 16) | subNext;
+        }
+
+        private int firstDocFromNextBlock() throws IOException {
+            while (true) {
+                block += 1;
+                if (block >= docIdSets.length) {
+                    sub = null;
+                    return doc = NO_MORE_DOCS;
+                } else if (docIdSets[block] != null) {
+                    sub = docIdSets[block].iterator();
+                    final int subNext = sub.nextDoc();
+                    assert subNext != NO_MORE_DOCS;
+                    return doc = (block << 16) | subNext;
+                }
+            }
+        }
+
+        @Override
+        public long cost() {
+            return cardinality;
+        }
+
+    }
+
+    /** Return the exact number of documents that are contained in this set. */
+    public int cardinality() {
+        return cardinality;
+    }
+
+}

--- a/src/main/java/org/elasticsearch/common/lucene/search/FilteredCollector.java
+++ b/src/main/java/org/elasticsearch/common/lucene/search/FilteredCollector.java
@@ -65,7 +65,7 @@ public class FilteredCollector extends XCollector {
     @Override
     public void setNextReader(AtomicReaderContext context) throws IOException {
         collector.setNextReader(context);
-        docSet = DocIdSets.toSafeBits(context.reader(), filter.getDocIdSet(context, null));
+        docSet = DocIdSets.fastInOrderedAccessBits(context.reader(), filter.getDocIdSet(context, null));
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/common/lucene/search/function/FiltersFunctionScoreQuery.java
+++ b/src/main/java/org/elasticsearch/common/lucene/search/function/FiltersFunctionScoreQuery.java
@@ -161,7 +161,7 @@ public class FiltersFunctionScoreQuery extends Query {
             for (int i = 0; i < filterFunctions.length; i++) {
                 FilterFunction filterFunction = filterFunctions[i];
                 filterFunction.function.setNextReader(context);
-                docSets[i] = DocIdSets.toSafeBits(context.reader(), filterFunction.filter.getDocIdSet(context, acceptDocs));
+                docSets[i] = DocIdSets.fastInOrderedAccessBits(context.reader(), filterFunction.filter.getDocIdSet(context, acceptDocs));
             }
             return new CustomBoostFactorScorer(this, subQueryScorer, scoreMode, filterFunctions, maxBoost, docSets, combineFunction);
         }
@@ -176,7 +176,7 @@ public class FiltersFunctionScoreQuery extends Query {
             // First: Gather explanations for all filters
             List<ComplexExplanation> filterExplanations = new ArrayList<>();
             for (FilterFunction filterFunction : filterFunctions) {
-                Bits docSet = DocIdSets.toSafeBits(context.reader(),
+                Bits docSet = DocIdSets.fastInOrderedAccessBits(context.reader(),
                         filterFunction.filter.getDocIdSet(context, context.reader().getLiveDocs()));
                 if (docSet.get(doc)) {
                     filterFunction.function.setNextReader(context);

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/children/ParentToChildrenAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/children/ParentToChildrenAggregator.java
@@ -131,7 +131,7 @@ public class ParentToChildrenAggregator extends SingleBucketAggregator implement
             // The DocIdSets.toSafeBits(...) can convert to FixedBitSet, but this
             // will only happen if the none filter cache is used. (which only happens in tests)
             // Otherwise the filter cache will produce a bitset based filter.
-            parentDocs = DocIdSets.toSafeBits(reader.reader(), parentDocIdSet);
+            parentDocs = DocIdSets.fastInOrderedAccessBits(reader.reader(), parentDocIdSet);
             DocIdSet childDocIdSet = childFilter.getDocIdSet(reader, null);
             if (globalOrdinals != null && !DocIdSets.isEmpty(childDocIdSet)) {
                 replay.add(reader);

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FilterAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FilterAggregator.java
@@ -49,7 +49,7 @@ public class FilterAggregator extends SingleBucketAggregator {
     @Override
     public void setNextReader(AtomicReaderContext reader) {
         try {
-            bits = DocIdSets.toSafeBits(reader.reader(), filter.getDocIdSet(reader, null));
+            bits = DocIdSets.fastInOrderedAccessBits(reader.reader(), filter.getDocIdSet(reader, null));
         } catch (IOException ioe) {
             throw new AggregationExecutionException("Failed to aggregate filter aggregator [" + name + "]", ioe);
         }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/filters/FiltersAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/filters/FiltersAggregator.java
@@ -69,7 +69,7 @@ public class FiltersAggregator extends BucketsAggregator {
     public void setNextReader(AtomicReaderContext reader) {
         try {
             for (int i = 0; i < filters.length; i++) {
-                bits[i] = DocIdSets.toSafeBits(reader.reader(), filters[i].filter.getDocIdSet(reader, null));
+                bits[i] = DocIdSets.fastInOrderedAccessBits(reader.reader(), filters[i].filter.getDocIdSet(reader, null));
             }
         } catch (IOException ioe) {
             throw new AggregationExecutionException("Failed to aggregate filter aggregator [" + name + "]", ioe);

--- a/src/main/java/org/elasticsearch/search/facet/filter/FilterFacetExecutor.java
+++ b/src/main/java/org/elasticsearch/search/facet/filter/FilterFacetExecutor.java
@@ -94,7 +94,7 @@ public class FilterFacetExecutor extends FacetExecutor {
 
         @Override
         public void setNextReader(AtomicReaderContext context) throws IOException {
-            bits = DocIdSets.toSafeBits(context.reader(), filter.getDocIdSet(context, context.reader().getLiveDocs()));
+            bits = DocIdSets.fastInOrderedAccessBits(context.reader(), filter.getDocIdSet(context, context.reader().getLiveDocs()));
         }
 
         @Override

--- a/src/main/java/org/elasticsearch/search/facet/nested/NestedFacetExecutor.java
+++ b/src/main/java/org/elasticsearch/search/facet/nested/NestedFacetExecutor.java
@@ -120,7 +120,7 @@ public class NestedFacetExecutor extends FacetExecutor {
                     continue;
                 }
                 // Im ES if parent is deleted, then also the children are deleted. Therefore acceptedDocs can also null here.
-                Bits childDocs = DocIdSets.toSafeBits(context.reader(), childFilter.getDocIdSet(context, null));
+                Bits childDocs = DocIdSets.fastInOrderedAccessBits(context.reader(), childFilter.getDocIdSet(context, null));
                 FixedBitSet parentDocs = (FixedBitSet) docIdSet;
 
                 DocIdSetIterator iter = entry.docSet.iterator();
@@ -189,7 +189,7 @@ public class NestedFacetExecutor extends FacetExecutor {
             // Can use null as acceptedDocs here, since only live doc ids are being pushed to collect method.
             DocIdSet docIdSet = parentFilter.getDocIdSet(context, null);
             // Im ES if parent is deleted, then also the children are deleted. Therefore acceptedDocs can also null here.
-            childDocs = DocIdSets.toSafeBits(context.reader(), childFilter.getDocIdSet(context, null));
+            childDocs = DocIdSets.fastInOrderedAccessBits(context.reader(), childFilter.getDocIdSet(context, null));
             if (DocIdSets.isEmpty(docIdSet)) {
                 parentDocs = null;
             } else {

--- a/src/main/java/org/elasticsearch/search/facet/query/QueryFacetExecutor.java
+++ b/src/main/java/org/elasticsearch/search/facet/query/QueryFacetExecutor.java
@@ -103,7 +103,7 @@ public class QueryFacetExecutor extends FacetExecutor {
 
         @Override
         public void setNextReader(AtomicReaderContext context) throws IOException {
-            bits = DocIdSets.toSafeBits(context.reader(), filter.getDocIdSet(context, context.reader().getLiveDocs()));
+            bits = DocIdSets.fastInOrderedAccessBits(context.reader(), filter.getDocIdSet(context, context.reader().getLiveDocs()));
         }
 
         @Override


### PR DESCRIPTION
The default DocIdBitSet used for caching is currently the FixedBitSet implementation. For very sparse or dense bitsets, there are better implementations.

Lucene currently uses WAH8DocIdSet. https://github.com/elasticsearch/elasticsearch/pull/7577 suggested that ES should also switch to that implementation. The PR was rejected, in favour of getting the RoaringDocIdSet from Lucene 5. Upgrading to Lucene 5 was done in https://github.com/elasticsearch/elasticsearch/commit/610ce078fb3c84c47d6d32aff7d77ba850e28f9d, and it does indeed use the RoaringDocId implementation. 

For ES users with large indices, it would be beneficial if the filter cache did not use so much memory, even before ES uses Lucene 5 (seems to be targeted for 2.0). This PR uses the RoaringDocIdSet from Lucene trunk (with minor modifications) instead of the FixedBitSet implementation. For the modifications, see inline comments.

I've ran the test suite locally a few times, and it works. I did see some issues, but fixed them.
