### PR TITLE
Adds methods to get to/from as Strings for Range Aggs

### DIFF
--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalRange.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalRange.java
@@ -19,13 +19,18 @@
 package org.elasticsearch.search.aggregations.bucket.range;
 
 import com.google.common.collect.Lists;
+
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.text.StringText;
 import org.elasticsearch.common.text.Text;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.search.aggregations.*;
+import org.elasticsearch.search.aggregations.AggregationStreams;
+import org.elasticsearch.search.aggregations.Aggregations;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.InternalAggregations;
+import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
 import org.elasticsearch.search.aggregations.bucket.BucketStreamContext;
 import org.elasticsearch.search.aggregations.bucket.BucketStreams;
 import org.elasticsearch.search.aggregations.support.format.ValueFormatter;
@@ -118,6 +123,28 @@ public class InternalRange<B extends InternalRange.Bucket> extends InternalMulti
         @Override
         public Number getTo() {
             return to;
+        }
+
+        @Override
+        public String getFromAsString() {
+            if (Double.isInfinite(from)) {
+                return null;
+            } else if (formatter == null) {
+                return ValueFormatter.RAW.format(from);
+            } else {
+                return formatter.format(from);
+            }
+        }
+
+        @Override
+        public String getToAsString() {
+            if (Double.isInfinite(to)) {
+                return null;
+            } else if (formatter == null) {
+                return ValueFormatter.RAW.format(to);
+            } else {
+                return formatter.format(to);
+            }
         }
 
         @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/range/Range.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/range/Range.java
