### PR TITLE
Dates: Fixed parsing issue with exact dates when using lte.

### DIFF
--- a/src/main/java/org/elasticsearch/common/joda/DateMathParser.java
+++ b/src/main/java/org/elasticsearch/common/joda/DateMathParser.java
@@ -52,14 +52,11 @@ public class DateMathParser {
             mathString = text.substring("now".length());
         } else {
             int index = text.indexOf("||");
-            String parseString;
             if (index == -1) {
-                parseString = text;
-                mathString = ""; // nothing else
-            } else {
-                parseString = text.substring(0, index);
-                mathString = text.substring(index + 2);
+                return parseStringValue(text, timeZone);
             }
+            String parseString = text.substring(0, index);
+            mathString = text.substring(index + 2);
             if (roundCeil) {
                 time = parseRoundCeilStringValue(parseString, timeZone);
             } else {

--- a/src/test/java/org/elasticsearch/common/joda/DateMathParserTests.java
+++ b/src/test/java/org/elasticsearch/common/joda/DateMathParserTests.java
@@ -57,6 +57,11 @@ public class DateMathParserTests extends ElasticsearchTestCase {
         assertDateMathEquals("2014-05-30T20:21:35.123", "2014-05-30T20:21:35.123");
     }
     
+    public void testRoundingDoesNotAffectExactDate() {
+        assertDateMathEquals("2014", "2014-01-01T00:00:00.000", 0, true, null);
+        assertDateMathEquals("2014", "2014-01-01T00:00:00.000", 0, false, null);
+    }
+    
     public void testBasicMath() {
         assertDateMathEquals("2014-11-18||+y", "2015-11-18");
         assertDateMathEquals("2014-11-18||-2y", "2012-11-18");

--- a/src/test/java/org/elasticsearch/common/joda/DateMathParserTests.java
+++ b/src/test/java/org/elasticsearch/common/joda/DateMathParserTests.java
@@ -58,8 +58,8 @@ public class DateMathParserTests extends ElasticsearchTestCase {
     }
     
     public void testRoundingDoesNotAffectExactDate() {
-        assertDateMathEquals("2014", "2014-01-01T00:00:00.000", 0, true, null);
-        assertDateMathEquals("2014", "2014-01-01T00:00:00.000", 0, false, null);
+        assertDateMathEquals("2014-11-12T22:55:00Z", "2014-11-12T22:55:00Z", 0, true, null);
+        assertDateMathEquals("2014-11-12T22:55:00Z", "2014-11-12T22:55:00Z", 0, false, null);
     }
     
     public void testBasicMath() {

--- a/src/test/java/org/elasticsearch/index/mapper/date/SimpleDateMappingTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/date/SimpleDateMappingTests.java
@@ -232,7 +232,7 @@ public class SimpleDateMappingTests extends ElasticsearchSingleNodeTest {
         }
         assertThat(filter, instanceOf(NumericRangeFilter.class));
         NumericRangeFilter<Long> rangeFilter = (NumericRangeFilter<Long>) filter;
-        assertThat(rangeFilter.getMax(), equalTo(new DateTime(TimeValue.timeValueHours(11).millis() + 999).getMillis())); // +999 to include the 00-01 minute
+        assertThat(rangeFilter.getMax(), equalTo(new DateTime(TimeValue.timeValueHours(11).millis()).getMillis()));
         assertThat(rangeFilter.getMin(), equalTo(new DateTime(TimeValue.timeValueHours(10).millis()).getMillis()));
     }
 
@@ -262,7 +262,7 @@ public class SimpleDateMappingTests extends ElasticsearchSingleNodeTest {
         }
         assertThat(filter, instanceOf(NumericRangeFilter.class));
         NumericRangeFilter<Long> rangeFilter = (NumericRangeFilter<Long>) filter;
-        assertThat(rangeFilter.getMax(), equalTo(new DateTime(TimeValue.timeValueHours(35).millis() + 999).getMillis())); // +999 to include the 00-01 minute
+        assertThat(rangeFilter.getMax(), equalTo(new DateTime(TimeValue.timeValueHours(35).millis()).getMillis()));
         assertThat(rangeFilter.getMin(), equalTo(new DateTime(TimeValue.timeValueHours(34).millis()).getMillis()));
     }
 

--- a/src/test/java/org/elasticsearch/search/simple/SimpleSearchTests.java
+++ b/src/test/java/org/elasticsearch/search/simple/SimpleSearchTests.java
@@ -129,10 +129,9 @@ public class SimpleSearchTests extends ElasticsearchIntegrationTest {
     public void simpleDateRangeWithUpperInclusiveEnabledTests() throws Exception {
         createIndex("test");
         client().prepareIndex("test", "type1", "1").setSource("field", "2010-01-05T02:00").execute().actionGet();
-        client().prepareIndex("test", "type1", "2").setSource("field", "2010-01-06T02:00").execute().actionGet();
+        client().prepareIndex("test", "type1", "2").setSource("field", "2010-01-06T00:00").execute().actionGet();
         refresh();
 
-        // test include upper on ranges to include the full day on the upper bound
         SearchResponse searchResponse = client().prepareSearch("test").setQuery(QueryBuilders.rangeQuery("field").gte("2010-01-05").lte("2010-01-06")).execute().actionGet();
         assertHitCount(searchResponse, 2l);
         searchResponse = client().prepareSearch("test").setQuery(QueryBuilders.rangeQuery("field").gte("2010-01-05").lt("2010-01-06")).execute().actionGet();


### PR DESCRIPTION
Date parsing uses a flag to indicate whether the rounding should be
inclusive or exclusive.  This change fixes the parsing to not use this
logic in the case of exact dates that do not have rounding syntax.

closes #8490
