### PR TITLE
Fix to make GET Index API consistent with docs

### DIFF
--- a/rest-api-spec/test/indices.get_alias/20_empty.yaml
+++ b/rest-api-spec/test/indices.get_alias/20_empty.yaml
@@ -1,0 +1,19 @@
+---
+setup:
+
+  - do:
+      indices.create:
+        index: test_index
+
+  - do:
+      indices.create:
+        index: test_index_2
+
+---
+"Check empty aliases when getting all aliases via /_alias":
+
+  - do:
+      indices.get_alias: {}
+
+  - match: {test_index.aliases: {}}
+  - match: {test_index_2.aliases: {}}

--- a/rest-api-spec/test/indices.get_mapping/60_empty.yaml
+++ b/rest-api-spec/test/indices.get_mapping/60_empty.yaml
@@ -1,0 +1,19 @@
+---
+setup:
+
+  - do:
+      indices.create:
+        index: test_1
+
+  - do:
+      indices.create:
+        index: test_2
+
+---
+"Check empty mapping when getting all mappings via /_mapping":
+
+ - do:
+    indices.get_mapping: {}
+
+ - match: { test_1.mappings: {}}
+ - match: { test_2.mappings: {}}

--- a/rest-api-spec/test/indices.get_warmer/20_empty.yaml
+++ b/rest-api-spec/test/indices.get_warmer/20_empty.yaml
@@ -1,0 +1,19 @@
+---
+setup:
+
+  - do:
+      indices.create:
+        index: test_1
+
+  - do:
+      indices.create:
+        index: test_2
+
+---
+"Check empty warmers when getting all warmers via /_warmer":
+
+ - do:
+    indices.get_warmer: {}
+
+ - match: { test_1.warmers: {}}
+ - match: { test_2.warmers: {}}

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/get/RestGetIndicesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/get/RestGetIndicesAction.java
@@ -117,24 +117,24 @@ public class RestGetIndicesAction extends BaseRestHandler {
             }
 
             private void writeAliases(ImmutableList<AliasMetaData> aliases, XContentBuilder builder, Params params) throws IOException {
+                builder.startObject(Fields.ALIASES);
                 if (aliases != null) {
-                    builder.startObject(Fields.ALIASES);
                     for (AliasMetaData alias : aliases) {
                         AliasMetaData.Builder.toXContent(alias, builder, params);
                     }
-                    builder.endObject();
                 }
+                builder.endObject();
             }
 
             private void writeMappings(ImmutableOpenMap<String, MappingMetaData> mappings, XContentBuilder builder, Params params) throws IOException {
+                builder.startObject(Fields.MAPPINGS);
                 if (mappings != null) {
-                    builder.startObject(Fields.MAPPINGS);
                     for (ObjectObjectCursor<String, MappingMetaData> typeEntry : mappings) {
                         builder.field(typeEntry.key);
                         builder.map(typeEntry.value.sourceAsMap());
                     }
-                    builder.endObject();
                 }
+                builder.endObject();
             }
 
             private void writeSettings(Settings settings, XContentBuilder builder, Params params) throws IOException {
@@ -144,13 +144,13 @@ public class RestGetIndicesAction extends BaseRestHandler {
             }
 
             private void writeWarmers(ImmutableList<IndexWarmersMetaData.Entry> warmers, XContentBuilder builder, Params params) throws IOException {
+                builder.startObject(Fields.WARMERS);
                 if (warmers != null) {
-                    builder.startObject(Fields.WARMERS);
                     for (IndexWarmersMetaData.Entry warmer : warmers) {
                         IndexWarmersMetaData.FACTORY.toXContent(warmer, builder, params);
                     }
-                    builder.endObject();
                 }
+                builder.endObject();
             }
         });
     }


### PR DESCRIPTION
This fix ensures that calls to the GET alias/mappings/settings/warmers APIs return the aliases/mappings/settings/warmers object even if there is no content within them.. This make them consistent with the GET Index API docs and the breaking changes in 1.4 docs

Closes #9148
