### PR TITLE
Test: fix InternalEngineTest.testIndexWriterIFDInfoStream to pass in IntelliJ

### DIFF
--- a/src/test/java/org/elasticsearch/index/engine/internal/InternalEngineTests.java
+++ b/src/test/java/org/elasticsearch/index/engine/internal/InternalEngineTests.java
@@ -23,6 +23,7 @@ import com.google.common.base.Predicate;
 import org.apache.log4j.AppenderSkeleton;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
+import org.apache.log4j.LogManager;
 import org.apache.log4j.spi.LoggingEvent;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.document.Field;
@@ -1324,7 +1325,14 @@ public class InternalEngineTests extends ElasticsearchTestCase {
     public void testIndexWriterIFDInfoStream() {
         MockAppender mockAppender = new MockAppender();
 
-        Logger iwIFDLogger = Logger.getLogger("index.engine.internal.lucene.iw.ifd");
+        // Works when running this test inside Intellij:
+        Logger iwIFDLogger = LogManager.exists("org.elasticsearch.index.engine.internal.lucene.iw.ifd");
+        if (iwIFDLogger == null) {
+            // Works when running this test from command line:
+            iwIFDLogger = LogManager.exists("index.engine.internal.lucene.iw.ifd");
+            assertNotNull(iwIFDLogger);
+        }
+
         Level savedLevel = iwIFDLogger.getLevel();
         iwIFDLogger.addAppender(mockAppender);
         iwIFDLogger.setLevel(Level.DEBUG);


### PR DESCRIPTION
The logger used to log IndexWriter's deletions seems to change its name when it runs inside IntelliJ ... I just fixed the test to try both possibilities.
