### PR TITLE
[API] indices.upgrade's wait_for_completion param defaults to false

### DIFF
--- a/rest-api-spec/api/indices.upgrade.json
+++ b/rest-api-spec/api/indices.upgrade.json
@@ -28,7 +28,7 @@
         },
         "wait_for_completion": {
           "type" : "boolean",
-          "description" : "Specify whether the request should block until the all segments are upgraded (default: true)"
+          "description" : "Specify whether the request should block until the all segments are upgraded (default: false)"
         }
       }
     },


### PR DESCRIPTION
Documentation is correct but the API spec has it backwards.

Code: https://github.com/elasticsearch/elasticsearch/blob/master/src/main/java/org/elasticsearch/rest/action/admin/indices/upgrade/RestUpgradeAction.java#L93
Docs: https://github.com/elasticsearch/elasticsearch/blob/master/docs/reference/indices/upgrade.asciidoc#request-parameters
