### PR TITLE
Added `verbose` option to segments api, with full ram tree as first additional element per segment

### DIFF
--- a/docs/reference/indices/segments.asciidoc
+++ b/docs/reference/indices/segments.asciidoc
@@ -74,3 +74,42 @@ compound::   Whether the segment is stored in a compound file. When true, this
              means that Lucene merged all files from the segment in a single
              one in order to save file descriptors.
 
+=== Verbose mode
+
+To add additional information that can be used for debugging, use the `verbose` flag.
+
+NOTE: The format of additional verbose information is experimental and can change at any time.
+
+[source,js]
+--------------------------------------------------
+curl -XGET 'http://localhost:9200/test/_segments?verbose=true'
+--------------------------------------------------
+
+Response:
+
+[source,js]
+--------------------------------------------------
+{
+    ...
+        "_3": {
+            ...
+            "ram_tree": [
+                {
+                    "description": "postings [PerFieldPostings(format=1)]",
+                    "size_in_bytes": 2696,
+                    "children": [
+                        {
+                            "description": "format 'Lucene50_0' ...",
+                            "size_in_bytes": 2608,
+                            "children" :[ ... ]
+                        },
+                        ...
+                    ]
+                },
+                ...
+                ]
+          
+        }
+    ...
+}
+--------------------------------------------------

--- a/src/main/java/org/elasticsearch/action/admin/indices/segments/IndicesSegmentResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/segments/IndicesSegmentResponse.java
@@ -22,17 +22,21 @@ package org.elasticsearch.action.admin.indices.segments;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import org.apache.lucene.util.Accountable;
 import org.elasticsearch.action.ShardOperationFailedException;
 import org.elasticsearch.action.support.broadcast.BroadcastOperationResponse;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentBuilderString;
 import org.elasticsearch.index.engine.Segment;
 
 import java.io.IOException;
+import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -139,6 +143,13 @@ public class IndicesSegmentResponse extends BroadcastOperationResponse implement
                         if (segment.getMergeId() != null) {
                             builder.field(Fields.MERGE_ID, segment.getMergeId());
                         }
+                        if (segment.ramTree != null) {
+                            builder.startArray(Fields.RAM_TREE);
+                            for (Accountable child : segment.ramTree.getChildResources()) {
+                                toXContent(builder, child);
+                            }
+                            builder.endArray();
+                        }
                         builder.endObject();
                     }
                     builder.endObject();
@@ -154,6 +165,21 @@ public class IndicesSegmentResponse extends BroadcastOperationResponse implement
 
         builder.endObject();
         return builder;
