### PR TITLE
Ban java.io.File in tests

### DIFF
--- a/dev-tools/forbidden/all-signatures.txt
+++ b/dev-tools/forbidden/all-signatures.txt
@@ -2,8 +2,14 @@
 java.net.URL#getPath()
 java.net.URL#getFile()
 
-java.io.File#delete() @ use Files.delete for real exception, IOUtils.deleteFilesIgnoringExceptions if you dont care
-
-# temporary situation, until we upgrade with LUCENE-6051 fix 
-# (at which point forbidden apis will fail and we remove this section)
-@defaultMessage Use FileSystemUtils methods for now to workaround LUCENE-6051
+@defaultMessage Use java.nio.file instead of java.io.File API
+java.util.jar.JarFile
+java.util.zip.ZipFile
+java.io.File
+java.io.FileInputStream
+java.io.FileOutputStream
+java.io.PrintStream#<init>(java.lang.String,java.lang.String)
+java.io.PrintWriter#<init>(java.lang.String,java.lang.String)
+java.util.Formatter#<init>(java.lang.String,java.lang.String,java.util.Locale)
+java.io.RandomAccessFile
+java.nio.file.Path#toFile()

--- a/dev-tools/forbidden/core-signatures.txt
+++ b/dev-tools/forbidden/core-signatures.txt
@@ -114,17 +114,3 @@ org.apache.lucene.search.TimeLimitingCollector#getGlobalCounter()
 
 @defaultMessage Don't interrupt threads use FutureUtils#cancel(Future<T>) instead
 java.util.concurrent.Future#cancel(boolean)
-
-@defaultMessage Use java.nio.file.Path / java.nio.file.Files instead of java.io.File API
-java.util.jar.JarFile
-java.util.zip.ZipFile
-java.io.File
-java.io.FileInputStream
-java.io.FileOutputStream
-java.io.PrintStream#<init>(java.lang.String,java.lang.String)
-java.io.PrintWriter#<init>(java.lang.String,java.lang.String)
-java.util.Formatter#<init>(java.lang.String,java.lang.String,java.util.Locale)
-java.io.RandomAccessFile
-java.nio.file.Path#toFile()
-
-

--- a/pom.xml
+++ b/pom.xml
@@ -1281,6 +1281,10 @@
                                 <!-- start exclude for test GC simulation using Thread.suspend -->
                                 <exclude>org/elasticsearch/test/disruption/LongGCDisruption.class</exclude>
                                 <!-- end exclude for GC simulation  -->
+                                <!-- start exclude for java.io.File bridging -->
+                                <exclude>org/elasticsearch/test/ExternalNode.class</exclude>
+                                <exclude>org/elasticsearch/test/ElasticsearchTestCase.class</exclude>
+                                <!-- end exclude for java.io.File bridging -->
                             </excludes>
                             <signaturesFiles>
                                 <signaturesFile>dev-tools/forbidden/test-signatures.txt</signaturesFile>

--- a/src/test/java/org/elasticsearch/benchmark/common/lucene/uidscan/LuceneUidScanBenchmark.java
+++ b/src/test/java/org/elasticsearch/benchmark/common/lucene/uidscan/LuceneUidScanBenchmark.java
@@ -29,7 +29,7 @@ import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.lucene.uid.Versions;
 import org.elasticsearch.common.unit.SizeValue;
 
