### PR TITLE
Native: Kernel32Library throws NoClassDefFound if JNA is missing

### DIFF
--- a/src/main/java/org/elasticsearch/common/jna/Natives.java
+++ b/src/main/java/org/elasticsearch/common/jna/Natives.java
@@ -72,6 +72,8 @@ public class Natives {
                 } else {
                     logger.warn("unknown error " + Native.getLastError() + " when adding console ctrl handler:");
                 }
+            } catch (NoClassDefFoundError e) {
+                logger.warn("JNA not found: native methods and handlers will be disabled.");
             } catch (UnsatisfiedLinkError e) {
                 // this will have already been logged by Kernel32Library, no need to repeat it
             }


### PR DESCRIPTION
Introduced by #8993
