### PR TITLE
Remove includeExisting flag from adding ObjectMapper and FieldMapper listeners

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
@@ -666,11 +666,8 @@ public class DocumentMapper implements ToXContent {
         }
     }
 
-    public void addFieldMapperListener(FieldMapperListener fieldMapperListener, boolean includeExisting) {
+    public void addFieldMapperListener(FieldMapperListener fieldMapperListener) {
         fieldMapperListeners.add(fieldMapperListener);
-        if (includeExisting) {
-            traverse(fieldMapperListener);
-        }
     }
 
     public void traverse(FieldMapperListener listener) {
@@ -702,11 +699,8 @@ public class DocumentMapper implements ToXContent {
         }
     }
 
-    public void addObjectMapperListener(ObjectMapperListener objectMapperListener, boolean includeExisting) {
+    public void addObjectMapperListener(ObjectMapperListener objectMapperListener) {
         objectMapperListeners.add(objectMapperListener);
-        if (includeExisting) {
-            traverse(objectMapperListener);
-        }
     }
 
     public void traverse(ObjectMapperListener listener) {

--- a/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -352,12 +352,12 @@ public class MapperService extends AbstractIndexComponent  {
                 FieldMapperListener.Aggregator fieldMappersAgg = new FieldMapperListener.Aggregator();
                 mapper.traverse(fieldMappersAgg);
                 addFieldMappers(fieldMappersAgg.mappers);
-                mapper.addFieldMapperListener(fieldMapperListener, false);
+                mapper.addFieldMapperListener(fieldMapperListener);
 
                 ObjectMapperListener.Aggregator objectMappersAgg = new ObjectMapperListener.Aggregator();
                 mapper.traverse(objectMappersAgg);
                 addObjectMappers(objectMappersAgg.mappers.toArray(new ObjectMapper[objectMappersAgg.mappers.size()]));
-                mapper.addObjectMapperListener(objectMapperListener, false);
+                mapper.addObjectMapperListener(objectMapperListener);
 
                 for (DocumentTypeListener typeListener : typeListeners) {
                     typeListener.beforeCreate(mapper);


### PR DESCRIPTION
This flag is unused by the 2 places that add these listeners.