@@ -20,7 +20,6 @@ package org.elasticsearch.search.aggregations.bucket.range;
 
 import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
 
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -40,9 +39,19 @@ public interface Range extends MultiBucketsAggregation {
         Number getFrom();
 
         /**
-         * @return  The upper bound of the range (excluding)
+         * @return The string value for the lower bound of the range
+         */
+        String getFromAsString();
+
+        /**
+         * @return The upper bound of the range (excluding)
          */
         Number getTo();
+
+        /**
+         * @return The string value for the upper bound of the range (excluding)
+         */
+        String getToAsString();
     }
 
     /**

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ipv4/IPv4Range.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ipv4/IPv4Range.java
@@ -20,7 +20,6 @@ package org.elasticsearch.search.aggregations.bucket.range.ipv4;
 
 import org.elasticsearch.search.aggregations.bucket.range.Range;
 
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -29,10 +28,6 @@ import java.util.List;
 public interface IPv4Range extends Range {
 
     static interface Bucket extends Range.Bucket {
-
-        String getFromAsString();
-
-        String getToAsString();
 
     }
 

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/DateRangeTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/DateRangeTests.java
@@ -163,6 +163,8 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getFromAsDate(), nullValue());
         assertThat(bucket.getTo().doubleValue(), equalTo((double) date(2, 15).getMillis()));
         assertThat(bucket.getToAsDate(), equalTo(date(2, 15)));
+        assertThat(bucket.getFromAsString(), nullValue());
+        assertThat(bucket.getToAsString(), equalTo("2012-02-15T00:00:00.000Z"));
         assertThat(bucket.getDocCount(), equalTo(2l));
 
         bucket = range.getBucketByKey("2012-02-15T00:00:00.000Z-2012-03-15T00:00:00.000Z");
@@ -172,6 +174,8 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getFromAsDate(), equalTo(date(2, 15)));
         assertThat(bucket.getTo().doubleValue(), equalTo((double) date(3, 15).getMillis()));
         assertThat(bucket.getToAsDate(), equalTo(date(3, 15)));
+        assertThat(bucket.getFromAsString(), equalTo("2012-02-15T00:00:00.000Z"));
+        assertThat(bucket.getToAsString(), equalTo("2012-03-15T00:00:00.000Z"));
         assertThat(bucket.getDocCount(), equalTo(2l));
 
         bucket = range.getBucketByKey("2012-03-15T00:00:00.000Z-*");
@@ -181,6 +185,8 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getFromAsDate(), equalTo(date(3, 15)));
         assertThat(bucket.getTo().doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getToAsDate(), nullValue());
+        assertThat(bucket.getFromAsString(), equalTo("2012-03-15T00:00:00.000Z"));
+        assertThat(bucket.getToAsString(), nullValue());
         assertThat(bucket.getDocCount(), equalTo(numDocs - 4l));
     }
 
@@ -209,6 +215,8 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getFromAsDate(), nullValue());
         assertThat(bucket.getTo().doubleValue(), equalTo((double) date(2, 15).getMillis()));
         assertThat(bucket.getToAsDate(), equalTo(date(2, 15)));
+        assertThat(bucket.getFromAsString(), nullValue());
+        assertThat(bucket.getToAsString(), equalTo("2012-02-15T00:00:00.000Z"));
         assertThat(bucket.getDocCount(), equalTo(2l));
 
         bucket = range.getBucketByKey("2012-02-15T00:00:00.000Z-2012-03-15T00:00:00.000Z");
@@ -218,6 +226,8 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getFromAsDate(), equalTo(date(2, 15)));
         assertThat(bucket.getTo().doubleValue(), equalTo((double) date(3, 15).getMillis()));
         assertThat(bucket.getToAsDate(), equalTo(date(3, 15)));
+        assertThat(bucket.getFromAsString(), equalTo("2012-02-15T00:00:00.000Z"));
+        assertThat(bucket.getToAsString(), equalTo("2012-03-15T00:00:00.000Z"));
         assertThat(bucket.getDocCount(), equalTo(2l));
 
         bucket = range.getBucketByKey("2012-03-15T00:00:00.000Z-*");
@@ -227,6 +237,8 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getFromAsDate(), equalTo(date(3, 15)));
         assertThat(bucket.getTo().doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getToAsDate(), nullValue());
+        assertThat(bucket.getFromAsString(), equalTo("2012-03-15T00:00:00.000Z"));
+        assertThat(bucket.getToAsString(), nullValue());
         assertThat(bucket.getDocCount(), equalTo(numDocs - 4l));
     }
 
@@ -256,6 +268,8 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getFromAsDate(), nullValue());
         assertThat(bucket.getTo().doubleValue(), equalTo((double) date(2, 15).getMillis()));
         assertThat(bucket.getToAsDate(), equalTo(date(2, 15)));
+        assertThat(bucket.getFromAsString(), nullValue());
+        assertThat(bucket.getToAsString(), equalTo("2012-02-15"));
         assertThat(bucket.getDocCount(), equalTo(2l));
 
         bucket = range.getBucketByKey("2012-02-15-2012-03-15");
@@ -265,6 +279,8 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getFromAsDate(), equalTo(date(2, 15)));
         assertThat(bucket.getTo().doubleValue(), equalTo((double) date(3, 15).getMillis()));
         assertThat(bucket.getToAsDate(), equalTo(date(3, 15)));
+        assertThat(bucket.getFromAsString(), equalTo("2012-02-15"));
+        assertThat(bucket.getToAsString(), equalTo("2012-03-15"));
         assertThat(bucket.getDocCount(), equalTo(2l));
 
         bucket = range.getBucketByKey("2012-03-15-*");
@@ -274,6 +290,8 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getFromAsDate(), equalTo(date(3, 15)));
         assertThat(bucket.getTo().doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getToAsDate(), nullValue());
+        assertThat(bucket.getFromAsString(), equalTo("2012-03-15"));
+        assertThat(bucket.getToAsString(), nullValue());
         assertThat(bucket.getDocCount(), equalTo(numDocs - 4l));
     }
 
@@ -302,6 +320,8 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getFromAsDate(), nullValue());
         assertThat(bucket.getTo().doubleValue(), equalTo((double) date(2, 15).getMillis()));
         assertThat(bucket.getToAsDate(), equalTo(date(2, 15)));
+        assertThat(bucket.getFromAsString(), nullValue());
+        assertThat(bucket.getToAsString(), equalTo("2012-02-15T00:00:00.000Z"));
         assertThat(bucket.getDocCount(), equalTo(2l));
 
         bucket = range.getBucketByKey("2012-02-15T00:00:00.000Z-2012-03-15T00:00:00.000Z");
@@ -311,6 +331,8 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getFromAsDate(), equalTo(date(2, 15)));
         assertThat(bucket.getTo().doubleValue(), equalTo((double) date(3, 15).getMillis()));
         assertThat(bucket.getToAsDate(), equalTo(date(3, 15)));
+        assertThat(bucket.getFromAsString(), equalTo("2012-02-15T00:00:00.000Z"));
+        assertThat(bucket.getToAsString(), equalTo("2012-03-15T00:00:00.000Z"));
         assertThat(bucket.getDocCount(), equalTo(2l));
 
         bucket = range.getBucketByKey("2012-03-15T00:00:00.000Z-*");
@@ -320,6 +342,8 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getFromAsDate(), equalTo(date(3, 15)));
         assertThat(bucket.getTo().doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getToAsDate(), nullValue());
+        assertThat(bucket.getFromAsString(), equalTo("2012-03-15T00:00:00.000Z"));
+        assertThat(bucket.getToAsString(), nullValue());
         assertThat(bucket.getDocCount(), equalTo(numDocs - 4l));
     }
 
@@ -348,6 +372,8 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getFromAsDate(), nullValue());
         assertThat(bucket.getTo().doubleValue(), equalTo((double) date(2, 15).getMillis()));
         assertThat(bucket.getToAsDate(), equalTo(date(2, 15)));
+        assertThat(bucket.getFromAsString(), nullValue());
+        assertThat(bucket.getToAsString(), equalTo("2012-02-15T00:00:00.000Z"));
         assertThat(bucket.getDocCount(), equalTo(2l));
 
         bucket = range.getBucketByKey("r2");
@@ -357,6 +383,8 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getFromAsDate(), equalTo(date(2, 15)));
         assertThat(bucket.getTo().doubleValue(), equalTo((double) date(3, 15).getMillis()));
         assertThat(bucket.getToAsDate(), equalTo(date(3, 15)));
+        assertThat(bucket.getFromAsString(), equalTo("2012-02-15T00:00:00.000Z"));
+        assertThat(bucket.getToAsString(), equalTo("2012-03-15T00:00:00.000Z"));
         assertThat(bucket.getDocCount(), equalTo(2l));
 
         bucket = range.getBucketByKey("r3");
@@ -366,6 +394,8 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getFromAsDate(), equalTo(date(3, 15)));
         assertThat(bucket.getTo().doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getToAsDate(), nullValue());
+        assertThat(bucket.getFromAsString(), equalTo("2012-03-15T00:00:00.000Z"));
+        assertThat(bucket.getToAsString(), nullValue());
         assertThat(bucket.getDocCount(), equalTo(numDocs - 4l));
     }
 
@@ -407,6 +437,8 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getFromAsDate(), nullValue());
         assertThat(bucket.getTo().doubleValue(), equalTo((double) date(2, 15).getMillis()));
         assertThat(bucket.getToAsDate(), equalTo(date(2, 15)));
+        assertThat(bucket.getFromAsString(), nullValue());
+        assertThat(bucket.getToAsString(), equalTo("2012-02-15T00:00:00.000Z"));
         assertThat(bucket.getDocCount(), equalTo(2l));
         Sum sum = bucket.getAggregations().get("sum");
         assertThat(sum, notNullValue());
@@ -422,6 +454,8 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getFromAsDate(), equalTo(date(2, 15)));
         assertThat(bucket.getTo().doubleValue(), equalTo((double) date(3, 15).getMillis()));
         assertThat(bucket.getToAsDate(), equalTo(date(3, 15)));
+        assertThat(bucket.getFromAsString(), equalTo("2012-02-15T00:00:00.000Z"));
+        assertThat(bucket.getToAsString(), equalTo("2012-03-15T00:00:00.000Z"));
         assertThat(bucket.getDocCount(), equalTo(2l));
         sum = bucket.getAggregations().get("sum");
         assertThat(sum, notNullValue());
@@ -437,6 +471,8 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getFromAsDate(), equalTo(date(3, 15)));
         assertThat(bucket.getTo().doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getToAsDate(), nullValue());
+        assertThat(bucket.getFromAsString(), equalTo("2012-03-15T00:00:00.000Z"));
+        assertThat(bucket.getToAsString(), nullValue());
         assertThat(bucket.getDocCount(), equalTo(numDocs - 4l));
         sum = bucket.getAggregations().get("sum");
         assertThat(sum, notNullValue());
@@ -470,6 +506,8 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getFromAsDate(), nullValue());
         assertThat(bucket.getTo().doubleValue(), equalTo((double) date(2, 15).getMillis()));
         assertThat(bucket.getToAsDate(), equalTo(date(2, 15)));
+        assertThat(bucket.getFromAsString(), nullValue());
+        assertThat(bucket.getToAsString(), equalTo("2012-02-15T00:00:00.000Z"));
         assertThat(bucket.getDocCount(), equalTo(2l));
         Min min = bucket.getAggregations().get("min");
         assertThat(min, notNullValue());
@@ -482,6 +520,8 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getFromAsDate(), equalTo(date(2, 15)));
         assertThat(bucket.getTo().doubleValue(), equalTo((double) date(3, 15).getMillis()));
         assertThat(bucket.getToAsDate(), equalTo(date(3, 15)));
+        assertThat(bucket.getFromAsString(), equalTo("2012-02-15T00:00:00.000Z"));
+        assertThat(bucket.getToAsString(), equalTo("2012-03-15T00:00:00.000Z"));
         assertThat(bucket.getDocCount(), equalTo(2l));
         min = bucket.getAggregations().get("min");
         assertThat(min, notNullValue());
@@ -494,6 +534,8 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getFromAsDate(), equalTo(date(3, 15)));
         assertThat(bucket.getTo().doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getToAsDate(), nullValue());
+        assertThat(bucket.getFromAsString(), equalTo("2012-03-15T00:00:00.000Z"));
+        assertThat(bucket.getToAsString(), nullValue());
         assertThat(bucket.getDocCount(), equalTo(numDocs - 4l));
         min = bucket.getAggregations().get("min");
         assertThat(min, notNullValue());
@@ -534,6 +576,8 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getFromAsDate(), nullValue());
         assertThat(bucket.getTo().doubleValue(), equalTo((double) date(2, 15).getMillis()));
         assertThat(bucket.getToAsDate(), equalTo(date(2, 15)));
+        assertThat(bucket.getFromAsString(), nullValue());
+        assertThat(bucket.getToAsString(), equalTo("2012-02-15T00:00:00.000Z"));
         assertThat(bucket.getDocCount(), equalTo(2l));
 
         bucket = range.getBucketByKey("2012-02-15T00:00:00.000Z-2012-03-15T00:00:00.000Z");
@@ -543,6 +587,8 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getFromAsDate(), equalTo(date(2, 15)));
         assertThat(bucket.getTo().doubleValue(), equalTo((double) date(3, 15).getMillis()));
         assertThat(bucket.getToAsDate(), equalTo(date(3, 15)));
+        assertThat(bucket.getFromAsString(), equalTo("2012-02-15T00:00:00.000Z"));
+        assertThat(bucket.getToAsString(), equalTo("2012-03-15T00:00:00.000Z"));
         assertThat(bucket.getDocCount(), equalTo(3l));
 
         bucket = range.getBucketByKey("2012-03-15T00:00:00.000Z-*");
@@ -552,6 +598,8 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getFromAsDate(), equalTo(date(3, 15)));
         assertThat(bucket.getTo().doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getToAsDate(), nullValue());
+        assertThat(bucket.getFromAsString(), equalTo("2012-03-15T00:00:00.000Z"));
+        assertThat(bucket.getToAsString(), nullValue());
         assertThat(bucket.getDocCount(), equalTo(numDocs - 2l));
     }
 
@@ -591,6 +639,8 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getFromAsDate(), nullValue());
         assertThat(bucket.getTo().doubleValue(), equalTo((double) date(2, 15).getMillis()));
         assertThat(bucket.getToAsDate(), equalTo(date(2, 15)));
+        assertThat(bucket.getFromAsString(), nullValue());
+        assertThat(bucket.getToAsString(), equalTo("2012-02-15T00:00:00.000Z"));
         assertThat(bucket.getDocCount(), equalTo(1l));
 
         bucket = range.getBucketByKey("2012-02-15T00:00:00.000Z-2012-03-15T00:00:00.000Z");
@@ -600,6 +650,8 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getFromAsDate(), equalTo(date(2, 15)));
         assertThat(bucket.getTo().doubleValue(), equalTo((double) date(3, 15).getMillis()));
         assertThat(bucket.getToAsDate(), equalTo(date(3, 15)));
+        assertThat(bucket.getFromAsString(), equalTo("2012-02-15T00:00:00.000Z"));
+        assertThat(bucket.getToAsString(), equalTo("2012-03-15T00:00:00.000Z"));
         assertThat(bucket.getDocCount(), equalTo(2l));
 
         bucket = range.getBucketByKey("2012-03-15T00:00:00.000Z-*");
@@ -609,6 +661,8 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getFromAsDate(), equalTo(date(3, 15)));
         assertThat(bucket.getTo().doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getToAsDate(), nullValue());
+        assertThat(bucket.getFromAsString(), equalTo("2012-03-15T00:00:00.000Z"));
+        assertThat(bucket.getToAsString(), nullValue());
         assertThat(bucket.getDocCount(), equalTo(numDocs - 1l));
     }
 
@@ -648,6 +702,8 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getFromAsDate(), nullValue());
         assertThat(bucket.getTo().doubleValue(), equalTo((double) date(2, 15).getMillis()));
         assertThat(bucket.getToAsDate(), equalTo(date(2, 15)));
+        assertThat(bucket.getFromAsString(), nullValue());
+        assertThat(bucket.getToAsString(), equalTo("2012-02-15T00:00:00.000Z"));
         assertThat(bucket.getDocCount(), equalTo(1l));
         Max max = bucket.getAggregations().get("max");
         assertThat(max, notNullValue());
@@ -660,6 +716,8 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getFromAsDate(), equalTo(date(2, 15)));
         assertThat(bucket.getTo().doubleValue(), equalTo((double) date(3, 15).getMillis()));
         assertThat(bucket.getToAsDate(), equalTo(date(3, 15)));
+        assertThat(bucket.getFromAsString(), equalTo("2012-02-15T00:00:00.000Z"));
+        assertThat(bucket.getToAsString(), equalTo("2012-03-15T00:00:00.000Z"));
         assertThat(bucket.getDocCount(), equalTo(2l));
         max = bucket.getAggregations().get("max");
         assertThat(max, notNullValue());
@@ -672,6 +730,8 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getFromAsDate(), equalTo(date(3, 15)));
         assertThat(bucket.getTo().doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getToAsDate(), nullValue());
+        assertThat(bucket.getFromAsString(), equalTo("2012-03-15T00:00:00.000Z"));
+        assertThat(bucket.getToAsString(), nullValue());
         assertThat(bucket.getDocCount(), equalTo(numDocs - 1l));
         max = bucket.getAggregations().get("max");
         assertThat(max, notNullValue());
@@ -702,6 +762,8 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getFromAsDate(), nullValue());
         assertThat(bucket.getTo().doubleValue(), equalTo((double) date(2, 15).getMillis()));
         assertThat(bucket.getToAsDate(), equalTo(date(2, 15)));
+        assertThat(bucket.getFromAsString(), nullValue());
+        assertThat(bucket.getToAsString(), equalTo("2012-02-15T00:00:00.000Z"));
         assertThat(bucket.getDocCount(), equalTo(2l));
 
         bucket = range.getBucketByKey("2012-02-15T00:00:00.000Z-2012-03-15T00:00:00.000Z");
@@ -711,6 +773,8 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getFromAsDate(), equalTo(date(2, 15)));
         assertThat(bucket.getTo().doubleValue(), equalTo((double) date(3, 15).getMillis()));
         assertThat(bucket.getToAsDate(), equalTo(date(3, 15)));
+        assertThat(bucket.getFromAsString(), equalTo("2012-02-15T00:00:00.000Z"));
+        assertThat(bucket.getToAsString(), equalTo("2012-03-15T00:00:00.000Z"));
         assertThat(bucket.getDocCount(), equalTo(2l));
 
         bucket = range.getBucketByKey("2012-03-15T00:00:00.000Z-*");
@@ -720,6 +784,8 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getFromAsDate(), equalTo(date(3, 15)));
         assertThat(bucket.getTo().doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getToAsDate(), nullValue());
+        assertThat(bucket.getFromAsString(), equalTo("2012-03-15T00:00:00.000Z"));
+        assertThat(bucket.getToAsString(), nullValue());
         assertThat(bucket.getDocCount(), equalTo(numDocs - 4l));
     }
 
@@ -749,6 +815,8 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getFromAsDate(), nullValue());
         assertThat(bucket.getTo().doubleValue(), equalTo((double) date(2, 15).getMillis()));
         assertThat(bucket.getToAsDate(), equalTo(date(2, 15)));
+        assertThat(bucket.getFromAsString(), nullValue());
+        assertThat(bucket.getToAsString(), equalTo("2012-02-15T00:00:00.000Z"));
         assertThat(bucket.getDocCount(), equalTo(2l));
         Max max = bucket.getAggregations().get("max");
         assertThat(max, notNullValue());
@@ -761,6 +829,8 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getFromAsDate(), equalTo(date(2, 15)));
         assertThat(bucket.getTo().doubleValue(), equalTo((double) date(3, 15).getMillis()));
         assertThat(bucket.getToAsDate(), equalTo(date(3, 15)));
+        assertThat(bucket.getFromAsString(), equalTo("2012-02-15T00:00:00.000Z"));
+        assertThat(bucket.getToAsString(), equalTo("2012-03-15T00:00:00.000Z"));
         assertThat(bucket.getDocCount(), equalTo(2l));
         max = bucket.getAggregations().get("max");
         assertThat(max, notNullValue());
@@ -773,6 +843,8 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getFromAsDate(), equalTo(date(3, 15)));
         assertThat(bucket.getTo().doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getToAsDate(), nullValue());
+        assertThat(bucket.getFromAsString(), equalTo("2012-03-15T00:00:00.000Z"));
+        assertThat(bucket.getToAsString(), nullValue());
         assertThat(bucket.getDocCount(), equalTo(numDocs - 4l));
         max = bucket.getAggregations().get("max");
         assertThat(max, notNullValue());
@@ -812,6 +884,8 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getFromAsDate(), nullValue());
         assertThat(bucket.getTo().doubleValue(), equalTo((double) date(2, 15).getMillis()));
         assertThat(bucket.getToAsDate(), equalTo(date(2, 15)));
+        assertThat(bucket.getFromAsString(), nullValue());
+        assertThat(bucket.getToAsString(), equalTo("2012-02-15T00:00:00.000Z"));
         assertThat(bucket.getDocCount(), equalTo(2l));
 
         bucket = range.getBucketByKey("2012-02-15T00:00:00.000Z-2012-03-15T00:00:00.000Z");
@@ -821,6 +895,8 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getFromAsDate(), equalTo(date(2, 15)));
         assertThat(bucket.getTo().doubleValue(), equalTo((double) date(3, 15).getMillis()));
         assertThat(bucket.getToAsDate(), equalTo(date(3, 15)));
+        assertThat(bucket.getFromAsString(), equalTo("2012-02-15T00:00:00.000Z"));
+        assertThat(bucket.getToAsString(), equalTo("2012-03-15T00:00:00.000Z"));
         assertThat(bucket.getDocCount(), equalTo(3l));
 
         bucket = range.getBucketByKey("2012-03-15T00:00:00.000Z-*");
@@ -830,6 +906,8 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getFromAsDate(), equalTo(date(3, 15)));
         assertThat(bucket.getTo().doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getToAsDate(), nullValue());
+        assertThat(bucket.getFromAsString(), equalTo("2012-03-15T00:00:00.000Z"));
+        assertThat(bucket.getToAsString(), nullValue());
         assertThat(bucket.getDocCount(), equalTo(numDocs - 2l));
     }
 
@@ -859,6 +937,8 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getFromAsDate(), nullValue());
         assertThat(bucket.getTo().doubleValue(), equalTo((double) date(2, 15).getMillis()));
         assertThat(bucket.getToAsDate(), equalTo(date(2, 15)));
+        assertThat(bucket.getFromAsString(), nullValue());
+        assertThat(bucket.getToAsString(), equalTo("2012-02-15T00:00:00.000Z"));
         assertThat(bucket.getDocCount(), equalTo(2l));
         Min min = bucket.getAggregations().get("min");
         assertThat(min, notNullValue());
@@ -871,6 +951,8 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getFromAsDate(), equalTo(date(2, 15)));
         assertThat(bucket.getTo().doubleValue(), equalTo((double) date(3, 15).getMillis()));
         assertThat(bucket.getToAsDate(), equalTo(date(3, 15)));
+        assertThat(bucket.getFromAsString(), equalTo("2012-02-15T00:00:00.000Z"));
+        assertThat(bucket.getToAsString(), equalTo("2012-03-15T00:00:00.000Z"));
         assertThat(bucket.getDocCount(), equalTo(3l));
         min = bucket.getAggregations().get("min");
         assertThat(min, notNullValue());
@@ -883,6 +965,8 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getFromAsDate(), equalTo(date(3, 15)));
         assertThat(bucket.getTo().doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getToAsDate(), nullValue());
+        assertThat(bucket.getFromAsString(), equalTo("2012-03-15T00:00:00.000Z"));
+        assertThat(bucket.getToAsString(), nullValue());
         assertThat(bucket.getDocCount(), equalTo(numDocs - 2l));
         min = bucket.getAggregations().get("min");
         assertThat(min, notNullValue());
@@ -916,6 +1000,8 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getFromAsDate(), nullValue());
         assertThat(bucket.getTo().doubleValue(), equalTo((double) date(2, 15).getMillis()));
         assertThat(bucket.getToAsDate(), equalTo(date(2, 15)));
+        assertThat(bucket.getFromAsString(), nullValue());
+        assertThat(bucket.getToAsString(), equalTo("2012-02-15T00:00:00.000Z"));
         assertThat(bucket.getDocCount(), equalTo(0l));
 
         bucket = range.getBucketByKey("2012-02-15T00:00:00.000Z-2012-03-15T00:00:00.000Z");
@@ -925,6 +1011,8 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getFromAsDate(), equalTo(date(2, 15)));
         assertThat(bucket.getTo().doubleValue(), equalTo((double) date(3, 15).getMillis()));
         assertThat(bucket.getToAsDate(), equalTo(date(3, 15)));
+        assertThat(bucket.getFromAsString(), equalTo("2012-02-15T00:00:00.000Z"));
+        assertThat(bucket.getToAsString(), equalTo("2012-03-15T00:00:00.000Z"));
         assertThat(bucket.getDocCount(), equalTo(0l));
 
         bucket = range.getBucketByKey("2012-03-15T00:00:00.000Z-*");
@@ -934,6 +1022,8 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getFromAsDate(), equalTo(date(3, 15)));
         assertThat(bucket.getTo().doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getToAsDate(), nullValue());
+        assertThat(bucket.getFromAsString(), equalTo("2012-03-15T00:00:00.000Z"));
+        assertThat(bucket.getToAsString(), nullValue());
         assertThat(bucket.getDocCount(), equalTo(0l));
     }
 
@@ -962,6 +1052,8 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getFromAsDate(), nullValue());
         assertThat(bucket.getTo().doubleValue(), equalTo((double) date(2, 15).getMillis()));
         assertThat(bucket.getToAsDate(), equalTo(date(2, 15)));
+        assertThat(bucket.getFromAsString(), nullValue());
+        assertThat(bucket.getToAsString(), equalTo("2012-02-15T00:00:00.000Z"));
         assertThat(bucket.getDocCount(), equalTo(0l));
 
         bucket = range.getBucketByKey("2012-02-15T00:00:00.000Z-2012-03-15T00:00:00.000Z");
@@ -971,6 +1063,8 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getFromAsDate(), equalTo(date(2, 15)));
         assertThat(bucket.getTo().doubleValue(), equalTo((double) date(3, 15).getMillis()));
         assertThat(bucket.getToAsDate(), equalTo(date(3, 15)));
+        assertThat(bucket.getFromAsString(), equalTo("2012-02-15T00:00:00.000Z"));
+        assertThat(bucket.getToAsString(), equalTo("2012-03-15T00:00:00.000Z"));
         assertThat(bucket.getDocCount(), equalTo(0l));
 
         bucket = range.getBucketByKey("2012-03-15T00:00:00.000Z-*");
@@ -980,6 +1074,8 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getFromAsDate(), equalTo(date(3, 15)));
         assertThat(bucket.getTo().doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getToAsDate(), nullValue());
+        assertThat(bucket.getFromAsString(), equalTo("2012-03-15T00:00:00.000Z"));
+        assertThat(bucket.getToAsString(), nullValue());
         assertThat(bucket.getDocCount(), equalTo(0l));
     }
 
@@ -1008,6 +1104,8 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getFromAsDate(), nullValue());
         assertThat(bucket.getTo().doubleValue(), equalTo((double) date(2, 15).getMillis()));
         assertThat(bucket.getToAsDate(), equalTo(date(2, 15)));
+        assertThat(bucket.getFromAsString(), nullValue());
+        assertThat(bucket.getToAsString(), equalTo("2012-02-15T00:00:00.000Z"));
         assertThat(bucket.getDocCount(), equalTo(2l));
 
         bucket = range.getBucketByKey("2012-02-15T00:00:00.000Z-2012-03-15T00:00:00.000Z");
@@ -1017,6 +1115,8 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getFromAsDate(), equalTo(date(2, 15)));
         assertThat(bucket.getTo().doubleValue(), equalTo((double) date(3, 15).getMillis()));
         assertThat(bucket.getToAsDate(), equalTo(date(3, 15)));
+        assertThat(bucket.getFromAsString(), equalTo("2012-02-15T00:00:00.000Z"));
+        assertThat(bucket.getToAsString(), equalTo("2012-03-15T00:00:00.000Z"));
         assertThat(bucket.getDocCount(), equalTo(2l));
 
         bucket = range.getBucketByKey("2012-03-15T00:00:00.000Z-*");
@@ -1026,6 +1126,8 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getFromAsDate(), equalTo(date(3, 15)));
         assertThat(bucket.getTo().doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getToAsDate(), nullValue());
+        assertThat(bucket.getFromAsString(), equalTo("2012-03-15T00:00:00.000Z"));
+        assertThat(bucket.getToAsString(), nullValue());
         assertThat(bucket.getDocCount(), equalTo(numDocs - 4l));
     }
 

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoDistanceTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoDistanceTests.java
@@ -18,11 +18,6 @@
  */
 package org.elasticsearch.search.aggregations.bucket;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Set;
