### PR TITLE
first cut at ephemeral fields

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
@@ -389,6 +389,16 @@ public class DocumentMapper implements ToXContent {
         return this.rootObjectMapper;
     }
 
+    // Added by Loggly - START
+    // needed by MapperService.smartName()
+    //
+    Settings indexSettings() {
+        return this.indexSettings;
+    }
+    //
+    // Added by Loggly - END
+
+
     public UidFieldMapper uidMapper() {
         return rootMapper(UidFieldMapper.class);
     }

--- a/src/main/java/org/elasticsearch/index/mapper/DocumentMapperParser.java
+++ b/src/main/java/org/elasticsearch/index/mapper/DocumentMapperParser.java
@@ -53,6 +53,19 @@ import org.elasticsearch.index.mapper.core.ShortFieldMapper;
 import org.elasticsearch.index.mapper.core.StringFieldMapper;
 import org.elasticsearch.index.mapper.core.TokenCountFieldMapper;
 import org.elasticsearch.index.mapper.core.TypeParsers;
+
+// Added by Jon - START
+import org.elasticsearch.index.mapper.core.EphemeralBooleanFieldMapper;
+import org.elasticsearch.index.mapper.core.EphemeralByteFieldMapper;
+import org.elasticsearch.index.mapper.core.EphemeralDateFieldMapper;
+import org.elasticsearch.index.mapper.core.EphemeralDoubleFieldMapper;
+import org.elasticsearch.index.mapper.core.EphemeralFloatFieldMapper;
+import org.elasticsearch.index.mapper.core.EphemeralIntegerFieldMapper;
+import org.elasticsearch.index.mapper.core.EphemeralLongFieldMapper;
+import org.elasticsearch.index.mapper.core.EphemeralShortFieldMapper;
+import org.elasticsearch.index.mapper.core.EphemeralStringFieldMapper;
+// Added by Jon - END
+
 import org.elasticsearch.index.mapper.geo.GeoPointFieldMapper;
 import org.elasticsearch.index.mapper.geo.GeoShapeFieldMapper;
 import org.elasticsearch.index.mapper.internal.AllFieldMapper;
@@ -71,6 +84,7 @@ import org.elasticsearch.index.mapper.internal.TypeFieldMapper;
 import org.elasticsearch.index.mapper.internal.UidFieldMapper;
 import org.elasticsearch.index.mapper.internal.VersionFieldMapper;
 import org.elasticsearch.index.mapper.ip.IpFieldMapper;
+import org.elasticsearch.index.mapper.ip.EphemeralIpFieldMapper;
 import org.elasticsearch.index.mapper.object.ObjectMapper;
 import org.elasticsearch.index.mapper.object.RootObjectMapper;
 import org.elasticsearch.index.settings.IndexSettings;
@@ -134,6 +148,26 @@ public class DocumentMapperParser extends AbstractIndexComponent {
                 .put(CompletionFieldMapper.CONTENT_TYPE, new CompletionFieldMapper.TypeParser())
                 .put(GeoPointFieldMapper.CONTENT_TYPE, new GeoPointFieldMapper.TypeParser())
                 .put(Murmur3FieldMapper.CONTENT_TYPE, new Murmur3FieldMapper.TypeParser());
+
+        // Added by Loggly - START
+        // TODO: should this be controlled by a flag?
+        //
+        if (true) {
+            typeParsersBuilder.put(EphemeralByteFieldMapper.CONTENT_TYPE, new EphemeralByteFieldMapper.TypeParser())
+                .put(EphemeralShortFieldMapper.CONTENT_TYPE, new EphemeralShortFieldMapper.TypeParser())
+                .put(EphemeralIntegerFieldMapper.CONTENT_TYPE, new EphemeralIntegerFieldMapper.TypeParser())
+                .put(EphemeralLongFieldMapper.CONTENT_TYPE, new EphemeralLongFieldMapper.TypeParser())
+                .put(EphemeralFloatFieldMapper.CONTENT_TYPE, new EphemeralFloatFieldMapper.TypeParser())
+                .put(EphemeralDoubleFieldMapper.CONTENT_TYPE, new EphemeralDoubleFieldMapper.TypeParser())
+                .put(EphemeralBooleanFieldMapper.CONTENT_TYPE, new EphemeralBooleanFieldMapper.TypeParser())
+                .put(EphemeralDateFieldMapper.CONTENT_TYPE, new EphemeralDateFieldMapper.TypeParser())
+                .put(EphemeralIpFieldMapper.CONTENT_TYPE, new EphemeralIpFieldMapper.TypeParser())
+                .put(EphemeralStringFieldMapper.CONTENT_TYPE, new EphemeralStringFieldMapper.TypeParser())
+                ;
+        }
+        //
+        // Added by Loggly - END
+
 
         if (ShapesAvailability.JTS_AVAILABLE) {
             typeParsersBuilder.put(GeoShapeFieldMapper.CONTENT_TYPE, new GeoShapeFieldMapper.TypeParser());
@@ -393,4 +427,14 @@ public class DocumentMapperParser extends AbstractIndexComponent {
         }
         return mapping;
     }
+
+    // Added by Loggly - START
+    //
+    // make typeParsers visible within the package so we can use it in MapperService.smartName()
+    //
+    ImmutableMap<String, Mapper.TypeParser> typeParsers() {
+        return typeParsers;
+    }
+    //
+    // Added by Loggly - END
 }

--- a/src/main/java/org/elasticsearch/index/mapper/Mapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/Mapper.java
@@ -151,4 +151,8 @@ public interface Mapper extends ToXContent {
     void traverse(ObjectMapperListener objectMapperListener);
 
     void close();
+
+    // Added by Loggly - START
+    boolean isEphemeral();
+    // Added by Loggly - END
 }

--- a/src/main/java/org/elasticsearch/index/mapper/MapperBuilders.java
+++ b/src/main/java/org/elasticsearch/index/mapper/MapperBuilders.java
@@ -25,6 +25,7 @@ import org.elasticsearch.index.mapper.geo.GeoPointFieldMapper;
 import org.elasticsearch.index.mapper.geo.GeoShapeFieldMapper;
 import org.elasticsearch.index.mapper.internal.*;
 import org.elasticsearch.index.mapper.ip.IpFieldMapper;
+import org.elasticsearch.index.mapper.ip.EphemeralIpFieldMapper;
 import org.elasticsearch.index.mapper.object.ObjectMapper;
 import org.elasticsearch.index.mapper.object.RootObjectMapper;
 
