### PR TITLE
Make the the number of ports to scan when trying to join a cluster configurable, and set the default to 2.

### DIFF
--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -320,6 +320,10 @@
 #    to perform discovery when new nodes (master or data) are started:
 #
 #discovery.zen.ping.unicast.hosts: ["host1", "host2:port"]
+#
+# 3. Set the number of ports to scan when trying to join a cluster:
+#
+#discovery.zen.ping.unicast.limit_ports_count: 2
 
 # EC2 discovery allows to use AWS EC2 API in order to perform discovery.
 #

--- a/docs/reference/modules/discovery/zen.asciidoc
+++ b/docs/reference/modules/discovery/zen.asciidoc
@@ -58,6 +58,8 @@ as gossip routers. It provides the following settings with the
 |`hosts` |Either an array setting or a comma delimited setting. Each
 value is either in the form of `host:port`, or in the form of
 `host[port1-port2]`.
+|`limit_ports_count` |The number of ports to scan when trying to join a 
+cluster. Defaults to `2`.
 |=======================================================================
 
 The unicast discovery uses the

--- a/src/main/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPing.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPing.java
@@ -66,7 +66,7 @@ public class UnicastZenPing extends AbstractLifecycleComponent<ZenPing> implemen
 
     public static final String ACTION_NAME = "internal:discovery/zen/unicast";
 
-    public static final int LIMIT_PORTS_COUNT = 1;
+    public static final String LIMIT_PORTS_COUNT = "discovery.zen.ping.unicast.limit_ports_count";
 
     private final ThreadPool threadPool;
     private final TransportService transportService;
@@ -125,8 +125,8 @@ public class UnicastZenPing extends AbstractLifecycleComponent<ZenPing> implemen
         for (String host : hosts) {
             try {
                 TransportAddress[] addresses = transportService.addressesFromString(host);
-                // we only limit to 1 addresses, makes no sense to ping 100 ports
-                for (int i = 0; (i < addresses.length && i < LIMIT_PORTS_COUNT); i++) {
+                int limitPortsCount = settings.getAsInt(LIMIT_PORTS_COUNT, 2);
+                for (int i = 0; (i < addresses.length && i < limitPortsCount); i++) {
                     configuredTargetNodes.add(new DiscoveryNode(UNICAST_NODE_PREFIX + unicastNodeIdGenerator.incrementAndGet() + "#", addresses[i], version.minimumCompatibilityVersion()));
                 }
             } catch (Exception e) {


### PR DESCRIPTION
Closes #7090
