### PR TITLE
[ENGINE] Fix updates dynamic settings in InternalEngineHolder

### DIFF
--- a/src/main/java/org/elasticsearch/index/codec/CodecService.java
+++ b/src/main/java/org/elasticsearch/index/codec/CodecService.java
@@ -99,4 +99,11 @@ public class CodecService extends AbstractIndexComponent {
         }
         return codec;
     }
+
+    /**
+     * Returns all registered available codec names
+     */
+    public String[] availableCodecs() {
+        return codecs.keySet().toArray(new String[0]);
+    }
 }

--- a/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
+++ b/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
@@ -1752,4 +1752,29 @@ public class InternalEngine implements Engine {
         // hard fail - we can't get a SegmentReader
         throw new ElasticsearchIllegalStateException("Can not extract segment reader from given index reader [" + reader + "]");
     }
+
+    long getGcDeletesInMillis() {
+        return gcDeletesInMillis;
+    }
+
+    String getCodecName() {
+        return codecName;
+    }
+
+    boolean isCompoundOnFlush() {
+        return compoundOnFlush;
+    }
+
+    int getIndexConcurrency() {
+        return indexConcurrency;
+    }
+
+    boolean isFailEngineOnCorruption() {
+        return failEngineOnCorruption;
+    }
+
+    LiveIndexWriterConfig getCurrentIndexWriterConfig() {
+        IndexWriter writer = currentIndexWriter();
+        return writer == null ? null : writer.getConfig();
+    }
 }

--- a/src/main/java/org/elasticsearch/index/engine/internal/InternalEngineHolder.java
+++ b/src/main/java/org/elasticsearch/index/engine/internal/InternalEngineHolder.java
@@ -24,6 +24,7 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Preconditions;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
@@ -64,7 +65,7 @@ public class InternalEngineHolder extends AbstractIndexShardComponent implements
     private final FailEngineOnMergeFailure mergeSchedulerFailureListener;
     private final ApplySettings settingsListener;
     private final MergeScheduleListener mergeSchedulerListener;
-    private volatile Boolean failOnMergeFailure;
+    protected volatile Boolean failOnMergeFailure;
     protected volatile boolean failEngineOnCorruption;
     protected volatile ByteSizeValue indexingBufferSize;
     protected volatile int indexConcurrency;
@@ -142,7 +143,7 @@ public class InternalEngineHolder extends AbstractIndexShardComponent implements
         this.mergeSchedulerListener = new MergeScheduleListener();
         this.mergeScheduler.addListener(mergeSchedulerListener);
 
-        this.settingsListener = new ApplySettings();
+        this.settingsListener = new ApplySettings(logger, this);
         this.indexSettingsService.addListener(this.settingsListener);
         store.incRef();
     }
@@ -214,20 +215,19 @@ public class InternalEngineHolder extends AbstractIndexShardComponent implements
 
     @Override
     public synchronized void close() throws ElasticsearchException {
-        if (closed) {
-            return;
-        }
-        closed = true;
-        try {
-            InternalEngine currentEngine = this.currentEngine.getAndSet(null);
-            if (currentEngine != null) {
-                currentEngine.close();
+        if (closed == false) {
+            closed = true;
+            try {
+                InternalEngine currentEngine = this.currentEngine.getAndSet(null);
+                if (currentEngine != null) {
+                    currentEngine.close();
+                }
+                mergeScheduler.removeFailureListener(mergeSchedulerFailureListener);
+                mergeScheduler.removeListener(mergeSchedulerListener);
+                indexSettingsService.removeListener(settingsListener);
+            } finally {
+                store.decRef();
             }
-            mergeScheduler.removeFailureListener(mergeSchedulerFailureListener);
-            mergeScheduler.removeListener(mergeSchedulerListener);
-            indexSettingsService.removeListener(settingsListener);
-        } finally {
-            store.decRef();
         }
     }
 
@@ -356,52 +356,73 @@ public class InternalEngineHolder extends AbstractIndexShardComponent implements
         }
     }
 
