### PR TITLE
Assert that we do not call blocking code from transport threads

### DIFF
--- a/src/main/java/org/elasticsearch/common/util/concurrent/BaseFuture.java
+++ b/src/main/java/org/elasticsearch/common/util/concurrent/BaseFuture.java
@@ -20,7 +20,9 @@
 package org.elasticsearch.common.util.concurrent;
 
 import com.google.common.annotations.Beta;
+
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.transport.Transports;
 
 import java.util.concurrent.*;
 import java.util.concurrent.locks.AbstractQueuedSynchronizer;
@@ -62,7 +64,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * @author Sven Mawson
  * @since 1.0
  */
-// Same as AbstractFuture from Guava, but without the listeners
+// Same as AbstractFuture from Guava, but without the listeners and with
+// additional assertions
 public abstract class BaseFuture<V> implements Future<V> {
 
     /**
@@ -89,6 +92,7 @@ public abstract class BaseFuture<V> implements Future<V> {
     @Override
     public V get(long timeout, TimeUnit unit) throws InterruptedException,
             TimeoutException, ExecutionException {
+        assert Transports.isTransportThread(Thread.currentThread()) == false : Thread.currentThread().getName();
         return sync.get(unit.toNanos(timeout));
     }
 
@@ -110,6 +114,7 @@ public abstract class BaseFuture<V> implements Future<V> {
      */
     @Override
     public V get() throws InterruptedException, ExecutionException {
+        assert Transports.isTransportThread(Thread.currentThread()) == false : Thread.currentThread().getName();
         return sync.get();
     }
 

--- a/src/main/java/org/elasticsearch/common/util/concurrent/BaseFuture.java
+++ b/src/main/java/org/elasticsearch/common/util/concurrent/BaseFuture.java
@@ -92,7 +92,7 @@ public abstract class BaseFuture<V> implements Future<V> {
     @Override
     public V get(long timeout, TimeUnit unit) throws InterruptedException,
             TimeoutException, ExecutionException {
-        assert Transports.isTransportThread(Thread.currentThread()) == false : Thread.currentThread().getName();
+        Transports.assertNotTransportThread();
         return sync.get(unit.toNanos(timeout));
     }
 
@@ -114,7 +114,7 @@ public abstract class BaseFuture<V> implements Future<V> {
      */
     @Override
     public V get() throws InterruptedException, ExecutionException {
-        assert Transports.isTransportThread(Thread.currentThread()) == false : Thread.currentThread().getName();
+        Transports.assertNotTransportThread();
         return sync.get();
     }
 

--- a/src/main/java/org/elasticsearch/transport/Transports.java
+++ b/src/main/java/org/elasticsearch/transport/Transports.java
@@ -23,7 +23,6 @@ import org.elasticsearch.transport.local.LocalTransport;
 import org.elasticsearch.transport.netty.NettyTransport;
 
 import java.util.Arrays;
-import java.util.concurrent.ThreadFactory;
 
 public enum Transports {
     ;
@@ -38,7 +37,9 @@ public enum Transports {
         for (String s : Arrays.asList(
                 LocalTransport.LOCAL_TRANSPORT_THREAD_NAME_PREFIX,
                 NettyTransport.HTTP_SERVER_BOSS_THREAD_NAME_PREFIX,
-                NettyTransport.HTTP_SERVER_WORKER_THREAD_NAME_PREFIX)) {
+                NettyTransport.HTTP_SERVER_WORKER_THREAD_NAME_PREFIX,
+                NettyTransport.TRANSPORT_CLIENT_WORKER_THREAD_NAME_PREFIX,
+                NettyTransport.TRANSPORT_CLIENT_BOSS_THREAD_NAME_PREFIX)) {
             if (threadName.contains(s)) {
                 return true;
             }
@@ -46,18 +47,13 @@ public enum Transports {
         return false;
     }
 
-    /**
-     * Utility method to detect whether a thread factory generates network
-     * threads.
-     * @see #isTransportThread
-     */
-    public static final boolean isTransportThreadFactory(ThreadFactory factory) {
-        final Thread thread = factory.newThread(new Runnable() {
-           @Override
-            public void run() {
-               // no-op
-            } 
-        });
-        return isTransportThread(thread);
+    public static void assertTransportThread() {
+        final Thread t = Thread.currentThread();
+        assert isTransportThread(t) : "Expected transport thread but got [" + t + "]";
+    }
+
+    public static void assertNotTransportThread() {
+        final Thread t = Thread.currentThread();
+        assert isTransportThread(t) ==false : "Thread [" + t + "] executed a blocking operation yet is a transport thread";
     }
 }

--- a/src/main/java/org/elasticsearch/transport/Transports.java
+++ b/src/main/java/org/elasticsearch/transport/Transports.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.transport;
+
+import org.elasticsearch.transport.local.LocalTransport;
+import org.elasticsearch.transport.netty.NettyTransport;
+
+import java.util.Arrays;
+import java.util.concurrent.ThreadFactory;
+
+public enum Transports {
+    ;
+
+    /**
+     * Utility method to detect whether a thread is a network thread. Typically
+     * used in assertions to make sure that we do not call blocking code from
+     * networking threads.
+     */
+    public static final boolean isTransportThread(Thread t) {
+        final String threadName = t.getName();
+        for (String s : Arrays.asList(
+                LocalTransport.LOCAL_TRANSPORT_THREAD_NAME_PREFIX,
+                NettyTransport.HTTP_SERVER_BOSS_THREAD_NAME_PREFIX,
+                NettyTransport.HTTP_SERVER_WORKER_THREAD_NAME_PREFIX)) {
+            if (threadName.contains(s)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Utility method to detect whether a thread factory generates network
+     * threads.
+     * @see #isTransportThread
+     */
+    public static final boolean isTransportThreadFactory(ThreadFactory factory) {
+        final Thread thread = factory.newThread(new Runnable() {
+           @Override
+            public void run() {
+               // no-op
+            } 
+        });
+        return isTransportThread(thread);
+    }
+}

--- a/src/main/java/org/elasticsearch/transport/netty/MessageChannelHandler.java
+++ b/src/main/java/org/elasticsearch/transport/netty/MessageChannelHandler.java
@@ -65,6 +65,7 @@ public class MessageChannelHandler extends SimpleChannelUpstreamHandler {
 
     @Override
     public void messageReceived(ChannelHandlerContext ctx, MessageEvent e) throws Exception {
+        Transports.assertTransportThread();
         Object m = e.getMessage();
         if (!(m instanceof ChannelBuffer)) {
             ctx.sendUpstream(e);


### PR DESCRIPTION
This currently only adds checks to BaseFuture, but this should already cover a
lot of client code. We could add more in the future, like interactions with the
filesystem and so on.
