### PR TITLE
Core: Don't forcefully release IW lock (this can cause corruption)

### DIFF
--- a/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
+++ b/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
@@ -1432,11 +1432,6 @@ public class InternalEngine implements Engine {
 
     private IndexWriter createWriter() throws IOException {
         try {
-            // release locks when started
-            if (IndexWriter.isLocked(store.directory())) {
-                logger.warn("shard is locked, releasing lock");
-                IndexWriter.unlock(store.directory());
-            }
             boolean create = !Lucene.indexExists(store.directory());
             IndexWriterConfig config = new IndexWriterConfig(Lucene.VERSION, analysisService.defaultIndexAnalyzer());
             config.setOpenMode(create ? IndexWriterConfig.OpenMode.CREATE : IndexWriterConfig.OpenMode.APPEND);

--- a/src/test/java/org/elasticsearch/index/engine/internal/InternalEngineTests.java
+++ b/src/test/java/org/elasticsearch/index/engine/internal/InternalEngineTests.java
@@ -388,8 +388,6 @@ public class InternalEngineTests extends ElasticsearchLuceneTestCase {
 
     @Test
     public void testSegmentsWithMergeFlag() throws Exception {
-        // Close engine from setUp (we create our own):
-        engine.close();
 
         ConcurrentMergeSchedulerProvider mergeSchedulerProvider = new ConcurrentMergeSchedulerProvider(shardId, EMPTY_SETTINGS, threadPool, new IndexSettingsService(shardId.index(), EMPTY_SETTINGS));
         final AtomicReference<CountDownLatch> waitTillMerge = new AtomicReference<>();
@@ -414,6 +412,7 @@ public class InternalEngineTests extends ElasticsearchLuceneTestCase {
             }
         });
 
+        final Store store = createStore();
         final Engine engine = createEngine(engineSettingsService, store, createTranslog(), mergeSchedulerProvider);
         engine.start();
         ParsedDocument doc = testParsedDocument("1", "1", "test", null, -1, -1, testDocument(), Lucene.STANDARD_ANALYZER, B_1, false);
@@ -484,6 +483,7 @@ public class InternalEngineTests extends ElasticsearchLuceneTestCase {
         }
 
         engine.close();
+        store.close();
     }
 
     @Test
@@ -1362,14 +1362,12 @@ public class InternalEngineTests extends ElasticsearchLuceneTestCase {
     @Test
     public void testEnableGcDeletes() throws Exception {
 
-        // Close engine from setUp (we create our own):
-        engine.close();
-
         // Make sure enableGCDeletes == false works:
         Settings settings = ImmutableSettings.builder()
                 .put(InternalEngineHolder.INDEX_GC_DELETES, "0ms")
                 .build();
 
+        Store store = createStore();
         Engine engine = new InternalEngineHolder(shardId, settings, threadPool,
                 engineSettingsService,
                 new ShardIndexingService(shardId, settings,
@@ -1432,6 +1430,7 @@ public class InternalEngineTests extends ElasticsearchLuceneTestCase {
         getResult = engine.get(new Engine.Get(true, newUid("2")));
         assertThat(getResult.exists(), equalTo(false));
         engine.close();
+        store.close();
     }
 
     protected Term newUid(String id) {

--- a/src/test/java/org/elasticsearch/index/engine/internal/InternalEngineTests.java
+++ b/src/test/java/org/elasticsearch/index/engine/internal/InternalEngineTests.java
@@ -388,6 +388,9 @@ public class InternalEngineTests extends ElasticsearchLuceneTestCase {
 
     @Test
     public void testSegmentsWithMergeFlag() throws Exception {
+        // Close engine from setUp (we create our own):
+        engine.close();
+
         ConcurrentMergeSchedulerProvider mergeSchedulerProvider = new ConcurrentMergeSchedulerProvider(shardId, EMPTY_SETTINGS, threadPool, new IndexSettingsService(shardId.index(), EMPTY_SETTINGS));
         final AtomicReference<CountDownLatch> waitTillMerge = new AtomicReference<>();
         final AtomicReference<CountDownLatch> waitForMerge = new AtomicReference<>();
@@ -1358,6 +1361,9 @@ public class InternalEngineTests extends ElasticsearchLuceneTestCase {
     @Slow
     @Test
     public void testEnableGcDeletes() throws Exception {
+
+        // Close engine from setUp (we create our own):
+        engine.close();
 
         // Make sure enableGCDeletes == false works:
         Settings settings = ImmutableSettings.builder()


### PR DESCRIPTION
This fixes the test failure at http://build-us-00.elasticsearch.org/job/es_core_1x_strong/1652/

I already fixed this in master with #8588 but I think we should back-port even though it's a behavior change: it's really dangerous to forcefully remove IW's lock on init (it can quickly cause index corruption as it did in this test failure, caught by our check index on close).

If the index is in fact locked it means somehow another ES instance is still open/writing to that store directory and it's better to get an exc saying that.
