### PR TITLE
GeoPolygonFilter not properly handling dateline and pole crossing

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/GeoPolygonFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoPolygonFilterParser.java
@@ -76,8 +76,8 @@ public class GeoPolygonFilterParser implements FilterParser {
 
         List<GeoPoint> shell = Lists.newArrayList();
 
-        boolean normalizeLon = true;
-        boolean normalizeLat = true;
+        boolean normalizeLon = false;
+        boolean normalizeLat = false;
 
         String filterName = null;
         String currentFieldName = null;

--- a/src/main/java/org/elasticsearch/index/search/geo/GeoPolygonFilter.java
+++ b/src/main/java/org/elasticsearch/index/search/geo/GeoPolygonFilter.java
@@ -109,10 +109,8 @@ public class GeoPolygonFilter extends Filter {
                 lat0 = (points[i-1].lat() < 0) ? points[i-1].lat() + 180.0 : points[i-1].lat();
                 lat1 = (points[i].lat() < 0) ? points[i].lat() + 180.0 : points[i].lat();
 
-                if (lon1 < lon && lon0 >= lon
-                        || lon0 < lon && lon1 >= lon) {
-                    if (lat1 + (lon - lon1) /
-                            (lon0 - lon1) * (lat0 - lat1) < lat) {
+                if (lon1 < lon && lon0 >= lon || lon0 < lon && lon1 >= lon) {
+                    if (lat1 + (lon - lon1) / (lon0 - lon1) * (lat0 - lat1) < lat) {
                         inPoly = !inPoly;
                     }
                 }

--- a/src/main/java/org/elasticsearch/index/search/geo/GeoPolygonFilter.java
+++ b/src/main/java/org/elasticsearch/index/search/geo/GeoPolygonFilter.java
@@ -93,27 +93,32 @@ public class GeoPolygonFilter extends Filter {
 
         private static boolean pointInPolygon(GeoPoint[] points, double lat, double lon) {
             boolean inPoly = false;
-            double lat0, lon0, lat1, lon1;
+            double lon0 = (points[0].lon() < 0) ? points[0].lon() + 360.0 : points[0].lon();
+            double lat0 = (points[0].lat() < 0) ? points[0].lat() + 180.0 : points[0].lat();
+            double lat1, lon1;
             if (lon < 0) {
                 lon += 360;
             }
 
-            if (lat <0) {
+            if (lat < 0) {
                 lat += 180;
             }
 
+            // simple even-odd PIP computation
+            //   1.  Determine if point is contained in the longitudinal range
+            //   2.  Determine whether point crosses the edge by computing the latitudinal delta
+            //       between the end-point of a parallel vector (originating at the point) and the
+            //       y-component of the edge sink
             for (int i = 1; i < points.length; i++) {
-                lon0 = (points[i-1].lon() < 0) ? points[i-1].lon() + 360.0 : points[i-1].lon();
                 lon1 = (points[i].lon() < 0) ? points[i].lon() + 360.0 : points[i].lon();
-
-                lat0 = (points[i-1].lat() < 0) ? points[i-1].lat() + 180.0 : points[i-1].lat();
                 lat1 = (points[i].lat() < 0) ? points[i].lat() + 180.0 : points[i].lat();
-
                 if (lon1 < lon && lon0 >= lon || lon0 < lon && lon1 >= lon) {
                     if (lat1 + (lon - lon1) / (lon0 - lon1) * (lat0 - lat1) < lat) {
                         inPoly = !inPoly;
                     }
                 }
+                lon0 = lon1;
+                lat0 = lat1;
             }
             return inPoly;
         }

--- a/src/main/java/org/elasticsearch/index/search/geo/GeoPolygonFilter.java
+++ b/src/main/java/org/elasticsearch/index/search/geo/GeoPolygonFilter.java
@@ -93,12 +93,26 @@ public class GeoPolygonFilter extends Filter {
 
         private static boolean pointInPolygon(GeoPoint[] points, double lat, double lon) {
             boolean inPoly = false;
+            double lat0, lon0, lat1, lon1;
+            if (lon < 0) {
+                lon += 360;
+            }
+
+            if (lat <0) {
+                lat += 180;
+            }
 
             for (int i = 1; i < points.length; i++) {
-                if (points[i].lon() < lon && points[i-1].lon() >= lon
-                        || points[i-1].lon() < lon && points[i].lon() >= lon) {
-                    if (points[i].lat() + (lon - points[i].lon()) /
-                            (points[i-1].lon() - points[i].lon()) * (points[i-1].lat() - points[i].lat()) < lat) {
+                lon0 = (points[i-1].lon() < 0) ? points[i-1].lon() + 360.0 : points[i-1].lon();
+                lon1 = (points[i].lon() < 0) ? points[i].lon() + 360.0 : points[i].lon();
+
+                lat0 = (points[i-1].lat() < 0) ? points[i-1].lat() + 180.0 : points[i-1].lat();
+                lat1 = (points[i].lat() < 0) ? points[i].lat() + 180.0 : points[i].lat();
+
+                if (lon1 < lon && lon0 >= lon
+                        || lon0 < lon && lon1 >= lon) {
+                    if (lat1 + (lon - lon1) /
+                            (lon0 - lon1) * (lat0 - lat1) < lat) {
                         inPoly = !inPoly;
                     }
                 }


### PR DESCRIPTION
By default GeoPolygonFilter normalizes GeoPoints to a [-180:180] lon, [-90:90] lat coordinate boundary. This requires the GeoPolygonFilter be split into east/west, north/south regions to properly return points collection that wrap the dateline and poles. To keep queries fast, this simple fix converts the GeoPoints for both the target polygon and candidate points to a [0:360] lon, [0:180] lat coordinate range. This way the user (or the filter logic) doesn't have to split the filter in two parts.

closes #5968