@@ -172,4 +173,76 @@ public final class MapperBuilders {
     public static CompletionFieldMapper.Builder completionField(String name) {
         return new CompletionFieldMapper.Builder(name);
     }
+
+    // Added by Loggly - START
+    //
+    
+    public static EphemeralByteFieldMapper.Builder ephemeralByteField(String name) {
+        return new EphemeralByteFieldMapper.Builder(name);
+    }
+    public static EphemeralShortFieldMapper.Builder ephemeralShortField(String name) {
+        return new EphemeralShortFieldMapper.Builder(name);
+    }
+    public static EphemeralIntegerFieldMapper.Builder ephemeralIntegerField(String name) {
+        return new EphemeralIntegerFieldMapper.Builder(name);
+    }
+    public static EphemeralLongFieldMapper.Builder ephemeralLongField(String name) {
+        return new EphemeralLongFieldMapper.Builder(name);
+    }
+    public static EphemeralFloatFieldMapper.Builder ephemeralFloatField(String name) {
+        return new EphemeralFloatFieldMapper.Builder(name);
+    }
+    public static EphemeralDoubleFieldMapper.Builder ephemeralDoubleField(String name) {
+        return new EphemeralDoubleFieldMapper.Builder(name);
+    }
+    public static EphemeralBooleanFieldMapper.Builder ephemeralBooleanField(String name) {
+        return new EphemeralBooleanFieldMapper.Builder(name);
+    }
+    public static EphemeralDateFieldMapper.Builder ephemeralDateField(String name) {
+        return new EphemeralDateFieldMapper.Builder(name);
+    }
+    public static EphemeralIpFieldMapper.Builder ephemeralIpField(String name) {
+        return new EphemeralIpFieldMapper.Builder(name);
+    }
+    public static EphemeralStringFieldMapper.Builder ephemeralStringField(String name) {
+        return new EphemeralStringFieldMapper.Builder(name);
+    }
+
+    public static Mapper.Builder getEphemeralBuilder(String typeName, String fieldName) {
+        if (EphemeralByteFieldMapper.CONTENT_TYPE.equals(typeName)) {
+            return new EphemeralByteFieldMapper.Builder(fieldName);
+        }
+        if (EphemeralShortFieldMapper.CONTENT_TYPE.equals(typeName)) {
+            return new EphemeralShortFieldMapper.Builder(fieldName);
+        }
+        if (EphemeralIntegerFieldMapper.CONTENT_TYPE.equals(typeName)) {
+            return new EphemeralIntegerFieldMapper.Builder(fieldName);
+        }
+        if (EphemeralLongFieldMapper.CONTENT_TYPE.equals(typeName)) {
+            return new EphemeralLongFieldMapper.Builder(fieldName);
+        }
+        if (EphemeralFloatFieldMapper.CONTENT_TYPE.equals(typeName)) {
+            return new EphemeralFloatFieldMapper.Builder(fieldName);
+        }
+        if (EphemeralDoubleFieldMapper.CONTENT_TYPE.equals(typeName)) {
+            return new EphemeralDoubleFieldMapper.Builder(fieldName);
+        }
+        if (EphemeralBooleanFieldMapper.CONTENT_TYPE.equals(typeName)) {
+            return new EphemeralBooleanFieldMapper.Builder(fieldName);
+        }
+        if (EphemeralDateFieldMapper.CONTENT_TYPE.equals(typeName)) {
+            return new EphemeralDateFieldMapper.Builder(fieldName);
+        }
+        if (EphemeralIpFieldMapper.CONTENT_TYPE.equals(typeName)) {
+            return new EphemeralIpFieldMapper.Builder(fieldName);
+        }
+        if (EphemeralStringFieldMapper.CONTENT_TYPE.equals(typeName)) {
+            return new EphemeralStringFieldMapper.Builder(fieldName);
+        }
+        
+        return null;
+    }
+    //
+    // Added by Loggly - END
+
 }

--- a/src/main/java/org/elasticsearch/index/mapper/core/AbstractFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/AbstractFieldMapper.java
@@ -695,6 +695,16 @@ public abstract class AbstractFieldMapper<T> implements FieldMapper<T> {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        // Added by Loggly - START
+        // If this is an ephemeral field, then do nothing. This effectively makes
+        // this field invisible, which means it will never be passed to the master
+        //
+        if (this.isEphemeral()) {
+            return builder;
+        }
+        //
+        // Added by Loggly - END
+
         builder.startObject(names.name());
         boolean includeDefaults = params.paramAsBoolean("include_defaults", false);
         doXContentBody(builder, includeDefaults, params);
@@ -1041,7 +1051,12 @@ public abstract class AbstractFieldMapper<T> implements FieldMapper<T> {
                 });
                 builder.startObject("fields");
                 for (Mapper mapper : sortedMappers) {
-                    mapper.toXContent(builder, params);
+                    // Changed by Loggly - START
+                    // Only add non-ephemeral mappers
+                    if (!mapper.isEphemeral()) {
+                        mapper.toXContent(builder, params);
+                    }
+                    // Changed by Loggly - END
                 }
                 builder.endObject();
             }
@@ -1183,5 +1198,16 @@ public abstract class AbstractFieldMapper<T> implements FieldMapper<T> {
     public boolean isGenerated() {
         return false;
     }
+
+    // Added by Loggly - START
+    //
+    // default behavior is that fields are NOT ephemeral
+    
+    @Override
+    public boolean isEphemeral() {
+        return false;
+    }
+    
+    // Added by Loggly - END
 
 }

--- a/src/main/java/org/elasticsearch/index/mapper/core/EphemeralBooleanFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/EphemeralBooleanFieldMapper.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper.core;
+
+import org.apache.lucene.document.FieldType;
+import org.elasticsearch.ElasticsearchIllegalArgumentException;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.codec.docvaluesformat.DocValuesFormatProvider;
+import org.elasticsearch.index.codec.postingsformat.PostingsFormatProvider;
+import org.elasticsearch.index.mapper.Mapper;
+import org.elasticsearch.index.mapper.MapperParsingException;
+import org.elasticsearch.index.similarity.SimilarityProvider;
+
+import java.util.Map;
+
+import static org.elasticsearch.common.xcontent.support.XContentMapValues.nodeBooleanValue;
+import static org.elasticsearch.index.mapper.MapperBuilders.ephemeralBooleanField;
+import static org.elasticsearch.index.mapper.core.TypeParsers.parseField;
+
+/**
+ *
+ */
+// TODO this can be made better, maybe storing a byte for it?
+public class EphemeralBooleanFieldMapper extends BooleanFieldMapper {
+
+    public static final String CONTENT_TYPE = "ephemeral_boolean";
+
+    public static class Builder extends AbstractFieldMapper.Builder<Builder, EphemeralBooleanFieldMapper> {
+
+        private Boolean nullValue = Defaults.NULL_VALUE;
+
+        public Builder(String name) {
+            super(name, new FieldType(Defaults.FIELD_TYPE));
+            this.builder = this;
+        }
+
+        public Builder nullValue(boolean nullValue) {
+            this.nullValue = nullValue;
+            return this;
+        }
+
+        @Override
+        public Builder tokenized(boolean tokenized) {
+            if (tokenized) {
+                throw new ElasticsearchIllegalArgumentException("bool field can't be tokenized");
+            }
+            return super.tokenized(tokenized);
+        }
+
+        @Override
+        public EphemeralBooleanFieldMapper build(BuilderContext context) {
+            return new EphemeralBooleanFieldMapper(buildNames(context), boost, fieldType, nullValue, postingsProvider, 
+                    docValuesProvider, similarity, normsLoading, fieldDataSettings, context.indexSettings(), multiFieldsBuilder.build(this, context), copyTo);
+        }
+    }
+
+    public static class TypeParser implements Mapper.TypeParser {
+        @Override
+        public Mapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
+            EphemeralBooleanFieldMapper.Builder builder = ephemeralBooleanField(name);
+            parseField(builder, name, node, parserContext);
+            for (Map.Entry<String, Object> entry : node.entrySet()) {
+                String propName = Strings.toUnderscoreCase(entry.getKey());
+                Object propNode = entry.getValue();
+                if (propName.equals("null_value")) {
+                    if (propNode == null) {
+                        throw new MapperParsingException("Property [null_value] cannot be null.");
+                    }
+                    builder.nullValue(nodeBooleanValue(propNode));
+                }
+            }
+            return builder;
+        }
+    }
+
+    protected EphemeralBooleanFieldMapper(Names names, float boost, FieldType fieldType, Boolean nullValue, PostingsFormatProvider postingsProvider,
+                                 DocValuesFormatProvider docValuesProvider, SimilarityProvider similarity, Loading normsLoading,
+                                 @Nullable Settings fieldDataSettings, Settings indexSettings, MultiFields multiFields, CopyTo copyTo) {
+        super(names, boost, fieldType, nullValue, postingsProvider,
+                docValuesProvider, similarity, normsLoading,
+                fieldDataSettings, indexSettings, multiFields, copyTo);
+    }
+
+    @Override
+    protected String contentType() { return CONTENT_TYPE; }
+
+    @Override
+    public boolean isEphemeral() { return true; }
+}

