### PR TITLE
Numeric metric aggregations are now formattable

### DIFF
--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalNumericMetricsAggregation.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalNumericMetricsAggregation.java
@@ -31,7 +31,7 @@ public abstract class InternalNumericMetricsAggregation extends InternalMetricsA
 
     protected ValueFormatter valueFormatter;
 
-    public static abstract class SingleValue extends InternalNumericMetricsAggregation {
+    public static abstract class SingleValue extends InternalNumericMetricsAggregation implements NumericMetricsAggregation.SingleValue {
 
         protected SingleValue() {}
 
@@ -39,7 +39,13 @@ public abstract class InternalNumericMetricsAggregation extends InternalMetricsA
             super(name, metaData);
         }
 
-        public abstract double value();
+        public String getValueAsString() {
+            if (valueFormatter == null) {
+                return ValueFormatter.RAW.format(value());
+            } else {
+                return valueFormatter.format(value());
+            }
+        }
 
         @Override
         public Object getProperty(List<String> path) {
@@ -54,7 +60,7 @@ public abstract class InternalNumericMetricsAggregation extends InternalMetricsA
 
     }
 
-    public static abstract class MultiValue extends InternalNumericMetricsAggregation {
+    public static abstract class MultiValue extends InternalNumericMetricsAggregation implements NumericMetricsAggregation.MultiValue {
 
         protected MultiValue() {}
 
@@ -63,6 +69,14 @@ public abstract class InternalNumericMetricsAggregation extends InternalMetricsA
         }
 
         public abstract double value(String name);
+
+        public String valueAsString(String name) {
+            if (valueFormatter == null) {
+                return ValueFormatter.RAW.format(value(name));
+            } else {
+                return valueFormatter.format(value(name));
+            }
+        }
 
         @Override
         public Object getProperty(List<String> path) {

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/NumericMetricsAggregation.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/NumericMetricsAggregation.java
@@ -16,17 +16,21 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.elasticsearch.search.aggregations.metrics.min;
 
-import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregation;
+package org.elasticsearch.search.aggregations.metrics;
 
-/**
- * An aggregation that computes the minimum of the values in the current bucket.
- */
-public interface Min extends NumericMetricsAggregation.SingleValue {
+import org.elasticsearch.search.aggregations.Aggregation;
 
-    /**
-     * The minimum.
-     */
-    double getValue();
+public interface NumericMetricsAggregation extends Aggregation {
+
+    public static interface SingleValue extends NumericMetricsAggregation {
+
+        double value();
+
+        String getValueAsString();
+
+    }
+
+    public static interface MultiValue extends NumericMetricsAggregation {
+    }
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/NumericValuesSourceMetricsAggregatorParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/NumericValuesSourceMetricsAggregatorParser.java
@@ -49,7 +49,7 @@ public abstract class NumericValuesSourceMetricsAggregatorParser<S extends Inter
     @Override
     public AggregatorFactory parse(String aggregationName, XContentParser parser, SearchContext context) throws IOException {
 
-        ValuesSourceParser<ValuesSource.Numeric> vsParser = ValuesSourceParser.numeric(aggregationName, aggType, context)
+        ValuesSourceParser<ValuesSource.Numeric> vsParser = ValuesSourceParser.numeric(aggregationName, aggType, context).formattable(true)
                 .build();
 
         XContentParser.Token token;

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/ValuesSourceMetricsAggregationBuilder.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/ValuesSourceMetricsAggregationBuilder.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.search.aggregations.metrics;
 
 import com.google.common.collect.Maps;
+
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -33,6 +34,7 @@ public abstract class ValuesSourceMetricsAggregationBuilder<B extends ValuesSour
     private String field;
     private String script;
     private String lang;
+    private String format;
     private Map<String, Object> params;
 
     protected ValuesSourceMetricsAggregationBuilder(String name, String type) {
@@ -54,6 +56,12 @@ public abstract class ValuesSourceMetricsAggregationBuilder<B extends ValuesSour
     @SuppressWarnings("unchecked")
     public B lang(String lang) {
         this.lang = lang;
+        return (B) this;
+    }
+
+    @SuppressWarnings("unchecked")
+    public B format(String format) {
+        this.format = format;
         return (B) this;
     }
 
@@ -88,6 +96,10 @@ public abstract class ValuesSourceMetricsAggregationBuilder<B extends ValuesSour
 
         if (lang != null) {
             builder.field("lang", lang);
+        }
+
+        if (format != null) {
+            builder.field("format", format);
         }
 
         if (this.params != null && !this.params.isEmpty()) {

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/avg/Avg.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/avg/Avg.java
@@ -18,12 +18,12 @@
  */
 package org.elasticsearch.search.aggregations.metrics.avg;
 
-import org.elasticsearch.search.aggregations.Aggregation;
+import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregation;
 
 /**
  * An aggregation that computes the average of the values in the current bucket.
  */
-public interface Avg extends Aggregation {
+public interface Avg extends NumericMetricsAggregation.SingleValue {
 
     /**
      * The average value.

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/avg/AvgAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/avg/AvgAggregator.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.search.aggregations.metrics.avg;
 
 import org.apache.lucene.index.LeafReaderContext;
+import org.elasticsearch.common.inject.internal.Nullable;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.util.DoubleArray;
 import org.elasticsearch.common.util.LongArray;
@@ -30,6 +31,7 @@ import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
+import org.elasticsearch.search.aggregations.support.format.ValueFormatter;
 
 import java.io.IOException;
 import java.util.Map;
@@ -44,10 +46,13 @@ public class AvgAggregator extends NumericMetricsAggregator.SingleValue {
 
     private LongArray counts;
     private DoubleArray sums;
+    private ValueFormatter formatter;
 
-    public AvgAggregator(String name, long estimatedBucketsCount, ValuesSource.Numeric valuesSource, AggregationContext context, Aggregator parent, Map<String, Object> metaData) {
+    public AvgAggregator(String name, long estimatedBucketsCount, ValuesSource.Numeric valuesSource, @Nullable ValueFormatter formatter,
+            AggregationContext context, Aggregator parent, Map<String, Object> metaData) {
         super(name, estimatedBucketsCount, context, parent, metaData);
         this.valuesSource = valuesSource;
+        this.formatter = formatter;
         if (valuesSource != null) {
             final long initialSize = estimatedBucketsCount < 2 ? 1 : estimatedBucketsCount;
             counts = bigArrays.newLongArray(initialSize, true);
@@ -88,14 +93,14 @@ public class AvgAggregator extends NumericMetricsAggregator.SingleValue {
     @Override
     public InternalAggregation buildAggregation(long owningBucketOrdinal) {
         if (valuesSource == null || owningBucketOrdinal >= counts.size()) {
-            return new InternalAvg(name, 0l, 0, getMetaData());
+            return new InternalAvg(name, 0l, 0, formatter, getMetaData());
         }
-        return new InternalAvg(name, sums.get(owningBucketOrdinal), counts.get(owningBucketOrdinal), getMetaData());
+        return new InternalAvg(name, sums.get(owningBucketOrdinal), counts.get(owningBucketOrdinal), formatter, getMetaData());
     }
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
-        return new InternalAvg(name, 0.0, 0l, getMetaData());
+        return new InternalAvg(name, 0.0, 0l, formatter, getMetaData());
     }
 
     public static class Factory extends ValuesSourceAggregatorFactory.LeafOnly<ValuesSource.Numeric, Map<String, Object>> {
@@ -106,12 +111,12 @@ public class AvgAggregator extends NumericMetricsAggregator.SingleValue {
 
         @Override
         protected Aggregator createUnmapped(AggregationContext aggregationContext, Aggregator parent, Map<String, Object> metaData) {
-            return new AvgAggregator(name, 0, null, aggregationContext, parent, metaData);
+            return new AvgAggregator(name, 0, null, config.formatter(), aggregationContext, parent, metaData);
         }
 
         @Override
         protected Aggregator create(ValuesSource.Numeric valuesSource, long expectedBucketsCount, AggregationContext aggregationContext, Aggregator parent, Map<String, Object> metaData) {
-            return new AvgAggregator(name, expectedBucketsCount, valuesSource, aggregationContext, parent, metaData);
+            return new AvgAggregator(name, expectedBucketsCount, valuesSource, config.formatter(), aggregationContext, parent, metaData);
         }
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/avg/InternalAvg.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/avg/InternalAvg.java
@@ -18,12 +18,14 @@
  */
 package org.elasticsearch.search.aggregations.metrics.avg;
 
+import org.elasticsearch.common.inject.internal.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.aggregations.AggregationStreams;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.metrics.InternalNumericMetricsAggregation;
+import org.elasticsearch.search.aggregations.support.format.ValueFormatter;
 import org.elasticsearch.search.aggregations.support.format.ValueFormatterStreams;
 
 import java.io.IOException;
@@ -54,10 +56,11 @@ public class InternalAvg extends InternalNumericMetricsAggregation.SingleValue i
 
     InternalAvg() {} // for serialization
 
-    public InternalAvg(String name, double sum, long count, Map<String, Object> metaData) {
+    public InternalAvg(String name, double sum, long count, @Nullable ValueFormatter formatter, Map<String, Object> metaData) {
         super(name, metaData);
         this.sum = sum;
         this.count = count;
+        this.valueFormatter = formatter;
     }
 
     @Override
@@ -82,7 +85,7 @@ public class InternalAvg extends InternalNumericMetricsAggregation.SingleValue i
             count += ((InternalAvg) aggregation).count;
             sum += ((InternalAvg) aggregation).sum;
         }
-        return new InternalAvg(getName(), sum, count, getMetaData());
+        return new InternalAvg(getName(), sum, count, valueFormatter, getMetaData());
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/Cardinality.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/Cardinality.java
@@ -19,12 +19,12 @@
 
 package org.elasticsearch.search.aggregations.metrics.cardinality;
 
-import org.elasticsearch.search.aggregations.Aggregation;
+import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregation;
 
 /**
  * An aggregation that computes approximate numbers of unique terms.
  */
-public interface Cardinality extends Aggregation {
+public interface Cardinality extends NumericMetricsAggregation.SingleValue {
 
     /**
      * The number of unique terms.

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/CardinalityAggregatorFactory.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/CardinalityAggregatorFactory.java
@@ -46,7 +46,8 @@ final class CardinalityAggregatorFactory extends ValuesSourceAggregatorFactory<V
 
     @Override
     protected Aggregator createUnmapped(AggregationContext context, Aggregator parent, Map<String, Object> metaData) {
-        return new CardinalityAggregator(name, parent == null ? 1 : parent.estimatedBucketCount(), null, true, precision(parent), context, parent, metaData);
+        return new CardinalityAggregator(name, parent == null ? 1 : parent.estimatedBucketCount(), null, true, precision(parent),
+                config.formatter(), context, parent, metaData);
     }
 
     @Override
@@ -54,7 +55,8 @@ final class CardinalityAggregatorFactory extends ValuesSourceAggregatorFactory<V
         if (!(valuesSource instanceof ValuesSource.Numeric) && !rehash) {
             throw new AggregationExecutionException("Turning off rehashing for cardinality aggregation [" + name + "] on non-numeric values in not allowed");
         }
-        return new CardinalityAggregator(name, parent == null ? 1 : parent.estimatedBucketCount(), valuesSource, rehash, precision(parent), context, parent, metaData);
+        return new CardinalityAggregator(name, parent == null ? 1 : parent.estimatedBucketCount(), valuesSource, rehash, precision(parent),
+                config.formatter(), context, parent, metaData);
     }
 
     /*

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/CardinalityParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/CardinalityParser.java
@@ -44,7 +44,7 @@ public class CardinalityParser implements Aggregator.Parser {
     @Override
     public AggregatorFactory parse(String name, XContentParser parser, SearchContext context) throws IOException {
 
-        ValuesSourceParser vsParser = ValuesSourceParser.any(name, InternalCardinality.TYPE, context).build();
+        ValuesSourceParser vsParser = ValuesSourceParser.any(name, InternalCardinality.TYPE, context).formattable(false).build();
 
         long precisionThreshold = -1;
         Boolean rehash = null;

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/InternalCardinality.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/InternalCardinality.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.search.aggregations.metrics.cardinality;
 
+import org.elasticsearch.common.inject.internal.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.util.BigArrays;
@@ -26,6 +27,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.aggregations.AggregationStreams;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.metrics.InternalNumericMetricsAggregation;
+import org.elasticsearch.search.aggregations.support.format.ValueFormatter;
 import org.elasticsearch.search.aggregations.support.format.ValueFormatterStreams;
 
 import java.io.IOException;
@@ -51,9 +53,10 @@ public final class InternalCardinality extends InternalNumericMetricsAggregation
 
     private HyperLogLogPlusPlus counts;
 
-    InternalCardinality(String name, HyperLogLogPlusPlus counts, Map<String, Object> metaData) {
+    InternalCardinality(String name, HyperLogLogPlusPlus counts, @Nullable ValueFormatter formatter, Map<String, Object> metaData) {
         super(name, metaData);
         this.counts = counts;
+        this.valueFormatter = formatter;
     }
 
     private InternalCardinality() {
@@ -103,7 +106,8 @@ public final class InternalCardinality extends InternalNumericMetricsAggregation
             final InternalCardinality cardinality = (InternalCardinality) aggregation;
             if (cardinality.counts != null) {
                 if (reduced == null) {
-                    reduced = new InternalCardinality(name, new HyperLogLogPlusPlus(cardinality.counts.precision(), BigArrays.NON_RECYCLING_INSTANCE, 1), getMetaData());
+                    reduced = new InternalCardinality(name, new HyperLogLogPlusPlus(cardinality.counts.precision(),
+                            BigArrays.NON_RECYCLING_INSTANCE, 1), this.valueFormatter, getMetaData());
                 }
                 reduced.merge(cardinality);
             }

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/max/InternalMax.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/max/InternalMax.java
@@ -18,12 +18,14 @@
  */
 package org.elasticsearch.search.aggregations.metrics.max;
 
+import org.elasticsearch.common.inject.internal.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.aggregations.AggregationStreams;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.metrics.InternalNumericMetricsAggregation;
+import org.elasticsearch.search.aggregations.support.format.ValueFormatter;
 import org.elasticsearch.search.aggregations.support.format.ValueFormatterStreams;
 
 import java.io.IOException;
@@ -53,8 +55,9 @@ public class InternalMax extends InternalNumericMetricsAggregation.SingleValue i
 
     InternalMax() {} // for serialization
 
-    public InternalMax(String name, double max, Map<String, Object> metaData) {
+    public InternalMax(String name, double max, @Nullable ValueFormatter formatter, Map<String, Object> metaData) {
         super(name, metaData);
+        this.valueFormatter = formatter;
         this.max = max;
     }
 
@@ -78,7 +81,7 @@ public class InternalMax extends InternalNumericMetricsAggregation.SingleValue i
         for (InternalAggregation aggregation : reduceContext.aggregations()) {
             max = Math.max(max, ((InternalMax) aggregation).max);
         }
-        return new InternalMax(name, max, getMetaData());
+        return new InternalMax(name, max, valueFormatter, getMetaData());
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/max/Max.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/max/Max.java
@@ -18,12 +18,12 @@
  */
 package org.elasticsearch.search.aggregations.metrics.max;
 
-import org.elasticsearch.search.aggregations.Aggregation;
+import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregation;
 
 /**
  * An aggregation that computes the maximum of the values in the current bucket.
  */
-public interface Max extends Aggregation {
+public interface Max extends NumericMetricsAggregation.SingleValue {
 
     /**
      * The maximum.

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/min/InternalMin.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/min/InternalMin.java
@@ -18,12 +18,14 @@
  */
 package org.elasticsearch.search.aggregations.metrics.min;
 
+import org.elasticsearch.common.inject.internal.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.aggregations.AggregationStreams;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.metrics.InternalNumericMetricsAggregation;
+import org.elasticsearch.search.aggregations.support.format.ValueFormatter;
 import org.elasticsearch.search.aggregations.support.format.ValueFormatterStreams;
 
 import java.io.IOException;
@@ -54,9 +56,10 @@ public class InternalMin extends InternalNumericMetricsAggregation.SingleValue i
 
     InternalMin() {} // for serialization
 
-    public InternalMin(String name, double min, Map<String, Object> metaData) {
+    public InternalMin(String name, double min, @Nullable ValueFormatter formatter, Map<String, Object> metaData) {
         super(name, metaData);
         this.min = min;
+        this.valueFormatter = formatter;
     }
 
     @Override
@@ -79,7 +82,7 @@ public class InternalMin extends InternalNumericMetricsAggregation.SingleValue i
         for (InternalAggregation aggregation : reduceContext.aggregations()) {
             min = Math.min(min, ((InternalMin) aggregation).min);
         }
-        return new InternalMin(getName(), min, getMetaData());
+        return new InternalMin(getName(), min, this.valueFormatter, getMetaData());
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/min/MinAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/min/MinAggregator.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.search.aggregations.metrics.min;
 
 import org.apache.lucene.index.LeafReaderContext;
+import org.elasticsearch.common.inject.internal.Nullable;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.util.DoubleArray;
 import org.elasticsearch.index.fielddata.NumericDoubleValues;
@@ -31,6 +32,7 @@ import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
+import org.elasticsearch.search.aggregations.support.format.ValueFormatter;
 
 import java.io.IOException;
 import java.util.Map;
@@ -44,8 +46,10 @@ public class MinAggregator extends NumericMetricsAggregator.SingleValue {
     private NumericDoubleValues values;
 
     private DoubleArray mins;
+    private ValueFormatter formatter;
 
-    public MinAggregator(String name, long estimatedBucketsCount, ValuesSource.Numeric valuesSource, AggregationContext context, Aggregator parent, Map<String, Object> metaData) {
+    public MinAggregator(String name, long estimatedBucketsCount, ValuesSource.Numeric valuesSource, @Nullable ValueFormatter formatter,
+            AggregationContext context, Aggregator parent, Map<String, Object> metaData) {
         super(name, estimatedBucketsCount, context, parent, metaData);
         this.valuesSource = valuesSource;
         if (valuesSource != null) {
@@ -53,6 +57,7 @@ public class MinAggregator extends NumericMetricsAggregator.SingleValue {
             mins = bigArrays.newDoubleArray(initialSize, false);
             mins.fill(0, mins.size(), Double.POSITIVE_INFINITY);
         }
+        this.formatter = formatter;
     }
 
     @Override
@@ -87,15 +92,15 @@ public class MinAggregator extends NumericMetricsAggregator.SingleValue {
     @Override
     public InternalAggregation buildAggregation(long owningBucketOrdinal) {
         if (valuesSource == null) {
-            return new InternalMin(name, Double.POSITIVE_INFINITY, getMetaData());
+            return new InternalMin(name, Double.POSITIVE_INFINITY, formatter, getMetaData());
         }
         assert owningBucketOrdinal < mins.size();
-        return new InternalMin(name, mins.get(owningBucketOrdinal), getMetaData());
+        return new InternalMin(name, mins.get(owningBucketOrdinal), formatter, getMetaData());
     }
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
-        return new InternalMin(name, Double.POSITIVE_INFINITY, getMetaData());
+        return new InternalMin(name, Double.POSITIVE_INFINITY, formatter, getMetaData());
     }
 
     public static class Factory extends ValuesSourceAggregatorFactory.LeafOnly<ValuesSource.Numeric, Map<String,Object>> {
@@ -106,12 +111,12 @@ public class MinAggregator extends NumericMetricsAggregator.SingleValue {
 
         @Override
         protected Aggregator createUnmapped(AggregationContext aggregationContext, Aggregator parent, Map<String, Object> metaData) {
-            return new MinAggregator(name, 0, null, aggregationContext, parent, metaData);
+            return new MinAggregator(name, 0, null, config.formatter(), aggregationContext, parent, metaData);
         }
 
         @Override
         protected Aggregator create(ValuesSource.Numeric valuesSource, long expectedBucketsCount, AggregationContext aggregationContext, Aggregator parent, Map<String, Object> metaData) {
-            return new MinAggregator(name, expectedBucketsCount, valuesSource, aggregationContext, parent, metaData);
+            return new MinAggregator(name, expectedBucketsCount, valuesSource, config.formatter(), aggregationContext, parent, metaData);
         }
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/AbstractInternalPercentiles.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/AbstractInternalPercentiles.java
@@ -21,12 +21,14 @@ package org.elasticsearch.search.aggregations.metrics.percentiles;
 
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.Version;
+import org.elasticsearch.common.inject.internal.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.metrics.InternalNumericMetricsAggregation;
 import org.elasticsearch.search.aggregations.metrics.percentiles.tdigest.TDigestState;
+import org.elasticsearch.search.aggregations.support.format.ValueFormatter;
 import org.elasticsearch.search.aggregations.support.format.ValueFormatterStreams;
 
 import java.io.IOException;
@@ -41,11 +43,13 @@ abstract class AbstractInternalPercentiles extends InternalNumericMetricsAggrega
 
     AbstractInternalPercentiles() {} // for serialization
 
-    public AbstractInternalPercentiles(String name, double[] keys, TDigestState state, boolean keyed, Map<String, Object> metaData) {
+    public AbstractInternalPercentiles(String name, double[] keys, TDigestState state, boolean keyed, @Nullable ValueFormatter formatter,
+            Map<String, Object> metaData) {
         super(name, metaData);
         this.keys = keys;
         this.state = state;
         this.keyed = keyed;
+        this.valueFormatter = formatter;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/AbstractPercentilesAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/AbstractPercentilesAggregator.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.search.aggregations.metrics.percentiles;
 
 import org.apache.lucene.index.LeafReaderContext;
+import org.elasticsearch.common.inject.internal.Nullable;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.util.ArrayUtils;
 import org.elasticsearch.common.util.ObjectArray;
@@ -29,6 +30,7 @@ import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregator;
 import org.elasticsearch.search.aggregations.metrics.percentiles.tdigest.TDigestState;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
+import org.elasticsearch.search.aggregations.support.format.ValueFormatter;
 
 import java.io.IOException;
 import java.util.Map;
@@ -45,12 +47,15 @@ public abstract class AbstractPercentilesAggregator extends NumericMetricsAggreg
     protected ObjectArray<TDigestState> states;
     protected final double compression;
     protected final boolean keyed;
+    protected ValueFormatter formatter;
 
     public AbstractPercentilesAggregator(String name, long estimatedBucketsCount, ValuesSource.Numeric valuesSource, AggregationContext context,
-                                 Aggregator parent, double[] keys, double compression, boolean keyed, Map<String, Object> metaData) {
+ Aggregator parent, double[] keys, double compression, boolean keyed,
+            @Nullable ValueFormatter formatter, Map<String, Object> metaData) {
         super(name, estimatedBucketsCount, context, parent, metaData);
         this.valuesSource = valuesSource;
         this.keyed = keyed;
+        this.formatter = formatter;
         this.states = bigArrays.newObjectArray(estimatedBucketsCount);
         this.keys = keys;
         this.compression = compression;

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/AbstractPercentilesParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/AbstractPercentilesParser.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.search.aggregations.metrics.percentiles;
 
 import com.carrotsearch.hppc.DoubleArrayList;
+
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.search.SearchParseException;
 import org.elasticsearch.search.aggregations.Aggregator;
@@ -35,14 +36,17 @@ import java.util.Arrays;
 
 public abstract class AbstractPercentilesParser implements Aggregator.Parser {
 
-    public AbstractPercentilesParser() {
-        super();
+    private boolean formattable;
+
+    public AbstractPercentilesParser(boolean formattable) {
+        this.formattable = formattable;
     }
 
     @Override
     public AggregatorFactory parse(String aggregationName, XContentParser parser, SearchContext context) throws IOException {
     
-        ValuesSourceParser<ValuesSource.Numeric> vsParser = ValuesSourceParser.numeric(aggregationName, InternalPercentiles.TYPE, context).build();
+        ValuesSourceParser<ValuesSource.Numeric> vsParser = ValuesSourceParser.numeric(aggregationName, InternalPercentiles.TYPE, context)
+                .formattable(formattable).build();
     
         double[] keys = null;
         boolean keyed = true;

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/InternalPercentileRanks.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/InternalPercentileRanks.java
@@ -19,9 +19,12 @@
 package org.elasticsearch.search.aggregations.metrics.percentiles;
 
 import com.google.common.collect.UnmodifiableIterator;
+
+import org.elasticsearch.common.inject.internal.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.search.aggregations.AggregationStreams;
 import org.elasticsearch.search.aggregations.metrics.percentiles.tdigest.TDigestState;
+import org.elasticsearch.search.aggregations.support.format.ValueFormatter;
 
 import java.io.IOException;
 import java.util.Iterator;
@@ -49,8 +52,9 @@ public class InternalPercentileRanks extends AbstractInternalPercentiles impleme
     
     InternalPercentileRanks() {} // for serialization
 
-    public InternalPercentileRanks(String name, double[] cdfValues, TDigestState state, boolean keyed, Map<String, Object> metaData) {
-        super(name, cdfValues, state, keyed, metaData);
+    public InternalPercentileRanks(String name, double[] cdfValues, TDigestState state, boolean keyed, @Nullable ValueFormatter formatter,
+            Map<String, Object> metaData) {
+        super(name, cdfValues, state, keyed, formatter, metaData);
     }
 
     @Override
@@ -64,12 +68,17 @@ public class InternalPercentileRanks extends AbstractInternalPercentiles impleme
     }
 
     @Override
+    public String percentAsString(double value) {
+        return valueAsString(String.valueOf(value));
+    }
+
+    @Override
     public double value(double key) {
         return percent(key);
     }
 
     protected AbstractInternalPercentiles createReduced(String name, double[] keys, TDigestState merged, boolean keyed, Map<String, Object> metaData) {
-        return new InternalPercentileRanks(name, keys, merged, keyed, metaData);
+        return new InternalPercentileRanks(name, keys, merged, keyed, valueFormatter, metaData);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/InternalPercentiles.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/InternalPercentiles.java
@@ -19,9 +19,12 @@
 package org.elasticsearch.search.aggregations.metrics.percentiles;
 
 import com.google.common.collect.UnmodifiableIterator;
+
+import org.elasticsearch.common.inject.internal.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.search.aggregations.AggregationStreams;
 import org.elasticsearch.search.aggregations.metrics.percentiles.tdigest.TDigestState;
+import org.elasticsearch.search.aggregations.support.format.ValueFormatter;
 
 import java.io.IOException;
 import java.util.Iterator;
@@ -49,8 +52,9 @@ public class InternalPercentiles extends AbstractInternalPercentiles implements 
 
     InternalPercentiles() {} // for serialization
 
-    public InternalPercentiles(String name, double[] percents, TDigestState state, boolean keyed, Map<String, Object> metaData) {
-        super(name, percents, state, keyed, metaData);
+    public InternalPercentiles(String name, double[] percents, TDigestState state, boolean keyed, @Nullable ValueFormatter formatter,
+            Map<String, Object> metaData) {
+        super(name, percents, state, keyed, formatter, metaData);
     }
 
     @Override
@@ -64,12 +68,17 @@ public class InternalPercentiles extends AbstractInternalPercentiles implements 
     }
 
     @Override
+    public String percentileAsString(double percent) {
+        return valueAsString(String.valueOf(percent));
+    }
+
+    @Override
     public double value(double key) {
         return percentile(key);
     }
 
     protected AbstractInternalPercentiles createReduced(String name, double[] keys, TDigestState merged, boolean keyed, Map<String, Object> metaData) {
-        return new InternalPercentiles(name, keys, merged, keyed, metaData);
+        return new InternalPercentiles(name, keys, merged, keyed, valueFormatter, metaData);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/PercentileRanks.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/PercentileRanks.java
@@ -19,15 +19,20 @@
 
 package org.elasticsearch.search.aggregations.metrics.percentiles;
 
-import org.elasticsearch.search.aggregations.Aggregation;
+import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregation;
 
 /**
  * An aggregation that computes approximate percentiles given values.
  */
-public interface PercentileRanks extends Aggregation, Iterable<Percentile>{
+public interface PercentileRanks extends NumericMetricsAggregation.MultiValue, Iterable<Percentile> {
 
     /**
      * Return the percentile for the given value.
      */
     double percent(double value);
+
+    /**
+     * Return the percentile for the given value as a String.
+     */
+    String percentAsString(double value);
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/PercentileRanksParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/PercentileRanksParser.java
@@ -29,6 +29,10 @@ import org.elasticsearch.search.internal.SearchContext;
  */
 public class PercentileRanksParser extends AbstractPercentilesParser {
 
+    public PercentileRanksParser() {
+        super(false);
+    }
+
     @Override
     public String type() {
         return InternalPercentileRanks.TYPE.name();

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/Percentiles.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/Percentiles.java
@@ -18,16 +18,21 @@
  */
 package org.elasticsearch.search.aggregations.metrics.percentiles;
 
-import org.elasticsearch.search.aggregations.Aggregation;
+import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregation;
 
 /**
  * An aggregation that computes approximate percentiles.
  */
-public interface Percentiles extends Aggregation, Iterable<Percentile> {
+public interface Percentiles extends NumericMetricsAggregation.MultiValue, Iterable<Percentile> {
 
     /**
      * Return the value associated with the provided percentile.
      */
     double percentile(double percent);
+
+    /**
+     * Return the value associated with the provided percentile as a String.
+     */
+    String percentileAsString(double percent);
 
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/PercentilesAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/PercentilesAggregator.java
@@ -18,11 +18,16 @@
  */
 package org.elasticsearch.search.aggregations.metrics.percentiles;
 
+import org.elasticsearch.common.inject.internal.Nullable;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.metrics.percentiles.tdigest.TDigestState;
-import org.elasticsearch.search.aggregations.support.*;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
+import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSource.Numeric;
+import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
+import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
+import org.elasticsearch.search.aggregations.support.format.ValueFormatter;
 
 import java.util.Map;
 
@@ -32,8 +37,9 @@ import java.util.Map;
 public class PercentilesAggregator extends AbstractPercentilesAggregator {
 
     public PercentilesAggregator(String name, long estimatedBucketsCount, Numeric valuesSource, AggregationContext context,
-            Aggregator parent, double[] percents, double compression, boolean keyed, Map<String, Object> metaData) {
-        super(name, estimatedBucketsCount, valuesSource, context, parent, percents, compression, keyed, metaData);
+            Aggregator parent, double[] percents, double compression, boolean keyed, @Nullable ValueFormatter formatter,
+            Map<String, Object> metaData) {
+        super(name, estimatedBucketsCount, valuesSource, context, parent, percents, compression, keyed, formatter, metaData);
     }
 
     @Override
@@ -42,7 +48,7 @@ public class PercentilesAggregator extends AbstractPercentilesAggregator {
         if (state == null) {
             return buildEmptyAggregation();
         } else {
-            return new InternalPercentiles(name, keys, state, keyed, getMetaData());
+            return new InternalPercentiles(name, keys, state, keyed, formatter, getMetaData());
         }
     }
     
@@ -58,7 +64,7 @@ public class PercentilesAggregator extends AbstractPercentilesAggregator {
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
-        return new InternalPercentiles(name, keys, new TDigestState(compression), keyed, getMetaData());
+        return new InternalPercentiles(name, keys, new TDigestState(compression), keyed, formatter, getMetaData());
     }
 
     public static class Factory extends ValuesSourceAggregatorFactory.LeafOnly<ValuesSource.Numeric, Map<String, Object>> {
@@ -77,12 +83,14 @@ public class PercentilesAggregator extends AbstractPercentilesAggregator {
 
         @Override
         protected Aggregator createUnmapped(AggregationContext aggregationContext, Aggregator parent, Map<String, Object> metaData) {
-            return new PercentilesAggregator(name, 0, null, aggregationContext, parent, percents, compression, keyed, metaData);
+            return new PercentilesAggregator(name, 0, null, aggregationContext, parent, percents, compression, keyed, config.formatter(),
+                    metaData);
         }
 
         @Override
         protected Aggregator create(ValuesSource.Numeric valuesSource, long expectedBucketsCount, AggregationContext aggregationContext, Aggregator parent, Map<String, Object> metaData) {
-            return new PercentilesAggregator(name, expectedBucketsCount, valuesSource, aggregationContext, parent, percents, compression, keyed, metaData);
+            return new PercentilesAggregator(name, expectedBucketsCount, valuesSource, aggregationContext, parent, percents, compression,
+                    keyed, config.formatter(), metaData);
         }
     }
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/PercentilesParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/PercentilesParser.java
@@ -28,6 +28,10 @@ import org.elasticsearch.search.internal.SearchContext;
  */
 public class PercentilesParser extends AbstractPercentilesParser {
 
+    public PercentilesParser() {
+        super(true);
+    }
+
     private final static double[] DEFAULT_PERCENTS = new double[] { 1, 5, 25, 50, 75, 95, 99 };
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/InternalStats.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/InternalStats.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.search.aggregations.metrics.stats;
 
+import org.elasticsearch.common.inject.internal.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -25,6 +26,7 @@ import org.elasticsearch.common.xcontent.XContentBuilderString;
 import org.elasticsearch.search.aggregations.AggregationStreams;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.metrics.InternalNumericMetricsAggregation;
+import org.elasticsearch.search.aggregations.support.format.ValueFormatter;
 import org.elasticsearch.search.aggregations.support.format.ValueFormatterStreams;
 
 import java.io.IOException;
@@ -66,12 +68,14 @@ public class InternalStats extends InternalNumericMetricsAggregation.MultiValue 
 
     protected InternalStats() {} // for serialization
 
-    public InternalStats(String name, long count, double sum, double min, double max, Map<String, Object> metaData) {
+    public InternalStats(String name, long count, double sum, double min, double max, @Nullable ValueFormatter formatter,
+            Map<String, Object> metaData) {
         super(name, metaData);
         this.count = count;
         this.sum = sum;
         this.min = min;
         this.max = max;
+        this.valueFormatter = formatter;
     }
 
     @Override
@@ -97,6 +101,31 @@ public class InternalStats extends InternalNumericMetricsAggregation.MultiValue 
     @Override
     public double getSum() {
         return sum;
+    }
+
+    @Override
+    public String getCountAsString() {
+        return valueAsString(Metrics.count.name());
+    }
+
+    @Override
+    public String getMinAsString() {
+        return valueAsString(Metrics.min.name());
+    }
+
+    @Override
+    public String getMaxAsString() {
+        return valueAsString(Metrics.max.name());
+    }
+
+    @Override
+    public String getAvgAsString() {
+        return valueAsString(Metrics.avg.name());
+    }
+
+    @Override
+    public String getSumAsString() {
+        return valueAsString(Metrics.sum.name());
     }
 
     @Override
@@ -131,7 +160,7 @@ public class InternalStats extends InternalNumericMetricsAggregation.MultiValue 
             max = Math.max(max, stats.getMax());
             sum += stats.getSum();
         }
-        return new InternalStats(name, count, sum, min, max, getMetaData());
+        return new InternalStats(name, count, sum, min, max, valueFormatter, getMetaData());
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/Stats.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/Stats.java
@@ -18,15 +18,15 @@
  */
 package org.elasticsearch.search.aggregations.metrics.stats;
 
-import org.elasticsearch.search.aggregations.Aggregation;
+import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregation;
 
 /**
  * Statistics over a set of values (either aggregated over field data or scripts)
  */
-public interface Stats extends Aggregation {
+public interface Stats extends NumericMetricsAggregation.MultiValue {
 
     /**
-     * @return The number of values that were aggregated
+     * @return The number of values that were aggregated.
      */
     long getCount();
 
@@ -49,5 +49,30 @@ public interface Stats extends Aggregation {
      * @return The sum of aggregated values.
      */
     double getSum();
+
+    /**
+     * @return The number of values that were aggregated as a String.
+     */
+    String getCountAsString();
+
+    /**
+     * @return The minimum value of all aggregated values as a String.
+     */
+    String getMinAsString();
+
+    /**
+     * @return The maximum value of all aggregated values as a String.
+     */
+    String getMaxAsString();
+
+    /**
+     * @return The avg value over all aggregated values as a String.
+     */
+    String getAvgAsString();
+
+    /**
+     * @return The sum of aggregated values as a String.
+     */
+    String getSumAsString();
 
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/extended/ExtendedStats.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/extended/ExtendedStats.java
@@ -40,4 +40,19 @@ public interface ExtendedStats extends Stats {
      */
     double getStdDeviation();
 
+    /**
+     * The sum of the squares of the collected values as a String.
+     */
+    String getSumOfSquaresAsString();
+
+    /**
+     * The variance of the collected values as a String.
+     */
+    String getVarianceAsString();
+
+    /**
+     * The standard deviation of the collected values as a String.
+     */
+    String getStdDeviationAsString();
+
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/sum/InternalSum.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/sum/InternalSum.java
@@ -18,12 +18,14 @@
  */
 package org.elasticsearch.search.aggregations.metrics.sum;
 
+import org.elasticsearch.common.inject.internal.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.aggregations.AggregationStreams;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.metrics.InternalNumericMetricsAggregation;
+import org.elasticsearch.search.aggregations.support.format.ValueFormatter;
 import org.elasticsearch.search.aggregations.support.format.ValueFormatterStreams;
 
 import java.io.IOException;
@@ -53,9 +55,10 @@ public class InternalSum extends InternalNumericMetricsAggregation.SingleValue i
 
     InternalSum() {} // for serialization
 
-    InternalSum(String name, double sum, Map<String, Object> metaData){
+    InternalSum(String name, double sum, @Nullable ValueFormatter formatter, Map<String, Object> metaData) {
         super(name, metaData);
         this.sum = sum;
+        this.valueFormatter = formatter;
     }
 
     @Override
@@ -78,7 +81,7 @@ public class InternalSum extends InternalNumericMetricsAggregation.SingleValue i
         for (InternalAggregation aggregation : reduceContext.aggregations()) {
             sum += ((InternalSum) aggregation).sum;
         }
-        return new InternalSum(name, sum, getMetaData());
+        return new InternalSum(name, sum, valueFormatter, getMetaData());
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/sum/Sum.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/sum/Sum.java
@@ -18,12 +18,12 @@
  */
 package org.elasticsearch.search.aggregations.metrics.sum;
 
-import org.elasticsearch.search.aggregations.Aggregation;
+import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregation;
 
 /**
  * An aggregation that computes the sum of the values in the current bucket.
  */
-public interface Sum extends Aggregation {
+public interface Sum extends NumericMetricsAggregation.SingleValue {
 
     /**
      * The sum.

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/valuecount/ValueCount.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/valuecount/ValueCount.java
@@ -18,13 +18,13 @@
  */
 package org.elasticsearch.search.aggregations.metrics.valuecount;
 
-import org.elasticsearch.search.aggregations.Aggregation;
+import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregation;
 
 /**
  * An get that holds the number of <strong>values</strong> that the current document set has for a specific
  * field.
  */
-public interface ValueCount extends Aggregation {
+public interface ValueCount extends NumericMetricsAggregation.SingleValue {
 
     /**
      * @return The count

--- a/src/test/java/org/elasticsearch/search/aggregations/metrics/AvgTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/metrics/AvgTests.java
@@ -22,7 +22,6 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.search.aggregations.bucket.global.Global;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.metrics.avg.Avg;
-import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.junit.Test;
 
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
@@ -158,6 +157,18 @@ public class AvgTests extends AbstractNumericTests {
         assertThat(avg.getValue(), equalTo((double) (2+3+4+5+6+7+8+9+10+11) / 10));
     }
 
+    public void testSingleValuedField_WithFormatter() throws Exception {
+        SearchResponse searchResponse = client().prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(avg("avg").format("#").field("value")).execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        Avg avg = searchResponse.getAggregations().get("avg");
+        assertThat(avg, notNullValue());
+        assertThat(avg.getName(), equalTo("avg"));
+        assertThat(avg.getValue(), equalTo((double) (1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10) / 10));
+        assertThat(avg.getValueAsString(), equalTo("6"));
+    }
 
     @Test
     public void testMultiValuedField() throws Exception {

--- a/src/test/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsTests.java
@@ -123,6 +123,33 @@ public class ExtendedStatsTests extends AbstractNumericTests {
         assertThat(stats.getStdDeviation(), equalTo(stdDev(1, 2, 3, 4, 5, 6, 7, 8 ,9, 10)));
     }
 
+    public void testSingleValuedField_WithFormatter() throws Exception {
+        SearchResponse searchResponse = client().prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(extendedStats("stats").format("0000.0").field("value")).execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        ExtendedStats stats = searchResponse.getAggregations().get("stats");
+        assertThat(stats, notNullValue());
+        assertThat(stats.getName(), equalTo("stats"));
+        assertThat(stats.getAvg(), equalTo((double) (1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10) / 10));
+        assertThat(stats.getAvgAsString(), equalTo("0005.5"));
+        assertThat(stats.getMin(), equalTo(1.0));
+        assertThat(stats.getMinAsString(), equalTo("0001.0"));
+        assertThat(stats.getMax(), equalTo(10.0));
+        assertThat(stats.getMaxAsString(), equalTo("0010.0"));
+        assertThat(stats.getSum(), equalTo((double) 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10));
+        assertThat(stats.getSumAsString(), equalTo("0055.0"));
+        assertThat(stats.getCount(), equalTo(10l));
+        assertThat(stats.getCountAsString(), equalTo("0010.0"));
+        assertThat(stats.getSumOfSquares(), equalTo((double) 1 + 4 + 9 + 16 + 25 + 36 + 49 + 64 + 81 + 100));
+        assertThat(stats.getSumOfSquaresAsString(), equalTo("0385.0"));
+        assertThat(stats.getVariance(), equalTo(variance(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
+        assertThat(stats.getVarianceAsString(), equalTo("0008.2"));
+        assertThat(stats.getStdDeviation(), equalTo(stdDev(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
+        assertThat(stats.getStdDeviationAsString(), equalTo("0002.9"));
+    }
+
     @Test
     public void testSingleValuedField_getProperty() throws Exception {
 

--- a/src/test/java/org/elasticsearch/search/aggregations/metrics/MaxTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/metrics/MaxTests.java
@@ -87,6 +87,20 @@ public class MaxTests extends AbstractNumericTests {
     }
 
     @Test
+    public void testSingleValuedField_WithFormatter() throws Exception {
+        SearchResponse searchResponse = client().prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(max("max").format("0000.0").field("value")).execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        Max max = searchResponse.getAggregations().get("max");
+        assertThat(max, notNullValue());
+        assertThat(max.getName(), equalTo("max"));
+        assertThat(max.getValue(), equalTo(10.0));
+        assertThat(max.getValueAsString(), equalTo("0010.0"));
+    }
+
+    @Test
     public void testSingleValuedField_getProperty() throws Exception {
 
         SearchResponse searchResponse = client().prepareSearch("idx").setQuery(matchAllQuery())

--- a/src/test/java/org/elasticsearch/search/aggregations/metrics/MinTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/metrics/MinTests.java
@@ -87,6 +87,20 @@ public class MinTests extends AbstractNumericTests {
     }
 
     @Test
+    public void testSingleValuedField_WithFormatter() throws Exception {
+        SearchResponse searchResponse = client().prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(min("min").format("0000.0").field("value")).execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        Min min = searchResponse.getAggregations().get("min");
+        assertThat(min, notNullValue());
+        assertThat(min.getName(), equalTo("min"));
+        assertThat(min.getValue(), equalTo(1.0));
+        assertThat(min.getValueAsString(), equalTo("0001.0"));
+    }
+
+    @Test
     public void testSingleValuedField_getProperty() throws Exception {
 
         SearchResponse searchResponse = client().prepareSearch("idx").setQuery(matchAllQuery())

--- a/src/test/java/org/elasticsearch/search/aggregations/metrics/PercentilesTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/metrics/PercentilesTests.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.search.aggregations.metrics;
 
 import com.google.common.collect.Lists;
+
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.search.aggregations.bucket.global.Global;

--- a/src/test/java/org/elasticsearch/search/aggregations/metrics/StatsTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/metrics/StatsTests.java
@@ -23,7 +23,6 @@ import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.search.aggregations.bucket.global.Global;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.metrics.stats.Stats;
-import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.junit.Test;
 
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
@@ -106,6 +105,28 @@ public class StatsTests extends AbstractNumericTests {
         assertThat(stats.getMax(), equalTo(10.0));
         assertThat(stats.getSum(), equalTo((double) 1+2+3+4+5+6+7+8+9+10));
         assertThat(stats.getCount(), equalTo(10l));
+    }
+
+    public void testSingleValuedField_WithFormatter() throws Exception {
+
+        SearchResponse searchResponse = client().prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(stats("stats").format("0000.0").field("value")).execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        Stats stats = searchResponse.getAggregations().get("stats");
+        assertThat(stats, notNullValue());
+        assertThat(stats.getName(), equalTo("stats"));
+        assertThat(stats.getAvg(), equalTo((double) (1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10) / 10));
+        assertThat(stats.getAvgAsString(), equalTo("0005.5"));
+        assertThat(stats.getMin(), equalTo(1.0));
+        assertThat(stats.getMinAsString(), equalTo("0001.0"));
+        assertThat(stats.getMax(), equalTo(10.0));
+        assertThat(stats.getMaxAsString(), equalTo("0010.0"));
+        assertThat(stats.getSum(), equalTo((double) 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10));
+        assertThat(stats.getSumAsString(), equalTo("0055.0"));
+        assertThat(stats.getCount(), equalTo(10l));
+        assertThat(stats.getCountAsString(), equalTo("0010.0"));
     }
 
     @Test

--- a/src/test/java/org/elasticsearch/search/aggregations/metrics/SumTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/metrics/SumTests.java
@@ -87,6 +87,20 @@ public class SumTests extends AbstractNumericTests {
     }
 
     @Test
+    public void testSingleValuedField_WithFormatter() throws Exception {
+        SearchResponse searchResponse = client().prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(sum("sum").format("0000.0").field("value")).execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        Sum sum = searchResponse.getAggregations().get("sum");
+        assertThat(sum, notNullValue());
+        assertThat(sum.getName(), equalTo("sum"));
+        assertThat(sum.getValue(), equalTo((double) 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10));
+        assertThat(sum.getValueAsString(), equalTo("0055.0"));
+    }
+
+    @Test
     public void testSingleValuedField_getProperty() throws Exception {
 
         SearchResponse searchResponse = client().prepareSearch("idx").setQuery(matchAllQuery())


### PR DESCRIPTION
You can now specify `format` in the request definition for most numeric metric aggregations. The exceptions are Percentile_Ranks, Cardinality and Value_Count as the response type of these can be different from the field type so the formatter won't work.

Closes #6812
