### PR TITLE
Windows: makes elasticsearch.bat more friendly to automated processes

### DIFF
--- a/bin/elasticsearch.bat
+++ b/bin/elasticsearch.bat
@@ -1,10 +1,46 @@
 @echo off
 
-SETLOCAL
+SETLOCAL enabledelayedexpansion
 TITLE Elasticsearch ${project.version}
 
-CALL "%~dp0elasticsearch.in.bat"
+SET params='%*'
 
-"%JAVA_HOME%\bin\java" %JAVA_OPTS% %ES_JAVA_OPTS% %ES_PARAMS% %* -cp "%ES_CLASSPATH%" "org.elasticsearch.bootstrap.Elasticsearch"
+:loop
+FOR /F "usebackq tokens=1* delims= " %%A IN (!params!) DO (
+    SET current=%%A
+    SET params='%%B'
+	SET silent=N
+	
+	IF "!current!" == "-s" (
+		SET silent=Y
+	)
+	IF "!current!" == "--silent" (
+		SET silent=Y
+	)	
+	
+	IF "!silent!" == "Y" (
+		SET nopauseonerror=Y
+	) ELSE (
+	    IF "x!newparams!" NEQ "x" (
+	        SET newparams=!newparams! !current!
+        ) ELSE (
+            SET newparams=!current!
+        )
+	)
+	
+    IF "x!params!" NEQ "x" (
+		GOTO loop
+	)
+)
+
+CALL "%~dp0elasticsearch.in.bat"
+IF ERRORLEVEL 1 (
+	IF NOT DEFINED nopauseonerror (
+		PAUSE
+	)
+	EXIT /B %ERRORLEVEL%
+)
+
+"%JAVA_HOME%\bin\java" %JAVA_OPTS% %ES_JAVA_OPTS% %ES_PARAMS% !newparams! -cp "%ES_CLASSPATH%" "org.elasticsearch.bootstrap.Elasticsearch"
 
 ENDLOCAL

--- a/bin/elasticsearch.in.bat
+++ b/bin/elasticsearch.in.bat
@@ -3,9 +3,8 @@
 if DEFINED JAVA_HOME goto cont
 
 :err
-echo JAVA_HOME environment variable must be set!
-pause
-exit
+ECHO JAVA_HOME environment variable must be set! 1>&2
+EXIT /B 1 
 
 :cont
 set SCRIPT_DIR=%~dp0


### PR DESCRIPTION
When JAVA_HOME is not defined on a Windows platform, a message is printed on standard output and the BAT script is paused until the user press a key. This behavior is not compliant to automated processes where elasticsearch.bat can be executed by another script. This commit adds a new parameter --silent / -s that allow to skip this pause. Also, the error message is directed to standard and error outputs.

 Closes #8913
