### PR TITLE
[TEST] upgrade randomized runner to 2.1.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>com.carrotsearch.randomizedtesting</groupId>
             <artifactId>randomizedtesting-runner</artifactId>
-            <version>2.1.10</version>
+            <version>2.1.11</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
2.1.11 contains the fix for this issue: https://github.com/carrotsearch/randomizedtesting/issues/179
