### PR TITLE
Fix TransportNodesListShardStoreMetaData for custom data paths

### DIFF
--- a/src/main/java/org/elasticsearch/gateway/GatewayAllocator.java
+++ b/src/main/java/org/elasticsearch/gateway/GatewayAllocator.java
@@ -330,6 +330,8 @@ public class GatewayAllocator extends AbstractComponent {
                                         sizeMatched += storeFileMetaData.length();
                                     }
                                 }
+                                logger.trace("{}: node [{}] has [{}/{}] bytes of re-usable data",
+                                        shard, discoNode.name(), new ByteSizeValue(sizeMatched), sizeMatched);
                                 if (sizeMatched > lastSizeMatched) {
                                     lastSizeMatched = sizeMatched;
                                     lastDiscoNodeMatched = discoNode;
@@ -345,7 +347,7 @@ public class GatewayAllocator extends AbstractComponent {
                 // we only check on THROTTLE since we checked before before on NO
                 Decision decision = allocation.deciders().canAllocate(shard, lastNodeMatched, allocation);
                 if (decision.type() == Decision.Type.THROTTLE) {
-                    if (logger.isTraceEnabled()) {
+                    if (logger.isDebugEnabled()) {
                         logger.debug("[{}][{}]: throttling allocation [{}] to [{}] in order to reuse its unallocated persistent store with total_size [{}]", shard.index(), shard.id(), shard, lastDiscoNodeMatched, new ByteSizeValue(lastSizeMatched));
                     }
                     // we are throttling this, but we have enough to allocate to this node, ignore it for now
@@ -411,6 +413,8 @@ public class GatewayAllocator extends AbstractComponent {
 
         for (TransportNodesListGatewayStartedShards.NodeGatewayStartedShards nodeShardState : response) {
             // -1 version means it does not exists, which is what the API returns, and what we expect to
+            logger.trace("[{}] on node [{}] has version [{}] of shard",
+                    shard, nodeShardState.getNode(), nodeShardState.version());
             shardStates.put(nodeShardState.getNode(), nodeShardState.version());
         }
         return shardStates;

--- a/src/main/java/org/elasticsearch/gateway/MetaDataStateFormat.java
+++ b/src/main/java/org/elasticsearch/gateway/MetaDataStateFormat.java
@@ -244,7 +244,9 @@ public abstract class MetaDataStateFormat<T> {
                             maxVersion = Math.max(maxVersion, version);
                             final boolean legacy = MetaDataStateFormat.STATE_FILE_EXTENSION.equals(matcher.group(2)) == false;
                             maxVersionIsLegacy &= legacy; // on purpose, see NOTE below
-                            files.add(new PathAndVersion(stateFile, version, legacy));
+                            PathAndVersion pav = new PathAndVersion(stateFile, version, legacy);
+                            logger.trace("found state file: {}", pav);
+                            files.add(pav);
                         }
                     }
                 }
@@ -275,6 +277,7 @@ public abstract class MetaDataStateFormat<T> {
                     }
                 } else {
                     state = format.read(stateFile, version);
+                    logger.trace("state version [{}] read from [{}]", version, stateFile.getFileName());
                 }
                 return state;
             } catch (Throwable e) {
@@ -323,6 +326,10 @@ public abstract class MetaDataStateFormat<T> {
             this.file = file;
             this.version = version;
             this.legacy = legacy;
+        }
+
+        public String toString() {
+            return "[version:" + version + ", legacy:" + legacy + ", file:" + file.toAbsolutePath() + "]";
         }
     }
 

--- a/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetaData.java
+++ b/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetaData.java
@@ -165,7 +165,7 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesOperatio
         if (!storeType.contains("fs")) {
             return new StoreFilesMetaData(false, shardId, ImmutableMap.<String, StoreFileMetaData>of());
         }
-        Path[] shardLocations = nodeEnv.shardPaths(shardId);
+        Path[] shardLocations = nodeEnv.shardDataPaths(shardId, metaData.settings());
         Path[] shardIndexLocations = new Path[shardLocations.length];
         for (int i = 0; i < shardLocations.length; i++) {
             shardIndexLocations[i] = shardLocations[i].resolve("index");


### PR DESCRIPTION
Cleans up the testReusePeerRecovery test as well

The actual fix is in TransportNodesListShardStoreMetaData.java, which
needs to use `nodeEnv.shardDataPaths` instead of `nodeEnv.shardPaths`.

Due to the difficulty in tracking this down, I've added a lot of
additional logging. This also fixes a logging issue in GatewayAllocator
