### PR TITLE
NPE when plugins dir is inaccessible

### DIFF
--- a/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -34,6 +34,7 @@ import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.component.LifecycleComponent;
 import org.elasticsearch.common.inject.Module;
+import org.elasticsearch.common.io.FileSystemUtils;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.settings.ImmutableSettings;
@@ -469,7 +470,7 @@ public class PluginsService extends AbstractComponent {
         // Let's try to find all _site plugins we did not already found
         Path pluginsFile = environment.pluginsFile();
 
-        if (!Files.exists(pluginsFile) || !Files.isDirectory(pluginsFile)) {
+        if (FileSystemUtils.isAccessibleDirectory(pluginsFile, logger) == false) {
             return sitePlugins.build();
         }
 


### PR DESCRIPTION
Steps to reproduce:
1. Download fresh es.
2. `sudo mkdir plugins && sudo chmod 0700 plugins`
3. Start elasticsearch

```
elasticsearch-1.4.1 λ ./bin/elasticsearch
[2014-12-09 12:18:59,025][INFO ][node                     ] [Piotr Rasputin] version[1.4.1], pid[16338], build[89d3241/2014-11-26T15:49:29Z]
[2014-12-09 12:18:59,025][INFO ][node                     ] [Piotr Rasputin] initializing ...
{1.4.1}: Initialization Failed ...
- NullPointerException[null]
```

Closes #8837.
