### PR TITLE
Remove `allow_type_wrapper` setting

### DIFF
--- a/docs/reference/docs/index_.asciidoc
+++ b/docs/reference/docs/index_.asciidoc
@@ -63,30 +63,6 @@ objects will automatically be added to the mapping definition of the
 type specified. Check out the <<mapping,mapping>>
 section for more information on mapping definitions.
 
-Note that the format of the JSON document can also include the type (very handy
-when using JSON mappers) if the `index.mapping.allow_type_wrapper` setting is
-set to true, for example:
-
-[source,js]
---------------------------------------------------
-$ curl -XPOST 'http://localhost:9200/twitter' -d '{
-  "settings": {
-    "index": {
-      "mapping.allow_type_wrapper": true
-    }
-  }
-}'
-{"acknowledged":true}
-
-$ curl -XPUT 'http://localhost:9200/twitter/tweet/1' -d '{
-    "tweet" : {
-        "user" : "kimchy",
-        "post_date" : "2009-11-15T14:12:12",
-        "message" : "trying out Elasticsearch"
-    }
-}'
---------------------------------------------------
-
 Automatic index creation can be disabled by setting
 `action.auto_create_index` to `false` in the config file of all nodes.
 Automatic mapping creation can be disabled by setting

--- a/docs/reference/migration/migrate_2_0.asciidoc
+++ b/docs/reference/migration/migrate_2_0.asciidoc
@@ -123,3 +123,7 @@ The meaning of the `_shards` headers in the delete by query response has changed
 shards aren't being kept track of. From version 2.0 the stats in the `_shards` header are based on all shards
 of an index. The http status code is left unchanged and is only based on failures that occurred while executing on
 primary shards.
+
+=== Mappings
+
+The setting `index.mapping.allow_type_wrapper` has been removed.  Documents should always be sent without the type as the root element.

--- a/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
@@ -259,8 +259,6 @@ public class DocumentMapper implements ToXContent {
         }
     };
 
-    public static final String ALLOW_TYPE_WRAPPER = "index.mapping.allow_type_wrapper";
-
     private final String index;
 
     private final Settings indexSettings;
@@ -525,16 +523,6 @@ public class DocumentMapper implements ToXContent {
                 emptyDoc = true;
             } else if (token != XContentParser.Token.FIELD_NAME) {
                 throw new MapperParsingException("Malformed content, after first object, either the type field or the actual properties should exist");
-            }
-            // first field is the same as the type, this might be because the
-            // type is provided, and the object exists within it or because
-            // there is a valid field that by chance is named as the type.
-            // Because of this, by default wrapping a document in a type is
-            // disabled, but can be enabled by setting
-            // index.mapping.allow_type_wrapper to true
-            if (type.equals(parser.currentName()) && indexSettings.getAsBoolean(ALLOW_TYPE_WRAPPER, false)) {
-                parser.nextToken();
-                countDownTokens++;
             }
 
             for (RootMapper rootMapper : rootMappersOrdered) {

--- a/src/test/java/org/elasticsearch/index/mapper/simple/SimpleMapperTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/simple/SimpleMapperTests.java
@@ -137,18 +137,4 @@ public class SimpleMapperTests extends ElasticsearchSingleNodeTest {
             assertThat(e.getMessage(), equalTo("failed to parse, document is empty"));
         }
     }
-
-    @Test
-    public void testTypeWrapperWithSetting() throws Exception {
-        String mapping = copyToStringFromClasspath("/org/elasticsearch/index/mapper/simple/test-mapping.json");
-        Settings settings = ImmutableSettings.settingsBuilder().put("index.mapping.allow_type_wrapper", true).build();
-        DocumentMapper docMapper = createIndex("test", settings).mapperService().documentMapperParser().parse(mapping);
-
-        assertThat((String) docMapper.meta().get("param1"), equalTo("value1"));
-
-        BytesReference json = new BytesArray(copyToBytesFromClasspath("/org/elasticsearch/index/mapper/simple/test1-withtype.json"));
-        Document doc = docMapper.parse(json).rootDoc();
-        assertThat(doc.get(docMapper.uidMapper().names().indexName()), equalTo(Uid.createUid("person", "1")));
-        assertThat(doc.get(docMapper.mappers().name("first").mapper().names().indexName()), equalTo("shay"));
-    }
 }


### PR DESCRIPTION
Before Elasticsearch 1.0, the type was allowed to be passed as the root
element when uploading a document.  However, this was ambiguous if the
mappings also contained a field with the same name as the type.  The
behavior was changed in 1.0 to not allow this, but a setting was added
for backwards compatibility.  This change removes the setting for 2.0.
