### PR TITLE
Remove circular dependency between IndicesService and IndicesStore

### DIFF
--- a/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -98,8 +98,6 @@ public class IndicesService extends AbstractLifecycleComponent<IndicesService> i
 
     private final IndicesAnalysisService indicesAnalysisService;
 
-    private IndicesStore indicesStore;
-
     private final Injector injector;
 
     private final PluginsService pluginsService;
@@ -123,11 +121,6 @@ public class IndicesService extends AbstractLifecycleComponent<IndicesService> i
 
         this.indicesLifecycle.addListener(oldShardsStats);
         this.nodeEnv = nodeEnv;
-    }
-
-    @Inject
-    void setIndicesStore(IndicesStore store) {
-        this.indicesStore = store;
     }
 
     @Override
@@ -180,9 +173,8 @@ public class IndicesService extends AbstractLifecycleComponent<IndicesService> i
 
     @Override
     protected void doClose() throws ElasticsearchException {
-        injector.getInstance(RecoverySettings.class).close();
-        indicesStore.close();
-        indicesAnalysisService.close();
+        IOUtils.closeWhileHandlingException(injector.getInstance(RecoverySettings.class),
+            indicesAnalysisService);
     }
 
     public IndicesLifecycle indicesLifecycle() {

--- a/src/main/java/org/elasticsearch/indices/analysis/IndicesAnalysisService.java
+++ b/src/main/java/org/elasticsearch/indices/analysis/IndicesAnalysisService.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.index.analysis.*;
 
+import java.io.Closeable;
 import java.util.Locale;
 import java.util.Map;
 
@@ -35,7 +36,7 @@ import static org.elasticsearch.common.settings.ImmutableSettings.Builder.EMPTY_
 /**
  * A node level registry of analyzers, to be reused by different indices which use default analyzers.
  */
-public class IndicesAnalysisService extends AbstractComponent {
+public class IndicesAnalysisService extends AbstractComponent implements Closeable {
 
     private final Map<String, PreBuiltAnalyzerProviderFactory> analyzerProviderFactories = ConcurrentCollections.newConcurrentMap();
     private final Map<String, PreBuiltTokenizerFactoryFactory> tokenizerFactories = ConcurrentCollections.newConcurrentMap();

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoverySettings.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoverySettings.java
@@ -32,12 +32,13 @@ import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.node.settings.NodeSettingsService;
 import org.elasticsearch.threadpool.ThreadPool;
 
+import java.io.Closeable;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 /**
  */
-public class RecoverySettings extends AbstractComponent {
+public class RecoverySettings extends AbstractComponent implements Closeable {
 
     public static final String INDICES_RECOVERY_FILE_CHUNK_SIZE = "indices.recovery.file_chunk_size";
     public static final String INDICES_RECOVERY_TRANSLOG_OPS = "indices.recovery.translog_ops";

--- a/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
+++ b/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.indices.store;
 
 import org.apache.lucene.store.StoreRateLimiting;
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.*;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -28,6 +29,7 @@ import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.component.AbstractComponent;
+import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.FileSystemUtils;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -46,6 +48,7 @@ import org.elasticsearch.node.settings.NodeSettingsService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.*;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -56,7 +59,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 /**
  *
  */
-public class IndicesStore extends AbstractComponent implements ClusterStateListener {
+public class IndicesStore extends AbstractComponent implements ClusterStateListener, Closeable {
 
     public static final String INDICES_STORE_THROTTLE_TYPE = "indices.store.throttle.type";
     public static final String INDICES_STORE_THROTTLE_MAX_BYTES_PER_SEC = "indices.store.throttle.max_bytes_per_sec";
@@ -85,7 +88,6 @@ public class IndicesStore extends AbstractComponent implements ClusterStateListe
             }
         }
     }
-
 
     private final NodeEnvironment nodeEnv;
 
@@ -138,6 +140,7 @@ public class IndicesStore extends AbstractComponent implements ClusterStateListe
         return this.rateLimiting;
     }
 
+    @Override
     public void close() {
         nodeSettingsService.removeListener(applySettings);
         clusterService.remove(this);

--- a/src/main/java/org/elasticsearch/node/internal/InternalNode.java
+++ b/src/main/java/org/elasticsearch/node/internal/InternalNode.java
@@ -71,6 +71,7 @@ import org.elasticsearch.indices.cache.filter.IndicesFilterCache;
 import org.elasticsearch.indices.cluster.IndicesClusterStateService;
 import org.elasticsearch.indices.fielddata.cache.IndicesFieldDataCache;
 import org.elasticsearch.indices.memory.IndexingMemoryController;
+import org.elasticsearch.indices.store.IndicesStore;
 import org.elasticsearch.indices.ttl.IndicesTTLService;
 import org.elasticsearch.monitor.MonitorModule;
 import org.elasticsearch.monitor.MonitorService;
@@ -349,6 +350,7 @@ public final class InternalNode implements Node {
         injector.getInstance(IndexingMemoryController.class).close();
         injector.getInstance(IndicesTTLService.class).close();
         injector.getInstance(IndicesService.class).close();
+        injector.getInstance(IndicesStore.class).close();
         stopWatch.stop().start("routing");
         injector.getInstance(RoutingService.class).close();
         stopWatch.stop().start("cluster");


### PR DESCRIPTION
this circular dep. was around forever but it got uncovered yesterday by refactoring the abstractions. I think we should remove it.
