### PR TITLE
[Docs] fix curl examples in Nodes Stats docs

### DIFF
--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -82,14 +82,14 @@ level or on index level.
 [source,js]
 --------------------------------------------------
 # Node Stats
-curl localhost:9200/_nodes/stats/indices/?fields=field1,field2&pretty
+curl -XGET 'http://localhost:9200/_nodes/stats/indices/?fields=field1,field2&pretty'
 
 # Indices Stat
-curl localhost:9200/_stats/fielddata/?fields=field1,field2&pretty
+curl -XGET 'http://localhost:9200/_stats/fielddata/?fields=field1,field2&pretty'
 
 # You can use wildcards for field names
-curl localhost:9200/_stats/fielddata/?fields=field*&pretty
-curl localhost:9200/_nodes/stats/indices/?fields=field*&pretty
+curl -XGET 'http://localhost:9200/_stats/fielddata/?fields=field*&pretty'
+curl -XGET 'http://localhost:9200/_nodes/stats/indices/?fields=field*&pretty'
 --------------------------------------------------
 
 [float]
@@ -102,8 +102,8 @@ on this node.
 [source,js]
 --------------------------------------------------
 # All groups with all stats
-curl localhost:9200/_nodes/stats?pretty&groups=_all
+curl -XGET 'http://localhost:9200/_nodes/stats?pretty&groups=_all'
 
 # Some groups from just the indices stats
-curl localhost:9200/_nodes/stats/indices?pretty&groups=foo,bar
+curl -XGET 'http://localhost:9200/_nodes/stats/indices?pretty&groups=foo,bar'
 --------------------------------------------------


### PR DESCRIPTION
Examples were not copy-pastable because they contain '&' symbols which have special meaning in shells. 
I've also added -XGET and `http://` for consistency with other examples.

There is a similar issue in 1.4 branch, and "edit" button in ES docs creates a PR for 1.4 branch. What is the best branch to send a PR against: master, 1.4 or both?
