### PR TITLE
cleanup: Remove `gateway.type: local`

### DIFF
--- a/src/test/java/org/elasticsearch/benchmark/aliases/AliasesBenchmark.java
+++ b/src/test/java/org/elasticsearch/benchmark/aliases/AliasesBenchmark.java
@@ -45,7 +45,6 @@ public class AliasesBenchmark {
         int NUM_ADD_ALIAS_REQUEST = 1000;
 
         Settings settings = ImmutableSettings.settingsBuilder()
-                .put("gateway.type", "local")
                 .put("node.master", false).build();
         Node node1 = NodeBuilder.nodeBuilder().settings(
                 ImmutableSettings.settingsBuilder().put(settings).put("node.master", true)

--- a/src/test/java/org/elasticsearch/benchmark/mapping/ManyMappingsBenchmark.java
+++ b/src/test/java/org/elasticsearch/benchmark/mapping/ManyMappingsBenchmark.java
@@ -88,7 +88,6 @@ public class ManyMappingsBenchmark {
         System.setProperty("es.logger.prefix", "");
         Natives.tryMlockall();
         Settings settings = settingsBuilder()
-                .put("gateway.type", "local")
                 .put(SETTING_NUMBER_OF_SHARDS, 5)
                 .put(SETTING_NUMBER_OF_REPLICAS, 0)
                 .build();

--- a/src/test/java/org/elasticsearch/benchmark/search/aggregations/GlobalOrdinalsBenchmark.java
+++ b/src/test/java/org/elasticsearch/benchmark/search/aggregations/GlobalOrdinalsBenchmark.java
@@ -73,7 +73,6 @@ public class GlobalOrdinalsBenchmark {
 
         Settings settings = settingsBuilder()
                 .put("index.refresh_interval", "-1")
-                .put("gateway.type", "local")
                 .put(SETTING_NUMBER_OF_SHARDS, 1)
                 .put(SETTING_NUMBER_OF_REPLICAS, 0)
                 .put(TransportModule.TRANSPORT_TYPE_KEY, "local")

--- a/src/test/java/org/elasticsearch/benchmark/search/aggregations/HistogramAggregationSearchBenchmark.java
+++ b/src/test/java/org/elasticsearch/benchmark/search/aggregations/HistogramAggregationSearchBenchmark.java
@@ -56,7 +56,6 @@ public class HistogramAggregationSearchBenchmark {
     public static void main(String[] args) throws Exception {
         Settings settings = settingsBuilder()
                 .put("refresh_interval", "-1")
-                .put("gateway.type", "local")
                 .put(SETTING_NUMBER_OF_SHARDS, 1)
                 .put(SETTING_NUMBER_OF_REPLICAS, 0)
                 .build();

--- a/src/test/java/org/elasticsearch/benchmark/search/aggregations/QueryFilterAggregationSearchBenchmark.java
+++ b/src/test/java/org/elasticsearch/benchmark/search/aggregations/QueryFilterAggregationSearchBenchmark.java
@@ -57,7 +57,6 @@ public class QueryFilterAggregationSearchBenchmark {
     public static void main(String[] args) throws Exception {
         Settings settings = settingsBuilder()
                 .put("index.refresh_interval", "-1")
-                .put("gateway.type", "local")
                 .put(SETTING_NUMBER_OF_SHARDS, 2)
                 .put(SETTING_NUMBER_OF_REPLICAS, 0)
                 .build();

--- a/src/test/java/org/elasticsearch/benchmark/search/aggregations/SubAggregationSearchCollectModeBenchmark.java
+++ b/src/test/java/org/elasticsearch/benchmark/search/aggregations/SubAggregationSearchCollectModeBenchmark.java
@@ -77,7 +77,6 @@ public class SubAggregationSearchCollectModeBenchmark {
 
         Settings settings = settingsBuilder()
                 .put("index.refresh_interval", "-1")
-                .put("gateway.type", "local")
                 .put(SETTING_NUMBER_OF_SHARDS, 1)
                 .put(SETTING_NUMBER_OF_REPLICAS, 0)
                 .build();

--- a/src/test/java/org/elasticsearch/benchmark/search/aggregations/TermsAggregationSearchBenchmark.java
+++ b/src/test/java/org/elasticsearch/benchmark/search/aggregations/TermsAggregationSearchBenchmark.java
@@ -105,7 +105,6 @@ public class TermsAggregationSearchBenchmark {
 
         Settings settings = settingsBuilder()
                 .put("index.refresh_interval", "-1")
-                .put("gateway.type", "local")
                 .put(SETTING_NUMBER_OF_SHARDS, 1)
                 .put(SETTING_NUMBER_OF_REPLICAS, 0)
                 .build();

--- a/src/test/java/org/elasticsearch/benchmark/search/aggregations/TimeDataHistogramAggregationBenchmark.java
+++ b/src/test/java/org/elasticsearch/benchmark/search/aggregations/TimeDataHistogramAggregationBenchmark.java
@@ -75,7 +75,6 @@ public class TimeDataHistogramAggregationBenchmark {
 
         Settings settings = settingsBuilder()
                 .put("index.refresh_interval", "-1")
-                .put("gateway.type", "local")
                 .put("node.local", true)
                 .put(SETTING_NUMBER_OF_SHARDS, 1)
                 .put(SETTING_NUMBER_OF_REPLICAS, 0)

--- a/src/test/java/org/elasticsearch/benchmark/search/child/ChildSearchAndIndexingBenchmark.java
+++ b/src/test/java/org/elasticsearch/benchmark/search/child/ChildSearchAndIndexingBenchmark.java
@@ -55,7 +55,6 @@ public class ChildSearchAndIndexingBenchmark {
     public static void main(String[] args) throws Exception {
         Settings settings = settingsBuilder()
                 .put("refresh_interval", "-1")
-                .put("gateway.type", "local")
                 .put(SETTING_NUMBER_OF_SHARDS, 1)
                 .put(SETTING_NUMBER_OF_REPLICAS, 0)
                 .build();

--- a/src/test/java/org/elasticsearch/benchmark/search/child/ChildSearchBenchmark.java
+++ b/src/test/java/org/elasticsearch/benchmark/search/child/ChildSearchBenchmark.java
@@ -48,7 +48,6 @@ public class ChildSearchBenchmark {
     public static void main(String[] args) throws Exception {
         Settings settings = settingsBuilder()
                 .put("index.refresh_interval", "-1")
-                .put("gateway.type", "local")
                 .put(SETTING_NUMBER_OF_SHARDS, 1)
                 .put(SETTING_NUMBER_OF_REPLICAS, 0)
                 .build();

--- a/src/test/java/org/elasticsearch/benchmark/search/child/ChildSearchShortCircuitBenchmark.java
+++ b/src/test/java/org/elasticsearch/benchmark/search/child/ChildSearchShortCircuitBenchmark.java
@@ -52,7 +52,6 @@ public class ChildSearchShortCircuitBenchmark {
     public static void main(String[] args) throws Exception {
         Settings settings = settingsBuilder()
                 .put("index.refresh_interval", "-1")
-                .put("gateway.type", "local")
                 .put(SETTING_NUMBER_OF_SHARDS, 1)
                 .put(SETTING_NUMBER_OF_REPLICAS, 0)
                 .build();

--- a/src/test/java/org/elasticsearch/benchmark/search/nested/NestedSearchBenchMark.java
+++ b/src/test/java/org/elasticsearch/benchmark/search/nested/NestedSearchBenchMark.java
@@ -48,7 +48,6 @@ public class NestedSearchBenchMark {
     public static void main(String[] args) throws Exception {
         Settings settings = settingsBuilder()
                 .put("index.refresh_interval", "-1")
-                .put("gateway.type", "local")
                 .put(SETTING_NUMBER_OF_SHARDS, 1)
                 .put(SETTING_NUMBER_OF_REPLICAS, 0)
                 .build();

--- a/src/test/java/org/elasticsearch/cluster/MinimumMasterNodesTests.java
+++ b/src/test/java/org/elasticsearch/cluster/MinimumMasterNodesTests.java
@@ -57,7 +57,6 @@ public class MinimumMasterNodesTests extends ElasticsearchIntegrationTest {
                 .put("discovery.zen.minimum_master_nodes", 2)
                 .put("discovery.zen.ping_timeout", "200ms")
                 .put("discovery.initial_state_timeout", "500ms")
-                .put("gateway.type", "local")
                 .build();
 
         logger.info("--> start first node");
@@ -175,7 +174,6 @@ public class MinimumMasterNodesTests extends ElasticsearchIntegrationTest {
                 .put("discovery.zen.minimum_master_nodes", 3)
                 .put("discovery.zen.ping_timeout", "1s")
                 .put("discovery.initial_state_timeout", "500ms")
-                .put("gateway.type", "local")
                 .build();
 
         logger.info("--> start first 2 nodes");
@@ -265,7 +263,6 @@ public class MinimumMasterNodesTests extends ElasticsearchIntegrationTest {
                 .put("discovery.type", "zen")
                 .put("discovery.zen.ping_timeout", "400ms")
                 .put("discovery.initial_state_timeout", "500ms")
-                .put("gateway.type", "local")
                 .build();
 
         logger.info("--> start 2 nodes");
@@ -318,8 +315,7 @@ public class MinimumMasterNodesTests extends ElasticsearchIntegrationTest {
         ImmutableSettings.Builder settings = settingsBuilder()
                 .put("discovery.type", "zen")
                 .put("discovery.zen.ping_timeout", "200ms")
-                .put("discovery.initial_state_timeout", "500ms")
-                .put("gateway.type", "local");
+                .put("discovery.initial_state_timeout", "500ms");
 
         // set an initial value which is at least quorum to avoid split brains during initial startup
         int initialMinMasterNodes = randomIntBetween(nodeCount / 2 + 1, nodeCount);

--- a/src/test/java/org/elasticsearch/cluster/allocation/ClusterRerouteTests.java
+++ b/src/test/java/org/elasticsearch/cluster/allocation/ClusterRerouteTests.java
@@ -71,7 +71,6 @@ public class ClusterRerouteTests extends ElasticsearchIntegrationTest {
     public void rerouteWithCommands_enableAllocationSettings() throws Exception {
         Settings commonSettings = settingsBuilder()
                 .put(EnableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ENABLE, EnableAllocationDecider.Allocation.NONE.name())
-                .put("gateway.type", "local")
                 .build();
         rerouteWithCommands(commonSettings);
     }
@@ -142,7 +141,6 @@ public class ClusterRerouteTests extends ElasticsearchIntegrationTest {
         Settings commonSettings = settingsBuilder()
                 .put(DisableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_DISABLE_NEW_ALLOCATION, true)
                 .put(DisableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_DISABLE_ALLOCATION, true)
-                .put("gateway.type", "local")
                 .build();
         rerouteWithAllocateLocalGateway(commonSettings);
     }
@@ -151,7 +149,6 @@ public class ClusterRerouteTests extends ElasticsearchIntegrationTest {
     public void rerouteWithAllocateLocalGateway_enableAllocationSettings() throws Exception {
         Settings commonSettings = settingsBuilder()
                 .put(EnableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ENABLE, EnableAllocationDecider.Allocation.NONE.name())
-                .put("gateway.type", "local")
                 .build();
         rerouteWithAllocateLocalGateway(commonSettings);
     }

--- a/src/test/java/org/elasticsearch/gateway/GatewayIndexStateTests.java
+++ b/src/test/java/org/elasticsearch/gateway/GatewayIndexStateTests.java
@@ -60,7 +60,7 @@ public class GatewayIndexStateTests extends ElasticsearchIntegrationTest {
     public void testMappingMetaDataParsed() throws Exception {
 
         logger.info("--> starting 1 nodes");
-        internalCluster().startNode(settingsBuilder().put("gateway.type", "local"));
+        internalCluster().startNode();
 
         logger.info("--> creating test index, with meta routing");
         client().admin().indices().prepareCreate("test")
@@ -89,7 +89,7 @@ public class GatewayIndexStateTests extends ElasticsearchIntegrationTest {
     public void testSimpleOpenClose() throws Exception {
 
         logger.info("--> starting 2 nodes");
-        internalCluster().startNodesAsync(2, settingsBuilder().put("gateway.type", "local").build()).get();
+        internalCluster().startNodesAsync(2).get();
 
         logger.info("--> creating test index");
         createIndex("test");
@@ -192,7 +192,7 @@ public class GatewayIndexStateTests extends ElasticsearchIntegrationTest {
         logger.info("--> cleaning nodes");
 
         logger.info("--> starting 1 master node non data");
-        internalCluster().startNode(settingsBuilder().put("node.data", false).put("gateway.type", "local").build());
+        internalCluster().startNode(settingsBuilder().put("node.data", false).build());
 
         logger.info("--> create an index");
         client().admin().indices().prepareCreate("test").execute().actionGet();
@@ -201,7 +201,7 @@ public class GatewayIndexStateTests extends ElasticsearchIntegrationTest {
         internalCluster().closeNonSharedNodes(false);
 
         logger.info("--> starting 1 master node non data again");
-        internalCluster().startNode(settingsBuilder().put("node.data", false).put("gateway.type", "local").build());
+        internalCluster().startNode(settingsBuilder().put("node.data", false).build());
 
         logger.info("--> waiting for test index to be created");
         ClusterHealthResponse health = client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setIndices("test").execute().actionGet();
@@ -217,8 +217,8 @@ public class GatewayIndexStateTests extends ElasticsearchIntegrationTest {
         logger.info("--> cleaning nodes");
 
         logger.info("--> starting 1 master node non data");
-        internalCluster().startNode(settingsBuilder().put("node.data", false).put("gateway.type", "local").build());
-        internalCluster().startNode(settingsBuilder().put("node.master", false).put("gateway.type", "local").build());
+        internalCluster().startNode(settingsBuilder().put("node.data", false).build());
+        internalCluster().startNode(settingsBuilder().put("node.master", false).build());
 
         logger.info("--> create an index");
         client().admin().indices().prepareCreate("test").execute().actionGet();
@@ -234,8 +234,8 @@ public class GatewayIndexStateTests extends ElasticsearchIntegrationTest {
         logger.info("--> cleaning nodes");
 
         logger.info("--> starting 2 nodes");
-        internalCluster().startNode(settingsBuilder().put("gateway.type", "local").build());
-        internalCluster().startNode(settingsBuilder().put("gateway.type", "local").build());
+        internalCluster().startNode();
+        internalCluster().startNode();
 
         logger.info("--> indexing a simple document");
         client().prepareIndex("test", "type1", "1").setSource("field1", "value1").setRefresh(true).execute().actionGet();
@@ -272,9 +272,8 @@ public class GatewayIndexStateTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testDanglingIndicesConflictWithAlias() throws Exception {
-        Settings settings = settingsBuilder().put("gateway.type", "local").build();
         logger.info("--> starting two nodes");
-        internalCluster().startNodesAsync(2, settings).get();
+        internalCluster().startNodesAsync(2).get();
 
         logger.info("--> indexing a simple document");
         client().prepareIndex("test", "type1", "1").setSource("field1", "value1").setRefresh(true).execute().actionGet();
@@ -302,7 +301,7 @@ public class GatewayIndexStateTests extends ElasticsearchIntegrationTest {
         assertAcked(client().admin().indices().prepareAliases().addAlias("test2", "test"));
 
         logger.info("--> starting node back up");
-        internalCluster().startNode(settings);
+        internalCluster().startNode();
 
         ensureGreen();
 
@@ -391,7 +390,7 @@ public class GatewayIndexStateTests extends ElasticsearchIntegrationTest {
     @Test
     public void testDanglingIndicesAutoImportClose() throws Exception {
         Settings settings = settingsBuilder()
-                .put("gateway.type", "local").put("gateway.local.auto_import_dangled", "closed")
+                .put("gateway.local.auto_import_dangled", "closed")
                 .build();
 
 
@@ -454,7 +453,7 @@ public class GatewayIndexStateTests extends ElasticsearchIntegrationTest {
     @Test
     public void testDanglingIndicesNoAutoImport() throws Exception {
         Settings settings = settingsBuilder()
-                .put("gateway.type", "local").put("gateway.local.auto_import_dangled", "no")
+                .put("gateway.local.auto_import_dangled", "no")
                 .build();
         logger.info("--> starting two nodes");
         final String node_1 = internalCluster().startNodesAsync(2, settings).get().get(0);
@@ -516,7 +515,7 @@ public class GatewayIndexStateTests extends ElasticsearchIntegrationTest {
     @Test
     public void testDanglingIndicesNoAutoImportStillDanglingAndCreatingSameIndex() throws Exception {
         Settings settings = settingsBuilder()
-                .put("gateway.type", "local").put("gateway.local.auto_import_dangled", "no")
+                .put("gateway.local.auto_import_dangled", "no")
                 .build();
 
         logger.info("--> starting two nodes");

--- a/src/test/java/org/elasticsearch/gateway/QuorumGatewayTests.java
+++ b/src/test/java/org/elasticsearch/gateway/QuorumGatewayTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
@@ -57,7 +58,7 @@ public class QuorumGatewayTests extends ElasticsearchIntegrationTest {
     @Slow
     public void testChangeInitialShardsRecovery() throws Exception {
         logger.info("--> starting 3 nodes");
-        final String[] nodes = internalCluster().startNodesAsync(3, settingsBuilder().put("gateway.type", "local").build()).get().toArray(new String[0]);
+        final String[] nodes = internalCluster().startNodesAsync(3).get().toArray(new String[0]);
 
         createIndex("test");
         ensureGreen();
@@ -80,7 +81,7 @@ public class QuorumGatewayTests extends ElasticsearchIntegrationTest {
         internalCluster().fullRestart(new RestartCallback() {
             @Override
             public Settings onNodeStopped(String nodeName) throws Exception {
-                return settingsBuilder().put("gateway.type", "local").build();
+                return ImmutableSettings.EMPTY;
             }
             
             @Override
@@ -123,7 +124,7 @@ public class QuorumGatewayTests extends ElasticsearchIntegrationTest {
     public void testQuorumRecovery() throws Exception {
 
         logger.info("--> starting 3 nodes");
-        internalCluster().startNodesAsync(3, settingsBuilder().put("gateway.type", "local").build()).get();
+        internalCluster().startNodesAsync(3).get();
         // we are shutting down nodes - make sure we don't have 2 clusters if we test network
         setMinimumMasterNodes(2);
 

--- a/src/test/java/org/elasticsearch/gateway/RecoveryFromGatewayTests.java
+++ b/src/test/java/org/elasticsearch/gateway/RecoveryFromGatewayTests.java
@@ -25,7 +25,6 @@ import org.elasticsearch.action.admin.indices.recovery.ShardRecoveryResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider;
-import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.query.FilterBuilders;
@@ -40,6 +39,7 @@ import org.junit.Test;
 
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_REPLICAS;
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
+import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.index.query.QueryBuilders.termQuery;
@@ -55,15 +55,11 @@ import static org.hamcrest.Matchers.*;
 @Slow
 public class RecoveryFromGatewayTests extends ElasticsearchIntegrationTest {
 
-    private ImmutableSettings.Builder settingsBuilder() {
-        return ImmutableSettings.settingsBuilder().put("gateway.type", "local");
-    }
-
     @Test
     @Slow
     public void testOneNodeRecoverFromGateway() throws Exception {
 
-        internalCluster().startNode(settingsBuilder().build());
+        internalCluster().startNode();
 
         String mapping = XContentFactory.jsonBuilder().startObject().startObject("type1")
                 .startObject("properties").startObject("appAccountIds").field("type", "string").endObject().endObject()
@@ -112,7 +108,7 @@ public class RecoveryFromGatewayTests extends ElasticsearchIntegrationTest {
     @Slow
     public void testSingleNodeNoFlush() throws Exception {
 
-        internalCluster().startNode(settingsBuilder().build());
+        internalCluster().startNode();
 
         String mapping = XContentFactory.jsonBuilder().startObject().startObject("type1")
                 .startObject("properties").startObject("field").field("type", "string").endObject().startObject("num").field("type", "integer").endObject().endObject()
@@ -200,7 +196,7 @@ public class RecoveryFromGatewayTests extends ElasticsearchIntegrationTest {
     @Slow
     public void testSingleNodeWithFlush() throws Exception {
 
-        internalCluster().startNode(settingsBuilder().build());
+        internalCluster().startNode();
         client().prepareIndex("test", "type1", "1").setSource(jsonBuilder().startObject().field("field", "value1").endObject()).execute().actionGet();
         flush();
         client().prepareIndex("test", "type1", "2").setSource(jsonBuilder().startObject().field("field", "value2").endObject()).execute().actionGet();
@@ -234,8 +230,8 @@ public class RecoveryFromGatewayTests extends ElasticsearchIntegrationTest {
     @Slow
     public void testTwoNodeFirstNodeCleared() throws Exception {
 
-        final String firstNode = internalCluster().startNode(settingsBuilder().build());
-        internalCluster().startNode(settingsBuilder().build());
+        final String firstNode = internalCluster().startNode();
+        internalCluster().startNode();
 
         client().prepareIndex("test", "type1", "1").setSource(jsonBuilder().startObject().field("field", "value1").endObject()).execute().actionGet();
         flush();
@@ -354,7 +350,7 @@ public class RecoveryFromGatewayTests extends ElasticsearchIntegrationTest {
         // prevent any rebalance actions during the peer recovery
         // if we run into a relocation the reuse count will be 0 and this fails the test. We are testing here if
         // we reuse the files on disk after full restarts for replicas.
-        assertAcked(prepareCreate("test").setSettings(ImmutableSettings.builder().put(indexSettings())));
+        assertAcked(prepareCreate("test").setSettings(settingsBuilder().put(indexSettings())));
         ensureGreen();
         logger.info("--> indexing docs");
         for (int i = 0; i < 1000; i++) {

--- a/src/test/java/org/elasticsearch/index/store/CorruptedFileTest.java
+++ b/src/test/java/org/elasticsearch/index/store/CorruptedFileTest.java
@@ -99,7 +99,7 @@ public class CorruptedFileTest extends ElasticsearchIntegrationTest {
         return ImmutableSettings.builder()
                 // we really need local GW here since this also checks for corruption etc.
                 // and we need to make sure primaries are not just trashed if we don't have replicas
-                .put(super.nodeSettings(nodeOrdinal)).put("gateway.type", "local")
+                .put(super.nodeSettings(nodeOrdinal))
                 .put(TransportModule.TRANSPORT_SERVICE_TYPE_KEY, MockTransportService.class.getName())
                         // speed up recoveries
                 .put(RecoverySettings.INDICES_RECOVERY_CONCURRENT_STREAMS, 10)

--- a/src/test/java/org/elasticsearch/index/store/CorruptedTranslogTests.java
+++ b/src/test/java/org/elasticsearch/index/store/CorruptedTranslogTests.java
@@ -65,7 +65,7 @@ public class CorruptedTranslogTests extends ElasticsearchIntegrationTest {
         return ImmutableSettings.builder()
                 // we really need local GW here since this also checks for corruption etc.
                 // and we need to make sure primaries are not just trashed if we don't have replicas
-                .put(super.nodeSettings(nodeOrdinal)).put("gateway.type", "local")
+                .put(super.nodeSettings(nodeOrdinal))
                 .put(TransportModule.TRANSPORT_SERVICE_TYPE_KEY, MockTransportService.class.getName()).build();
     }
 

--- a/src/test/java/org/elasticsearch/index/store/ExceptionRetryTests.java
+++ b/src/test/java/org/elasticsearch/index/store/ExceptionRetryTests.java
@@ -55,7 +55,7 @@ public class ExceptionRetryTests extends ElasticsearchIntegrationTest {
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {
         return ImmutableSettings.builder()
-                .put(super.nodeSettings(nodeOrdinal)).put("gateway.type", "local")
+                .put(super.nodeSettings(nodeOrdinal))
                 .put(TransportModule.TRANSPORT_SERVICE_TYPE_KEY, MockTransportService.class.getName())
                 .build();
     }

--- a/src/test/java/org/elasticsearch/indices/recovery/IndexRecoveryTests.java
+++ b/src/test/java/org/elasticsearch/indices/recovery/IndexRecoveryTests.java
@@ -124,7 +124,7 @@ public class IndexRecoveryTests extends ElasticsearchIntegrationTest {
     @Test
     public void gatewayRecoveryTest() throws Exception {
         logger.info("--> start nodes");
-        String node = internalCluster().startNode(settingsBuilder().put("gateway.type", "local"));
+        String node = internalCluster().startNode();
 
         createAndPopulateIndex(INDEX_NAME, 1, SHARD_COUNT, REPLICA_COUNT);
 
@@ -151,7 +151,7 @@ public class IndexRecoveryTests extends ElasticsearchIntegrationTest {
     @Test
     public void gatewayRecoveryTestActiveOnly() throws Exception {
         logger.info("--> start nodes");
-        internalCluster().startNode(settingsBuilder().put("gateway.type", "local"));
+        internalCluster().startNode();
 
         createAndPopulateIndex(INDEX_NAME, 1, SHARD_COUNT, REPLICA_COUNT);
 
@@ -169,13 +169,13 @@ public class IndexRecoveryTests extends ElasticsearchIntegrationTest {
     @Test
     public void replicaRecoveryTest() throws Exception {
         logger.info("--> start node A");
-        String nodeA = internalCluster().startNode(settingsBuilder().put("gateway.type", "local"));
+        String nodeA = internalCluster().startNode();
 
         logger.info("--> create index on node: {}", nodeA);
         createAndPopulateIndex(INDEX_NAME, 1, SHARD_COUNT, REPLICA_COUNT);
 
         logger.info("--> start node B");
-        String nodeB = internalCluster().startNode(settingsBuilder().put("gateway.type", "local"));
+        String nodeB = internalCluster().startNode();
         ensureGreen();
 
         // force a shard recovery from nodeA to nodeB
@@ -211,13 +211,13 @@ public class IndexRecoveryTests extends ElasticsearchIntegrationTest {
     @TestLogging("indices.recovery:TRACE")
     public void rerouteRecoveryTest() throws Exception {
         logger.info("--> start node A");
-        String nodeA = internalCluster().startNode(settingsBuilder().put("gateway.type", "local"));
+        String nodeA = internalCluster().startNode();
 
         logger.info("--> create index on node: {}", nodeA);
         ByteSizeValue shardSize = createAndPopulateIndex(INDEX_NAME, 1, SHARD_COUNT, REPLICA_COUNT).getShards()[0].getStats().getStore().size();
 
         logger.info("--> start node B");
-        String nodeB = internalCluster().startNode(settingsBuilder().put("gateway.type", "local"));
+        String nodeB = internalCluster().startNode();
 
         ensureGreen();
 
@@ -265,7 +265,7 @@ public class IndexRecoveryTests extends ElasticsearchIntegrationTest {
         ensureGreen();
 
         logger.info("--> start node C");
-        String nodeC = internalCluster().startNode(settingsBuilder().put("gateway.type", "local"));
+        String nodeC = internalCluster().startNode();
         assertFalse(client().admin().cluster().prepareHealth().setWaitForNodes("3").get().isTimedOut());
 
         logger.info("--> slowing down recoveries");
@@ -321,7 +321,7 @@ public class IndexRecoveryTests extends ElasticsearchIntegrationTest {
     @Test
     public void snapshotRecoveryTest() throws Exception {
         logger.info("--> start node A");
-        String nodeA = internalCluster().startNode(settingsBuilder().put("gateway.type", "local"));
+        String nodeA = internalCluster().startNode();
 
         logger.info("--> create repository");
         assertAcked(client().admin().cluster().preparePutRepository(REPO_NAME)

--- a/src/test/java/org/elasticsearch/indices/state/RareClusterStateTests.java
+++ b/src/test/java/org/elasticsearch/indices/state/RareClusterStateTests.java
@@ -50,14 +50,6 @@ public class RareClusterStateTests extends ElasticsearchIntegrationTest {
         return 0;
     }
 
-    @Override
-    protected Settings nodeSettings(int nodeOrdinal) {
-        return ImmutableSettings.builder()
-                .put(super.nodeSettings(nodeOrdinal))
-                .put("gateway.type", "local")
-                .build();
-    }
-
     @Test
     public void testUnassignedShardAndEmptyNodesInRoutingTable() throws Exception {
         createIndex("a");

--- a/src/test/java/org/elasticsearch/indices/store/IndicesStoreIntegrationTests.java
+++ b/src/test/java/org/elasticsearch/indices/store/IndicesStoreIntegrationTests.java
@@ -52,12 +52,11 @@ import static org.hamcrest.Matchers.equalTo;
  */
 @ClusterScope(scope= Scope.TEST, numDataNodes = 0)
 public class IndicesStoreIntegrationTests extends ElasticsearchIntegrationTest {
-    private static final Settings SETTINGS = settingsBuilder().put("gateway.type", "local").build();
 
     @Test
     public void shardsCleanup() throws Exception {
-        final String node_1 = internalCluster().startNode(SETTINGS);
-        final String node_2 = internalCluster().startNode(SETTINGS);
+        final String node_1 = internalCluster().startNode();
+        final String node_2 = internalCluster().startNode();
         logger.info("--> creating index [test] with one shard and on replica");
         assertAcked(prepareCreate("test").setSettings(
                         ImmutableSettings.builder().put(indexSettings())
@@ -71,7 +70,7 @@ public class IndicesStoreIntegrationTests extends ElasticsearchIntegrationTest {
         assertThat(Files.exists(shardDirectory(node_2, "test", 0)), equalTo(true));
 
         logger.info("--> starting node server3");
-        String node_3 = internalCluster().startNode(SETTINGS);
+        String node_3 = internalCluster().startNode();
         logger.info("--> running cluster_health");
         ClusterHealthResponse clusterHealth = client().admin().cluster().prepareHealth()
                 .setWaitForNodes("3")
@@ -103,7 +102,7 @@ public class IndicesStoreIntegrationTests extends ElasticsearchIntegrationTest {
         assertThat(Files.exists(shardDirectory(node_3, "test", 0)), equalTo(true));
 
         logger.info("--> starting node node_4");
-        final String node_4 = internalCluster().startNode(SETTINGS);
+        final String node_4 = internalCluster().startNode();
 
         logger.info("--> running cluster_health");
         ensureGreen();
@@ -116,8 +115,8 @@ public class IndicesStoreIntegrationTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testShardActiveElseWhere() throws Exception {
-        String node_1 = internalCluster().startNode(SETTINGS);
-        String node_2 = internalCluster().startNode(SETTINGS);
+        String node_1 = internalCluster().startNode();
+        String node_2 = internalCluster().startNode();
         final String node_1_id = internalCluster().getInstance(DiscoveryService.class, node_1).localNode().getId();
         final String node_2_id = internalCluster().getInstance(DiscoveryService.class, node_2).localNode().getId();
 

--- a/src/test/java/org/elasticsearch/indices/warmer/GatewayIndicesWarmerTests.java
+++ b/src/test/java/org/elasticsearch/indices/warmer/GatewayIndicesWarmerTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.action.admin.indices.warmer.delete.DeleteWarmerResponse
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.warmer.IndexWarmersMetaData;
@@ -48,7 +49,7 @@ public class GatewayIndicesWarmerTests extends ElasticsearchIntegrationTest {
     public void testStatePersistence() throws Exception {
 
         logger.info("--> starting 1 nodes");
-        internalCluster().startNode(settingsBuilder().put("gateway.type", "local"));
+        internalCluster().startNode();
 
         logger.info("--> putting two templates");
         createIndex("test");
@@ -92,7 +93,7 @@ public class GatewayIndicesWarmerTests extends ElasticsearchIntegrationTest {
         internalCluster().fullRestart(new RestartCallback() {
             @Override
             public Settings onNodeStopped(String nodeName) throws Exception {
-                return settingsBuilder().put("gateway.type", "local").build();
+                return ImmutableSettings.EMPTY;
             }
         });
 
@@ -130,7 +131,7 @@ public class GatewayIndicesWarmerTests extends ElasticsearchIntegrationTest {
         internalCluster().fullRestart(new RestartCallback() {
             @Override
             public Settings onNodeStopped(String nodeName) throws Exception {
-                return settingsBuilder().put("gateway.type", "local").build();
+                return ImmutableSettings.EMPTY;
             }
         });
 

--- a/src/test/java/org/elasticsearch/percolator/RecoveryPercolatorTests.java
+++ b/src/test/java/org/elasticsearch/percolator/RecoveryPercolatorTests.java
@@ -63,11 +63,6 @@ public class RecoveryPercolatorTests extends ElasticsearchIntegrationTest {
         return 1;
     }
 
-    @Override
-    protected Settings nodeSettings(int nodeOrdinal) {
-        return builder().put(super.nodeSettings(nodeOrdinal)).put("gateway.type", "local").build();
-    }
-
     @Test
     @Slow
     public void testRestartNodePercolator1() throws Exception {

--- a/src/test/java/org/elasticsearch/search/basic/SearchWithRandomExceptionsTests.java
+++ b/src/test/java/org/elasticsearch/search/basic/SearchWithRandomExceptionsTests.java
@@ -89,8 +89,7 @@ public class SearchWithRandomExceptionsTests extends ElasticsearchIntegrationTes
 
         if (createIndexWithoutErrors) {
             Builder settings = settingsBuilder()
-                    .put("index.number_of_replicas", randomIntBetween(0, 1))
-                    .put("gateway.type", "local");
+                    .put("index.number_of_replicas", randomIntBetween(0, 1));
             logger.info("creating index: [test] using settings: [{}]", settings.build().getAsMap());
             client().admin().indices().prepareCreate("test")
                     .setSettings(settings)

--- a/src/test/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreTests.java
+++ b/src/test/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreTests.java
@@ -83,7 +83,7 @@ public class DedicatedClusterSnapshotRestoreTests extends AbstractSnapshotTests 
     @Test
     public void restorePersistentSettingsTest() throws Exception {
         logger.info("--> start node");
-        internalCluster().startNode(settingsBuilder().put("gateway.type", "local"));
+        internalCluster().startNode();
         Client client = client();
 
         // Add dummy persistent setting
@@ -120,7 +120,7 @@ public class DedicatedClusterSnapshotRestoreTests extends AbstractSnapshotTests 
         Path tempDir = newTempDirPath();
 
         logger.info("--> start node");
-        internalCluster().startNode(settingsBuilder().put("gateway.type", "local"));
+        internalCluster().startNode();
         Client client = client();
         createIndex("test-idx");
         ensureYellow();
@@ -358,8 +358,8 @@ public class DedicatedClusterSnapshotRestoreTests extends AbstractSnapshotTests 
     @Test
     public void restoreIndexWithMissingShards() throws Exception {
         logger.info("--> start 2 nodes");
-        internalCluster().startNode(settingsBuilder().put("gateway.type", "local"));
-        internalCluster().startNode(settingsBuilder().put("gateway.type", "local"));
+        internalCluster().startNode();
+        internalCluster().startNode();
         cluster().wipeIndices("_all");
 
         logger.info("--> create an index that will have some unallocated shards");
@@ -495,8 +495,8 @@ public class DedicatedClusterSnapshotRestoreTests extends AbstractSnapshotTests 
     @Test
     public void restoreIndexWithShardsMissingInLocalGateway() throws Exception {
         logger.info("--> start 2 nodes");
-        internalCluster().startNode(settingsBuilder().put("gateway.type", "local"));
-        internalCluster().startNode(settingsBuilder().put("gateway.type", "local"));
+        internalCluster().startNode();
+        internalCluster().startNode();
         cluster().wipeIndices("_all");
 
         logger.info("--> create repository");

--- a/src/test/java/org/elasticsearch/stresstest/manyindices/ManyIndicesStressTest.java
+++ b/src/test/java/org/elasticsearch/stresstest/manyindices/ManyIndicesStressTest.java
@@ -47,7 +47,6 @@ public class ManyIndicesStressTest {
 
         Settings settings = ImmutableSettings.settingsBuilder()
                 .put("index.shard.check_on_startup", false)
-                .put("gateway.type", "local")
                 .put("index.number_of_shards", 1)
                 .build();
         Node node = NodeBuilder.nodeBuilder().settings(settings).node();

--- a/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
@@ -1880,7 +1880,6 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
         assertTrue(Files.exists(dest));
         ImmutableSettings.Builder builder = ImmutableSettings.builder()
                 .put(settings)
-                .put("gateway.type", "local") // this is important we need to recover from gateway
                 .put("path.data", dataDir.toAbsolutePath());
 
         Path configDir = indexDir.resolve("config");

--- a/src/test/java/org/elasticsearch/test/ExternalNode.java
+++ b/src/test/java/org/elasticsearch/test/ExternalNode.java
@@ -57,8 +57,7 @@ final class ExternalNode implements Closeable {
     public static final Settings REQUIRED_SETTINGS = ImmutableSettings.builder()
             .put("config.ignore_system_properties", true)
             .put(DiscoveryModule.DISCOVERY_TYPE_KEY, "zen")
-            .put("node.mode", "network") // we need network mode for this
-            .put("gateway.type", "local").build(); // we require local gateway to mimic upgrades of nodes
+            .put("node.mode", "network").build(); // we need network mode for this
 
     private final Path path;
     private final Random random;
@@ -116,7 +115,6 @@ final class ExternalNode implements Closeable {
                 case "node.local":
                 case TransportModule.TRANSPORT_TYPE_KEY:
                 case DiscoveryModule.DISCOVERY_TYPE_KEY:
-                case "gateway.type":
                 case TransportModule.TRANSPORT_SERVICE_TYPE_KEY:
                 case "config.ignore_system_properties":
                     continue;


### PR DESCRIPTION
This property was removed in 45408844e786fe9c3eb3a8faa6c65ad4fa638a61 and 1247774ff1e91e762fe102d6e167f3da8c4a27ff
