### PR TITLE
Remove optional original indices

### DIFF
--- a/src/main/java/org/elasticsearch/action/OriginalIndices.java
+++ b/src/main/java/org/elasticsearch/action/OriginalIndices.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -31,15 +30,8 @@ import java.io.IOException;
  */
 public class OriginalIndices implements IndicesRequest {
 
-    public static OriginalIndices EMPTY = new OriginalIndices();
-
     private final String[] indices;
     private final IndicesOptions indicesOptions;
-
-    private OriginalIndices() {
-        this.indices = null;
-        this.indicesOptions = null;
-    }
 
     public OriginalIndices(IndicesRequest indicesRequest) {
         this(indicesRequest.indices(), indicesRequest.indicesOptions());
@@ -59,23 +51,6 @@ public class OriginalIndices implements IndicesRequest {
     @Override
     public IndicesOptions indicesOptions() {
         return indicesOptions;
-    }
-
-    public static OriginalIndices readOptionalOriginalIndices(StreamInput in) throws IOException {
-        boolean empty = in.readBoolean();
-        if (!empty) {
-            return new OriginalIndices(in.readStringArray(), IndicesOptions.readIndicesOptions(in));
-        }
-        return OriginalIndices.EMPTY;
-    }
-
-    public static void writeOptionalOriginalIndices(OriginalIndices originalIndices, StreamOutput out) throws IOException {
-        boolean empty = originalIndices == EMPTY;
-        out.writeBoolean(empty);
-        if (!empty) {
-            out.writeStringArrayNullable(originalIndices.indices);
-            originalIndices.indicesOptions.writeIndicesOptions(out);
-        }
     }
 
     public static OriginalIndices readOriginalIndices(StreamInput in) throws IOException {

--- a/src/main/java/org/elasticsearch/action/deletebyquery/ShardDeleteByQueryRequest.java
+++ b/src/main/java/org/elasticsearch/action/deletebyquery/ShardDeleteByQueryRequest.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.deletebyquery;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.OriginalIndices;
 import org.elasticsearch.action.support.IndicesOptions;
@@ -137,7 +136,7 @@ public class ShardDeleteByQueryRequest extends ShardReplicationOperationRequest<
         }
 
         nowInMillis = in.readVLong();
-        originalIndices = OriginalIndices.readOptionalOriginalIndices(in);
+        originalIndices = OriginalIndices.readOriginalIndices(in);
     }
 
     @Override
@@ -163,7 +162,7 @@ public class ShardDeleteByQueryRequest extends ShardReplicationOperationRequest<
             out.writeVInt(0);
         }
         out.writeVLong(nowInMillis);
-        OriginalIndices.writeOptionalOriginalIndices(originalIndices, out);
+        OriginalIndices.writeOriginalIndices(originalIndices, out);
     }
 
     @Override

--- a/src/test/java/org/elasticsearch/action/OriginalIndicesTests.java
+++ b/src/test/java/org/elasticsearch/action/OriginalIndicesTests.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.io.stream.BytesStreamInput;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
@@ -29,7 +28,6 @@ import org.junit.Test;
 import java.io.IOException;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.nullValue;
 
 public class OriginalIndicesTests extends ElasticsearchTestCase {
 
@@ -50,31 +48,6 @@ public class OriginalIndicesTests extends ElasticsearchTestCase {
             BytesStreamInput in = new BytesStreamInput(out.bytes());
             in.setVersion(out.getVersion());
             OriginalIndices originalIndices2 = OriginalIndices.readOriginalIndices(in);
-
-            assertThat(originalIndices2.indices(), equalTo(originalIndices.indices()));
-            assertThat(originalIndices2.indicesOptions(), equalTo(originalIndices.indicesOptions()));
-        }
-    }
-
-    @Test
-    public void testOptionalOriginalIndicesSerialization() throws IOException {
-        int iterations = iterations(10, 30);
-        for (int i = 0; i < iterations; i++) {
-            OriginalIndices originalIndices;
-            boolean missing = randomBoolean();
-            if (missing) {
-                originalIndices = randomOriginalIndices();
-            } else {
-                originalIndices = OriginalIndices.EMPTY;
-            }
-
-            BytesStreamOutput out = new BytesStreamOutput();
-            out.setVersion(randomVersion());
-            OriginalIndices.writeOptionalOriginalIndices(originalIndices, out);
-
-            BytesStreamInput in = new BytesStreamInput(out.bytes());
-            in.setVersion(out.getVersion());
-            OriginalIndices originalIndices2 = OriginalIndices.readOptionalOriginalIndices(in);
 
             assertThat(originalIndices2.indices(), equalTo(originalIndices.indices()));
             assertThat(originalIndices2.indicesOptions(), equalTo(originalIndices.indicesOptions()));


### PR DESCRIPTION
Original indices are optional in ShardDeleteByQueryRequest only for backwards compatibility, see #7406. We can remove this in master since 2.0 will require a full cluster restart.
