### PR TITLE
[SPEC] terminate_after querystring option on search 

### DIFF
--- a/rest-api-spec/api/search.json
+++ b/rest-api-spec/api/search.json
@@ -113,6 +113,10 @@
           "type" : "list",
           "description" : "A list of fields to extract and return from the _source field"
         },
+        "terminate_after": {
+          "type" : "number",
+          "description" : "The maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early."
+        },
         "stats": {
           "type" : "list",
           "description" : "Specific 'tag' of the request for logging and statistical purposes"


### PR DESCRIPTION
As implemented in https://github.com/elasticsearch/elasticsearch/pull/6885
