### PR TITLE
Translog: Never delete translog file from a snapshot

### DIFF
--- a/src/main/java/org/elasticsearch/index/translog/fs/FsChannelSnapshot.java
+++ b/src/main/java/org/elasticsearch/index/translog/fs/FsChannelSnapshot.java
@@ -146,6 +146,6 @@ public class FsChannelSnapshot implements Translog.Snapshot {
         if (!closed.compareAndSet(false, true)) {
             return;
         }
-        raf.decreaseRefCount(true);
+        raf.decreaseRefCount(false);
     }
 }

--- a/src/test/java/org/elasticsearch/index/translog/AbstractSimpleTranslogTests.java
+++ b/src/test/java/org/elasticsearch/index/translog/AbstractSimpleTranslogTests.java
@@ -23,6 +23,7 @@ import org.apache.lucene.index.Term;
 import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.io.FileSystemUtils;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.index.shard.ShardId;
@@ -36,6 +37,10 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
@@ -456,5 +461,24 @@ public abstract class AbstractSimpleTranslogTests extends ElasticsearchTestCase 
 
     private Term newUid(String id) {
         return new Term("_uid", id);
+    }
+
+    @Test
+    public void testVerifyTranslogIsNotDeletedBySnapshotClose() throws IOException {
+        Path path = Paths.get(translogFileDirectory());
+        assertTrue(Files.exists(path.resolve("translog-1")));
+        translog.add(new Translog.Create("test", "1", new byte[]{1}));
+        Translog.Snapshot snapshot = translog.snapshot();
+        MatcherAssert.assertThat(snapshot, TranslogSizeMatcher.translogSize(1));
+        assertThat(snapshot.estimatedTotalOperations(), equalTo(1));
+        if (randomBoolean()) {
+            translog.close();
+            snapshot.close();
+        } else {
+            snapshot.close();
+            translog.close();
+        }
+
+        assertTrue(Files.exists(path.resolve("translog-1")));
     }
 }


### PR DESCRIPTION
If we are currently running a recovery and the source node is
closed due to a restart the last reference to the translog is from
the snapshot. The delete logic respects only the last passed parameter.
This causes the transaction log file to be fully deleted and essentially
loses all documents in the translog.

This usually happens during rolling restarts where the node holing
the primary is shutting down while a replica is recovering from it. Once
the primnary is coming up again recovering from gateway it will skip the
transaction log since it can't find the file.

Note: This logic has been remove entirely in 2.0. Deleting are only happening if
they are safe from a reference counting point of view.

Here is a smoking gun:

```
http://build-us-00.elasticsearch.org/job/es_bwc_1x/5686/CHECK_BRANCH=origin%2F1.3,jdk=JDK7,label=bwc/
```
