### PR TITLE
Add support for filtering by publish IP address

### DIFF
--- a/core/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeFiltersTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeFiltersTests.java
@@ -23,17 +23,37 @@ import com.google.common.collect.ImmutableMap;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.DummyTransportAddress;
+import org.elasticsearch.common.transport.InetSocketTransportAddress;
 import org.elasticsearch.test.ESTestCase;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 import static org.elasticsearch.cluster.node.DiscoveryNodeFilters.OpType.AND;
 import static org.elasticsearch.cluster.node.DiscoveryNodeFilters.OpType.OR;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 /**
  */
 public class DiscoveryNodeFiltersTests extends ESTestCase {
+
+    private static InetSocketTransportAddress localAddress;
+
+    @BeforeClass
+    public static void createLocalAddress() throws UnknownHostException {
+        localAddress = new InetSocketTransportAddress(InetAddress.getByName("192.1.1.54"), 9999);
+    }
+
+    @AfterClass
+    public static void releaseLocalAddress() {
+        localAddress = null;
+    }
 
     @Test
     public void nameMatch() {
@@ -65,10 +85,10 @@ public class DiscoveryNodeFiltersTests extends ESTestCase {
 
     @Test
     public void idOrNameMatch() {
-        Settings settings = Settings.settingsBuilder()
+        Settings settings = shuffleSettings(Settings.settingsBuilder()
                 .put("xxx._id", "id1,blah")
                 .put("xxx.name", "blah,name2")
-                .build();
+                .build());
         DiscoveryNodeFilters filters = DiscoveryNodeFilters.buildFromSettings(OR, "xxx.", settings);
 
         DiscoveryNode node = new DiscoveryNode("name1", "id1", DummyTransportAddress.INSTANCE, ImmutableMap.<String, String>of(), Version.CURRENT);
@@ -83,22 +103,22 @@ public class DiscoveryNodeFiltersTests extends ESTestCase {
 
     @Test
     public void tagAndGroupMatch() {
-        Settings settings = Settings.settingsBuilder()
+        Settings settings = shuffleSettings(Settings.settingsBuilder()
                 .put("xxx.tag", "A")
                 .put("xxx.group", "B")
-                .build();
+                .build());
         DiscoveryNodeFilters filters = DiscoveryNodeFilters.buildFromSettings(AND, "xxx.", settings);
 
         DiscoveryNode node = new DiscoveryNode("name1", "id1", DummyTransportAddress.INSTANCE,
-                ImmutableMap.<String, String>of("tag", "A", "group", "B"), Version.CURRENT);
+                ImmutableMap.of("tag", "A", "group", "B"), Version.CURRENT);
         assertThat(filters.match(node), equalTo(true));
 
         node = new DiscoveryNode("name2", "id2", DummyTransportAddress.INSTANCE,
-                ImmutableMap.<String, String>of("tag", "A", "group", "B", "name", "X"), Version.CURRENT);
+                ImmutableMap.of("tag", "A", "group", "B", "name", "X"), Version.CURRENT);
         assertThat(filters.match(node), equalTo(true));
 
         node = new DiscoveryNode("name3", "id3", DummyTransportAddress.INSTANCE,
-                ImmutableMap.<String, String>of("tag", "A", "group", "F", "name", "X"), Version.CURRENT);
+                ImmutableMap.of("tag", "A", "group", "F", "name", "X"), Version.CURRENT);
         assertThat(filters.match(node), equalTo(false));
 
         node = new DiscoveryNode("name4", "id4", DummyTransportAddress.INSTANCE, ImmutableMap.<String, String>of(), Version.CURRENT);
@@ -115,4 +135,124 @@ public class DiscoveryNodeFiltersTests extends ESTestCase {
         DiscoveryNode node = new DiscoveryNode("name1", "id1", DummyTransportAddress.INSTANCE, ImmutableMap.<String, String>of(), Version.CURRENT);
         assertThat(filters.match(node), equalTo(true));
     }
+
+    @Test
+    public void ipBindFilteringMatchingAnd() {
+        Settings settings = shuffleSettings(Settings.settingsBuilder()
+                .put("xxx.tag", "A")
+                .put("xxx." + randomFrom("_ip", "_host_ip", "_publish_ip"), "192.1.1.54")
+                .build());
+        DiscoveryNodeFilters filters = DiscoveryNodeFilters.buildFromSettings(AND, "xxx.", settings);
+
+        DiscoveryNode node = new DiscoveryNode("", "", "", "192.1.1.54", localAddress, ImmutableMap.of("tag", "A"), null);
+        assertThat(filters.match(node), equalTo(true));
+    }
+
+    @Test
+    public void ipBindFilteringNotMatching() {
+        Settings settings = shuffleSettings(Settings.settingsBuilder()
+                .put("xxx.tag", "B")
+                .put("xxx." + randomFrom("_ip", "_host_ip", "_publish_ip"), "192.1.1.54")
+                .build());
+        DiscoveryNodeFilters filters = DiscoveryNodeFilters.buildFromSettings(AND, "xxx.", settings);
+
+        DiscoveryNode node = new DiscoveryNode("", "", "", "192.1.1.54", localAddress, ImmutableMap.of("tag", "A"), null);
+        assertThat(filters.match(node), equalTo(false));
+    }
+
+    @Test
+    public void ipBindFilteringNotMatchingAnd() {
+        Settings settings = shuffleSettings(Settings.settingsBuilder()
+                .put("xxx.tag", "A")
+                .put("xxx." + randomFrom("_ip", "_host_ip", "_publish_ip"), "8.8.8.8")
+                .build());
+        DiscoveryNodeFilters filters = DiscoveryNodeFilters.buildFromSettings(AND, "xxx.", settings);
+
+        DiscoveryNode node = new DiscoveryNode("", "", "", "192.1.1.54", localAddress, ImmutableMap.of("tag", "A"), null);
+        assertThat(filters.match(node), equalTo(false));
+    }
+
+    @Test
+    public void ipBindFilteringMatchingOr() {
+        Settings settings = shuffleSettings(Settings.settingsBuilder()
+                .put("xxx." + randomFrom("_ip", "_host_ip", "_publish_ip"), "192.1.1.54")
+                .put("xxx.tag", "A")
+                .build());
+        DiscoveryNodeFilters filters = DiscoveryNodeFilters.buildFromSettings(OR, "xxx.", settings);
+
+        DiscoveryNode node = new DiscoveryNode("", "", "", "192.1.1.54", localAddress, ImmutableMap.of("tag", "A"), null);
+        assertThat(filters.match(node), equalTo(true));
+    }
+
+    @Test
+    public void ipBindFilteringNotMatchingOr() {
+        Settings settings = shuffleSettings(Settings.settingsBuilder()
+                .put("xxx.tag", "A")
+                .put("xxx." + randomFrom("_ip", "_host_ip", "_publish_ip"), "8.8.8.8")
+                .build());
+        DiscoveryNodeFilters filters = DiscoveryNodeFilters.buildFromSettings(OR, "xxx.", settings);
+
+        DiscoveryNode node = new DiscoveryNode("", "", "", "192.1.1.54", localAddress, ImmutableMap.of("tag", "A"), null);
+        assertThat(filters.match(node), equalTo(true));
+    }
+
+    @Test
+    public void ipPublishFilteringMatchingAnd() {
+        Settings settings = shuffleSettings(Settings.settingsBuilder()
+                .put("xxx.tag", "A")
+                .put("xxx._publish_ip", "192.1.1.54")
+                .build());
+        DiscoveryNodeFilters filters = DiscoveryNodeFilters.buildFromSettings(AND, "xxx.", settings);
+
+        DiscoveryNode node = new DiscoveryNode("", "", "", "192.1.1.54", localAddress, ImmutableMap.of("tag", "A"), null);
+        assertThat(filters.match(node), equalTo(true));
+    }
+
+    @Test
+    public void ipPublishFilteringNotMatchingAnd() {
+        Settings settings = shuffleSettings(Settings.settingsBuilder()
+                .put("xxx.tag", "A")
+                .put("xxx._publish_ip", "8.8.8.8")
+                .build());
+        DiscoveryNodeFilters filters = DiscoveryNodeFilters.buildFromSettings(AND, "xxx.", settings);
+
+        DiscoveryNode node = new DiscoveryNode("", "", "", "192.1.1.54", localAddress, ImmutableMap.of("tag", "A"), null);
+        assertThat(filters.match(node), equalTo(false));
+    }
+
+    @Test
+    public void ipPublishFilteringMatchingOr() {
+        Settings settings = shuffleSettings(Settings.settingsBuilder()
+                .put("xxx._publish_ip", "192.1.1.54")
+                .put("xxx.tag", "A")
+                .build());
+        DiscoveryNodeFilters filters = DiscoveryNodeFilters.buildFromSettings(OR, "xxx.", settings);
+
+        DiscoveryNode node = new DiscoveryNode("", "", "", "192.1.1.54", localAddress, ImmutableMap.of("tag", "A"), null);
+        assertThat(filters.match(node), equalTo(true));
+    }
+
+    @Test
+    public void ipPublishFilteringNotMatchingOr() {
+        Settings settings = shuffleSettings(Settings.settingsBuilder()
+                .put("xxx.tag", "A")
+                .put("xxx._publish_ip", "8.8.8.8")
+                .build());
+        DiscoveryNodeFilters filters = DiscoveryNodeFilters.buildFromSettings(OR, "xxx.", settings);
+
+        DiscoveryNode node = new DiscoveryNode("", "", "", "192.1.1.54", localAddress, ImmutableMap.of("tag", "A"), null);
+        assertThat(filters.match(node), equalTo(true));
+    }
+
+    private Settings shuffleSettings(Settings source) {
+        Settings.Builder settings = Settings.settingsBuilder();
+        List<String> keys = new ArrayList(source.getAsMap().keySet());
+        Collections.shuffle(keys, getRandom());
+        for (String o : keys) {
+            settings.put(o, source.getAsMap().get(o));
+        }
+        return settings.build();
+    }
+
+
 }

--- a/docs/reference/index-modules/allocation/filtering.asciidoc
+++ b/docs/reference/index-modules/allocation/filtering.asciidoc
@@ -81,9 +81,11 @@ one set of nodes to another:
 These special attributes are also supported:
 
 [horizontal]
-`_name`::   Match nodes by node name
-`_ip`::     Match nodes by IP address (the IP address associated with the hostname)
-`_host`::   Match nodes by hostname
+`_name`::       Match nodes by node name
+`_host_ip`::    Match nodes by host IP address (IP associated with hostname)
+`_publish_ip`:: Match nodes by publish IP address
+`_ip`::         Match either `_host_ip` or `_publish_ip`
+`_host`::       Match nodes by hostname
 
 All attribute values can be specified with wildcards, eg:
 


### PR DESCRIPTION
Allocation filtering by IP only works today using the node host address. But in some cases, you might want to filter using the publish address which could be different.

For example, let say your nodes are like this:

``` js
// First node
{
 "host" : "es1.acme.com",
 "transport_address" : "inet[/192.168.1.1:9300]",
 "ip" : "127.0.0.1",
 "http_address" : "inet[/192.168.1.1:9200]",
}
```

``` js
// Second node
{
 "host" : "es2.acme.com",
 "transport_address" : "inet[/192.168.1.2:9300]",
 "ip" : "127.0.0.1",
 "http_address" : "inet[/192.168.1.2:9200]",
}
```

You can not filter using ip because it will be the same for all nodes:

```
PUT test/_settings
{
  "index.routing.allocation.include._ip": "127.0.0.1"
}
```

This change adds support for either:
- `_name`: Match nodes by node name
- `_host_ip`: Match nodes by host IP address (IP associated with hostname)
- `_publish_ip`: Match nodes by publish IP address
- `_ip`: Match either `_host_ip` or `_publish_ip`
- `_host`: Match nodes by hostname

So you can filter allocation using now:

```
PUT test/_settings
{
  "index.routing.allocation.include._publish_ip": "192.168.1.1"
}
```
