### PR TITLE
[docs] formatting and general pedantry

### DIFF
--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -68,7 +68,7 @@ The following options can be applied to all of the REST APIs.
 
 When appending `?pretty=true` to any request made, the JSON returned
 will be pretty formatted (use it for debugging only!). Another option is
-to set `format=yaml` which will cause the result to be returned in the
+to set `?format=yaml` which will cause the result to be returned in the
 (sometimes) more readable yaml format.
 
 
@@ -77,7 +77,7 @@ to set `format=yaml` which will cause the result to be returned in the
 
 Statistics are returned in a format suitable for humans
 (eg `"exists_time": "1h"` or `"size": "1kb"`) and for computers
-(eg `"exists_time_in_millis": 3600000`` or `"size_in_bytes": 1024`).
+(eg `"exists_time_in_millis": 3600000` or `"size_in_bytes": 1024`).
 The human readable values can be turned off by adding `?human=false`
 to the query string. This makes sense when the stats results are
 being consumed by a monitoring tool, rather than intended for human
@@ -88,7 +88,7 @@ consumption.  The default for the `human` flag is
 === Flat Settings
 
 The `flat_settings` flag affects rendering of the lists of settings. When
-flat_settings` flag is `true` settings are returned in a flat format:
+`flat_settings` flag is `true` settings are returned in a flat format:
 
 [source,js]
 --------------------------------------------------


### PR DESCRIPTION
I'm not sure if the `distance-units` section is totally clear, when using the 'Geohash Cell Filter' and omitting a unit, the default is to interpret the integer as the 'length of the geohash prefix', not to default it to 'meter'. Maybe I'm being pedantic.
