### PR TITLE
Feature/Fix for OGC compliant polygons failing with ambiguity

### DIFF
--- a/docs/reference/mapping/types/geo-shape-type.asciidoc
+++ b/docs/reference/mapping/types/geo-shape-type.asciidoc
@@ -157,7 +157,7 @@ units, which default to `METERS`.
 For all types, both the inner `type` and `coordinates` fields are
 required.
 
-Note: In GeoJSON, and therefore Elasticsearch, the correct *coordinate
+In GeoJSON, and therefore Elasticsearch, the correct *coordinate
 order is longitude, latitude (X, Y)* within coordinate arrays. This
 differs from many Geospatial APIs (e.g., Google Maps) that generally
 use the colloquial latitude, longitude (Y, X).
@@ -230,6 +230,36 @@ arrays represent the interior shapes ("holes"):
         "coordinates" : [
             [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ],
             [ [100.2, 0.2], [100.8, 0.2], [100.8, 0.8], [100.2, 0.8], [100.2, 0.2] ]
+        ]
+    }
+}
+--------------------------------------------------
+
+*IMPORTANT NOTE:* GeoJSON does not mandate a specific order for vertices thus ambiguous
+polygons around the dateline and poles are possible. To alleviate ambiguity
+the Open Geospatial Consortium (OGC)
+http://www.opengeospatial.org/standards/sfa[Simple Feature Access] specification
+defines the following vertex ordering:
+
+* Outer Ring - Counterclockwise
+* Inner Ring(s) / Holes - Clockwise
+
+For polygons that do not cross the dateline, vertex order will not matter in
+Elasticsearch. For polygons that do cross the dateline, Elasticsearch requires
+vertex orderinging comply with the OGC specification. Otherwise, an unintended polygon
+may be created and unexpected query/filter results will be returned.
+
+The following provides an example of an ambiguous polygon.  Elasticsearch will apply
+OGC standards to eliminate ambiguity resulting in a polygon that crosses the dateline.
+
+[source,js]
+--------------------------------------------------
+{
+    "location" : {
+        "type" : "polygon",
+        "coordinates" : [
+            [ [-177.0, 10.0], [176.0, 15.0], [172.0, 0.0], [176.0, -15.0], [-177.0, -10.0], [-177.0, 10.0] ],
+            [ [178.2, 8.2], [-178.8, 8.2], [-180.8, -8.8], [178.2, 8.8] ]
         ]
     }
 }

--- a/src/main/java/org/elasticsearch/common/geo/builders/BasePolygonBuilder.java
+++ b/src/main/java/org/elasticsearch/common/geo/builders/BasePolygonBuilder.java
@@ -126,9 +126,9 @@ public abstract class BasePolygonBuilder<E extends BasePolygonBuilder<E>> extend
         Edge[] edges = new Edge[numEdges];
         Edge[] holeComponents = new Edge[holes.size()];
 
-        int offset = createEdges(0, true, shell, edges, 0);
+        int offset = createEdges(0, false, shell, edges, 0);
         for (int i = 0; i < holes.size(); i++) {
-            int length = createEdges(i+1, false, this.holes.get(i), edges, offset);
+            int length = createEdges(i+1, true, this.holes.get(i), edges, offset);
             holeComponents[i] = edges[offset];
             offset += length;
         }

--- a/src/main/java/org/elasticsearch/common/geo/builders/BasePolygonBuilder.java
+++ b/src/main/java/org/elasticsearch/common/geo/builders/BasePolygonBuilder.java
@@ -404,7 +404,8 @@ public abstract class BasePolygonBuilder<E extends BasePolygonBuilder<E>> extend
             // The connect method creates a new edge for these paired edges in the linked list. 
             // For boundary conditions (e.g., intersect but not crossing) there is no sibling edge 
             // to connect. Thus the following enforces the pairwise rule 
-            if (e1.intersect != Edge.MAX_COORDINATE && e2.intersect != Edge.MAX_COORDINATE) {
+            if (e1.intersect != Edge.MAX_COORDINATE && e2.intersect != Edge.MAX_COORDINATE 
+                    && (e1.next.next.coordinate != e2.coordinate) ) {
                 connect(e1, e2);
             }
         }
