### PR TITLE
Remove explicit .cleanUp() on cache clear

### DIFF
--- a/src/main/java/org/elasticsearch/index/cache/bitset/BitsetFilterCache.java
+++ b/src/main/java/org/elasticsearch/index/cache/bitset/BitsetFilterCache.java
@@ -117,9 +117,8 @@ public class BitsetFilterCache extends AbstractIndexComponent implements LeafRea
     }
 
     public void clear(String reason) {
-        logger.debug("Clearing all Bitsets because [{}]", reason);
+        logger.debug("clearing all bitsets because [{}]", reason);
         loadedFilters.invalidateAll();
-        loadedFilters.cleanUp();
     }
 
     private BitDocIdSet getAndLoadIfNotPresent(final Filter filter, final LeafReaderContext context) throws IOException, ExecutionException {

--- a/src/main/java/org/elasticsearch/indices/cache/filter/IndicesFilterCache.java
+++ b/src/main/java/org/elasticsearch/indices/cache/filter/IndicesFilterCache.java
@@ -154,7 +154,6 @@ public class IndicesFilterCache extends AbstractComponent implements RemovalList
     public void close() {
         closed = true;
         cache.invalidateAll();
-        cache.cleanUp();
     }
 
     public Cache<WeightedFilterCache.FilterCacheKey, DocIdSet> cache() {

--- a/src/main/java/org/elasticsearch/indices/fielddata/cache/IndicesFieldDataCache.java
+++ b/src/main/java/org/elasticsearch/indices/fielddata/cache/IndicesFieldDataCache.java
@@ -154,13 +154,6 @@ public class IndicesFieldDataCache extends AbstractComponent implements RemovalL
             assert indexService != null;
         }
 
-        /**
-         * Clean up the internal Guava cache
-         */
-        public void cleanUp() {
-            cache.cleanUp();
-        }
-
         @Override
         public <FD extends AtomicFieldData, IFD extends IndexFieldData<FD>> FD load(final LeafReaderContext context, final IFD indexFieldData) throws Exception {
             final Key key = new Key(this, context.reader().getCoreCacheKey());
@@ -235,24 +228,18 @@ public class IndicesFieldDataCache extends AbstractComponent implements RemovalL
 
         @Override
         public void clear() {
-            // TODO: determine whether there is ever anything in this cache that doesn't share the index and consider .invalidateAll() instead
+            // Note that cache invalidation in Guava does not immediately remove
+            // values from the cache. In the case of a cache with a rare write or
+            // read rate, it's possible for values to persist longer than desired.
+            //
+            // Note this is intended by the Guava developers, see:
+            // https://code.google.com/p/guava-libraries/wiki/CachesExplained#Eviction
+            // (the "When Does Cleanup Happen" section)
             for (Key key : cache.asMap().keySet()) {
                 if (key.indexCache.index.equals(index)) {
                     cache.invalidate(key);
                 }
             }
-            // There is an explicit call to cache.cleanUp() here because cache
-            // invalidation in Guava does not immediately remove values from the
-            // cache. In the case of a cache with a rare write or read rate,
-            // it's possible for values to persist longer than desired. In the
-            // case of the circuit breaker, when clearing the entire cache all
-            // entries should immediately be evicted so that their sizes are
-            // removed from the breaker estimates.
-            //
-            // Note this is intended by the Guava developers, see:
-            // https://code.google.com/p/guava-libraries/wiki/CachesExplained#Eviction
-            // (the "When Does Cleanup Happen" section)
-            cache.cleanUp();
         }
 
         @Override


### PR DESCRIPTION
Calling cache.cleanUp() is kind of like calling System.gc(), meaning
that we should never have (non-test) things that rely on this
functionality.

For the field data and filter cache, we already have a periodic process
that runs this .cleanUp(), so there is no need to block index
closing/clearing on it. Instead, we can clean the field data cache in
InternalTestCluster before we check the circuit breaker.

This can help tests that time out because cleaning the cache is taking
too long.

Tests that rely on this behavior should be fixed.