-    class ApplySettings implements IndexSettingsService.Listener {
+    static class ApplySettings implements IndexSettingsService.Listener {
+
+        private final ESLogger logger;
+        private final InternalEngineHolder holder;
+
+        ApplySettings(ESLogger logger, InternalEngineHolder holder) {
+            this.logger = logger;
+            this.holder = holder;
+        }
 
         @Override
         public void onRefreshSettings(Settings settings) {
-            InternalEngine currentEngine = InternalEngineHolder.this.currentEngine.get();
             boolean change = false;
-            long gcDeletesInMillis = settings.getAsTime(INDEX_GC_DELETES, TimeValue.timeValueMillis(InternalEngineHolder.this.gcDeletesInMillis)).millis();
-            if (gcDeletesInMillis != InternalEngineHolder.this.gcDeletesInMillis) {
-                logger.info("updating index.gc_deletes from [{}] to [{}]", TimeValue.timeValueMillis(InternalEngineHolder.this.gcDeletesInMillis), TimeValue.timeValueMillis(gcDeletesInMillis));
-                InternalEngineHolder.this.gcDeletesInMillis = gcDeletesInMillis;
+            long gcDeletesInMillis = settings.getAsTime(INDEX_GC_DELETES, TimeValue.timeValueMillis(holder.gcDeletesInMillis)).millis();
+            if (gcDeletesInMillis != holder.gcDeletesInMillis) {
+                logger.info("updating index.gc_deletes from [{}] to [{}]", TimeValue.timeValueMillis(holder.gcDeletesInMillis), TimeValue.timeValueMillis(gcDeletesInMillis));
+                holder.gcDeletesInMillis = gcDeletesInMillis;
                 change = true;
             }
 
-            final boolean compoundOnFlush = settings.getAsBoolean(INDEX_COMPOUND_ON_FLUSH, InternalEngineHolder.this.compoundOnFlush);
-            if (compoundOnFlush != InternalEngineHolder.this.compoundOnFlush) {
-                logger.info("updating {} from [{}] to [{}]", INDEX_COMPOUND_ON_FLUSH, InternalEngineHolder.this.compoundOnFlush, compoundOnFlush);
-                InternalEngineHolder.this.compoundOnFlush = compoundOnFlush;
+            final boolean compoundOnFlush = settings.getAsBoolean(INDEX_COMPOUND_ON_FLUSH, holder.compoundOnFlush);
+            if (compoundOnFlush != holder.compoundOnFlush) {
+                logger.info("updating {} from [{}] to [{}]", INDEX_COMPOUND_ON_FLUSH, holder.compoundOnFlush, compoundOnFlush);
+                holder.compoundOnFlush = compoundOnFlush;
                 change = true;
             }
 
-            final boolean failEngineOnCorruption = settings.getAsBoolean(INDEX_FAIL_ON_CORRUPTION, InternalEngineHolder.this.failEngineOnCorruption);
-            if (failEngineOnCorruption != InternalEngineHolder.this.failEngineOnCorruption) {
-                logger.info("updating {} from [{}] to [{}]", INDEX_FAIL_ON_CORRUPTION, InternalEngineHolder.this.failEngineOnCorruption, failEngineOnCorruption);
-                InternalEngineHolder.this.failEngineOnCorruption = failEngineOnCorruption;
+            final boolean failEngineOnCorruption = settings.getAsBoolean(INDEX_FAIL_ON_CORRUPTION, holder.failEngineOnCorruption);
+            if (failEngineOnCorruption != holder.failEngineOnCorruption) {
+                logger.info("updating {} from [{}] to [{}]", INDEX_FAIL_ON_CORRUPTION, holder.failEngineOnCorruption, failEngineOnCorruption);
+                holder.failEngineOnCorruption = failEngineOnCorruption;
                 change = true;
             }
-            int indexConcurrency = settings.getAsInt(INDEX_INDEX_CONCURRENCY, InternalEngineHolder.this.indexConcurrency);
-            if (indexConcurrency != InternalEngineHolder.this.indexConcurrency) {
-                logger.info("updating index.index_concurrency from [{}] to [{}]", InternalEngineHolder.this.indexConcurrency, indexConcurrency);
-                InternalEngineHolder.this.indexConcurrency = indexConcurrency;
+            int indexConcurrency = settings.getAsInt(INDEX_INDEX_CONCURRENCY, holder.indexConcurrency);
+            if (indexConcurrency != holder.indexConcurrency) {
+                logger.info("updating index.index_concurrency from [{}] to [{}]", holder.indexConcurrency, indexConcurrency);
+                holder.indexConcurrency = indexConcurrency;
                 // we have to flush in this case, since it only applies on a new index writer
                 change = true;
             }
-            if (!codecName.equals(InternalEngineHolder.this.codecName)) {
-                logger.info("updating index.codec from [{}] to [{}]", InternalEngineHolder.this.codecName, codecName);
-                InternalEngineHolder.this.codecName = codecName;
+            final String codecName = settings.get(INDEX_CODEC, holder.codecName);
+            if (!codecName.equals(holder.codecName)) {
+                logger.info("updating index.codec from [{}] to [{}]", holder.codecName, codecName);
+                holder.codecName = codecName;
                 // we want to flush in this case, so the new codec will be reflected right away...
                 change = true;
             }
-            if (failOnMergeFailure != InternalEngineHolder.this.failOnMergeFailure) {
-                logger.info("updating {} from [{}] to [{}]", INDEX_FAIL_ON_MERGE_FAILURE, InternalEngineHolder.this.failOnMergeFailure, failOnMergeFailure);
-                InternalEngineHolder.this.failOnMergeFailure = failOnMergeFailure;
+            final boolean failOnMergeFailure = settings.getAsBoolean(INDEX_FAIL_ON_MERGE_FAILURE, holder.failOnMergeFailure);
+            if (failOnMergeFailure != holder.failOnMergeFailure) {
+                logger.info("updating {} from [{}] to [{}]", INDEX_FAIL_ON_MERGE_FAILURE, holder.failOnMergeFailure, failOnMergeFailure);
+                holder.failOnMergeFailure = failOnMergeFailure;
             }
-            if (change && currentEngine != null) {
-                currentEngine.updateSettings(gcDeletesInMillis, compoundOnFlush, failEngineOnCorruption, indexConcurrency, codecName);
+
+
+            if (change) {
+                holder.updateSettings();
             }
+        }
+    }
+
+     synchronized void updateSettings() {
+        // we need to make sure that we wait for the engine to be fully initialized
+        // the start method sets the current engine once it's done but samples the settings
+        // at construction time.
+        final InternalEngine engine = currentEngine.get();
+        if (engine != null) {
+            engine.updateSettings(gcDeletesInMillis, compoundOnFlush, failEngineOnCorruption, indexConcurrency, codecName);
         }
     }
 

--- a/src/main/java/org/elasticsearch/index/settings/IndexDynamicSettingsModule.java
+++ b/src/main/java/org/elasticsearch/index/settings/IndexDynamicSettingsModule.java
@@ -134,4 +134,11 @@ public class IndexDynamicSettingsModule extends AbstractModule {
     protected void configure() {
         bind(DynamicSettings.class).annotatedWith(IndexDynamicSettings.class).toInstance(indexDynamicSettings);
     }
+
+    /**
+     * Returns <code>true</code> iff the given setting is in the dynamic settings map. Otherwise <code>false</code>.
+     */
+    public boolean containsSetting(String setting) {
+        return indexDynamicSettings.hasDynamicSetting(setting);
+    }
 }


### PR DESCRIPTION
After the refactoring in #8784 some settings didn't get passed to the
actual engine and there exists a race if the settings are updated while
the engine is started such that the actual starting engine doesn't see
the latest settings. This commit fixes the concurrency issue as well as
adds tests to ensure the settings are reflected.

here is an example of the concurrency issue
http://build-us-00.elasticsearch.org/job/es_core_1x_suse/166/

```
[node_s2] [test][0] updating index.fail_on_corruption from [false] to [true]

... but further down we see

[node_s2] [test][0] corrupt file detected source: [recovery phase 1] but [index.fail_on_corruption] is set to [false]
```
