### PR TITLE
Populate metadata.writtenBy for pre 1.3 index files.

### DIFF
--- a/src/main/java/org/elasticsearch/index/store/StoreFileMetaData.java
+++ b/src/main/java/org/elasticsearch/index/store/StoreFileMetaData.java
@@ -147,7 +147,7 @@ public class StoreFileMetaData implements Streamable {
      * a Lucene version greater or equal to Lucene 4.8
      */
     public boolean hasLegacyChecksum() {
-        return checksum != null && ((writtenBy != null  && writtenBy.onOrAfter(Version.LUCENE_4_8)) == false);
+        return checksum != null && (writtenBy == null || writtenBy.onOrAfter(Version.LUCENE_4_8) == false);
     }
 
     /**


### PR DESCRIPTION
Today this not populated (null) in these cases. But it would be useful to have
this available, even just for improved error messages.

The trickiest part today is the handling of 1.2.x files written with
lucene 4.8+ which have both ES checksums and lucene ones. This is now simplified:
when the lucene checksum is there, we always use it.
