### PR TITLE
Packaging: Add java7/8 java-package paths to init script

### DIFF
--- a/docs/reference/setup/as-a-service.asciidoc
+++ b/docs/reference/setup/as-a-service.asciidoc
@@ -53,7 +53,7 @@ sudo apt-get install oracle-java7-installer
 java -version
 --------------------------------------------------
 
-The last command should verify a successful installation of the Oracle JDK.
+The last command should verify a successful installation of the Oracle JDK. If you want to install java8, you can call `apt-get install oracle-java8-installer`
 
 
 [float]

--- a/src/deb/init.d/elasticsearch
+++ b/src/deb/init.d/elasticsearch
@@ -44,7 +44,7 @@ ES_USER=elasticsearch
 ES_GROUP=elasticsearch
 
 # The first existing directory is used for JAVA_HOME (if JAVA_HOME is not defined in $DEFAULT)
-JDK_DIRS="/usr/lib/jvm/jdk-7-oracle-x64 /usr/lib/jvm/java-7-oracle /usr/lib/jvm/java-7-openjdk /usr/lib/jvm/java-7-openjdk-amd64/ /usr/lib/jvm/java-7-openjdk-armhf /usr/lib/jvm/java-7-openjdk-i386/ /usr/lib/jvm/default-java"
+JDK_DIRS="/usr/lib/jvm/java-8-oracle/ /usr/lib/jvm/j2sdk1.8-oracle/ /usr/lib/jvm/jdk-7-oracle-x64 /usr/lib/jvm/java-7-oracle /usr/lib/jvm/j2sdk1.7-oracle/ /usr/lib/jvm/java-7-openjdk /usr/lib/jvm/java-7-openjdk-amd64/ /usr/lib/jvm/java-7-openjdk-armhf /usr/lib/jvm/java-7-openjdk-i386/ /usr/lib/jvm/default-java"
 
 # Look for the right JVM to use
 for jdir in $JDK_DIRS; do


### PR DESCRIPTION
If you use the java-package tool to create java packages, those
paths also should be added to the debian init script.

Also updated the docs, that it is ok to install java8.

Closes #7383