--- a/src/main/java/org/elasticsearch/index/mapper/core/EphemeralByteFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/EphemeralByteFieldMapper.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.index.mapper.core;
+
+import org.apache.lucene.document.FieldType;
+import org.elasticsearch.common.Explicit;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.codec.docvaluesformat.DocValuesFormatProvider;
+import org.elasticsearch.index.codec.postingsformat.PostingsFormatProvider;
+import org.elasticsearch.index.mapper.Mapper;
+import org.elasticsearch.index.mapper.MapperParsingException;
+import org.elasticsearch.index.similarity.SimilarityProvider;
+
+import java.util.Map;
+
+import static org.elasticsearch.common.xcontent.support.XContentMapValues.nodeByteValue;
+import static org.elasticsearch.index.mapper.MapperBuilders.ephemeralByteField;
+import static org.elasticsearch.index.mapper.core.TypeParsers.parseNumberField;
+
+/**
+ *
+ */
+public class EphemeralByteFieldMapper extends ByteFieldMapper {
+
+    public static final String CONTENT_TYPE = "ephemeral_byte";
+
+    public static class Builder extends NumberFieldMapper.Builder<Builder, EphemeralByteFieldMapper> {
+
+        protected Byte nullValue = Defaults.NULL_VALUE;
+
+        public Builder(String name) {
+            super(name, new FieldType(Defaults.FIELD_TYPE), Defaults.PRECISION_STEP_8_BIT);
+            builder = this;
+        }
+
+        public Builder nullValue(byte nullValue) {
+            this.nullValue = nullValue;
+            return this;
+        }
+
+        @Override
+        public EphemeralByteFieldMapper build(BuilderContext context) {
+            fieldType.setOmitNorms(fieldType.omitNorms() && boost == 1.0f);
+            EphemeralByteFieldMapper fieldMapper = new EphemeralByteFieldMapper(buildNames(context),
+                    fieldType.numericPrecisionStep(), boost, fieldType, docValues, nullValue, ignoreMalformed(context),
+                    coerce(context), postingsProvider, docValuesProvider, similarity, normsLoading, 
+                    fieldDataSettings, context.indexSettings(), multiFieldsBuilder.build(this, context), copyTo);
+            fieldMapper.includeInAll(includeInAll);
+            return fieldMapper;
+        }
+    }
+
+    public static class TypeParser implements Mapper.TypeParser {
+        @Override
+        public Mapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
+            EphemeralByteFieldMapper.Builder builder = ephemeralByteField(name);
+            parseNumberField(builder, name, node, parserContext);
+            for (Map.Entry<String, Object> entry : node.entrySet()) {
+                String propName = Strings.toUnderscoreCase(entry.getKey());
+                Object propNode = entry.getValue();
+                if (propName.equals("null_value")) {
+                    if (propNode == null) {
+                        throw new MapperParsingException("Property [null_value] cannot be null.");
+                    }
+                    builder.nullValue(nodeByteValue(propNode));
+                }
+            }
+            return builder;
+        }
+    }
+
+    protected EphemeralByteFieldMapper(Names names, int precisionStep, float boost, FieldType fieldType, Boolean docValues,
+                              Byte nullValue, Explicit<Boolean> ignoreMalformed, Explicit<Boolean> coerce, 
+                              PostingsFormatProvider postingsProvider,
+                              DocValuesFormatProvider docValuesProvider, SimilarityProvider similarity, Loading normsLoading,
+                              @Nullable Settings fieldDataSettings, Settings indexSettings, MultiFields multiFields, CopyTo copyTo) {
+        super(names, precisionStep, boost, fieldType, docValues,
+                nullValue, ignoreMalformed, coerce,
+                postingsProvider,
+                docValuesProvider, similarity, normsLoading,
+                fieldDataSettings, indexSettings, multiFields, copyTo);
+    }
+
+
+    @Override
+    protected String contentType() { return CONTENT_TYPE; }
+
+    @Override
+    public boolean isEphemeral() { return true; }
+}

--- a/src/main/java/org/elasticsearch/index/mapper/core/EphemeralDateFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/EphemeralDateFieldMapper.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper.core;
+
+import org.apache.lucene.document.FieldType;
+import org.elasticsearch.common.Explicit;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.joda.FormatDateTimeFormatter;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.LocaleUtils;
+import org.elasticsearch.index.codec.docvaluesformat.DocValuesFormatProvider;
+import org.elasticsearch.index.codec.postingsformat.PostingsFormatProvider;
+import org.elasticsearch.index.mapper.Mapper;
+import org.elasticsearch.index.mapper.MapperParsingException;
+import org.elasticsearch.index.similarity.SimilarityProvider;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.elasticsearch.index.mapper.MapperBuilders.ephemeralDateField;
+import static org.elasticsearch.index.mapper.core.TypeParsers.parseDateTimeFormatter;
+import static org.elasticsearch.index.mapper.core.TypeParsers.parseNumberField;
+
+/**
+ *
+ */
+public class EphemeralDateFieldMapper extends DateFieldMapper {
+
+    public static final String CONTENT_TYPE = "ephemeral_date";
+
+    public static class Builder extends NumberFieldMapper.Builder<Builder, EphemeralDateFieldMapper> {
+
+        protected TimeUnit timeUnit = Defaults.TIME_UNIT;
+
+        protected String nullValue = Defaults.NULL_VALUE;
+
+        protected FormatDateTimeFormatter dateTimeFormatter = Defaults.DATE_TIME_FORMATTER;
+
+        private Locale locale;
+
+        public Builder(String name) {
+            super(name, new FieldType(Defaults.FIELD_TYPE), Defaults.PRECISION_STEP_64_BIT);
+            builder = this;
+            // do *NOT* rely on the default locale
+            locale = Locale.ROOT;
+        }
+
+        public Builder timeUnit(TimeUnit timeUnit) {
+            this.timeUnit = timeUnit;
+            return this;
+        }
+
+        public Builder nullValue(String nullValue) {
+            this.nullValue = nullValue;
+            return this;
+        }
+
+        public Builder dateTimeFormatter(FormatDateTimeFormatter dateTimeFormatter) {
+            this.dateTimeFormatter = dateTimeFormatter;
+            return this;
+        }
+
+        @Override
+        public EphemeralDateFieldMapper build(BuilderContext context) {
+            fieldType.setOmitNorms(fieldType.omitNorms() && boost == 1.0f);
+            if (!locale.equals(dateTimeFormatter.locale())) {
+                dateTimeFormatter = new FormatDateTimeFormatter(dateTimeFormatter.format(), dateTimeFormatter.parser(), dateTimeFormatter.printer(), locale);
+            }
+            EphemeralDateFieldMapper fieldMapper = new EphemeralDateFieldMapper(buildNames(context), dateTimeFormatter,
+                    fieldType.numericPrecisionStep(), boost, fieldType, docValues, nullValue, timeUnit, ignoreMalformed(context), coerce(context),
+                    postingsProvider, docValuesProvider, similarity, normsLoading, fieldDataSettings, context.indexSettings(),
+                    multiFieldsBuilder.build(this, context), copyTo);
+            fieldMapper.includeInAll(includeInAll);
+            return fieldMapper;
+        }
+
+        public Builder locale(Locale locale) {
+            this.locale = locale;
+            return this;
+        }
+    }
+
+    public static class TypeParser implements Mapper.TypeParser {
+        @Override
+        public Mapper.Builder<?, ?> parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
+            EphemeralDateFieldMapper.Builder builder = ephemeralDateField(name);
+            parseNumberField(builder, name, node, parserContext);
+            for (Map.Entry<String, Object> entry : node.entrySet()) {
+                String propName = Strings.toUnderscoreCase(entry.getKey());
+                Object propNode = entry.getValue();
+                if (propName.equals("null_value")) {
+                    if (propNode == null) {
+                        throw new MapperParsingException("Property [null_value] cannot be null.");
+                    }
+                    builder.nullValue(propNode.toString());
+                } else if (propName.equals("format")) {
+                    builder.dateTimeFormatter(parseDateTimeFormatter(propNode));
+                } else if (propName.equals("numeric_resolution")) {
+                    builder.timeUnit(TimeUnit.valueOf(propNode.toString().toUpperCase(Locale.ROOT)));
+                } else if (propName.equals("locale")) {
+                    builder.locale(LocaleUtils.parse(propNode.toString()));
+                }
+            }
+            return builder;
+        }
+    }
+
+    protected EphemeralDateFieldMapper(Names names, FormatDateTimeFormatter dateTimeFormatter, int precisionStep, float boost, FieldType fieldType, Boolean docValues,
+            String nullValue, TimeUnit timeUnit, Explicit<Boolean> ignoreMalformed,Explicit<Boolean> coerce,
+            PostingsFormatProvider postingsProvider, DocValuesFormatProvider docValuesProvider, SimilarityProvider similarity,
+            Loading normsLoading, @Nullable Settings fieldDataSettings, Settings indexSettings, MultiFields multiFields, CopyTo copyTo) {
+        super(names, dateTimeFormatter, precisionStep, boost, fieldType, docValues,
+                nullValue, timeUnit, ignoreMalformed, coerce,
+                postingsProvider, docValuesProvider, similarity,
+                normsLoading, fieldDataSettings, indexSettings, multiFields, copyTo);
+    }
+
+    @Override
+    protected String contentType() { return CONTENT_TYPE; }
+
+    @Override
+    public boolean isEphemeral() { return true; }
+}