-import java.io.File;
+import java.nio.file.Paths;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -40,7 +40,7 @@ public class LuceneUidScanBenchmark {
 
     public static void main(String[] args) throws Exception {
 
-        FSDirectory dir = FSDirectory.open(new File("work/test").toPath());
+        FSDirectory dir = FSDirectory.open(Paths.get("work/test"));
         IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig(Lucene.STANDARD_ANALYZER));
 
         final int NUMBER_OF_THREADS = 2;

--- a/src/test/java/org/elasticsearch/benchmark/fs/FsAppendBenchmark.java
+++ b/src/test/java/org/elasticsearch/benchmark/fs/FsAppendBenchmark.java
@@ -22,11 +22,11 @@ import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.common.StopWatch;
 import org.elasticsearch.common.unit.ByteSizeValue;
 
-import java.io.File;
-import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
+import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 import java.util.Random;
 
 /**
@@ -35,11 +35,9 @@ import java.util.Random;
 public class FsAppendBenchmark {
 
     public static void main(String[] args) throws Exception {
-        IOUtils.deleteFilesIgnoringExceptions(Paths.get("work/test.log"));
-        RandomAccessFile raf = new RandomAccessFile("work/test.log", "rw");
-        raf.setLength(0);
+        Path path = Paths.get("work/test.log");
+        IOUtils.deleteFilesIgnoringExceptions(path);
 
-        boolean CHANNEL = true;
         int CHUNK = (int) ByteSizeValue.parseBytesSizeValue("1k").bytes();
         long DATA = ByteSizeValue.parseBytesSizeValue("10gb").bytes();
 
@@ -47,8 +45,7 @@ public class FsAppendBenchmark {
         new Random().nextBytes(data);
 
         StopWatch watch = new StopWatch().start("write");
-        if (CHANNEL) {
-            FileChannel channel = raf.getChannel();
+        try (FileChannel channel = FileChannel.open(path, StandardOpenOption.WRITE, StandardOpenOption.CREATE_NEW)) {
             long position = 0;
             while (position < DATA) {
                 channel.write(ByteBuffer.wrap(data), position);
@@ -56,16 +53,7 @@ public class FsAppendBenchmark {
             }
             watch.stop().start("flush");
             channel.force(true);
-        } else {
-            long position = 0;
-            while (position < DATA) {
-                raf.write(data);
-                position += data.length;
-            }
-            watch.stop().start("flush");
-            raf.getFD().sync();
         }
-        raf.close();
         watch.stop();
         System.out.println("Wrote [" + (new ByteSizeValue(DATA)) + "], chunk [" + (new ByteSizeValue(CHUNK)) + "], in " + watch);
     }

--- a/src/test/java/org/elasticsearch/benchmark/scripts/score/BasicScriptBenchmark.java
+++ b/src/test/java/org/elasticsearch/benchmark/scripts/score/BasicScriptBenchmark.java
@@ -19,8 +19,6 @@
 
 package org.elasticsearch.benchmark.scripts.score;
 
-import com.google.common.base.Charsets;
-import com.google.common.io.Files;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
@@ -37,9 +35,11 @@ import org.elasticsearch.index.query.functionscore.script.ScriptScoreFunctionBui
 import org.joda.time.DateTime;
 
 import java.io.BufferedWriter;
-import java.io.File;
 import java.io.IOException;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.security.SecureRandom;
 import java.util.*;
 import java.util.Map.Entry;
@@ -150,24 +150,18 @@ public class BasicScriptBenchmark {
     }
 
     public static void writeHelperFunction() throws IOException {
-        File file = new File("addToPlot.m");
-        BufferedWriter out = Files.newWriter(file, Charsets.UTF_8);
-
-        out.write("function handle = addToPlot(numTerms, perDoc, color, linestyle, linewidth)\n" + "handle = line(numTerms, perDoc);\n"
+        try (BufferedWriter out = Files.newBufferedWriter(Paths.get("addToPlot.m"), StandardCharsets.UTF_8)) {
+            out.write("function handle = addToPlot(numTerms, perDoc, color, linestyle, linewidth)\n" + "handle = line(numTerms, perDoc);\n"
                 + "set(handle, 'color', color);\n" + "set(handle, 'linestyle',linestyle);\n" + "set(handle, 'LineWidth',linewidth);\n"
                 + "end\n");
-        out.close();
+        }
     }
 
     public static void printOctaveScript(List<Results> allResults, String[] args) throws IOException {
         if (args.length == 0) {
             return;
         }
-        BufferedWriter out = null;
-        try {
-            File file = new File(args[0]);
-            out = Files.newWriter(file, Charsets.UTF_8);
-
+        try (BufferedWriter out = Files.newBufferedWriter(Paths.get(args[0]), StandardCharsets.UTF_8)) {
             out.write("#! /usr/local/bin/octave -qf");
             out.write("\n\n\n\n");
             out.write("######################################\n");
@@ -195,10 +189,6 @@ public class BasicScriptBenchmark {
             out.write("hold off;\n\n");
         } catch (IOException e) {
             System.err.println("Error: " + e.getMessage());
-        } finally {
-            if (out != null) {
-                out.close();
-            }
         }
         writeHelperFunction();
     }

--- a/src/test/java/org/elasticsearch/bwcompat/StaticIndexBackwardCompatibilityTest.java
+++ b/src/test/java/org/elasticsearch/bwcompat/StaticIndexBackwardCompatibilityTest.java
@@ -35,6 +35,7 @@ import org.elasticsearch.test.rest.client.http.HttpRequestBuilder;
 
 import java.io.File;
 import java.net.InetSocketAddress;
+import java.nio.file.Paths;
 
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
@@ -48,7 +49,7 @@ public class StaticIndexBackwardCompatibilityTest extends ElasticsearchIntegrati
 
     public void loadIndex(String index, Object... settings) throws Exception {
         logger.info("Checking static index " + index);
-        Settings nodeSettings = prepareBackwardsDataDir(new File(getClass().getResource(index).toURI()), settings);
+        Settings nodeSettings = prepareBackwardsDataDir(Paths.get(getClass().getResource(index).toURI()), settings);
         internalCluster().startNode(nodeSettings);
         ensureGreen("test");
         assertIndexSanity();

--- a/src/test/java/org/elasticsearch/cluster/routing/RoutingBackwardCompatibilityUponUpgradeTests.java
+++ b/src/test/java/org/elasticsearch/cluster/routing/RoutingBackwardCompatibilityUponUpgradeTests.java
@@ -33,7 +33,8 @@ import org.elasticsearch.node.internal.InternalNode;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 
-import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
@@ -50,7 +51,7 @@ public class RoutingBackwardCompatibilityUponUpgradeTests extends ElasticsearchI
     }
 
     private void test(String name, Class<? extends HashFunction> expectedHashFunction, boolean expectedUseType) throws Exception {
-        File zippedIndexDir = new File(getClass().getResource("/org/elasticsearch/cluster/routing/" + name + ".zip").toURI());
+        Path zippedIndexDir = Paths.get(getClass().getResource("/org/elasticsearch/cluster/routing/" + name + ".zip").toURI());
         Settings baseSettings = prepareBackwardsDataDir(zippedIndexDir);
         internalCluster().startNode(ImmutableSettings.builder()
                 .put(baseSettings)

--- a/src/test/java/org/elasticsearch/common/ChannelsTests.java
+++ b/src/test/java/org/elasticsearch/common/ChannelsTests.java
@@ -41,26 +41,26 @@ import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 
 public class ChannelsTests extends ElasticsearchTestCase {
 
     byte[] randomBytes;
     FileChannel fileChannel;
-    RandomAccessFile randomAccessFile;
 
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        File tmpFile = newTempFile();
-        randomAccessFile = new RandomAccessFile(tmpFile, "rw");
-        fileChannel = new MockFileChannel(randomAccessFile.getChannel());
+        Path tmpFile = newTempFilePath();
+        FileChannel randomAccessFile = FileChannel.open(tmpFile, StandardOpenOption.READ, StandardOpenOption.WRITE);
+        fileChannel = new MockFileChannel(randomAccessFile);
         randomBytes = randomUnicodeOfLength(scaledRandomIntBetween(10, 100000)).getBytes("UTF-8");
     }
 
     @After
     public void tearDown() throws Exception {
         fileChannel.close();
-        randomAccessFile.close();
         super.tearDown();
     }
 

--- a/src/test/java/org/elasticsearch/common/PidFileTests.java
+++ b/src/test/java/org/elasticsearch/common/PidFileTests.java
@@ -37,7 +37,7 @@ public class PidFileTests extends ElasticsearchTestCase {
 
     @Test(expected = ElasticsearchIllegalArgumentException.class)
     public void testParentIsFile() throws IOException {
-        Path dir = newTempDir().toPath();
+        Path dir = newTempDirPath();
         Path parent = dir.resolve("foo");
         try(BufferedWriter stream = Files.newBufferedWriter(parent, Charsets.UTF_8, StandardOpenOption.CREATE_NEW)) {
             stream.write("foo");
@@ -48,7 +48,7 @@ public class PidFileTests extends ElasticsearchTestCase {
 
     @Test
     public void testPidFile() throws IOException {
-        Path dir = newTempDir().toPath();
+        Path dir = newTempDirPath();
         Path parent = dir.resolve("foo");
         if (randomBoolean()) {
             Files.createDirectories(parent);

--- a/src/test/java/org/elasticsearch/common/blobstore/BlobStoreTest.java
+++ b/src/test/java/org/elasticsearch/common/blobstore/BlobStoreTest.java
@@ -140,7 +140,7 @@ public class BlobStoreTest extends ElasticsearchTestCase {
     }
 
     protected BlobStore newBlobStore() throws IOException {
-        Path tempDir = newTempDir(LifecycleScope.TEST).toPath();
+        Path tempDir = newTempDirPath(LifecycleScope.TEST);
         Settings settings = randomBoolean() ? ImmutableSettings.EMPTY : ImmutableSettings.builder().put("buffer_size", new ByteSizeValue(randomIntBetween(1, 100), ByteSizeUnit.KB)).build();
         FsBlobStore store = new FsBlobStore(settings, tempDir);
         return store;

--- a/src/test/java/org/elasticsearch/common/bytes/PagedBytesReferenceTest.java
+++ b/src/test/java/org/elasticsearch/common/bytes/PagedBytesReferenceTest.java
@@ -37,10 +37,11 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.EOFException;
-import java.io.File;
 import java.io.IOException;
-import java.io.RandomAccessFile;
+import java.nio.channels.FileChannel;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
 
 public class PagedBytesReferenceTest extends ElasticsearchTestCase {
@@ -260,12 +261,12 @@ public class PagedBytesReferenceTest extends ElasticsearchTestCase {
     public void testWriteToChannel() throws IOException {
         int length = randomIntBetween(10, PAGE_SIZE * 4);
         BytesReference pbr = getRandomizedPagedBytesReference(length);
-        File tFile = newTempFile();
-        try (RandomAccessFile file = new RandomAccessFile(tFile, "rw")) {
-            pbr.writeTo(file.getChannel());
-            assertEquals(pbr.length(), file.length());
-            assertArrayEquals(pbr.toBytes(), Files.readAllBytes(tFile.toPath()));
+        Path tFile = newTempFilePath();
+        try (FileChannel channel = FileChannel.open(tFile, StandardOpenOption.WRITE)) {
+            pbr.writeTo(channel);
+            assertEquals(pbr.length(), channel.position());
         }
+        assertArrayEquals(pbr.toBytes(), Files.readAllBytes(tFile));
     }
 
     public void testSliceWriteToOutputStream() throws IOException {
@@ -287,12 +288,12 @@ public class PagedBytesReferenceTest extends ElasticsearchTestCase {
         int sliceOffset = randomIntBetween(1, length / 2);
         int sliceLength = length - sliceOffset;
         BytesReference slice = pbr.slice(sliceOffset, sliceLength);
-        File tFile = newTempFile();
-        try (RandomAccessFile file = new RandomAccessFile(tFile, "rw")) {
-            slice.writeTo(file.getChannel());
-            assertEquals(slice.length(), file.length());
-            assertArrayEquals(slice.toBytes(), Files.readAllBytes(tFile.toPath()));
+        Path tFile = newTempFilePath();
+        try (FileChannel channel = FileChannel.open(tFile, StandardOpenOption.WRITE)) {
+            slice.writeTo(channel);
+            assertEquals(slice.length(), channel.position());
         }
+        assertArrayEquals(slice.toBytes(), Files.readAllBytes(tFile));
     }
 
     public void testToBytes() {

--- a/src/test/java/org/elasticsearch/common/io/FileSystemUtilsTests.java
+++ b/src/test/java/org/elasticsearch/common/io/FileSystemUtilsTests.java
@@ -24,7 +24,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -47,7 +46,7 @@ public class FileSystemUtilsTests extends ElasticsearchTestCase {
 
     @Before
     public void copySourceFilesToTarget() throws IOException {
-        Path globalTempDir = globalTempDir().toPath();
+        Path globalTempDir = globalTempDirPath();
         src = globalTempDir.resolve("iocopyappend-src");
         dst = globalTempDir.resolve("iocopyappend-dst");
         Files.createDirectories(src);
@@ -92,7 +91,7 @@ public class FileSystemUtilsTests extends ElasticsearchTestCase {
 
     @Test
     public void testMoveOverExistingFileAndIgnore() throws IOException {
-        Path dest = globalTempDir().toPath();
+        Path dest = globalTempDirPath();
 
         FileSystemUtils.moveFilesWithoutOverwriting(src.resolve("v1"), dest, null);
         assertFileContent(dest, "file1.txt", "version1");

--- a/src/test/java/org/elasticsearch/common/logging/log4j/Log4jESLoggerTests.java
+++ b/src/test/java/org/elasticsearch/common/logging/log4j/Log4jESLoggerTests.java
@@ -30,8 +30,9 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.junit.Test;
 
-import java.io.File;
 import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -47,10 +48,10 @@ public class Log4jESLoggerTests extends ElasticsearchTestCase {
     public void setUp() throws Exception {
         super.setUp();
         LogConfigurator.reset();
-        File configDir = resolveConfigDir();
+        Path configDir = resolveConfigDir();
         // Need to set custom path.conf so we can use a custom logging.yml file for the test
         Settings settings = ImmutableSettings.builder()
-                .put("path.conf", configDir.getAbsolutePath())
+                .put("path.conf", configDir.toAbsolutePath())
                 .build();
         LogConfigurator.configure(settings);
 
@@ -114,9 +115,9 @@ public class Log4jESLoggerTests extends ElasticsearchTestCase {
         
     }
 
-    private static File resolveConfigDir() throws Exception {
+    private static Path resolveConfigDir() throws Exception {
         URL url = Log4jESLoggerTests.class.getResource("config");
-        return new File(url.toURI());
+        return Paths.get(url.toURI());
     }
 
     private static class TestAppender extends AppenderSkeleton {

--- a/src/test/java/org/elasticsearch/env/EnvironmentTests.java
+++ b/src/test/java/org/elasticsearch/env/EnvironmentTests.java
@@ -19,29 +19,16 @@
 package org.elasticsearch.env;
 
 import com.google.common.base.Charsets;
-import org.apache.lucene.store.LockObtainFailedException;
-import org.apache.lucene.util.IOUtils;
-import org.elasticsearch.ElasticsearchIllegalStateException;
 import org.elasticsearch.common.io.FileSystemUtils;
 import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.index.Index;
-import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.junit.Test;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Simple unit-tests for Environment.java
@@ -55,7 +42,7 @@ public class EnvironmentTests extends ElasticsearchTestCase {
     public Environment newEnvironment(Settings settings) throws IOException {
         Settings build = ImmutableSettings.builder()
                 .put(settings)
-                .put("path.home", newTempDir().getAbsolutePath())
+                .put("path.home", newTempDirPath().toAbsolutePath())
                 .putArray("path.data", tmpPaths()).build();
         return new Environment(build);
     }

--- a/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
+++ b/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
@@ -291,7 +291,7 @@ public class NodeEnvironmentTests extends ElasticsearchTestCase {
     public NodeEnvironment newNodeEnvironment(Settings settings) throws IOException {
         Settings build = ImmutableSettings.builder()
                 .put(settings)
-                .put("path.home", newTempDir().getAbsolutePath())
+                .put("path.home", newTempDirPath().toAbsolutePath())
                 .putArray("path.data", tmpPaths()).build();
         return new NodeEnvironment(build, new Environment(build));
     }

--- a/src/test/java/org/elasticsearch/index/analysis/AnalysisModuleTests.java
+++ b/src/test/java/org/elasticsearch/index/analysis/AnalysisModuleTests.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.analysis;
 
-import com.google.common.base.Charsets;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.Tokenizer;
@@ -48,7 +47,12 @@ import org.elasticsearch.test.ElasticsearchTestCase;
 import org.hamcrest.MatcherAssert;
 import org.junit.Test;
 
-import java.io.*;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Set;
 
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
@@ -198,28 +202,21 @@ public class AnalysisModuleTests extends ElasticsearchTestCase {
         Environment env = new Environment(ImmutableSettings.Builder.EMPTY_SETTINGS);
         String[] words = new String[]{"donau", "dampf", "schiff", "spargel", "creme", "suppe"};
 
-        File wordListFile = generateWordList(words);
-        Settings settings = settingsBuilder().loadFromSource("index: \n  word_list_path: " + wordListFile.getAbsolutePath()).build();
+        Path wordListFile = generateWordList(words);
+        Settings settings = settingsBuilder().loadFromSource("index: \n  word_list_path: " + wordListFile.toAbsolutePath()).build();
 
         Set<?> wordList = Analysis.getWordSet(env, settings, "index.word_list");
         MatcherAssert.assertThat(wordList.size(), equalTo(6));
 //        MatcherAssert.assertThat(wordList, hasItems(words));
+        Files.delete(wordListFile);
     }
 
-    private File generateWordList(String[] words) throws Exception {
-        File wordListFile = File.createTempFile("wordlist", ".txt");
-        wordListFile.deleteOnExit();
-
-        BufferedWriter writer = null;
-        try {
-            writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(wordListFile), Charsets.UTF_8));
+    private Path generateWordList(String[] words) throws Exception {
+        Path wordListFile = newTempDirPath().resolve("wordlist.txt");
+        try (BufferedWriter writer = Files.newBufferedWriter(wordListFile, StandardCharsets.UTF_8)) {
             for (String word : words) {
                 writer.write(word);
                 writer.write('\n');
-            }
-        } finally {
-            if (writer != null) {
-                writer.close();
             }
         }
         return wordListFile;

--- a/src/test/java/org/elasticsearch/index/analysis/HunspellTokenFilterFactoryTests.java
+++ b/src/test/java/org/elasticsearch/index/analysis/HunspellTokenFilterFactoryTests.java
@@ -33,7 +33,7 @@ public class HunspellTokenFilterFactoryTests extends ElasticsearchTestCase {
     @Test
     public void testDedup() throws IOException {
         Settings settings = settingsBuilder()
-                .put("path.conf", getResource("/indices/analyze/conf_dir"))
+                .put("path.conf", getResourcePath("/indices/analyze/conf_dir"))
                 .put("index.analysis.filter.en_US.type", "hunspell")
                 .put("index.analysis.filter.en_US.locale", "en_US")
                 .build();
@@ -45,7 +45,7 @@ public class HunspellTokenFilterFactoryTests extends ElasticsearchTestCase {
         assertThat(hunspellTokenFilter.dedup(), is(true));
 
         settings = settingsBuilder()
-                .put("path.conf", getResource("/indices/analyze/conf_dir"))
+                .put("path.conf", getResourcePath("/indices/analyze/conf_dir"))
                 .put("index.analysis.filter.en_US.type", "hunspell")
                 .put("index.analysis.filter.en_US.dedup", false)
                 .put("index.analysis.filter.en_US.locale", "en_US")

--- a/src/test/java/org/elasticsearch/index/query/TemplateQueryParserTest.java
+++ b/src/test/java/org/elasticsearch/index/query/TemplateQueryParserTest.java
@@ -68,7 +68,7 @@ public class TemplateQueryParserTest extends ElasticsearchTestCase {
     @Before
     public void setup() throws IOException {
         Settings settings = ImmutableSettings.settingsBuilder()
-                .put("path.conf", this.getResource("config").getPath())
+                .put("path.conf", this.getResourcePath("config"))
                 .put("name", getClass().getName())
                 .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
                 .build();

--- a/src/test/java/org/elasticsearch/index/query/TemplateQueryTest.java
+++ b/src/test/java/org/elasticsearch/index/query/TemplateQueryTest.java
@@ -65,7 +65,7 @@ public class TemplateQueryTest extends ElasticsearchIntegrationTest {
     @Override
     public Settings nodeSettings(int nodeOrdinal) {
         return settingsBuilder().put(super.nodeSettings(nodeOrdinal))
-                .put("path.conf", this.getResource("config").getPath()).build();
+                .put("path.conf", this.getResourcePath("config")).build();
     }
 
     @Test

--- a/src/test/java/org/elasticsearch/index/store/DirectoryUtilsTest.java
+++ b/src/test/java/org/elasticsearch/index/store/DirectoryUtilsTest.java
@@ -19,15 +19,14 @@
 package org.elasticsearch.index.store;
 
 import com.carrotsearch.randomizedtesting.LifecycleScope;
-import com.carrotsearch.randomizedtesting.annotations.Repeat;
-import com.carrotsearch.randomizedtesting.annotations.Seed;
+
 import org.apache.lucene.store.*;
 import org.elasticsearch.test.ElasticsearchLuceneTestCase;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.junit.Test;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Set;
 
@@ -37,11 +36,11 @@ public class DirectoryUtilsTest extends ElasticsearchLuceneTestCase {
 
     @Test
     public void testGetLeave() throws IOException {
-        File file = ElasticsearchTestCase.newTempDir(LifecycleScope.TEST);
+        Path file = ElasticsearchTestCase.newTempDirPath(LifecycleScope.TEST);
         final int iters = scaledRandomIntBetween(10, 100);
         for (int i = 0; i < iters; i++) {
             {
-                BaseDirectoryWrapper dir = newFSDirectory(file.toPath());
+                BaseDirectoryWrapper dir = newFSDirectory(file);
                 FSDirectory directory = DirectoryUtils.getLeaf(new FilterDirectory(dir) {}, FSDirectory.class, null);
                 assertThat(directory, notNullValue());
                 assertThat(directory, sameInstance(DirectoryUtils.getLeafDirectory(dir)));
@@ -49,7 +48,7 @@ public class DirectoryUtilsTest extends ElasticsearchLuceneTestCase {
             }
 
             {
-                BaseDirectoryWrapper dir = newFSDirectory(file.toPath());
+                BaseDirectoryWrapper dir = newFSDirectory(file);
                 FSDirectory directory = DirectoryUtils.getLeaf(dir, FSDirectory.class, null);
                 assertThat(directory, notNullValue());
                 assertThat(directory, sameInstance(DirectoryUtils.getLeafDirectory(dir)));
@@ -58,7 +57,7 @@ public class DirectoryUtilsTest extends ElasticsearchLuceneTestCase {
 
             {
                 Set<String> stringSet = Collections.emptySet();
-                BaseDirectoryWrapper dir = newFSDirectory(file.toPath());
+                BaseDirectoryWrapper dir = newFSDirectory(file);
                 FSDirectory directory = DirectoryUtils.getLeaf(new FileSwitchDirectory(stringSet, dir, dir, random().nextBoolean()), FSDirectory.class, null);
                 assertThat(directory, notNullValue());
                 assertThat(directory, sameInstance(DirectoryUtils.getLeafDirectory(dir)));
@@ -67,7 +66,7 @@ public class DirectoryUtilsTest extends ElasticsearchLuceneTestCase {
 
             {
                 Set<String> stringSet = Collections.emptySet();
-                BaseDirectoryWrapper dir = newFSDirectory(file.toPath());
+                BaseDirectoryWrapper dir = newFSDirectory(file);
                 FSDirectory directory = DirectoryUtils.getLeaf(new FilterDirectory(new FileSwitchDirectory(stringSet, dir, dir, random().nextBoolean())) {}, FSDirectory.class, null);
                 assertThat(directory, notNullValue());
                 assertThat(directory, sameInstance(DirectoryUtils.getLeafDirectory(dir)));
@@ -76,7 +75,7 @@ public class DirectoryUtilsTest extends ElasticsearchLuceneTestCase {
 
             {
                 Set<String> stringSet = Collections.emptySet();
-                BaseDirectoryWrapper dir = newFSDirectory(file.toPath());
+                BaseDirectoryWrapper dir = newFSDirectory(file);
                 RAMDirectory directory = DirectoryUtils.getLeaf(new FilterDirectory(new FileSwitchDirectory(stringSet, dir, dir, random().nextBoolean())) {}, RAMDirectory.class, null);
                 assertThat(directory, nullValue());
                 dir.close();

--- a/src/test/java/org/elasticsearch/index/translog/fs/FsBufferedTranslogTests.java
+++ b/src/test/java/org/elasticsearch/index/translog/fs/FsBufferedTranslogTests.java
@@ -28,6 +28,7 @@ import org.junit.AfterClass;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 
 /**
@@ -42,13 +43,13 @@ public class FsBufferedTranslogTests extends AbstractSimpleTranslogTests {
                         .put("index.translog.fs.type", FsTranslogFile.Type.BUFFERED.name())
                         .put("index.translog.fs.buffer_size", 10 + randomInt(128 * 1024))
                         .build(),
-                Paths.get(translogFileDirectory())
+                translogFileDirectory()
         );
     }
 
     @Override
-    protected String translogFileDirectory() {
-        return "data/fs-buf-translog";
+    protected Path translogFileDirectory() {
+        return Paths.get("data/fs-buf-translog");
     }
 
     @AfterClass

--- a/src/test/java/org/elasticsearch/index/translog/fs/FsSimpleTranslogTests.java
+++ b/src/test/java/org/elasticsearch/index/translog/fs/FsSimpleTranslogTests.java
@@ -28,6 +28,7 @@ import org.junit.AfterClass;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 
 /**
@@ -39,12 +40,12 @@ public class FsSimpleTranslogTests extends AbstractSimpleTranslogTests {
     protected Translog create() throws IOException {
         return new FsTranslog(shardId,
                 ImmutableSettings.settingsBuilder().put("index.translog.fs.type", FsTranslogFile.Type.SIMPLE.name()).build(),
-                Paths.get(translogFileDirectory()));
+                translogFileDirectory());
     }
 
     @Override
-    protected String translogFileDirectory() {
-        return "data/fs-simple-translog";
+    protected Path translogFileDirectory() {
+        return Paths.get("data/fs-simple-translog");
     }
 
     @AfterClass

--- a/src/test/java/org/elasticsearch/indices/analyze/HunspellServiceTests.java
+++ b/src/test/java/org/elasticsearch/indices/analyze/HunspellServiceTests.java
@@ -44,7 +44,7 @@ public class HunspellServiceTests extends ElasticsearchIntegrationTest {
     @Test
     public void testLocaleDirectoryWithNodeLevelConfig() throws Exception {
         Settings settings = ImmutableSettings.settingsBuilder()
-                .put("path.conf", getResource("/indices/analyze/conf_dir"))
+                .put("path.conf", getResourcePath("/indices/analyze/conf_dir"))
                 .put(HUNSPELL_LAZY_LOAD, randomBoolean())
                 .put(HUNSPELL_IGNORE_CASE, true)
                 .build();
@@ -58,7 +58,7 @@ public class HunspellServiceTests extends ElasticsearchIntegrationTest {
     @Test
     public void testLocaleDirectoryWithLocaleSpecificConfig() throws Exception {
         Settings settings = ImmutableSettings.settingsBuilder()
-                .put("path.conf", getResource("/indices/analyze/conf_dir"))
+                .put("path.conf", getResourcePath("/indices/analyze/conf_dir"))
                 .put(HUNSPELL_LAZY_LOAD, randomBoolean())
                 .put(HUNSPELL_IGNORE_CASE, true)
                 .put("indices.analysis.hunspell.dictionary.en_US.strict_affix_parsing", false)
@@ -81,7 +81,7 @@ public class HunspellServiceTests extends ElasticsearchIntegrationTest {
     @Test
     public void testCustomizeLocaleDirectory() throws Exception {
         Settings settings = ImmutableSettings.settingsBuilder()
-                .put(HUNSPELL_LOCATION, getResource("/indices/analyze/conf_dir/hunspell"))
+                .put(HUNSPELL_LOCATION, getResourcePath("/indices/analyze/conf_dir/hunspell"))
                 .build();
 
         internalCluster().startNode(settings);
@@ -92,7 +92,7 @@ public class HunspellServiceTests extends ElasticsearchIntegrationTest {
     @Test
     public void testDicWithNoAff() throws Exception {
         Settings settings = ImmutableSettings.settingsBuilder()
-                .put("path.conf", getResource("/indices/analyze/no_aff_conf_dir"))
+                .put("path.conf", getResourcePath("/indices/analyze/no_aff_conf_dir"))
                 .put(HUNSPELL_LAZY_LOAD, randomBoolean())
                 .build();
 
@@ -111,7 +111,7 @@ public class HunspellServiceTests extends ElasticsearchIntegrationTest {
     @Test
     public void testDicWithTwoAffs() throws Exception {
         Settings settings = ImmutableSettings.settingsBuilder()
-                .put("path.conf", getResource("/indices/analyze/two_aff_conf_dir"))
+                .put("path.conf", getResourcePath("/indices/analyze/two_aff_conf_dir"))
                 .put(HUNSPELL_LAZY_LOAD, randomBoolean())
                 .build();
 

--- a/src/test/java/org/elasticsearch/indices/template/IndexTemplateFileLoadingTests.java
+++ b/src/test/java/org/elasticsearch/indices/template/IndexTemplateFileLoadingTests.java
@@ -20,7 +20,7 @@ package org.elasticsearch.indices.template;
 
 import com.carrotsearch.randomizedtesting.LifecycleScope;
 import com.google.common.base.Charsets;
-import com.google.common.io.Files;
+
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.settings.ImmutableSettings;
@@ -29,7 +29,9 @@ import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
 import org.junit.Test;
 
-import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -46,18 +48,18 @@ public class IndexTemplateFileLoadingTests extends ElasticsearchIntegrationTest 
         settingsBuilder.put(super.nodeSettings(nodeOrdinal));
 
         try {
-            File directory = newTempDir(LifecycleScope.SUITE);
-            settingsBuilder.put("path.conf", directory.getPath());
+            Path directory = newTempDirPath(LifecycleScope.SUITE);
+            settingsBuilder.put("path.conf", directory.toAbsolutePath());
 
-            File templatesDir = new File(directory + File.separator + "templates");
-            templatesDir.mkdir();
+            Path templatesDir = directory.resolve("templates");
+            Files.createDirectory(templatesDir);
 
-            File dst = new File(templatesDir, "template.json");
+            Path dst = templatesDir.resolve("template.json");
             String templatePath = "/org/elasticsearch/indices/template/template" + randomInt(5) + ".json";
             logger.info("Picking template path [{}]", templatePath);
             // random template, one uses the 'setting.index.number_of_shards', the other 'settings.number_of_shards'
             String template = Streams.copyToStringFromClasspath(templatePath);
-            Files.write(template, dst, Charsets.UTF_8);
+            Files.write(dst, template.getBytes(StandardCharsets.UTF_8));
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/src/test/java/org/elasticsearch/nodesinfo/SimpleNodesInfoTests.java
+++ b/src/test/java/org/elasticsearch/nodesinfo/SimpleNodesInfoTests.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.nodesinfo;
 
 import com.google.common.collect.Lists;
+
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoResponse;
 import org.elasticsearch.action.admin.cluster.node.info.PluginInfo;
@@ -33,9 +34,9 @@ import org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
 import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.junit.Test;
 
-import java.io.File;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
 
@@ -161,7 +162,7 @@ public class SimpleNodesInfoTests extends ElasticsearchIntegrationTest {
         ImmutableSettings.Builder settings = settingsBuilder();
         settings.put(nodeSettings);
         if (resource != null) {
-            settings.put("path.plugins", new File(resource.toURI()).getAbsolutePath());
+            settings.put("path.plugins", Paths.get(resource.toURI()).toAbsolutePath());
         }
 
         if (pluginClassNames.length > 0) {

--- a/src/test/java/org/elasticsearch/plugins/PluginManagerTests.java
+++ b/src/test/java/org/elasticsearch/plugins/PluginManagerTests.java
@@ -386,7 +386,7 @@ public class PluginManagerTests extends ElasticsearchIntegrationTest {
 
         // We want to check that Plugin Manager moves content to _site
         String pluginDir = PLUGIN_DIR.concat("/plugin-site/_site");
-        assertFileExists(new File(pluginDir));
+        assertFileExists(Paths.get(pluginDir));
     }
 
 

--- a/src/test/java/org/elasticsearch/plugins/PluginManagerUnitTests.java
+++ b/src/test/java/org/elasticsearch/plugins/PluginManagerUnitTests.java
@@ -20,13 +20,14 @@
 package org.elasticsearch.plugins;
 
 import com.google.common.io.Files;
+
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.junit.Test;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 import static org.hamcrest.Matchers.is;
@@ -39,8 +40,8 @@ public class PluginManagerUnitTests extends ElasticsearchTestCase {
     @Test
     public void testThatConfigDirectoryCanBeOutsideOfElasticsearchHomeDirectory() throws IOException {
         String pluginName = randomAsciiOfLength(10);
-        File homeFolder = newTempDir();
-        File genericConfigFolder = newTempDir();
+        Path homeFolder = newTempDirPath();
+        Path genericConfigFolder = newTempDirPath();
 
         Settings settings = settingsBuilder()
                 .put("path.conf", genericConfigFolder)
@@ -50,7 +51,7 @@ public class PluginManagerUnitTests extends ElasticsearchTestCase {
 
         PluginManager.PluginHandle pluginHandle = new PluginManager.PluginHandle(pluginName, "version", "user", "repo");
         String configDirPath = Files.simplifyPath(pluginHandle.configDir(environment).normalize().toString());
-        String expectedDirPath = Files.simplifyPath(new File(genericConfigFolder, pluginName).toPath().normalize().toString());
+        String expectedDirPath = Files.simplifyPath(genericConfigFolder.resolve(pluginName).normalize().toString());
 
         assertThat(configDirPath, is(expectedDirPath));
     }

--- a/src/test/java/org/elasticsearch/plugins/SitePluginTests.java
+++ b/src/test/java/org/elasticsearch/plugins/SitePluginTests.java
@@ -30,8 +30,9 @@ import org.elasticsearch.test.rest.client.http.HttpRequestBuilder;
 import org.elasticsearch.test.rest.client.http.HttpResponse;
 import org.junit.Test;
 
-import java.io.File;
 import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 import static org.elasticsearch.test.ElasticsearchIntegrationTest.Scope;
@@ -48,10 +49,10 @@ public class SitePluginTests extends ElasticsearchIntegrationTest {
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {
         try {
-            File pluginDir = new File(SitePluginTests.class.getResource("/org/elasticsearch/plugins").toURI());
+            Path pluginDir = Paths.get(SitePluginTests.class.getResource("/org/elasticsearch/plugins").toURI());
             return settingsBuilder()
                     .put(super.nodeSettings(nodeOrdinal))
-                    .put("path.plugins", pluginDir.getAbsolutePath())
+                    .put("path.plugins", pluginDir.toAbsolutePath())
                     .put("force.http.enabled", true)
                     .build();
         } catch (URISyntaxException ex) {

--- a/src/test/java/org/elasticsearch/script/OnDiskScriptTests.java
+++ b/src/test/java/org/elasticsearch/script/OnDiskScriptTests.java
@@ -41,7 +41,7 @@ public class OnDiskScriptTests extends ElasticsearchIntegrationTest {
     public Settings nodeSettings(int nodeOrdinal) {
         //Set path so ScriptService will pick up the test scripts
         return settingsBuilder().put(super.nodeSettings(nodeOrdinal))
-                .put("path.conf", this.getResource("config").getPath()).build();
+                .put("path.conf", this.getResourcePath("config")).build();
     }
 
 

--- a/src/test/java/org/elasticsearch/script/ScriptServiceTests.java
+++ b/src/test/java/org/elasticsearch/script/ScriptServiceTests.java
@@ -29,7 +29,6 @@ import org.elasticsearch.test.ElasticsearchTestCase;
 import org.elasticsearch.watcher.ResourceWatcherService;
 import org.junit.Test;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -46,8 +45,8 @@ public class ScriptServiceTests extends ElasticsearchTestCase {
 
     @Test
     public void testScriptsWithoutExtensions() throws IOException {
-        Path homeFolder = newTempDir().toPath();
-        Path genericConfigFolder = newTempDir().toPath();
+        Path homeFolder = newTempDirPath();
+        Path genericConfigFolder = newTempDirPath();
 
         Settings settings = settingsBuilder()
                 .put("path.conf", genericConfigFolder)

--- a/src/test/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricTests.java
@@ -114,7 +114,7 @@ public class ScriptedMetricTests extends ElasticsearchIntegrationTest {
     protected Settings nodeSettings(int nodeOrdinal) {
         Settings settings = ImmutableSettings.settingsBuilder()
                 .put(super.nodeSettings(nodeOrdinal))
-                .put("path.conf", getResource("/org/elasticsearch/search/aggregations/metrics/scripted/conf"))
+                .put("path.conf", getResourcePath("/org/elasticsearch/search/aggregations/metrics/scripted/conf"))
                 .build();
         return settings;
     }

--- a/src/test/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreTests.java
+++ b/src/test/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreTests.java
@@ -25,6 +25,7 @@ import com.carrotsearch.randomizedtesting.LifecycleScope;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
+
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.action.ListenableActionFuture;
 import org.elasticsearch.action.admin.cluster.repositories.put.PutRepositoryResponse;
@@ -58,8 +59,8 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
@@ -116,7 +117,7 @@ public class DedicatedClusterSnapshotRestoreTests extends AbstractSnapshotTests 
 
     @Test
     public void restoreCustomMetadata() throws Exception {
-        File tempDir = newTempDir();
+        Path tempDir = newTempDirPath();
 
         logger.info("--> start node");
         internalCluster().startNode(settingsBuilder().put("gateway.type", "local"));
@@ -308,7 +309,7 @@ public class DedicatedClusterSnapshotRestoreTests extends AbstractSnapshotTests 
         assertThat(client.prepareCount("test-idx").get().getCount(), equalTo(100L));
 
         logger.info("--> creating repository");
-        File repo = newTempDir(LifecycleScope.TEST);
+        Path repo = newTempDirPath(LifecycleScope.TEST);
         PutRepositoryResponse putRepositoryResponse = client.admin().cluster().preparePutRepository("test-repo")
                 .setType(MockRepositoryModule.class.getCanonicalName()).setSettings(
                         ImmutableSettings.settingsBuilder()

--- a/src/test/java/org/elasticsearch/snapshots/RepositoriesTests.java
+++ b/src/test/java/org/elasticsearch/snapshots/RepositoriesTests.java
@@ -20,6 +20,7 @@ package org.elasticsearch.snapshots;
 
 import com.carrotsearch.randomizedtesting.LifecycleScope;
 import com.google.common.collect.ImmutableList;
+
 import org.elasticsearch.action.admin.cluster.repositories.delete.DeleteRepositoryResponse;
 import org.elasticsearch.action.admin.cluster.repositories.get.GetRepositoriesResponse;
 import org.elasticsearch.action.admin.cluster.repositories.put.PutRepositoryResponse;
@@ -29,6 +30,7 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.metadata.RepositoriesMetaData;
 import org.elasticsearch.cluster.metadata.RepositoryMetaData;
+import org.elasticsearch.common.io.FileSystemUtils;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.repositories.RepositoryException;
@@ -36,7 +38,7 @@ import org.elasticsearch.repositories.RepositoryVerificationException;
 import org.elasticsearch.snapshots.mockstore.MockRepositoryModule;
 import org.junit.Test;
 
-import java.io.File;
+import java.nio.file.Path;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertThrows;
@@ -52,7 +54,7 @@ public class RepositoriesTests extends AbstractSnapshotTests {
     public void testRepositoryCreation() throws Exception {
         Client client = client();
 
-        File location = newTempDir(LifecycleScope.SUITE);
+        Path location = newTempDirPath(LifecycleScope.SUITE);
 
         logger.info("-->  creating repository");
         PutRepositoryResponse putRepositoryResponse = client.admin().cluster().preparePutRepository("test-repo-1")
@@ -62,12 +64,12 @@ public class RepositoriesTests extends AbstractSnapshotTests {
         assertThat(putRepositoryResponse.isAcknowledged(), equalTo(true));
 
         logger.info("--> verify the repository");
-        int numberOfFiles = location.listFiles().length;
+        int numberOfFiles = FileSystemUtils.files(location).length;
         VerifyRepositoryResponse verifyRepositoryResponse = client.admin().cluster().prepareVerifyRepository("test-repo-1").get();
         assertThat(verifyRepositoryResponse.getNodes().length, equalTo(cluster().numDataAndMasterNodes()));
 
         logger.info("--> verify that we didn't leave any files as a result of verification");
-        assertThat(location.listFiles().length, equalTo(numberOfFiles));
+        assertThat(FileSystemUtils.files(location).length, equalTo(numberOfFiles));
 
         logger.info("--> check that repository is really there");
         ClusterStateResponse clusterStateResponse = client.admin().cluster().prepareState().clear().setMetaData(true).get();
@@ -185,7 +187,7 @@ public class RepositoriesTests extends AbstractSnapshotTests {
         logger.info("-->  verifying repository");
         assertThrows(client.admin().cluster().prepareVerifyRepository("test-repo-1"), RepositoryVerificationException.class);
 
-        File location = newTempDir(LifecycleScope.SUITE);
+        Path location = newTempDirPath(LifecycleScope.SUITE);
 
         logger.info("-->  creating repository");
         try {
@@ -220,7 +222,7 @@ public class RepositoriesTests extends AbstractSnapshotTests {
         logger.info("-->  verifying repository");
         assertThrows(client.admin().cluster().prepareVerifyRepository("test-repo-1"), RepositoryVerificationException.class);
 
-        File location = newTempDir(LifecycleScope.SUITE);
+        Path location = newTempDirPath(LifecycleScope.SUITE);
 
         logger.info("-->  creating repository");
         try {

--- a/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreTests.java
+++ b/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreTests.java
@@ -22,6 +22,7 @@ package org.elasticsearch.snapshots;
 import com.carrotsearch.randomizedtesting.LifecycleScope;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
+
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.LuceneTestCase.Slow;
 import org.elasticsearch.ExceptionsHelper;
@@ -53,8 +54,8 @@ import org.elasticsearch.repositories.RepositoriesService;
 import org.elasticsearch.snapshots.mockstore.MockRepositoryModule;
 import org.junit.Test;
 
-import java.io.File;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -76,7 +77,7 @@ public class SharedClusterSnapshotRestoreTests extends AbstractSnapshotTests {
         logger.info("-->  creating repository");
         assertAcked(client.admin().cluster().preparePutRepository("test-repo")
                 .setType("fs").setSettings(ImmutableSettings.settingsBuilder()
-                        .put("location", newTempDir(LifecycleScope.SUITE))
+                        .put("location", newTempDirPath(LifecycleScope.SUITE))
                         .put("compress", randomBoolean())
                         .put("chunk_size", randomIntBetween(100, 1000))));
 
@@ -169,7 +170,7 @@ public class SharedClusterSnapshotRestoreTests extends AbstractSnapshotTests {
         String indexName = "testindex";
         String repoName = "test-restore-snapshot-repo";
         String snapshotName = "test-restore-snapshot";
-        String absolutePath = newTempDir().getAbsolutePath();
+        String absolutePath = newTempDirPath().toAbsolutePath().toString();
         logger.info("Path [{}]", absolutePath);
         String restoredIndexName = indexName + "-restored";
         String typeName = "actions";
@@ -215,7 +216,7 @@ public class SharedClusterSnapshotRestoreTests extends AbstractSnapshotTests {
         logger.info("-->  creating repository");
         assertAcked(client.admin().cluster().preparePutRepository("test-repo")
                 .setType("fs").setSettings(ImmutableSettings.settingsBuilder()
-                        .put("location", newTempDir(LifecycleScope.SUITE))
+                        .put("location", newTempDirPath(LifecycleScope.SUITE))
                         .put("compress", randomBoolean())
                         .put("chunk_size", randomIntBetween(100, 1000))));
 
@@ -263,7 +264,7 @@ public class SharedClusterSnapshotRestoreTests extends AbstractSnapshotTests {
 
         logger.info("-->  creating repository");
         PutRepositoryResponse putRepositoryResponse = client.admin().cluster().preparePutRepository("test-repo")
-                .setType("fs").setSettings(ImmutableSettings.settingsBuilder().put("location", newTempDir())).get();
+                .setType("fs").setSettings(ImmutableSettings.settingsBuilder().put("location", newTempDirPath())).get();
         assertThat(putRepositoryResponse.isAcknowledged(), equalTo(true));
 
         logger.info("--> snapshot");
@@ -280,7 +281,7 @@ public class SharedClusterSnapshotRestoreTests extends AbstractSnapshotTests {
 
         logger.info("-->  creating repository");
         assertAcked(client.admin().cluster().preparePutRepository("test-repo")
-                .setType("fs").setSettings(ImmutableSettings.settingsBuilder().put("location", newTempDir())));
+                .setType("fs").setSettings(ImmutableSettings.settingsBuilder().put("location", newTempDirPath())));
 
         logger.info("--> create test indices");
         createIndex("test-idx-1", "test-idx-2", "test-idx-3");
@@ -336,7 +337,7 @@ public class SharedClusterSnapshotRestoreTests extends AbstractSnapshotTests {
 
         logger.info("-->  creating repository");
         assertAcked(client.admin().cluster().preparePutRepository("test-repo")
-                .setType("fs").setSettings(ImmutableSettings.settingsBuilder().put("location", newTempDir())));
+                .setType("fs").setSettings(ImmutableSettings.settingsBuilder().put("location", newTempDirPath())));
 
         logger.info("-->  creating test template");
         assertThat(client.admin().indices().preparePutTemplate("test-template").setTemplate("te*").addMapping("test-mapping", "{}").get().isAcknowledged(), equalTo(true));
@@ -368,7 +369,7 @@ public class SharedClusterSnapshotRestoreTests extends AbstractSnapshotTests {
         Client client = client();
 
         logger.info("-->  creating repository");
-        File location = newTempDir();
+        Path location = newTempDirPath();
         assertAcked(client.admin().cluster().preparePutRepository("test-repo")
                 .setType("fs").setSettings(ImmutableSettings.settingsBuilder().put("location", location)));
 
@@ -450,7 +451,7 @@ public class SharedClusterSnapshotRestoreTests extends AbstractSnapshotTests {
         assertAcked(client.admin().cluster().preparePutRepository("test-repo")
                 .setType(MockRepositoryModule.class.getCanonicalName()).setSettings(
                         ImmutableSettings.settingsBuilder()
-                                .put("location", newTempDir(LifecycleScope.TEST))
+                                .put("location", newTempDirPath(LifecycleScope.TEST))
                                 .put("random", randomAsciiOfLength(10))
                                 .put("random_control_io_exception_rate", 0.2))
                 .setVerify(false));
@@ -500,7 +501,7 @@ public class SharedClusterSnapshotRestoreTests extends AbstractSnapshotTests {
         assertAcked(client.admin().cluster().preparePutRepository("test-repo")
                 .setType(MockRepositoryModule.class.getCanonicalName()).setSettings(
                         ImmutableSettings.settingsBuilder()
-                                .put("location", newTempDir(LifecycleScope.TEST))
+                                .put("location", newTempDirPath(LifecycleScope.TEST))
                                 .put("random", randomAsciiOfLength(10))
                                 .put("random_data_file_io_exception_rate", 0.3)));
 
@@ -562,7 +563,7 @@ public class SharedClusterSnapshotRestoreTests extends AbstractSnapshotTests {
 
     @Test
     public void dataFileFailureDuringRestoreTest() throws Exception {
-        File repositoryLocation = newTempDir(LifecycleScope.TEST);
+        Path repositoryLocation = newTempDirPath(LifecycleScope.TEST);
         Client client = client();
         logger.info("-->  creating repository");
         assertAcked(client.admin().cluster().preparePutRepository("test-repo")
@@ -604,7 +605,7 @@ public class SharedClusterSnapshotRestoreTests extends AbstractSnapshotTests {
 
     @Test
     public void deletionOfFailingToRecoverIndexShouldStopRestore() throws Exception {
-        File repositoryLocation = newTempDir(LifecycleScope.TEST);
+        Path repositoryLocation = newTempDirPath(LifecycleScope.TEST);
         Client client = client();
         logger.info("-->  creating repository");
         assertAcked(client.admin().cluster().preparePutRepository("test-repo")
@@ -673,7 +674,7 @@ public class SharedClusterSnapshotRestoreTests extends AbstractSnapshotTests {
         logger.info("-->  creating repository");
         assertAcked(client.admin().cluster().preparePutRepository("test-repo")
                 .setType("fs").setSettings(ImmutableSettings.settingsBuilder()
-                        .put("location", newTempDir(LifecycleScope.SUITE))));
+                        .put("location", newTempDirPath(LifecycleScope.SUITE))));
 
         logger.info("-->  creating index that cannot be allocated");
         prepareCreate("test-idx", 2, ImmutableSettings.builder().put(FilterAllocationDecider.INDEX_ROUTING_INCLUDE_GROUP + ".tag", "nowhere").put("index.number_of_shards", 3)).get();
@@ -691,8 +692,8 @@ public class SharedClusterSnapshotRestoreTests extends AbstractSnapshotTests {
         final int numberOfSnapshots = between(5, 15);
         Client client = client();
 
-        File repo = newTempDir(LifecycleScope.SUITE);
-        logger.info("-->  creating repository at " + repo.getAbsolutePath());
+        Path repo = newTempDirPath(LifecycleScope.SUITE);
+        logger.info("-->  creating repository at " + repo.toAbsolutePath());
         assertAcked(client.admin().cluster().preparePutRepository("test-repo")
                 .setType("fs").setSettings(ImmutableSettings.settingsBuilder()
                         .put("location", repo)
@@ -748,8 +749,8 @@ public class SharedClusterSnapshotRestoreTests extends AbstractSnapshotTests {
     public void deleteSnapshotWithMissingIndexAndShardMetadataTest() throws Exception {
         Client client = client();
 
-        File repo = newTempDir(LifecycleScope.SUITE);
-        logger.info("-->  creating repository at " + repo.getAbsolutePath());
+        Path repo = newTempDirPath(LifecycleScope.SUITE);
+        logger.info("-->  creating repository at " + repo.toAbsolutePath());
         assertAcked(client.admin().cluster().preparePutRepository("test-repo")
                 .setType("fs").setSettings(ImmutableSettings.settingsBuilder()
                         .put("location", repo)
@@ -769,12 +770,12 @@ public class SharedClusterSnapshotRestoreTests extends AbstractSnapshotTests {
         assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(), equalTo(createSnapshotResponse.getSnapshotInfo().totalShards()));
 
         logger.info("--> delete index metadata and shard metadata");
-        File indices = new File(repo, "indices");
-        File testIndex1 = new File(indices, "test-idx-1");
-        File testIndex2 = new File(indices, "test-idx-2");
-        File testIndex2Shard0 = new File(testIndex2, "0");
-        IOUtils.deleteFilesIgnoringExceptions(new File(testIndex1, "snapshot-test-snap-1").toPath());
-        IOUtils.deleteFilesIgnoringExceptions(new File(testIndex2Shard0, "snapshot-test-snap-1").toPath());
+        Path indices = repo.resolve("indices");
+        Path testIndex1 = indices.resolve("test-idx-1");
+        Path testIndex2 = indices.resolve("test-idx-2");
+        Path testIndex2Shard0 = testIndex2.resolve("0");
+        IOUtils.deleteFilesIgnoringExceptions(testIndex1.resolve("snapshot-test-snap-1"));
+        IOUtils.deleteFilesIgnoringExceptions(testIndex2Shard0.resolve("snapshot-test-snap-1"));
 
         logger.info("--> delete snapshot");
         client.admin().cluster().prepareDeleteSnapshot("test-repo", "test-snap-1").get();
@@ -787,8 +788,8 @@ public class SharedClusterSnapshotRestoreTests extends AbstractSnapshotTests {
     public void deleteSnapshotWithMissingMetadataTest() throws Exception {
         Client client = client();
 
-        File repo = newTempDir(LifecycleScope.SUITE);
-        logger.info("-->  creating repository at " + repo.getAbsolutePath());
+        Path repo = newTempDirPath(LifecycleScope.SUITE);
+        logger.info("-->  creating repository at " + repo.toAbsolutePath());
         assertAcked(client.admin().cluster().preparePutRepository("test-repo")
                 .setType("fs").setSettings(ImmutableSettings.settingsBuilder()
                         .put("location", repo)
@@ -808,8 +809,8 @@ public class SharedClusterSnapshotRestoreTests extends AbstractSnapshotTests {
         assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(), equalTo(createSnapshotResponse.getSnapshotInfo().totalShards()));
 
         logger.info("--> delete index metadata and shard metadata");
-        File metadata = new File(repo, "metadata-test-snap-1");
-        Files.delete(metadata.toPath());
+        Path metadata = repo.resolve("metadata-test-snap-1");
+        Files.delete(metadata);
 
         logger.info("--> delete snapshot");
         client.admin().cluster().prepareDeleteSnapshot("test-repo", "test-snap-1").get();
@@ -825,7 +826,7 @@ public class SharedClusterSnapshotRestoreTests extends AbstractSnapshotTests {
         logger.info("-->  creating repository");
         assertAcked(client.admin().cluster().preparePutRepository("test-repo")
                 .setType("fs").setSettings(ImmutableSettings.settingsBuilder()
-                        .put("location", newTempDir(LifecycleScope.SUITE))));
+                        .put("location", newTempDirPath(LifecycleScope.SUITE))));
 
         createIndex("test-idx", "test-idx-closed");
         ensureGreen();
@@ -851,7 +852,7 @@ public class SharedClusterSnapshotRestoreTests extends AbstractSnapshotTests {
         logger.info("-->  creating repository");
         assertAcked(client.admin().cluster().preparePutRepository("test-repo")
                 .setType("fs").setSettings(ImmutableSettings.settingsBuilder()
-                        .put("location", newTempDir(LifecycleScope.SUITE))));
+                        .put("location", newTempDirPath(LifecycleScope.SUITE))));
 
         createIndex("test-idx");
         ensureGreen();
@@ -872,7 +873,7 @@ public class SharedClusterSnapshotRestoreTests extends AbstractSnapshotTests {
         logger.info("-->  creating repository");
         assertAcked(client.admin().cluster().preparePutRepository("test-repo")
                 .setType("fs").setSettings(ImmutableSettings.settingsBuilder()
-                        .put("location", newTempDir(LifecycleScope.SUITE))));
+                        .put("location", newTempDirPath(LifecycleScope.SUITE))));
 
         createIndex("test-idx-1", "test-idx-2", "test-idx-3");
         ensureGreen();
@@ -988,7 +989,7 @@ public class SharedClusterSnapshotRestoreTests extends AbstractSnapshotTests {
     @Test
     public void moveShardWhileSnapshottingTest() throws Exception {
         Client client = client();
-        File repositoryLocation = newTempDir(LifecycleScope.TEST);
+        Path repositoryLocation = newTempDirPath(LifecycleScope.TEST);
         logger.info("-->  creating repository");
         assertAcked(client.admin().cluster().preparePutRepository("test-repo")
                 .setType(MockRepositoryModule.class.getCanonicalName()).setSettings(
@@ -1050,7 +1051,7 @@ public class SharedClusterSnapshotRestoreTests extends AbstractSnapshotTests {
     @Test
     public void deleteRepositoryWhileSnapshottingTest() throws Exception {
         Client client = client();
-        File repositoryLocation = newTempDir(LifecycleScope.TEST);
+        Path repositoryLocation = newTempDirPath(LifecycleScope.TEST);
         logger.info("-->  creating repository");
         PutRepositoryResponse putRepositoryResponse = client.admin().cluster().preparePutRepository("test-repo")
                 .setType(MockRepositoryModule.class.getCanonicalName()).setSettings(
@@ -1092,7 +1093,7 @@ public class SharedClusterSnapshotRestoreTests extends AbstractSnapshotTests {
         logger.info("--> trying to move repository to another location");
         try {
             client.admin().cluster().preparePutRepository("test-repo")
-                    .setType("fs").setSettings(ImmutableSettings.settingsBuilder().put("location", new File(repositoryLocation, "test"))
+                    .setType("fs").setSettings(ImmutableSettings.settingsBuilder().put("location", repositoryLocation.resolve("test"))
             ).get();
             fail("shouldn't be able to replace in-use repository");
         } catch (Exception ex) {
@@ -1101,7 +1102,7 @@ public class SharedClusterSnapshotRestoreTests extends AbstractSnapshotTests {
 
         logger.info("--> trying to create a repository with different name");
         assertAcked(client.admin().cluster().preparePutRepository("test-repo-2")
-                .setType("fs").setSettings(ImmutableSettings.settingsBuilder().put("location", new File(repositoryLocation, "test"))));
+                .setType("fs").setSettings(ImmutableSettings.settingsBuilder().put("location", repositoryLocation.resolve("test"))));
 
         logger.info("--> unblocking blocked node");
         unblockNode(blockedNode);
@@ -1135,7 +1136,7 @@ public class SharedClusterSnapshotRestoreTests extends AbstractSnapshotTests {
         Client client = client();
 
         logger.info("-->  creating repository");
-        File repositoryLocation = newTempDir(LifecycleScope.SUITE);
+        Path repositoryLocation = newTempDirPath(LifecycleScope.SUITE);
         assertAcked(client.admin().cluster().preparePutRepository("test-repo")
                 .setType("fs").setSettings(ImmutableSettings.settingsBuilder()
                         .put("location", repositoryLocation)
@@ -1165,7 +1166,7 @@ public class SharedClusterSnapshotRestoreTests extends AbstractSnapshotTests {
         logger.info("--> create read-only URL repository");
         assertAcked(client.admin().cluster().preparePutRepository("url-repo")
                 .setType("url").setSettings(ImmutableSettings.settingsBuilder()
-                        .put("url", repositoryLocation.toURI().toURL())
+                        .put("url", repositoryLocation.toUri().toURL())
                         .put("list_directories", randomBoolean())));
         logger.info("--> restore index after deletion");
         RestoreSnapshotResponse restoreSnapshotResponse = client.admin().cluster().prepareRestoreSnapshot("url-repo", "test-snap").setWaitForCompletion(true).setIndices("test-idx").execute().actionGet();
@@ -1193,7 +1194,7 @@ public class SharedClusterSnapshotRestoreTests extends AbstractSnapshotTests {
         Client client = client();
 
         logger.info("-->  creating repository");
-        File repositoryLocation = newTempDir(LifecycleScope.SUITE);
+        Path repositoryLocation = newTempDirPath(LifecycleScope.SUITE);
         boolean throttleSnapshot = randomBoolean();
         boolean throttleRestore = randomBoolean();
         assertAcked(client.admin().cluster().preparePutRepository("test-repo")
@@ -1251,7 +1252,7 @@ public class SharedClusterSnapshotRestoreTests extends AbstractSnapshotTests {
     @Test
     public void snapshotStatusTest() throws Exception {
         Client client = client();
-        File repositoryLocation = newTempDir(LifecycleScope.TEST);
+        Path repositoryLocation = newTempDirPath(LifecycleScope.TEST);
         logger.info("-->  creating repository");
         PutRepositoryResponse putRepositoryResponse = client.admin().cluster().preparePutRepository("test-repo")
                 .setType(MockRepositoryModule.class.getCanonicalName()).setSettings(
@@ -1346,7 +1347,7 @@ public class SharedClusterSnapshotRestoreTests extends AbstractSnapshotTests {
         logger.info("-->  creating repository");
         assertAcked(client.admin().cluster().preparePutRepository("test-repo")
                 .setType("fs").setSettings(ImmutableSettings.settingsBuilder()
-                        .put("location", newTempDir(LifecycleScope.SUITE))
+                        .put("location", newTempDirPath(LifecycleScope.SUITE))
                         .put("compress", randomBoolean())
                         .put("chunk_size", randomIntBetween(100, 1000))));
 
@@ -1394,7 +1395,7 @@ public class SharedClusterSnapshotRestoreTests extends AbstractSnapshotTests {
         logger.info("-->  creating repository");
         assertAcked(client.admin().cluster().preparePutRepository("test-repo")
                 .setType("fs").setSettings(ImmutableSettings.settingsBuilder()
-                        .put("location", newTempDir(LifecycleScope.SUITE))
+                        .put("location", newTempDirPath(LifecycleScope.SUITE))
                         .put("compress", randomBoolean())
                         .put("chunk_size", randomIntBetween(100, 1000))));
 

--- a/src/test/java/org/elasticsearch/snapshots/mockstore/MockRepository.java
+++ b/src/test/java/org/elasticsearch/snapshots/mockstore/MockRepository.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.snapshots.mockstore;
 
 import com.google.common.collect.ImmutableMap;
+
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.common.blobstore.BlobMetaData;
@@ -33,7 +34,12 @@ import org.elasticsearch.repositories.RepositoryName;
 import org.elasticsearch.repositories.RepositorySettings;
 import org.elasticsearch.repositories.fs.FsRepository;
 
-import java.io.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.concurrent.ConcurrentHashMap;
@@ -92,9 +98,9 @@ public class MockRepository extends FsRepository {
     }
 
     private static Settings localizeLocation(Settings settings, ClusterService clusterService) {
-        File location = new File(settings.get("location"));
-        location = new File(location, clusterService.localNode().getId());
-        return settingsBuilder().put(settings).put("location", location.getAbsolutePath()).build();
+        Path location = Paths.get(settings.get("location"));
+        location = location.resolve(clusterService.localNode().getId());
+        return settingsBuilder().put(settings).put("location", location.toAbsolutePath()).build();
     }
 
     private void addFailure() {
@@ -200,9 +206,7 @@ public class MockRepository extends FsRepository {
                     int i = 0;
                     return ((bytes[i++] & 0xFF) << 24) | ((bytes[i++] & 0xFF) << 16)
                             | ((bytes[i++] & 0xFF) << 8) | (bytes[i++] & 0xFF);
-                } catch (NoSuchAlgorithmException ex) {
-                    throw new ElasticsearchException("cannot calculate hashcode", ex);
-                } catch (UnsupportedEncodingException ex) {
+                } catch (NoSuchAlgorithmException | UnsupportedEncodingException ex) {
                     throw new ElasticsearchException("cannot calculate hashcode", ex);
                 }
             }

--- a/src/test/java/org/elasticsearch/test/ElasticsearchBackwardsCompatIntegrationTest.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchBackwardsCompatIntegrationTest.java
@@ -37,8 +37,10 @@ import org.elasticsearch.transport.netty.NettyTransport;
 import org.junit.Before;
 import org.junit.Ignore;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.is;
@@ -84,7 +86,7 @@ import static org.hamcrest.Matchers.is;
 @Ignore
 public abstract class ElasticsearchBackwardsCompatIntegrationTest extends ElasticsearchIntegrationTest {
 
-    private static File backwardsCompatibilityPath() {
+    private static Path backwardsCompatibilityPath() {
         String path = System.getProperty(TESTS_BACKWARDS_COMPATIBILITY_PATH);
         if (path == null || path.isEmpty()) {
             throw new IllegalArgumentException("Must specify backwards test path with property " + TESTS_BACKWARDS_COMPATIBILITY_PATH);
@@ -97,12 +99,12 @@ public abstract class ElasticsearchBackwardsCompatIntegrationTest extends Elasti
             throw new IllegalArgumentException("Backcompat elasticsearch version must be same major version as current. " +
                 "backcompat: " + version + ", current: " + Version.CURRENT.toString());
         }
-        File file = new File(path, "elasticsearch-" + version);
-        if (!file.exists()) {
-            throw new IllegalArgumentException("Backwards tests location is missing: " + file.getAbsolutePath());
+        Path file = Paths.get(path, "elasticsearch-" + version);
+        if (!Files.exists(file)) {
+            throw new IllegalArgumentException("Backwards tests location is missing: " + file.toAbsolutePath());
         }
-        if (!file.isDirectory()) {
-            throw new IllegalArgumentException("Backwards tests location is not a directory: " + file.getAbsolutePath());
+        if (!Files.isDirectory(file)) {
+            throw new IllegalArgumentException("Backwards tests location is not a directory: " + file.toAbsolutePath());
         }
         return file;
     }

--- a/src/test/java/org/elasticsearch/test/ElasticsearchTestCase.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchTestCase.java
@@ -18,11 +18,13 @@
  */
 package org.elasticsearch.test;
 
+import com.carrotsearch.randomizedtesting.LifecycleScope;
 import com.carrotsearch.randomizedtesting.RandomizedTest;
 import com.carrotsearch.randomizedtesting.annotations.*;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope.Scope;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
+
 import org.apache.lucene.store.MockDirectoryWrapper;
 import org.apache.lucene.store.SimpleFSDirectory;
 import org.apache.lucene.util.AbstractRandomizedTest;
@@ -193,19 +195,6 @@ public abstract class ElasticsearchTestCase extends AbstractRandomizedTest {
 
     public static String randomNumericType(Random random) {
         return numericTypes[random.nextInt(numericTypes.length)];
-    }
-
-    /**
-     * Returns a {@link File} pointing to the class path relative resource given
-     * as the first argument. In contrast to
-     * <code>getClass().getResource(...).getFile()</code> this method will not
-     * return URL encoded paths if the parent path contains spaces or other
-     * non-standard characters.
-     */
-    @Deprecated
-    public File getResource(String relativePath) {
-        URI uri = URI.create(getClass().getResource(relativePath).toString());
-        return new File(uri);
     }
 
     /**
@@ -550,6 +539,37 @@ public abstract class ElasticsearchTestCase extends AbstractRandomizedTest {
     public static boolean terminate(ThreadPool service) throws InterruptedException {
         return ThreadPool.terminate(service, 10, TimeUnit.SECONDS);
     }
+    
+    // TODO: these method names stink, but are a temporary solution.
+    // see https://github.com/carrotsearch/randomizedtesting/pull/178
+
+    /**
+     * Returns a temporary file
+     */
+    public Path newTempFilePath() {
+        return newTempFile().toPath();
+    }
+    
+    /**
+     * Returns a temporary directory
+     */
+    public Path newTempDirPath() {
+        return newTempDir().toPath();
+    }
+    
+    /**
+     * Returns a temporary directory
+     */
+    public static Path newTempDirPath(LifecycleScope scope) {
+        return newTempDir(scope).toPath();
+    }
+    
+    /**
+     * Returns 'global' temp dir (seems like a bad idea)
+     */
+    public static Path globalTempDirPath() {
+        return globalTempDir().toPath();
+    }
 
     /**
      * Returns a random number of temporary paths.
@@ -558,7 +578,7 @@ public abstract class ElasticsearchTestCase extends AbstractRandomizedTest {
         final int numPaths = randomIntBetween(1, 3);
         final String[] absPaths = new String[numPaths];
         for (int i = 0; i < numPaths; i++) {
-            absPaths[i] = newTempDir().getAbsolutePath();
+            absPaths[i] = newTempDirPath().toAbsolutePath().toString();
         }
         return absPaths;
     }

--- a/src/test/java/org/elasticsearch/test/ExternalNode.java
+++ b/src/test/java/org/elasticsearch/test/ExternalNode.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.test;
 
 import com.google.common.base.Predicate;
+
 import org.apache.lucene.util.Constants;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
@@ -35,8 +36,10 @@ import org.elasticsearch.discovery.DiscoveryModule;
 import org.elasticsearch.transport.TransportModule;
 
 import java.io.Closeable;
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -57,7 +60,7 @@ final class ExternalNode implements Closeable {
             .put("node.mode", "network") // we need network mode for this
             .put("gateway.type", "local").build(); // we require local gateway to mimic upgrades of nodes
 
-    private final File path;
+    private final Path path;
     private final Random random;
     private final SettingsSource settingsSource;
     private Process process;
@@ -69,12 +72,12 @@ final class ExternalNode implements Closeable {
     private Settings externalNodeSettings;
 
 
-    ExternalNode(File path, long seed, SettingsSource settingsSource) {
+    ExternalNode(Path path, long seed, SettingsSource settingsSource) {
         this(path, null, seed, settingsSource);
     }
 
-    ExternalNode(File path, String clusterName, long seed, SettingsSource settingsSource) {
-        if (!path.isDirectory()) {
+    ExternalNode(Path path, String clusterName, long seed, SettingsSource settingsSource) {
+        if (!Files.isDirectory(path)) {
             throw new IllegalArgumentException("path must be a directory");
         }
         this.path = path;
@@ -127,11 +130,11 @@ final class ExternalNode implements Closeable {
             params.add("-Des." + entry.getKey() + "=" + entry.getValue());
         }
 
-        params.add("-Des.path.home=" + new File("").getAbsolutePath());
+        params.add("-Des.path.home=" + Paths.get(".").toAbsolutePath());
         params.add("-Des.path.conf=" + path + "/config");
 
         ProcessBuilder builder = new ProcessBuilder(params);
-        builder.directory(path);
+        builder.directory(path.toFile());
         builder.inheritIO();
         boolean success = false;
         try {

--- a/src/test/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/src/test/java/org/elasticsearch/test/InternalTestCluster.java
@@ -29,6 +29,7 @@ import com.google.common.collect.*;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
+
 import org.apache.lucene.store.Lock;
 import org.apache.lucene.store.NativeFSLockFactory;
 import org.apache.lucene.util.AbstractRandomizedTest;
@@ -108,6 +109,7 @@ import java.nio.file.FileVisitResult;
 import java.nio.file.FileVisitor;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.*;
 import java.util.concurrent.ExecutorService;
@@ -277,7 +279,7 @@ public final class InternalTestCluster extends TestCluster {
             if (numOfDataPaths > 0) {
                 StringBuilder dataPath = new StringBuilder();
                 for (int i = 0; i < numOfDataPaths; i++) {
-                    dataPath.append(new File("data/d" + i).getAbsolutePath()).append(',');
+                    dataPath.append(Paths.get("data/d" + i).toAbsolutePath()).append(',');
                 }
                 builder.put("path.data", dataPath.toString());
             }

--- a/src/test/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
+++ b/src/test/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
@@ -23,6 +23,7 @@ import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Iterables;
+
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.ElasticsearchException;
@@ -70,10 +71,10 @@ import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
 
-import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
@@ -787,22 +788,8 @@ public class ElasticsearchAssertions {
     /**
      * Check if a file exists
      */
-    public static void assertFileExists(File file) {
-        assertThat("file/dir [" + file + "] should exist.", file.exists(), is(true));
-    }
-
-    /**
-     * Check if a file exists
-     */
     public static void assertFileExists(Path file) {
-        assertFileExists(file.toFile());
-    }
-
-    /**
-     * Check if a directory exists
-     */
-    public static void assertDirectoryExists(File dir) {
-        assertFileExists(dir);
+        assertThat("file/dir [" + file + "] should exist.", Files.exists(file), is(true));
     }
 
     /**
@@ -810,5 +797,6 @@ public class ElasticsearchAssertions {
      */
     public static void assertDirectoryExists(Path dir) {
         assertFileExists(dir);
+        assertThat("file [" + dir + "] should be a directory.", Files.isDirectory(dir), is(true));
     }
 }

--- a/src/test/java/org/elasticsearch/test/rest/ElasticsearchRestTests.java
+++ b/src/test/java/org/elasticsearch/test/rest/ElasticsearchRestTests.java
@@ -25,6 +25,7 @@ import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import com.carrotsearch.randomizedtesting.annotations.TestGroup;
 import com.carrotsearch.randomizedtesting.annotations.TimeoutSuite;
 import com.google.common.collect.Lists;
+
 import org.apache.lucene.util.AbstractRandomizedTest;
 import org.apache.lucene.util.TimeUnits;
 import org.elasticsearch.Version;
@@ -47,6 +48,7 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileSystems;
+import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
 import java.util.*;
@@ -129,14 +131,14 @@ public class ElasticsearchRestTests extends ElasticsearchIntegrationTest {
 
     private static List<RestTestCandidate> collectTestCandidates() throws RestTestParseException, IOException {
         String[] paths = resolvePathsProperty(REST_TESTS_SUITE, DEFAULT_TESTS_PATH);
-        Map<String, Set<File>> yamlSuites = FileUtils.findYamlSuites(DEFAULT_TESTS_PATH, paths);
+        Map<String, Set<Path>> yamlSuites = FileUtils.findYamlSuites(DEFAULT_TESTS_PATH, paths);
 
         List<RestTestCandidate> testCandidates = Lists.newArrayList();
         RestTestSuiteParser restTestSuiteParser = new RestTestSuiteParser();
         //yaml suites are grouped by directory (effectively by api)
         for (String api : yamlSuites.keySet()) {
-            List<File> yamlFiles = Lists.newArrayList(yamlSuites.get(api));
-            for (File yamlFile : yamlFiles) {
+            List<Path> yamlFiles = Lists.newArrayList(yamlSuites.get(api));
+            for (Path yamlFile : yamlFiles) {
                 //tests distribution disabled for now since it causes reporting problems,
                 // due to the non unique suite name
                 //if (mustExecute(yamlFile.getAbsolutePath())) {

--- a/src/test/java/org/elasticsearch/test/rest/spec/RestSpec.java
+++ b/src/test/java/org/elasticsearch/test/rest/spec/RestSpec.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.test.rest.spec;
 
 import com.google.common.collect.Maps;
+
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.test.rest.support.FileUtils;
@@ -26,6 +27,9 @@ import org.elasticsearch.test.rest.support.FileUtils;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Map;
 
 /**
@@ -51,9 +55,9 @@ public class RestSpec {
     public static RestSpec parseFrom(String optionalPathPrefix, String... paths) throws IOException {
         RestSpec restSpec = new RestSpec();
         for (String path : paths) {
-            for (File jsonFile : FileUtils.findJsonSpec(optionalPathPrefix, path)) {
-                try {
-                    XContentParser parser = JsonXContent.jsonXContent.createParser(new FileInputStream(jsonFile));
+            for (Path jsonFile : FileUtils.findJsonSpec(optionalPathPrefix, path)) {
+                try (InputStream stream = Files.newInputStream(jsonFile)) {
+                    XContentParser parser = JsonXContent.jsonXContent.createParser(stream);
                     RestApi restApi = new RestApiParser().parse(parser);
                     restSpec.addApi(restApi);
                 } catch (Throwable ex) {

--- a/src/test/java/org/elasticsearch/test/rest/support/FileUtils.java
+++ b/src/test/java/org/elasticsearch/test/rest/support/FileUtils.java
@@ -20,13 +20,23 @@ package org.elasticsearch.test.rest.support;
 
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+
 import org.elasticsearch.common.Strings;
 
-import java.io.File;
-import java.io.FileFilter;
-import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
+import java.nio.file.DirectoryStream;
+import java.nio.file.FileSystems;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.NotDirectoryException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -43,25 +53,27 @@ public final class FileUtils {
      * Returns the json files found within the directory provided as argument.
      * Files are looked up in the classpath first, then outside of it if not found.
      */
-    public static Set<File> findJsonSpec(String optionalPathPrefix, String path) throws FileNotFoundException {
-        File dir = resolveFile(optionalPathPrefix, path, null);
+    public static Set<Path> findJsonSpec(String optionalPathPrefix, String path) throws IOException {
+        Path dir = resolveFile(optionalPathPrefix, path, null);
 
-        if (!dir.isDirectory()) {
-            throw new FileNotFoundException("file [" + path + "] is not a directory");
+        if (!Files.isDirectory(dir)) {
+            throw new NotDirectoryException(path);
         }
 
-        File[] jsonFiles = dir.listFiles(new FileFilter() {
-            @Override
-            public boolean accept(File pathname) {
-                return pathname.getName().endsWith(JSON_SUFFIX);
+        Set<Path> jsonFiles = new HashSet<>();
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(dir)) {
+            for (Path item : stream) {
+                if (item.toString().endsWith(JSON_SUFFIX)) {
+                    jsonFiles.add(item);
+                }
             }
-        });
-
-        if (jsonFiles == null || jsonFiles.length == 0) {
-            throw new FileNotFoundException("no json files found within [" + path + "]");
         }
 
-        return Sets.newHashSet(jsonFiles);
+        if (jsonFiles.isEmpty()) {
+            throw new NoSuchFileException(path, null, "no json files found");
+        }
+
+        return jsonFiles;
     }
 
     /**
@@ -69,15 +81,15 @@ public final class FileUtils {
      * Each input path can either be a single file (the .yaml suffix is optional) or a directory.
      * Each path is looked up in the classpath first, then outside of it if not found yet.
      */
-    public static Map<String, Set<File>> findYamlSuites(final String optionalPathPrefix, final String... paths) throws FileNotFoundException {
-        Map<String, Set<File>> yamlSuites = Maps.newHashMap();
+    public static Map<String, Set<Path>> findYamlSuites(final String optionalPathPrefix, final String... paths) throws IOException {
+        Map<String, Set<Path>> yamlSuites = Maps.newHashMap();
         for (String path : paths) {
             collectFiles(resolveFile(optionalPathPrefix, path, YAML_SUFFIX), YAML_SUFFIX, yamlSuites);
         }
         return yamlSuites;
     }
 
-    private static File resolveFile(String optionalPathPrefix, String path, String optionalFileSuffix) throws FileNotFoundException {
+    private static Path resolveFile(String optionalPathPrefix, String path, String optionalFileSuffix) throws IOException {
         //try within classpath with and without file suffix (as it could be a single test suite)
         URL resource = findResource(path, optionalFileSuffix);
         if (resource == null) {
@@ -85,16 +97,16 @@ public final class FileUtils {
             String newPath = optionalPathPrefix + "/" + path;
             resource = findResource(newPath, optionalFileSuffix);
             if (resource == null) {
-                //if it wasn't on classpath we look outside ouf the classpath
-                File file = findFile(path, optionalFileSuffix);
-                if (!file.exists()) {
-                    throw new FileNotFoundException("file [" + path + "] doesn't exist");
+                //if it wasn't on classpath we look outside of the classpath
+                Path file = findFile(path, optionalFileSuffix);
+                if (!Files.exists(file)) {
+                    throw new NoSuchFileException(path);
                 }
                 return file;
             }
         }
 
-        return new File(URI.create(resource.toString()));
+        return Paths.get(URI.create(resource.toString()));
     }
 
     private static URL findResource(String path, String optionalFileSuffix) {
@@ -108,38 +120,29 @@ public final class FileUtils {
         return resource;
     }
 
-    private static File findFile(String path, String optionalFileSuffix) {
-        File file = new File(path);
-        if (!file.exists()) {
-            file = new File(path + optionalFileSuffix);
+    private static Path findFile(String path, String optionalFileSuffix) {
+        Path file = Paths.get(path);
+        if (!Files.exists(file)) {
+            file = Paths.get(path + optionalFileSuffix);
         }
         return file;
     }
 
-    private static void collectFiles(final File file, final String fileSuffix, final Map<String, Set<File>> files) {
-        if (file.isFile()) {
-            String groupName = file.getParentFile().getName();
-            Set<File> filesSet = files.get(groupName);
-            if (filesSet == null) {
-                filesSet = Sets.newHashSet();
-                files.put(groupName, filesSet);
-            }
-            filesSet.add(file);
-        } else if (file.isDirectory()) {
-            walkDir(file, fileSuffix, files);
-        }
-    }
-
-    private static void walkDir(final File dir, final String fileSuffix, final Map<String, Set<File>> files) {
-        File[] children = dir.listFiles(new FileFilter() {
+    private static void collectFiles(final Path dir, final String fileSuffix, final Map<String, Set<Path>> files) throws IOException {
+        Files.walkFileTree(dir, new SimpleFileVisitor<Path>() {
             @Override
-            public boolean accept(File pathname) {
-                return pathname.isDirectory() || pathname.getName().endsWith(fileSuffix);
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                if (file.toString().endsWith(fileSuffix)) {
+                    String groupName = file.toAbsolutePath().getParent().getFileName().toString();
+                    Set<Path> filesSet = files.get(groupName);
+                    if (filesSet == null) {
+                        filesSet = Sets.newHashSet();
+                        files.put(groupName, filesSet);
+                    }
+                    filesSet.add(file);
+                }
+                return FileVisitResult.CONTINUE;
             }
         });
-
-        for (File file : children) {
-            collectFiles(file, fileSuffix, files);
-        }
     }
 }


### PR DESCRIPTION
Restrict use of java.io.File to 5 methods (excluded), but otherwise ban.
This is a prerequisite to do any mocking here.

I don't try to do any heavy cleanup on these tests, I am not familiar with them.
So this is mostly a rote straightforward conversion.
