### PR TITLE
Add `ignore_idle_threads` (default: true) to hot threads

### DIFF
--- a/docs/reference/cluster/nodes-hot-threads.asciidoc
+++ b/docs/reference/cluster/nodes-hot-threads.asciidoc
@@ -14,3 +14,5 @@ threads. Parameters allowed are:
 				Defaults to 500ms.
 `type`:: 		The type to sample, defaults to cpu, but supports wait and
 				block to see hot threads that are in wait or block state.
+`ignore_idle_threads`::    If true, known idle threads (e.g. waiting in a socket select, or to
+			   get a task from an empty queue) are filtered out.  Defaults to true.

--- a/rest-api-spec/api/nodes.hot_threads.json
+++ b/rest-api-spec/api/nodes.hot_threads.json
@@ -24,6 +24,10 @@
           "type" : "number",
           "description" : "Specify the number of threads to provide information for (default: 3)"
         },
+	"ignore_idle_threads": {
+          "type" : "boolean",
+          "description" : "Don't show threads that are in known-idle places, such as waiting on a socket select or pulling from an empty task queue (default: true)"
+        },
         "type": {
           "type" : "enum",
           "options" : ["cpu", "wait", "block"],

--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/NodesHotThreadsRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/NodesHotThreadsRequest.java
@@ -96,7 +96,8 @@ public class NodesHotThreadsRequest extends NodesOperationRequest<NodesHotThread
         super.readFrom(in);
         threads = in.readInt();
         if (in.getVersion().before(Version.V_1_5_0)) {
-            ignoreIdleThreads = true;
+            // Pre-1.5.0 did not filter hot threads, so we shouldn't:
+            ignoreIdleThreads = false;
         } else {
             ignoreIdleThreads = in.readBoolean();
         }

--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/NodesHotThreadsRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/NodesHotThreadsRequest.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.action.admin.cluster.node.hotthreads;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.support.nodes.NodesOperationRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -94,7 +95,11 @@ public class NodesHotThreadsRequest extends NodesOperationRequest<NodesHotThread
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
         threads = in.readInt();
-        ignoreIdleThreads = in.readBoolean();
+        if (in.getVersion().before(Version.V_1_5_0)) {
+            ignoreIdleThreads = true;
+        } else {
+            ignoreIdleThreads = in.readBoolean();
+        }
         type = in.readString();
         interval = TimeValue.readTimeValue(in);
         snapshots = in.readInt();
@@ -104,7 +109,9 @@ public class NodesHotThreadsRequest extends NodesOperationRequest<NodesHotThread
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeInt(threads);
-        out.writeBoolean(ignoreIdleThreads);
+        if (out.getVersion().onOrAfter(Version.V_1_5_0)) {
+            out.writeBoolean(ignoreIdleThreads);
+        }
         out.writeString(type);
         interval.writeTo(out);
         out.writeInt(snapshots);

--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/NodesHotThreadsRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/NodesHotThreadsRequest.java
@@ -35,6 +35,7 @@ public class NodesHotThreadsRequest extends NodesOperationRequest<NodesHotThread
     String type = "cpu";
     TimeValue interval = new TimeValue(500, TimeUnit.MILLISECONDS);
     int snapshots = 10;
+    boolean ignoreIdleThreads = true;
 
     /**
      * Get hot threads from nodes based on the nodes ids specified. If none are passed, hot
@@ -50,6 +51,15 @@ public class NodesHotThreadsRequest extends NodesOperationRequest<NodesHotThread
 
     public NodesHotThreadsRequest threads(int threads) {
         this.threads = threads;
+        return this;
+    }
+
+    public boolean ignoreIdleThreads() {
+        return this.ignoreIdleThreads;
+    }
+
+    public NodesHotThreadsRequest ignoreIdleThreads(boolean ignoreIdleThreads) {
+        this.ignoreIdleThreads = ignoreIdleThreads;
         return this;
     }
 
@@ -84,6 +94,7 @@ public class NodesHotThreadsRequest extends NodesOperationRequest<NodesHotThread
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
         threads = in.readInt();
+        ignoreIdleThreads = in.readBoolean();
         type = in.readString();
         interval = TimeValue.readTimeValue(in);
         snapshots = in.readInt();
@@ -93,6 +104,7 @@ public class NodesHotThreadsRequest extends NodesOperationRequest<NodesHotThread
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeInt(threads);
+        out.writeBoolean(ignoreIdleThreads);
         out.writeString(type);
         interval.writeTo(out);
         out.writeInt(snapshots);

--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/NodesHotThreadsRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/NodesHotThreadsRequestBuilder.java
@@ -37,6 +37,11 @@ public class NodesHotThreadsRequestBuilder extends NodesOperationRequestBuilder<
         return this;
     }
 
+    public NodesHotThreadsRequestBuilder setIgnoreIdleThreads(boolean ignoreIdleThreads) {
+        request.ignoreIdleThreads(ignoreIdleThreads);
+        return this;
+    }
+
     public NodesHotThreadsRequestBuilder setType(String type) {
         request.type(type);
         return this;

--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/TransportNodesHotThreadsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/TransportNodesHotThreadsAction.java
@@ -92,7 +92,8 @@ public class TransportNodesHotThreadsAction extends TransportNodesOperationActio
                 .busiestThreads(request.request.threads)
                 .type(request.request.type)
                 .interval(request.request.interval)
-                .threadElementsSnapshotCount(request.request.snapshots);
+                .threadElementsSnapshotCount(request.request.snapshots)
+                .ignoreIdleThreads(request.request.ignoreIdleThreads);
         try {
             return new NodeHotThreads(clusterService.localNode(), hotThreads.detect());
         } catch (Exception e) {

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/hotthreads/RestNodesHotThreadsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/hotthreads/RestNodesHotThreadsAction.java
@@ -54,6 +54,7 @@ public class RestNodesHotThreadsAction extends BaseRestHandler {
         String[] nodesIds = Strings.splitStringByCommaToArray(request.param("nodeId"));
         NodesHotThreadsRequest nodesHotThreadsRequest = new NodesHotThreadsRequest(nodesIds);
         nodesHotThreadsRequest.threads(request.paramAsInt("threads", nodesHotThreadsRequest.threads()));
+        nodesHotThreadsRequest.ignoreIdleThreads(request.paramAsBoolean("ignore_idle_threads", nodesHotThreadsRequest.ignoreIdleThreads()));
         nodesHotThreadsRequest.type(request.param("type", nodesHotThreadsRequest.type()));
         nodesHotThreadsRequest.interval(TimeValue.parseTimeValue(request.param("interval"), nodesHotThreadsRequest.interval()));
         nodesHotThreadsRequest.snapshots(request.paramAsInt("snapshots", nodesHotThreadsRequest.snapshots()));

--- a/src/test/java/org/elasticsearch/action/admin/HotThreadsTest.java
+++ b/src/test/java/org/elasticsearch/action/admin/HotThreadsTest.java
@@ -40,6 +40,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitC
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.Matchers.lessThan;
 
 /**
  */
@@ -63,6 +64,7 @@ public class HotThreadsTest extends ElasticsearchIntegrationTest {
             if (randomBoolean()) {
                 nodesHotThreadsRequestBuilder.setThreads(rarely() ? randomIntBetween(500, 5000) : randomIntBetween(1, 500));
             }
+            nodesHotThreadsRequestBuilder.setIgnoreIdleThreads(randomBoolean());
             if (randomBoolean()) {
                 switch (randomIntBetween(0, 2)) {
                     case 2:
@@ -130,5 +132,35 @@ public class HotThreadsTest extends ElasticsearchIntegrationTest {
             latch.await();
             assertThat(hasErrors.get(), is(false));
         }
+    }
+
+    public void testIgnoreIdleThreads() throws ExecutionException, InterruptedException {
+
+        // First time, don't ignore idle threads:
+        NodesHotThreadsRequestBuilder builder = client().admin().cluster().prepareNodesHotThreads();
+        builder.setIgnoreIdleThreads(false);
+        builder.setThreads(Integer.MAX_VALUE);
+        NodesHotThreadsResponse response = builder.execute().get();
+
+        int totSizeAll = 0;
+        for (NodeHotThreads node : response.getNodesMap().values()) {
+            totSizeAll += node.getHotThreads().length();
+        }
+
+        // Second time, do ignore idle threads:
+        builder = client().admin().cluster().prepareNodesHotThreads();
+        builder.setThreads(Integer.MAX_VALUE);
+
+        // Make sure default is true:
+        assertEquals(true, builder.request().ignoreIdleThreads());
+        response = builder.execute().get();
+
+        int totSizeIgnoreIdle = 0;
+        for (NodeHotThreads node : response.getNodesMap().values()) {
+            totSizeIgnoreIdle += node.getHotThreads().length();
+        }
+
+        // The filtered stacks should be smaller than unfiltered ones:
+        assertThat(totSizeIgnoreIdle, lessThan(totSizeAll));
     }
 }


### PR DESCRIPTION
Adds ignore_idle_threads to hot threads request, defaulting to true.

It's somewhat heuristicky ... but seems to work.

Closes #8908
