### PR TITLE
Reduce apache (cloud-aws) logging when rootLogger is DEBUG

### DIFF
--- a/config/logging.yml
+++ b/config/logging.yml
@@ -6,6 +6,7 @@ logger:
   action: DEBUG
   # reduce the logging for aws, too much is logged under the default INFO
   com.amazonaws: WARN
+  org.apache.http: INFO
 
   # gateway
   #gateway: DEBUG


### PR DESCRIPTION
When the cloud-aws plugin is in use, and you set rootLogger to `DEBUG`, you get wire-level output from `org.apache.http`.  Can we default to hard-coding that to `INFO`?  See attached.

```
[2014-12-09 17:54:47,015][DEBUG][org.apache.http.wire     ] >> "User-Agent: aws-sdk-java/1.7.3 Linux/3.2.0-54-virtual Java_HotSpot(TM)_64-Bit_Server_VM/24.65-b04/1.7.0_67[\r][\n]"
[2014-12-09 17:54:47,015][DEBUG][org.apache.http.wire     ] >> "Content-Type: application/x-www-form-urlencoded; charset=utf-8[\r][\n]"
[2014-12-09 17:54:47,015][DEBUG][org.apache.http.wire     ] >> "Connection: Keep-Alive[\r][\n]"
[2014-12-09 17:54:47,015][DEBUG][org.apache.http.wire     ] >> "[\r][\n]"
[2014-12-09 17:54:47,015][DEBUG][org.apache.http.headers  ] >> GET /indices/project_17592576970537_0/0/snapshot-ec2-east-prod_2014-12-02_08 HTTP/1.1
[2014-12-09 17:54:47,015][DEBUG][org.apache.http.headers  ] >> Host: cicayda.elasticsearch-snapshots.ec2-east-prod.1.s3.amazonaws.com
[2014-12-09 17:54:47,015][DEBUG][org.apache.http.headers  ] >> Authorization: AWS AKIAJEZUBK77CA6LJ42Q:UnwFwes6TC84f9PnlJmCuuKrXeM=
[2014-12-09 17:54:47,015][DEBUG][org.apache.http.headers  ] >> Date: Tue, 09 Dec 2014 17:54:47 GMT
[2014-12-09 17:54:47,015][DEBUG][org.apache.http.headers  ] >> User-Agent: aws-sdk-java/1.7.3 Linux/3.2.0-54-virtual Java_HotSpot(TM)_64-Bit_Server_VM/24.65-b04/1.7.0_67
[2014-12-09 17:54:47,015][DEBUG][org.apache.http.headers  ] >> Content-Type: application/x-www-form-urlencoded; charset=utf-8
[2014-12-09 17:54:47,015][DEBUG][org.apache.http.headers  ] >> Connection: Keep-Alive
[2014-12-09 17:54:47,040][DEBUG][org.apache.http.wire     ] << "HTTP/1.1 200 OK[\r][\n]"
[2014-12-09 17:54:47,040][DEBUG][org.apache.http.wire     ] << "x-amz-id-2: 9LnmcM+yBt/zxiiDLF4e4A+/k29kr7f56j2zZ+LbiSH66M+fHtG8Q53ClB15NsOg[\r][\n]"
[2014-12-09 17:54:47,040][DEBUG][org.apache.http.wire     ] << "x-amz-request-id: A57E4362506FE0EE[\r][\n]"
[2014-12-09 17:54:47,040][DEBUG][org.apache.http.wire     ] << "Date: Tue, 09 Dec 2014 17:54:48 GMT[\r][\n]"
[2014-12-09 17:54:47,040][DEBUG][org.apache.http.wire     ] << "Last-Modified: Tue, 02 Dec 2014 08:07:39 GMT[\r][\n]"
[2014-12-09 17:54:47,040][DEBUG][org.apache.http.wire     ] << "ETag: "b2a08d6d38b3ac09a987f7db31b25cb6"[\r][\n]"
[2014-12-09 17:54:47,040][DEBUG][org.apache.http.wire     ] << "Accept-Ranges: bytes[\r][\n]"
[2014-12-09 17:54:47,040][DEBUG][org.apache.http.wire     ] << "Content-Type: application/octet-stream[\r][\n]"
[2014-12-09 17:54:47,040][DEBUG][org.apache.http.wire     ] << "Content-Length: 291[\r][\n]"
[2014-12-09 17:54:47,040][DEBUG][org.apache.http.wire     ] << "Server: AmazonS3[\r][\n]"
[2014-12-09 17:54:47,040][DEBUG][org.apache.http.wire     ] << "[\r][\n]"
[2014-12-09 17:54:47,040][DEBUG][org.apache.http.impl.conn.DefaultClientConnection] Receiving response: HTTP/1.1 200 OK
[2014-12-09 17:54:47,040][DEBUG][org.apache.http.headers  ] << HTTP/1.1 200 OK
[2014-12-09 17:54:47,040][DEBUG][org.apache.http.headers  ] << x-amz-id-2: 9LnmcM+yBt/zxiiDLF4e4A+/k29kr7f56j2zZ+LbiSH66M+fHtG8Q53ClB15NsOg
[2014-12-09 17:54:47,040][DEBUG][org.apache.http.headers  ] << x-amz-request-id: A57E4362506FE0EE
[2014-12-09 17:54:47,040][DEBUG][org.apache.http.headers  ] << Date: Tue, 09 Dec 2014 17:54:48 GMT
[2014-12-09 17:54:47,040][DEBUG][org.apache.http.headers  ] << Last-Modified: Tue, 02 Dec 2014 08:07:39 GMT
[2014-12-09 17:54:47,040][DEBUG][org.apache.http.headers  ] << ETag: "b2a08d6d38b3ac09a987f7db31b25cb6"
[2014-12-09 17:54:47,040][DEBUG][org.apache.http.headers  ] << Accept-Ranges: bytes
[2014-12-09 17:54:47,040][DEBUG][org.apache.http.headers  ] << Content-Type: application/octet-stream
[2014-12-09 17:54:47,040][DEBUG][org.apache.http.headers  ] << Content-Length: 291
[2014-12-09 17:54:47,040][DEBUG][org.apache.http.headers  ] << Server: AmazonS3
[2014-12-09 17:54:47,041][DEBUG][org.apache.http.wire     ] << "{[\n]"
[2014-12-09 17:54:47,041][DEBUG][org.apache.http.wire     ] << "  "name" : "ec2-east-prod_2014-12-02_08",[\n]"
[2014-12-09 17:54:47,041][DEBUG][org.apache.http.wire     ] << "  "index_version" : 43,[\n]"
[2014-12-09 17:54:47,041][DEBUG][org.apache.http.wire     ] << "  "start_time" : 1417507656862,[\n]"
```