--- a/src/main/java/org/elasticsearch/index/mapper/core/EphemeralDoubleFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/EphemeralDoubleFieldMapper.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper.core;
+
+import org.apache.lucene.document.FieldType;
+import org.elasticsearch.common.Explicit;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.codec.docvaluesformat.DocValuesFormatProvider;
+import org.elasticsearch.index.codec.postingsformat.PostingsFormatProvider;
+import org.elasticsearch.index.mapper.Mapper;
+import org.elasticsearch.index.mapper.MapperParsingException;
+import org.elasticsearch.index.similarity.SimilarityProvider;
+
+import java.util.Map;
+
+import static org.elasticsearch.common.xcontent.support.XContentMapValues.nodeDoubleValue;
+import static org.elasticsearch.index.mapper.MapperBuilders.ephemeralDoubleField;
+import static org.elasticsearch.index.mapper.core.TypeParsers.parseNumberField;
+
+/**
+ *
+ */
+public class EphemeralDoubleFieldMapper extends DoubleFieldMapper {
+
+    public static final String CONTENT_TYPE = "ephemeral_double";
+
+   
+
+    public static class Builder extends NumberFieldMapper.Builder<Builder, EphemeralDoubleFieldMapper> {
+
+        protected Double nullValue = Defaults.NULL_VALUE;
+
+        public Builder(String name) {
+            super(name, new FieldType(Defaults.FIELD_TYPE), Defaults.PRECISION_STEP_64_BIT);
+            builder = this;
+        }
+
+        public Builder nullValue(double nullValue) {
+            this.nullValue = nullValue;
+            return this;
+        }
+
+        @Override
+        public EphemeralDoubleFieldMapper build(BuilderContext context) {
+            fieldType.setOmitNorms(fieldType.omitNorms() && boost == 1.0f);
+            EphemeralDoubleFieldMapper fieldMapper = new EphemeralDoubleFieldMapper(buildNames(context),
+                    fieldType.numericPrecisionStep(), boost, fieldType, docValues, nullValue, ignoreMalformed(context), coerce(context), postingsProvider, 
+                    docValuesProvider, similarity, normsLoading, fieldDataSettings, context.indexSettings(), multiFieldsBuilder.build(this, context), copyTo);
+            fieldMapper.includeInAll(includeInAll);
+            return fieldMapper;
+        }
+    }
+
+    public static class TypeParser implements Mapper.TypeParser {
+        @Override
+        public Mapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
+            EphemeralDoubleFieldMapper.Builder builder = ephemeralDoubleField(name);
+            parseNumberField(builder, name, node, parserContext);
+            for (Map.Entry<String, Object> entry : node.entrySet()) {
+                String propName = entry.getKey();
+                Object propNode = entry.getValue();
+                if (propName.equals("nullValue") || propName.equals("null_value")) {
+                    if (propNode == null) {
+                        throw new MapperParsingException("Property [null_value] cannot be null.");
+                    }
+                    builder.nullValue(nodeDoubleValue(propNode));
+                }
+            }
+            return builder;
+        }
+    }
+
+    protected EphemeralDoubleFieldMapper(Names names, int precisionStep, float boost, FieldType fieldType, Boolean docValues,
+                                Double nullValue, Explicit<Boolean> ignoreMalformed,  Explicit<Boolean> coerce,
+                                PostingsFormatProvider postingsProvider, DocValuesFormatProvider docValuesProvider,
+                                SimilarityProvider similarity, Loading normsLoading, @Nullable Settings fieldDataSettings, 
+                                Settings indexSettings, MultiFields multiFields, CopyTo copyTo) {
+        super(names, precisionStep, boost, fieldType, docValues,
+                nullValue, ignoreMalformed, coerce,
+                postingsProvider,
+                docValuesProvider, similarity, normsLoading,
+                fieldDataSettings, indexSettings, multiFields, copyTo);
+    }
+
+
+    @Override
+    protected String contentType() { return CONTENT_TYPE; }
+
+    @Override
+    public boolean isEphemeral() { return true; }
+}

