### PR TITLE
updated (m)termvectors api specs to reflect #7530

### DIFF
--- a/rest-api-spec/api/mtermvectors.json
+++ b/rest-api-spec/api/mtermvectors.json
@@ -13,11 +13,7 @@
         "type" : {
           "type" : "string",
           "description" : "The type of the document."
-        },
-        "id" : {
-           "type" : "string",
-           "description" : "The id of the document."
-         }
+        }
       },
       "params" : {
         "ids" : {
@@ -83,7 +79,7 @@
       }
     },
     "body" : {
-        "description" : "Define ids, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.",
+        "description" : "Define ids, documents, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.",
         "required" : false
 
     }

--- a/rest-api-spec/api/termvectors.json
+++ b/rest-api-spec/api/termvectors.json
@@ -3,8 +3,8 @@
     "documentation" : "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/docs-termvectors.html",
     "methods" : ["GET", "POST"],
     "url" : {
-      "path" : "/{index}/{type}/{id}/_termvectors",
-      "paths" : ["/{index}/{type}/{id}/_termvectors"],
+      "path" : "/{index}/{type}/_termvectors",
+      "paths" : ["/{index}/{type}/_termvectors", "/{index}/{type}/{id}/_termvectors"],
       "parts" : {
         "index" : {
          "type" : "string",
@@ -18,8 +18,7 @@
         },
         "id" : {
            "type" : "string",
-           "description" : "The id of the document.",
-           "required" : true
+           "description" : "The id of the document, when not specified a doc param should be supplied."
          }
       },
       "params": {
@@ -87,7 +86,7 @@
       }
     },
     "body": {
-      "description" : "Define parameters. See documentation.",
+      "description" : "Define parameters and or supply a document to get termvectors for. See documentation.",
       "required" : false
     }
   }


### PR DESCRIPTION
#7530 introduced an option to specify `doc` instead of `id` this change was not included in the rest spec.

mtermvectors listed id as part but its not a part of the url.

Will open a separate PR against 1.4 branch which does not have the `dfs` feature introduced here: https://github.com/elasticsearch/elasticsearch/pull/8144

@alexksikes please correct me if I misunderstood the new feature.
