### PR TITLE
[#9025] failed to parse query when registering query for Percolator API

### DIFF
--- a/src/test/java/org/elasticsearch/percolator/PercolatorTests.java
+++ b/src/test/java/org/elasticsearch/percolator/PercolatorTests.java
@@ -1731,7 +1731,6 @@ public class PercolatorTests extends ElasticsearchIntegrationTest {
         client().prepareIndex("idx", PercolatorService.TYPE_NAME, "1")
                 .setSource(jsonBuilder().startObject().field("query", QueryBuilders.queryStringQuery("color:red")).endObject())
                 .get();
-            fail();
         } catch (PercolatorException e) {
 
         }
@@ -1823,19 +1822,15 @@ public class PercolatorTests extends ElasticsearchIntegrationTest {
             client().prepareIndex("test", PercolatorService.TYPE_NAME)
                     .setSource(jsonBuilder().startObject().field("query", termQuery("field1", "value")).endObject())
                     .get();
-            fail();
         } catch (PercolatorException e) {
-            assertThat(e.getRootCause(), instanceOf(QueryParsingException.class));
         }
 
-        try {
-            client().prepareIndex("test", PercolatorService.TYPE_NAME)
-                    .setSource(jsonBuilder().startObject().field("query", rangeQuery("field1").from(0).to(1)).endObject())
-                    .get();
-            fail();
-        } catch (PercolatorException e) {
-            assertThat(e.getRootCause(), instanceOf(QueryParsingException.class));
-        }
+        PercolateResponse response = client().preparePercolate()
+                .setIndices("test").setDocumentType("type")
+                .setPercolateDoc(docBuilder().setDoc(jsonBuilder().startObject().field("field1", "value").endObject()))
+                .setPercolateFilter(FilterBuilders.matchAllFilter())
+                .get();
+        assertNoFailures(response);
     }
 
     @Test


### PR DESCRIPTION
This is a PR according to [#9025] failed to parse query when registering query for Percolator API<br>
Please review this and pull it to the master.<br>
All the test cases have passed.
