### PR TITLE
Upgrade to lucene-5.0.0-snapshot-1646179.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <lucene.version>5.0.0</lucene.version>
-        <lucene.maven.version>5.0.0-snapshot-1644303</lucene.maven.version>
+        <lucene.maven.version>5.0.0-snapshot-1646179</lucene.maven.version>
         <tests.jvms>auto</tests.jvms>
         <tests.shuffle>true</tests.shuffle>
         <tests.output>onerror</tests.output>
@@ -54,7 +54,7 @@
         </repository>
         <repository>
             <id>Lucene snapshots</id>
-            <url>https://download.elasticsearch.org/lucenesnapshots/1644303</url>
+            <url>https://download.elasticsearch.org/lucenesnapshots/1646179</url>
         </repository>
     </repositories>
 

--- a/src/main/java/org/elasticsearch/common/util/AbstractArray.java
+++ b/src/main/java/org/elasticsearch/common/util/AbstractArray.java
@@ -46,7 +46,7 @@ abstract class AbstractArray implements BigArray {
     protected abstract void doClose();
 
     @Override
-    public Iterable<? extends Accountable> getChildResources() {
+    public Iterable<Accountable> getChildResources() {
         return Collections.emptyList();
     }
 }

--- a/src/main/java/org/elasticsearch/index/codec/postingsformat/BloomFilterPostingsFormat.java
+++ b/src/main/java/org/elasticsearch/index/codec/postingsformat/BloomFilterPostingsFormat.java
@@ -130,7 +130,7 @@ public final class BloomFilterPostingsFormat extends PostingsFormat {
         }
 
         @Override
-        public Iterable<? extends Accountable> getChildResources() {
+        public Iterable<Accountable> getChildResources() {
             return Collections.singleton(Accountables.namedAccountable("bloom", ramBytesUsed()));
         }
     }
@@ -209,7 +209,7 @@ public final class BloomFilterPostingsFormat extends PostingsFormat {
         }
 
         @Override
-        public Iterable<? extends Accountable> getChildResources() {
+        public Iterable<Accountable> getChildResources() {
             List<Accountable> resources = new ArrayList<>();
             resources.addAll(Accountables.namedAccountables("field", bloomsByFieldName));
             if (delegateFieldsProducer != null) {

--- a/src/main/java/org/elasticsearch/index/engine/internal/LiveVersionMap.java
+++ b/src/main/java/org/elasticsearch/index/engine/internal/LiveVersionMap.java
@@ -251,7 +251,7 @@ class LiveVersionMap implements ReferenceManager.RefreshListener, Accountable {
     }
 
     @Override
-    public Iterable<? extends Accountable> getChildResources() {
+    public Iterable<Accountable> getChildResources() {
         // TODO: useful to break down RAM usage here?
         return Collections.emptyList();
     }

--- a/src/main/java/org/elasticsearch/index/engine/internal/VersionValue.java
+++ b/src/main/java/org/elasticsearch/index/engine/internal/VersionValue.java
@@ -58,7 +58,7 @@ class VersionValue implements Accountable {
     }
     
     @Override
-    public Iterable<? extends Accountable> getChildResources() {
+    public Iterable<Accountable> getChildResources() {
         return Collections.emptyList();
     }
 }

--- a/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalsIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalsIndexFieldData.java
@@ -94,7 +94,7 @@ public abstract class GlobalOrdinalsIndexFieldData extends AbstractIndexComponen
     }
 
     @Override
-    public Iterable<? extends Accountable> getChildResources() {
+    public Iterable<Accountable> getChildResources() {
         // TODO: break down ram usage?
         return Collections.emptyList();
     }

--- a/src/main/java/org/elasticsearch/index/fielddata/ordinals/InternalGlobalOrdinalsIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/ordinals/InternalGlobalOrdinalsIndexFieldData.java
@@ -81,7 +81,7 @@ final class InternalGlobalOrdinalsIndexFieldData extends GlobalOrdinalsIndexFiel
         }
 
         @Override
-        public Iterable<? extends Accountable> getChildResources() {
+        public Iterable<Accountable> getChildResources() {
             return afd.getChildResources();
         }
 

--- a/src/main/java/org/elasticsearch/index/fielddata/ordinals/MultiOrdinals.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/ordinals/MultiOrdinals.java
@@ -91,7 +91,7 @@ public class MultiOrdinals extends Ordinals {
     }
 
     @Override
-    public Iterable<? extends Accountable> getChildResources() {
+    public Iterable<Accountable> getChildResources() {
         List<Accountable> resources = new ArrayList<>();
         resources.add(Accountables.namedAccountable("offsets", endOffsets));
         resources.add(Accountables.namedAccountable("ordinals", ords));

--- a/src/main/java/org/elasticsearch/index/fielddata/ordinals/SinglePackedOrdinals.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/ordinals/SinglePackedOrdinals.java
@@ -53,7 +53,7 @@ public class SinglePackedOrdinals extends Ordinals {
     }
 
     @Override
-    public Iterable<? extends Accountable> getChildResources() {
+    public Iterable<Accountable> getChildResources() {
         return Collections.singleton(Accountables.namedAccountable("reader", reader));
     }
 

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractAtomicGeoPointFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractAtomicGeoPointFieldData.java
@@ -45,7 +45,7 @@ abstract class AbstractAtomicGeoPointFieldData implements AtomicGeoPointFieldDat
             }
             
             @Override
-            public Iterable<? extends Accountable> getChildResources() {
+            public Iterable<Accountable> getChildResources() {
                 return Collections.emptyList();
             }
 

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractAtomicOrdinalsFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractAtomicOrdinalsFieldData.java
@@ -54,7 +54,7 @@ public abstract class AbstractAtomicOrdinalsFieldData implements AtomicOrdinalsF
             }
             
             @Override
-            public Iterable<? extends Accountable> getChildResources() {
+            public Iterable<Accountable> getChildResources() {
                 return Collections.emptyList();
             }
 

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractAtomicParentChildFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractAtomicParentChildFieldData.java
@@ -92,7 +92,7 @@ abstract class AbstractAtomicParentChildFieldData implements AtomicParentChildFi
             }
             
             @Override
-            public Iterable<? extends Accountable> getChildResources() {
+            public Iterable<Accountable> getChildResources() {
                 return Collections.emptyList();
             }
 

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/AtomicDoubleFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/AtomicDoubleFieldData.java
@@ -66,7 +66,7 @@ abstract class AtomicDoubleFieldData implements AtomicNumericFieldData {
             }
             
             @Override
-            public Iterable<? extends Accountable> getChildResources() {
+            public Iterable<Accountable> getChildResources() {
                 return Collections.emptyList();
             }
 

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/AtomicLongFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/AtomicLongFieldData.java
@@ -67,7 +67,7 @@ abstract class AtomicLongFieldData implements AtomicNumericFieldData {
             }
 
             @Override
-            public Iterable<? extends Accountable> getChildResources() {
+            public Iterable<Accountable> getChildResources() {
                 return Collections.emptyList();
             }
 

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/BinaryDVAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/BinaryDVAtomicFieldData.java
@@ -69,7 +69,7 @@ public class BinaryDVAtomicFieldData implements AtomicFieldData {
     }
     
     @Override
-    public Iterable<? extends Accountable> getChildResources() {
+    public Iterable<Accountable> getChildResources() {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/BinaryDVNumericIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/BinaryDVNumericIndexFieldData.java
@@ -85,7 +85,7 @@ public class BinaryDVNumericIndexFieldData extends DocValuesIndexFieldData imple
                     }
                     
                     @Override
-                    public Iterable<? extends Accountable> getChildResources() {
+                    public Iterable<Accountable> getChildResources() {
                         return Collections.emptyList();
                     }
 
@@ -99,7 +99,7 @@ public class BinaryDVNumericIndexFieldData extends DocValuesIndexFieldData imple
                     }
                     
                     @Override
-                    public Iterable<? extends Accountable> getChildResources() {
+                    public Iterable<Accountable> getChildResources() {
                         return Collections.emptyList();
                     }
 

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/BytesBinaryDVAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/BytesBinaryDVAtomicFieldData.java
@@ -48,7 +48,7 @@ final class BytesBinaryDVAtomicFieldData implements AtomicFieldData {
     }
 
     @Override
-    public Iterable<? extends Accountable> getChildResources() {
+    public Iterable<Accountable> getChildResources() {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/DoubleArrayIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/DoubleArrayIndexFieldData.java
@@ -108,7 +108,7 @@ public class DoubleArrayIndexFieldData extends AbstractIndexFieldData<AtomicNume
                     }
                     
                     @Override
-                    public Iterable<? extends Accountable> getChildResources() {
+                    public Iterable<Accountable> getChildResources() {
                         List<Accountable> resources = new ArrayList<>();
                         resources.add(Accountables.namedAccountable("ordinals", build));
                         resources.add(Accountables.namedAccountable("values", finalValues));
@@ -134,7 +134,7 @@ public class DoubleArrayIndexFieldData extends AbstractIndexFieldData<AtomicNume
                         }
                         
                         @Override
-                        public Iterable<? extends Accountable> getChildResources() {
+                        public Iterable<Accountable> getChildResources() {
                             List<Accountable> resources = new ArrayList<>();
                             resources.add(Accountables.namedAccountable("ordinals", build));
                             resources.add(Accountables.namedAccountable("values", finalValues));
@@ -163,7 +163,7 @@ public class DoubleArrayIndexFieldData extends AbstractIndexFieldData<AtomicNume
                     }
                     
                     @Override
-                    public Iterable<? extends Accountable> getChildResources() {
+                    public Iterable<Accountable> getChildResources() {
                         List<Accountable> resources = new ArrayList<>();
                         resources.add(Accountables.namedAccountable("values", sValues));
                         resources.add(Accountables.namedAccountable("missing bitset", set));

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/FSTBytesAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/FSTBytesAtomicFieldData.java
@@ -69,7 +69,7 @@ public class FSTBytesAtomicFieldData extends AbstractAtomicOrdinalsFieldData {
     }
 
     @Override
-    public Iterable<? extends Accountable> getChildResources() {
+    public Iterable<Accountable> getChildResources() {
         List<Accountable> resources = new ArrayList<>();
         resources.add(Accountables.namedAccountable("ordinals", ordinals));
         if (fst != null) {

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/FloatArrayIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/FloatArrayIndexFieldData.java
@@ -106,7 +106,7 @@ public class FloatArrayIndexFieldData extends AbstractIndexFieldData<AtomicNumer
                     }
                     
                     @Override
-                    public Iterable<? extends Accountable> getChildResources() {
+                    public Iterable<Accountable> getChildResources() {
                         List<Accountable> resources = new ArrayList<>();
                         resources.add(Accountables.namedAccountable("ordinals", build));
                         resources.add(Accountables.namedAccountable("values", finalValues));
@@ -132,7 +132,7 @@ public class FloatArrayIndexFieldData extends AbstractIndexFieldData<AtomicNumer
                         }
                         
                         @Override
-                        public Iterable<? extends Accountable> getChildResources() {
+                        public Iterable<Accountable> getChildResources() {
                             List<Accountable> resources = new ArrayList<>();
                             resources.add(Accountables.namedAccountable("ordinals", build));
                             resources.add(Accountables.namedAccountable("values", finalValues));
@@ -161,7 +161,7 @@ public class FloatArrayIndexFieldData extends AbstractIndexFieldData<AtomicNumer
                     }
                     
                     @Override
-                    public Iterable<? extends Accountable> getChildResources() {
+                    public Iterable<Accountable> getChildResources() {
                         List<Accountable> resources = new ArrayList<>();
                         resources.add(Accountables.namedAccountable("values", sValues));
                         resources.add(Accountables.namedAccountable("missing bitset", set));

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointBinaryDVAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointBinaryDVAtomicFieldData.java
@@ -49,7 +49,7 @@ final class GeoPointBinaryDVAtomicFieldData extends AbstractAtomicGeoPointFieldD
     }
     
     @Override
-    public Iterable<? extends Accountable> getChildResources() {
+    public Iterable<Accountable> getChildResources() {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointCompressedAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointCompressedAtomicFieldData.java
@@ -68,7 +68,7 @@ public abstract class GeoPointCompressedAtomicFieldData extends AbstractAtomicGe
         }
 
         @Override
-        public Iterable<? extends Accountable> getChildResources() {
+        public Iterable<Accountable> getChildResources() {
             List<Accountable> resources = new ArrayList<>();
             resources.add(Accountables.namedAccountable("latitude", lat));
             resources.add(Accountables.namedAccountable("longitude", lon));
@@ -142,7 +142,7 @@ public abstract class GeoPointCompressedAtomicFieldData extends AbstractAtomicGe
         }
         
         @Override
-        public Iterable<? extends Accountable> getChildResources() {
+        public Iterable<Accountable> getChildResources() {
             List<Accountable> resources = new ArrayList<>();
             resources.add(Accountables.namedAccountable("latitude", lat));
             resources.add(Accountables.namedAccountable("longitude", lon));

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointDoubleArrayAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointDoubleArrayAtomicFieldData.java
@@ -64,7 +64,7 @@ public abstract class GeoPointDoubleArrayAtomicFieldData extends AbstractAtomicG
         }
         
         @Override
-        public Iterable<? extends Accountable> getChildResources() {
+        public Iterable<Accountable> getChildResources() {
             List<Accountable> resources = new ArrayList<>();
             resources.add(Accountables.namedAccountable("latitude", lat));
             resources.add(Accountables.namedAccountable("longitude", lon));
@@ -133,7 +133,7 @@ public abstract class GeoPointDoubleArrayAtomicFieldData extends AbstractAtomicG
         }
         
         @Override
-        public Iterable<? extends Accountable> getChildResources() {
+        public Iterable<Accountable> getChildResources() {
             List<Accountable> resources = new ArrayList<>();
             resources.add(Accountables.namedAccountable("latitude", lat));
             resources.add(Accountables.namedAccountable("longitude", lon));

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/IndexIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/IndexIndexFieldData.java
@@ -58,7 +58,7 @@ public class IndexIndexFieldData extends AbstractIndexOrdinalsFieldData {
         }
 
         @Override
-        public Iterable<? extends Accountable> getChildResources() {
+        public Iterable<Accountable> getChildResources() {
             return Collections.emptyList();
         }
 

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/NumericDVIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/NumericDVIndexFieldData.java
@@ -57,7 +57,7 @@ public class NumericDVIndexFieldData extends DocValuesIndexFieldData implements 
             }
             
             @Override
-            public Iterable<? extends Accountable> getChildResources() {
+            public Iterable<Accountable> getChildResources() {
                 return Collections.emptyList();
             }
         };

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/PackedArrayIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/PackedArrayIndexFieldData.java
@@ -130,7 +130,7 @@ public class PackedArrayIndexFieldData extends AbstractIndexFieldData<AtomicNume
                     }
 
                     @Override
-                    public Iterable<? extends Accountable> getChildResources() {
+                    public Iterable<Accountable> getChildResources() {
                         List<Accountable> resources = new ArrayList<>();
                         resources.add(Accountables.namedAccountable("ordinals", build));
                         resources.add(Accountables.namedAccountable("values", values));
@@ -213,7 +213,7 @@ public class PackedArrayIndexFieldData extends AbstractIndexFieldData<AtomicNume
                             }
                             
                             @Override
-                            public Iterable<? extends Accountable> getChildResources() {
+                            public Iterable<Accountable> getChildResources() {
                                 List<Accountable> resources = new ArrayList<>();
                                 resources.add(Accountables.namedAccountable("values", sValues));
                                 if (docsWithValues != null) {
@@ -249,7 +249,7 @@ public class PackedArrayIndexFieldData extends AbstractIndexFieldData<AtomicNume
                             }
 
                             @Override
-                            public Iterable<? extends Accountable> getChildResources() {
+                            public Iterable<Accountable> getChildResources() {
                                 List<Accountable> resources = new ArrayList<>();
                                 resources.add(Accountables.namedAccountable("values", pagedValues));
                                 if (docsWithValues != null) {
@@ -270,7 +270,7 @@ public class PackedArrayIndexFieldData extends AbstractIndexFieldData<AtomicNume
                             }
                             
                             @Override
-                            public Iterable<? extends Accountable> getChildResources() {
+                            public Iterable<Accountable> getChildResources() {
                                 List<Accountable> resources = new ArrayList<>();
                                 resources.add(Accountables.namedAccountable("ordinals", build));
                                 resources.add(Accountables.namedAccountable("values", values));

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/PagedBytesAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/PagedBytesAtomicFieldData.java
@@ -59,7 +59,7 @@ public class PagedBytesAtomicFieldData extends AbstractAtomicOrdinalsFieldData {
     }
 
     @Override
-    public Iterable<? extends Accountable> getChildResources() {
+    public Iterable<Accountable> getChildResources() {
         List<Accountable> resources = new ArrayList<>();
         resources.add(Accountables.namedAccountable("ordinals", ordinals));
         resources.add(Accountables.namedAccountable("term bytes", bytes));

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/ParentChildAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/ParentChildAtomicFieldData.java
@@ -53,7 +53,7 @@ public class ParentChildAtomicFieldData extends AbstractAtomicParentChildFieldDa
     }
 
     @Override
-    public Iterable<? extends Accountable> getChildResources() {
+    public Iterable<Accountable> getChildResources() {
         // TODO: should we break down by type?
         // the current 'map' does not impl java.util.Map so we cant use Accountables.namedAccountables...
         return Collections.emptyList();

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/ParentChildIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/ParentChildIndexFieldData.java
@@ -368,7 +368,7 @@ public class ParentChildIndexFieldData extends AbstractIndexFieldData<AtomicPare
                     }
 
                     @Override
-                    public Iterable<? extends Accountable> getChildResources() {
+                    public Iterable<Accountable> getChildResources() {
                         // TODO: is this really the best?
                         return Collections.emptyList();
                     }
@@ -395,7 +395,7 @@ public class ParentChildIndexFieldData extends AbstractIndexFieldData<AtomicPare
         }
 
         @Override
-        public Iterable<? extends Accountable> getChildResources() {
+        public Iterable<Accountable> getChildResources() {
             return Collections.emptyList();
         }
 

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/SortedNumericDVIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/SortedNumericDVIndexFieldData.java
@@ -120,7 +120,7 @@ public class SortedNumericDVIndexFieldData extends DocValuesIndexFieldData imple
         }
         
         @Override
-        public Iterable<? extends Accountable> getChildResources() {
+        public Iterable<Accountable> getChildResources() {
             return Collections.emptyList();
         }
     }
@@ -169,7 +169,7 @@ public class SortedNumericDVIndexFieldData extends DocValuesIndexFieldData imple
         }
         
         @Override
-        public Iterable<? extends Accountable> getChildResources() {
+        public Iterable<Accountable> getChildResources() {
             return Collections.emptyList();
         }
     }
@@ -254,7 +254,7 @@ public class SortedNumericDVIndexFieldData extends DocValuesIndexFieldData imple
         }
         
         @Override
-        public Iterable<? extends Accountable> getChildResources() {
+        public Iterable<Accountable> getChildResources() {
             return Collections.emptyList();
         }
     }

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/SortedSetDVBytesAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/SortedSetDVBytesAtomicFieldData.java
@@ -63,7 +63,7 @@ public final class SortedSetDVBytesAtomicFieldData extends AbstractAtomicOrdinal
     }
     
     @Override
-    public Iterable<? extends Accountable> getChildResources() {
+    public Iterable<Accountable> getChildResources() {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/elasticsearch/index/translog/Translog.java
+++ b/src/main/java/org/elasticsearch/index/translog/Translog.java
@@ -173,7 +173,7 @@ public interface Translog extends IndexShardComponent, Closeable, Accountable {
         }
 
         @Override
-        public Iterable<? extends Accountable> getChildResources() {
+        public Iterable<Accountable> getChildResources() {
             return Collections.emptyList();
         }
 

--- a/src/main/java/org/elasticsearch/index/translog/fs/FsTranslog.java
+++ b/src/main/java/org/elasticsearch/index/translog/fs/FsTranslog.java
@@ -178,7 +178,7 @@ public class FsTranslog extends AbstractIndexShardComponent implements Translog 
     }
 
     @Override
-    public Iterable<? extends Accountable> getChildResources() {
+    public Iterable<Accountable> getChildResources() {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/elasticsearch/indices/cache/query/IndicesQueryCache.java
+++ b/src/main/java/org/elasticsearch/indices/cache/query/IndicesQueryCache.java
@@ -284,7 +284,7 @@ public class IndicesQueryCache extends AbstractComponent implements RemovalListe
         }
 
         @Override
-        public Iterable<? extends Accountable> getChildResources() {
+        public Iterable<Accountable> getChildResources() {
             // TODO: more detailed ram usage?
             return Collections.emptyList();
         }

--- a/src/main/java/org/elasticsearch/search/suggest/completion/AnalyzingCompletionLookupProvider.java
+++ b/src/main/java/org/elasticsearch/search/suggest/completion/AnalyzingCompletionLookupProvider.java
@@ -300,7 +300,7 @@ public class AnalyzingCompletionLookupProvider extends CompletionLookupProvider 
             }
 
             @Override
-            public Iterable<? extends Accountable> getChildResources() {
+            public Iterable<Accountable> getChildResources() {
                 return Accountables.namedAccountables("field", lookupMap);
             }
         };
@@ -360,7 +360,7 @@ public class AnalyzingCompletionLookupProvider extends CompletionLookupProvider 
         }
 
         @Override
-        public Iterable<? extends Accountable> getChildResources() {
+        public Iterable<Accountable> getChildResources() {
             if (fst != null) {
                 return Collections.singleton(Accountables.namedAccountable("fst", fst));
             } else {

--- a/src/main/java/org/elasticsearch/search/suggest/completion/Completion090PostingsFormat.java
+++ b/src/main/java/org/elasticsearch/search/suggest/completion/Completion090PostingsFormat.java
@@ -218,7 +218,7 @@ public class Completion090PostingsFormat extends PostingsFormat {
         }
 
         @Override
-        public Iterable<? extends Accountable> getChildResources() {
+        public Iterable<Accountable> getChildResources() {
             List<Accountable> resources = new ArrayList<>();
             if (lookupFactory != null) {
                 resources.add(Accountables.namedAccountable("lookup", lookupFactory));

--- a/src/test/java/org/elasticsearch/search/suggest/completion/AnalyzingCompletionLookupProviderV1.java
+++ b/src/test/java/org/elasticsearch/search/suggest/completion/AnalyzingCompletionLookupProviderV1.java
@@ -289,7 +289,7 @@ public class AnalyzingCompletionLookupProviderV1 extends CompletionLookupProvide
             }
 
             @Override
-            public Iterable<? extends Accountable> getChildResources() {
+            public Iterable<Accountable> getChildResources() {
                 return Accountables.namedAccountables("field", lookupMap);
             }
         };

--- a/src/test/java/org/elasticsearch/test/cache/recycler/MockBigArrays.java
+++ b/src/test/java/org/elasticsearch/test/cache/recycler/MockBigArrays.java
@@ -333,7 +333,7 @@ public class MockBigArrays extends BigArrays {
         }
 
         @Override
-        public Iterable<? extends Accountable> getChildResources() {
+        public Iterable<Accountable> getChildResources() {
             return Collections.singleton(Accountables.namedAccountable("delegate", in));
         }
     }
@@ -378,7 +378,7 @@ public class MockBigArrays extends BigArrays {
         }
         
         @Override
-        public Iterable<? extends Accountable> getChildResources() {
+        public Iterable<Accountable> getChildResources() {
             return Collections.singleton(Accountables.namedAccountable("delegate", in));
         }
     }
@@ -423,7 +423,7 @@ public class MockBigArrays extends BigArrays {
         }
         
         @Override
-        public Iterable<? extends Accountable> getChildResources() {
+        public Iterable<Accountable> getChildResources() {
             return Collections.singleton(Accountables.namedAccountable("delegate", in));
         }
 
@@ -469,7 +469,7 @@ public class MockBigArrays extends BigArrays {
         }
 
         @Override
-        public Iterable<? extends Accountable> getChildResources() {
+        public Iterable<Accountable> getChildResources() {
             return Collections.singleton(Accountables.namedAccountable("delegate", in));
         }
     }
@@ -514,7 +514,7 @@ public class MockBigArrays extends BigArrays {
         }
 
         @Override
-        public Iterable<? extends Accountable> getChildResources() {
+        public Iterable<Accountable> getChildResources() {
             return Collections.singleton(Accountables.namedAccountable("delegate", in));
         }
     }
@@ -549,7 +549,7 @@ public class MockBigArrays extends BigArrays {
         }
 
         @Override
-        public Iterable<? extends Accountable> getChildResources() {
+        public Iterable<Accountable> getChildResources() {
             return Collections.singleton(Accountables.namedAccountable("delegate", in));
         }
     }


### PR DESCRIPTION
The only fix needed was due to the change of the signature of Accountable.getChildResources to not require a wildcard anymore.
