### PR TITLE
Add support for registering custom circuit breaker

### DIFF
--- a/src/main/java/org/elasticsearch/common/breaker/ChildMemoryCircuitBreaker.java
+++ b/src/main/java/org/elasticsearch/common/breaker/ChildMemoryCircuitBreaker.java
@@ -141,7 +141,7 @@ public class ChildMemoryCircuitBreaker implements CircuitBreaker {
                             newUsedWithOverhead, new ByteSizeValue(newUsedWithOverhead));
                 }
                 if (memoryBytesLimit > 0 && newUsedWithOverhead > memoryBytesLimit) {
-                    logger.warn("[{}] New used memory {} [{}] from field [{}] would be larger than configured breaker: {} [{}], breaking",
+                    logger.warn("[{}] New used memory {} [{}] for data of [{}] would be larger than configured breaker: {} [{}], breaking",
                             this.name,
                             newUsedWithOverhead, new ByteSizeValue(newUsedWithOverhead), label,
                             memoryBytesLimit, new ByteSizeValue(memoryBytesLimit));

--- a/src/main/java/org/elasticsearch/common/breaker/ChildMemoryCircuitBreaker.java
+++ b/src/main/java/org/elasticsearch/common/breaker/ChildMemoryCircuitBreaker.java
@@ -38,7 +38,7 @@ public class ChildMemoryCircuitBreaker implements CircuitBreaker {
     private final AtomicLong trippedCount;
     private final ESLogger logger;
     private final HierarchyCircuitBreakerService parent;
-    private final Name name;
+    private final String name;
 
     /**
      * Create a circuit breaker that will break if the number of estimated
@@ -49,7 +49,7 @@ public class ChildMemoryCircuitBreaker implements CircuitBreaker {
      * @param name the name of the breaker
      */
     public ChildMemoryCircuitBreaker(BreakerSettings settings, ESLogger logger,
-                                     HierarchyCircuitBreakerService parent, Name name) {
+                                     HierarchyCircuitBreakerService parent, String name) {
         this(settings, null, logger, parent, name);
     }
 
@@ -64,7 +64,7 @@ public class ChildMemoryCircuitBreaker implements CircuitBreaker {
      * @param oldBreaker the previous circuit breaker to inherit the used value from (starting offset)
      */
     public ChildMemoryCircuitBreaker(BreakerSettings settings, ChildMemoryCircuitBreaker oldBreaker,
-                                     ESLogger logger, HierarchyCircuitBreakerService parent, Name name) {
+                                     ESLogger logger, HierarchyCircuitBreakerService parent, String name) {
         this.name = name;
         this.settings = settings;
         this.memoryBytesLimit = settings.getLimit();
@@ -220,7 +220,7 @@ public class ChildMemoryCircuitBreaker implements CircuitBreaker {
     /**
      * @return the name of the breaker
      */
-    public Name getName() {
+    public String getName() {
         return this.name;
     }
 }

--- a/src/main/java/org/elasticsearch/common/breaker/CircuitBreaker.java
+++ b/src/main/java/org/elasticsearch/common/breaker/CircuitBreaker.java
@@ -24,7 +24,9 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Locale;
+import java.util.Map;
 
 /**
  * Interface for an object that can be incremented, breaking after some
@@ -35,37 +37,72 @@ public interface CircuitBreaker {
     /**
      * Enum used for specifying different types of circuit breakers
      */
-    public static enum Name {
-        PARENT(0),
-        FIELDDATA(1),
-        REQUEST(2);
+    public static class Name {
 
-        private int ordinal;
+        private static Map<Integer, Name> names = new HashMap<>();
 
-        Name(int ordinal) {
-            this.ordinal = ordinal;
+        public static final Name PARENT = register(0, "parent");
+        public static final Name FIELDDATA = register(1, "fielddata");
+        public static final Name REQUEST = register(2, "request");
+
+        private final int id;
+        private final String label;
+
+        Name(int ordinal, String label) {
+            this.id = ordinal;
+            this.label = label;
         }
 
         public int getSerializableValue() {
-            return this.ordinal;
+            return this.id;
+        }
+
+        public String toString() {
+            return label.toUpperCase(Locale.ENGLISH);
+        }
+
+        public static Name register(int id, String label) {
+            if (names.containsKey(id)) {
+                throw new ElasticsearchIllegalArgumentException(
+                        String.format(Locale.ENGLISH,
+                                "CircuitBreaker.Name with id %d already registered", id));
+            }
+            Name name = new Name(id, label);
+            names.put(id, name);
+            return name;
         }
 
         public static Name readFrom(StreamInput in) throws IOException {
             int value = in.readVInt();
-            switch (value) {
-                case 0:
-                    return Name.PARENT;
-                case 1:
-                    return Name.FIELDDATA;
-                case 2:
-                    return Name.REQUEST;
-                default:
-                    throw new ElasticsearchIllegalArgumentException("No CircuitBreaker with ordinal: " + value);
+            Name name = names.get(value);
+            if (name == null) {
+                throw new ElasticsearchIllegalArgumentException("No CircuitBreaker.Name with id: " + value);
             }
+            return name;
         }
 
         public static void writeTo(Name name, StreamOutput out) throws IOException {
             out.writeVInt(name.getSerializableValue());
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            Name name = (Name) o;
+
+            if (id != name.id) return false;
+            if (label != null ? !label.equals(name.label) : name.label != null) return false;
+
+            return true;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = id;
+            result = 31 * result + (label != null ? label.hashCode() : 0);
+            return result;
         }
     }
 

--- a/src/main/java/org/elasticsearch/common/breaker/CircuitBreaker.java
+++ b/src/main/java/org/elasticsearch/common/breaker/CircuitBreaker.java
@@ -20,13 +20,8 @@
 package org.elasticsearch.common.breaker;
 
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
 
-import java.io.IOException;
-import java.util.HashMap;
 import java.util.Locale;
-import java.util.Map;
 
 /**
  * Interface for an object that can be incremented, breaking after some
@@ -34,77 +29,9 @@ import java.util.Map;
  */
 public interface CircuitBreaker {
 
-    /**
-     * Enum used for specifying different types of circuit breakers
-     */
-    public static class Name {
-
-        private static Map<Integer, Name> names = new HashMap<>();
-
-        public static final Name PARENT = register(0, "parent");
-        public static final Name FIELDDATA = register(1, "fielddata");
-        public static final Name REQUEST = register(2, "request");
-
-        private final int id;
-        private final String label;
-
-        Name(int ordinal, String label) {
-            this.id = ordinal;
-            this.label = label;
-        }
-
-        public int getSerializableValue() {
-            return this.id;
-        }
-
-        public String toString() {
-            return label.toUpperCase(Locale.ENGLISH);
-        }
-
-        public static Name register(int id, String label) {
-            if (names.containsKey(id)) {
-                throw new ElasticsearchIllegalArgumentException(
-                        String.format(Locale.ENGLISH,
-                                "CircuitBreaker.Name with id %d already registered", id));
-            }
-            Name name = new Name(id, label);
-            names.put(id, name);
-            return name;
-        }
-
-        public static Name readFrom(StreamInput in) throws IOException {
-            int value = in.readVInt();
-            Name name = names.get(value);
-            if (name == null) {
-                throw new ElasticsearchIllegalArgumentException("No CircuitBreaker.Name with id: " + value);
-            }
-            return name;
-        }
-
-        public static void writeTo(Name name, StreamOutput out) throws IOException {
-            out.writeVInt(name.getSerializableValue());
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-
-            Name name = (Name) o;
-
-            if (id != name.id) return false;
-            if (label != null ? !label.equals(name.label) : name.label != null) return false;
-
-            return true;
-        }
-
-        @Override
-        public int hashCode() {
-            int result = id;
-            result = 31 * result + (label != null ? label.hashCode() : 0);
-            return result;
-        }
-    }
+    public static final String PARENT = "PARENT";
+    public static final String FIELDDATA = "FIELDDATA";
+    public static final String REQUEST = "REQUEST";
 
     public static enum Type {
         // A regular or child MemoryCircuitBreaker
@@ -172,5 +99,5 @@ public interface CircuitBreaker {
     /**
      * @return the name of the breaker
      */
-    public Name getName();
+    public String getName();
 }

--- a/src/main/java/org/elasticsearch/common/breaker/CircuitBreaker.java
+++ b/src/main/java/org/elasticsearch/common/breaker/CircuitBreaker.java
@@ -29,9 +29,9 @@ import java.util.Locale;
  */
 public interface CircuitBreaker {
 
-    public static final String PARENT = "PARENT";
-    public static final String FIELDDATA = "FIELDDATA";
-    public static final String REQUEST = "REQUEST";
+    public static final String PARENT = "parent";
+    public static final String FIELDDATA = "fielddata";
+    public static final String REQUEST = "request";
 
     public static enum Type {
         // A regular or child MemoryCircuitBreaker

--- a/src/main/java/org/elasticsearch/common/breaker/MemoryCircuitBreaker.java
+++ b/src/main/java/org/elasticsearch/common/breaker/MemoryCircuitBreaker.java
@@ -186,7 +186,7 @@ public class MemoryCircuitBreaker implements CircuitBreaker {
     /**
      * @return the name of the breaker
      */
-    public Name getName() {
-        return Name.FIELDDATA;
+    public String getName() {
+        return FIELDDATA;
     }
 }

--- a/src/main/java/org/elasticsearch/common/breaker/NoopCircuitBreaker.java
+++ b/src/main/java/org/elasticsearch/common/breaker/NoopCircuitBreaker.java
@@ -25,9 +25,9 @@ package org.elasticsearch.common.breaker;
  */
 public class NoopCircuitBreaker implements CircuitBreaker {
 
-    private final Name name;
+    private final String name;
 
-    public NoopCircuitBreaker(Name name) {
+    public NoopCircuitBreaker(String name) {
         this.name = name;
     }
 
@@ -67,7 +67,7 @@ public class NoopCircuitBreaker implements CircuitBreaker {
     }
 
     @Override
-    public Name getName() {
+    public String getName() {
         return this.name;
     }
 }

--- a/src/main/java/org/elasticsearch/common/util/BigArrays.java
+++ b/src/main/java/org/elasticsearch/common/util/BigArrays.java
@@ -387,7 +387,7 @@ public class BigArrays extends AbstractComponent {
      */
     void adjustBreaker(long delta) {
         if (this.breakerService != null) {
-            CircuitBreaker breaker = this.breakerService.getBreaker(CircuitBreaker.Name.REQUEST);
+            CircuitBreaker breaker = this.breakerService.getBreaker(CircuitBreaker.REQUEST);
             if (this.checkBreaker == true) {
                 // checking breaker means potentially tripping, but it doesn't
                 // have to if the delta is negative

--- a/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalsBuilder.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalsBuilder.java
@@ -53,7 +53,7 @@ public enum GlobalOrdinalsBuilder {
         }
         final OrdinalMap ordinalMap = OrdinalMap.build(null, subs, PackedInts.DEFAULT);
         final long memorySizeInBytes = ordinalMap.ramBytesUsed();
-        breakerService.getBreaker(CircuitBreaker.Name.FIELDDATA).addWithoutBreaking(memorySizeInBytes);
+        breakerService.getBreaker(CircuitBreaker.FIELDDATA).addWithoutBreaking(memorySizeInBytes);
 
         if (logger.isDebugEnabled()) {
             logger.debug(

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/DoubleArrayIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/DoubleArrayIndexFieldData.java
@@ -75,7 +75,7 @@ public class DoubleArrayIndexFieldData extends AbstractIndexFieldData<AtomicNume
         Terms terms = reader.terms(getFieldNames().indexName());
         AtomicNumericFieldData data = null;
         // TODO: Use an actual estimator to estimate before loading.
-        NonEstimatingEstimator estimator = new NonEstimatingEstimator(breakerService.getBreaker(CircuitBreaker.Name.FIELDDATA));
+        NonEstimatingEstimator estimator = new NonEstimatingEstimator(breakerService.getBreaker(CircuitBreaker.FIELDDATA));
         if (terms == null) {
             data = AtomicDoubleFieldData.empty(reader.maxDoc());
             estimator.afterLoad(null, data.ramBytesUsed());

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/FSTBytesIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/FSTBytesIndexFieldData.java
@@ -64,7 +64,7 @@ public class FSTBytesIndexFieldData extends AbstractIndexOrdinalsFieldData {
         Terms terms = reader.terms(getFieldNames().indexName());
         AtomicOrdinalsFieldData data = null;
         // TODO: Use an actual estimator to estimate before loading.
-        NonEstimatingEstimator estimator = new NonEstimatingEstimator(breakerService.getBreaker(CircuitBreaker.Name.FIELDDATA));
+        NonEstimatingEstimator estimator = new NonEstimatingEstimator(breakerService.getBreaker(CircuitBreaker.FIELDDATA));
         if (terms == null) {
             data = AbstractAtomicOrdinalsFieldData.empty();
             estimator.afterLoad(null, data.ramBytesUsed());

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/FloatArrayIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/FloatArrayIndexFieldData.java
@@ -73,7 +73,7 @@ public class FloatArrayIndexFieldData extends AbstractIndexFieldData<AtomicNumer
         Terms terms = reader.terms(getFieldNames().indexName());
         AtomicNumericFieldData data = null;
         // TODO: Use an actual estimator to estimate before loading.
-        NonEstimatingEstimator estimator = new NonEstimatingEstimator(breakerService.getBreaker(CircuitBreaker.Name.FIELDDATA));
+        NonEstimatingEstimator estimator = new NonEstimatingEstimator(breakerService.getBreaker(CircuitBreaker.FIELDDATA));
         if (terms == null) {
             data = AtomicDoubleFieldData.empty(reader.maxDoc());
             estimator.afterLoad(null, data.ramBytesUsed());

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointCompressedIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointCompressedIndexFieldData.java
@@ -83,7 +83,7 @@ public class GeoPointCompressedIndexFieldData extends AbstractIndexGeoPointField
         Terms terms = reader.terms(getFieldNames().indexName());
         AtomicGeoPointFieldData data = null;
         // TODO: Use an actual estimator to estimate before loading.
-        NonEstimatingEstimator estimator = new NonEstimatingEstimator(breakerService.getBreaker(CircuitBreaker.Name.FIELDDATA));
+        NonEstimatingEstimator estimator = new NonEstimatingEstimator(breakerService.getBreaker(CircuitBreaker.FIELDDATA));
         if (terms == null) {
             data = AbstractAtomicGeoPointFieldData.empty(reader.maxDoc());
             estimator.afterLoad(null, data.ramBytesUsed());

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointDoubleArrayIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointDoubleArrayIndexFieldData.java
@@ -65,7 +65,7 @@ public class GeoPointDoubleArrayIndexFieldData extends AbstractIndexGeoPointFiel
         Terms terms = reader.terms(getFieldNames().indexName());
         AtomicGeoPointFieldData data = null;
         // TODO: Use an actual estimator to estimate before loading.
-        NonEstimatingEstimator estimator = new NonEstimatingEstimator(breakerService.getBreaker(CircuitBreaker.Name.FIELDDATA));
+        NonEstimatingEstimator estimator = new NonEstimatingEstimator(breakerService.getBreaker(CircuitBreaker.FIELDDATA));
         if (terms == null) {
             data = AbstractAtomicGeoPointFieldData.empty(reader.maxDoc());
             estimator.afterLoad(null, data.ramBytesUsed());

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/PackedArrayIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/PackedArrayIndexFieldData.java
@@ -90,7 +90,7 @@ public class PackedArrayIndexFieldData extends AbstractIndexFieldData<AtomicNume
         final LeafReader reader = context.reader();
         Terms terms = reader.terms(getFieldNames().indexName());
         AtomicNumericFieldData data = null;
-        PackedArrayEstimator estimator = new PackedArrayEstimator(breakerService.getBreaker(CircuitBreaker.Name.FIELDDATA), getNumericType(), getFieldNames().fullName());
+        PackedArrayEstimator estimator = new PackedArrayEstimator(breakerService.getBreaker(CircuitBreaker.FIELDDATA), getNumericType(), getFieldNames().fullName());
         if (terms == null) {
             data = AtomicLongFieldData.empty(reader.maxDoc());
             estimator.adjustForNoTerms(data.ramBytesUsed());

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/PagedBytesIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/PagedBytesIndexFieldData.java
@@ -62,7 +62,7 @@ public class PagedBytesIndexFieldData extends AbstractIndexOrdinalsFieldData {
         LeafReader reader = context.reader();
         AtomicOrdinalsFieldData data = null;
 
-        PagedBytesEstimator estimator = new PagedBytesEstimator(context, breakerService.getBreaker(CircuitBreaker.Name.FIELDDATA), getFieldNames().fullName());
+        PagedBytesEstimator estimator = new PagedBytesEstimator(context, breakerService.getBreaker(CircuitBreaker.FIELDDATA), getFieldNames().fullName());
         Terms terms = reader.terms(getFieldNames().indexName());
         if (terms == null) {
             data = AbstractAtomicOrdinalsFieldData.empty();

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/ParentChildIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/ParentChildIndexFieldData.java
@@ -102,7 +102,7 @@ public class ParentChildIndexFieldData extends AbstractIndexFieldData<AtomicPare
                 new ParentChildIntersectTermsEnum(reader, UidFieldMapper.NAME, ParentFieldMapper.NAME),
                 parentTypes
         );
-        ParentChildEstimator estimator = new ParentChildEstimator(breakerService.getBreaker(CircuitBreaker.Name.FIELDDATA), termsEnum);
+        ParentChildEstimator estimator = new ParentChildEstimator(breakerService.getBreaker(CircuitBreaker.FIELDDATA), termsEnum);
         TermsEnum estimatedTermsEnum = estimator.beforeLoad(null);
         ObjectObjectOpenHashMap<String, TypeBuilder> typeBuilders = ObjectObjectOpenHashMap.newInstance();
         try {
@@ -338,7 +338,7 @@ public class ParentChildIndexFieldData extends AbstractIndexFieldData<AtomicPare
             }
         }
 
-        breakerService.getBreaker(CircuitBreaker.Name.FIELDDATA).addWithoutBreaking(ramBytesUsed);
+        breakerService.getBreaker(CircuitBreaker.FIELDDATA).addWithoutBreaking(ramBytesUsed);
         if (logger.isDebugEnabled()) {
             logger.debug(
                     "Global-ordinals[_parent] took {}",

--- a/src/main/java/org/elasticsearch/indices/breaker/AllCircuitBreakerStats.java
+++ b/src/main/java/org/elasticsearch/indices/breaker/AllCircuitBreakerStats.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.indices.breaker;
 
-import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
@@ -48,9 +47,9 @@ public class AllCircuitBreakerStats implements Streamable, ToXContent {
         return this.allStats;
     }
 
-    public CircuitBreakerStats getStats(CircuitBreaker.Name name) {
+    public CircuitBreakerStats getStats(String name) {
         for (CircuitBreakerStats stats : allStats) {
-            if (stats.getName() == name) {
+            if (stats.getName().equals(name)) {
                 return stats;
             }
         }

--- a/src/main/java/org/elasticsearch/indices/breaker/BreakerSettings.java
+++ b/src/main/java/org/elasticsearch/indices/breaker/BreakerSettings.java
@@ -27,23 +27,23 @@ import org.elasticsearch.common.unit.ByteSizeValue;
  */
 public class BreakerSettings {
 
-    private final CircuitBreaker.Name name;
+    private final String name;
     private final long limitBytes;
     private final double overhead;
     private final CircuitBreaker.Type type;
 
-    public BreakerSettings(CircuitBreaker.Name name, long limitBytes, double overhead) {
+    public BreakerSettings(String name, long limitBytes, double overhead) {
         this(name, limitBytes, overhead, CircuitBreaker.Type.MEMORY);
     }
 
-    public BreakerSettings(CircuitBreaker.Name name, long limitBytes, double overhead, CircuitBreaker.Type type) {
+    public BreakerSettings(String name, long limitBytes, double overhead, CircuitBreaker.Type type) {
         this.name = name;
         this.limitBytes = limitBytes;
         this.overhead = overhead;
         this.type = type;
     }
 
-    public CircuitBreaker.Name getName() {
+    public String getName() {
         return this.name;
     }
 
@@ -61,7 +61,7 @@ public class BreakerSettings {
 
     @Override
     public String toString() {
-        return "[" + this.name.toString() +
+        return "[" + this.name +
                 ",type=" + this.type.toString() +
                 ",limit=" + this.limitBytes + "/" + new ByteSizeValue(this.limitBytes) +
                 ",overhead=" + this.overhead + "]";

--- a/src/main/java/org/elasticsearch/indices/breaker/CircuitBreakerService.java
+++ b/src/main/java/org/elasticsearch/indices/breaker/CircuitBreakerService.java
@@ -35,6 +35,13 @@ public abstract class CircuitBreakerService extends AbstractLifecycleComponent<C
     }
 
     /**
+     * Allows to register of a custom circuit breaker.
+     *
+     * @param breakerSettings
+     */
+    public abstract void registerBreaker(BreakerSettings breakerSettings);
+
+    /**
      * @return the breaker that can be used to register estimates against
      */
     public abstract CircuitBreaker getBreaker(CircuitBreaker.Name type);

--- a/src/main/java/org/elasticsearch/indices/breaker/CircuitBreakerService.java
+++ b/src/main/java/org/elasticsearch/indices/breaker/CircuitBreakerService.java
@@ -44,7 +44,7 @@ public abstract class CircuitBreakerService extends AbstractLifecycleComponent<C
     /**
      * @return the breaker that can be used to register estimates against
      */
-    public abstract CircuitBreaker getBreaker(CircuitBreaker.Name type);
+    public abstract CircuitBreaker getBreaker(String name);
 
     /**
      * @return stats about all breakers
@@ -54,7 +54,7 @@ public abstract class CircuitBreakerService extends AbstractLifecycleComponent<C
     /**
      * @return stats about a specific breaker
      */
-    public abstract CircuitBreakerStats stats(CircuitBreaker.Name name);
+    public abstract CircuitBreakerStats stats(String name);
 
     protected void doStart() throws ElasticsearchException {
     }

--- a/src/main/java/org/elasticsearch/indices/breaker/CircuitBreakerStats.java
+++ b/src/main/java/org/elasticsearch/indices/breaker/CircuitBreakerStats.java
@@ -19,8 +19,6 @@
 
 package org.elasticsearch.indices.breaker;
 
-import org.elasticsearch.Version;
-import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
@@ -37,7 +35,7 @@ import java.util.Locale;
  */
 public class CircuitBreakerStats implements Streamable, ToXContent {
 
-    private CircuitBreaker.Name name;
+    private String name;
     private long limit;
     private long estimated;
     private long trippedCount;
@@ -47,7 +45,7 @@ public class CircuitBreakerStats implements Streamable, ToXContent {
 
     }
 
-    public CircuitBreakerStats(CircuitBreaker.Name name, long limit, long estimated, double overhead, long trippedCount) {
+    public CircuitBreakerStats(String name, long limit, long estimated, double overhead, long trippedCount) {
         this.name = name;
         this.limit = limit;
         this.estimated = estimated;
@@ -55,7 +53,7 @@ public class CircuitBreakerStats implements Streamable, ToXContent {
         this.overhead = overhead;
     }
 
-    public CircuitBreaker.Name getName() {
+    public String getName() {
         return this.name;
     }
 
@@ -87,7 +85,7 @@ public class CircuitBreakerStats implements Streamable, ToXContent {
         estimated = in.readLong();
         overhead = in.readDouble();
         this.trippedCount = in.readLong();
-        this.name = CircuitBreaker.Name.readFrom(in);
+        this.name = in.readString();
     }
 
     @Override
@@ -96,12 +94,12 @@ public class CircuitBreakerStats implements Streamable, ToXContent {
         out.writeLong(estimated);
         out.writeDouble(overhead);
         out.writeLong(trippedCount);
-        CircuitBreaker.Name.writeTo(name, out);
+        out.writeString(name);
     }
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(name.toString().toLowerCase(Locale.ROOT));
+        builder.startObject(name.toLowerCase(Locale.ROOT));
         builder.field(Fields.LIMIT, limit);
         builder.field(Fields.LIMIT_HUMAN, new ByteSizeValue(limit));
         builder.field(Fields.ESTIMATED, estimated);
@@ -114,7 +112,7 @@ public class CircuitBreakerStats implements Streamable, ToXContent {
 
     @Override
     public String toString() {
-        return "[" + this.name.toString() +
+        return "[" + this.name +
                 ",limit=" + this.limit + "/" + new ByteSizeValue(this.limit) +
                 ",estimated=" + this.estimated + "/" + new ByteSizeValue(this.estimated) +
                 ",overhead=" + this.overhead + ",tripped=" + this.trippedCount + "]";

--- a/src/main/java/org/elasticsearch/indices/breaker/NoneCircuitBreakerService.java
+++ b/src/main/java/org/elasticsearch/indices/breaker/NoneCircuitBreakerService.java
@@ -48,4 +48,9 @@ public class NoneCircuitBreakerService extends CircuitBreakerService {
     public CircuitBreakerStats stats(CircuitBreaker.Name name) {
         return new CircuitBreakerStats(CircuitBreaker.Name.FIELDDATA, -1, -1, 0, 0);
     }
+
+    @Override
+    public void registerBreaker(BreakerSettings breakerSettings) {
+        // ignore
+    }
 }

--- a/src/main/java/org/elasticsearch/indices/breaker/NoneCircuitBreakerService.java
+++ b/src/main/java/org/elasticsearch/indices/breaker/NoneCircuitBreakerService.java
@@ -28,25 +28,25 @@ import org.elasticsearch.common.settings.ImmutableSettings;
  */
 public class NoneCircuitBreakerService extends CircuitBreakerService {
 
-    private final CircuitBreaker breaker = new NoopCircuitBreaker(CircuitBreaker.Name.FIELDDATA);
+    private final CircuitBreaker breaker = new NoopCircuitBreaker(CircuitBreaker.FIELDDATA);
 
     public NoneCircuitBreakerService() {
         super(ImmutableSettings.EMPTY);
     }
 
     @Override
-    public CircuitBreaker getBreaker(CircuitBreaker.Name name) {
+    public CircuitBreaker getBreaker(String name) {
         return breaker;
     }
 
     @Override
     public AllCircuitBreakerStats stats() {
-        return new AllCircuitBreakerStats(new CircuitBreakerStats[] {stats(CircuitBreaker.Name.FIELDDATA)});
+        return new AllCircuitBreakerStats(new CircuitBreakerStats[] {stats(CircuitBreaker.FIELDDATA)});
     }
 
     @Override
-    public CircuitBreakerStats stats(CircuitBreaker.Name name) {
-        return new CircuitBreakerStats(CircuitBreaker.Name.FIELDDATA, -1, -1, 0, 0);
+    public CircuitBreakerStats stats(String name) {
+        return new CircuitBreakerStats(CircuitBreaker.FIELDDATA, -1, -1, 0, 0);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/indices/fielddata/cache/IndicesFieldDataCacheListener.java
+++ b/src/main/java/org/elasticsearch/indices/fielddata/cache/IndicesFieldDataCacheListener.java
@@ -49,7 +49,7 @@ public class IndicesFieldDataCacheListener implements IndexFieldDataCache.Listen
     @Override
     public void onUnload(FieldMapper.Names fieldNames, FieldDataType fieldDataType, boolean wasEvicted, long sizeInBytes) {
         assert sizeInBytes >= 0 : "When reducing circuit breaker, it should be adjusted with a number higher or equal to 0 and not [" + sizeInBytes + "]";
-        circuitBreakerService.getBreaker(CircuitBreaker.Name.FIELDDATA).addWithoutBreaking(-sizeInBytes);
+        circuitBreakerService.getBreaker(CircuitBreaker.FIELDDATA).addWithoutBreaking(-sizeInBytes);
     }
 
 }

--- a/src/test/java/org/elasticsearch/common/breaker/MemoryCircuitBreakerTests.java
+++ b/src/test/java/org/elasticsearch/common/breaker/MemoryCircuitBreakerTests.java
@@ -94,7 +94,7 @@ public class MemoryCircuitBreakerTests extends ElasticsearchTestCase {
         final CircuitBreakerService service = new HierarchyCircuitBreakerService(ImmutableSettings.EMPTY, new NodeSettingsService(ImmutableSettings.EMPTY)) {
 
             @Override
-            public CircuitBreaker getBreaker(CircuitBreaker.Name type) {
+            public CircuitBreaker getBreaker(String name) {
                 return breakerRef.get();
             }
 
@@ -103,9 +103,9 @@ public class MemoryCircuitBreakerTests extends ElasticsearchTestCase {
                 // never trip
             }
         };
-        final BreakerSettings settings = new BreakerSettings(CircuitBreaker.Name.REQUEST, (BYTES_PER_THREAD * NUM_THREADS) - 1, 1.0);
+        final BreakerSettings settings = new BreakerSettings(CircuitBreaker.REQUEST, (BYTES_PER_THREAD * NUM_THREADS) - 1, 1.0);
         final ChildMemoryCircuitBreaker breaker = new ChildMemoryCircuitBreaker(settings, logger,
-                (HierarchyCircuitBreakerService)service, CircuitBreaker.Name.REQUEST);
+                (HierarchyCircuitBreakerService)service, CircuitBreaker.REQUEST);
         breakerRef.set(breaker);
 
         for (int i = 0; i < NUM_THREADS; i++) {
@@ -155,23 +155,23 @@ public class MemoryCircuitBreakerTests extends ElasticsearchTestCase {
         final CircuitBreakerService service = new HierarchyCircuitBreakerService(ImmutableSettings.EMPTY, new NodeSettingsService(ImmutableSettings.EMPTY)) {
 
             @Override
-            public CircuitBreaker getBreaker(CircuitBreaker.Name type) {
+            public CircuitBreaker getBreaker(String name) {
                 return breakerRef.get();
             }
 
             @Override
             public void checkParentLimit(String label) throws CircuitBreakingException {
                 // Parent will trip right before regular breaker would trip
-                if (getBreaker(CircuitBreaker.Name.REQUEST).getUsed() > parentLimit) {
+                if (getBreaker(CircuitBreaker.REQUEST).getUsed() > parentLimit) {
                     parentTripped.incrementAndGet();
                     logger.info("--> parent tripped");
                     throw new CircuitBreakingException("parent tripped");
                 }
             }
         };
-        final BreakerSettings settings = new BreakerSettings(CircuitBreaker.Name.REQUEST, childLimit, 1.0);
+        final BreakerSettings settings = new BreakerSettings(CircuitBreaker.REQUEST, childLimit, 1.0);
         final ChildMemoryCircuitBreaker breaker = new ChildMemoryCircuitBreaker(settings, logger,
-                (HierarchyCircuitBreakerService)service, CircuitBreaker.Name.REQUEST);
+                (HierarchyCircuitBreakerService)service, CircuitBreaker.REQUEST);
         breakerRef.set(breaker);
 
         for (int i = 0; i < NUM_THREADS; i++) {

--- a/src/test/java/org/elasticsearch/common/util/BigArraysTests.java
+++ b/src/test/java/org/elasticsearch/common/util/BigArraysTests.java
@@ -347,7 +347,7 @@ public class BigArraysTests extends ElasticsearchSingleNodeTest {
             } catch (InvocationTargetException e) {
                 assertTrue(e.getCause() instanceof CircuitBreakingException);
             }
-            assertEquals(0, hcbs.getBreaker(CircuitBreaker.Name.REQUEST).getUsed());
+            assertEquals(0, hcbs.getBreaker(CircuitBreaker.REQUEST).getUsed());
         }
     }
 
@@ -373,9 +373,9 @@ public class BigArraysTests extends ElasticsearchSingleNodeTest {
                     break;
                 }
             }
-            assertEquals(array.ramBytesUsed(), hcbs.getBreaker(CircuitBreaker.Name.REQUEST).getUsed());
+            assertEquals(array.ramBytesUsed(), hcbs.getBreaker(CircuitBreaker.REQUEST).getUsed());
             array.close();
-            assertEquals(0, hcbs.getBreaker(CircuitBreaker.Name.REQUEST).getUsed());
+            assertEquals(0, hcbs.getBreaker(CircuitBreaker.REQUEST).getUsed());
         }
     }
 

--- a/src/test/java/org/elasticsearch/indices/memory/breaker/CircuitBreakerServiceTests.java
+++ b/src/test/java/org/elasticsearch/indices/memory/breaker/CircuitBreakerServiceTests.java
@@ -94,10 +94,10 @@ public class CircuitBreakerServiceTests extends ElasticsearchIntegrationTest {
     private boolean noopBreakerUsed() {
         NodesStatsResponse stats = client().admin().cluster().prepareNodesStats().setBreaker(true).get();
         for (NodeStats nodeStats : stats) {
-            if (nodeStats.getBreaker().getStats(CircuitBreaker.Name.REQUEST).getLimit() == 0) {
+            if (nodeStats.getBreaker().getStats(CircuitBreaker.REQUEST).getLimit() == 0) {
                 return true;
             }
-            if (nodeStats.getBreaker().getStats(CircuitBreaker.Name.FIELDDATA).getLimit() == 0) {
+            if (nodeStats.getBreaker().getStats(CircuitBreaker.FIELDDATA).getLimit() == 0) {
                 return true;
             }
         }
@@ -144,7 +144,7 @@ public class CircuitBreakerServiceTests extends ElasticsearchIntegrationTest {
         NodesStatsResponse stats = client.admin().cluster().prepareNodesStats().setBreaker(true).get();
         int breaks = 0;
         for (NodeStats stat : stats.getNodes()) {
-            CircuitBreakerStats breakerStats = stat.getBreaker().getStats(CircuitBreaker.Name.FIELDDATA);
+            CircuitBreakerStats breakerStats = stat.getBreaker().getStats(CircuitBreaker.FIELDDATA);
             breaks += breakerStats.getTrippedCount();
         }
         assertThat(breaks, greaterThanOrEqualTo(1));
@@ -194,7 +194,7 @@ public class CircuitBreakerServiceTests extends ElasticsearchIntegrationTest {
         NodesStatsResponse stats = client.admin().cluster().prepareNodesStats().setBreaker(true).get();
         int breaks = 0;
         for (NodeStats stat : stats.getNodes()) {
-            CircuitBreakerStats breakerStats = stat.getBreaker().getStats(CircuitBreaker.Name.FIELDDATA);
+            CircuitBreakerStats breakerStats = stat.getBreaker().getStats(CircuitBreaker.FIELDDATA);
             breaks += breakerStats.getTrippedCount();
         }
         assertThat(breaks, greaterThanOrEqualTo(1));
@@ -223,7 +223,7 @@ public class CircuitBreakerServiceTests extends ElasticsearchIntegrationTest {
 
         // We need the request limit beforehand, just from a single node because the limit should always be the same
         long beforeReqLimit = client.admin().cluster().prepareNodesStats().setBreaker(true).get()
-                .getNodes()[0].getBreaker().getStats(CircuitBreaker.Name.REQUEST).getLimit();
+                .getNodes()[0].getBreaker().getStats(CircuitBreaker.REQUEST).getLimit();
 
         Settings resetSettings = settingsBuilder()
                 .put(HierarchyCircuitBreakerService.FIELDDATA_CIRCUIT_BREAKER_LIMIT_SETTING, "10b")
@@ -308,7 +308,7 @@ public class CircuitBreakerServiceTests extends ElasticsearchIntegrationTest {
                         .clear().setBreaker(true).get(new TimeValue(15, TimeUnit.SECONDS));
                 for (NodeStats nStats : resp.getNodes()) {
                     assertThat("fielddata breaker never reset back to 0",
-                            nStats.getBreaker().getStats(CircuitBreaker.Name.FIELDDATA).getEstimated(),
+                            nStats.getBreaker().getStats(CircuitBreaker.FIELDDATA).getEstimated(),
                             equalTo(0L));
                 }
             }

--- a/src/test/java/org/elasticsearch/indices/memory/breaker/CircuitBreakerUnitTests.java
+++ b/src/test/java/org/elasticsearch/indices/memory/breaker/CircuitBreakerUnitTests.java
@@ -19,9 +19,7 @@
 
 package org.elasticsearch.indices.memory.breaker;
 
-import org.elasticsearch.common.breaker.ChildMemoryCircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreaker;
-import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.indices.breaker.BreakerSettings;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
@@ -30,13 +28,7 @@ import org.elasticsearch.node.settings.NodeSettingsService;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.junit.Test;
 
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
-
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 
 /**
  * Unit tests for the circuit breaker
@@ -50,21 +42,21 @@ public class CircuitBreakerUnitTests extends ElasticsearchTestCase {
     @Test
     public void testBreakerSettingsValidationWithValidSettings() {
         // parent: {:limit 70}, fd: {:limit 50}, request: {:limit 20}
-        BreakerSettings fd = new BreakerSettings(CircuitBreaker.Name.FIELDDATA, pctBytes("50%"), 1.0);
-        BreakerSettings request = new BreakerSettings(CircuitBreaker.Name.REQUEST, pctBytes("20%"), 1.0);
+        BreakerSettings fd = new BreakerSettings(CircuitBreaker.FIELDDATA, pctBytes("50%"), 1.0);
+        BreakerSettings request = new BreakerSettings(CircuitBreaker.REQUEST, pctBytes("20%"), 1.0);
         HierarchyCircuitBreakerService.validateSettings(new BreakerSettings[]{fd, request});
 
         // parent: {:limit 70}, fd: {:limit 40}, request: {:limit 30}
-        fd = new BreakerSettings(CircuitBreaker.Name.FIELDDATA, pctBytes("40%"), 1.0);
-        request = new BreakerSettings(CircuitBreaker.Name.REQUEST, pctBytes("30%"), 1.0);
+        fd = new BreakerSettings(CircuitBreaker.FIELDDATA, pctBytes("40%"), 1.0);
+        request = new BreakerSettings(CircuitBreaker.REQUEST, pctBytes("30%"), 1.0);
         HierarchyCircuitBreakerService.validateSettings(new BreakerSettings[]{fd, request});
     }
 
     @Test
     public void testBreakerSettingsValidationNegativeOverhead() {
         // parent: {:limit 70}, fd: {:limit 50}, request: {:limit 20}
-        BreakerSettings fd = new BreakerSettings(CircuitBreaker.Name.FIELDDATA, pctBytes("50%"), -0.1);
-        BreakerSettings request = new BreakerSettings(CircuitBreaker.Name.REQUEST, pctBytes("20%"), 1.0);
+        BreakerSettings fd = new BreakerSettings(CircuitBreaker.FIELDDATA, pctBytes("50%"), -0.1);
+        BreakerSettings request = new BreakerSettings(CircuitBreaker.REQUEST, pctBytes("20%"), 1.0);
         try {
             HierarchyCircuitBreakerService.validateSettings(new BreakerSettings[]{fd, request});
             fail("settings are invalid but validate settings did not throw an exception");
@@ -77,7 +69,7 @@ public class CircuitBreakerUnitTests extends ElasticsearchTestCase {
     @Test
     public void testRegisterCustomBreaker() throws Exception {
         CircuitBreakerService service = new HierarchyCircuitBreakerService(ImmutableSettings.EMPTY, new NodeSettingsService(ImmutableSettings.EMPTY));
-        CircuitBreaker.Name customName = CircuitBreaker.Name.register(3, "custom");
+        String customName = "custom";
         BreakerSettings settings = new BreakerSettings(customName, 20, 1.0);
         service.registerBreaker(settings);
 
@@ -85,20 +77,6 @@ public class CircuitBreakerUnitTests extends ElasticsearchTestCase {
         assertThat(breaker, notNullValue());
         assertThat(breaker, instanceOf(CircuitBreaker.class));
         assertThat(breaker.getName(), is(customName));
-    }
-
-    @Test
-    public void testRegisterBuiltInBreakerForbidden() throws Exception {
-        CircuitBreakerService service = new HierarchyCircuitBreakerService(ImmutableSettings.EMPTY, new NodeSettingsService(ImmutableSettings.EMPTY));
-        BreakerSettings settings = new BreakerSettings(CircuitBreaker.Name.FIELDDATA, 20, 1.0);
-
-        try {
-            service.registerBreaker(settings);
-            fail("registering built-in breaker is forbidden but did not throw an exception");
-        } catch (Exception e) {
-            assertThat("Incorrect message: " + e.getMessage(),
-                    e.getMessage().contains("Overwriting of built-in breaker " + CircuitBreaker.Name.FIELDDATA + " is forbidden"), equalTo(true));
-        }
     }
 
 }

--- a/src/test/java/org/elasticsearch/indices/memory/breaker/RandomExceptionCircuitBreakerTests.java
+++ b/src/test/java/org/elasticsearch/indices/memory/breaker/RandomExceptionCircuitBreakerTests.java
@@ -60,7 +60,7 @@ public class RandomExceptionCircuitBreakerTests extends ElasticsearchIntegration
     public void testBreakerWithRandomExceptions() throws IOException, InterruptedException, ExecutionException {
         for (NodeStats node : client().admin().cluster().prepareNodesStats()
                 .clear().setBreaker(true).execute().actionGet().getNodes()) {
-            assertThat("Breaker is not set to 0", node.getBreaker().getStats(CircuitBreaker.Name.FIELDDATA).getEstimated(), equalTo(0L));
+            assertThat("Breaker is not set to 0", node.getBreaker().getStats(CircuitBreaker.FIELDDATA).getEstimated(), equalTo(0L));
         }
 
         String mapping = XContentFactory.jsonBuilder()
@@ -146,7 +146,7 @@ public class RandomExceptionCircuitBreakerTests extends ElasticsearchIntegration
         NodesStatsResponse resp = client().admin().cluster().prepareNodesStats()
                 .clear().setBreaker(true).execute().actionGet();
         for (NodeStats stats : resp.getNodes()) {
-            assertThat("Breaker is set to 0", stats.getBreaker().getStats(CircuitBreaker.Name.FIELDDATA).getEstimated(), equalTo(0L));
+            assertThat("Breaker is set to 0", stats.getBreaker().getStats(CircuitBreaker.FIELDDATA).getEstimated(), equalTo(0L));
         }
 
         for (int i = 0; i < numSearches; i++) {
@@ -190,7 +190,7 @@ public class RandomExceptionCircuitBreakerTests extends ElasticsearchIntegration
                         .clear().setBreaker(true).execute().actionGet();
                 for (NodeStats stats : nodeStats.getNodes()) {
                     assertThat("Breaker reset to 0 last search success: " + success + " mapping: " + mapping,
-                            stats.getBreaker().getStats(CircuitBreaker.Name.FIELDDATA).getEstimated(), equalTo(0L));
+                            stats.getBreaker().getStats(CircuitBreaker.FIELDDATA).getEstimated(), equalTo(0L));
                 }
             }
         }

--- a/src/test/java/org/elasticsearch/test/CompositeTestCluster.java
+++ b/src/test/java/org/elasticsearch/test/CompositeTestCluster.java
@@ -242,7 +242,7 @@ public class CompositeTestCluster extends TestCluster {
                     .clear().setBreaker(true).execute().actionGet();
             for (NodeStats stats : nodeStats.getNodes()) {
                 assertThat("Fielddata breaker not reset to 0 on node: " + stats.getNode(),
-                        stats.getBreaker().getStats(CircuitBreaker.Name.FIELDDATA).getEstimated(), equalTo(0L));
+                        stats.getBreaker().getStats(CircuitBreaker.FIELDDATA).getEstimated(), equalTo(0L));
             }
             // CompositeTestCluster does not check the request breaker,
             // because checking it requires a network request, which in

--- a/src/test/java/org/elasticsearch/test/ExternalTestCluster.java
+++ b/src/test/java/org/elasticsearch/test/ExternalTestCluster.java
@@ -147,7 +147,7 @@ public final class ExternalTestCluster extends TestCluster {
                     .clear().setBreaker(true).setIndices(true).execute().actionGet();
             for (NodeStats stats : nodeStats.getNodes()) {
                 assertThat("Fielddata breaker not reset to 0 on node: " + stats.getNode(),
-                        stats.getBreaker().getStats(CircuitBreaker.Name.FIELDDATA).getEstimated(), equalTo(0L));
+                        stats.getBreaker().getStats(CircuitBreaker.FIELDDATA).getEstimated(), equalTo(0L));
                 // ExternalTestCluster does not check the request breaker,
                 // because checking it requires a network request, which in
                 // turn increments the breaker, making it non-0

--- a/src/test/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/src/test/java/org/elasticsearch/test/InternalTestCluster.java
@@ -1693,7 +1693,7 @@ public final class InternalTestCluster extends TestCluster {
 
                 final String name = nodeAndClient.name;
                 final CircuitBreakerService breakerService = getInstanceFromNode(CircuitBreakerService.class, nodeAndClient.node);
-                CircuitBreaker fdBreaker = breakerService.getBreaker(CircuitBreaker.Name.FIELDDATA);
+                CircuitBreaker fdBreaker = breakerService.getBreaker(CircuitBreaker.FIELDDATA);
                 assertThat("Fielddata breaker not reset to 0 on node: " + name, fdBreaker.getUsed(), equalTo(0L));
                 // Anything that uses transport or HTTP can increase the
                 // request breaker (because they use bigarrays), because of
@@ -1707,7 +1707,7 @@ public final class InternalTestCluster extends TestCluster {
                     assertBusy(new Runnable() {
                         @Override
                         public void run() {
-                            CircuitBreaker reqBreaker = breakerService.getBreaker(CircuitBreaker.Name.REQUEST);
+                            CircuitBreaker reqBreaker = breakerService.getBreaker(CircuitBreaker.REQUEST);
                             assertThat("Request breaker not reset to 0 on node: " + name, reqBreaker.getUsed(), equalTo(0L));
                         }
                     });


### PR DESCRIPTION
This PR adds support for registering custom circuit breakers besides PARENT, REQUEST and FIELDDATA.
We needed to account memory consumption of different contexts than request or fielddata caches, but of course, this makes only sense by hooking up a new circuit breaker into the breaker hierarchy.
Maybe this is also interesting for someone else like plugin developers. 
