### PR TITLE
Update index.asciidoc

### DIFF
--- a/docs/river/index.asciidoc
+++ b/docs/river/index.asciidoc
@@ -41,7 +41,7 @@ associated with it):
 
 [source,js]
 --------------------------------------------------
-curl -XDELETE 'localhost:9200/_river/my_river/'
+curl -XDELETE 'localhost:9200/_river/my_river/' -d '{"type": "dummy"}'
 --------------------------------------------------
 
 


### PR DESCRIPTION
In some occasions you may get an HTTP 404 error when you try to delete a river. 
{"error":"TypeMissingException[[_all] type[[test]] missing: No index has the type.]","status":404}

In this case you need to supply JSON data with your HTTP DELETE request
curl -XDELETE 'localhost:9200/_river/my_river/' -d '{"type": "dummy"}'
