### PR TITLE
upgrade to lucene 4.10.3 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <lucene.version>4.10.3</lucene.version>
-        <lucene.maven.version>4.10.3-snapshot-1637985</lucene.maven.version>
+        <lucene.maven.version>4.10.3</lucene.maven.version>
         <tests.jvms>auto</tests.jvms>
         <tests.shuffle>true</tests.shuffle>
         <tests.output>onerror</tests.output>


### PR DESCRIPTION
Lucene 4.10.3 is released, switch pom.xml for 1.x to the official release (rather than a snapshot).
