### PR TITLE
Bootstrap: Implement VirtualLock on Windows

### DIFF
--- a/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
+++ b/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
@@ -37,6 +37,7 @@ import org.elasticsearch.node.Node;
 import org.elasticsearch.node.NodeBuilder;
 import org.elasticsearch.node.internal.InternalSettingsPreparer;
 
+import com.sun.jna.Platform;
 import java.nio.file.Paths;
 import java.util.Locale;
 import java.util.Set;
@@ -59,7 +60,11 @@ public class Bootstrap {
 
     private void setup(boolean addShutdownHook, Tuple<Settings, Environment> tuple) throws Exception {
         if (tuple.v1().getAsBoolean("bootstrap.mlockall", false)) {
-            Natives.tryMlockall();
+            if (Platform.isWindows()) {
+                Natives.tryVirtualLock();
+            } else {
+                Natives.tryMlockall();
+            }
         }
 
         NodeBuilder nodeBuilder = NodeBuilder.nodeBuilder().settings(tuple.v1()).loadConfigSettings(false);

--- a/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
+++ b/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.bootstrap;
 
+import org.apache.lucene.util.Constants;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.PidFile;
@@ -37,7 +38,6 @@ import org.elasticsearch.node.Node;
 import org.elasticsearch.node.NodeBuilder;
 import org.elasticsearch.node.internal.InternalSettingsPreparer;
 
-import com.sun.jna.Platform;
 import java.nio.file.Paths;
 import java.util.Locale;
 import java.util.Set;
@@ -60,7 +60,7 @@ public class Bootstrap {
 
     private void setup(boolean addShutdownHook, Tuple<Settings, Environment> tuple) throws Exception {
         if (tuple.v1().getAsBoolean("bootstrap.mlockall", false)) {
-            if (Platform.isWindows()) {
+            if (Constants.WINDOWS) {
                 Natives.tryVirtualLock();
             } else {
                 Natives.tryMlockall();


### PR DESCRIPTION
This PR implements `mlockall` like functionality on Windows by leveraging the native [VirtualLock](http://msdn.microsoft.com/en-us/library/windows/desktop/aa366895) function.

As explained in #8480, unlike `mlockall` on *nix,  `VirtualLock` requires a base memory address and the size of a region to lock.  The only sane approach, to my knowledge, was to use [VirtualQueryEx](http://msdn.microsoft.com/en-us/library/windows/desktop/aa366907) to iterate the address space of the JVM and lock each page individually.

To test this, I used a combination of a few tools:
- [VMMap](http://technet.microsoft.com/en-us/sysinternals/dd535533.aspx)
- [Testlimit](http://download.sysinternals.com/files/TestLimit.zip) (for stressing system memory and monitoring page faults)
- [Resource Monitor](http://windows.microsoft.com/en-us/windows7/open-resource-monitor)

Here's what the results look like in resource monitor when starting Elasticsearch with:  `-Xmx4g -Xms4g`:

with `bootstrap.mlockall` = `false`

![mlockall_disabled](https://cloud.githubusercontent.com/assets/1594777/5654972/aca1ac92-9696-11e4-8e3c-4300bc461d63.PNG)

the JVM is initialized with ~4GB of virtual memory (Commit), but only ~200MB is actual physical memory (Working Set).

with `boostrap.mlockall` = `true`

![mlockall_enabled](https://cloud.githubusercontent.com/assets/1594777/5654977/b93bc370-9696-11e4-8bab-c557ca385780.PNG)

the working set is now also ~4GB upon start up of elasticsearch.

Additionally, I've stressed my system using Testlimit and observed up to ~100 page faults/s with mlockall disabled, and 0 page faults/s with mlockall enabled.

These results indicate to me that this is working, but it would be great to get some additional eyes/testing on this.

Closes #8480
