### PR TITLE
Don't acquire Engine's readLock in segmentsStats

### DIFF
--- a/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
+++ b/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
@@ -332,7 +332,7 @@ public class InternalEngine implements Engine {
 
     @Override
     public TimeValue defaultRefreshInterval() {
-        return InternalEngineHolder.DEFAULT_REFRESH_ITERVAL;
+        return InternalEngineHolder.DEFAULT_REFRESH_INTERVAL;
     }
 
     /** return the current indexing buffer size setting * */
@@ -1231,9 +1231,12 @@ public class InternalEngine implements Engine {
 
     @Override
     public SegmentsStats segmentsStats() {
-        try (InternalLock _ = readLock.acquire()) {
-            ensureOpen();
-            try (final Searcher searcher = acquireSearcher("segments_stats")) {
+
+        // Does ensureOpen for us:
+        final IndexWriter indexWriter = currentIndexWriter();
+        assert indexWriter != null;
+
+        try (final Searcher searcher = acquireSearcher("segments_stats")) {
                 SegmentsStats stats = new SegmentsStats();
                 for (LeafReaderContext reader : searcher.reader().leaves()) {
                     final SegmentReader segmentReader = segmentReader(reader.reader());
@@ -1248,7 +1251,6 @@ public class InternalEngine implements Engine {
                 stats.addIndexWriterMemoryInBytes(indexWriter.ramBytesUsed());
                 stats.addIndexWriterMaxMemoryInBytes((long) (indexWriter.getConfig().getRAMBufferSizeMB() * 1024 * 1024));
                 return stats;
-            }
         }
     }
 

--- a/src/main/java/org/elasticsearch/index/engine/internal/InternalEngineHolder.java
+++ b/src/main/java/org/elasticsearch/index/engine/internal/InternalEngineHolder.java
@@ -101,7 +101,7 @@ public class InternalEngineHolder extends AbstractIndexShardComponent implements
     public static final String INDEX_FAIL_ON_MERGE_FAILURE = "index.fail_on_merge_failure";
     public static final String INDEX_FAIL_ON_CORRUPTION = "index.fail_on_corruption";
 
-    public static final TimeValue DEFAULT_REFRESH_ITERVAL = new TimeValue(1, TimeUnit.SECONDS);
+    public static final TimeValue DEFAULT_REFRESH_INTERVAL = new TimeValue(1, TimeUnit.SECONDS);
 
     private final CopyOnWriteArrayList<FailedEngineListener> failedEngineListeners = new CopyOnWriteArrayList<>();
 
@@ -150,7 +150,7 @@ public class InternalEngineHolder extends AbstractIndexShardComponent implements
 
     @Override
     public TimeValue defaultRefreshInterval() {
-        return DEFAULT_REFRESH_ITERVAL;
+        return DEFAULT_REFRESH_INTERVAL;
     }
 
 


### PR DESCRIPTION
I think we don't really need the readLock in InternalEngine.segmentsStats?

Related to #8905
