### PR TITLE
Upsert does not use ttl value

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/update/UpdateRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/update/UpdateRequest.java
@@ -690,16 +690,18 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest> 
         return this.docAsUpsert;
     }
 
-    public void docAsUpsert(boolean shouldUpsertDoc) {
+    public UpdateRequest docAsUpsert(boolean shouldUpsertDoc) {
         this.docAsUpsert = shouldUpsertDoc;
+        return this;
     }
     
     public boolean scriptedUpsert(){
         return this.scriptedUpsert;
     }
     
-    public void scriptedUpsert(boolean scriptedUpsert) {
+    public UpdateRequest scriptedUpsert(boolean scriptedUpsert) {
         this.scriptedUpsert = scriptedUpsert;
+        return this;
     }
     
 

--- a/core/src/test/java/org/elasticsearch/ttl/SimpleTTLTests.java
+++ b/core/src/test/java/org/elasticsearch/ttl/SimpleTTLTests.java
@@ -39,7 +39,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.common.settings.Settings.settingsBuilder;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
-import static org.elasticsearch.test.ElasticsearchIntegrationTest.*;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.Scope;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.*;
 


### PR DESCRIPTION
When running an upsert which defines a ttl value, the ttl value is set to null and ignored.

Related to #3256#issuecomment-64963409
