### PR TITLE
AdapterActionFuture should not set currentThread().interrupt()

### DIFF
--- a/src/main/java/org/elasticsearch/action/ActionFuture.java
+++ b/src/main/java/org/elasticsearch/action/ActionFuture.java
@@ -34,9 +34,9 @@ import java.util.concurrent.TimeUnit;
 public interface ActionFuture<T> extends Future<T> {
 
     /**
-     * Similar to {@link #get()}, just catching the {@link InterruptedException} with
-     * restoring the interrupted state on the thread and throwing an {@link org.elasticsearch.ElasticsearchIllegalStateException},
-     * and throwing the actual cause of the {@link java.util.concurrent.ExecutionException}.
+     * Similar to {@link #get()}, just catching the {@link InterruptedException} and throwing
+     * an {@link org.elasticsearch.ElasticsearchIllegalStateException} instead. Also catches
+     * {@link java.util.concurrent.ExecutionException} and throws the actual cause instead.
      * <p/>
      * <p>Note, the actual cause is unwrapped to the actual failure (for example, unwrapped
      * from {@link org.elasticsearch.transport.RemoteTransportException}. The root failure is
@@ -45,9 +45,9 @@ public interface ActionFuture<T> extends Future<T> {
     T actionGet() throws ElasticsearchException;
 
     /**
-     * Similar to {@link #get(long, java.util.concurrent.TimeUnit)}, just catching the {@link InterruptedException} with
-     * restoring the interrupted state on the thread and throwing an {@link org.elasticsearch.ElasticsearchIllegalStateException},
-     * and throwing the actual cause of the {@link java.util.concurrent.ExecutionException}.
+     * Similar to {@link #get(long, java.util.concurrent.TimeUnit)}, just catching the {@link InterruptedException} and throwing
+     * an {@link org.elasticsearch.ElasticsearchIllegalStateException} instead. Also catches
+     * {@link java.util.concurrent.ExecutionException} and throws the actual cause instead.
      * <p/>
      * <p>Note, the actual cause is unwrapped to the actual failure (for example, unwrapped
      * from {@link org.elasticsearch.transport.RemoteTransportException}. The root failure is
@@ -56,9 +56,9 @@ public interface ActionFuture<T> extends Future<T> {
     T actionGet(String timeout) throws ElasticsearchException;
 
     /**
-     * Similar to {@link #get(long, java.util.concurrent.TimeUnit)}, just catching the {@link InterruptedException} with
-     * restoring the interrupted state on the thread and throwing an {@link org.elasticsearch.ElasticsearchIllegalStateException},
-     * and throwing the actual cause of the {@link java.util.concurrent.ExecutionException}.
+     * Similar to {@link #get(long, java.util.concurrent.TimeUnit)}, just catching the {@link InterruptedException} and throwing
+     * an {@link org.elasticsearch.ElasticsearchIllegalStateException} instead. Also catches
+     * {@link java.util.concurrent.ExecutionException} and throws the actual cause instead.
      * <p/>
      * <p>Note, the actual cause is unwrapped to the actual failure (for example, unwrapped
      * from {@link org.elasticsearch.transport.RemoteTransportException}. The root failure is
@@ -69,9 +69,9 @@ public interface ActionFuture<T> extends Future<T> {
     T actionGet(long timeoutMillis) throws ElasticsearchException;
 
     /**
-     * Similar to {@link #get(long, java.util.concurrent.TimeUnit)}, just catching the {@link InterruptedException} with
-     * restoring the interrupted state on the thread and throwing an {@link org.elasticsearch.ElasticsearchIllegalStateException},
-     * and throwing the actual cause of the {@link java.util.concurrent.ExecutionException}.
+     * Similar to {@link #get(long, java.util.concurrent.TimeUnit)}, just catching the {@link InterruptedException} and throwing
+     * an {@link org.elasticsearch.ElasticsearchIllegalStateException} instead. Also catches
+     * {@link java.util.concurrent.ExecutionException} and throws the actual cause instead.
      * <p/>
      * <p>Note, the actual cause is unwrapped to the actual failure (for example, unwrapped
      * from {@link org.elasticsearch.transport.RemoteTransportException}. The root failure is
@@ -80,9 +80,9 @@ public interface ActionFuture<T> extends Future<T> {
     T actionGet(long timeout, TimeUnit unit) throws ElasticsearchException;
 
     /**
-     * Similar to {@link #get(long, java.util.concurrent.TimeUnit)}, just catching the {@link InterruptedException} with
-     * restoring the interrupted state on the thread and throwing an {@link org.elasticsearch.ElasticsearchIllegalStateException},
-     * and throwing the actual cause of the {@link java.util.concurrent.ExecutionException}.
+     * Similar to {@link #get(long, java.util.concurrent.TimeUnit)}, just catching the {@link InterruptedException} and throwing
+     * an {@link org.elasticsearch.ElasticsearchIllegalStateException} instead. Also catches
+     * {@link java.util.concurrent.ExecutionException} and throws the actual cause instead.
      * <p/>
      * <p>Note, the actual cause is unwrapped to the actual failure (for example, unwrapped
      * from {@link org.elasticsearch.transport.RemoteTransportException}. The root failure is

--- a/src/main/java/org/elasticsearch/action/support/AdapterActionFuture.java
+++ b/src/main/java/org/elasticsearch/action/support/AdapterActionFuture.java
@@ -44,7 +44,6 @@ public abstract class AdapterActionFuture<T, L> extends BaseFuture<T> implements
         try {
             return get();
         } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
             throw new ElasticsearchIllegalStateException("Future got interrupted", e);
         } catch (ExecutionException e) {
             throw rethrowExecutionException(e);
@@ -73,7 +72,6 @@ public abstract class AdapterActionFuture<T, L> extends BaseFuture<T> implements
         } catch (TimeoutException e) {
             throw new ElasticsearchTimeoutException(e.getMessage());
         } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
             throw new ElasticsearchIllegalStateException("Future got interrupted", e);
         } catch (ExecutionException e) {
             throw rethrowExecutionException(e);


### PR DESCRIPTION
If someone blocks on it and it is interrupted, we throw an ElasticsearchIllegalStateException. We should not set Thread.currentThread().interrupt(); in this case because we already communicate the interrupt through an exception.

Similar to #9001
