### PR TITLE
Add support for adding multiple fields to QueryStringQueryBuilder

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
@@ -138,6 +138,19 @@ public class QueryStringQueryBuilder extends BaseQueryBuilder implements Boostab
         return this;
     }
 
+   /**
+     * Adds multiple fields to run the query string against.
+     */
+    public QueryStringQueryBuilder fields(String... fieldList) {
+        for (String field : fieldList) {
+            if (fields == null) {
+                fields = newArrayList();
+            }
+            fields.add(field);
+        }
+        return this;
+    }
+
     /**
      * When more than one field is used with the query string, should queries be combined using
      * dis max, or boolean query. Defaults to dis max (<tt>true</tt>).

--- a/src/test/java/org/elasticsearch/search/query/SimpleQueryTests.java
+++ b/src/test/java/org/elasticsearch/search/query/SimpleQueryTests.java
@@ -1639,6 +1639,8 @@ public class SimpleQueryTests extends ElasticsearchIntegrationTest {
         logger.info("regexp");
         assertHitCount(client().prepareSearch("test").setQuery(queryStringQuery("/value[01]/").field("field1").field("field2")).get(), 1);
         assertHitCount(client().prepareSearch("test").setQuery(queryStringQuery("field\\*:/value[01]/")).get(), 1);
+        logger.info("varargs");
+        assertHitCount(client().prepareSearch("test").setQuery(queryStringQuery("value*").fields("field1", "field2")).get(), 1);
     }
 
     // see #3881 - for extensive description of the issue


### PR DESCRIPTION
Adds support for adding multiple fields at once to QueryStringQueryBuilder. It is already possible to do this via JSON, but the Java support is missing. 

<pre><code>
{
    "query_string" : {
        "fields" : ["content", "name"],
        "query" : "this AND that"
    }
}
</code></pre>

http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html
