### PR TITLE
PlainTransportFuture should not set currentThread().interrupt()

### DIFF
--- a/src/main/java/org/elasticsearch/transport/PlainTransportFuture.java
+++ b/src/main/java/org/elasticsearch/transport/PlainTransportFuture.java
@@ -62,7 +62,6 @@ public class PlainTransportFuture<V extends TransportResponse> extends BaseFutur
         } catch (TimeoutException e) {
             throw new ElasticsearchTimeoutException(e.getMessage());
         } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
             throw new ElasticsearchIllegalStateException("Future got interrupted", e);
         } catch (ExecutionException e) {
             if (e.getCause() instanceof ElasticsearchException) {


### PR DESCRIPTION
We use PlainTransportFuture as a future for our transport calls. If someone blocks on it and it is interrupted, we throw an ElasticsearchIllegalStateException. We should not set  Thread.currentThread().interrupt(); in this case because we already communicate the interrupt through an exception.
