### PR TITLE
[SPEC] indices.upgrade wait_for_completion defaults to false

### DIFF
--- a/rest-api-spec/api/indices.upgrade.json
+++ b/rest-api-spec/api/indices.upgrade.json
@@ -28,7 +28,7 @@
         },
         "wait_for_completion": {
           "type" : "boolean",
-          "description" : "Specify whether the request should block until the all segments are upgraded (default: true)"
+          "description" : "Specify whether the request should block until the all segments are upgraded (default: false)"
         }
       }
     },


### PR DESCRIPTION
https://github.com/elasticsearch/elasticsearch/blob/master/src/main/java/org/elasticsearch/rest/action/admin/indices/upgrade/RestUpgradeAction.java#L93

The docs are correct: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-upgrade.html#upgrade-parameters, but the description in the spec is wrong.
