### PR TITLE
make it possible to register a mapper for dynamic arrays

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/DocumentMapperParser.java
+++ b/src/main/java/org/elasticsearch/index/mapper/DocumentMapperParser.java
@@ -39,37 +39,11 @@ import org.elasticsearch.index.analysis.AnalysisService;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.codec.docvaluesformat.DocValuesFormatService;
 import org.elasticsearch.index.codec.postingsformat.PostingsFormatService;
-import org.elasticsearch.index.mapper.core.BinaryFieldMapper;
-import org.elasticsearch.index.mapper.core.BooleanFieldMapper;
-import org.elasticsearch.index.mapper.core.ByteFieldMapper;
-import org.elasticsearch.index.mapper.core.CompletionFieldMapper;
-import org.elasticsearch.index.mapper.core.DateFieldMapper;
-import org.elasticsearch.index.mapper.core.DoubleFieldMapper;
-import org.elasticsearch.index.mapper.core.FloatFieldMapper;
-import org.elasticsearch.index.mapper.core.IntegerFieldMapper;
-import org.elasticsearch.index.mapper.core.LongFieldMapper;
-import org.elasticsearch.index.mapper.core.Murmur3FieldMapper;
-import org.elasticsearch.index.mapper.core.ShortFieldMapper;
-import org.elasticsearch.index.mapper.core.StringFieldMapper;
-import org.elasticsearch.index.mapper.core.TokenCountFieldMapper;
-import org.elasticsearch.index.mapper.core.TypeParsers;
+import org.elasticsearch.index.mapper.array.DynamicArrayFieldMapperBuilderFactory;
+import org.elasticsearch.index.mapper.core.*;
 import org.elasticsearch.index.mapper.geo.GeoPointFieldMapper;
 import org.elasticsearch.index.mapper.geo.GeoShapeFieldMapper;
-import org.elasticsearch.index.mapper.internal.AllFieldMapper;
-import org.elasticsearch.index.mapper.internal.AnalyzerMapper;
-import org.elasticsearch.index.mapper.internal.BoostFieldMapper;
-import org.elasticsearch.index.mapper.internal.FieldNamesFieldMapper;
-import org.elasticsearch.index.mapper.internal.IdFieldMapper;
-import org.elasticsearch.index.mapper.internal.IndexFieldMapper;
-import org.elasticsearch.index.mapper.internal.ParentFieldMapper;
-import org.elasticsearch.index.mapper.internal.RoutingFieldMapper;
-import org.elasticsearch.index.mapper.internal.SizeFieldMapper;
-import org.elasticsearch.index.mapper.internal.SourceFieldMapper;
-import org.elasticsearch.index.mapper.internal.TTLFieldMapper;
-import org.elasticsearch.index.mapper.internal.TimestampFieldMapper;
-import org.elasticsearch.index.mapper.internal.TypeFieldMapper;
-import org.elasticsearch.index.mapper.internal.UidFieldMapper;
-import org.elasticsearch.index.mapper.internal.VersionFieldMapper;
+import org.elasticsearch.index.mapper.internal.*;
 import org.elasticsearch.index.mapper.ip.IpFieldMapper;
 import org.elasticsearch.index.mapper.object.ObjectMapper;
 import org.elasticsearch.index.mapper.object.RootObjectMapper;
