### PR TITLE
Add zenPings(ImmutableList) again

### DIFF
--- a/src/main/java/org/elasticsearch/discovery/zen/ping/ZenPingService.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ping/ZenPingService.java
@@ -68,6 +68,22 @@ public class ZenPingService extends AbstractLifecycleComponent<ZenPing> implemen
         return this.zenPings;
     }
 
+    /**
+     * This method could be used by discovery plugins
+     */
+    public void zenPings(ImmutableList<? extends ZenPing> pings) {
+        this.zenPings = pings;
+        if (lifecycle.started()) {
+            for (ZenPing zenPing : zenPings) {
+                zenPing.start();
+            }
+        } else if (lifecycle.stopped()) {
+            for (ZenPing zenPing : zenPings) {
+                zenPing.stop();
+            }
+        }
+    }
+
     @Override
     public void setPingContextProvider(PingContextProvider contextProvider) {
         if (lifecycle.started()) {

--- a/src/main/java/org/elasticsearch/discovery/zen/ping/ZenPingService.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ping/ZenPingService.java
@@ -69,8 +69,12 @@ public class ZenPingService extends AbstractLifecycleComponent<ZenPing> implemen
     }
 
     /**
-     * This method could be used by discovery plugins
+     * This method could be used by discovery plugins. For example in EC2 discovery,
+     * we are adding a HostsProvider to unicastZenPing.
+     * This hosts provider makes AWS API calls to get back the list of potential elasticsearch nodes.
+     * https://github.com/elasticsearch/elasticsearch-cloud-aws/blob/master/src/main/java/org/elasticsearch/discovery/ec2/Ec2Discovery.java#L64-71
      */
+    @SuppressWarnings("unused")
     public void zenPings(ImmutableList<? extends ZenPing> pings) {
         this.zenPings = pings;
         if (lifecycle.started()) {


### PR DESCRIPTION
Commit 95c2d844a93f15289be78a479a361c0356e10274 removed `zenPings(ImmutableList<? extends ZenPing> pings)` which actually used by discovery plugins.
For example here: https://github.com/elasticsearch/elasticsearch-cloud-aws/blob/master/src/main/java/org/elasticsearch/discovery/ec2/Ec2Discovery.java#L68

This PR add it back.
