### PR TITLE
remove global shared test cluster

### DIFF
--- a/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
@@ -139,21 +139,17 @@ import static org.hamcrest.Matchers.*;
 
 /**
  * {@link ElasticsearchIntegrationTest} is an abstract base class to run integration
- * tests against a JVM private Elasticsearch Cluster. The test class supports 3 different
+ * tests against a JVM private Elasticsearch Cluster. The test class supports 2 different
  * cluster scopes.
  * <ul>
- * <li>{@link Scope#GLOBAL} - uses a cluster shared across test suites. This cluster doesn't allow any modifications to
- * the cluster settings and will fail if any persistent cluster settings are applied during tear down.</li>
  * <li>{@link Scope#TEST} - uses a new cluster for each individual test method.</li>
  * <li>{@link Scope#SUITE} - uses a cluster shared across all test method in the same suite</li>
  * </ul>
  * <p/>
- * The most common test scope it {@link Scope#GLOBAL} which shares a cluster per JVM. This cluster is only set-up once
- * and can be used as long as the tests work on a per index basis without changing any cluster wide settings or require
- * any specific node configuration. This is the best performing option since it sets up the cluster only once.
+ * The most common test scope it {@link Scope#SUITE} which shares a cluster per test suite.
  * <p/>
- * If the tests need specific node settings or change persistent and/or transient cluster settings either {@link Scope#TEST}
- * or {@link Scope#SUITE} should be used. To configure a scope for the test cluster the {@link ClusterScope} annotation
+ * If the test methods need specific node settings or change persistent and/or transient cluster settings {@link Scope#TEST}
+ * should be used. To configure a scope for the test cluster the {@link ClusterScope} annotation
  * should be used, here is an example:
  * <pre>
  *
@@ -162,12 +158,11 @@ import static org.hamcrest.Matchers.*;
  * }
  * </pre>
  * <p/>
- * If no {@link ClusterScope} annotation is present on an integration test the default scope it {@link Scope#GLOBAL}
+ * If no {@link ClusterScope} annotation is present on an integration test the default scope is {@link Scope#SUITE}
  * <p/>
  * A test cluster creates a set of nodes in the background before the test starts. The number of nodes in the cluster is
- * determined at random and can change across tests. The minimum number of nodes in the shared global cluster is <code>2</code>.
- * For other scopes the {@link ClusterScope} allows configuring the initial number of nodes that are created before
- * the tests start.
+ * determined at random and can change across tests. The {@link ClusterScope} allows configuring the initial number of nodes 
+ * that are created before the tests start.
  * <p/>
  *  <pre>
  * @ClusterScope(scope=Scope.SUITE, numDataNodes=3)
@@ -200,7 +195,6 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
     public static final String SUITE_CLUSTER_NODE_PREFIX = "node_s";
     public static final String TEST_CLUSTER_NODE_PREFIX = "node_t";
 
-    private static TestCluster GLOBAL_CLUSTER;
     /**
      * Key used to set the transport client ratio via the commandline -D{@value #TESTS_CLIENT_RATIO}
      */