@@ -102,19 +76,22 @@ public class DocumentMapperParser extends AbstractIndexComponent {
 
     private final Object typeParsersMutex = new Object();
     private final Version indexVersionCreated;
+    private final DynamicArrayFieldMapperBuilderFactory dynamicArrayFieldMapperBuilderFactory;
 
     private volatile ImmutableMap<String, Mapper.TypeParser> typeParsers;
     private volatile ImmutableMap<String, Mapper.TypeParser> rootTypeParsers;
 
     public DocumentMapperParser(Index index, @IndexSettings Settings indexSettings, AnalysisService analysisService,
                                 PostingsFormatService postingsFormatService, DocValuesFormatService docValuesFormatService,
-                                SimilarityLookupService similarityLookupService, ScriptService scriptService) {
+                                SimilarityLookupService similarityLookupService, ScriptService scriptService,
+                                @Nullable DynamicArrayFieldMapperBuilderFactory dynamicArrayFieldMapperBuilderFactory) {
         super(index, indexSettings);
         this.analysisService = analysisService;
         this.postingsFormatService = postingsFormatService;
         this.docValuesFormatService = docValuesFormatService;
         this.similarityLookupService = similarityLookupService;
         this.scriptService = scriptService;
+        this.dynamicArrayFieldMapperBuilderFactory = dynamicArrayFieldMapperBuilderFactory;
         MapBuilder<String, Mapper.TypeParser> typeParsersBuilder = new MapBuilder<String, Mapper.TypeParser>()
                 .put(ByteFieldMapper.CONTENT_TYPE, new ByteFieldMapper.TypeParser())
                 .put(ShortFieldMapper.CONTENT_TYPE, new ShortFieldMapper.TypeParser())
@@ -159,6 +136,11 @@ public class DocumentMapperParser extends AbstractIndexComponent {
                 .put(FieldNamesFieldMapper.NAME, new FieldNamesFieldMapper.TypeParser())
                 .immutableMap();
         indexVersionCreated = Version.indexCreated(indexSettings);
+    }
+
+    @Nullable
+    public DynamicArrayFieldMapperBuilderFactory dynamicArrayFieldMapperBuilderFactory() {
+        return dynamicArrayFieldMapperBuilderFactory;
     }
 
     public void putTypeParser(String type, Mapper.TypeParser typeParser) {

--- a/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -22,7 +22,10 @@ package org.elasticsearch.index.mapper;
 import com.carrotsearch.hppc.ObjectOpenHashSet;
 import com.google.common.base.Charsets;
 import com.google.common.base.Predicate;
-import com.google.common.collect.*;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.DelegatingAnalyzerWrapper;
 import org.apache.lucene.index.IndexOptions;
@@ -56,6 +59,7 @@ import org.elasticsearch.index.codec.docvaluesformat.DocValuesFormatService;
 import org.elasticsearch.index.codec.postingsformat.PostingsFormatService;
 import org.elasticsearch.index.fielddata.IndexFieldDataService;
 import org.elasticsearch.index.mapper.Mapper.BuilderContext;
+import org.elasticsearch.index.mapper.array.DynamicArrayFieldMapperBuilderFactoryProvider;
 import org.elasticsearch.index.mapper.internal.TypeFieldMapper;
 import org.elasticsearch.index.mapper.object.ObjectMapper;
 import org.elasticsearch.index.search.nested.NonNestedDocsFilter;
@@ -66,14 +70,9 @@ import org.elasticsearch.indices.TypeMissingException;
 import org.elasticsearch.percolator.PercolatorService;
 import org.elasticsearch.script.ScriptService;
 
-import java.io.File;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.net.MalformedURLException;
-import java.net.URISyntaxException;
 import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -128,12 +127,13 @@ public class MapperService extends AbstractIndexComponent  {
     @Inject
     public MapperService(Index index, @IndexSettings Settings indexSettings, Environment environment, AnalysisService analysisService, IndexFieldDataService fieldDataService,
                          PostingsFormatService postingsFormatService, DocValuesFormatService docValuesFormatService, SimilarityLookupService similarityLookupService,
-                         ScriptService scriptService) {
+                         ScriptService scriptService,
+                         DynamicArrayFieldMapperBuilderFactoryProvider dynamicArrayFieldMapperBuilderFactoryProvider) {
         super(index, indexSettings);
         this.analysisService = analysisService;
         this.fieldDataService = fieldDataService;
         this.fieldMappers = new FieldMappersLookup();
-        this.documentParser = new DocumentMapperParser(index, indexSettings, analysisService, postingsFormatService, docValuesFormatService, similarityLookupService, scriptService);
+        this.documentParser = new DocumentMapperParser(index, indexSettings, analysisService, postingsFormatService, docValuesFormatService, similarityLookupService, scriptService, dynamicArrayFieldMapperBuilderFactoryProvider.get());
         this.searchAnalyzer = new SmartIndexNameSearchAnalyzer(analysisService.defaultSearchAnalyzer());
         this.searchQuoteAnalyzer = new SmartIndexNameSearchQuoteAnalyzer(analysisService.defaultSearchQuoteAnalyzer());
 

--- a/src/main/java/org/elasticsearch/index/mapper/array/ArrayValueMapperParser.java
+++ b/src/main/java/org/elasticsearch/index/mapper/array/ArrayValueMapperParser.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper.array;
+
+/**
+ * A marker interface indicating that this mapper can handle array value, and the array
+ * itself should be passed to it.
+ *
+ *
+ */
+public interface ArrayValueMapperParser {
+}

--- a/src/main/java/org/elasticsearch/index/mapper/array/DynamicArrayFieldMapperBuilderFactory.java
+++ b/src/main/java/org/elasticsearch/index/mapper/array/DynamicArrayFieldMapperBuilderFactory.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper.array;
+
+import org.elasticsearch.index.mapper.Mapper;
+
+/**
+ * marker interface for a factory that creates Mapper.Builder
+ * which can handle a DynamicArrayField.
+ *
+ * This is used to create a Mapper.Builder which builds a mapper that is
+ * capable of handling dynamic arrays.
+ * Bind an implementation of this interface in a plugin to provide a
+ * mapper that is then used to parse dynamic arrays and create the appropriate mappings
+ * and field- and/or object-mappers.
+ */
+public interface DynamicArrayFieldMapperBuilderFactory {
+
+    public Mapper.Builder create(String name);
+}

--- a/src/main/java/org/elasticsearch/index/mapper/array/DynamicArrayFieldMapperBuilderFactoryProvider.java
+++ b/src/main/java/org/elasticsearch/index/mapper/array/DynamicArrayFieldMapperBuilderFactoryProvider.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper.array;
+
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Provider;
+
+/**
+ *  provides a DynamicArrayFieldMapperBuilderFactory if one is bound, else
+ *  this provider returns null.
+ *
+ *  So it's possible for external plugins to create DynamicArrayFields and
+ *  handle those on their own
+ */
+public class DynamicArrayFieldMapperBuilderFactoryProvider implements Provider<DynamicArrayFieldMapperBuilderFactory> {
+
+    @Inject(optional = true)
+    private DynamicArrayFieldMapperBuilderFactory dynamicArrayFieldMapperBuilderFactory;
+
+    @Override
+    public DynamicArrayFieldMapperBuilderFactory get() {
+        return dynamicArrayFieldMapperBuilderFactory;
+    }
+}

--- a/src/main/java/org/elasticsearch/index/mapper/array/DynamicArrayFieldMapperException.java
+++ b/src/main/java/org/elasticsearch/index/mapper/array/DynamicArrayFieldMapperException.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper.array;
+
+import java.io.IOException;
+
+/**
+ * Exception thrown when a dynamic array could not be parsed,
+ * its type could not be guessed or something worse happened.
+ *
+ * In this case no mapper and no fields are added.
+ *
+ * IOException is extended to fit the interface of
+ * {@linkplain org.elasticsearch.index.mapper.Mapper#parse(org.elasticsearch.index.mapper.ParseContext)}
+ */
+public class DynamicArrayFieldMapperException extends IOException {
+}

--- a/src/main/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapper.java
@@ -48,7 +48,7 @@ import org.elasticsearch.index.fielddata.FieldDataType;
 import org.elasticsearch.index.mapper.*;
 import org.elasticsearch.index.mapper.core.*;
 import org.elasticsearch.index.mapper.core.NumberFieldMapper.CustomNumericDocValuesField;
-import org.elasticsearch.index.mapper.object.ArrayValueMapperParser;
+import org.elasticsearch.index.mapper.array.ArrayValueMapperParser;
 import org.elasticsearch.index.similarity.SimilarityProvider;
 
 import java.io.IOException;

--- a/src/main/java/org/elasticsearch/index/mapper/object/DynamicValueMapperLookup.java
+++ b/src/main/java/org/elasticsearch/index/mapper/object/DynamicValueMapperLookup.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper.object;
+
+import org.elasticsearch.ElasticsearchIllegalStateException;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.joda.FormatDateTimeFormatter;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.mapper.Mapper;
+import org.elasticsearch.index.mapper.MapperBuilders;
+import org.elasticsearch.index.mapper.ParseContext;
+
+import java.io.IOException;
+
+import static org.elasticsearch.index.mapper.MapperBuilders.*;
+
+public class DynamicValueMapperLookup {
+
+    public static Mapper getMapper(final ParseContext context, String currentFieldName, XContentParser.Token token) throws IOException {
+        Mapper mapper = null;
+        Mapper.BuilderContext builderContext = new Mapper.BuilderContext(context.indexSettings(), context.path());
+        if (token == XContentParser.Token.VALUE_STRING) {
+            boolean resolved = false;
+
+            // do a quick test to see if its fits a dynamic template, if so, use it.
+            // we need to do it here so we can handle things like attachment templates, where calling
+            // text (to see if its a date) causes the binary value to be cleared
+            if (!resolved) {
+                Mapper.Builder builder = context.root().findTemplateBuilder(context, currentFieldName, "string", null);
+                if (builder != null) {
+                    mapper = builder.build(builderContext);
+                    resolved = true;
+                }
+            }
+
+            if (!resolved && context.root().dateDetection()) {
+                String text = context.parser().text();
+                // a safe check since "1" gets parsed as well
+                if (Strings.countOccurrencesOf(text, ":") > 1 || Strings.countOccurrencesOf(text, "-") > 1 || Strings.countOccurrencesOf(text, "/") > 1) {
+                    for (FormatDateTimeFormatter dateTimeFormatter : context.root().dynamicDateTimeFormatters()) {
+                        try {
+                            dateTimeFormatter.parser().parseMillis(text);
+                            Mapper.Builder builder = context.root().findTemplateBuilder(context, currentFieldName, "date");
+                            if (builder == null) {
+                                builder = dateField(currentFieldName).dateTimeFormatter(dateTimeFormatter);
+                            }
+                            mapper = builder.build(builderContext);
+                            resolved = true;
+                            break;
+                        } catch (Exception e) {
+                            // failure to parse this, continue
+                        }
+                    }
+                }
+            }
+            if (!resolved && context.root().numericDetection()) {
+                String text = context.parser().text();
+                try {
+                    Long.parseLong(text);
+                    Mapper.Builder builder = context.root().findTemplateBuilder(context, currentFieldName, "long");
+                    if (builder == null) {
+                        builder = longField(currentFieldName);
+                    }
+                    mapper = builder.build(builderContext);
+                    resolved = true;
+                } catch (Exception e) {
+                    // not a long number
+                }
+                if (!resolved) {
+                    try {
+                        Double.parseDouble(text);
+                        Mapper.Builder builder = context.root().findTemplateBuilder(context, currentFieldName, "double");
+                        if (builder == null) {
+                            builder = doubleField(currentFieldName);
+                        }
+                        mapper = builder.build(builderContext);
+                        resolved = true;
+                    } catch (Exception e) {
+                        // not a long number
+                    }
+                }
+            }
+            if (!resolved) {
+                Mapper.Builder builder = context.root().findTemplateBuilder(context, currentFieldName, "string");
+                if (builder == null) {
+                    builder = stringField(currentFieldName);
+                }
+                mapper = builder.build(builderContext);
+            }
+        } else if (token == XContentParser.Token.VALUE_NUMBER) {
+            XContentParser.NumberType numberType = context.parser().numberType();
+            if (numberType == XContentParser.NumberType.INT) {
+                if (context.parser().estimatedNumberType()) {
+                    Mapper.Builder builder = context.root().findTemplateBuilder(context, currentFieldName, "long");
+                    if (builder == null) {
+                        builder = longField(currentFieldName);
+                    }
+                    mapper = builder.build(builderContext);
+                } else {
+                    Mapper.Builder builder = context.root().findTemplateBuilder(context, currentFieldName, "integer");
+                    if (builder == null) {
+                        builder = integerField(currentFieldName);
+                    }
+                    mapper = builder.build(builderContext);
+                }
+            } else if (numberType == XContentParser.NumberType.LONG) {
+                Mapper.Builder builder = context.root().findTemplateBuilder(context, currentFieldName, "long");
+                if (builder == null) {
+                    builder = longField(currentFieldName);
+                }
+                mapper = builder.build(builderContext);
+            } else if (numberType == XContentParser.NumberType.FLOAT) {
+                if (context.parser().estimatedNumberType()) {
+                    Mapper.Builder builder = context.root().findTemplateBuilder(context, currentFieldName, "double");
+                    if (builder == null) {
+                        builder = doubleField(currentFieldName);
+                    }
+                    mapper = builder.build(builderContext);
+                } else {
+                    Mapper.Builder builder = context.root().findTemplateBuilder(context, currentFieldName, "float");
+                    if (builder == null) {
+                        builder = floatField(currentFieldName);
+                    }
+                    mapper = builder.build(builderContext);
+                }
+            } else if (numberType == XContentParser.NumberType.DOUBLE) {
+                Mapper.Builder builder = context.root().findTemplateBuilder(context, currentFieldName, "double");
+                if (builder == null) {
+                    builder = doubleField(currentFieldName);
+                }
+                mapper = builder.build(builderContext);
+            }
+        } else if (token == XContentParser.Token.VALUE_BOOLEAN) {
+            Mapper.Builder builder = context.root().findTemplateBuilder(context, currentFieldName, "boolean");
+            if (builder == null) {
+                builder = booleanField(currentFieldName);
+            }
+            mapper = builder.build(builderContext);
+        } else if (token == XContentParser.Token.VALUE_EMBEDDED_OBJECT) {
+            Mapper.Builder builder = context.root().findTemplateBuilder(context, currentFieldName, "binary");
+            if (builder == null) {
+                builder = binaryField(currentFieldName);
+            }
+            mapper = builder.build(builderContext);
+        } else if (token == XContentParser.Token.START_OBJECT){
+            Mapper.Builder builder = context.root().findTemplateBuilder(context, currentFieldName, "object");
+            if(builder == null){
+                builder = MapperBuilders.object(currentFieldName).enabled(true).pathType(context.path().pathType());
+            }
+            mapper = builder.build(builderContext);
+        } else {
+            Mapper.Builder builder = context.root().findTemplateBuilder(context, currentFieldName, null);
+            if (builder != null) {
+                mapper = builder.build(builderContext);
+            } else {
+                // TODO how do we identify dynamically that its a binary value?
+                throw new ElasticsearchIllegalStateException("Can't handle serializing a dynamic type with content token [" + token + "] and field name [" + currentFieldName + "]");
+            }
+        }
+        return mapper;
+    }
+}

--- a/src/test/java/org/elasticsearch/index/mapper/dynamic/DynamicArrayMapperTest.java
+++ b/src/test/java/org/elasticsearch/index/mapper/dynamic/DynamicArrayMapperTest.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.index.mapper.dynamic;
+
+
+import com.google.common.base.Predicate;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.mapper.*;
+import org.elasticsearch.index.mapper.array.DynamicArrayFieldMapperBuilderFactory;
+import org.elasticsearch.index.mapper.array.DynamicArrayFieldMapperException;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+@ElasticsearchIntegrationTest.ClusterScope(scope = ElasticsearchIntegrationTest.Scope.SUITE, numDataNodes = 1, numClientNodes = 0, enableRandomBenchNodes = false)
+public class DynamicArrayMapperTest extends ElasticsearchIntegrationTest {
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return ImmutableSettings.settingsBuilder()
+                .put(super.nodeSettings(nodeOrdinal))
+                .put("plugin.types", ExternalDynamicArrayMapperPlugin.class.getName())
+                .build();
+    }
+
+    @Test
+    public void testInjectionOfDynamicArrayMapper() throws Exception {
+        prepareCreate("test-array").addMapping("type",
+                XContentFactory.jsonBuilder()
+                        .startObject().startObject("type")
+                        .startObject("properties")
+                        .startObject("field1").field("type", "string").endObject()
+                        .endObject().endObject().endObject()).execute().get();
+        ensureYellow("test-array");
+
+        ExternalDynamicArrayMapperModule.Builder.BuilderFactory factory = (ExternalDynamicArrayMapperModule.Builder.BuilderFactory) internalCluster().getInstance(DynamicArrayFieldMapperBuilderFactory.class);
+        final ExternalDynamicArrayMapper mapper = new ExternalDynamicArrayMapper();
+        factory.dynamicArrayMapper(mapper);
+
+        index("test-array", "type", "1", XContentFactory.jsonBuilder()
+                .startObject()
+                    .startArray("field").value("a").value("b").value("c").endArray()
+                .endObject());
+        refresh();
+        waitNoPendingTasksOnAll();
+
+        assertThat(mapper.parsedTokens.size(), equalTo(4));
+        assertThat(mapper.parsedTokens.get(0), equalTo(XContentParser.Token.START_ARRAY));
+        assertThat(mapper.parsedTokens.get(1), equalTo(XContentParser.Token.VALUE_STRING));
+        assertThat(mapper.parsedTokens.get(2), equalTo(XContentParser.Token.VALUE_STRING));
+        assertThat(mapper.parsedTokens.get(3), equalTo(XContentParser.Token.VALUE_STRING));
+
+        assertThat(mapper.traversedFields.size(), is(1));
+        assertThat(mapper.traversedObjects.size(), is(1));
+
+        // cluster state is serialized asynchronously, wait for it.
+        awaitBusy(new Predicate<Object>() {
+            @Override
+            public boolean apply(Object input) {
+                return mapper.toXContentCalled >= 1;
+            }
+        });
+
+        // index again, another parse run will throw DynamicArrayMapperException
+        // but this will be catched
+        index("test-array", "type", "2", XContentFactory.jsonBuilder()
+                .startObject()
+                .array("field") // empty array
+                .endObject());
+    }
+
+    public static class ExternalDynamicArrayMapper implements Mapper {
+
+        public List<XContentParser.Token> parsedTokens = new ArrayList<>();
+        public List<FieldMapperListener> traversedFields = new ArrayList<>();
+        public List<ObjectMapperListener> traversedObjects = new ArrayList<>();
+        public int toXContentCalled = 0;
+
+        private boolean parsedOnce;
+
+        @Override
+        public String name() {
+            return "dynamic-test-mapper";
+        }
+
+        @Override
+        public void parse(ParseContext context) throws IOException {
+            if (parsedOnce) {
+                throw new DynamicArrayFieldMapperException();
+            } else {
+                XContentParser parser = context.parser();
+                XContentParser.Token token = parser.currentToken();
+                while(token != XContentParser.Token.END_ARRAY){
+                    parsedTokens.add(token);
+                    token = parser.nextToken();
+                }
+            }
+            parsedOnce = true;
+        }
+
+        @Override
+        public void merge(Mapper mergeWith, MergeContext mergeContext) throws MergeMappingException { }
+
+        @Override
+        public void traverse(FieldMapperListener fieldMapperListener) {
+            traversedFields.add(fieldMapperListener);
+        }
+
+        @Override
+        public void traverse(ObjectMapperListener objectMapperListener) {
+            traversedObjects.add(objectMapperListener);
+        }
+
+        @Override
+        public void close() { }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            toXContentCalled += 1;
+            return builder;
+        }
+
+    }
+}

--- a/src/test/java/org/elasticsearch/index/mapper/dynamic/ExternalDynamicArrayMapperModule.java
+++ b/src/test/java/org/elasticsearch/index/mapper/dynamic/ExternalDynamicArrayMapperModule.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.index.mapper.dynamic;
+
+
+import org.elasticsearch.common.inject.AbstractModule;
+import org.elasticsearch.index.mapper.Mapper;
+import org.elasticsearch.index.mapper.array.DynamicArrayFieldMapperBuilderFactory;
+
+public class ExternalDynamicArrayMapperModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+        bind(DynamicArrayFieldMapperBuilderFactory.class).to(Builder.BuilderFactory.class).asEagerSingleton();
+    }
+
+    public static class Builder extends Mapper.Builder<Builder, DynamicArrayMapperTest.ExternalDynamicArrayMapper> {
+
+        public static class BuilderFactory implements DynamicArrayFieldMapperBuilderFactory {
+
+            private DynamicArrayMapperTest.ExternalDynamicArrayMapper dynamicArrayMapper;
+
+            public void dynamicArrayMapper(DynamicArrayMapperTest.ExternalDynamicArrayMapper mapper){
+                this.dynamicArrayMapper = mapper;
+            }
+
+            public Builder create(String name){
+                Builder builder = new Builder(name);
+                builder.dynamicArrayMapper(this.dynamicArrayMapper);
+                return builder;
+            }
+        }
+
+        private DynamicArrayMapperTest.ExternalDynamicArrayMapper dynamicArrayMapper;
+
+        public void dynamicArrayMapper(DynamicArrayMapperTest.ExternalDynamicArrayMapper mapper){
+            this.dynamicArrayMapper = mapper;
+        }
+
+        public Builder(String name) {
+            super(name);
+        }
+
+        @Override
+        public DynamicArrayMapperTest.ExternalDynamicArrayMapper build(Mapper.BuilderContext context) {
+            return dynamicArrayMapper;
+        }
+    }
+}

--- a/src/test/java/org/elasticsearch/index/mapper/dynamic/ExternalDynamicArrayMapperPlugin.java
+++ b/src/test/java/org/elasticsearch/index/mapper/dynamic/ExternalDynamicArrayMapperPlugin.java
@@ -16,14 +16,32 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+package org.elasticsearch.index.mapper.dynamic;
 
-package org.elasticsearch.index.mapper.object;
 
-/**
- * A marker interface indicating that this mapper can handle array value, and the array
- * itself should be passed to it.
- *
- *
- */
-public interface ArrayValueMapperParser {
+import org.elasticsearch.common.inject.Module;
+import org.elasticsearch.plugins.AbstractPlugin;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class ExternalDynamicArrayMapperPlugin extends AbstractPlugin {
+
+    @Override
+    public String name() {
+        return "dynamic-array-mapper";
+    }
+
+    @Override
+    public String description() {
+        return "External Dynamic array Mapper Plugin";
+    }
+
+    @Override
+    public Collection<Class<? extends Module>> modules() {
+        Collection<Class<? extends Module>> modules = new ArrayList<>();
+        modules.add(ExternalDynamicArrayMapperModule.class);
+        return modules;
+    }
+
 }


### PR DESCRIPTION
A DynamicArrayFieldMapperBuilderFactory has to be implemented which returns a
Builder for a mapper that is able to handle dynamic arrays and creates FieldMappers and/or ObjectMappers for it.
It's main usecase is mapping arrays explicitly. For this to work consistently even with dynamic fields
it is necessary to catch parsing dynamic array columns in the indexed sources.

If no DynamicArrayFieldMapperBuilderFactory is bound via guice, everything is working as before.

An example for usage of this feature is: https://github.com/crate/crate/blob/1c6252c27d6b85642915f83ceab48660e47b8c2c/sql/src/main/java/org/elasticsearch/index/mapper/core/ArrayMapper.java
There we actually added an explicit array type and use it for dynamic arrays as well to stay consistent even with dynamically added columns. 
