### PR TITLE
`ignore_unavailable` shouldn't ignore closed indices

### DIFF
--- a/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -23,15 +23,13 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.type.*;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
-import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.indices.IndexClosedException;
 import org.elasticsearch.indices.IndexMissingException;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.transport.BaseTransportRequestHandler;
-import org.elasticsearch.transport.TransportChannel;
 import org.elasticsearch.transport.TransportService;
 
 import java.util.Map;
@@ -89,9 +87,8 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                     // if we only have one group, then we always want Q_A_F, no need for DFS, and no need to do THEN since we hit one shard
                     searchRequest.searchType(QUERY_AND_FETCH);
                 }
-            } catch (IndexMissingException e) {
-                // ignore this, we will notify the search response if its really the case
-                // from the actual action
+            } catch (IndexMissingException|IndexClosedException e) {
+                // ignore these failures, we will notify the search response if its really the case from the actual action
             } catch (Exception e) {
                 logger.debug("failed to optimize search type, continue as normal", e);
             }

--- a/src/test/java/org/elasticsearch/indices/IndicesOptionsIntegrationTests.java
+++ b/src/test/java/org/elasticsearch/indices/IndicesOptionsIntegrationTests.java
@@ -68,7 +68,7 @@ import static org.hamcrest.Matchers.*;
 public class IndicesOptionsIntegrationTests extends ElasticsearchIntegrationTest {
 
     @Test
-    public void testSpecifiedIndexUnavailable() throws Exception {
+    public void testSpecifiedIndexUnavailable_multipleIndices() throws Exception {
         createIndex("test1");
         ensureYellow();
 
@@ -165,6 +165,158 @@ public class IndicesOptionsIntegrationTests extends ElasticsearchIntegrationTest
         verify(getMapping("test1", "test2").setIndicesOptions(options), false);
         verify(getWarmer("test1", "test2").setIndicesOptions(options), false);
         verify(getSettings("test1", "test2").setIndicesOptions(options), false);
+    }
+
+    @Test
+    public void testSpecifiedIndexUnavailable_singleIndexThatIsClosed() throws Exception {
+        assertAcked(prepareCreate("test1"));
+        ensureYellow();
+
+        assertAcked(client().admin().indices().prepareClose("test1"));
+
+        IndicesOptions options = IndicesOptions.strictExpandOpenAndForbidClosed();
+        verify(search("test1").setIndicesOptions(options), true);
+        verify(msearch(options, "test1"), true);
+        verify(count("test1").setIndicesOptions(options), true);
+        verify(clearCache("test1").setIndicesOptions(options), true);
+        verify(_flush("test1").setIndicesOptions(options),true);
+        verify(segments("test1").setIndicesOptions(options), true);
+        verify(stats("test1").setIndicesOptions(options), true);
+        verify(optimize("test1").setIndicesOptions(options), true);
+        verify(refresh("test1").setIndicesOptions(options), true);
+        verify(validateQuery("test1").setIndicesOptions(options), true);
+        verify(aliasExists("test1").setIndicesOptions(options), true);
+        verify(typesExists("test1").setIndicesOptions(options), true);
+        verify(deleteByQuery("test1").setIndicesOptions(options), true);
+        verify(percolate("test1").setIndicesOptions(options), true);
+        verify(mpercolate(options, "test1").setIndicesOptions(options), true);
+        verify(suggest("test1").setIndicesOptions(options), true);
+        verify(getAliases("test1").setIndicesOptions(options), true);
+        verify(getFieldMapping("test1").setIndicesOptions(options), true);
+        verify(getMapping("test1").setIndicesOptions(options), true);
+        verify(getWarmer("test1").setIndicesOptions(options), true);
+        verify(getSettings("test1").setIndicesOptions(options), true);
+
+        options = IndicesOptions.fromOptions(true, options.allowNoIndices(), options.expandWildcardsOpen(), options.expandWildcardsClosed(), options);
+        verify(search("test1").setIndicesOptions(options), false);
+        verify(msearch(options, "test1"), false);
+        verify(count("test1").setIndicesOptions(options), false);
+        verify(clearCache("test1").setIndicesOptions(options), false);
+        verify(_flush("test1").setIndicesOptions(options),false);
+        verify(segments("test1").setIndicesOptions(options), false);
+        verify(stats("test1").setIndicesOptions(options), false);
+        verify(optimize("test1").setIndicesOptions(options), false);
+        verify(refresh("test1").setIndicesOptions(options), false);
+        verify(validateQuery("test1").setIndicesOptions(options), false);
+        verify(aliasExists("test1").setIndicesOptions(options), false);
+        verify(typesExists("test1").setIndicesOptions(options), false);
+        verify(deleteByQuery("test1").setIndicesOptions(options), false);
+        verify(percolate("test1").setIndicesOptions(options), false);
+        verify(mpercolate(options, "test1").setIndicesOptions(options), false);
+        verify(suggest("test1").setIndicesOptions(options), false);
+        verify(getAliases("test1").setIndicesOptions(options), false);
+        verify(getFieldMapping("test1").setIndicesOptions(options), false);
+        verify(getMapping("test1").setIndicesOptions(options), false);
+        verify(getWarmer("test1").setIndicesOptions(options), false);
+        verify(getSettings("test1").setIndicesOptions(options), false);
+
+        assertAcked(client().admin().indices().prepareOpen("test1"));
+        ensureYellow();
+
+        options = IndicesOptions.strictExpandOpenAndForbidClosed();
+        verify(search("test1").setIndicesOptions(options), false);
+        verify(msearch(options, "test1"), false);
+        verify(count("test1").setIndicesOptions(options), false);
+        verify(clearCache("test1").setIndicesOptions(options), false);
+        verify(_flush("test1").setIndicesOptions(options),false);
+        verify(segments("test1").setIndicesOptions(options), false);
+        verify(stats("test1").setIndicesOptions(options), false);
+        verify(optimize("test1").setIndicesOptions(options), false);
+        verify(refresh("test1").setIndicesOptions(options), false);
+        verify(validateQuery("test1").setIndicesOptions(options), false);
+        verify(aliasExists("test1").setIndicesOptions(options), false);
+        verify(typesExists("test1").setIndicesOptions(options), false);
+        verify(deleteByQuery("test1").setIndicesOptions(options), false);
+        verify(percolate("test1").setIndicesOptions(options), false);
+        verify(mpercolate(options, "test1").setIndicesOptions(options), false);
+        verify(suggest("test1").setIndicesOptions(options), false);
+        verify(getAliases("test1").setIndicesOptions(options), false);
+        verify(getFieldMapping("test1").setIndicesOptions(options), false);
+        verify(getMapping("test1").setIndicesOptions(options), false);
+        verify(getWarmer("test1").setIndicesOptions(options), false);
+        verify(getSettings("test1").setIndicesOptions(options), false);
+    }
+
+    @Test
+    public void testSpecifiedIndexUnavailable_singleIndex() throws Exception {
+        IndicesOptions options = IndicesOptions.strictExpandOpenAndForbidClosed();
+        verify(search("test1").setIndicesOptions(options), true);
+        verify(msearch(options, "test1"), true);
+        verify(count("test1").setIndicesOptions(options), true);
+        verify(clearCache("test1").setIndicesOptions(options), true);
+        verify(_flush("test1").setIndicesOptions(options),true);
+        verify(segments("test1").setIndicesOptions(options), true);
+        verify(stats("test1").setIndicesOptions(options), true);
+        verify(optimize("test1").setIndicesOptions(options), true);
+        verify(refresh("test1").setIndicesOptions(options), true);
+        verify(validateQuery("test1").setIndicesOptions(options), true);
+        verify(aliasExists("test1").setIndicesOptions(options), true);
+        verify(typesExists("test1").setIndicesOptions(options), true);
+        verify(deleteByQuery("test1").setIndicesOptions(options), true);
+        verify(percolate("test1").setIndicesOptions(options), true);
+        verify(suggest("test1").setIndicesOptions(options), true);
+        verify(getAliases("test1").setIndicesOptions(options), true);
+        verify(getFieldMapping("test1").setIndicesOptions(options), true);
+        verify(getMapping("test1").setIndicesOptions(options), true);
+        verify(getWarmer("test1").setIndicesOptions(options), true);
+        verify(getSettings("test1").setIndicesOptions(options), true);
+
+        options = IndicesOptions.fromOptions(true, options.allowNoIndices(), options.expandWildcardsOpen(), options.expandWildcardsClosed(), options);
+        verify(search("test1").setIndicesOptions(options), false);
+        verify(msearch(options, "test1"), false);
+        verify(count("test1").setIndicesOptions(options), false);
+        verify(clearCache("test1").setIndicesOptions(options), false);
+        verify(_flush("test1").setIndicesOptions(options),false);
+        verify(segments("test1").setIndicesOptions(options), false);
+        verify(stats("test1").setIndicesOptions(options), false);
+        verify(optimize("test1").setIndicesOptions(options), false);
+        verify(refresh("test1").setIndicesOptions(options), false);
+        verify(validateQuery("test1").setIndicesOptions(options), false);
+        verify(aliasExists("test1").setIndicesOptions(options), false);
+        verify(typesExists("test1").setIndicesOptions(options), false);
+        verify(deleteByQuery("test1").setIndicesOptions(options), false);
+        verify(percolate("test1").setIndicesOptions(options), false);
+        verify(suggest("test1").setIndicesOptions(options), false);
+        verify(getAliases("test1").setIndicesOptions(options), false);
+        verify(getFieldMapping("test1").setIndicesOptions(options), false);
+        verify(getMapping("test1").setIndicesOptions(options), false);
+        verify(getWarmer("test1").setIndicesOptions(options), false);
+        verify(getSettings("test1").setIndicesOptions(options), false);
+
+        assertAcked(prepareCreate("test1"));
+        ensureYellow();
+
+        options = IndicesOptions.strictExpandOpenAndForbidClosed();
+        verify(search("test1").setIndicesOptions(options), false);
+        verify(msearch(options, "test1"), false);
+        verify(count("test1").setIndicesOptions(options), false);
+        verify(clearCache("test1").setIndicesOptions(options), false);
+        verify(_flush("test1").setIndicesOptions(options),false);
+        verify(segments("test1").setIndicesOptions(options), false);
+        verify(stats("test1").setIndicesOptions(options), false);
+        verify(optimize("test1").setIndicesOptions(options), false);
+        verify(refresh("test1").setIndicesOptions(options), false);
+        verify(validateQuery("test1").setIndicesOptions(options), false);
+        verify(aliasExists("test1").setIndicesOptions(options), false);
+        verify(typesExists("test1").setIndicesOptions(options), false);
+        verify(deleteByQuery("test1").setIndicesOptions(options), false);
+        verify(percolate("test1").setIndicesOptions(options), false);
+        verify(suggest("test1").setIndicesOptions(options), false);
+        verify(getAliases("test1").setIndicesOptions(options), false);
+        verify(getFieldMapping("test1").setIndicesOptions(options), false);
+        verify(getMapping("test1").setIndicesOptions(options), false);
+        verify(getWarmer("test1").setIndicesOptions(options), false);
+        verify(getSettings("test1").setIndicesOptions(options), false);
     }
 
     @Test


### PR DESCRIPTION
The `ignore_unavailable` request setting shouldn't ignore closed indices if a single index is specified in a search or broadcast request.

PR for #7153