--- a/src/main/java/org/elasticsearch/index/mapper/core/EphemeralFloatFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/EphemeralFloatFieldMapper.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper.core;
+
+import org.apache.lucene.document.FieldType;
+import org.elasticsearch.common.Explicit;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.codec.docvaluesformat.DocValuesFormatProvider;
+import org.elasticsearch.index.codec.postingsformat.PostingsFormatProvider;
+import org.elasticsearch.index.mapper.Mapper;
+import org.elasticsearch.index.mapper.MapperParsingException;
+import org.elasticsearch.index.similarity.SimilarityProvider;
+
+import java.util.Map;
+
+import static org.elasticsearch.common.xcontent.support.XContentMapValues.nodeFloatValue;
+import static org.elasticsearch.index.mapper.MapperBuilders.ephemeralFloatField;
+import static org.elasticsearch.index.mapper.core.TypeParsers.parseNumberField;
+
+/**
+ *
+ */
+public class EphemeralFloatFieldMapper extends FloatFieldMapper {
+
+    public static final String CONTENT_TYPE = "ephemeral_float";
+
+    public static class Builder extends NumberFieldMapper.Builder<Builder, EphemeralFloatFieldMapper> {
+
+        protected Float nullValue = Defaults.NULL_VALUE;
+
+        public Builder(String name) {
+            super(name, new FieldType(Defaults.FIELD_TYPE), Defaults.PRECISION_STEP_32_BIT);
+            builder = this;
+        }
+
+        public Builder nullValue(float nullValue) {
+            this.nullValue = nullValue;
+            return this;
+        }
+
+        @Override
+        public EphemeralFloatFieldMapper build(BuilderContext context) {
+            fieldType.setOmitNorms(fieldType.omitNorms() && boost == 1.0f);
+            EphemeralFloatFieldMapper fieldMapper = new EphemeralFloatFieldMapper(buildNames(context),
+                    fieldType.numericPrecisionStep(), boost, fieldType, docValues, nullValue, ignoreMalformed(context), coerce(context), postingsProvider, 
+                    docValuesProvider, similarity, normsLoading, fieldDataSettings, context.indexSettings(), multiFieldsBuilder.build(this, context), copyTo);
+            fieldMapper.includeInAll(includeInAll);
+            return fieldMapper;
+        }
+    }
+
+    public static class TypeParser implements Mapper.TypeParser {
+        @Override
+        public Mapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
+            EphemeralFloatFieldMapper.Builder builder = ephemeralFloatField(name);
+            parseNumberField(builder, name, node, parserContext);
+            for (Map.Entry<String, Object> entry : node.entrySet()) {
+                String propName = Strings.toUnderscoreCase(entry.getKey());
+                Object propNode = entry.getValue();
+                if (propName.equals("null_value")) {
+                    if (propNode == null) {
+                        throw new MapperParsingException("Property [null_value] cannot be null.");
+                    }
+                    builder.nullValue(nodeFloatValue(propNode));
+                }
+            }
+            return builder;
+        }
+    }
+
+    protected EphemeralFloatFieldMapper(Names names, int precisionStep, float boost, FieldType fieldType, Boolean docValues,
+                               Float nullValue, Explicit<Boolean> ignoreMalformed, Explicit<Boolean> coerce,
+                               PostingsFormatProvider postingsProvider, DocValuesFormatProvider docValuesProvider,
+                               SimilarityProvider similarity, Loading normsLoading, @Nullable Settings fieldDataSettings, 
+                               Settings indexSettings, MultiFields multiFields, CopyTo copyTo) {
+        super(names, precisionStep, boost, fieldType, docValues,
+                nullValue, ignoreMalformed, coerce,
+                postingsProvider, docValuesProvider, 
+                similarity, normsLoading, fieldDataSettings, 
+                indexSettings, multiFields, copyTo);
+    }
+
+
+    @Override
+    protected String contentType() { return CONTENT_TYPE; }
+
+    @Override
+    public boolean isEphemeral() { return true; }
+ 
+}

--- a/src/main/java/org/elasticsearch/index/mapper/core/EphemeralIntegerFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/EphemeralIntegerFieldMapper.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper.core;
+
+import org.apache.lucene.document.FieldType;
+import org.elasticsearch.common.Explicit;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.codec.docvaluesformat.DocValuesFormatProvider;
+import org.elasticsearch.index.codec.postingsformat.PostingsFormatProvider;
+import org.elasticsearch.index.mapper.Mapper;
+import org.elasticsearch.index.mapper.MapperParsingException;
+import org.elasticsearch.index.similarity.SimilarityProvider;
+
+import java.util.Map;
+
+import static org.elasticsearch.common.xcontent.support.XContentMapValues.nodeIntegerValue;
+import static org.elasticsearch.index.mapper.MapperBuilders.ephemeralIntegerField;
+import static org.elasticsearch.index.mapper.core.TypeParsers.parseNumberField;
+
+/**
+ *
+ */
+public class EphemeralIntegerFieldMapper extends IntegerFieldMapper {
+
+    public static final String CONTENT_TYPE = "ephemeral_integer";
+
+    public static class Builder extends NumberFieldMapper.Builder<Builder, EphemeralIntegerFieldMapper> {
+
+        protected Integer nullValue = Defaults.NULL_VALUE;
+
+        public Builder(String name) {
+            super(name, new FieldType(Defaults.FIELD_TYPE), Defaults.PRECISION_STEP_32_BIT);
+            builder = this;
+        }
+
+        public Builder nullValue(int nullValue) {
+            this.nullValue = nullValue;
+            return this;
+        }
+
+        @Override
+        public EphemeralIntegerFieldMapper build(BuilderContext context) {
+            fieldType.setOmitNorms(fieldType.omitNorms() && boost == 1.0f);
+            EphemeralIntegerFieldMapper fieldMapper = new EphemeralIntegerFieldMapper(buildNames(context), fieldType.numericPrecisionStep(), boost, fieldType, docValues,
+                    nullValue, ignoreMalformed(context), coerce(context), postingsProvider, docValuesProvider, similarity, normsLoading, fieldDataSettings, 
+                    context.indexSettings(), multiFieldsBuilder.build(this, context), copyTo);
+            fieldMapper.includeInAll(includeInAll);
+            return fieldMapper;
+        }
+    }
+
+    public static class TypeParser implements Mapper.TypeParser {
+        @Override
+        public Mapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
+            EphemeralIntegerFieldMapper.Builder builder = ephemeralIntegerField(name);
+            parseNumberField(builder, name, node, parserContext);
+            for (Map.Entry<String, Object> entry : node.entrySet()) {
+                String propName = Strings.toUnderscoreCase(entry.getKey());
+                Object propNode = entry.getValue();
+                if (propName.equals("null_value")) {
+                    if (propNode == null) {
+                        throw new MapperParsingException("Property [null_value] cannot be null.");
+                    }
+                    builder.nullValue(nodeIntegerValue(propNode));
+                }
+            }
+            return builder;
+        }
+    }
+
+    
+
+    protected EphemeralIntegerFieldMapper(Names names, int precisionStep, float boost, FieldType fieldType, Boolean docValues,
+                                 Integer nullValue, Explicit<Boolean> ignoreMalformed, Explicit<Boolean> coerce,
+                                 PostingsFormatProvider postingsProvider, DocValuesFormatProvider docValuesProvider,
+                                 SimilarityProvider similarity, Loading normsLoading, @Nullable Settings fieldDataSettings,
+                                 Settings indexSettings, MultiFields multiFields, CopyTo copyTo) {
+        super(names, precisionStep, boost, fieldType, docValues,
+                nullValue, ignoreMalformed, coerce,
+                postingsProvider, docValuesProvider, 
+                similarity, normsLoading, fieldDataSettings, 
+                indexSettings, multiFields, copyTo);
+    }
+
+
+    @Override
+    protected String contentType() { return CONTENT_TYPE; }
+
+    @Override
+    public boolean isEphemeral() { return true; }
+}

