### PR TITLE
systemd service: wait for networking, don't daemonize

### DIFF
--- a/src/rpm/systemd/elasticsearch.service
+++ b/src/rpm/systemd/elasticsearch.service
@@ -1,14 +1,20 @@
 [Unit]
 Description=Starts and stops a single elasticsearch instance on this system
 Documentation=http://www.elasticsearch.org
+Wants=network-online.target
+After=network-online.target
 
 [Service]
-Type=forking
 EnvironmentFile=/etc/sysconfig/elasticsearch
 User=elasticsearch
 Group=elasticsearch
-PIDFile=/var/run/elasticsearch/elasticsearch.pid
-ExecStart=/usr/share/elasticsearch/bin/elasticsearch -d -p /var/run/elasticsearch/elasticsearch.pid -Des.default.config=$CONF_FILE -Des.default.path.home=$ES_HOME -Des.default.path.logs=$LOG_DIR -Des.default.path.data=$DATA_DIR -Des.default.path.work=$WORK_DIR -Des.default.path.conf=$CONF_DIR
+ExecStart=/usr/share/elasticsearch/bin/elasticsearch            \
+                            -Des.default.config=$CONF_FILE      \
+                            -Des.default.path.home=$ES_HOME     \
+                            -Des.default.path.logs=$LOG_DIR     \
+                            -Des.default.path.data=$DATA_DIR    \
+                            -Des.default.path.work=$WORK_DIR    \
+                            -Des.default.path.conf=$CONF_DIR
 # See MAX_OPEN_FILES in sysconfig
 LimitNOFILE=65535
 # See MAX_LOCKED_MEMORY in sysconfig, use "infinity" when MAX_LOCKED_MEMORY=unlimited and using bootstrap.mlockall: true


### PR DESCRIPTION
This change updates the systemd elasticsearch service configuration to depend
on boot-time networking being available before ES is started (see
http://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/ for a
discussion of the specific network-online target used in the service file).

Also, the ES script does not fork / daemonize when started by systemd since
this is the recommended behaviour for systemd services (see
http://0pointer.de/blog/projects/systemd-for-admins-3.html).

fixes #8636

Signed-off-by: Thilo Fromm github@thilo-fromm.de
