### PR TITLE
Bootstrap.java: fix PID file creation

### DIFF
--- a/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
+++ b/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
@@ -152,8 +152,18 @@ public class Bootstrap {
         if (pidFile != null) {
             try {
                 Path fPidFile = Paths.get(pidFile);
-                Files.createDirectories(fPidFile.getParent());
-                OutputStream outputStream = Files.newOutputStream(fPidFile, StandardOpenOption.DELETE_ON_CLOSE);
+                Path dir = fPidFile.getParent();
+                // if pidFile is relative there may be no path
+                if (dir != null) {
+                    try   { Files.createDirectories(dir); }
+                    // thrown if dir exists and is a soft link, ignore for now
+                    catch (FileAlreadyExistsException ignored) { }
+                }
+                OpenOption[] opts = new OpenOption[] {
+                                        StandardOpenOption.CREATE,
+                                        StandardOpenOption.TRUNCATE_EXISTING,
+                                        StandardOpenOption.DELETE_ON_CLOSE };
+                OutputStream outputStream = Files.newOutputStream(fPidFile, opts);
                 outputStream.write(Long.toString(JvmInfo.jvmInfo().pid()).getBytes(Charsets.UTF_8));
                 outputStream.flush(); // make those bytes visible...
                 // don't close this stream we will delete on JVM exit


### PR DESCRIPTION
This change fixes various failure modes on PID file creation which have been
introduced by using nio:
- check if PID file has a directory part
- Allow PID directory creation fail w/ FileAlreadyExistsException
  (thrown if directory exists and is a soft link)
- create PID file if it doesn't exist, truncate it if it does

fixes #8771
