### PR TITLE
Upgrade to Lucene 5.0.0-snapshot-1649544.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <lucene.version>5.0.0</lucene.version>
-        <lucene.maven.version>5.0.0-snapshot-1646179</lucene.maven.version>
+        <lucene.maven.version>5.0.0-snapshot-1649544</lucene.maven.version>
         <tests.jvms>auto</tests.jvms>
         <tests.shuffle>true</tests.shuffle>
         <tests.output>onerror</tests.output>
@@ -54,7 +54,7 @@
         </repository>
         <repository>
             <id>Lucene snapshots</id>
-            <url>https://download.elasticsearch.org/lucenesnapshots/1646179</url>
+            <url>https://download.elasticsearch.org/lucenesnapshots/1649544</url>
         </repository>
     </repositories>
 

--- a/src/main/java/org/apache/lucene/index/TrackingConcurrentMergeScheduler.java
+++ b/src/main/java/org/apache/lucene/index/TrackingConcurrentMergeScheduler.java
@@ -88,7 +88,7 @@ public class TrackingConcurrentMergeScheduler extends ConcurrentMergeScheduler {
     }
 
     @Override
-    protected void doMerge(MergePolicy.OneMerge merge) throws IOException {
+    protected void doMerge(IndexWriter writer, MergePolicy.OneMerge merge) throws IOException {
         int totalNumDocs = merge.totalNumDocs();
         long totalSizeInBytes = merge.totalBytesSize();
         long time = System.currentTimeMillis();
@@ -104,7 +104,7 @@ public class TrackingConcurrentMergeScheduler extends ConcurrentMergeScheduler {
         }
         try {
             beforeMerge(onGoingMerge);
-            super.doMerge(merge);
+            super.doMerge(writer, merge);
         } finally {
             long took = System.currentTimeMillis() - time;
 

--- a/src/main/java/org/apache/lucene/store/RateLimitedFSDirectory.java
+++ b/src/main/java/org/apache/lucene/store/RateLimitedFSDirectory.java
@@ -67,7 +67,7 @@ public final class RateLimitedFSDirectory extends FilterDirectory {
         if (type == StoreRateLimiting.Type.NONE || limiter == null) {
             return StoreUtils.toString(in);
         } else {
-            return "rate_limited(" + StoreUtils.toString(in) + ", type=" + type.name() + ", rate=" + limiter.getMbPerSec() + ")";
+            return "rate_limited(" + StoreUtils.toString(in) + ", type=" + type.name() + ", rate=" + limiter.getMBPerSec() + ")";
         }
     }
 
@@ -82,17 +82,17 @@ public final class RateLimitedFSDirectory extends FilterDirectory {
         }
 
         @Override
-        public void setMbPerSec(double mbPerSec) {
-            delegate.setMbPerSec(mbPerSec);
+        public void setMBPerSec(double mbPerSec) {
+            delegate.setMBPerSec(mbPerSec);
         }
 
         @Override
-        public double getMbPerSec() {
-            return delegate.getMbPerSec();
+        public double getMBPerSec() {
+            return delegate.getMBPerSec();
         }
 
         @Override
-        public long pause(long bytes) {
+        public long pause(long bytes) throws IOException {
             long pause = delegate.pause(bytes);
             rateListener.onPause(pause);
             return pause;

--- a/src/main/java/org/apache/lucene/store/StoreRateLimiting.java
+++ b/src/main/java/org/apache/lucene/store/StoreRateLimiting.java
@@ -73,10 +73,10 @@ public class StoreRateLimiting {
             actualRateLimiter = null;
         } else if (actualRateLimiter == null) {
             actualRateLimiter = rateLimiter;
-            actualRateLimiter.setMbPerSec(rate.mbFrac());
+            actualRateLimiter.setMBPerSec(rate.mbFrac());
         } else {
             assert rateLimiter == actualRateLimiter;
-            rateLimiter.setMbPerSec(rate.mbFrac());
+            rateLimiter.setMBPerSec(rate.mbFrac());
         }
     }
 

--- a/src/main/java/org/elasticsearch/common/util/AbstractArray.java
+++ b/src/main/java/org/elasticsearch/common/util/AbstractArray.java
@@ -19,9 +19,10 @@
 
 package org.elasticsearch.common.util;
 
-import java.util.Collections;
-
 import org.apache.lucene.util.Accountable;
+
+import java.util.Collection;
+import java.util.Collections;
 
 
 abstract class AbstractArray implements BigArray {
@@ -46,7 +47,7 @@ abstract class AbstractArray implements BigArray {
     protected abstract void doClose();
 
     @Override
-    public Iterable<Accountable> getChildResources() {
+    public Collection<Accountable> getChildResources() {
         return Collections.emptyList();
     }
 }

--- a/src/main/java/org/elasticsearch/index/engine/internal/LiveVersionMap.java
+++ b/src/main/java/org/elasticsearch/index/engine/internal/LiveVersionMap.java
@@ -19,17 +19,17 @@
 
 package org.elasticsearch.index.engine.internal;
 
-import java.io.IOException;
-import java.util.Collections;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicLong;
-
 import org.apache.lucene.search.ReferenceManager;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.RamUsageEstimator;
-import org.elasticsearch.Version;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
 
 /** Maps _uid value to its version information. */
 class LiveVersionMap implements ReferenceManager.RefreshListener, Accountable {
@@ -251,7 +251,7 @@ class LiveVersionMap implements ReferenceManager.RefreshListener, Accountable {
     }
 
     @Override
-    public Iterable<Accountable> getChildResources() {
+    public Collection<Accountable> getChildResources() {
         // TODO: useful to break down RAM usage here?
         return Collections.emptyList();
     }

--- a/src/main/java/org/elasticsearch/index/engine/internal/VersionValue.java
+++ b/src/main/java/org/elasticsearch/index/engine/internal/VersionValue.java
@@ -19,12 +19,12 @@
 
 package org.elasticsearch.index.engine.internal;
 
-import java.util.Collections;
-
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.RamUsageEstimator;
-import org.elasticsearch.Version;
 import org.elasticsearch.index.translog.Translog;
+
+import java.util.Collection;
+import java.util.Collections;
 
 class VersionValue implements Accountable {
 
@@ -58,7 +58,7 @@ class VersionValue implements Accountable {
     }
     
     @Override
-    public Iterable<Accountable> getChildResources() {
+    public Collection<Accountable> getChildResources() {
         return Collections.emptyList();
     }
 }

--- a/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalsIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalsIndexFieldData.java
@@ -18,19 +18,23 @@
  */
 package org.elasticsearch.index.fielddata.ordinals;
 
-import java.util.Collections;
-
-import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.util.Accountable;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.AbstractIndexComponent;
 import org.elasticsearch.index.Index;
-import org.elasticsearch.index.fielddata.*;
+import org.elasticsearch.index.fielddata.AtomicOrdinalsFieldData;
+import org.elasticsearch.index.fielddata.FieldDataType;
+import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource.Nested;
+import org.elasticsearch.index.fielddata.IndexOrdinalsFieldData;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.search.MultiValueMode;
+
+import java.util.Collection;
+import java.util.Collections;
 
 /**
  * {@link IndexFieldData} base class for concrete global ordinals implementations.
@@ -94,7 +98,7 @@ public abstract class GlobalOrdinalsIndexFieldData extends AbstractIndexComponen
     }
 
     @Override
-    public Iterable<Accountable> getChildResources() {
+    public Collection<Accountable> getChildResources() {
         // TODO: break down ram usage?
         return Collections.emptyList();
     }

--- a/src/main/java/org/elasticsearch/index/fielddata/ordinals/InternalGlobalOrdinalsIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/ordinals/InternalGlobalOrdinalsIndexFieldData.java
@@ -29,6 +29,8 @@ import org.elasticsearch.index.fielddata.FieldDataType;
 import org.elasticsearch.index.fielddata.plain.AbstractAtomicOrdinalsFieldData;
 import org.elasticsearch.index.mapper.FieldMapper;
 
+import java.util.Collection;
+
 /**
  * {@link org.elasticsearch.index.fielddata.IndexFieldData} impl based on global ordinals.
  */
@@ -81,7 +83,7 @@ final class InternalGlobalOrdinalsIndexFieldData extends GlobalOrdinalsIndexFiel
         }
 
         @Override
-        public Iterable<Accountable> getChildResources() {
+        public Collection<Accountable> getChildResources() {
             return afd.getChildResources();
         }
 

--- a/src/main/java/org/elasticsearch/index/fielddata/ordinals/MultiOrdinals.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/ordinals/MultiOrdinals.java
@@ -19,9 +19,6 @@
 
 package org.elasticsearch.index.fielddata.ordinals;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.RandomAccessOrds;
 import org.apache.lucene.index.SortedDocValues;
@@ -32,6 +29,11 @@ import org.apache.lucene.util.LongsRef;
 import org.apache.lucene.util.packed.PackedInts;
 import org.apache.lucene.util.packed.PackedLongValues;
 import org.elasticsearch.index.fielddata.AbstractRandomAccessOrds;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * {@link Ordinals} implementation which is efficient at storing field data ordinals for multi-valued or sparse fields.
@@ -91,11 +93,11 @@ public class MultiOrdinals extends Ordinals {
     }
 
     @Override
-    public Iterable<Accountable> getChildResources() {
+    public Collection<Accountable> getChildResources() {
         List<Accountable> resources = new ArrayList<>();
         resources.add(Accountables.namedAccountable("offsets", endOffsets));
         resources.add(Accountables.namedAccountable("ordinals", ords));
-        return resources;
+        return Collections.unmodifiableCollection(resources);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/fielddata/ordinals/SinglePackedOrdinals.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/ordinals/SinglePackedOrdinals.java
@@ -19,8 +19,6 @@
 
 package org.elasticsearch.index.fielddata.ordinals;
 
-import java.util.Collections;
-
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.RandomAccessOrds;
 import org.apache.lucene.index.SortedDocValues;
@@ -29,6 +27,9 @@ import org.apache.lucene.util.Accountables;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.apache.lucene.util.packed.PackedInts;
+
+import java.util.Collection;
+import java.util.Collections;
 
 /**
  */
@@ -53,7 +54,7 @@ public class SinglePackedOrdinals extends Ordinals {
     }
 
     @Override
-    public Iterable<Accountable> getChildResources() {
+    public Collection<Accountable> getChildResources() {
         return Collections.singleton(Accountables.namedAccountable("reader", reader));
     }
 

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractAtomicGeoPointFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractAtomicGeoPointFieldData.java
@@ -18,10 +18,15 @@
  */
 package org.elasticsearch.index.fielddata.plain;
 
-import java.util.Collections;
-
 import org.apache.lucene.util.Accountable;
-import org.elasticsearch.index.fielddata.*;
+import org.elasticsearch.index.fielddata.AtomicGeoPointFieldData;
+import org.elasticsearch.index.fielddata.FieldData;
+import org.elasticsearch.index.fielddata.MultiGeoPointValues;
+import org.elasticsearch.index.fielddata.ScriptDocValues;
+import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
+
+import java.util.Collection;
+import java.util.Collections;
 
 /**
  */
@@ -45,7 +50,7 @@ abstract class AbstractAtomicGeoPointFieldData implements AtomicGeoPointFieldDat
             }
             
             @Override
-            public Iterable<Accountable> getChildResources() {
+            public Collection<Accountable> getChildResources() {
                 return Collections.emptyList();
             }
 

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractAtomicOrdinalsFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractAtomicOrdinalsFieldData.java
@@ -19,16 +19,16 @@
 
 package org.elasticsearch.index.fielddata.plain;
 
-import org.apache.lucene.util.Accountable;
-
-import java.util.Collections;
-
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.RandomAccessOrds;
+import org.apache.lucene.util.Accountable;
 import org.elasticsearch.index.fielddata.AtomicOrdinalsFieldData;
 import org.elasticsearch.index.fielddata.FieldData;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
+
+import java.util.Collection;
+import java.util.Collections;
 
 
 /**
@@ -54,7 +54,7 @@ public abstract class AbstractAtomicOrdinalsFieldData implements AtomicOrdinalsF
             }
             
             @Override
-            public Iterable<Accountable> getChildResources() {
+            public Collection<Accountable> getChildResources() {
                 return Collections.emptyList();
             }
 

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractAtomicParentChildFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractAtomicParentChildFieldData.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.fielddata.plain;
 
 import com.google.common.collect.ImmutableSet;
+
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.SortedDocValues;
 import org.apache.lucene.util.Accountable;
@@ -29,6 +30,7 @@ import org.elasticsearch.index.fielddata.AtomicParentChildFieldData;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
 
@@ -92,7 +94,7 @@ abstract class AbstractAtomicParentChildFieldData implements AtomicParentChildFi
             }
             
             @Override
-            public Iterable<Accountable> getChildResources() {
+            public Collection<Accountable> getChildResources() {
                 return Collections.emptyList();
             }
 

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/AtomicDoubleFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/AtomicDoubleFieldData.java
@@ -19,11 +19,16 @@
 
 package org.elasticsearch.index.fielddata.plain;
 
-import java.util.Collections;
-
 import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.util.Accountable;
-import org.elasticsearch.index.fielddata.*;
+import org.elasticsearch.index.fielddata.AtomicNumericFieldData;
+import org.elasticsearch.index.fielddata.FieldData;
+import org.elasticsearch.index.fielddata.ScriptDocValues;
+import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
+import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
+
+import java.util.Collection;
+import java.util.Collections;
 
 
 /**
@@ -66,7 +71,7 @@ abstract class AtomicDoubleFieldData implements AtomicNumericFieldData {
             }
             
             @Override
-            public Iterable<Accountable> getChildResources() {
+            public Collection<Accountable> getChildResources() {
                 return Collections.emptyList();
             }
 

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/AtomicLongFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/AtomicLongFieldData.java
@@ -19,12 +19,17 @@
 
 package org.elasticsearch.index.fielddata.plain;
 
-import java.util.Collections;
-
-import org.apache.lucene.util.Accountable;
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.SortedNumericDocValues;
-import org.elasticsearch.index.fielddata.*;
+import org.apache.lucene.util.Accountable;
+import org.elasticsearch.index.fielddata.AtomicNumericFieldData;
+import org.elasticsearch.index.fielddata.FieldData;
+import org.elasticsearch.index.fielddata.ScriptDocValues;
+import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
+import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
+
+import java.util.Collection;
+import java.util.Collections;
 
 
 /**
@@ -67,7 +72,7 @@ abstract class AtomicLongFieldData implements AtomicNumericFieldData {
             }
 
             @Override
-            public Iterable<Accountable> getChildResources() {
+            public Collection<Accountable> getChildResources() {
                 return Collections.emptyList();
             }
 

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/BinaryDVAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/BinaryDVAtomicFieldData.java
@@ -19,16 +19,20 @@
 
 package org.elasticsearch.index.fielddata.plain;
 
-import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.Bits;
 import org.elasticsearch.ElasticsearchIllegalStateException;
-import org.elasticsearch.index.fielddata.*;
+import org.elasticsearch.index.fielddata.AtomicFieldData;
+import org.elasticsearch.index.fielddata.FieldData;
+import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.index.fielddata.ScriptDocValues.Strings;
+import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Collections;
 
 /** {@link AtomicFieldData} impl on top of Lucene's binary doc values. */
@@ -69,7 +73,7 @@ public class BinaryDVAtomicFieldData implements AtomicFieldData {
     }
     
     @Override
-    public Iterable<Accountable> getChildResources() {
+    public Collection<Accountable> getChildResources() {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/BinaryDVNumericIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/BinaryDVNumericIndexFieldData.java
@@ -20,9 +20,10 @@
 package org.elasticsearch.index.fielddata.plain;
 
 import com.google.common.base.Preconditions;
-import org.apache.lucene.index.LeafReaderContext;
+
 import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.store.ByteArrayDataInput;
 import org.apache.lucene.util.Accountable;
@@ -32,8 +33,11 @@ import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.ElasticsearchIllegalStateException;
 import org.elasticsearch.common.util.ByteUtils;
 import org.elasticsearch.index.Index;
-import org.elasticsearch.index.fielddata.*;
+import org.elasticsearch.index.fielddata.AtomicNumericFieldData;
+import org.elasticsearch.index.fielddata.FieldDataType;
 import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource.Nested;
+import org.elasticsearch.index.fielddata.IndexNumericFieldData;
+import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 import org.elasticsearch.index.fielddata.fieldcomparator.DoubleValuesComparatorSource;
 import org.elasticsearch.index.fielddata.fieldcomparator.FloatValuesComparatorSource;
 import org.elasticsearch.index.fielddata.fieldcomparator.LongValuesComparatorSource;
@@ -41,6 +45,7 @@ import org.elasticsearch.index.mapper.FieldMapper.Names;
 import org.elasticsearch.search.MultiValueMode;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Collections;
 
 public class BinaryDVNumericIndexFieldData extends DocValuesIndexFieldData implements IndexNumericFieldData {
@@ -85,7 +90,7 @@ public class BinaryDVNumericIndexFieldData extends DocValuesIndexFieldData imple
                     }
                     
                     @Override
-                    public Iterable<Accountable> getChildResources() {
+                    public Collection<Accountable> getChildResources() {
                         return Collections.emptyList();
                     }
 
@@ -99,7 +104,7 @@ public class BinaryDVNumericIndexFieldData extends DocValuesIndexFieldData imple
                     }
                     
                     @Override
-                    public Iterable<Accountable> getChildResources() {
+                    public Collection<Accountable> getChildResources() {
                         return Collections.emptyList();
                     }
 

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/BytesBinaryDVAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/BytesBinaryDVAtomicFieldData.java
@@ -31,6 +31,7 @@ import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 
 final class BytesBinaryDVAtomicFieldData implements AtomicFieldData {
@@ -48,7 +49,7 @@ final class BytesBinaryDVAtomicFieldData implements AtomicFieldData {
     }
 
     @Override
-    public Iterable<Accountable> getChildResources() {
+    public Collection<Accountable> getChildResources() {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/DoubleArrayIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/DoubleArrayIndexFieldData.java
@@ -19,20 +19,36 @@
 
 package org.elasticsearch.index.fielddata.plain;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
-import org.apache.lucene.index.*;
-import org.apache.lucene.util.*;
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.RandomAccessOrds;
+import org.apache.lucene.index.SortedDocValues;
+import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.index.Terms;
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.Accountables;
+import org.apache.lucene.util.BitSet;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.BytesRefIterator;
+import org.apache.lucene.util.NumericUtils;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.DoubleArray;
 import org.elasticsearch.index.Index;
-import org.elasticsearch.index.fielddata.*;
+import org.elasticsearch.index.fielddata.AtomicNumericFieldData;
+import org.elasticsearch.index.fielddata.FieldData;
+import org.elasticsearch.index.fielddata.FieldDataType;
+import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource.Nested;
+import org.elasticsearch.index.fielddata.IndexFieldDataCache;
+import org.elasticsearch.index.fielddata.IndexNumericFieldData;
+import org.elasticsearch.index.fielddata.NumericDoubleValues;
+import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 import org.elasticsearch.index.fielddata.fieldcomparator.DoubleValuesComparatorSource;
 import org.elasticsearch.index.fielddata.ordinals.Ordinals;
 import org.elasticsearch.index.fielddata.ordinals.OrdinalsBuilder;
@@ -41,6 +57,11 @@ import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.settings.IndexSettings;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.search.MultiValueMode;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 /**
  */
@@ -108,7 +129,7 @@ public class DoubleArrayIndexFieldData extends AbstractIndexFieldData<AtomicNume
                     }
                     
                     @Override
-                    public Iterable<Accountable> getChildResources() {
+                    public Collection<Accountable> getChildResources() {
                         List<Accountable> resources = new ArrayList<>();
                         resources.add(Accountables.namedAccountable("ordinals", build));
                         resources.add(Accountables.namedAccountable("values", finalValues));
@@ -134,7 +155,7 @@ public class DoubleArrayIndexFieldData extends AbstractIndexFieldData<AtomicNume
                         }
                         
                         @Override
-                        public Iterable<Accountable> getChildResources() {
+                        public Collection<Accountable> getChildResources() {
                             List<Accountable> resources = new ArrayList<>();
                             resources.add(Accountables.namedAccountable("ordinals", build));
                             resources.add(Accountables.namedAccountable("values", finalValues));
@@ -163,7 +184,7 @@ public class DoubleArrayIndexFieldData extends AbstractIndexFieldData<AtomicNume
                     }
                     
                     @Override
-                    public Iterable<Accountable> getChildResources() {
+                    public Collection<Accountable> getChildResources() {
                         List<Accountable> resources = new ArrayList<>();
                         resources.add(Accountables.namedAccountable("values", sValues));
                         resources.add(Accountables.namedAccountable("missing bitset", set));

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/FSTBytesAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/FSTBytesAtomicFieldData.java
@@ -34,6 +34,7 @@ import org.elasticsearch.index.fielddata.ordinals.Ordinals;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -69,7 +70,7 @@ public class FSTBytesAtomicFieldData extends AbstractAtomicOrdinalsFieldData {
     }
 
     @Override
-    public Iterable<Accountable> getChildResources() {
+    public Collection<Accountable> getChildResources() {
         List<Accountable> resources = new ArrayList<>();
         resources.add(Accountables.namedAccountable("ordinals", ordinals));
         if (fst != null) {

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/FloatArrayIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/FloatArrayIndexFieldData.java
@@ -18,20 +18,36 @@
  */
 package org.elasticsearch.index.fielddata.plain;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
-import org.apache.lucene.index.*;
-import org.apache.lucene.util.*;
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.RandomAccessOrds;
+import org.apache.lucene.index.SortedDocValues;
+import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.index.Terms;
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.Accountables;
+import org.apache.lucene.util.BitSet;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.BytesRefIterator;
+import org.apache.lucene.util.NumericUtils;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.FloatArray;
 import org.elasticsearch.index.Index;
-import org.elasticsearch.index.fielddata.*;
+import org.elasticsearch.index.fielddata.AtomicNumericFieldData;
+import org.elasticsearch.index.fielddata.FieldData;
+import org.elasticsearch.index.fielddata.FieldDataType;
+import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource.Nested;
+import org.elasticsearch.index.fielddata.IndexFieldDataCache;
+import org.elasticsearch.index.fielddata.IndexNumericFieldData;
+import org.elasticsearch.index.fielddata.NumericDoubleValues;
+import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 import org.elasticsearch.index.fielddata.fieldcomparator.FloatValuesComparatorSource;
 import org.elasticsearch.index.fielddata.ordinals.Ordinals;
 import org.elasticsearch.index.fielddata.ordinals.OrdinalsBuilder;
@@ -40,6 +56,11 @@ import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.settings.IndexSettings;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.search.MultiValueMode;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 /**
  */
@@ -106,7 +127,7 @@ public class FloatArrayIndexFieldData extends AbstractIndexFieldData<AtomicNumer
                     }
                     
                     @Override
-                    public Iterable<Accountable> getChildResources() {
+                    public Collection<Accountable> getChildResources() {
                         List<Accountable> resources = new ArrayList<>();
                         resources.add(Accountables.namedAccountable("ordinals", build));
                         resources.add(Accountables.namedAccountable("values", finalValues));
@@ -132,7 +153,7 @@ public class FloatArrayIndexFieldData extends AbstractIndexFieldData<AtomicNumer
                         }
                         
                         @Override
-                        public Iterable<Accountable> getChildResources() {
+                        public Collection<Accountable> getChildResources() {
                             List<Accountable> resources = new ArrayList<>();
                             resources.add(Accountables.namedAccountable("ordinals", build));
                             resources.add(Accountables.namedAccountable("values", finalValues));
@@ -161,7 +182,7 @@ public class FloatArrayIndexFieldData extends AbstractIndexFieldData<AtomicNumer
                     }
                     
                     @Override
-                    public Iterable<Accountable> getChildResources() {
+                    public Collection<Accountable> getChildResources() {
                         List<Accountable> resources = new ArrayList<>();
                         resources.add(Accountables.namedAccountable("values", sValues));
                         resources.add(Accountables.namedAccountable("missing bitset", set));

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointBinaryDVAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointBinaryDVAtomicFieldData.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.util.ByteUtils;
 import org.elasticsearch.index.fielddata.MultiGeoPointValues;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 
 final class GeoPointBinaryDVAtomicFieldData extends AbstractAtomicGeoPointFieldData {
@@ -49,7 +50,7 @@ final class GeoPointBinaryDVAtomicFieldData extends AbstractAtomicGeoPointFieldD
     }
     
     @Override
-    public Iterable<Accountable> getChildResources() {
+    public Collection<Accountable> getChildResources() {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointCompressedAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointCompressedAtomicFieldData.java
@@ -18,10 +18,6 @@
  */
 package org.elasticsearch.index.fielddata.plain;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.RandomAccessOrds;
 import org.apache.lucene.index.SortedDocValues;
@@ -36,6 +32,11 @@ import org.elasticsearch.index.fielddata.GeoPointValues;
 import org.elasticsearch.index.fielddata.MultiGeoPointValues;
 import org.elasticsearch.index.fielddata.ordinals.Ordinals;
 import org.elasticsearch.index.mapper.geo.GeoPointFieldMapper;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Field data atomic impl for geo points with lossy compression.
@@ -68,7 +69,7 @@ public abstract class GeoPointCompressedAtomicFieldData extends AbstractAtomicGe
         }
 
         @Override
-        public Iterable<Accountable> getChildResources() {
+        public Collection<Accountable> getChildResources() {
             List<Accountable> resources = new ArrayList<>();
             resources.add(Accountables.namedAccountable("latitude", lat));
             resources.add(Accountables.namedAccountable("longitude", lon));
@@ -142,7 +143,7 @@ public abstract class GeoPointCompressedAtomicFieldData extends AbstractAtomicGe
         }
         
         @Override
-        public Iterable<Accountable> getChildResources() {
+        public Collection<Accountable> getChildResources() {
             List<Accountable> resources = new ArrayList<>();
             resources.add(Accountables.namedAccountable("latitude", lat));
             resources.add(Accountables.namedAccountable("longitude", lon));

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointDoubleArrayAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointDoubleArrayAtomicFieldData.java
@@ -18,10 +18,6 @@
  */
 package org.elasticsearch.index.fielddata.plain;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.RandomAccessOrds;
 import org.apache.lucene.index.SortedDocValues;
@@ -35,6 +31,11 @@ import org.elasticsearch.index.fielddata.FieldData;
 import org.elasticsearch.index.fielddata.GeoPointValues;
 import org.elasticsearch.index.fielddata.MultiGeoPointValues;
 import org.elasticsearch.index.fielddata.ordinals.Ordinals;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 /**
  */
@@ -64,7 +65,7 @@ public abstract class GeoPointDoubleArrayAtomicFieldData extends AbstractAtomicG
         }
         
         @Override
-        public Iterable<Accountable> getChildResources() {
+        public Collection<Accountable> getChildResources() {
             List<Accountable> resources = new ArrayList<>();
             resources.add(Accountables.namedAccountable("latitude", lat));
             resources.add(Accountables.namedAccountable("longitude", lon));
@@ -133,7 +134,7 @@ public abstract class GeoPointDoubleArrayAtomicFieldData extends AbstractAtomicG
         }
         
         @Override
-        public Iterable<Accountable> getChildResources() {
+        public Collection<Accountable> getChildResources() {
             List<Accountable> resources = new ArrayList<>();
             resources.add(Accountables.namedAccountable("latitude", lat));
             resources.add(Accountables.namedAccountable("longitude", lon));

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/IndexIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/IndexIndexFieldData.java
@@ -19,18 +19,27 @@
 
 package org.elasticsearch.index.fielddata.plain;
 
-import java.util.Collections;
-
-import org.apache.lucene.index.*;
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.RandomAccessOrds;
+import org.apache.lucene.index.SortedDocValues;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
-import org.elasticsearch.index.fielddata.*;
+import org.elasticsearch.index.fielddata.AtomicOrdinalsFieldData;
+import org.elasticsearch.index.fielddata.FieldDataType;
+import org.elasticsearch.index.fielddata.IndexFieldData;
+import org.elasticsearch.index.fielddata.IndexFieldDataCache;
+import org.elasticsearch.index.fielddata.IndexOrdinalsFieldData;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
+
+import java.util.Collection;
+import java.util.Collections;
 
 public class IndexIndexFieldData extends AbstractIndexOrdinalsFieldData {
 
@@ -58,7 +67,7 @@ public class IndexIndexFieldData extends AbstractIndexOrdinalsFieldData {
         }
 
         @Override
-        public Iterable<Accountable> getChildResources() {
+        public Collection<Accountable> getChildResources() {
             return Collections.emptyList();
         }
 

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/NumericDVIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/NumericDVIndexFieldData.java
@@ -19,7 +19,11 @@
 
 package org.elasticsearch.index.fielddata.plain;
 
-import org.apache.lucene.index.*;
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.Bits;
 import org.elasticsearch.ElasticsearchIllegalStateException;
@@ -32,6 +36,7 @@ import org.elasticsearch.index.mapper.FieldMapper.Names;
 import org.elasticsearch.search.MultiValueMode;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Collections;
 
 public class NumericDVIndexFieldData extends DocValuesIndexFieldData implements IndexNumericFieldData {
@@ -57,7 +62,7 @@ public class NumericDVIndexFieldData extends DocValuesIndexFieldData implements 
             }
             
             @Override
-            public Iterable<Accountable> getChildResources() {
+            public Collection<Accountable> getChildResources() {
                 return Collections.emptyList();
             }
         };

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/PackedArrayIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/PackedArrayIndexFieldData.java
@@ -20,8 +20,25 @@
 package org.elasticsearch.index.fielddata.plain;
 
 import com.google.common.base.Preconditions;
-import org.apache.lucene.index.*;
-import org.apache.lucene.util.*;
+
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.index.RandomAccessOrds;
+import org.apache.lucene.index.SortedDocValues;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.index.Terms;
+import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.Accountables;
+import org.apache.lucene.util.BitSet;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.BytesRefIterator;
+import org.apache.lucene.util.LongValues;
+import org.apache.lucene.util.NumericUtils;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.apache.lucene.util.packed.PackedInts;
 import org.apache.lucene.util.packed.PackedLongValues;
 import org.elasticsearch.ElasticsearchException;
@@ -29,8 +46,14 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
-import org.elasticsearch.index.fielddata.*;
+import org.elasticsearch.index.fielddata.AtomicNumericFieldData;
+import org.elasticsearch.index.fielddata.FieldData;
+import org.elasticsearch.index.fielddata.FieldDataType;
+import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource.Nested;
+import org.elasticsearch.index.fielddata.IndexFieldDataCache;
+import org.elasticsearch.index.fielddata.IndexNumericFieldData;
+import org.elasticsearch.index.fielddata.RamAccountingTermsEnum;
 import org.elasticsearch.index.fielddata.fieldcomparator.LongValuesComparatorSource;
 import org.elasticsearch.index.fielddata.ordinals.Ordinals;
 import org.elasticsearch.index.fielddata.ordinals.OrdinalsBuilder;
@@ -42,6 +65,7 @@ import org.elasticsearch.search.MultiValueMode;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
@@ -130,7 +154,7 @@ public class PackedArrayIndexFieldData extends AbstractIndexFieldData<AtomicNume
                     }
 
                     @Override
-                    public Iterable<Accountable> getChildResources() {
+                    public Collection<Accountable> getChildResources() {
                         List<Accountable> resources = new ArrayList<>();
                         resources.add(Accountables.namedAccountable("ordinals", build));
                         resources.add(Accountables.namedAccountable("values", values));
@@ -213,7 +237,7 @@ public class PackedArrayIndexFieldData extends AbstractIndexFieldData<AtomicNume
                             }
                             
                             @Override
-                            public Iterable<Accountable> getChildResources() {
+                            public Collection<Accountable> getChildResources() {
                                 List<Accountable> resources = new ArrayList<>();
                                 resources.add(Accountables.namedAccountable("values", sValues));
                                 if (docsWithValues != null) {
@@ -249,7 +273,7 @@ public class PackedArrayIndexFieldData extends AbstractIndexFieldData<AtomicNume
                             }
 
                             @Override
-                            public Iterable<Accountable> getChildResources() {
+                            public Collection<Accountable> getChildResources() {
                                 List<Accountable> resources = new ArrayList<>();
                                 resources.add(Accountables.namedAccountable("values", pagedValues));
                                 if (docsWithValues != null) {
@@ -270,7 +294,7 @@ public class PackedArrayIndexFieldData extends AbstractIndexFieldData<AtomicNume
                             }
                             
                             @Override
-                            public Iterable<Accountable> getChildResources() {
+                            public Collection<Accountable> getChildResources() {
                                 List<Accountable> resources = new ArrayList<>();
                                 resources.add(Accountables.namedAccountable("ordinals", build));
                                 resources.add(Accountables.namedAccountable("values", values));

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/PagedBytesAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/PagedBytesAtomicFieldData.java
@@ -18,17 +18,18 @@
  */
 package org.elasticsearch.index.fielddata.plain;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
 import org.apache.lucene.index.RandomAccessOrds;
-import org.apache.lucene.util.Accountables;
 import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.Accountables;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.PagedBytes;
 import org.apache.lucene.util.packed.PackedLongValues;
 import org.elasticsearch.index.fielddata.ordinals.Ordinals;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 /**
  */
@@ -59,7 +60,7 @@ public class PagedBytesAtomicFieldData extends AbstractAtomicOrdinalsFieldData {
     }
 
     @Override
-    public Iterable<Accountable> getChildResources() {
+    public Collection<Accountable> getChildResources() {
         List<Accountable> resources = new ArrayList<>();
         resources.add(Accountables.namedAccountable("ordinals", ordinals));
         resources.add(Accountables.namedAccountable("term bytes", bytes));

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/ParentChildAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/ParentChildAtomicFieldData.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.fielddata.plain;
 
 import com.carrotsearch.hppc.cursors.ObjectCursor;
+
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.SortedDocValues;
 import org.apache.lucene.util.Accountable;
@@ -27,6 +28,7 @@ import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.index.fielddata.AtomicOrdinalsFieldData;
 import org.elasticsearch.search.MultiValueMode;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -53,7 +55,7 @@ public class ParentChildAtomicFieldData extends AbstractAtomicParentChildFieldDa
     }
 
     @Override
-    public Iterable<Accountable> getChildResources() {
+    public Collection<Accountable> getChildResources() {
         // TODO: should we break down by type?
         // the current 'map' does not impl java.util.Map so we cant use Accountables.namedAccountables...
         return Collections.emptyList();

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/SortedNumericDVIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/SortedNumericDVIndexFieldData.java
@@ -20,13 +20,24 @@
 package org.elasticsearch.index.fielddata.plain;
 
 import com.google.common.base.Preconditions;
-import org.apache.lucene.index.*;
+
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.NumericUtils;
 import org.elasticsearch.ElasticsearchIllegalStateException;
 import org.elasticsearch.index.Index;
-import org.elasticsearch.index.fielddata.*;
+import org.elasticsearch.index.fielddata.AtomicNumericFieldData;
+import org.elasticsearch.index.fielddata.FieldData;
+import org.elasticsearch.index.fielddata.FieldDataType;
 import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource.Nested;
+import org.elasticsearch.index.fielddata.IndexNumericFieldData;
+import org.elasticsearch.index.fielddata.NumericDoubleValues;
+import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 import org.elasticsearch.index.fielddata.fieldcomparator.DoubleValuesComparatorSource;
 import org.elasticsearch.index.fielddata.fieldcomparator.FloatValuesComparatorSource;
 import org.elasticsearch.index.fielddata.fieldcomparator.LongValuesComparatorSource;
@@ -34,6 +45,7 @@ import org.elasticsearch.index.mapper.FieldMapper.Names;
 import org.elasticsearch.search.MultiValueMode;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Collections;
 
 /**
@@ -120,7 +132,7 @@ public class SortedNumericDVIndexFieldData extends DocValuesIndexFieldData imple
         }
         
         @Override
-        public Iterable<Accountable> getChildResources() {
+        public Collection<Accountable> getChildResources() {
             return Collections.emptyList();
         }
     }
@@ -169,7 +181,7 @@ public class SortedNumericDVIndexFieldData extends DocValuesIndexFieldData imple
         }
         
         @Override
-        public Iterable<Accountable> getChildResources() {
+        public Collection<Accountable> getChildResources() {
             return Collections.emptyList();
         }
     }
@@ -254,7 +266,7 @@ public class SortedNumericDVIndexFieldData extends DocValuesIndexFieldData imple
         }
         
         @Override
-        public Iterable<Accountable> getChildResources() {
+        public Collection<Accountable> getChildResources() {
             return Collections.emptyList();
         }
     }

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/SortedSetDVBytesAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/SortedSetDVBytesAtomicFieldData.java
@@ -19,16 +19,16 @@
 
 package org.elasticsearch.index.fielddata.plain;
 
-import org.apache.lucene.util.Accountable;
-
-import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.RandomAccessOrds;
+import org.apache.lucene.util.Accountable;
 import org.elasticsearch.ElasticsearchIllegalStateException;
 import org.elasticsearch.index.fielddata.AtomicFieldData;
 import org.elasticsearch.index.fielddata.FieldData;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Collections;
 
 /**
@@ -63,7 +63,7 @@ public final class SortedSetDVBytesAtomicFieldData extends AbstractAtomicOrdinal
     }
     
     @Override
-    public Iterable<Accountable> getChildResources() {
+    public Collection<Accountable> getChildResources() {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/elasticsearch/index/merge/scheduler/ConcurrentMergeSchedulerProvider.java
+++ b/src/main/java/org/elasticsearch/index/merge/scheduler/ConcurrentMergeSchedulerProvider.java
@@ -20,10 +20,12 @@
 package org.elasticsearch.index.merge.scheduler;
 
 import com.google.common.collect.ImmutableSet;
+
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.MergePolicy;
 import org.apache.lucene.index.MergeScheduler;
 import org.apache.lucene.index.TrackingConcurrentMergeScheduler;
+import org.apache.lucene.store.Directory;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.settings.Settings;
@@ -128,10 +130,10 @@ public class ConcurrentMergeSchedulerProvider extends MergeSchedulerProvider {
         }
 
         @Override
-        protected void handleMergeException(Throwable exc) {
+        protected void handleMergeException(Directory dir, Throwable exc) {
             logger.warn("failed to merge", exc);
             provider.failedMerge(new MergePolicy.MergeException(exc, dir));
-            super.handleMergeException(exc);
+            super.handleMergeException(dir, exc);
         }
 
         @Override
@@ -153,7 +155,7 @@ public class ConcurrentMergeSchedulerProvider extends MergeSchedulerProvider {
         }
 
         @Override
-        protected void maybeStall() {
+        protected void maybeStall(IndexWriter writer) {
             // Don't stall here, because we do our own index throttling (in InternalEngine.IndexThrottle) when merges can't keep up
         }
     }

--- a/src/main/java/org/elasticsearch/index/query/SimpleQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SimpleQueryParser.java
@@ -147,7 +147,6 @@ public class SimpleQueryParser extends org.apache.lucene.queryparser.simple.Simp
      */
     private Query newPossiblyAnalyzedQuery(String field, String termStr) {
         try (TokenStream source = getAnalyzer().tokenStream(field, termStr)) {
-            source.reset();
             // Use the analyzer to get all the tokens, and then build a TermQuery,
             // PhraseQuery, or nothing based on the term count
             CachingTokenFilter buffer = new CachingTokenFilter(source);

--- a/src/main/java/org/elasticsearch/index/snapshots/blobstore/RateLimitingInputStream.java
+++ b/src/main/java/org/elasticsearch/index/snapshots/blobstore/RateLimitingInputStream.java
@@ -46,7 +46,7 @@ public class RateLimitingInputStream extends FilterInputStream {
         this.listener = listener;
     }
 
-    private void maybePause(int bytes) {
+    private void maybePause(int bytes) throws IOException {
         bytesSinceLastRateLimit += bytes;
         if (bytesSinceLastRateLimit >= rateLimiter.getMinPauseCheckBytes()) {
             long pause = rateLimiter.pause(bytesSinceLastRateLimit);

--- a/src/main/java/org/elasticsearch/index/store/DistributorDirectory.java
+++ b/src/main/java/org/elasticsearch/index/store/DistributorDirectory.java
@@ -37,6 +37,7 @@ public final class DistributorDirectory extends Directory {
 
     private final Distributor distributor;
     private final HashMap<String, Directory> nameDirMapping = new HashMap<>();
+    private boolean closed = false;
 
     /**
      * Creates a new DistributorDirectory from multiple directories. Note: The first directory in the given array
@@ -126,9 +127,13 @@ public final class DistributorDirectory extends Directory {
 
     @Override
     public synchronized void close() throws IOException {
+        if (closed) {
+            return;
+        }
         try {
             assert assertConsistency();
         } finally {
+            closed = true;
             IOUtils.close(distributor.all());
         }
     }

--- a/src/main/java/org/elasticsearch/index/translog/Translog.java
+++ b/src/main/java/org/elasticsearch/index/translog/Translog.java
@@ -42,6 +42,7 @@ import org.elasticsearch.index.shard.IndexShardComponent;
 import java.io.Closeable;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.Collections;
 
 
@@ -173,7 +174,7 @@ public interface Translog extends IndexShardComponent, Closeable, Accountable {
         }
 
         @Override
-        public Iterable<Accountable> getChildResources() {
+        public Collection<Accountable> getChildResources() {
             return Collections.emptyList();
         }
 

--- a/src/main/java/org/elasticsearch/index/translog/fs/FsTranslog.java
+++ b/src/main/java/org/elasticsearch/index/translog/fs/FsTranslog.java
@@ -43,7 +43,13 @@ import org.elasticsearch.index.translog.TranslogStreams;
 
 import java.io.IOException;
 import java.nio.channels.ClosedChannelException;
-import java.nio.file.*;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -180,7 +186,7 @@ public class FsTranslog extends AbstractIndexShardComponent implements Translog 
     }
 
     @Override
-    public Iterable<Accountable> getChildResources() {
+    public Collection<Accountable> getChildResources() {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/elasticsearch/indices/cache/query/IndicesQueryCache.java
+++ b/src/main/java/org/elasticsearch/indices/cache/query/IndicesQueryCache.java
@@ -21,7 +21,12 @@ package org.elasticsearch.indices.cache.query;
 
 import com.carrotsearch.hppc.ObjectOpenHashSet;
 import com.carrotsearch.hppc.ObjectSet;
-import com.google.common.cache.*;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.RemovalListener;
+import com.google.common.cache.RemovalNotification;
+import com.google.common.cache.Weigher;
+
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.util.Accountable;
@@ -43,8 +48,8 @@ import org.elasticsearch.common.unit.MemorySizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
-import org.elasticsearch.index.shard.IndexShardState;
 import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.index.shard.IndexShardState;
 import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.internal.ShardSearchRequest;
@@ -54,6 +59,7 @@ import org.elasticsearch.search.query.QuerySearchResultProvider;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Set;
@@ -284,7 +290,7 @@ public class IndicesQueryCache extends AbstractComponent implements RemovalListe
         }
 
         @Override
-        public Iterable<Accountable> getChildResources() {
+        public Collection<Accountable> getChildResources() {
             // TODO: more detailed ram usage?
             return Collections.emptyList();
         }

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoverySettings.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoverySettings.java
@@ -148,7 +148,7 @@ public class RecoverySettings extends AbstractComponent implements Closeable {
                 if (maxSizePerSec.bytes() <= 0) {
                     rateLimiter = null;
                 } else if (rateLimiter != null) {
-                    rateLimiter.setMbPerSec(maxSizePerSec.mbFrac());
+                    rateLimiter.setMBPerSec(maxSizePerSec.mbFrac());
                 } else {
                     rateLimiter = new SimpleRateLimiter(maxSizePerSec.mbFrac());
                 }

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoveryStatus.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoveryStatus.java
@@ -186,26 +186,14 @@ public class RecoveryStatus extends AbstractRefCounted {
         }
     }
 
-    private String getTempNameForFile(String origFile) {
+    /** Get a temporary name for the provided file name. */
+    public String getTempNameForFile(String origFile) {
         return tempFilePrefix + origFile;
-    }
-
-    /** return true if the give file is a temporary file name issued by this recovery */
-    private boolean isTempFile(String filename) {
-        return tempFileNames.containsKey(filename);
     }
 
     public IndexOutput getOpenIndexOutput(String key) {
         ensureRefCount();
         return openIndexOutputs.get(key);
-    }
-
-    /** returns the original file name for a temporary file name issued by this recovery */
-    private String originalNameForTempFile(String tempFile) {
-        if (!isTempFile(tempFile)) {
-            throw new ElasticsearchException("[" + tempFile + "] is not a temporary file made by this recovery");
-        }
-        return tempFile.substring(tempFilePrefix.length());
     }
 
     /** remove and {@link org.apache.lucene.store.IndexOutput} for a given file. It is the caller's responsibility to close it */

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
@@ -46,6 +46,7 @@ import org.elasticsearch.indices.IndicesLifecycle;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.*;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
@@ -440,7 +441,9 @@ public class RecoveryTarget extends AbstractComponent {
                     }
                     // write the checksum
                     recoveryStatus.legacyChecksums().add(request.metadata());
-                    store.directory().sync(Collections.singleton(request.name()));
+                    final String temporaryFileName = recoveryStatus.getTempNameForFile(request.name());
+                    assert Arrays.asList(store.directory().listAll()).contains(temporaryFileName);
+                    store.directory().sync(Collections.singleton(temporaryFileName));
                     IndexOutput remove = recoveryStatus.removeOpenIndexOutputs(request.name());
                     recoveryStatus.state().getIndex().addRecoveredFileCount(1);
                     assert remove == null || remove == indexOutput; // remove maybe null if we got finished

--- a/src/main/java/org/elasticsearch/search/suggest/completion/AnalyzingCompletionLookupProvider.java
+++ b/src/main/java/org/elasticsearch/search/suggest/completion/AnalyzingCompletionLookupProvider.java
@@ -20,9 +20,14 @@
 package org.elasticsearch.search.suggest.completion;
 
 import com.carrotsearch.hppc.ObjectLongOpenHashMap;
+
 import org.apache.lucene.analysis.TokenStream;
-import org.apache.lucene.codecs.*;
-import org.apache.lucene.index.*;
+import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.codecs.FieldsConsumer;
+import org.apache.lucene.index.DocsAndPositionsEnum;
+import org.apache.lucene.index.Fields;
+import org.apache.lucene.index.Terms;
+import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.suggest.Lookup;
 import org.apache.lucene.search.suggest.analyzing.XAnalyzingSuggester;
@@ -35,8 +40,11 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.IntsRef;
 import org.apache.lucene.util.automaton.Automaton;
-import org.apache.lucene.util.fst.*;
+import org.apache.lucene.util.fst.ByteSequenceOutputs;
+import org.apache.lucene.util.fst.FST;
+import org.apache.lucene.util.fst.PairOutputs;
 import org.apache.lucene.util.fst.PairOutputs.Pair;
+import org.apache.lucene.util.fst.PositiveIntOutputs;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.index.mapper.core.CompletionFieldMapper;
 import org.elasticsearch.search.suggest.completion.Completion090PostingsFormat.CompletionLookupProvider;
@@ -44,7 +52,12 @@ import org.elasticsearch.search.suggest.completion.Completion090PostingsFormat.L
 import org.elasticsearch.search.suggest.context.ContextMapping.ContextQuery;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
 
 public class AnalyzingCompletionLookupProvider extends CompletionLookupProvider {
 
@@ -300,7 +313,7 @@ public class AnalyzingCompletionLookupProvider extends CompletionLookupProvider 
             }
 
             @Override
-            public Iterable<Accountable> getChildResources() {
+            public Collection<Accountable> getChildResources() {
                 return Accountables.namedAccountables("field", lookupMap);
             }
         };
@@ -360,7 +373,7 @@ public class AnalyzingCompletionLookupProvider extends CompletionLookupProvider 
         }
 
         @Override
-        public Iterable<Accountable> getChildResources() {
+        public Collection<Accountable> getChildResources() {
             if (fst != null) {
                 return Collections.singleton(Accountables.namedAccountable("fst", fst));
             } else {

--- a/src/main/java/org/elasticsearch/search/suggest/completion/Completion090PostingsFormat.java
+++ b/src/main/java/org/elasticsearch/search/suggest/completion/Completion090PostingsFormat.java
@@ -20,12 +20,26 @@ package org.elasticsearch.search.suggest.completion;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMap.Builder;
-import org.apache.lucene.codecs.*;
-import org.apache.lucene.index.*;
+
+import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.codecs.FieldsConsumer;
+import org.apache.lucene.codecs.FieldsProducer;
+import org.apache.lucene.codecs.PostingsFormat;
+import org.apache.lucene.index.Fields;
 import org.apache.lucene.index.FilterLeafReader.FilterTerms;
+import org.apache.lucene.index.IndexFileNames;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.SegmentWriteState;
+import org.apache.lucene.index.Terms;
 import org.apache.lucene.search.suggest.Lookup;
 import org.apache.lucene.store.IOContext.Context;
-import org.apache.lucene.store.*;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.store.InputStreamDataInput;
+import org.apache.lucene.store.OutputStreamDataOutput;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.Accountables;
 import org.apache.lucene.util.BytesRef;
@@ -40,6 +54,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -218,7 +233,7 @@ public class Completion090PostingsFormat extends PostingsFormat {
         }
 
         @Override
-        public Iterable<Accountable> getChildResources() {
+        public Collection<Accountable> getChildResources() {
             List<Accountable> resources = new ArrayList<>();
             if (lookupFactory != null) {
                 resources.add(Accountables.namedAccountable("lookup", lookupFactory));

--- a/src/test/java/org/elasticsearch/indices/settings/UpdateSettingsTests.java
+++ b/src/test/java/org/elasticsearch/indices/settings/UpdateSettingsTests.java
@@ -23,6 +23,7 @@ import org.apache.log4j.AppenderSkeleton;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.apache.log4j.spi.LoggingEvent;
+import org.apache.lucene.util.LuceneTestCase.AwaitsFix;
 import org.apache.lucene.util.LuceneTestCase.Slow;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
@@ -291,6 +292,7 @@ public class UpdateSettingsTests extends ElasticsearchIntegrationTest {
     // #6882: make sure we can change index.merge.scheduler.max_thread_count live
     @Test
     @Slow
+    @AwaitsFix(bugUrl="Super slow because of LUCENE-6119. Muted until we clean up merge throttling.")
     public void testUpdateMergeMaxThreadCount() {
 
         MockAppender mockAppender = new MockAppender();

--- a/src/test/java/org/elasticsearch/search/suggest/completion/AnalyzingCompletionLookupProviderV1.java
+++ b/src/test/java/org/elasticsearch/search/suggest/completion/AnalyzingCompletionLookupProviderV1.java
@@ -20,10 +20,14 @@
 package org.elasticsearch.search.suggest.completion;
 
 import com.carrotsearch.hppc.ObjectLongOpenHashMap;
+
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.codecs.FieldsConsumer;
-import org.apache.lucene.index.*;
+import org.apache.lucene.index.DocsAndPositionsEnum;
+import org.apache.lucene.index.Fields;
+import org.apache.lucene.index.Terms;
+import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.suggest.Lookup;
 import org.apache.lucene.search.suggest.analyzing.XAnalyzingSuggester;
@@ -49,6 +53,7 @@ import org.elasticsearch.search.suggest.completion.Completion090PostingsFormat.L
 import org.elasticsearch.search.suggest.context.ContextMapping.ContextQuery;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -289,7 +294,7 @@ public class AnalyzingCompletionLookupProviderV1 extends CompletionLookupProvide
             }
 
             @Override
-            public Iterable<Accountable> getChildResources() {
+            public Collection<Accountable> getChildResources() {
                 return Accountables.namedAccountables("field", lookupMap);
             }
         };

--- a/src/test/java/org/elasticsearch/test/cache/recycler/MockBigArrays.java
+++ b/src/test/java/org/elasticsearch/test/cache/recycler/MockBigArrays.java
@@ -24,17 +24,30 @@ import com.carrotsearch.randomizedtesting.SeedUtils;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.Accountables;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.cache.recycler.PageCacheRecycler;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.util.*;
+import org.elasticsearch.common.util.BigArray;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.ByteArray;
+import org.elasticsearch.common.util.DoubleArray;
+import org.elasticsearch.common.util.FloatArray;
+import org.elasticsearch.common.util.IntArray;
+import org.elasticsearch.common.util.LongArray;
+import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.test.ElasticsearchTestCase;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -333,7 +346,7 @@ public class MockBigArrays extends BigArrays {
         }
 
         @Override
-        public Iterable<Accountable> getChildResources() {
+        public Collection<Accountable> getChildResources() {
             return Collections.singleton(Accountables.namedAccountable("delegate", in));
         }
     }
@@ -378,7 +391,7 @@ public class MockBigArrays extends BigArrays {
         }
         
         @Override
-        public Iterable<Accountable> getChildResources() {
+        public Collection<Accountable> getChildResources() {
             return Collections.singleton(Accountables.namedAccountable("delegate", in));
         }
     }
@@ -423,7 +436,7 @@ public class MockBigArrays extends BigArrays {
         }
         
         @Override
-        public Iterable<Accountable> getChildResources() {
+        public Collection<Accountable> getChildResources() {
             return Collections.singleton(Accountables.namedAccountable("delegate", in));
         }
 
@@ -469,7 +482,7 @@ public class MockBigArrays extends BigArrays {
         }
 
         @Override
-        public Iterable<Accountable> getChildResources() {
+        public Collection<Accountable> getChildResources() {
             return Collections.singleton(Accountables.namedAccountable("delegate", in));
         }
     }
@@ -514,7 +527,7 @@ public class MockBigArrays extends BigArrays {
         }
 
         @Override
-        public Iterable<Accountable> getChildResources() {
+        public Collection<Accountable> getChildResources() {
             return Collections.singleton(Accountables.namedAccountable("delegate", in));
         }
     }
@@ -549,7 +562,7 @@ public class MockBigArrays extends BigArrays {
         }
 
         @Override
-        public Iterable<Accountable> getChildResources() {
+        public Collection<Accountable> getChildResources() {
             return Collections.singleton(Accountables.namedAccountable("delegate", in));
         }
     }


### PR DESCRIPTION
A couple of changes that triggerred a refactoring in Elasticsearch:
- LUCENE-6148: Accountable.getChildResources returns a collection instead of
   a list.
- LUCENE-6121: CachingTokenFilter now propagates reset(), as a result
   SimpleQueryParser.newPossiblyAnalyzedQuery has been fixed to not reset both
   the underlying stream and the wrapper (otherwise lucene would barf because of
   a doubl reset).
- LUCENE-6119: The auto-throttle issue changed a couple of method
   names/parameters. It also made
   `UpdateSettingsTests.testUpdateMergeMaxThreadCount` dead slow so I muted this
   test until we clea up merge throttling to use LUCENE-6119.
- LUCENE-6150: Fsyncs on unknown files are no longer ignored, which found a bug in
   our recovery code.