@@ -273,9 +267,6 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
         try {
             final Scope currentClusterScope = getCurrentClusterScope();
             switch (currentClusterScope) {
-                case GLOBAL:
-                    currentCluster = buildAndPutCluster(currentClusterScope, SeedUtils.parseSeed(RandomizedContext.current().getRunnerSeedAsString()));
-                    break;
                 case SUITE:
                     assert SUITE_SEED != null : "Suite seed was not initialized";
                     currentCluster = buildAndPutCluster(currentClusterScope, SUITE_SEED.longValue());
@@ -558,12 +549,6 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
         TestCluster testCluster = clusters.remove(clazz); // remove this cluster first
         clearClusters(); // all leftovers are gone by now... this is really just a double safety if we miss something somewhere
         switch (currentClusterScope) {
-            case GLOBAL:
-                // never put the global cluster into the map otherwise it will be closed
-                if (GLOBAL_CLUSTER == null) {
-                    return GLOBAL_CLUSTER = buildWithPrivateContext(currentClusterScope, seed);
-                }
-                return GLOBAL_CLUSTER;
             case SUITE:
                 if (testCluster == null) { // only build if it's not there yet
                     testCluster = buildWithPrivateContext(currentClusterScope, seed);
@@ -575,7 +560,6 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
                 testCluster = buildTestCluster(currentClusterScope, seed);
                 break;
         }
-        assert testCluster != GLOBAL_CLUSTER : "Global cluster must be handled via the GLOBAL_CLUSTER static member";
         clusters.put(clazz, testCluster);
         return testCluster;
     }
@@ -622,12 +606,6 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
                 // we also reset everything in the case we had a failure in the suite to make sure subsequent
                 // tests get a new / clean cluster
                 clearClusters();
-                if (currentCluster == GLOBAL_CLUSTER) {
-                    if (GLOBAL_CLUSTER != null) {
-                        IOUtils.closeWhileHandlingException(GLOBAL_CLUSTER);
-                    }
-                    GLOBAL_CLUSTER = null;
-                }
                 currentCluster = null;
             }
             if (currentCluster != null) {
@@ -1405,11 +1383,6 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
      */
     public static enum Scope {
         /**
-         * A globally shared cluster. This cluster doesn't allow modification of transient or persistent
-         * cluster settings.
-         */
-        GLOBAL,
-        /**
          * A cluster shared across all method in a single test suite
          */
         SUITE,
@@ -1428,9 +1401,9 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
     @Target({ElementType.TYPE})
     public @interface ClusterScope {
         /**
-         * Returns the scope. {@link org.elasticsearch.test.ElasticsearchIntegrationTest.Scope#GLOBAL} is default.
+         * Returns the scope. {@link org.elasticsearch.test.ElasticsearchIntegrationTest.Scope#SUITE} is default.
          */
-        Scope scope() default Scope.GLOBAL;
+        Scope scope() default Scope.SUITE;
 
         /**
          * Returns the number of nodes in the cluster. Default is <tt>-1</tt> which means
@@ -1544,8 +1517,8 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
 
     private static Scope getCurrentClusterScope(Class<?> clazz) {
         ClusterScope annotation = getAnnotation(clazz);
-        // if we are not annotated assume global!
-        return annotation == null ? Scope.GLOBAL : annotation.scope();
+        // if we are not annotated assume suite!
+        return annotation == null ? Scope.SUITE : annotation.scope();
     }
 
     private int getNumDataNodes() {
@@ -1613,12 +1586,6 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
         SettingsSource settingsSource = InternalTestCluster.DEFAULT_SETTINGS_SOURCE;
         final String nodePrefix;
         switch (scope) {
-            case GLOBAL:
-                if (globalCompatibilityVersion().before(Version.V_1_2_0)) {
-                    numClientNodes = 0;
-                }
-                nodePrefix = GLOBAL_CLUSTER_NODE_PREFIX;
-                break;
             case TEST:
                 nodePrefix = TEST_CLUSTER_NODE_PREFIX;
                 break;
@@ -1628,50 +1595,30 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
             default:
                 throw new ElasticsearchException("Scope not supported: " + scope);
         }
-        if (scope == Scope.GLOBAL) {
-            String cluster = System.getProperty(TESTS_CLUSTER);
-            if (Strings.hasLength(cluster)) {
-                String[] stringAddresses = cluster.split(",");
-                TransportAddress[] transportAddresses = new TransportAddress[stringAddresses.length];
-                int i = 0;
-                for (String stringAddress : stringAddresses) {
-                    String[] split = stringAddress.split(":");
-                    if (split.length < 2) {
-                        throw new IllegalArgumentException("address [" + cluster + "] not valid");
-                    }
-                    try {
-                        transportAddresses[i++] = new InetSocketTransportAddress(split[0], Integer.valueOf(split[1]));
-                    } catch (NumberFormatException e) {
-                        throw new IllegalArgumentException("port is not valid, expected number but was [" + split[1] + "]");
-                    }
-                }
-                return new ExternalTestCluster(transportAddresses);
+        settingsSource = new SettingsSource() {
+            @Override
+            public Settings node(int nodeOrdinal) {
+                return ImmutableSettings.builder().put(InternalNode.HTTP_ENABLED, false).
+                        put(nodeSettings(nodeOrdinal)).build();
             }
+            
+            @Override
+            public Settings transportClient() {
+                return transportClientSettings();
+            }
+        };
+        
+        int numDataNodes = getNumDataNodes();
+        if (numDataNodes >= 0) {
+            minNumDataNodes = maxNumDataNodes = numDataNodes;
         } else {
-            settingsSource = new SettingsSource() {
-                @Override
-                public Settings node(int nodeOrdinal) {
-                    return ImmutableSettings.builder().put(InternalNode.HTTP_ENABLED, false).
-                            put(nodeSettings(nodeOrdinal)).build();
-                }
-
-                @Override
-                public Settings transportClient() {
-                    return transportClientSettings();
-                }
-            };
-
-            int numDataNodes = getNumDataNodes();
-            if (numDataNodes >= 0) {
-                minNumDataNodes = maxNumDataNodes = numDataNodes;
-            } else {
-                minNumDataNodes = getMinNumDataNodes();
-                maxNumDataNodes = getMaxNumDataNodes();
-            }
-
-            numClientNodes = getNumClientNodes();
-            enableRandomBenchNodes = enableRandomBenchNodes();
+            minNumDataNodes = getMinNumDataNodes();
+            maxNumDataNodes = getMaxNumDataNodes();
         }
+        
+        numClientNodes = getNumClientNodes();
+        enableRandomBenchNodes = enableRandomBenchNodes();
+        
         return new InternalTestCluster(seed, minNumDataNodes, maxNumDataNodes,
                 clusterName(scope.name(), Integer.toString(CHILD_JVM_ID), seed), settingsSource, numClientNodes,
                 enableRandomBenchNodes, enableHttpPipelining, CHILD_JVM_ID, nodePrefix);

--- a/src/test/java/org/elasticsearch/test/discovery/ClusterDiscoveryConfiguration.java
+++ b/src/test/java/org/elasticsearch/test/discovery/ClusterDiscoveryConfiguration.java
@@ -114,17 +114,10 @@ public class ClusterDiscoveryConfiguration extends SettingsSource {
         }
 
         private static int scopeId(ElasticsearchIntegrationTest.Scope scope) {
-            switch(scope) {
-                case GLOBAL:
-                    //we reserve a special base port for global clusters, as they stick around
-                    //the assumption is that no counter is needed as there's only one global cluster per jvm
-                    return 0;
-                default:
-                    //ports can be reused as suite or test clusters are never run concurrently
-                    //we don't reuse the same port immediately though but leave some time to make sure ports are freed
-                    //reserve 0 to global cluster, prevent conflicts between jvms by never going above 9
-                    return 1 + portCounter.incrementAndGet() % 9;
-            }
+            //ports can be reused as suite or test clusters are never run concurrently
+            //we don't reuse the same port immediately though but leave some time to make sure ports are freed
+            //reserve 0 to global cluster, prevent conflicts between jvms by never going above 9
+            return 1 + portCounter.incrementAndGet() % 9;
         }
 
         @Override


### PR DESCRIPTION
In my experiments, this doesnt really buy much, but it causes reproducibility grief, and prevents things like leak detection from working (I would like to do more e.g. with the filesystem).

master:
[INFO] Execution time total: 5 minutes 51 seconds
[INFO] Tests summary: 672 suites, 4412 tests, 478 errors, 51 ignored (49 assumptions)

patch:
[INFO] Execution time total: 6 minutes 40 seconds
[INFO] Tests summary: 672 suites, 4412 tests, 479 errors, 51 ignored (49 assumptions)

So the savings is really not much in the scheme of things: I think reproducibility is better. 
