### PR TITLE
Upgrade netty to 3.10.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -254,7 +254,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty</artifactId>
-            <version>3.9.3.Final</version>
+            <version>3.10.0.Final</version>
             <scope>compile</scope>
         </dependency>
 


### PR DESCRIPTION
Changelog is available at
http://netty.io/news/2014/12/17/3-9-6-Final-and-3-10-0-Final.html