-
 import com.google.common.collect.Sets;
 
 import org.elasticsearch.action.index.IndexRequestBuilder;
@@ -37,6 +32,11 @@ import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.geoDistance;
@@ -47,6 +47,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.core.IsNull.notNullValue;
+import static org.hamcrest.core.IsNull.nullValue;
 
 /**
  *
@@ -146,6 +147,8 @@ public class GeoDistanceTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("*-500.0"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(0.0));
         assertThat(bucket.getTo().doubleValue(), equalTo(500.0));
+        assertThat(bucket.getFromAsString(), equalTo("0.0"));
+        assertThat(bucket.getToAsString(), equalTo("500.0"));
         assertThat(bucket.getDocCount(), equalTo(2l));
 
         bucket = geoDist.getBucketByKey("500.0-1000.0");
@@ -153,6 +156,8 @@ public class GeoDistanceTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("500.0-1000.0"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(500.0));
         assertThat(bucket.getTo().doubleValue(), equalTo(1000.0));
+        assertThat(bucket.getFromAsString(), equalTo("500.0"));
+        assertThat(bucket.getToAsString(), equalTo("1000.0"));
         assertThat(bucket.getDocCount(), equalTo(2l));
 
         bucket = geoDist.getBucketByKey("1000.0-*");
@@ -160,6 +165,8 @@ public class GeoDistanceTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("1000.0-*"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(1000.0));
         assertThat(bucket.getTo().doubleValue(), equalTo(Double.POSITIVE_INFINITY));
+        assertThat(bucket.getFromAsString(), equalTo("1000.0"));
+        assertThat(bucket.getToAsString(), nullValue());
         assertThat(bucket.getDocCount(), equalTo(1l));
     }
 
@@ -188,6 +195,8 @@ public class GeoDistanceTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("ring1"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(0.0));
         assertThat(bucket.getTo().doubleValue(), equalTo(500.0));
+        assertThat(bucket.getFromAsString(), equalTo("0.0"));
+        assertThat(bucket.getToAsString(), equalTo("500.0"));
         assertThat(bucket.getDocCount(), equalTo(2l));
 
         bucket = geoDist.getBucketByKey("ring2");
@@ -195,6 +204,8 @@ public class GeoDistanceTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("ring2"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(500.0));
         assertThat(bucket.getTo().doubleValue(), equalTo(1000.0));
+        assertThat(bucket.getFromAsString(), equalTo("500.0"));
+        assertThat(bucket.getToAsString(), equalTo("1000.0"));
         assertThat(bucket.getDocCount(), equalTo(2l));
 
         bucket = geoDist.getBucketByKey("ring3");
@@ -202,6 +213,8 @@ public class GeoDistanceTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("ring3"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(1000.0));
         assertThat(bucket.getTo().doubleValue(), equalTo(Double.POSITIVE_INFINITY));
+        assertThat(bucket.getFromAsString(), equalTo("1000.0"));
+        assertThat(bucket.getToAsString(), nullValue());
         assertThat(bucket.getDocCount(), equalTo(1l));
     }
 
@@ -232,6 +245,8 @@ public class GeoDistanceTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("*-500.0"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(0.0));
         assertThat(bucket.getTo().doubleValue(), equalTo(500.0));
+        assertThat(bucket.getFromAsString(), equalTo("0.0"));
+        assertThat(bucket.getToAsString(), equalTo("500.0"));
         assertThat(bucket.getDocCount(), equalTo(0l));
 
         bucket = geoDist.getBucketByKey("500.0-1000.0");
@@ -239,6 +254,8 @@ public class GeoDistanceTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("500.0-1000.0"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(500.0));
         assertThat(bucket.getTo().doubleValue(), equalTo(1000.0));
+        assertThat(bucket.getFromAsString(), equalTo("500.0"));
+        assertThat(bucket.getToAsString(), equalTo("1000.0"));
         assertThat(bucket.getDocCount(), equalTo(0l));
 
         bucket = geoDist.getBucketByKey("1000.0-*");
@@ -246,6 +263,8 @@ public class GeoDistanceTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("1000.0-*"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(1000.0));
         assertThat(bucket.getTo().doubleValue(), equalTo(Double.POSITIVE_INFINITY));
+        assertThat(bucket.getFromAsString(), equalTo("1000.0"));
+        assertThat(bucket.getToAsString(), nullValue());
         assertThat(bucket.getDocCount(), equalTo(0l));
     }
 
@@ -274,6 +293,8 @@ public class GeoDistanceTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("*-500.0"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(0.0));
         assertThat(bucket.getTo().doubleValue(), equalTo(500.0));
+        assertThat(bucket.getFromAsString(), equalTo("0.0"));
+        assertThat(bucket.getToAsString(), equalTo("500.0"));
         assertThat(bucket.getDocCount(), equalTo(2l));
 
         bucket = geoDist.getBucketByKey("500.0-1000.0");
@@ -281,6 +302,8 @@ public class GeoDistanceTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("500.0-1000.0"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(500.0));
         assertThat(bucket.getTo().doubleValue(), equalTo(1000.0));
+        assertThat(bucket.getFromAsString(), equalTo("500.0"));
+        assertThat(bucket.getToAsString(), equalTo("1000.0"));
         assertThat(bucket.getDocCount(), equalTo(2l));
 
         bucket = geoDist.getBucketByKey("1000.0-*");
@@ -288,6 +311,8 @@ public class GeoDistanceTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("1000.0-*"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(1000.0));
         assertThat(bucket.getTo().doubleValue(), equalTo(Double.POSITIVE_INFINITY));
+        assertThat(bucket.getFromAsString(), equalTo("1000.0"));
+        assertThat(bucket.getToAsString(), nullValue());
         assertThat(bucket.getDocCount(), equalTo(1l));
     }
 
@@ -322,6 +347,8 @@ public class GeoDistanceTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("*-500.0"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(0.0));
         assertThat(bucket.getTo().doubleValue(), equalTo(500.0));
+        assertThat(bucket.getFromAsString(), equalTo("0.0"));
+        assertThat(bucket.getToAsString(), equalTo("500.0"));
         assertThat(bucket.getDocCount(), equalTo(2l));
         assertThat(bucket.getAggregations().asList().isEmpty(), is(false));
         Terms cities = bucket.getAggregations().get("cities");
@@ -340,6 +367,8 @@ public class GeoDistanceTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("500.0-1000.0"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(500.0));
         assertThat(bucket.getTo().doubleValue(), equalTo(1000.0));
+        assertThat(bucket.getFromAsString(), equalTo("500.0"));
+        assertThat(bucket.getToAsString(), equalTo("1000.0"));
         assertThat(bucket.getDocCount(), equalTo(2l));
         assertThat(bucket.getAggregations().asList().isEmpty(), is(false));
         cities = bucket.getAggregations().get("cities");
@@ -358,6 +387,8 @@ public class GeoDistanceTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("1000.0-*"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(1000.0));
         assertThat(bucket.getTo().doubleValue(), equalTo(Double.POSITIVE_INFINITY));
+        assertThat(bucket.getFromAsString(), equalTo("1000.0"));
+        assertThat(bucket.getToAsString(), nullValue());
         assertThat(bucket.getDocCount(), equalTo(1l));
         assertThat(bucket.getAggregations().asList().isEmpty(), is(false));
         cities = bucket.getAggregations().get("cities");
@@ -394,6 +425,8 @@ public class GeoDistanceTests extends ElasticsearchIntegrationTest {
         assertThat(buckets.get(0).getKey(), equalTo("0-100"));
         assertThat(buckets.get(0).getFrom().doubleValue(), equalTo(0.0));
         assertThat(buckets.get(0).getTo().doubleValue(), equalTo(100.0));
+        assertThat(buckets.get(0).getFromAsString(), equalTo("0.0"));
+        assertThat(buckets.get(0).getToAsString(), equalTo("100.0"));
         assertThat(buckets.get(0).getDocCount(), equalTo(0l));
     }
 
@@ -422,6 +455,8 @@ public class GeoDistanceTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("*-500.0"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(0.0));
         assertThat(bucket.getTo().doubleValue(), equalTo(500.0));
+        assertThat(bucket.getFromAsString(), equalTo("0.0"));
+        assertThat(bucket.getToAsString(), equalTo("500.0"));
         assertThat(bucket.getDocCount(), equalTo(2l));
 
         bucket = geoDist.getBucketByKey("500.0-1000.0");
@@ -429,6 +464,8 @@ public class GeoDistanceTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("500.0-1000.0"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(500.0));
         assertThat(bucket.getTo().doubleValue(), equalTo(1000.0));
+        assertThat(bucket.getFromAsString(), equalTo("500.0"));
+        assertThat(bucket.getToAsString(), equalTo("1000.0"));
         assertThat(bucket.getDocCount(), equalTo(2l));
 
         bucket = geoDist.getBucketByKey("1000.0-*");
@@ -436,6 +473,8 @@ public class GeoDistanceTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("1000.0-*"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(1000.0));
         assertThat(bucket.getTo().doubleValue(), equalTo(Double.POSITIVE_INFINITY));
+        assertThat(bucket.getFromAsString(), equalTo("1000.0"));
+        assertThat(bucket.getToAsString(), nullValue());
         assertThat(bucket.getDocCount(), equalTo(1l));
     }
 

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/RangeTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/RangeTests.java
@@ -44,6 +44,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSear
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsNull.notNullValue;
+import static org.hamcrest.core.IsNull.nullValue;
 
 /**
  *
@@ -104,6 +105,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
             Range range = bucket.getAggregations().get("range");
             Range.Bucket rangeBucket = range.getBucketByKey("*-3.0");
             assertThat(rangeBucket, notNullValue());
+            assertThat(rangeBucket.getFromAsString(), nullValue());
+            assertThat(rangeBucket.getToAsString(), equalTo("3.0"));
             if (i == 1 || i == 3) {
                 assertThat(rangeBucket.getDocCount(), equalTo(1L));
             } else if (i == 2) {
@@ -113,6 +116,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
             }
             rangeBucket = range.getBucketByKey("3.0-6.0");
             assertThat(rangeBucket, notNullValue());
+            assertThat(rangeBucket.getFromAsString(), equalTo("3.0"));
+            assertThat(rangeBucket.getToAsString(), equalTo("6.0"));
             if (i == 3 || i == 6) {
                 assertThat(rangeBucket.getDocCount(), equalTo(1L));
             } else if (i == 4 || i == 5) {
@@ -122,6 +127,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
             }
             rangeBucket = range.getBucketByKey("6.0-*");
             assertThat(rangeBucket, notNullValue());
+            assertThat(rangeBucket.getFromAsString(), equalTo("6.0"));
+            assertThat(rangeBucket.getToAsString(), nullValue());
             if (i == 6 || i == numDocs + 1) {
                 assertThat(rangeBucket.getDocCount(), equalTo(1L));
             } else if (i < 6) {
@@ -155,6 +162,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("*-3.0"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(Double.NEGATIVE_INFINITY));
         assertThat(bucket.getTo().doubleValue(), equalTo(3.0));
+        assertThat(bucket.getFromAsString(), nullValue());
+        assertThat(bucket.getToAsString(), equalTo("3.0"));
         assertThat(bucket.getDocCount(), equalTo(2l));
 
         bucket = range.getBucketByKey("3.0-6.0");
@@ -162,6 +171,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("3.0-6.0"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(3.0));
         assertThat(bucket.getTo().doubleValue(), equalTo(6.0));
+        assertThat(bucket.getFromAsString(), equalTo("3.0"));
+        assertThat(bucket.getToAsString(), equalTo("6.0"));
         assertThat(bucket.getDocCount(), equalTo(3l));
 
         bucket = range.getBucketByKey("6.0-*");
@@ -169,6 +180,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("6.0-*"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(6.0));
         assertThat(bucket.getTo().doubleValue(), equalTo(Double.POSITIVE_INFINITY));
+        assertThat(bucket.getFromAsString(), equalTo("6.0"));
+        assertThat(bucket.getToAsString(), nullValue());
         assertThat(bucket.getDocCount(), equalTo(numDocs - 5L));
     }
 
@@ -197,6 +210,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("*-3"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(Double.NEGATIVE_INFINITY));
         assertThat(bucket.getTo().doubleValue(), equalTo(3.0));
+        assertThat(bucket.getFromAsString(), nullValue());
+        assertThat(bucket.getToAsString(), equalTo("3"));
         assertThat(bucket.getDocCount(), equalTo(2l));
 
         bucket = range.getBucketByKey("3-6");
@@ -204,6 +219,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("3-6"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(3.0));
         assertThat(bucket.getTo().doubleValue(), equalTo(6.0));
+        assertThat(bucket.getFromAsString(), equalTo("3"));
+        assertThat(bucket.getToAsString(), equalTo("6"));
         assertThat(bucket.getDocCount(), equalTo(3l));
 
         bucket = range.getBucketByKey("6-*");
@@ -211,6 +228,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("6-*"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(6.0));
         assertThat(bucket.getTo().doubleValue(), equalTo(Double.POSITIVE_INFINITY));
+        assertThat(bucket.getFromAsString(), equalTo("6"));
+        assertThat(bucket.getToAsString(), nullValue());
         assertThat(bucket.getDocCount(), equalTo(numDocs - 5L));
     }
 
@@ -237,6 +256,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("r1"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(Double.NEGATIVE_INFINITY));
         assertThat(bucket.getTo().doubleValue(), equalTo(3.0));
+        assertThat(bucket.getFromAsString(), nullValue());
+        assertThat(bucket.getToAsString(), equalTo("3.0"));
         assertThat(bucket.getDocCount(), equalTo(2l));
 
         bucket = range.getBucketByKey("r2");
@@ -244,6 +265,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("r2"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(3.0));
         assertThat(bucket.getTo().doubleValue(), equalTo(6.0));
+        assertThat(bucket.getFromAsString(), equalTo("3.0"));
+        assertThat(bucket.getToAsString(), equalTo("6.0"));
         assertThat(bucket.getDocCount(), equalTo(3l));
 
         bucket = range.getBucketByKey("r3");
@@ -251,6 +274,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("r3"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(6.0));
         assertThat(bucket.getTo().doubleValue(), equalTo(Double.POSITIVE_INFINITY));
+        assertThat(bucket.getFromAsString(), equalTo("6.0"));
+        assertThat(bucket.getToAsString(), nullValue());
         assertThat(bucket.getDocCount(), equalTo(numDocs - 5L));
     }
 
@@ -281,6 +306,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("*-3.0"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(Double.NEGATIVE_INFINITY));
         assertThat(bucket.getTo().doubleValue(), equalTo(3.0));
+        assertThat(bucket.getFromAsString(), nullValue());
+        assertThat(bucket.getToAsString(), equalTo("3.0"));
         assertThat(bucket.getDocCount(), equalTo(2l));
         Sum sum = bucket.getAggregations().get("sum");
         assertThat(sum, notNullValue());
@@ -294,6 +321,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("3.0-6.0"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(3.0));
         assertThat(bucket.getTo().doubleValue(), equalTo(6.0));
+        assertThat(bucket.getFromAsString(), equalTo("3.0"));
+        assertThat(bucket.getToAsString(), equalTo("6.0"));
         assertThat(bucket.getDocCount(), equalTo(3l));
         sum = bucket.getAggregations().get("sum");
         assertThat(sum, notNullValue());
@@ -307,6 +336,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("6.0-*"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(6.0));
         assertThat(bucket.getTo().doubleValue(), equalTo(Double.POSITIVE_INFINITY));
+        assertThat(bucket.getFromAsString(), equalTo("6.0"));
+        assertThat(bucket.getToAsString(), nullValue());
         assertThat(bucket.getDocCount(), equalTo(numDocs - 5l));
         sum = bucket.getAggregations().get("sum");
         assertThat(sum, notNullValue());
@@ -344,6 +375,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("*-3.0"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(Double.NEGATIVE_INFINITY));
         assertThat(bucket.getTo().doubleValue(), equalTo(3.0));
+        assertThat(bucket.getFromAsString(), nullValue());
+        assertThat(bucket.getToAsString(), equalTo("3.0"));
         assertThat(bucket.getDocCount(), equalTo(2l));
         Avg avg = bucket.getAggregations().get("avg");
         assertThat(avg, notNullValue());
@@ -354,6 +387,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("3.0-6.0"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(3.0));
         assertThat(bucket.getTo().doubleValue(), equalTo(6.0));
+        assertThat(bucket.getFromAsString(), equalTo("3.0"));
+        assertThat(bucket.getToAsString(), equalTo("6.0"));
         assertThat(bucket.getDocCount(), equalTo(3l));
         avg = bucket.getAggregations().get("avg");
         assertThat(avg, notNullValue());
@@ -364,6 +399,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("6.0-*"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(6.0));
         assertThat(bucket.getTo().doubleValue(), equalTo(Double.POSITIVE_INFINITY));
+        assertThat(bucket.getFromAsString(), equalTo("6.0"));
+        assertThat(bucket.getToAsString(), nullValue());
         assertThat(bucket.getDocCount(), equalTo(numDocs - 5l));
         avg = bucket.getAggregations().get("avg");
         assertThat(avg, notNullValue());
@@ -398,6 +435,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("*-3.0"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(Double.NEGATIVE_INFINITY));
         assertThat(bucket.getTo().doubleValue(), equalTo(3.0));
+        assertThat(bucket.getFromAsString(), nullValue());
+        assertThat(bucket.getToAsString(), equalTo("3.0"));
         assertThat(bucket.getDocCount(), equalTo(1l)); // 2
 
         bucket = range.getBucketByKey("3.0-6.0");
@@ -405,6 +444,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("3.0-6.0"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(3.0));
         assertThat(bucket.getTo().doubleValue(), equalTo(6.0));
+        assertThat(bucket.getFromAsString(), equalTo("3.0"));
+        assertThat(bucket.getToAsString(), equalTo("6.0"));
         assertThat(bucket.getDocCount(), equalTo(3l)); // 3, 4, 5
 
         bucket = range.getBucketByKey("6.0-*");
@@ -412,6 +453,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("6.0-*"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(6.0));
         assertThat(bucket.getTo().doubleValue(), equalTo(Double.POSITIVE_INFINITY));
+        assertThat(bucket.getFromAsString(), equalTo("6.0"));
+        assertThat(bucket.getToAsString(), nullValue());
         assertThat(bucket.getDocCount(), equalTo(numDocs - 4l));
     }
 
@@ -451,6 +494,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("*-3.0"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(Double.NEGATIVE_INFINITY));
         assertThat(bucket.getTo().doubleValue(), equalTo(3.0));
+        assertThat(bucket.getFromAsString(), nullValue());
+        assertThat(bucket.getToAsString(), equalTo("3.0"));
         assertThat(bucket.getDocCount(), equalTo(2l));
 
         bucket = range.getBucketByKey("3.0-6.0");
@@ -458,6 +503,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("3.0-6.0"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(3.0));
         assertThat(bucket.getTo().doubleValue(), equalTo(6.0));
+        assertThat(bucket.getFromAsString(), equalTo("3.0"));
+        assertThat(bucket.getToAsString(), equalTo("6.0"));
         assertThat(bucket.getDocCount(), equalTo(4l));
 
         bucket = range.getBucketByKey("6.0-*");
@@ -465,6 +512,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("6.0-*"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(6.0));
         assertThat(bucket.getTo().doubleValue(), equalTo(Double.POSITIVE_INFINITY));
+        assertThat(bucket.getFromAsString(), equalTo("6.0"));
+        assertThat(bucket.getToAsString(), nullValue());
         assertThat(bucket.getDocCount(), equalTo(numDocs - 4l));
     }
 
@@ -505,6 +554,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("*-3.0"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(Double.NEGATIVE_INFINITY));
         assertThat(bucket.getTo().doubleValue(), equalTo(3.0));
+        assertThat(bucket.getFromAsString(), nullValue());
+        assertThat(bucket.getToAsString(), equalTo("3.0"));
         assertThat(bucket.getDocCount(), equalTo(1l));
 
         bucket = range.getBucketByKey("3.0-6.0");
@@ -512,6 +563,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("3.0-6.0"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(3.0));
         assertThat(bucket.getTo().doubleValue(), equalTo(6.0));
+        assertThat(bucket.getFromAsString(), equalTo("3.0"));
+        assertThat(bucket.getToAsString(), equalTo("6.0"));
         assertThat(bucket.getDocCount(), equalTo(4l));
 
         bucket = range.getBucketByKey("6.0-*");
@@ -519,6 +572,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("6.0-*"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(6.0));
         assertThat(bucket.getTo().doubleValue(), equalTo(Double.POSITIVE_INFINITY));
+        assertThat(bucket.getFromAsString(), equalTo("6.0"));
+        assertThat(bucket.getToAsString(), nullValue());
         assertThat(bucket.getDocCount(), equalTo(numDocs - 3l));
     }
 
@@ -564,6 +619,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("*-3.0"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(Double.NEGATIVE_INFINITY));
         assertThat(bucket.getTo().doubleValue(), equalTo(3.0));
+        assertThat(bucket.getFromAsString(), nullValue());
+        assertThat(bucket.getToAsString(), equalTo("3.0"));
         assertThat(bucket.getDocCount(), equalTo(1l));
         Sum sum = bucket.getAggregations().get("sum");
         assertThat(sum, notNullValue());
@@ -575,6 +632,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("3.0-6.0"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(3.0));
         assertThat(bucket.getTo().doubleValue(), equalTo(6.0));
+        assertThat(bucket.getFromAsString(), equalTo("3.0"));
+        assertThat(bucket.getToAsString(), equalTo("6.0"));
         assertThat(bucket.getDocCount(), equalTo(4l));
         sum = bucket.getAggregations().get("sum");
         assertThat(sum, notNullValue());
@@ -586,6 +645,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("6.0-*"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(6.0));
         assertThat(bucket.getTo().doubleValue(), equalTo(Double.POSITIVE_INFINITY));
+        assertThat(bucket.getFromAsString(), equalTo("6.0"));
+        assertThat(bucket.getToAsString(), nullValue());
         assertThat(bucket.getDocCount(), equalTo(numDocs - 3L));
         sum = bucket.getAggregations().get("sum");
         assertThat(sum, notNullValue());
@@ -620,6 +681,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("*-3.0"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(Double.NEGATIVE_INFINITY));
         assertThat(bucket.getTo().doubleValue(), equalTo(3.0));
+        assertThat(bucket.getFromAsString(), nullValue());
+        assertThat(bucket.getToAsString(), equalTo("3.0"));
         assertThat(bucket.getDocCount(), equalTo(2l));
 
         bucket = range.getBucketByKey("3.0-6.0");
@@ -627,6 +690,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("3.0-6.0"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(3.0));
         assertThat(bucket.getTo().doubleValue(), equalTo(6.0));
+        assertThat(bucket.getFromAsString(), equalTo("3.0"));
+        assertThat(bucket.getToAsString(), equalTo("6.0"));
         assertThat(bucket.getDocCount(), equalTo(3l));
 
         bucket = range.getBucketByKey("6.0-*");
@@ -634,6 +699,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("6.0-*"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(6.0));
         assertThat(bucket.getTo().doubleValue(), equalTo(Double.POSITIVE_INFINITY));
+        assertThat(bucket.getFromAsString(), equalTo("6.0"));
+        assertThat(bucket.getToAsString(), nullValue());
         assertThat(bucket.getDocCount(), equalTo(numDocs - 5l));
     }
 
@@ -661,6 +728,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("*-3.0"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(Double.NEGATIVE_INFINITY));
         assertThat(bucket.getTo().doubleValue(), equalTo(3.0));
+        assertThat(bucket.getFromAsString(), nullValue());
+        assertThat(bucket.getToAsString(), equalTo("3.0"));
         assertThat(bucket.getDocCount(), equalTo(2l));
         Avg avg = bucket.getAggregations().get("avg");
         assertThat(avg, notNullValue());
@@ -671,6 +740,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("3.0-6.0"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(3.0));
         assertThat(bucket.getTo().doubleValue(), equalTo(6.0));
+        assertThat(bucket.getFromAsString(), equalTo("3.0"));
+        assertThat(bucket.getToAsString(), equalTo("6.0"));
         assertThat(bucket.getDocCount(), equalTo(3l));
         avg = bucket.getAggregations().get("avg");
         assertThat(avg, notNullValue());
@@ -681,6 +752,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("6.0-*"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(6.0));
         assertThat(bucket.getTo().doubleValue(), equalTo(Double.POSITIVE_INFINITY));
+        assertThat(bucket.getFromAsString(), equalTo("6.0"));
+        assertThat(bucket.getToAsString(), nullValue());
         assertThat(bucket.getDocCount(), equalTo(numDocs - 5l));
         avg = bucket.getAggregations().get("avg");
         assertThat(avg, notNullValue());
@@ -713,6 +786,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("*--1.0"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(Double.NEGATIVE_INFINITY));
         assertThat(bucket.getTo().doubleValue(), equalTo(-1.0));
+        assertThat(bucket.getFromAsString(), nullValue());
+        assertThat(bucket.getToAsString(), equalTo("-1.0"));
         assertThat(bucket.getDocCount(), equalTo(0l));
 
         bucket = range.getBucketByKey("1000.0-*");
@@ -720,6 +795,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("1000.0-*"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(1000d));
         assertThat(bucket.getTo().doubleValue(), equalTo(Double.POSITIVE_INFINITY));
+        assertThat(bucket.getFromAsString(), equalTo("1000.0"));
+        assertThat(bucket.getToAsString(), nullValue());
         assertThat(bucket.getDocCount(), equalTo(0l));
     }
 
@@ -746,6 +823,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("*-3.0"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(Double.NEGATIVE_INFINITY));
         assertThat(bucket.getTo().doubleValue(), equalTo(3.0));
+        assertThat(bucket.getFromAsString(), nullValue());
+        assertThat(bucket.getToAsString(), equalTo("3.0"));
         assertThat(bucket.getDocCount(), equalTo(2l));
 
         bucket = range.getBucketByKey("3.0-6.0");
@@ -753,6 +832,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("3.0-6.0"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(3.0));
         assertThat(bucket.getTo().doubleValue(), equalTo(6.0));
+        assertThat(bucket.getFromAsString(), equalTo("3.0"));
+        assertThat(bucket.getToAsString(), equalTo("6.0"));
         assertThat(bucket.getDocCount(), equalTo(4l));
 
         bucket = range.getBucketByKey("6.0-*");
@@ -760,6 +841,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("6.0-*"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(6.0));
         assertThat(bucket.getTo().doubleValue(), equalTo(Double.POSITIVE_INFINITY));
+        assertThat(bucket.getFromAsString(), equalTo("6.0"));
+        assertThat(bucket.getToAsString(), nullValue());
         assertThat(bucket.getDocCount(), equalTo(numDocs - 4l));
     }
     
@@ -804,6 +887,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("r1"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(Double.NEGATIVE_INFINITY));
         assertThat(bucket.getTo().doubleValue(), equalTo(3.0));
+        assertThat(bucket.getFromAsString(), nullValue());
+        assertThat(bucket.getToAsString(), equalTo("3.0"));
         assertThat(bucket.getDocCount(), equalTo(2l));
         Sum sum = bucket.getAggregations().get("sum");
         assertThat(sum, notNullValue());
@@ -815,6 +900,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("r2"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(3.0));
         assertThat(bucket.getTo().doubleValue(), equalTo(6.0));
+        assertThat(bucket.getFromAsString(), equalTo("3.0"));
+        assertThat(bucket.getToAsString(), equalTo("6.0"));
         assertThat(bucket.getDocCount(), equalTo(4l));
         sum = bucket.getAggregations().get("sum");
         assertThat(sum, notNullValue());
@@ -826,6 +913,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("r3"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(6.0));
         assertThat(bucket.getTo().doubleValue(), equalTo(Double.POSITIVE_INFINITY));
+        assertThat(bucket.getFromAsString(), equalTo("6.0"));
+        assertThat(bucket.getToAsString(), nullValue());
         assertThat(bucket.getDocCount(), equalTo(numDocs - 4l));
         sum = bucket.getAggregations().get("sum");
         assertThat(sum, notNullValue());
@@ -860,6 +949,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("*-3.0"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(Double.NEGATIVE_INFINITY));
         assertThat(bucket.getTo().doubleValue(), equalTo(3.0));
+        assertThat(bucket.getFromAsString(), nullValue());
+        assertThat(bucket.getToAsString(), equalTo("3.0"));
         assertThat(bucket.getDocCount(), equalTo(0l));
 
         bucket = range.getBucketByKey("3.0-6.0");
@@ -867,6 +958,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("3.0-6.0"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(3.0));
         assertThat(bucket.getTo().doubleValue(), equalTo(6.0));
+        assertThat(bucket.getFromAsString(), equalTo("3.0"));
+        assertThat(bucket.getToAsString(), equalTo("6.0"));
         assertThat(bucket.getDocCount(), equalTo(0l));
 
         bucket = range.getBucketByKey("6.0-*");
@@ -874,6 +967,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("6.0-*"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(6.0));
         assertThat(bucket.getTo().doubleValue(), equalTo(Double.POSITIVE_INFINITY));
+        assertThat(bucket.getFromAsString(), equalTo("6.0"));
+        assertThat(bucket.getToAsString(), nullValue());
         assertThat(bucket.getDocCount(), equalTo(0l));
     }
 
@@ -902,6 +997,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("*-3.0"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(Double.NEGATIVE_INFINITY));
         assertThat(bucket.getTo().doubleValue(), equalTo(3.0));
+        assertThat(bucket.getFromAsString(), nullValue());
+        assertThat(bucket.getToAsString(), equalTo("3.0"));
         assertThat(bucket.getDocCount(), equalTo(2l));
 
         bucket = range.getBucketByKey("3.0-6.0");
@@ -909,6 +1006,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("3.0-6.0"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(3.0));
         assertThat(bucket.getTo().doubleValue(), equalTo(6.0));
+        assertThat(bucket.getFromAsString(), equalTo("3.0"));
+        assertThat(bucket.getToAsString(), equalTo("6.0"));
         assertThat(bucket.getDocCount(), equalTo(3l));
 
         bucket = range.getBucketByKey("6.0-*");
@@ -916,6 +1015,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("6.0-*"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(6.0));
         assertThat(bucket.getTo().doubleValue(), equalTo(Double.POSITIVE_INFINITY));
+        assertThat(bucket.getFromAsString(), equalTo("6.0"));
+        assertThat(bucket.getToAsString(), nullValue());
         assertThat(bucket.getDocCount(), equalTo(numDocs - 5l));
     }
 
@@ -943,6 +1044,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("*-5.0"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(Double.NEGATIVE_INFINITY));
         assertThat(bucket.getTo().doubleValue(), equalTo(5.0));
+        assertThat(bucket.getFromAsString(), nullValue());
+        assertThat(bucket.getToAsString(), equalTo("5.0"));
         assertThat(bucket.getDocCount(), equalTo(4l));
 
         bucket = range.getBucketByKey("3.0-6.0");
@@ -950,6 +1053,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("3.0-6.0"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(3.0));
         assertThat(bucket.getTo().doubleValue(), equalTo(6.0));
+        assertThat(bucket.getFromAsString(), equalTo("3.0"));
+        assertThat(bucket.getToAsString(), equalTo("6.0"));
         assertThat(bucket.getDocCount(), equalTo(4l));
 
         bucket = range.getBucketByKey("4.0-5.0");
@@ -957,6 +1062,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("4.0-5.0"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(4.0));
         assertThat(bucket.getTo().doubleValue(), equalTo(5.0));
+        assertThat(bucket.getFromAsString(), equalTo("4.0"));
+        assertThat(bucket.getToAsString(), equalTo("5.0"));
         assertThat(bucket.getDocCount(), equalTo(2l));
 
         bucket = range.getBucketByKey("4.0-*");
@@ -964,6 +1071,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKey(), equalTo("4.0-*"));
         assertThat(bucket.getFrom().doubleValue(), equalTo(4.0));
         assertThat(bucket.getTo().doubleValue(), equalTo(Double.POSITIVE_INFINITY));
+        assertThat(bucket.getFromAsString(), equalTo("4.0"));
+        assertThat(bucket.getToAsString(), nullValue());
         assertThat(bucket.getDocCount(), equalTo(numDocs - 2l));
     }
 
@@ -989,6 +1098,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         assertThat(buckets.get(0).getKey(), equalTo("0-2"));
         assertThat(buckets.get(0).getFrom().doubleValue(), equalTo(0.0));
         assertThat(buckets.get(0).getTo().doubleValue(), equalTo(2.0));
+        assertThat(buckets.get(0).getFromAsString(), equalTo("0.0"));
+        assertThat(buckets.get(0).getToAsString(), equalTo("2.0"));
         assertThat(buckets.get(0).getDocCount(), equalTo(0l));
 
     }


### PR DESCRIPTION
Adds getToAsString and getFromAsString to Range interface and implements them for all range aggregations

Closes #9003