@@ -431,7 +432,7 @@ public abstract class BasePolygonBuilder<E extends BasePolygonBuilder<E>> extend
                 in.next = new Edge(in.intersect, out.next, in.intersect);
             }
             out.next = new Edge(out.intersect, e1, out.intersect);
-        } else if (in.next != out){
+        } else if (in.next != out && in.coordinate != out.intersect) {
             // first edge intersects with dateline
             Edge e2 = new Edge(out.intersect, in.next, out.intersect);
 

--- a/src/main/java/org/elasticsearch/common/geo/builders/BasePolygonBuilder.java
+++ b/src/main/java/org/elasticsearch/common/geo/builders/BasePolygonBuilder.java
@@ -403,9 +403,10 @@ public abstract class BasePolygonBuilder<E extends BasePolygonBuilder<E>> extend
             // The connect method creates a new edge for these paired edges in the linked list. 
             // For boundary conditions (e.g., intersect but not crossing) there is no sibling edge 
             // to connect. Thus the first logic check enforces the pairwise rule
-            // 2. the second logic ensures the two candidate edges aren't already connected by an
-            //    existing along the dateline - this is necessary due to a logic change that
-            //    computes dateline edges as valid intersect points in support of OGC standards
+            // 2. the second logic check ensures the two candidate edges aren't already connected by an
+            //    existing edge along the dateline - this is necessary due to a logic change in
+            //    ShapeBuilder.intersection that computes dateline edges as valid intersect points 
+            //    in support of OGC standards
             if (e1.intersect != Edge.MAX_COORDINATE && e2.intersect != Edge.MAX_COORDINATE 
                     && !(e1.next.next.coordinate.equals3D(e2.coordinate) && Math.abs(e1.next.coordinate.x) == DATELINE
                     && Math.abs(e2.coordinate.x) == DATELINE) ) {

--- a/src/main/java/org/elasticsearch/common/geo/builders/PointCollection.java
+++ b/src/main/java/org/elasticsearch/common/geo/builders/PointCollection.java
@@ -34,6 +34,7 @@ import com.vividsolutions.jts.geom.Coordinate;
 public abstract class PointCollection<E extends PointCollection<E>> extends ShapeBuilder {
 
     protected final ArrayList<Coordinate> points;
+    protected boolean translated = false;
 
     protected PointCollection() {
         this(new ArrayList<Coordinate>());

--- a/src/main/java/org/elasticsearch/common/geo/builders/ShapeBuilder.java
+++ b/src/main/java/org/elasticsearch/common/geo/builders/ShapeBuilder.java
@@ -508,14 +508,15 @@ public abstract class ShapeBuilder implements ToXContent {
             //   1.  shell orientation is cw and range is greater than a hemisphere (180 degrees) but not spanning 2 hemispheres 
             //       (translation would result in a collapsed poly)
             //   2.  the shell of the candidate hole has been translated (to preserve the coordinate system)
-            if ((rng > DATELINE && rng != 2*DATELINE && orientation && component == 0) || (shell.translated && component != 0)) {
+            if (((component == 0 && orientation) && (rng > DATELINE && rng != 2*DATELINE))
+                    || (shell.translated && component != 0)) {
                 translate(points);
                 // flip the translation bit if the shell is being translated
-                if (component == 0 && !shell.translated) {
+                if (component == 0) {
                     shell.translated = true;
                 }
                 // correct the orientation post translation (ccw for shell, cw for holes)
-                if ((component == 0 && orientation) || (component != 0 && !orientation)) {
+                if (component == 0 || (component != 0 && !orientation)) {
                     orientation = !orientation;
                 }
             }

--- a/src/main/java/org/elasticsearch/common/geo/builders/ShapeBuilder.java
+++ b/src/main/java/org/elasticsearch/common/geo/builders/ShapeBuilder.java
@@ -486,7 +486,7 @@ public abstract class ShapeBuilder implements ToXContent {
          * @return Array of edges
          */
         protected static Edge[] ring(int component, boolean direction, BaseLineStringBuilder<?> shell, Coordinate[] points, int offset, 
-                                     Edge[] edges, int toffset, int length) {
+                Edge[] edges, int toffset, int length) {
             // calculate the direction of the points:
             // find the point a the top of the set and check its
             // neighbors orientation. So direction is equivalent
@@ -505,11 +505,11 @@ public abstract class ShapeBuilder implements ToXContent {
             Pair<Pair, Pair> range = range(points, offset, length);
             final double rng = (Double)range.getLeft().getRight() - (Double)range.getLeft().getLeft();
             // translate the points if the following is true
-            //   1.  range is greater than a hemisphere (180 degrees) but not spanning 2 hemispheres (translation would result in
-            //         a collapsed poly)
+            //   1.  shell orientation is cw and range is greater than a hemisphere (180 degrees) but not spanning 2 hemispheres 
+            //       (translation would result in a collapsed poly)
             //   2.  the shell of the candidate hole has been translated (to preserve the coordinate system)
-            if ((rng > DATELINE && rng != 2*DATELINE && orientation) || (shell.translated && component != 0)) {
-                transform(points);
+            if ((rng > DATELINE && rng != 2*DATELINE && orientation && component == 0) || (shell.translated && component != 0)) {
+                translate(points);
                 // flip the translation bit if the shell is being translated
                 if (component == 0 && !shell.translated) {
                     shell.translated = true;
@@ -526,7 +526,7 @@ public abstract class ShapeBuilder implements ToXContent {
          * Transforms coordinates in the eastern hemisphere (-180:0) to a (180:360) range 
          * @param points
          */
-        protected static void transform(Coordinate[] points) {
+        protected static void translate(Coordinate[] points) {
             for (Coordinate c : points) {
                 if (c.x < 0) {
                     c.x += 2*DATELINE;

--- a/src/test/java/org/elasticsearch/common/geo/GeoJSONShapeParserTests.java
+++ b/src/test/java/org/elasticsearch/common/geo/GeoJSONShapeParserTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.common.geo;
 
+import com.spatial4j.core.exception.InvalidShapeException;
 import com.spatial4j.core.shape.Circle;
 import com.spatial4j.core.shape.Rectangle;
 import com.spatial4j.core.shape.Shape;
@@ -428,6 +429,28 @@ public class GeoJSONShapeParserTests extends ElasticsearchTestCase {
                 holeCoordinates.toArray(new Coordinate[holeCoordinates.size()]));
         Polygon expected = GEOMETRY_FACTORY.createPolygon(shell, holes);
         assertGeometryEquals(jtsGeom(expected), polygonGeoJson);
+    }
+
+    @Test
+    public void testParse_selfCrossingPolygon() throws IOException {
+        // test self crossing ccw poly not crossing dateline
+        String polygonGeoJson = XContentFactory.jsonBuilder().startObject().field("type", "Polygon")
+                .startArray("coordinates")
+                .startArray()
+                .startArray().value(176.0).value(15.0).endArray()
+                .startArray().value(-177.0).value(10.0).endArray()
+                .startArray().value(-177.0).value(-10.0).endArray()
+                .startArray().value(176.0).value(-15.0).endArray()
+                .startArray().value(-177.0).value(15.0).endArray()
+                .startArray().value(172.0).value(0.0).endArray()
+                .startArray().value(176.0).value(15.0).endArray()
+                .endArray()
+                .endArray()
+                .endObject().string();
+
+        XContentParser parser = JsonXContent.jsonXContent.createParser(polygonGeoJson);
+        parser.nextToken();
+        ElasticsearchGeoAssertions.assertValidException(parser, InvalidShapeException.class);
     }
 
     @Test

--- a/src/test/java/org/elasticsearch/common/geo/GeoJSONShapeParserTests.java
+++ b/src/test/java/org/elasticsearch/common/geo/GeoJSONShapeParserTests.java
@@ -210,6 +210,50 @@ public class GeoJSONShapeParserTests extends ElasticsearchTestCase {
     }
 
     @Test
+    public void testParse_polygonNoHolesOGCCompliance() throws IOException {
+        // test ccw poly (large poly intended to not cross dateline)
+        String polygonGeoJson = XContentFactory.jsonBuilder().startObject().field("type", "Polygon")
+                .startArray("coordinates")
+                .startArray()
+                .startArray().value(176.0).value(15.0).endArray()
+                .startArray().value(-177.0).value(10.0).endArray()
+                .startArray().value(-177.0).value(-10.0).endArray()
+                .startArray().value(176.0).value(-15.0).endArray()
+                .startArray().value(172.0).value(0.0).endArray()
+                .startArray().value(176.0).value(15.0).endArray()
+                .endArray()
+                .endArray()
+                .endObject().string();
+
+        XContentParser parser = JsonXContent.jsonXContent.createParser(polygonGeoJson);
+        parser.nextToken();
+        Shape shape = ShapeBuilder.parse(parser).build();
+
+        // test cw poly (small poly expected to cross dateline)
+        polygonGeoJson = XContentFactory.jsonBuilder().startObject().field("type", "Polygon")
+                .startArray("coordinates")
+                .startArray()
+                .startArray().value(-177.0).value(10.0).endArray()
+                .startArray().value(176.0).value(15.0).endArray()
+                .startArray().value(172.0).value(0.0).endArray()
+                .startArray().value(176.0).value(-15.0).endArray()
+                .startArray().value(-177.0).value(-10.0).endArray()
+                .startArray().value(-177.0).value(10.0).endArray()
+                .endArray()
+                .endArray()
+                .endObject().string();
+
+        parser = JsonXContent.jsonXContent.createParser(polygonGeoJson);
+        parser.nextToken();
+        shape = ShapeBuilder.parse(parser).build();
+    }
+
+//    @Test
+//    public void testParse_polygonWithHolesWKTReorder() throws IOException {
+//
+//    }
+
+    @Test
     public void testParse_invalidPolygon() throws IOException {
         /**
          * The following 3 test cases ensure proper error handling of invalid polygons 

--- a/src/test/java/org/elasticsearch/common/geo/GeoJSONShapeParserTests.java
+++ b/src/test/java/org/elasticsearch/common/geo/GeoJSONShapeParserTests.java
@@ -212,7 +212,7 @@ public class GeoJSONShapeParserTests extends ElasticsearchTestCase {
 
     @Test
     public void testParse_OGCPolygonWithoutHoles() throws IOException {
-        // test ccw poly not crossing dateline
+        // test 1: ccw poly not crossing dateline
         String polygonGeoJson = XContentFactory.jsonBuilder().startObject().field("type", "Polygon")
                 .startArray("coordinates")
                 .startArray()
@@ -232,7 +232,7 @@ public class GeoJSONShapeParserTests extends ElasticsearchTestCase {
         
         ElasticsearchGeoAssertions.assertPolygon(shape);
 
-        // test ccw poly crossing dateline
+        // test 2: ccw poly crossing dateline
         polygonGeoJson = XContentFactory.jsonBuilder().startObject().field("type", "Polygon")
                 .startArray("coordinates")
                 .startArray()
@@ -251,11 +251,51 @@ public class GeoJSONShapeParserTests extends ElasticsearchTestCase {
         shape = ShapeBuilder.parse(parser).build();
         
         ElasticsearchGeoAssertions.assertMultiPolygon(shape);
+
+        // test 3: cw poly not crossing dateline
+        polygonGeoJson = XContentFactory.jsonBuilder().startObject().field("type", "Polygon")
+                .startArray("coordinates")
+                .startArray()
+                .startArray().value(176.0).value(15.0).endArray()
+                .startArray().value(180.0).value(10.0).endArray()
+                .startArray().value(180.0).value(-10.0).endArray()
+                .startArray().value(176.0).value(-15.0).endArray()
+                .startArray().value(172.0).value(0.0).endArray()
+                .startArray().value(176.0).value(15.0).endArray()
+                .endArray()
+                .endArray()
+                .endObject().string();
+
+        parser = JsonXContent.jsonXContent.createParser(polygonGeoJson);
+        parser.nextToken();
+        shape = ShapeBuilder.parse(parser).build();
+
+        ElasticsearchGeoAssertions.assertPolygon(shape);
+
+        // test 4: cw poly crossing dateline
+        polygonGeoJson = XContentFactory.jsonBuilder().startObject().field("type", "Polygon")
+                .startArray("coordinates")
+                .startArray()
+                .startArray().value(176.0).value(15.0).endArray()
+                .startArray().value(184.0).value(15.0).endArray()
+                .startArray().value(184.0).value(0.0).endArray()
+                .startArray().value(176.0).value(-15.0).endArray()
+                .startArray().value(174.0).value(-10.0).endArray()
+                .startArray().value(176.0).value(15.0).endArray()
+                .endArray()
+                .endArray()
+                .endObject().string();
+
+        parser = JsonXContent.jsonXContent.createParser(polygonGeoJson);
+        parser.nextToken();
+        shape = ShapeBuilder.parse(parser).build();
+
+        ElasticsearchGeoAssertions.assertMultiPolygon(shape);
     }
 
     @Test
     public void testParse_OGCPolygonWithHoles() throws IOException {
-        // test ccw poly not crossing dateline
+        // test 1: ccw poly not crossing dateline
         String polygonGeoJson = XContentFactory.jsonBuilder().startObject().field("type", "Polygon")
                 .startArray("coordinates")
                 .startArray()
@@ -281,7 +321,7 @@ public class GeoJSONShapeParserTests extends ElasticsearchTestCase {
 
         ElasticsearchGeoAssertions.assertPolygon(shape);
 
-        // test ccw poly crossing dateline
+        // test 2: ccw poly crossing dateline
         polygonGeoJson = XContentFactory.jsonBuilder().startObject().field("type", "Polygon")
                 .startArray("coordinates")
                 .startArray()
@@ -296,6 +336,58 @@ public class GeoJSONShapeParserTests extends ElasticsearchTestCase {
                 .startArray().value(178.0).value(8.0).endArray()
                 .startArray().value(-178.0).value(8.0).endArray()
                 .startArray().value(-180.0).value(-8.0).endArray()
+                .startArray().value(178.0).value(8.0).endArray()
+                .endArray()
+                .endArray()
+                .endObject().string();
+
+        parser = JsonXContent.jsonXContent.createParser(polygonGeoJson);
+        parser.nextToken();
+        shape = ShapeBuilder.parse(parser).build();
+
+        ElasticsearchGeoAssertions.assertMultiPolygon(shape);
+
+        // test 3: cw poly not crossing dateline
+        polygonGeoJson = XContentFactory.jsonBuilder().startObject().field("type", "Polygon")
+                .startArray("coordinates")
+                .startArray()
+                .startArray().value(176.0).value(15.0).endArray()
+                .startArray().value(180.0).value(10.0).endArray()
+                .startArray().value(179.0).value(-10.0).endArray()
+                .startArray().value(176.0).value(-15.0).endArray()
+                .startArray().value(172.0).value(0.0).endArray()
+                .startArray().value(176.0).value(15.0).endArray()
+                .endArray()
+                .startArray()
+                .startArray().value(177.0).value(8.0).endArray()
+                .startArray().value(179.0).value(10.0).endArray()
+                .startArray().value(179.0).value(-8.0).endArray()
+                .startArray().value(177.0).value(8.0).endArray()
+                .endArray()
+                .endArray()
+                .endObject().string();
+
+        parser = JsonXContent.jsonXContent.createParser(polygonGeoJson);
+        parser.nextToken();
+        shape = ShapeBuilder.parse(parser).build();
+
+        ElasticsearchGeoAssertions.assertPolygon(shape);
+
+        // test 4: cw poly crossing dateline
+        polygonGeoJson = XContentFactory.jsonBuilder().startObject().field("type", "Polygon")
+                .startArray("coordinates")
+                .startArray()
+                .startArray().value(183.0).value(10.0).endArray()
+                .startArray().value(183.0).value(-10.0).endArray()
+                .startArray().value(176.0).value(-15.0).endArray()
+                .startArray().value(172.0).value(0.0).endArray()
+                .startArray().value(176.0).value(15.0).endArray()
+                .startArray().value(183.0).value(10.0).endArray()
+                .endArray()
+                .startArray()
+                .startArray().value(178.0).value(8.0).endArray()
+                .startArray().value(182.0).value(8.0).endArray()
+                .startArray().value(180.0).value(-8.0).endArray()
                 .startArray().value(178.0).value(8.0).endArray()
                 .endArray()
                 .endArray()
@@ -538,7 +630,7 @@ public class GeoJSONShapeParserTests extends ElasticsearchTestCase {
     @Test
     public void testParse_geometryCollection() throws IOException {
         String geometryCollectionGeoJson = XContentFactory.jsonBuilder().startObject()
-                .field("type","GeometryCollection")
+                .field("type", "GeometryCollection")
                 .startArray("geometries")
                     .startObject()
                         .field("type", "LineString")

--- a/src/test/java/org/elasticsearch/common/geo/ShapeBuilderTests.java
+++ b/src/test/java/org/elasticsearch/common/geo/ShapeBuilderTests.java
@@ -240,7 +240,7 @@ public class ShapeBuilderTests extends ElasticsearchTestCase {
     }
 
     @Test
-    public void testDateline() {
+    public void testDatelineOGC() {
         // view shape at https://gist.github.com/anonymous/7f1bb6d7e9cd72f5977c
         // expect 3 polygons, 1 with a hole
 
@@ -281,6 +281,48 @@ public class ShapeBuilderTests extends ElasticsearchTestCase {
         assertMultiPolygon(shape);
     }
 
+    @Test
+    public void testDateline() {
+        // view shape at https://gist.github.com/anonymous/7f1bb6d7e9cd72f5977c
+        // expect 3 polygons, 1 with a hole
+
+        // a giant c shape
+        PolygonBuilder builder = ShapeBuilder.newPolygon()
+                .point(-186,0)
+                .point(-176,0)
+                .point(-176,3)
+                .point(-183,3)
+                .point(-183,5)
+                .point(-176,5)
+                .point(-176,8)
+                .point(-186,8)
+                .point(-186,0);
+
+        // 3/4 of an embedded 'c', crossing dateline once
+        builder.hole()
+                .point(-185,1)
+                .point(-181,1)
+                .point(-181,2)
+                .point(-184,2)
+                .point(-184,6)
+                .point(-178,6)
+                .point(-178,7)
+                .point(-185,7)
+                .point(-185,1);
+
+        // embedded hole right of the dateline
+        builder.hole()
+                .point(-179,1)
+                .point(-177,1)
+                .point(-177,2)
+                .point(-179,2)
+                .point(-179,1);
+
+        Shape shape = builder.close().build();
+
+        assertMultiPolygon(shape);
+    }
+    
     @Test
     public void testComplexShapeWithHole() {
         PolygonBuilder builder = ShapeBuilder.newPolygon()

--- a/src/test/java/org/elasticsearch/common/geo/ShapeBuilderTests.java
+++ b/src/test/java/org/elasticsearch/common/geo/ShapeBuilderTests.java
@@ -406,14 +406,50 @@ public class ShapeBuilderTests extends ElasticsearchTestCase {
 
         // test case 2: test the negative side of the dateline
         builder = ShapeBuilder.newPolygon()
-                .point(-180, 0)
                 .point(-176, 4)
+                .point(-180, 0)
                 .point(-180, -4)
-                .point(-180, 0);
+                .point(-176, 4);
 
         shape = builder.close().build();
         assertPolygon(shape);
      }
+
+    @Test
+    public void testShapeWithBoundaryHoles() {
+        // test case 1: test the positive side of the dateline
+        PolygonBuilder builder = ShapeBuilder.newPolygon()
+                .point(-177, 10)
+                .point(176, 15)
+                .point(172, 0)
+                .point(176, -15)
+                .point(-177, -10)
+                .point(-177, 10);
+        builder.hole()
+                .point(176, 10)
+                .point(180, 5)
+                .point(180, -5)
+                .point(176, -10)
+                .point(176, 10);
+        Shape shape = builder.close().build();
+        assertMultiPolygon(shape);
+
+        // test case 2: test the negative side of the dateline
+        builder = ShapeBuilder.newPolygon()
+                .point(-176, 15)
+                .point(179, 10)
+                .point(179, -10)
+                .point(-176, -15)
+                .point(-172,0);
+        builder.hole()
+                .point(-176, 10)
+                .point(-180, 5)
+                .point(-180, -5)
+                .point(-176, -10)
+                .point(-176, 10);
+        shape = builder.close().build();
+        assertMultiPolygon(shape);
+    }
 
     /**
      * Test an enveloping polygon around the max mercator bounds

--- a/src/test/java/org/elasticsearch/common/geo/ShapeBuilderTests.java
+++ b/src/test/java/org/elasticsearch/common/geo/ShapeBuilderTests.java
@@ -246,35 +246,35 @@ public class ShapeBuilderTests extends ElasticsearchTestCase {
 
         // a giant c shape
         PolygonBuilder builder = ShapeBuilder.newPolygon()
-                .point(174,0)
-                .point(-176,0)
-                .point(-176,3)
-                .point(177,3)
-                .point(177,5)
-                .point(-176,5)
-                .point(-176,8)
-                .point(174,8)
-                .point(174,0);
+            .point(174,0)
+            .point(-176,0)
+            .point(-176,3)
+            .point(177,3)
+            .point(177,5)
+            .point(-176,5)
+            .point(-176,8)
+            .point(174,8)
+            .point(174,0);
 
         // 3/4 of an embedded 'c', crossing dateline once
         builder.hole()
-                .point(175, 1)
-                .point(175, 7)
-                .point(-178, 7)
-                .point(-178, 6)
-                .point(176, 6)
-                .point(176, 2)
-                .point(179, 2)
-                .point(179,1)
-                .point(175, 1);
+            .point(175, 1)
+            .point(175, 7)
+            .point(-178, 7)
+            .point(-178, 6)
+            .point(176, 6)
+            .point(176, 2)
+            .point(179, 2)
+            .point(179,1)
+            .point(175, 1);
 
         // embedded hole right of the dateline
         builder.hole()
-                .point(-179, 1)
-                .point(-179, 2)
-                .point(-177, 2)
-                .point(-177,1)
-                .point(-179,1);
+            .point(-179, 1)
+            .point(-179, 2)
+            .point(-177, 2)
+            .point(-177,1)
+            .point(-179,1);
 
         Shape shape = builder.close().build();
 

--- a/src/test/java/org/elasticsearch/common/geo/ShapeBuilderTests.java
+++ b/src/test/java/org/elasticsearch/common/geo/ShapeBuilderTests.java
@@ -246,40 +246,40 @@ public class ShapeBuilderTests extends ElasticsearchTestCase {
 
         // a giant c shape
         PolygonBuilder builder = ShapeBuilder.newPolygon()
-            .point(-186,0)
-            .point(-176,0)
-            .point(-176,3)
-            .point(-183,3)
-            .point(-183,5)
-            .point(-176,5)
-            .point(-176,8)
-            .point(-186,8)
-            .point(-186,0);
+                .point(174,0)
+                .point(-176,0)
+                .point(-176,3)
+                .point(177,3)
+                .point(177,5)
+                .point(-176,5)
+                .point(-176,8)
+                .point(174,8)
+                .point(174,0);
 
         // 3/4 of an embedded 'c', crossing dateline once
         builder.hole()
-            .point(-185,1)
-            .point(-181,1)
-            .point(-181,2)
-            .point(-184,2)
-            .point(-184,6)
-            .point(-178,6)
-            .point(-178,7)
-            .point(-185,7)
-            .point(-185,1);
+                .point(175, 1)
+                .point(175, 7)
+                .point(-178, 7)
+                .point(-178, 6)
+                .point(176, 6)
+                .point(176, 2)
+                .point(179, 2)
+                .point(179,1)
+                .point(175, 1);
 
         // embedded hole right of the dateline
         builder.hole()
-            .point(-179,1)
-            .point(-177,1)
-            .point(-177,2)
-            .point(-179,2)
-            .point(-179,1);
+                .point(-179, 1)
+                .point(-179, 2)
+                .point(-177, 2)
+                .point(-177,1)
+                .point(-179,1);
 
         Shape shape = builder.close().build();
 
-         assertMultiPolygon(shape);
-     }
+        assertMultiPolygon(shape);
+    }
 
     @Test
     public void testComplexShapeWithHole() {
@@ -443,9 +443,9 @@ public class ShapeBuilderTests extends ElasticsearchTestCase {
                 .point(-172,0);
         builder.hole()
                 .point(-176, 10)
-                .point(-180, 5)
-                .point(-180, -5)
                 .point(-176, -10)
+                .point(-180, -5)
+                .point(-180, 5)
                 .point(-176, 10);
         shape = builder.close().build();
         assertMultiPolygon(shape);
@@ -468,7 +468,8 @@ public class ShapeBuilderTests extends ElasticsearchTestCase {
     }
 
     @Test
-    public void testShapeWithEdgeAcrossDateline() {
+    public void testShapeWithAlternateOrientation() {
+        // ccw: should produce a single polygon spanning hemispheres
         PolygonBuilder builder = ShapeBuilder.newPolygon()
                 .point(180, 0)
                 .point(176, 4)
@@ -476,7 +477,17 @@ public class ShapeBuilderTests extends ElasticsearchTestCase {
                 .point(180, 0);
 
         Shape shape = builder.close().build();
+        assertPolygon(shape);
 
-         assertPolygon(shape);
+        // cw: geo core will convert to ccw across the dateline
+        builder = ShapeBuilder.newPolygon()
+                .point(180, 0)
+                .point(-176, 4)
+                .point(176, 4)
+                .point(180, 0);
+
+        shape = builder.close().build();
+
+        assertMultiPolygon(shape);
      }
 }

--- a/src/test/java/org/elasticsearch/common/geo/ShapeBuilderTests.java
+++ b/src/test/java/org/elasticsearch/common/geo/ShapeBuilderTests.java
@@ -241,8 +241,9 @@ public class ShapeBuilderTests extends ElasticsearchTestCase {
 
     @Test
     public void testDatelineOGC() {
-        // view shape at https://gist.github.com/anonymous/7f1bb6d7e9cd72f5977c
-        // expect 3 polygons, 1 with a hole
+        // tests that the following shape (defined in counterclockwise OGC order)
+        // https://gist.github.com/anonymous/7f1bb6d7e9cd72f5977c crosses the dateline
+        // expected results: 3 polygons, 1 with a hole
 
         // a giant c shape
         PolygonBuilder builder = ShapeBuilder.newPolygon()
@@ -283,8 +284,9 @@ public class ShapeBuilderTests extends ElasticsearchTestCase {
 
     @Test
     public void testDateline() {
-        // view shape at https://gist.github.com/anonymous/7f1bb6d7e9cd72f5977c
-        // expect 3 polygons, 1 with a hole
+        // tests that the following shape (defined in clockwise non-OGC order)
+        // https://gist.github.com/anonymous/7f1bb6d7e9cd72f5977c crosses the dateline
+        // expected results: 3 polygons, 1 with a hole
 
         // a giant c shape
         PolygonBuilder builder = ShapeBuilder.newPolygon()

--- a/src/test/java/org/elasticsearch/test/hamcrest/ElasticsearchGeoAssertions.java
+++ b/src/test/java/org/elasticsearch/test/hamcrest/ElasticsearchGeoAssertions.java
@@ -251,7 +251,7 @@ public class ElasticsearchGeoAssertions {
 
     public static void assertValidException(XContentParser parser, Class expectedException) {
         try {
-            ShapeBuilder.parse(parser);
+            ShapeBuilder.parse(parser).build();
             Assert.fail("process completed successfully when " + expectedException.getName() + " expected");
         } catch (Exception e) {
             assert(e.getClass().equals(expectedException)):


### PR DESCRIPTION
This feature/fix implements OGC compliance for Polygon/Multi-polygon to correctly cross the dateline without requiring the user specify invalid lat/lon pairs (e.g., 183/-70).  That is, vertex order for the exterior ring follows the right-hand rule (ccw) and all holes follow the left-hand rule (cw).  While GeoJSON imposes no restrictions, a user that wants to specify a complex poly across the dateline can now do so in compliance with the OGC spec, otherwise a polygon that spans the globe will be assumed.  Note that this could break a users current vertex order (i.e., the user specified a non-dateline crossing global poly in cw order - see ShapeBuilderTests.testShapeWithAlternateOrientation).  In this case the user would have to comply with OGC standards and reorder the vertices ccw.  This does not, however, break existing ordering for polys < 180 degrees (90% of most geo datasets) or invalid lat/lon pairs.  So a user or existing deployment can still specify a dateline crossing poly using invalid lat/lon pairs. This simply implements OGC compliance to handle the ambiguous polygon problem.  

Closes #8672
