### PR TITLE
Hard wire utf-8 encoding, so unicode filenames work

### DIFF
--- a/bin/elasticsearch.in.bat
+++ b/bin/elasticsearch.in.bat
@@ -79,5 +79,8 @@ REM JAVA_OPTS=%JAVA_OPTS% -XX:HeapDumpPath=$ES_HOME/logs/heapdump.hprof
 REM Disables explicit GC
 set JAVA_OPTS=%JAVA_OPTS% -XX:+DisableExplicitGC
 
+REM Ensure UTF-8 encoding by default (e.g. filenames)
+set JAVA_OPTS=%JAVA_OPTS% -Dfile.encoding=UTF-8
+
 set ES_CLASSPATH=%ES_CLASSPATH%;%ES_HOME%/lib/${project.build.finalName}.jar;%ES_HOME%/lib/*;%ES_HOME%/lib/sigar/*
 set ES_PARAMS=-Delasticsearch -Des-foreground=yes -Des.path.home="%ES_HOME%"

--- a/bin/elasticsearch.in.sh
+++ b/bin/elasticsearch.in.sh
@@ -65,3 +65,6 @@ JAVA_OPTS="$JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError"
 
 # Disables explicit GC
 JAVA_OPTS="$JAVA_OPTS -XX:+DisableExplicitGC"
+
+# Ensure UTF-8 encoding by default (e.g. filenames)
+JAVA_OPTS="$JAVA_OPTS -Dfile.encoding=UTF-8"


### PR DESCRIPTION
Today e.g unicode index names are allowed, but you will get no error if a machine is misconfigured. Because they are allowed, we should explicitly set UTF-8 encoding by default.

For a server-side app, this is really a good flag to pass to the JVM anyway. it will dodge bugs in third party libraries and so on.
