### PR TITLE
[TEST] LoggingListener to restore the initial logger levels after any modification

### DIFF
--- a/src/test/java/org/elasticsearch/test/junit/listeners/LoggingListener.java
+++ b/src/test/java/org/elasticsearch/test/junit/listeners/LoggingListener.java
@@ -47,7 +47,7 @@ public class LoggingListener extends RunListener {
 
     @Override
     public void testRunStarted(Description description) throws Exception {
-        previousPackageLoggingMap = processTestLogging( description.getTestClass().getPackage().getAnnotation(TestLogging.class));
+        previousPackageLoggingMap = processTestLogging(description.getTestClass().getPackage().getAnnotation(TestLogging.class));
         previousClassLoggingMap = processTestLogging(description.getAnnotation(TestLogging.class));
     }
 
@@ -80,11 +80,13 @@ public class LoggingListener extends RunListener {
         if (map == null) {
             return null;
         }
+        Map<String, String> previousValues = new HashMap<>();
         for (Map.Entry<String, String> entry : map.entrySet()) {
             ESLogger esLogger = resolveLogger(entry.getKey());
+            previousValues.put(entry.getKey(), esLogger.getLevel());
             esLogger.setLevel(entry.getValue());
         }
-        return map;
+        return previousValues;
     }
 
     public static Map<String, String> getLoggersAndLevelsFromAnnotation(TestLogging testLogging) {

--- a/src/test/java/org/elasticsearch/test/test/LoggingListenerTests.java
+++ b/src/test/java/org/elasticsearch/test/test/LoggingListenerTests.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test.test;
+
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.test.junit.annotations.TestLogging;
+import org.elasticsearch.test.junit.listeners.LoggingListener;
+import org.junit.Test;
+import org.junit.runner.Description;
+import org.junit.runner.Result;
+
+import java.lang.reflect.Method;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
+
+public class LoggingListenerTests extends ElasticsearchTestCase {
+
+    @Test
+    public void testCustomLevelPerMethod() throws Exception {
+
+        LoggingListener loggingListener = new LoggingListener();
+
+        Description suiteDescription = Description.createSuiteDescription(TestClass.class);
+
+        ESLogger abcLogger = Loggers.getLogger("abc");
+        ESLogger xyzLogger = Loggers.getLogger("xyz");
+
+        assertThat(abcLogger.getLevel(), nullValue());
+        assertThat(xyzLogger.getLevel(), nullValue());
+        loggingListener.testRunStarted(suiteDescription);
+        assertThat(xyzLogger.getLevel(), nullValue());
+        assertThat(abcLogger.getLevel(), nullValue());
+
+        Method method = TestClass.class.getDeclaredMethod("annotatedTestMethod");
+        TestLogging annotation = method.getAnnotation(TestLogging.class);
+        Description testDescription = Description.createTestDescription(LoggingListenerTests.class, "annotatedTestMethod", annotation);
+        loggingListener.testStarted(testDescription);
+        assertThat(xyzLogger.getLevel(), equalTo("TRACE"));
+        assertThat(abcLogger.getLevel(), nullValue());
+
+        loggingListener.testFinished(testDescription);
+        assertThat(xyzLogger.getLevel(), nullValue());
+        assertThat(abcLogger.getLevel(), nullValue());
+
+        loggingListener.testRunFinished(new Result());
+        assertThat(xyzLogger.getLevel(), nullValue());
+        assertThat(abcLogger.getLevel(), nullValue());
+    }
+
+    @Test
+    public void testCustomLevelPerClass() throws Exception {
+
+        LoggingListener loggingListener = new LoggingListener();
+
+        Description suiteDescription = Description.createSuiteDescription(AnnotatedTestClass.class);
+
+        ESLogger abcLogger = Loggers.getLogger("abc");
+        ESLogger xyzLogger = Loggers.getLogger("xyz");
+
+        assertThat(xyzLogger.getLevel(), nullValue());
+        assertThat(abcLogger.getLevel(), nullValue());
+        loggingListener.testRunStarted(suiteDescription);
+        assertThat(abcLogger.getLevel(), equalTo("ERROR"));
+        assertThat(xyzLogger.getLevel(), nullValue());
+
+        Description testDescription = Description.createTestDescription(LoggingListenerTests.class, "test");
+        loggingListener.testStarted(testDescription);
+        assertThat(abcLogger.getLevel(), equalTo("ERROR"));
+        assertThat(xyzLogger.getLevel(), nullValue());
+
+        loggingListener.testFinished(testDescription);
+        assertThat(abcLogger.getLevel(), equalTo("ERROR"));
+        assertThat(xyzLogger.getLevel(), nullValue());
+
+        loggingListener.testRunFinished(new Result());
+        assertThat(abcLogger.getLevel(), nullValue());
+        assertThat(xyzLogger.getLevel(), nullValue());
+    }
+
+    @Test
+    public void testCustomLevelPerClassAndPerMethod() throws Exception {
+
+        LoggingListener loggingListener = new LoggingListener();
+
+        Description suiteDescription = Description.createSuiteDescription(AnnotatedTestClass.class);
+
+        ESLogger abcLogger = Loggers.getLogger("abc");
+        ESLogger xyzLogger = Loggers.getLogger("xyz");
+
+        assertThat(xyzLogger.getLevel(), nullValue());
+        assertThat(abcLogger.getLevel(), nullValue());
+        loggingListener.testRunStarted(suiteDescription);
+        assertThat(abcLogger.getLevel(), equalTo("ERROR"));
+        assertThat(xyzLogger.getLevel(), nullValue());
+
+        Method method = TestClass.class.getDeclaredMethod("annotatedTestMethod");
+        TestLogging annotation = method.getAnnotation(TestLogging.class);
+        Description testDescription = Description.createTestDescription(LoggingListenerTests.class, "annotatedTestMethod", annotation);
+        loggingListener.testStarted(testDescription);
+        assertThat(abcLogger.getLevel(), equalTo("ERROR"));
+        assertThat(xyzLogger.getLevel(), equalTo("TRACE"));
+
+        loggingListener.testFinished(testDescription);
+        assertThat(abcLogger.getLevel(), equalTo("ERROR"));
+        assertThat(xyzLogger.getLevel(), nullValue());
+
+        Method method2 = TestClass.class.getDeclaredMethod("annotatedTestMethod2");
+        TestLogging annotation2 = method2.getAnnotation(TestLogging.class);
+        Description testDescription2 = Description.createTestDescription(LoggingListenerTests.class, "annotatedTestMethod2", annotation2);
+        loggingListener.testStarted(testDescription2);
+        assertThat(abcLogger.getLevel(), equalTo("TRACE"));
+        assertThat(xyzLogger.getLevel(), equalTo("DEBUG"));
+
+        loggingListener.testFinished(testDescription2);
+        assertThat(abcLogger.getLevel(), equalTo("ERROR"));
+        assertThat(xyzLogger.getLevel(), nullValue());
+
+        loggingListener.testRunFinished(new Result());
+        assertThat(abcLogger.getLevel(), nullValue());
+        assertThat(xyzLogger.getLevel(), nullValue());
+    }
+
+    @TestLogging("abc:ERROR")
+    public static class AnnotatedTestClass {
+        //dummy class used to create a junit suite description that has the @TestLogging annotation
+    }
+
+    public static class TestClass {
+        //dummy class used to create a junit suite description that doesn't have the @TestLogging annotation, but its test methods have it
+
+        @SuppressWarnings("unused")
+        @TestLogging("xyz:TRACE")
+        public void annotatedTestMethod() {}
+
+        @SuppressWarnings("unused")
+        @TestLogging("abc:TRACE,xyz:DEBUG")
+        public void annotatedTestMethod2() {}
+    }
+}


### PR DESCRIPTION
Recent changes made to LoggingListener and pushed with #8820 caused the original logger levels not to be reset after modifications, as the new state was saved for restore instead of the previous one.

Added unit tests for LoggingListener as well.