--- a/src/main/java/org/elasticsearch/index/mapper/core/EphemeralLongFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/EphemeralLongFieldMapper.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper.core;
+
+import org.apache.lucene.document.FieldType;
+import org.elasticsearch.common.Explicit;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.codec.docvaluesformat.DocValuesFormatProvider;
+import org.elasticsearch.index.codec.postingsformat.PostingsFormatProvider;
+import org.elasticsearch.index.mapper.Mapper;
+import org.elasticsearch.index.mapper.MapperParsingException;
+import org.elasticsearch.index.similarity.SimilarityProvider;
+
+import java.util.Map;
+
+import static org.elasticsearch.common.xcontent.support.XContentMapValues.nodeLongValue;
+import static org.elasticsearch.index.mapper.MapperBuilders.ephemeralLongField;
+import static org.elasticsearch.index.mapper.core.TypeParsers.parseNumberField;
+
+/**
+ *
+ */
+public class EphemeralLongFieldMapper extends LongFieldMapper {
+
+    public static final String CONTENT_TYPE = "ephemeral_long";
+
+    public static class Builder extends NumberFieldMapper.Builder<Builder, EphemeralLongFieldMapper> {
+
+        protected Long nullValue = Defaults.NULL_VALUE;
+
+        public Builder(String name) {
+            super(name, new FieldType(Defaults.FIELD_TYPE), Defaults.PRECISION_STEP_64_BIT);
+            builder = this;
+        }
+
+        public Builder nullValue(long nullValue) {
+            this.nullValue = nullValue;
+            return this;
+        }
+
+        @Override
+        public EphemeralLongFieldMapper build(BuilderContext context) {
+            fieldType.setOmitNorms(fieldType.omitNorms() && boost == 1.0f);
+            EphemeralLongFieldMapper fieldMapper = new EphemeralLongFieldMapper(buildNames(context), fieldType.numericPrecisionStep(), boost, fieldType, docValues, nullValue,
+                    ignoreMalformed(context), coerce(context), postingsProvider, docValuesProvider, similarity, normsLoading, 
+                    fieldDataSettings, context.indexSettings(), multiFieldsBuilder.build(this, context), copyTo);
+            fieldMapper.includeInAll(includeInAll);
+            return fieldMapper;
+        }
+    }
+
+    public static class TypeParser implements Mapper.TypeParser {
+        @Override
+        public Mapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
+            EphemeralLongFieldMapper.Builder builder = ephemeralLongField(name);
+            parseNumberField(builder, name, node, parserContext);
+            for (Map.Entry<String, Object> entry : node.entrySet()) {
+                String propName = Strings.toUnderscoreCase(entry.getKey());
+                Object propNode = entry.getValue();
+                if (propName.equals("null_value")) {
+                    if (propNode == null) {
+                        throw new MapperParsingException("Property [null_value] cannot be null.");
+                    }
+                    builder.nullValue(nodeLongValue(propNode));
+                }
+            }
+            return builder;
+        }
+    }
+
+    protected EphemeralLongFieldMapper(Names names, int precisionStep, float boost, FieldType fieldType, Boolean docValues,
+                              Long nullValue, Explicit<Boolean> ignoreMalformed, Explicit<Boolean> coerce,
+                              PostingsFormatProvider postingsProvider, DocValuesFormatProvider docValuesProvider,
+                              SimilarityProvider similarity, Loading normsLoading, @Nullable Settings fieldDataSettings, 
+                              Settings indexSettings, MultiFields multiFields, CopyTo copyTo) {
+        super(names, precisionStep, boost, fieldType, docValues,
+                nullValue, ignoreMalformed, coerce,
+                postingsProvider, docValuesProvider, 
+                similarity, normsLoading, fieldDataSettings, 
+                indexSettings, multiFields, copyTo);
+    }
+
+
+    @Override
+    protected String contentType() { return CONTENT_TYPE; }
+
+    @Override
+    public boolean isEphemeral() { return true; }
+ 
+}

--- a/src/main/java/org/elasticsearch/index/mapper/core/EphemeralShortFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/EphemeralShortFieldMapper.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper.core;
+
+import org.apache.lucene.document.FieldType;
+import org.elasticsearch.common.Explicit;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.codec.docvaluesformat.DocValuesFormatProvider;
+import org.elasticsearch.index.codec.postingsformat.PostingsFormatProvider;
+import org.elasticsearch.index.mapper.Mapper;
+import org.elasticsearch.index.mapper.MapperParsingException;
+import org.elasticsearch.index.similarity.SimilarityProvider;
+
+import java.util.Map;
+
+import static org.elasticsearch.common.xcontent.support.XContentMapValues.nodeShortValue;
+import static org.elasticsearch.index.mapper.MapperBuilders.ephemeralShortField;
+import static org.elasticsearch.index.mapper.core.TypeParsers.parseNumberField;
+
+/**
+ *
+ */
+public class EphemeralShortFieldMapper extends ShortFieldMapper {
+
+    public static final String CONTENT_TYPE = "ephemeral_short";
+
+    public static class Builder extends NumberFieldMapper.Builder<Builder, EphemeralShortFieldMapper> {
+
+        protected Short nullValue = Defaults.NULL_VALUE;
+
+        public Builder(String name) {
+            super(name, new FieldType(Defaults.FIELD_TYPE), DEFAULT_PRECISION_STEP);
+            builder = this;
+        }
+
+        public Builder nullValue(short nullValue) {
+            this.nullValue = nullValue;
+            return this;
+        }
+
+        @Override
+        public EphemeralShortFieldMapper build(BuilderContext context) {
+            fieldType.setOmitNorms(fieldType.omitNorms() && boost == 1.0f);
+            EphemeralShortFieldMapper fieldMapper = new EphemeralShortFieldMapper(buildNames(context), fieldType.numericPrecisionStep(), boost, fieldType, docValues, nullValue,
+                    ignoreMalformed(context), coerce(context),postingsProvider, docValuesProvider, similarity, normsLoading, fieldDataSettings, 
+                    context.indexSettings(), multiFieldsBuilder.build(this, context), copyTo);
+            fieldMapper.includeInAll(includeInAll);
+            return fieldMapper;
+        }
+    }
+
+    public static class TypeParser implements Mapper.TypeParser {
+        @Override
+        public Mapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
+            EphemeralShortFieldMapper.Builder builder = ephemeralShortField(name);
+            parseNumberField(builder, name, node, parserContext);
+            for (Map.Entry<String, Object> entry : node.entrySet()) {
+                String propName = Strings.toUnderscoreCase(entry.getKey());
+                Object propNode = entry.getValue();
+                if (propName.equals("null_value")) {
+                    if (propNode == null) {
+                        throw new MapperParsingException("Property [null_value] cannot be null.");
+                    }
+                    builder.nullValue(nodeShortValue(propNode));
+                }
+            }
+            return builder;
+        }
+    }
+
+    protected EphemeralShortFieldMapper(Names names, int precisionStep, float boost, FieldType fieldType, Boolean docValues,
+                               Short nullValue, Explicit<Boolean> ignoreMalformed, Explicit<Boolean> coerce,
+                               PostingsFormatProvider postingsProvider, DocValuesFormatProvider docValuesProvider,
+                               SimilarityProvider similarity, Loading normsLoading, @Nullable Settings fieldDataSettings, 
+                               Settings indexSettings, MultiFields multiFields, CopyTo copyTo) {
+        super(names, precisionStep, boost, fieldType, docValues,
+                nullValue, ignoreMalformed, coerce,
+                postingsProvider, docValuesProvider, 
+                similarity, normsLoading, fieldDataSettings, 
+                indexSettings, multiFields, copyTo);
+    }
+
+
+    @Override
+    protected String contentType() {
+        return CONTENT_TYPE;
+    }
+
+    @Override
+    public boolean isEphemeral() {
+        return true; 
+    }
+ 
+}

