### PR TITLE
background start-up: use PID file to signal success

### DIFF
--- a/bin/elasticsearch
+++ b/bin/elasticsearch
@@ -2,6 +2,7 @@
 
 # OPTIONS:
 #    -d            daemonize (run in background)
+#    -w            timeout (seconds) to wait for ES to start when daemonized
 #    -p pidfile    write PID to <pidfile>
 #    -h
 #    --help        print command line options
@@ -66,6 +67,9 @@ or visit http://www.elasticsearch.org/download to get a pre-built package.
 EOF
     exit 1
 fi
+
+# -w command line option default
+BG_STARTUP_TIMEOUT=120
 
 CDPATH=""
 SCRIPT="$0"
@@ -139,6 +143,10 @@ launch_service()
     props=$3
     es_parms="-Delasticsearch"
 
+    # we need a PID file when daemonizing to check for successful start-up
+    [ "x$daemonized" != "x" -a "x$pidpath" = "x" ] \
+        && pidpath=`mktemp -t elasticsearch.pid.XXXXX`
+
     if [ "x$pidpath" != "x" ]; then
         es_parms="$es_parms -Des.pidfile=$pidpath"
     fi
@@ -156,10 +164,27 @@ launch_service()
         # exec without running it in the background, makes it replace this shell, we'll never get here...
         # no need to return something
     else
-        # Startup Elasticsearch, background it, and write the pid.
-        exec "$JAVA" $JAVA_OPTS $ES_JAVA_OPTS $es_parms -Des.path.home="$ES_HOME" -cp "$ES_CLASSPATH" $props \
+        # Startup Elasticsearch, background it, and wait for the PID file to
+        #  appear (signalling successful start-up).
+
+        setsid=`which setsid 2>/dev/null`
+        echo "Starting elasticsearch in background, please stand by..."
+        exec $setsid "$JAVA" $JAVA_OPTS $ES_JAVA_OPTS $es_parms -Des.path.home="$ES_HOME" -cp "$ES_CLASSPATH" $props \
                     org.elasticsearch.bootstrap.Elasticsearch <&- &
-        return $?
+
+        local timeout=$((`date +%s` + $BG_STARTUP_TIMEOUT))
+        while [ `date +%s` -lt $timeout ]; do
+            kill -0 `cat $pidpath 2>&1` >/dev/null 2>&1 && break
+            sleep 1
+        done
+
+        kill -0 `cat $pidpath 2>&1` >/dev/null 2>&1 || {
+            echo ""
+            echo "ERROR: Start-up timed out (no PID file after ${BG_STARTUP_TIMEOUT}s)."
+            return 1; }
+
+        echo "OK"
+        return 0
     fi
 }
 
@@ -168,6 +193,8 @@ usage() {
     echo "Usage: $0 [-vdh] [-p pidfile] [-D prop] [-X prop]"
     echo "Start elasticsearch."
     echo "    -d            daemonize (run in background)"
+    echo "    -w            timeout (seconds) to wait for ES to start when daemonized"
+    echo "                   (default: $BG_STARTUP_TIMEOUT)"
     echo "    -p pidfile    write PID to <pidfile>"
     echo "    -h"
     echo "    --help        print command line options"
@@ -201,7 +228,7 @@ do
 done
 
 # Parse any command line options.
-args=`getopt vdhp:D:X: $ARGV`
+args=`getopt vdhp:D:X:w: $ARGV`
 eval set -- "$args"
 
 while true; do
@@ -218,6 +245,10 @@ while true; do
         -d)
             daemonized="yes"
             shift
+        ;;
+        -w)
+            BG_STARTUP_TIMEOUT="$2"
+            shift 2
         ;;
         -h)
             usage

--- a/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
+++ b/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
@@ -147,18 +147,7 @@ public class Bootstrap {
     public static void main(String[] args) {
         System.setProperty("es.logger.prefix", "");
         bootstrap = new Bootstrap();
-        final String pidFile = System.getProperty("es.pidfile", System.getProperty("es-pidfile"));
 
-        if (pidFile != null) {
-            try {
-                PidFile.create(Paths.get(pidFile), true);
-            } catch (Exception e) {
-                String errorMessage = buildErrorMessage("pid", e);
-                System.err.println(errorMessage);
-                System.err.flush();
-                System.exit(3);
-            }
-        }
         boolean foreground = System.getProperty("es.foreground", System.getProperty("es-foreground")) != null;
         // handle the wrapper system property, if its a service, don't run as a service
         if (System.getProperty("wrapper.service", "XXX").equalsIgnoreCase("true")) {
@@ -237,6 +226,20 @@ public class Bootstrap {
             logger.error("Exception", e);
             
             System.exit(3);
+        }
+
+        // Start-up succeeded - write the PID file
+        final String pidFile = System.getProperty("es.pidfile", System.getProperty("es-pidfile"));
+
+        if (pidFile != null) {
+            try {
+                PidFile.create(Paths.get(pidFile), true);
+            } catch (Exception e) {
+                String errorMessage = buildErrorMessage("pid", e);
+                System.err.println(errorMessage);
+                System.err.flush();
+                System.exit(3);
+            }
         }
     }
 


### PR DESCRIPTION
This change introduces the use of elasticsearch's PID file to signal a
successful start-up. The start script `bin/elasticsearch` will wait a
configurable amount of time (default: 120s) for the PID file to appear. After
this timed out the script will print an error and return an error code.

Note that if no PID file was specified on the command line the script will now
use `mktemp` to create a "private" PID file (only if ES is to be started in the
background, though). The command line help was updated correspondingly.

Also, the PID file generation code has been moved from the beginning of the
bootstrap `main()` method to the end.

Fixes #8652.

**NOTE**
Please review my changes to `src/main/java/org/elasticsearch/bootstrap/Bootstrap.java` very closely; I'm not too familiar with ES code and am not sure if I broke something.

**NOTE 2**
This change introduces a (theoretical) new error condition: If elasticsearch requires longer than the timeout to bootstrap, a "false positive" start-up error will be reported by the script even though elasticsearch will be up and running eventually. This can be worked around by setting an appropriately long timeout via the new `-w` command line option.
