### PR TITLE
fix #8897 : typo in cluster stats documentation example

### DIFF
--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -117,7 +117,7 @@ Will return, for example:
       "jvm": {
          "max_uptime": "24s",
          "max_uptime_in_millis": 24054,
-         "version": [
+         "versions": [
             {
                "version": "1.6.0_45",
                "vm_name": "Java HotSpot(TM) 64-Bit Server VM",


### PR DESCRIPTION
Closes #8897
