### PR TITLE
rpm,deb: make ES user own plugins dir, remove on uninstall

### DIFF
--- a/src/deb/control/postinst
+++ b/src/deb/control/postinst
@@ -26,9 +26,12 @@ case "$1" in
 		"$ES_USER"
 	fi
 
-	# Set user permissions on /var/log/elasticsearch and /var/lib/elasticsearch
-	mkdir -p /var/log/elasticsearch /var/lib/elasticsearch
-	chown -R $ES_USER:$ES_GROUP /var/log/elasticsearch /var/lib/elasticsearch
+	# Set user permissions on /var/log/elasticsearch, /var/lib/elasticsearch,
+	#   and /usr/share/elasticsearch/plugins
+	mkdir -p /var/log/elasticsearch /var/lib/elasticsearch \
+                                            /usr/share/elasticsearch/plugins
+	chown -R $ES_USER:$ES_GROUP /var/log/elasticsearch /var/lib/elasticsearch \
+                                            /usr/share/elasticsearch/plugins
 	chmod 755 /var/log/elasticsearch /var/lib/elasticsearch
 	
 	# configuration files should not be modifiable by elasticsearch user, as this can be a security issue

--- a/src/deb/control/postrm
+++ b/src/deb/control/postrm
@@ -5,6 +5,9 @@ case "$1" in
     remove)
         # Remove logs
         rm -rf /var/log/elasticsearch
+
+        # Remove plugin directory and all plugins
+        rm -rf /usr/share/elasticsearch/plugins
         
         # remove **only** empty data dir
         rmdir --ignore-fail-on-non-empty /var/lib/elasticsearch
@@ -14,8 +17,9 @@ case "$1" in
     	# Remove service
         update-rc.d elasticsearch remove >/dev/null || true
     
-        # Remove logs and data
-        rm -rf /var/log/elasticsearch /var/lib/elasticsearch
+        # Remove logs, data and plugins
+        rm -rf /var/log/elasticsearch /var/lib/elasticsearch \
+                                            /usr/share/elasticsearch/plugins
 
         # Remove user/group
         deluser elasticsearch || true

--- a/src/rpm/scripts/postinstall
+++ b/src/rpm/scripts/postinstall
@@ -1,6 +1,10 @@
 
 [ -f /etc/sysconfig/elasticsearch ] && . /etc/sysconfig/elasticsearch
 
+# Generate ES plugin directory and hand over ownership to ES user
+mkdir -p /usr/share/elasticsearch/plugins
+chown elasticsearch:elasticsearch /usr/share/elasticsearch/plugins
+
 startElasticsearch() {
 	if [ -x /bin/systemctl ] ; then
 		/bin/systemctl start elasticsearch.service

--- a/src/rpm/scripts/postremove
+++ b/src/rpm/scripts/postremove
@@ -10,6 +10,9 @@ if [ $1 -eq 0 ] ; then
     if [ "$?" == "0" ] ; then
         groupdel elasticsearch
     fi
+
+    # Remove plugin directory and all plugins
+    rm -rf /usr/share/elasticsearch/plugins
 fi
 
 exit


### PR DESCRIPTION
This change will chown /usr/share/elasticsearch/plugins to the elasticsearch user (the directory was formerly owned by root). This enables the ES user to manage plugins.

Also, please note that /usr/share/elasticsearch/plugins **is now removed when the elasticsearch package is un-installed**. Previously it was left lying there.

Fixes #8419, tested with Fedora 21 (RPM) and Debian 7 (DEB).
