### PR TITLE
Adding REST ACL plugin

### DIFF
--- a/docs/community/misc.asciidoc
+++ b/docs/community/misc.asciidoc
@@ -1,6 +1,10 @@
 [[misc]]
 == Misc
 
+
+* https://github.com/sscarduzio/elasticsearch-readonlyrest-plugin[Readonly REST]:
+  High performance access control for Elasticsearch native REST API.
+  
 * https://github.com/elasticsearch/puppet-elasticsearch[Puppet]:
   Elasticsearch puppet module.
 


### PR DESCRIPTION
I know that the official Elasticsearch is about to release a more powerful plugin to dominate also this aspect among others. But still, I'd like to offer this simpler, minimalistic one as an option for the community.

Disclaimer: I'm the author.
