### PR TITLE
GIS envelope validation

### DIFF
--- a/src/test/java/org/elasticsearch/common/geo/GeoJSONShapeParserTests.java
+++ b/src/test/java/org/elasticsearch/common/geo/GeoJSONShapeParserTests.java
@@ -121,6 +121,7 @@ public class GeoJSONShapeParserTests extends ElasticsearchTestCase {
 
     @Test
     public void testParse_envelope() throws IOException {
+        // test #1: envelope with expected coordinate order (TopLeft, BottomRight)
         String multilinesGeoJson = XContentFactory.jsonBuilder().startObject().field("type", "envelope")
                 .startArray("coordinates")
                 .startArray().value(-50).value(30).endArray()
@@ -130,6 +131,38 @@ public class GeoJSONShapeParserTests extends ElasticsearchTestCase {
 
         Rectangle expected = SPATIAL_CONTEXT.makeRectangle(-50, 50, -30, 30);
         assertGeometryEquals(expected, multilinesGeoJson);
+
+        // test #2: envelope with agnostic coordinate order (TopRight, BottomLeft)
+        multilinesGeoJson = XContentFactory.jsonBuilder().startObject().field("type", "envelope")
+                .startArray("coordinates")
+                .startArray().value(50).value(30).endArray()
+                .startArray().value(-50).value(-30).endArray()
+                .endArray()
+                .endObject().string();
+
+        expected = SPATIAL_CONTEXT.makeRectangle(-50, 50, -30, 30);
+        assertGeometryEquals(expected, multilinesGeoJson);
+
+        // test #3: "envelope" (actually a triangle) with invalid number of coordinates (TopRight, BottomLeft, BottomRight)
+        multilinesGeoJson = XContentFactory.jsonBuilder().startObject().field("type", "envelope")
+                .startArray("coordinates")
+                .startArray().value(50).value(30).endArray()
+                .startArray().value(-50).value(-30).endArray()
+                .startArray().value(50).value(-39).endArray()
+                .endArray()
+                .endObject().string();
+        XContentParser parser = JsonXContent.jsonXContent.createParser(multilinesGeoJson);
+        parser.nextToken();
+        ElasticsearchGeoAssertions.assertValidException(parser, ElasticsearchParseException.class);
+
+        // test #4: "envelope" with empty coordinates
+        multilinesGeoJson = XContentFactory.jsonBuilder().startObject().field("type", "envelope")
+                .startArray("coordinates")
+                .endArray()
+                .endObject().string();
+        parser = JsonXContent.jsonXContent.createParser(multilinesGeoJson);
+        parser.nextToken();
+        ElasticsearchGeoAssertions.assertValidException(parser, ElasticsearchParseException.class);
     }
 
     @Test


### PR DESCRIPTION
ShapeBuilder expected coordinates for Envelope types in strict Top-Left, Bottom-Right order. Given that GeoJSON does not enforce coordinate order (as seen in #8672) clients could specify envelope bounds in any order and be compliant with the GeoJSON spec but not the ES ShapeBuilder logic. This change loosens the ShapeBuilder requirements on envelope coordinate order, reordering where necessary.

closes #2544
closes #9067
closes #9079
closes #9080
