### PR TITLE
Use Lucene's defaults for compound file format

### DIFF
--- a/src/main/java/org/elasticsearch/index/merge/policy/AbstractMergePolicyProvider.java
+++ b/src/main/java/org/elasticsearch/index/merge/policy/AbstractMergePolicyProvider.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.index.merge.policy;
 
 import org.apache.lucene.index.MergePolicy;
+import org.apache.lucene.index.TieredMergePolicy;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.index.shard.AbstractIndexShardComponent;
 import org.elasticsearch.index.store.Store;
@@ -31,7 +32,8 @@ public abstract class AbstractMergePolicyProvider<MP extends MergePolicy> extend
 
     protected AbstractMergePolicyProvider(Store store) {
         super(store.shardId(), store.indexSettings());
-        this.noCFSRatio = parseNoCFSRatio(indexSettings.get(INDEX_COMPOUND_FORMAT, Boolean.toString(store.suggestUseCompoundFile())));
+        // Default to Lucene's default:
+        this.noCFSRatio = parseNoCFSRatio(indexSettings.get(INDEX_COMPOUND_FORMAT, Double.toString(TieredMergePolicy.DEFAULT_NO_CFS_RATIO)));
     }
 
     public static double parseNoCFSRatio(String noCFSRatio) {

--- a/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/src/main/java/org/elasticsearch/index/store/Store.java
@@ -285,13 +285,6 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
     }
 
     /**
-     * Returns <tt>true</tt> by default.
-     */
-    public boolean suggestUseCompoundFile() {
-        return false;
-    }
-
-    /**
      * Increments the refCount of this Store instance.  RefCounts are used to determine when a
      * Store can be closed safely, i.e. as soon as there are no more references. Be sure to always call a
      * corresponding {@link #decRef}, in a finally clause; otherwise the store may never be closed.  Note that

--- a/src/test/java/org/elasticsearch/index/merge/policy/MergePolicySettingsTest.java
+++ b/src/test/java/org/elasticsearch/index/merge/policy/MergePolicySettingsTest.java
@@ -46,7 +46,7 @@ public class MergePolicySettingsTest extends ElasticsearchTestCase {
     public void testCompoundFileSettings() throws IOException {
         IndexSettingsService service = new IndexSettingsService(new Index("test"), EMPTY_SETTINGS);
 
-        assertThat(new TieredMergePolicyProvider(createStore(EMPTY_SETTINGS), service).getMergePolicy().getNoCFSRatio(), equalTo(0.0));
+        assertThat(new TieredMergePolicyProvider(createStore(EMPTY_SETTINGS), service).getMergePolicy().getNoCFSRatio(), equalTo(0.1));
         assertThat(new TieredMergePolicyProvider(createStore(build(true)), service).getMergePolicy().getNoCFSRatio(), equalTo(1.0));
         assertThat(new TieredMergePolicyProvider(createStore(build(0.5)), service).getMergePolicy().getNoCFSRatio(), equalTo(0.5));
         assertThat(new TieredMergePolicyProvider(createStore(build(1.0)), service).getMergePolicy().getNoCFSRatio(), equalTo(1.0));
@@ -58,7 +58,7 @@ public class MergePolicySettingsTest extends ElasticsearchTestCase {
         assertThat(new TieredMergePolicyProvider(createStore(build(0)), service).getMergePolicy().getNoCFSRatio(), equalTo(0.0));
         assertThat(new TieredMergePolicyProvider(createStore(build(0.0)), service).getMergePolicy().getNoCFSRatio(), equalTo(0.0));
 
-        assertThat(new LogByteSizeMergePolicyProvider(createStore(EMPTY_SETTINGS), service).getMergePolicy().getNoCFSRatio(), equalTo(0.0));
+        assertThat(new LogByteSizeMergePolicyProvider(createStore(EMPTY_SETTINGS), service).getMergePolicy().getNoCFSRatio(), equalTo(0.1));
         assertThat(new LogByteSizeMergePolicyProvider(createStore(build(true)), service).getMergePolicy().getNoCFSRatio(), equalTo(1.0));
         assertThat(new LogByteSizeMergePolicyProvider(createStore(build(0.5)), service).getMergePolicy().getNoCFSRatio(), equalTo(0.5));
         assertThat(new LogByteSizeMergePolicyProvider(createStore(build(1.0)), service).getMergePolicy().getNoCFSRatio(), equalTo(1.0));
@@ -70,7 +70,7 @@ public class MergePolicySettingsTest extends ElasticsearchTestCase {
         assertThat(new LogByteSizeMergePolicyProvider(createStore(build(0)), service).getMergePolicy().getNoCFSRatio(), equalTo(0.0));
         assertThat(new LogByteSizeMergePolicyProvider(createStore(build(0.0)), service).getMergePolicy().getNoCFSRatio(), equalTo(0.0));
 
-        assertThat(new LogDocMergePolicyProvider(createStore(EMPTY_SETTINGS), service).getMergePolicy().getNoCFSRatio(), equalTo(0.0));
+        assertThat(new LogDocMergePolicyProvider(createStore(EMPTY_SETTINGS), service).getMergePolicy().getNoCFSRatio(), equalTo(0.1));
         assertThat(new LogDocMergePolicyProvider(createStore(build(true)), service).getMergePolicy().getNoCFSRatio(), equalTo(1.0));
         assertThat(new LogDocMergePolicyProvider(createStore(build(0.5)), service).getMergePolicy().getNoCFSRatio(), equalTo(0.5));
         assertThat(new LogDocMergePolicyProvider(createStore(build(1.0)), service).getMergePolicy().getNoCFSRatio(), equalTo(1.0));
@@ -113,7 +113,7 @@ public class MergePolicySettingsTest extends ElasticsearchTestCase {
         {
             IndexSettingsService service = new IndexSettingsService(new Index("test"), EMPTY_SETTINGS);
             TieredMergePolicyProvider mp = new TieredMergePolicyProvider(createStore(EMPTY_SETTINGS), service);
-            assertThat(mp.getMergePolicy().getNoCFSRatio(), equalTo(0.0));
+            assertThat(mp.getMergePolicy().getNoCFSRatio(), equalTo(0.1));
 
             service.refreshSettings(build(1.0));
             assertThat(mp.getMergePolicy().getNoCFSRatio(), equalTo(1.0));
@@ -128,7 +128,7 @@ public class MergePolicySettingsTest extends ElasticsearchTestCase {
         {
             IndexSettingsService service = new IndexSettingsService(new Index("test"), EMPTY_SETTINGS);
             LogByteSizeMergePolicyProvider mp = new LogByteSizeMergePolicyProvider(createStore(EMPTY_SETTINGS), service);
-            assertThat(mp.getMergePolicy().getNoCFSRatio(), equalTo(0.0));
+            assertThat(mp.getMergePolicy().getNoCFSRatio(), equalTo(0.1));
 
             service.refreshSettings(build(1.0));
             assertThat(mp.getMergePolicy().getNoCFSRatio(), equalTo(1.0));
@@ -143,7 +143,7 @@ public class MergePolicySettingsTest extends ElasticsearchTestCase {
         {
             IndexSettingsService service = new IndexSettingsService(new Index("test"), EMPTY_SETTINGS);
             LogDocMergePolicyProvider mp = new LogDocMergePolicyProvider(createStore(EMPTY_SETTINGS), service);
-            assertThat(mp.getMergePolicy().getNoCFSRatio(), equalTo(0.0));
+            assertThat(mp.getMergePolicy().getNoCFSRatio(), equalTo(0.1));
 
             service.refreshSettings(build(1.0));
             assertThat(mp.getMergePolicy().getNoCFSRatio(), equalTo(1.0));


### PR DESCRIPTION
This just switches to Lucene's default for compound files, which is to use compound file format for merged segments that are < 10% of the total index size.  ES already uses Lucene's default (true) for newly flushed segments.

Closes #8919 
