### PR TITLE
Remove `status` code from main action `/`

### DIFF
--- a/docs/reference/migration/migrate_2_0.asciidoc
+++ b/docs/reference/migration/migrate_2_0.asciidoc
@@ -89,6 +89,11 @@ with values in a single array.
 }
 ---------------
 
+=== Main API
+
+Previously, calling `GET /` was giving back the http status code within the json response
+in addition to the actual HTTP status code. We removed `status` field in json response.
+
 === Java API
 
 Some query builders have been removed or renamed:

--- a/rest-api-spec/test/info/10_info.yaml
+++ b/rest-api-spec/test/info/10_info.yaml
@@ -1,7 +1,6 @@
 ---
 "Info":
     - do:         {info: {}}
-    - match:      {status: 200}
     - is_true:    name
     - is_true:    cluster_name
     - is_true:    tagline

--- a/rest-api-spec/test/info/20_lucene_version.yaml
+++ b/rest-api-spec/test/info/20_lucene_version.yaml
@@ -1,7 +1,6 @@
 ---
 "Lucene Version":
     - do:         {info: {}}
-    - match:      {status: 200}
     - is_true:    version.lucene_version
 
 

--- a/src/main/java/org/elasticsearch/rest/action/main/RestMainAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/main/RestMainAction.java
@@ -72,7 +72,6 @@ public class RestMainAction extends BaseRestHandler {
         }
 
         builder.startObject();
-        builder.field("status", status.getStatus());
         if (settings.get("name") != null) {
             builder.field("name", settings.get("name"));
         }


### PR DESCRIPTION
Today we give the HTTP status back within the HTTP response itself and within the JSON response as well:

``` sh
curl localhost:9200/
```

``` js
{
  "status" : 200,
  "name" : "Red Wolf",
  "version" : {
    "number" : "2.0.0",
    "build_hash" : "6837a61d8a646a2ac7dc8da1ab3c4ab85d60882d",
    "build_timestamp" : "2014-08-19T13:55:56Z",
    "build_snapshot" : true,
    "lucene_version" : "4.9"
  },
  "tagline" : "You Know, for Search"
}
```

We can remove the `status` in elasticsearch 2.0.
