### PR TITLE
Default _cat APIs to verbose

### DIFF
--- a/rest-api-spec/api/cat.aliases.json
+++ b/rest-api-spec/api/cat.aliases.json
@@ -32,7 +32,7 @@
         "v": {
           "type": "boolean",
           "description": "Verbose mode. Display column headers",
-          "default": false
+          "default": true
         }
       }
     },

--- a/rest-api-spec/api/cat.allocation.json
+++ b/rest-api-spec/api/cat.allocation.json
@@ -37,7 +37,7 @@
         "v": {
           "type": "boolean",
           "description": "Verbose mode. Display column headers",
-          "default": false
+          "default": true
         }
       }
     },

--- a/rest-api-spec/api/cat.count.json
+++ b/rest-api-spec/api/cat.count.json
@@ -32,7 +32,7 @@
         "v": {
           "type": "boolean",
           "description": "Verbose mode. Display column headers",
-          "default": false
+          "default": true
         }
       }
     },

--- a/rest-api-spec/api/cat.fielddata.json
+++ b/rest-api-spec/api/cat.fielddata.json
@@ -37,7 +37,7 @@
         "v": {
           "type": "boolean",
           "description": "Verbose mode. Display column headers",
-          "default": false
+          "default": true
         },
         "fields": {
           "type": "list",

--- a/rest-api-spec/api/cat.health.json
+++ b/rest-api-spec/api/cat.health.json
@@ -33,7 +33,7 @@
         "v": {
           "type": "boolean",
           "description": "Verbose mode. Display column headers",
-          "default": false
+          "default": true
         }
       }
     },

--- a/rest-api-spec/api/cat.indices.json
+++ b/rest-api-spec/api/cat.indices.json
@@ -42,7 +42,7 @@
         "v": {
           "type": "boolean",
           "description": "Verbose mode. Display column headers",
-          "default": false
+          "default": true
         }
       }
     },

--- a/rest-api-spec/api/cat.master.json
+++ b/rest-api-spec/api/cat.master.json
@@ -28,7 +28,7 @@
         "v": {
           "type": "boolean",
           "description": "Verbose mode. Display column headers",
-          "default": false
+          "default": true
         }
       }
     },

--- a/rest-api-spec/api/cat.nodes.json
+++ b/rest-api-spec/api/cat.nodes.json
@@ -28,7 +28,7 @@
         "v": {
           "type": "boolean",
           "description": "Verbose mode. Display column headers",
-          "default": false
+          "default": true
         }
       }
     },

--- a/rest-api-spec/api/cat.pending_tasks.json
+++ b/rest-api-spec/api/cat.pending_tasks.json
@@ -28,7 +28,7 @@
         "v": {
           "type": "boolean",
           "description": "Verbose mode. Display column headers",
-          "default": false
+          "default": true
         }
       }
     },

--- a/rest-api-spec/api/cat.plugins.json
+++ b/rest-api-spec/api/cat.plugins.json
@@ -26,7 +26,7 @@
         "v": {
           "type": "boolean",
           "description": "Verbose mode. Display column headers",
-          "default": false
+          "default": true
         }
       }
     },

--- a/rest-api-spec/api/cat.recovery.json
+++ b/rest-api-spec/api/cat.recovery.json
@@ -33,7 +33,7 @@
         "v": {
           "type": "boolean",
           "description": "Verbose mode. Display column headers",
-          "default": false
+          "default": true
         }
       }
     },

--- a/rest-api-spec/api/cat.shards.json
+++ b/rest-api-spec/api/cat.shards.json
@@ -32,7 +32,7 @@
         "v": {
           "type": "boolean",
           "description": "Verbose mode. Display column headers",
-          "default": false
+          "default": true
         }
       }
     },

