### PR TITLE
Terms filter lookup caching should cache values, not filters.

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/TermsFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TermsFilterParser.java
@@ -188,18 +188,8 @@ public class TermsFilterParser implements FilterParser {
             }
 
             // external lookup, use it
-            TermsLookup termsLookup = new TermsLookup(fieldMapper, lookupIndex, lookupType, lookupId, lookupRouting, lookupPath, parseContext);
-
-            Filter filter = termsFilterCache.termsFilter(termsLookup, lookupCache, cacheKey);
-            if (filter == null) {
-                return null;
-            }
-
-            // cache the whole filter by default, or if explicitly told to
-            if (cache != null) {
-                filter = parseContext.cacheFilter(filter, cacheKey, cache);
-            }
-            return filter;
+            TermsLookup termsLookup = new TermsLookup(lookupIndex, lookupType, lookupId, lookupRouting, lookupPath, parseContext);
+            terms.addAll(termsFilterCache.terms(termsLookup, lookupCache, cacheKey));
         }
 
         if (terms.isEmpty()) {

--- a/src/main/java/org/elasticsearch/indices/cache/filter/terms/TermsLookup.java
+++ b/src/main/java/org/elasticsearch/indices/cache/filter/terms/TermsLookup.java
@@ -20,14 +20,11 @@
 package org.elasticsearch.indices.cache.filter.terms;
 
 import org.elasticsearch.common.Nullable;
-import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.query.QueryParseContext;
 
 /**
  */
 public class TermsLookup {
-
-    private final FieldMapper fieldMapper;
 
     private final String index;
     private final String type;
@@ -38,18 +35,13 @@ public class TermsLookup {
     @Nullable
     private final QueryParseContext queryParseContext;
 
-    public TermsLookup(FieldMapper fieldMapper, String index, String type, String id, String routing, String path, @Nullable QueryParseContext queryParseContext) {
-        this.fieldMapper = fieldMapper;
+    public TermsLookup(String index, String type, String id, String routing, String path, @Nullable QueryParseContext queryParseContext) {
         this.index = index;
         this.type = type;
         this.id = id;
         this.routing = routing;
         this.path = path;
         this.queryParseContext = queryParseContext;
-    }
-
-    public FieldMapper getFieldMapper() {
-        return fieldMapper;
     }
 
     public String getIndex() {
@@ -78,6 +70,6 @@ public class TermsLookup {
     }
 
     public String toString() {
-        return fieldMapper.names().fullName() + ":" + index + "/" + type + "/" + id + "/" + path;
+        return index + "/" + type + "/" + id + "/" + path;
     }
 }


### PR DESCRIPTION
The terms filter lookup mechanism today caches filters. Because of this, the
cache values depend on two things: the values that can be found in the lookup
index AND the mapping of the local index, since changing the mapping can change
the way that the filter is parsed. We should make the cache depend solely on
the content of the lookup index.

For instance the issue I was seeing was due to the following scenario:
- create index1 with _id indexed
- run terms filter with caching, the parsed filter looks like `_id: 1 OR _id: 2`
- remove index1
- create index1 with _id not indexed
- run terms filter without caching, the parsed filter is `_uid: type#1 OR _uid: type#2` (the _id field mapper knows how to use the _uid field when _id is not indexed)
- run terms filter with caching, the filter is fetched from the cache: `_id: 1 OR _id: 2` but does not match anything since `_id` is not indexed.
