### PR TITLE
Adds parameters to API endpoint cluster put settings specification

### DIFF
--- a/rest-api-spec/api/cluster.put_settings.json
+++ b/rest-api-spec/api/cluster.put_settings.json
@@ -10,6 +10,14 @@
         "flat_settings": {
           "type": "boolean",
           "description": "Return settings in flat format (default: false)"
+        },
+        "master_timeout": {
+          "type" : "time",
+          "description" : "Explicit operation timeout for connection to master node"
+        },
+        "timeout": {
+          "type" : "time",
+          "description" : "Explicit operation timeout"
         }
       }
     },


### PR DESCRIPTION
This PR adds missing query parameters to the put_settings (cluster) specification file. According to the Java code the specification of this API endpoint accepts the parameters `timeout` & `master_timeout`.