--- a/src/main/java/org/elasticsearch/index/mapper/core/EphemeralStringFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/EphemeralStringFieldMapper.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper.core;
+
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.index.IndexOptions;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.support.XContentMapValues;
+import org.elasticsearch.index.analysis.NamedAnalyzer;
+import org.elasticsearch.index.codec.docvaluesformat.DocValuesFormatProvider;
+import org.elasticsearch.index.codec.postingsformat.PostingsFormatProvider;
+import org.elasticsearch.index.mapper.Mapper;
+import org.elasticsearch.index.mapper.MapperParsingException;
+import org.elasticsearch.index.similarity.SimilarityProvider;
+
+import java.util.Map;
+
+import static org.elasticsearch.index.mapper.MapperBuilders.ephemeralStringField;
+import static org.elasticsearch.index.mapper.core.TypeParsers.parseField;
+import static org.elasticsearch.index.mapper.core.TypeParsers.parseMultiField;
+
+/**
+ * This class extends StringFieldMapper only to the extent that it makes it into an auto field
+ * 
+ * However, in order to do this, we MUST have local copies of the Builder and TypeParser
+ * with all references to the parent class modified appropriately.
+ * - NO OTHER CHANGES ARE REQUIRED IN THESE LOCAL COPIES
+ * 
+ */
+public class EphemeralStringFieldMapper extends StringFieldMapper {
+    
+    public static final String CONTENT_TYPE = "ephemeral_string";
+
+
+    
+    public static class Builder extends AbstractFieldMapper.Builder<Builder, EphemeralStringFieldMapper> {
+
+        protected String nullValue = Defaults.NULL_VALUE;
+
+        protected int positionOffsetGap = Defaults.POSITION_OFFSET_GAP;
+
+        protected NamedAnalyzer searchQuotedAnalyzer;
+
+        protected int ignoreAbove = Defaults.IGNORE_ABOVE;
+
+        public Builder(String name) {
+            super(name, new FieldType(Defaults.FIELD_TYPE));
+            builder = this;
+        }
+
+        public Builder nullValue(String nullValue) {
+            this.nullValue = nullValue;
+            return this;
+        }
+
+        @Override
+        public Builder searchAnalyzer(NamedAnalyzer searchAnalyzer) {
+            super.searchAnalyzer(searchAnalyzer);
+            if (searchQuotedAnalyzer == null) {
+                searchQuotedAnalyzer = searchAnalyzer;
+            }
+            return this;
+        }
+
+        public Builder positionOffsetGap(int positionOffsetGap) {
+            this.positionOffsetGap = positionOffsetGap;
+            return this;
+        }
+
+        public Builder searchQuotedAnalyzer(NamedAnalyzer analyzer) {
+            this.searchQuotedAnalyzer = analyzer;
+            return builder;
+        }
+
+        public Builder ignoreAbove(int ignoreAbove) {
+            this.ignoreAbove = ignoreAbove;
+            return this;
+        }
+
+        @Override
+        public EphemeralStringFieldMapper build(BuilderContext context) {
+            if (positionOffsetGap > 0) {
+                indexAnalyzer = new NamedAnalyzer(indexAnalyzer, positionOffsetGap);
+                searchAnalyzer = new NamedAnalyzer(searchAnalyzer, positionOffsetGap);
+                searchQuotedAnalyzer = new NamedAnalyzer(searchQuotedAnalyzer, positionOffsetGap);
+            }
+            // if the field is not analyzed, then by default, we should omit norms and have docs only
+            // index options, as probably what the user really wants
+            // if they are set explicitly, we will use those values
+            // we also change the values on the default field type so that toXContent emits what
+            // differs from the defaults
+            FieldType defaultFieldType = new FieldType(Defaults.FIELD_TYPE);
+            if (fieldType.indexOptions() != IndexOptions.NONE && !fieldType.tokenized()) {
+                defaultFieldType.setOmitNorms(true);
+                defaultFieldType.setIndexOptions(IndexOptions.DOCS);
+                if (!omitNormsSet && boost == Defaults.BOOST) {
+                    fieldType.setOmitNorms(true);
+                }
+                if (!indexOptionsSet) {
+                    fieldType.setIndexOptions(IndexOptions.DOCS);
+                }
+            }
+            defaultFieldType.freeze();
+            EphemeralStringFieldMapper fieldMapper = new EphemeralStringFieldMapper(buildNames(context),
+                    boost, fieldType, defaultFieldType, docValues, nullValue, indexAnalyzer, searchAnalyzer, searchQuotedAnalyzer,
+                    positionOffsetGap, ignoreAbove, postingsProvider, docValuesProvider, similarity, normsLoading, 
+                    fieldDataSettings, context.indexSettings(), multiFieldsBuilder.build(this, context), copyTo);
+            fieldMapper.includeInAll(includeInAll);
+            return fieldMapper;
+        }
+    }
+    
+    public static class TypeParser implements Mapper.TypeParser {
+        @Override
+        public Mapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
+            EphemeralStringFieldMapper.Builder builder = ephemeralStringField(name);
+            parseField(builder, name, node, parserContext);
+            for (Map.Entry<String, Object> entry : node.entrySet()) {
+                String propName = Strings.toUnderscoreCase(entry.getKey());
+                Object propNode = entry.getValue();
+                if (propName.equals("null_value")) {
+                    if (propNode == null) {
+                        throw new MapperParsingException("Property [null_value] cannot be null.");
+                    }
+                    builder.nullValue(propNode.toString());
+                } else if (propName.equals("search_quote_analyzer")) {
+                    NamedAnalyzer analyzer = parserContext.analysisService().analyzer(propNode.toString());
+                    if (analyzer == null) {
+                        throw new MapperParsingException("Analyzer [" + propNode.toString() + "] not found for field [" + name + "]");
+                    }
+                    builder.searchQuotedAnalyzer(analyzer);
+                } else if (propName.equals("position_offset_gap")) {
+                    builder.positionOffsetGap(XContentMapValues.nodeIntegerValue(propNode, -1));
+                    // we need to update to actual analyzers if they are not set in this case...
+                    // so we can inject the position offset gap...
+                    if (builder.indexAnalyzer == null) {
+                        builder.indexAnalyzer = parserContext.analysisService().defaultIndexAnalyzer();
+                    }
+                    if (builder.searchAnalyzer == null) {
+                        builder.searchAnalyzer = parserContext.analysisService().defaultSearchAnalyzer();
+                    }
+                    if (builder.searchQuotedAnalyzer == null) {
+                        builder.searchQuotedAnalyzer = parserContext.analysisService().defaultSearchQuoteAnalyzer();
+                    }
+                } else if (propName.equals("ignore_above")) {
+                    builder.ignoreAbove(XContentMapValues.nodeIntegerValue(propNode, -1));
+                } else {
+                    parseMultiField(builder, name, parserContext, propName, propNode);
+                }
+            }
+            return builder;
+        }
+    }
+    
+    // Just pass all the work to super
+    protected EphemeralStringFieldMapper(org.elasticsearch.index.mapper.FieldMapper.Names names, float boost, FieldType fieldType,
+            FieldType defaultFieldType, Boolean docValues, String nullValue, NamedAnalyzer indexAnalyzer, NamedAnalyzer searchAnalyzer,
+            NamedAnalyzer searchQuotedAnalyzer, int positionOffsetGap, int ignoreAbove, PostingsFormatProvider postingsFormat,
+            DocValuesFormatProvider docValuesFormat, SimilarityProvider similarity,
+            org.elasticsearch.index.mapper.FieldMapper.Loading normsLoading, Settings fieldDataSettings, Settings indexSettings,
+            org.elasticsearch.index.mapper.core.AbstractFieldMapper.MultiFields multiFields,
+            org.elasticsearch.index.mapper.core.AbstractFieldMapper.CopyTo copyTo) {
+        super(names, boost, fieldType, defaultFieldType, docValues, nullValue, indexAnalyzer, searchAnalyzer, searchQuotedAnalyzer,
+                positionOffsetGap, ignoreAbove, postingsFormat, docValuesFormat, similarity, normsLoading, fieldDataSettings, indexSettings,
+                multiFields, copyTo);
+    }
+
+    @Override
+    protected String contentType() { return CONTENT_TYPE; }
+
+    @Override
+    public boolean isEphemeral() { return true; }
+}

--- a/src/main/java/org/elasticsearch/index/mapper/internal/AnalyzerMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/AnalyzerMapper.java
@@ -186,4 +186,13 @@ public class AnalyzerMapper implements Mapper, InternalMapper, RootMapper {
     public void close() {
 
     }
+
+    // Added by Loggly - START
+    
+    @Override
+    public boolean isEphemeral() {
+        return false;
+    }
+
+    // Added by Loggly - END
 }