--- a/rest-api-spec/api/cat.thread_pool.json
+++ b/rest-api-spec/api/cat.thread_pool.json
@@ -28,7 +28,7 @@
         "v": {
           "type": "boolean",
           "description": "Verbose mode. Display column headers",
-          "default": false
+          "default": true
         },
         "full_id": {
           "type": "boolean",

--- a/rest-api-spec/test/cat.aliases/10_basic.yaml
+++ b/rest-api-spec/test/cat.aliases/10_basic.yaml
@@ -17,7 +17,8 @@
 "Empty cluster":
 
   - do:
-      cat.aliases: {}
+      cat.aliases:
+        v: false
 
   - match:
       $body: |
@@ -37,7 +38,8 @@
             name:  test_alias
 
   - do:
-      cat.aliases: {}
+      cat.aliases:
+        v: false
 
   - match:
       $body: |
@@ -73,7 +75,8 @@
                     term:
                         foo: bar
   - do:
-      cat.aliases: {}
+      cat.aliases:
+        v: false
 
   - match:
       $body: |
@@ -105,12 +108,14 @@
   - do:
       cat.aliases:
         name: test_1
+        v: false
 
   - match:
       $body: /^test_1 .+ \n$/
 
   - do:
       cat.aliases:
+        v: false
         name: test_2
 
   - match:
@@ -118,6 +123,7 @@
 
   - do:
       cat.aliases:
+        v: false
         name: test_*
 
   - match:
@@ -172,7 +178,8 @@
 
   - do:
         cat.aliases:
-            h:      [index, alias]
+          v: false
+          h:      [index, alias]
 
   - match:
       $body: /^ test \s+ test_1 \s+ $/

--- a/rest-api-spec/test/cat.allocation/10_basic.yaml
+++ b/rest-api-spec/test/cat.allocation/10_basic.yaml
@@ -3,6 +3,7 @@
   - do:
       cat.allocation:
         help: true
+        v: false
 
   - match:
       $body: |
@@ -20,7 +21,8 @@
 "Empty cluster":
 
   - do:
-      cat.allocation: {}
+      cat.allocation:
+        v: false
 
   - match:
       $body: |
@@ -50,7 +52,8 @@
             timeout: 1s
 
   - do:
-        cat.allocation: {}
+        cat.allocation:
+          v: false
 
   - match:
       $body: |
@@ -80,6 +83,7 @@
   - do:
         cat.allocation:
             node_id: _master
+            v: false
 
   - match:
       $body: |
@@ -99,6 +103,7 @@
   - do:
         cat.allocation:
             node_id: non_existent
+            v: false
 
   - match:
       $body: |
@@ -143,6 +148,7 @@
   - do:
         cat.allocation:
             h: [disk.percent, node]
+            v: false
 
   - match:
       $body: |
@@ -179,6 +185,7 @@
   - do:
       cat.allocation:
         bytes: g
+        v: false
 
   - match:
       $body: |

--- a/rest-api-spec/test/cat.count/10_basic.yaml
+++ b/rest-api-spec/test/cat.count/10_basic.yaml
@@ -14,7 +14,8 @@
 "Test cat count output":
 
   - do:
-      cat.count: {}
+      cat.count:
+        v: false
 
   - match:
       $body: |
@@ -30,7 +31,8 @@
         refresh: true
 
   - do:
-      cat.count: {}
+      cat.count:
+        v: false
 
   - match:
       $body: |
@@ -48,6 +50,7 @@
   - do:
       cat.count:
         h: count
+        v: false
 
   - match:
       $body: |
@@ -58,6 +61,7 @@
   - do:
       cat.count:
         index: index1
+        v: false
 
   - match:
       $body: |

--- a/rest-api-spec/test/cat.fielddata/10_basic.yaml
+++ b/rest-api-spec/test/cat.fielddata/10_basic.yaml
@@ -17,7 +17,8 @@
 "Test cat fielddata output":
 
   - do:
-      cat.fielddata: {}
+      cat.fielddata:
+        v: false
 
   - do:
       index:

--- a/rest-api-spec/test/cat.indices/10_basic.yaml
+++ b/rest-api-spec/test/cat.indices/10_basic.yaml
@@ -2,7 +2,8 @@
 "Test cat indices output":
 
   - do:
-      cat.indices: {}
+      cat.indices:
+        v: false
 
   - match:
       $body: |
@@ -19,7 +20,8 @@
        cluster.health:
          wait_for_status: yellow
   - do:
-      cat.indices: {}
+      cat.indices:
+        v: false
 
   - match:
       $body: |

--- a/rest-api-spec/test/cat.nodes/10_basic.yaml
+++ b/rest-api-spec/test/cat.nodes/10_basic.yaml
@@ -2,7 +2,8 @@
 "Test cat nodes output":
 
   - do:
-      cat.nodes: {}
+      cat.nodes:
+        v: false
 
   - match:
       $body: |

--- a/rest-api-spec/test/cat.recovery/10_basic.yaml
+++ b/rest-api-spec/test/cat.recovery/10_basic.yaml
@@ -2,7 +2,8 @@
 "Test cat recovery output":
 
   - do:
-      cat.recovery: {}
+      cat.recovery:
+        v: false
 
   - match:
       $body: |
@@ -19,7 +20,8 @@
        cluster.health:
          wait_for_status: yellow
   - do:
-      cat.recovery: {}
+      cat.recovery:
+        v: false
 
   - match:
       $body: |

--- a/rest-api-spec/test/cat.shards/10_basic.yaml
+++ b/rest-api-spec/test/cat.shards/10_basic.yaml
@@ -2,7 +2,8 @@
 "Test cat shards output":
 
   - do:
-      cat.shards: {}
+      cat.shards:
+        v: false
 
   - match:
       $body: |
@@ -19,7 +20,8 @@
        cluster.health:
          wait_for_status: yellow
   - do:
-      cat.shards: {}
+      cat.shards:
+        v: false
 
   - match:
       $body: |
@@ -38,7 +40,8 @@
          wait_for_relocating_shards: 0
 
   - do:
-      cat.shards: {}
+      cat.shards:
+        v: false
   - match:
       $body: |
                /^(index(1|2) \s+ \d \s+ (p|r) \s+ ((STARTED|INITIALIZING) \s+ (\d \s+ (\d+|\d+[.]\d+)(kb|b) \s+)? \d{1,3}.\d{1,3}.\d{1,3}.\d{1,3} \s+ .+|UNASSIGNED \s+) \n?){15}$/
@@ -46,6 +49,7 @@
   - do:
       cat.shards:
         index: index2
+        v: false
   - match:
       $body: |
                /^(index2 \s+ \d \s+ (p|r) \s+ ((STARTED|INITIALIZING) \s+ (\d \s+ (\d+|\d+[.]\d+)(kb|b) \s+)? \d{1,3}.\d{1,3}.\d{1,3}.\d{1,3} \s+ .+|UNASSIGNED \s+) \n?){5}$/

--- a/rest-api-spec/test/cat.thread_pool/10_basic.yaml
+++ b/rest-api-spec/test/cat.thread_pool/10_basic.yaml
@@ -2,7 +2,8 @@
 "Test cat thread_pool output":
 
   - do:
-      cat.thread_pool: {}
+      cat.thread_pool:
+        v: false
 
   - match:
       $body: |
@@ -21,6 +22,7 @@
   - do:
       cat.thread_pool:
           h: pid,id,h,i,po
+          v: false
 
   - match:
       $body: |

--- a/src/main/java/org/elasticsearch/rest/action/support/RestTable.java
+++ b/src/main/java/org/elasticsearch/rest/action/support/RestTable.java
@@ -68,7 +68,7 @@ public class RestTable {
 
     public static RestResponse buildTextPlainResponse(Table table, RestChannel channel) throws IOException {
         RestRequest request = channel.request();
-        boolean verbose = request.paramAsBoolean("v", false);
+        boolean verbose = request.paramAsBoolean("v", true);
 
         List<DisplayHeader> headers = buildDisplayHeaders(table, request);
         int[] width = buildWidths(table, request, verbose, headers);


### PR DESCRIPTION
`?v=false` can be used if the headers are not desired.

Resolves #8922
