### PR TITLE
Deprecate duplications of methods: hits() and getHits(). According names...

### DIFF
--- a/src/main/java/org/elasticsearch/search/SearchHits.java
+++ b/src/main/java/org/elasticsearch/search/SearchHits.java
@@ -52,6 +52,7 @@ public interface SearchHits extends Streamable, ToXContent, Iterable<SearchHit> 
     /**
      * The hits of the search request (based on the search type, and from / size provided).
      */
+    @Deprecated
     SearchHit[] hits();
 
     /**


### PR DESCRIPTION
..., decriptions methods are equal.