+    }
+    
+    static void toXContent(XContentBuilder builder, Accountable tree) throws IOException {
+        builder.startObject();
+        builder.field(Fields.DESCRIPTION, tree.toString());
+        builder.byteSizeField(Fields.SIZE_IN_BYTES, Fields.SIZE, new ByteSizeValue(tree.ramBytesUsed()));
+        Collection<Accountable> children = tree.getChildResources();
+        if (children.isEmpty() == false) {
+            builder.startArray(Fields.CHILDREN);
+            for (Accountable child : children) {
+                toXContent(builder, child);
+            }
+            builder.endArray();
+        }
+        builder.endObject();
     }
 
     static final class Fields {
@@ -180,5 +206,8 @@ public class IndicesSegmentResponse extends BroadcastOperationResponse implement
         static final XContentBuilderString MERGE_ID = new XContentBuilderString("merge_id");
         static final XContentBuilderString MEMORY = new XContentBuilderString("memory");
         static final XContentBuilderString MEMORY_IN_BYTES = new XContentBuilderString("memory_in_bytes");
+        static final XContentBuilderString RAM_TREE = new XContentBuilderString("ram_tree");
+        static final XContentBuilderString DESCRIPTION = new XContentBuilderString("description");
+        static final XContentBuilderString CHILDREN = new XContentBuilderString("children");
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/segments/IndicesSegmentsRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/segments/IndicesSegmentsRequest.java
@@ -22,9 +22,15 @@ package org.elasticsearch.action.admin.indices.segments;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.broadcast.BroadcastOperationRequest;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
 
 public class IndicesSegmentsRequest extends BroadcastOperationRequest<IndicesSegmentsRequest> {
 
+    protected boolean verbose = false;
+    
     public IndicesSegmentsRequest() {
         this(Strings.EMPTY_ARRAY);
     }
@@ -33,4 +39,34 @@ public class IndicesSegmentsRequest extends BroadcastOperationRequest<IndicesSeg
         super(indices);
         indicesOptions(IndicesOptions.fromOptions(false, false, true, false));
     }
+
+    /**
+     * <code>true</code> if detailed information about each segment should be returned,
+     * <code>false</code> otherwise.
+     */
+    public boolean verbose() {
+        return verbose;
+    }
+
+    /**
+     * Sets the <code>verbose</code> option.
+     * @see #verbose()
+     */
+    public void verbose(boolean v) {
+        verbose = v;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeBoolean(verbose);
+        
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+        verbose = in.readBoolean();
+    }
+    
 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/segments/IndicesSegmentsRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/segments/IndicesSegmentsRequestBuilder.java
@@ -31,6 +31,11 @@ public class IndicesSegmentsRequestBuilder extends BroadcastOperationRequestBuil
     public IndicesSegmentsRequestBuilder(IndicesAdminClient indicesClient) {
         super(indicesClient, new IndicesSegmentsRequest());
     }
+    
+    public IndicesSegmentsRequestBuilder setVerbose(boolean verbose) {
+        request.verbose = verbose;
+        return this;
+    }
 
     @Override
     protected void doExecute(ActionListener<IndicesSegmentResponse> listener) {

--- a/src/main/java/org/elasticsearch/action/admin/indices/segments/TransportIndicesSegmentsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/segments/TransportIndicesSegmentsAction.java
@@ -131,16 +131,19 @@ public class TransportIndicesSegmentsAction extends TransportBroadcastOperationA
     protected ShardSegments shardOperation(IndexShardSegmentRequest request) throws ElasticsearchException {
         IndexService indexService = indicesService.indexServiceSafe(request.shardId().getIndex());
         IndexShard indexShard = indexService.shardSafe(request.shardId().id());
-        return new ShardSegments(indexShard.routingEntry(), indexShard.engine().segments());
+        return new ShardSegments(indexShard.routingEntry(), indexShard.engine().segments(request.verbose));
     }
 
     static class IndexShardSegmentRequest extends BroadcastShardOperationRequest {
-
+        final boolean verbose;
+        
         IndexShardSegmentRequest() {
+            verbose = false;
         }
 
         IndexShardSegmentRequest(ShardId shardId, IndicesSegmentsRequest request) {
             super(shardId, request);
+            verbose = request.verbose();
         }
     }
 }

--- a/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -103,7 +103,7 @@ public interface Engine extends CloseableComponent {
     /**
      * The list of segments in the engine.
      */
-    List<Segment> segments();
+    List<Segment> segments(boolean verbose);
 
     /**
      * Returns <tt>true</tt> if a refresh is really needed.

--- a/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
+++ b/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
@@ -27,6 +27,7 @@ import org.apache.lucene.search.*;
 import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.store.LockObtainFailedException;
 import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.Accountables;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.ElasticsearchException;
@@ -1266,7 +1267,7 @@ public class InternalEngine implements Engine {
     }
 
     @Override
-    public List<Segment> segments() {
+    public List<Segment> segments(boolean verbose) {
         try (InternalLock _ = readLock.acquire()) {
             ensureOpen();
             Map<String, Segment> segments = new HashMap<>();
@@ -1290,6 +1291,9 @@ public class InternalEngine implements Engine {
                     }
                     final SegmentReader segmentReader = segmentReader(reader.reader());
                     segment.memoryInBytes = segmentReader.ramBytesUsed();
+                    if (verbose) {
+                        segment.ramTree = Accountables.namedAccountable("root", segmentReader);
+                    }
                     // TODO: add more fine grained mem stats values to per segment info here
                     segments.put(info.info.name, segment);
                 }

--- a/src/main/java/org/elasticsearch/index/engine/internal/InternalEngineHolder.java
+++ b/src/main/java/org/elasticsearch/index/engine/internal/InternalEngineHolder.java
@@ -274,8 +274,8 @@ public class InternalEngineHolder extends AbstractIndexShardComponent implements
     }
 
     @Override
-    public List<Segment> segments() {
-        return engineSafe().segments();
+    public List<Segment> segments(boolean verbose) {
+        return engineSafe().segments(verbose);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/segments/RestIndicesSegmentsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/segments/RestIndicesSegmentsAction.java
@@ -48,6 +48,7 @@ public class RestIndicesSegmentsAction extends BaseRestHandler {
     @Override
     public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         IndicesSegmentsRequest indicesSegmentsRequest = new IndicesSegmentsRequest(Strings.splitStringByCommaToArray(request.param("index")));
+        indicesSegmentsRequest.verbose(request.paramAsBoolean("verbose", false));
         indicesSegmentsRequest.listenerThreaded(false);
         indicesSegmentsRequest.indicesOptions(IndicesOptions.fromRequest(request, indicesSegmentsRequest.indicesOptions()));
         client.admin().indices().segments(indicesSegmentsRequest, new RestBuilderListener<IndicesSegmentResponse>(channel) {

--- a/src/test/java/org/elasticsearch/action/admin/indices/segments/IndicesSegmentsRequestTests.java
+++ b/src/test/java/org/elasticsearch/action/admin/indices/segments/IndicesSegmentsRequestTests.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.admin.indices.segments;
+
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.engine.Segment;
+import org.elasticsearch.test.ElasticsearchSingleNodeTest;
+import org.junit.Before;
+
+import java.util.List;
+
+public class IndicesSegmentsRequestTests extends ElasticsearchSingleNodeTest {
+    
+    @Before
+    public void setupIndex() {
+        Settings settings = ImmutableSettings.builder()
+            // don't allow any merges so that the num docs is the expected segments
+            .put("index.merge.policy.segments_per_tier", 1000000f)
+            .build();
+        createIndex("test", settings);
+
+        int numDocs = scaledRandomIntBetween(100, 1000);
+        for (int j = 0; j < numDocs; ++j) {
+            String id = Integer.toString(j);
+            client().prepareIndex("test", "type1", id).setSource("text", "sometext").get();
+        }
+        client().admin().indices().prepareFlush("test").get();
+    }
+
+    public void testBasic() {
+        IndicesSegmentResponse rsp = client().admin().indices().prepareSegments("test").get();
+        List<Segment> segments = rsp.getIndices().get("test").iterator().next().getShards()[0].getSegments();
+        assertNull(segments.get(0).ramTree);
+    }
+    
+    public void testVerbose() {
+        IndicesSegmentResponse rsp = client().admin().indices().prepareSegments("test").setVerbose(true).get();
+        List<Segment> segments = rsp.getIndices().get("test").iterator().next().getShards()[0].getSegments();
+        assertNotNull(segments.get(0).ramTree);
+    }
+}


### PR DESCRIPTION
This commit adds a verbose flag to the _segments api.  Currently the
only additional information returned when set to true is the full
ram tree from lucene for each segment.

Note: I added the ramTree as a public member on the `Segment` class.  This class has a mix of struct like members and some that have getters.  It really should be cleaned up, but here I tried to follow what seemed like the most common pattern there.
