### PR TITLE
ScriptService can deadlock entire nodes if script index is recovering

### DIFF
--- a/src/main/java/org/elasticsearch/action/indexedscripts/get/TransportGetIndexedScriptAction.java
+++ b/src/main/java/org/elasticsearch/action/indexedscripts/get/TransportGetIndexedScriptAction.java
@@ -51,7 +51,7 @@ public class TransportGetIndexedScriptAction extends HandledTransportAction<GetI
     @Override
     public void doExecute(GetIndexedScriptRequest request, final ActionListener<GetIndexedScriptResponse> listener){
         // forward the handling to the script service we are running on a network thread here...
-        scriptService.queryScriptIndex(request,new ActionListener<GetResponse>() {
+        scriptService.queryScriptIndex(request, new ActionListener<GetResponse>() {
             @Override
             public void onResponse(GetResponse getFields) {
                 listener.onResponse(new GetIndexedScriptResponse(getFields));

--- a/src/main/java/org/elasticsearch/script/ScriptService.java
+++ b/src/main/java/org/elasticsearch/script/ScriptService.java
@@ -361,7 +361,7 @@ public class ScriptService extends AbstractComponent {
         String scriptLang = validateScriptLanguage(request.scriptLang());
         GetRequest getRequest = new GetRequest(request, SCRIPT_INDEX).type(scriptLang).id(request.id())
                 .version(request.version()).versionType(request.versionType())
-                .operationThreaded(false).preference("_local"); //Set preference for no forking
+                .preference("_local"); //Set preference for no forking
         client.get(getRequest, listener);
     }
 
@@ -416,7 +416,7 @@ public class ScriptService extends AbstractComponent {
         validate(request.safeSource(), scriptLang);
 
         IndexRequest indexRequest = new IndexRequest(request).index(SCRIPT_INDEX).type(scriptLang).id(request.id())
-                .listenerThreaded(false).operationThreaded(false).version(request.version()).versionType(request.versionType())
+                .version(request.version()).versionType(request.versionType())
                 .source(request.safeSource(), true).opType(request.opType()).refresh(true); //Always refresh after indexing a template
         client.index(indexRequest, listener);
     }


### PR DESCRIPTION
we currently have operationThreaded set to false when indexing a script. This setting
means that if we are executing the operation locally that we don't spawn a new thread for
it although incoming thread in this case is the network thread. Now since we are indexing here
the engine is currently recovering which sometimes locks the engine for finalization blocks on
a network call waiting for the recovery target to come back the internal lock in engine will never be
released since we are waiting with our network thread for it to be released.

here is a smoking gun:

```
http://build-us-00.elasticsearch.org/job/es_core_1x_suse/164/
```

the interested reader follows the thread dump ;)
