### PR TITLE
GatewayService should register cluster state listener before checking for current state

### DIFF
--- a/src/main/java/org/elasticsearch/gateway/GatewayService.java
+++ b/src/main/java/org/elasticsearch/gateway/GatewayService.java
@@ -104,6 +104,7 @@ public class GatewayService extends AbstractLifecycleComponent<GatewayService> i
     @Override
     protected void doStart() throws ElasticsearchException {
         gateway.start();
+        clusterService.addLast(this);
         // if we received initial state, see if we can recover within the start phase, so we hold the
         // node from starting until we recovered properly
         if (discoveryService.initialStateReceived()) {
@@ -114,7 +115,6 @@ public class GatewayService extends AbstractLifecycleComponent<GatewayService> i
         } else {
             logger.debug("can't wait on start for (possibly) reading state from gateway, will do it asynchronously");
         }
-        clusterService.addLast(this);
     }
 
     @Override


### PR DESCRIPTION
At the moment we may miss a state change and fail to recover on time.

Exposed by build failure: http://build-us-00.elasticsearch.org/job/es_core_1x_suse/53/testReport/junit/org.elasticsearch.cluster/NoMasterNodeTests/testNoMasterActions_writeMasterBlock/