--- a/src/main/java/org/elasticsearch/index/mapper/ip/EphemeralIpFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/ip/EphemeralIpFieldMapper.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper.ip;
+
+import org.apache.lucene.document.FieldType;
+import org.elasticsearch.common.Explicit;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.codec.docvaluesformat.DocValuesFormatProvider;
+import org.elasticsearch.index.codec.postingsformat.PostingsFormatProvider;
+import org.elasticsearch.index.mapper.Mapper;
+import org.elasticsearch.index.mapper.MapperParsingException;
+import org.elasticsearch.index.mapper.core.NumberFieldMapper;
+import org.elasticsearch.index.similarity.SimilarityProvider;
+
+import java.util.Map;
+
+import static org.elasticsearch.index.mapper.MapperBuilders.ephemeralIpField;
+import static org.elasticsearch.index.mapper.core.TypeParsers.parseNumberField;
+
+/**
+ *
+ */
+public class EphemeralIpFieldMapper extends IpFieldMapper {
+
+    public static final String CONTENT_TYPE = "ephemeral_ip";
+
+    public static class Builder extends NumberFieldMapper.Builder<Builder, EphemeralIpFieldMapper> {
+
+        protected String nullValue = Defaults.NULL_VALUE;
+
+        public Builder(String name) {
+            super(name, new FieldType(Defaults.FIELD_TYPE), Defaults.PRECISION_STEP_64_BIT);
+            builder = this;
+        }
+
+        public Builder nullValue(String nullValue) {
+            this.nullValue = nullValue;
+            return this;
+        }
+
+        @Override
+        public EphemeralIpFieldMapper build(BuilderContext context) {
+            fieldType.setOmitNorms(fieldType.omitNorms() && boost == 1.0f);
+            EphemeralIpFieldMapper fieldMapper = new EphemeralIpFieldMapper(buildNames(context),
+                    fieldType.numericPrecisionStep(), boost, fieldType, docValues, nullValue, ignoreMalformed(context), coerce(context),
+                    postingsProvider, docValuesProvider, similarity,
+                    normsLoading, fieldDataSettings, context.indexSettings(), multiFieldsBuilder.build(this, context), copyTo);
+            fieldMapper.includeInAll(includeInAll);
+            return fieldMapper;
+        }
+    }
+
+    public static class TypeParser implements Mapper.TypeParser {
+        @Override
+        public Mapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
+            EphemeralIpFieldMapper.Builder builder = ephemeralIpField(name);
+            parseNumberField(builder, name, node, parserContext);
+            for (Map.Entry<String, Object> entry : node.entrySet()) {
+                String propName = Strings.toUnderscoreCase(entry.getKey());
+                Object propNode = entry.getValue();
+                if (propName.equals("null_value")) {
+                    if (propNode == null) {
+                        throw new MapperParsingException("Property [null_value] cannot be null.");
+                    }
+                    builder.nullValue(propNode.toString());
+                }
+            }
+            return builder;
+        }
+    }
+
+
+    protected EphemeralIpFieldMapper(Names names, int precisionStep, float boost, FieldType fieldType, Boolean docValues,
+                            String nullValue, Explicit<Boolean> ignoreMalformed, Explicit<Boolean> coerce,
+                            PostingsFormatProvider postingsProvider, DocValuesFormatProvider docValuesProvider,
+                            SimilarityProvider similarity, Loading normsLoading, @Nullable Settings fieldDataSettings, 
+                            Settings indexSettings, MultiFields multiFields, CopyTo copyTo) {
+        super(names, precisionStep, boost, fieldType, docValues,
+                nullValue, ignoreMalformed, coerce, 
+                postingsProvider, docValuesProvider,
+                similarity, normsLoading, fieldDataSettings,
+                indexSettings, multiFields, copyTo);
+    }
+
+
+
+    @Override
+    public boolean isEphemeral() {
+        return true;
+    }
+}

--- a/src/test/java/org/elasticsearch/index/mapper/externalvalues/ExternalRootMapper.java
+++ b/src/test/java/org/elasticsearch/index/mapper/externalvalues/ExternalRootMapper.java
@@ -80,6 +80,13 @@ public class ExternalRootMapper implements RootMapper {
         return false;
     }
 
+    // Added by Loggly - START
+    @Override
+    public boolean isEphemeral() {
+        return false;
+    }
+    // Added by Loggly - END
+
     public static class Builder extends Mapper.Builder<Builder, ExternalRootMapper> {
 
         protected Builder() {


### PR DESCRIPTION
We have a large number of unique fields in our indices, which means
our cluster state is very large (>500MB). This size causes some
cluster level operations within ES to run more slowly than we'd like.

This change adds support for ephemeral fields, which

1) behave exactly like normal fields during indexing,
2) behave differently during search (a new Mapper is created on-demand
    if required) 
3) are invisible when rendering cluster state (solving our problem)

The basic idea is to add a new method to the Mapper interface
(isEphemeral())  then use this to control both the visibility of the
node in the cluster state tree, and the impact of adding such a node
to that tree.

In the first case (visibility), ephemeral nodes do not support
toXContent(). This effectively removes them from the serialized
cluster state string. In the case of nested fields, if all nodes under
a particular root are ephemeral, then that entire sub-tree become
invisible.  However, the structure is visible if any child node is not
ephemeral. For example, if we have a field named a.b.c.d and it is
ephemeral and there are no other non-ephemeral fields under a, then no
part of that tree/path is visible. If we now add a field named a.b.f
and it is not ephemeral, then that field will be visible, including
the path to it. I.e we will serialize a, b, and f. Note that in this
case we still don't serialize c or d. By making ephemeral fields
"invisible" we reduce the size of the cluster state, and therefore
reduce or remove some of the issues we've seen in out cluster

In the second case (impact), adding an ephemeral node does not mark
the context as modified. This is an optimisation that reduces the
number of updates to the cluster state, since even if the context was
marked as modified when the field was added, the serialized form of
the tree would be identical to its previous (pre-addition) form due to
the field being invisible. In a scenario where we are adding a large
number of fields quickly, this optimization is important because it
eliminates "NO-OP" updates to the cluster state.

In order to support this functionality, we've added Ephemeral
subclasses of each of the standard field types, which seemed like the
lowest impact change to the code base.  These new classes extend the
existing classes, but because of the way the Builder and TypeParser
classes are designed, we had to cut'n'paste these internal classes
from the base classes and make a few minor changes to reflect their
new parent classes. This does add maintenance overhead which could be
avoided by making the core classes natively support ephemerality, but
since we were not sure how viable this approach was, we chose minimal
impact on the code base over maintenance for this pull request.

Because these new field types are treated as peers of the current core
field types, we can use the existing field definition mechanisms to
define them in our config file.  Most usefully to us, this means that
we can define templates using prefix or suffix matching on the field
names to use these new fields. For example, we can use the following
to define any field with an _INT suffix

  "mappings" : {
    "data" : {
      "dynamic_templates" : [
         { "template_INT" : { "match" : "*_INT", "mapping" : { "type" : "ephemeral_integer" } } }
         ...

Also note that because they are sub-classes of the core classes, we
can use all of the standard modifiers for analyzer chain etc when
defining these fields.

The two main issues that we're aware of are:

1) Because we create a new field on demand when servicing a search
request, and do not try and inject that into the local context for the
index, there would (a) be additional  GC activity to clean up these
short-lived objects, and (b) additional overhead on each  search
request that uses ephemeral fields.

2) Because ephemeral fields are added to the context while indexing
but never removed there is concern that over time the indexing nodes
will be using a significant amount of heap for these fields. More
troubling is that this heap usage will not correspond with the
reported cluster state size. We're looking at a solution whereby we
could scrub  fields from the cluster state using a REST request
(specifying a root node in the tree), but need more thinking on this.
