### PR TITLE
Update repositories.asciidoc

### DIFF
--- a/docs/reference/setup/repositories.asciidoc
+++ b/docs/reference/setup/repositories.asciidoc
@@ -20,14 +20,14 @@ Add the following to your /etc/apt/sources.list to enable the repository
 
 ["source","sh",subs="attributes,callouts"]
 --------------------------------------------------
-deb http://packages.elasticsearch.org/elasticsearch/{branch}/debian stable main
+sudo add-apt-repository "deb http://packages.elasticsearch.org/elasticsearch/1.4/debian stable main"
 --------------------------------------------------
 
 Run apt-get update and the repository is ready for use. You can install it with :
 
 [source,sh]
 --------------------------------------------------
-apt-get update && apt-get install elasticsearch
+sudo apt-get update && sudo apt-get install elasticsearch
 --------------------------------------------------
 
 


### PR DESCRIPTION
1. Enable the repository using "add-apt-repository" to avoid this error "No command 'deb' found". 
2. Adding "sudo" to update and install command.
