### PR TITLE
Nested sorting: only use random access bitset for parent

### DIFF
--- a/src/main/java/org/elasticsearch/index/fielddata/IndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/IndexFieldData.java
@@ -129,9 +129,11 @@ public interface IndexFieldData<FD extends AtomicFieldData> extends IndexCompone
          * parent + 1, or 0 if there is no previous parent, and R (excluded).
          */
         public static class Nested {
-            private final FixedBitSetFilter rootFilter, innerFilter;
 
-            public Nested(FixedBitSetFilter rootFilter, FixedBitSetFilter innerFilter) {
+            private final FixedBitSetFilter rootFilter;
+            private final Filter innerFilter;
+
+            public Nested(FixedBitSetFilter rootFilter, Filter innerFilter) {
                 this.rootFilter = rootFilter;
                 this.innerFilter = innerFilter;
             }
@@ -146,7 +148,7 @@ public interface IndexFieldData<FD extends AtomicFieldData> extends IndexCompone
             /**
              * Get a {@link FixedBitSet} that matches the inner documents.
              */
-            public FixedBitSet innerDocs(AtomicReaderContext ctx) throws IOException {
+            public DocIdSet innerDocs(AtomicReaderContext ctx) throws IOException {
                 return innerFilter.getDocIdSet(ctx, null);
             }
         }

--- a/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/BytesRefFieldComparatorSource.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/BytesRefFieldComparatorSource.java
@@ -23,6 +23,7 @@ import org.apache.lucene.index.AtomicReaderContext;
 import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.RandomAccessOrds;
 import org.apache.lucene.index.SortedDocValues;
+import org.apache.lucene.search.DocIdSet;
 import org.apache.lucene.search.FieldComparator;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.SortField;
@@ -81,7 +82,7 @@ public class BytesRefFieldComparatorSource extends IndexFieldData.XFieldComparat
                         selectedValues = sortMode.select(values);
                     } else {
                         final FixedBitSet rootDocs = nested.rootDocs(context);
-                        final FixedBitSet innerDocs = nested.innerDocs(context);
+                        final DocIdSet innerDocs = nested.innerDocs(context);
                         selectedValues = sortMode.select(values, rootDocs, innerDocs);
                     }
                     if (sortMissingFirst(missingValue) || sortMissingLast(missingValue)) {
@@ -132,7 +133,7 @@ public class BytesRefFieldComparatorSource extends IndexFieldData.XFieldComparat
                     selectedValues = sortMode.select(values, nonNullMissingBytes);
                 } else {
                     final FixedBitSet rootDocs = nested.rootDocs(context);
-                    final FixedBitSet innerDocs = nested.innerDocs(context);
+                    final DocIdSet innerDocs = nested.innerDocs(context);
                     selectedValues = sortMode.select(values, nonNullMissingBytes, rootDocs, innerDocs, context.reader().maxDoc());
                 }
                 return selectedValues;

--- a/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/DoubleValuesComparatorSource.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/DoubleValuesComparatorSource.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.fielddata.fieldcomparator;
 
 import org.apache.lucene.index.AtomicReaderContext;
+import org.apache.lucene.search.DocIdSet;
 import org.apache.lucene.search.FieldCache.Doubles;
 import org.apache.lucene.search.FieldComparator;
 import org.apache.lucene.search.Scorer;
@@ -78,7 +79,7 @@ public class DoubleValuesComparatorSource extends IndexFieldData.XFieldComparato
                     selectedValues = sortMode.select(values, dMissingValue);
                 } else {
                     final FixedBitSet rootDocs = nested.rootDocs(context);
-                    final FixedBitSet innerDocs = nested.innerDocs(context);
+                    final DocIdSet innerDocs = nested.innerDocs(context);
                     selectedValues = sortMode.select(values, dMissingValue, rootDocs, innerDocs, context.reader().maxDoc());
                 }
                 return new Doubles() {

--- a/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/FloatValuesComparatorSource.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/FloatValuesComparatorSource.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.index.fielddata.fieldcomparator;
 
 import org.apache.lucene.index.AtomicReaderContext;
+import org.apache.lucene.search.DocIdSet;
 import org.apache.lucene.search.FieldCache.Floats;
 import org.apache.lucene.search.FieldComparator;
 import org.apache.lucene.search.SortField;
@@ -70,7 +71,7 @@ public class FloatValuesComparatorSource extends IndexFieldData.XFieldComparator
                     selectedValues = sortMode.select(values, dMissingValue);
                 } else {
                     final FixedBitSet rootDocs = nested.rootDocs(context);
-                    final FixedBitSet innerDocs = nested.innerDocs(context);
+                    final DocIdSet  innerDocs = nested.innerDocs(context);
                     selectedValues = sortMode.select(values, dMissingValue, rootDocs, innerDocs, context.reader().maxDoc());
                 }
                 return new Floats() {

--- a/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/LongValuesComparatorSource.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/LongValuesComparatorSource.java
@@ -21,6 +21,7 @@ package org.elasticsearch.index.fielddata.fieldcomparator;
 import org.apache.lucene.index.AtomicReaderContext;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.search.DocIdSet;
 import org.apache.lucene.search.FieldCache.Longs;
 import org.apache.lucene.search.FieldComparator;
 import org.apache.lucene.search.SortField;
@@ -70,7 +71,7 @@ public class LongValuesComparatorSource extends IndexFieldData.XFieldComparatorS
                     selectedValues = sortMode.select(values, dMissingValue);
                 } else {
                     final FixedBitSet rootDocs = nested.rootDocs(context);
-                    final FixedBitSet innerDocs = nested.innerDocs(context);
+                    final DocIdSet innerDocs = nested.innerDocs(context);
                     selectedValues = sortMode.select(values, dMissingValue, rootDocs, innerDocs, context.reader().maxDoc());
                 }
                 return new Longs() {

--- a/src/main/java/org/elasticsearch/percolator/PercolateContext.java
+++ b/src/main/java/org/elasticsearch/percolator/PercolateContext.java
@@ -112,6 +112,7 @@ public class PercolateContext extends SearchContext {
     private SearchContextAggregations aggregations;
     private QuerySearchResult querySearchResult;
     private Sort sort;
+    private boolean executeDocsInOrder;
 
     public PercolateContext(PercolateShardRequest request, SearchShardTarget searchShardTarget, IndexShard indexShard,
                             IndexService indexService, CacheRecycler cacheRecycler, PageCacheRecycler pageCacheRecycler,
@@ -719,5 +720,15 @@ public class PercolateContext extends SearchContext {
     @Override
     public Counter timeEstimateCounter() {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean requireDocsCollectedInOrder() {
+        return executeDocsInOrder;
+    }
+
+    @Override
+    public void setRequireDocsCollectedInOrder(boolean docsInOrder) {
+        this.executeDocsInOrder = docsInOrder;
     }
 }

--- a/src/main/java/org/elasticsearch/percolator/PercolateContext.java
+++ b/src/main/java/org/elasticsearch/percolator/PercolateContext.java
@@ -728,7 +728,7 @@ public class PercolateContext extends SearchContext {
     }
 
     @Override
-    public void setRequireDocsCollectedInOrder(boolean docsInOrder) {
-        this.executeDocsInOrder = docsInOrder;
+    public void setRequireDocsCollectedInOrder() {
+        this.executeDocsInOrder = true;
     }
 }

--- a/src/main/java/org/elasticsearch/search/MultiValueMode.java
+++ b/src/main/java/org/elasticsearch/search/MultiValueMode.java
@@ -21,6 +21,8 @@
 package org.elasticsearch.search;
 
 import org.apache.lucene.index.*;
+import org.apache.lucene.search.DocIdSet;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
@@ -31,6 +33,7 @@ import org.elasticsearch.index.fielddata.NumericDoubleValues;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 
+import java.io.IOException;
 import java.util.Locale;
 
 /**
@@ -438,11 +441,19 @@ public enum MultiValueMode {
      *
      * NOTE: Calling the returned instance on docs that are not root docs is illegal
      */
-    public NumericDocValues select(final SortedNumericDocValues values, final long missingValue, final FixedBitSet rootDocs, final FixedBitSet innerDocs, int maxDoc) {
-        if (rootDocs == null || innerDocs == null) {
+    public NumericDocValues select(final SortedNumericDocValues values, final long missingValue, final FixedBitSet rootDocs, DocIdSet innerDocSet, int maxDoc) throws IOException {
+        if (rootDocs == null || innerDocSet == null) {
             return select(DocValues.emptySortedNumeric(maxDoc), missingValue);
         }
+        final DocIdSetIterator innerDocs = innerDocSet.iterator();
+        if (innerDocs == null) {
+            return select(DocValues.emptySortedNumeric(maxDoc), missingValue);
+        }
+
         return new NumericDocValues() {
+
+            int lastSeenRootDoc = -1;
+            long lastEmittedValue;
 
             @Override
             public long get(int rootDoc) {
@@ -451,25 +462,33 @@ public enum MultiValueMode {
                     return missingValue;
                 }
 
-                final int prevRootDoc = rootDocs.prevSetBit(rootDoc - 1);
-                final int firstNestedDoc = innerDocs.nextSetBit(prevRootDoc + 1);
-
-                long accumulated = startLong();
-                int numValues = 0;
-
-                for (int doc = firstNestedDoc; doc != -1 && doc < rootDoc; doc = innerDocs.nextSetBit(doc + 1)) {
-                    values.setDocument(doc);
-                    final int count = values.count();
-                    for (int i = 0; i < count; ++i) {
-                        final long value = values.valueAt(i);
-                        accumulated = apply(accumulated, value);
-                    }
-                    numValues += count;
+                // If via compareBottom this method has previously invoked for the same rootDoc then we need to use the
+                // last seen value as innerDocs can't re-iterate over nested child docs it already emitted,
+                // because DocIdSetIterator can only advance forwards.
+                if (rootDoc == lastSeenRootDoc) {
+                    return lastEmittedValue;
                 }
+                try {
+                    final int prevRootDoc = rootDocs.prevSetBit(rootDoc - 1);
+                    final int firstNestedDoc = innerDocs.advance(prevRootDoc + 1);
 
-                return numValues == 0
-                        ? missingValue
-                        : reduce(accumulated, numValues);
+                    long accumulated = startLong();
+                    int numValues = 0;
+
+                    for (int doc = firstNestedDoc; doc > prevRootDoc && doc < rootDoc; doc = innerDocs.advance(doc + 1)) {
+                        values.setDocument(doc);
+                        final int count = values.count();
+                        for (int i = 0; i < count; ++i) {
+                            final long value = values.valueAt(i);
+                            accumulated = apply(accumulated, value);
+                        }
+                        numValues += count;
+                    }
+                    lastSeenRootDoc = rootDoc;
+                    return lastEmittedValue = numValues == 0 ? missingValue : reduce(accumulated, numValues);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
             }
         };
     }
@@ -530,11 +549,20 @@ public enum MultiValueMode {
      *
      * NOTE: Calling the returned instance on docs that are not root docs is illegal
      */
-    public NumericDoubleValues select(final SortedNumericDoubleValues values, final double missingValue, final FixedBitSet rootDocs, final FixedBitSet innerDocs, int maxDoc) {
-        if (rootDocs == null || innerDocs == null) {
+    public NumericDoubleValues select(final SortedNumericDoubleValues values, final double missingValue, final FixedBitSet rootDocs, DocIdSet innerDocSet, int maxDoc) throws IOException {
+        if (rootDocs == null || innerDocSet == null) {
             return select(FieldData.emptySortedNumericDoubles(maxDoc), missingValue);
         }
+
+        final DocIdSetIterator innerDocs = innerDocSet.iterator();
+        if (innerDocs == null) {
+            return select(FieldData.emptySortedNumericDoubles(maxDoc), missingValue);
+        }
+
         return new NumericDoubleValues() {
+
+            int lastSeenRootDoc = -1;
+            double lastEmittedValue;
 
             @Override
             public double get(int rootDoc) {
@@ -543,25 +571,31 @@ public enum MultiValueMode {
                     return missingValue;
                 }
 
-                final int prevRootDoc = rootDocs.prevSetBit(rootDoc - 1);
-                final int firstNestedDoc = innerDocs.nextSetBit(prevRootDoc + 1);
-
-                double accumulated = startDouble();
-                int numValues = 0;
-
-                for (int doc = firstNestedDoc; doc != -1 && doc < rootDoc; doc = innerDocs.nextSetBit(doc + 1)) {
-                    values.setDocument(doc);
-                    final int count = values.count();
-                    for (int i = 0; i < count; ++i) {
-                        final double value = values.valueAt(i);
-                        accumulated = apply(accumulated, value);
-                    }
-                    numValues += count;
+                if (rootDoc == lastSeenRootDoc) {
+                    return lastEmittedValue;
                 }
+                try {
+                    final int prevRootDoc = rootDocs.prevSetBit(rootDoc - 1);
+                    final int firstNestedDoc = innerDocs.advance(prevRootDoc + 1);
 
-                return numValues == 0
-                        ? missingValue
-                        : reduce(accumulated, numValues);
+                    double accumulated = startDouble();
+                    int numValues = 0;
+
+                    for (int doc = firstNestedDoc; doc > prevRootDoc && doc < rootDoc; doc = innerDocs.advance(doc + 1)) {
+                        values.setDocument(doc);
+                        final int count = values.count();
+                        for (int i = 0; i < count; ++i) {
+                            final double value = values.valueAt(i);
+                            accumulated = apply(accumulated, value);
+                        }
+                        numValues += count;
+                    }
+
+                    lastSeenRootDoc = rootDoc;
+                    return lastEmittedValue = numValues == 0 ? missingValue : reduce(accumulated, numValues);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
             }
         };
     }
@@ -613,10 +647,16 @@ public enum MultiValueMode {
      *
      * NOTE: Calling the returned instance on docs that are not root docs is illegal
      */
-    public BinaryDocValues select(final SortedBinaryDocValues values, final BytesRef missingValue, final FixedBitSet rootDocs, final FixedBitSet innerDocs, int maxDoc) {
-        if (rootDocs == null || innerDocs == null) {
+    public BinaryDocValues select(final SortedBinaryDocValues values, final BytesRef missingValue, final FixedBitSet rootDocs, DocIdSet innerDocSet, int maxDoc) throws IOException {
+        if (rootDocs == null || innerDocSet == null) {
             return select(FieldData.emptySortedBinary(maxDoc), missingValue);
         }
+
+        final DocIdSetIterator innerDocs = innerDocSet.iterator();
+        if (innerDocs == null) {
+            return select(FieldData.emptySortedBinary(maxDoc), missingValue);
+        }
+
         final BinaryDocValues selectedValues = select(values, new BytesRef());
         final Bits docsWithValue;
         if (FieldData.unwrapSingleton(values) != null) {
@@ -628,6 +668,9 @@ public enum MultiValueMode {
 
             final BytesRefBuilder spare = new BytesRefBuilder();
 
+            int lastSeenRootDoc = -1;
+            BytesRef lastEmittedValue;
+
             @Override
             public BytesRef get(int rootDoc) {
                 assert rootDocs.get(rootDoc) : "can only sort root documents";
@@ -635,28 +678,37 @@ public enum MultiValueMode {
                     return missingValue;
                 }
 
-                final int prevRootDoc = rootDocs.prevSetBit(rootDoc - 1);
-                final int firstNestedDoc = innerDocs.nextSetBit(prevRootDoc + 1);
+                if (rootDoc == lastSeenRootDoc) {
+                    return lastEmittedValue;
+                }
 
-                BytesRefBuilder accumulated = null;
+                try {
+                    final int prevRootDoc = rootDocs.prevSetBit(rootDoc - 1);
+                    final int firstNestedDoc = innerDocs.advance(prevRootDoc + 1);
 
-                for (int doc = firstNestedDoc; doc != -1 && doc < rootDoc; doc = innerDocs.nextSetBit(doc + 1)) {
-                    values.setDocument(doc);
-                    final BytesRef innerValue = selectedValues.get(doc);
-                    if (innerValue.length > 0 || docsWithValue == null || docsWithValue.get(doc)) {
-                        if (accumulated == null) {
-                            spare.copyBytes(innerValue);
-                            accumulated = spare;
-                        } else {
-                            final BytesRef applied = apply(accumulated.get(), innerValue);
-                            if (applied == innerValue) {
-                                accumulated.copyBytes(innerValue);
+                    BytesRefBuilder accumulated = null;
+
+                    for (int doc = firstNestedDoc; doc > prevRootDoc && doc < rootDoc; doc = innerDocs.advance(doc + 1)) {
+                        values.setDocument(doc);
+                        final BytesRef innerValue = selectedValues.get(doc);
+                        if (innerValue.length > 0 || docsWithValue == null || docsWithValue.get(doc)) {
+                            if (accumulated == null) {
+                                spare.copyBytes(innerValue);
+                                accumulated = spare;
+                            } else {
+                                final BytesRef applied = apply(accumulated.get(), innerValue);
+                                if (applied == innerValue) {
+                                    accumulated.copyBytes(innerValue);
+                                }
                             }
                         }
                     }
-                }
 
-                return accumulated == null ? missingValue : accumulated.get();
+                    lastSeenRootDoc = rootDoc;
+                    return lastEmittedValue = accumulated == null ? missingValue : accumulated.get();
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
             }
         };
     }
@@ -706,12 +758,21 @@ public enum MultiValueMode {
      *
      * NOTE: Calling the returned instance on docs that are not root docs is illegal
      */
-    public SortedDocValues select(final RandomAccessOrds values, final FixedBitSet rootDocs, final FixedBitSet innerDocs) {
-        if (rootDocs == null || innerDocs == null) {
-            return select((RandomAccessOrds) DocValues.emptySortedSet());
+    public SortedDocValues select(final RandomAccessOrds values, final FixedBitSet rootDocs, DocIdSet innerDocSet) throws IOException {
+        if (rootDocs == null || innerDocSet == null) {
+            return select(DocValues.emptySortedSet());
         }
+
+        final DocIdSetIterator innerDocs = innerDocSet.iterator();
+        if (innerDocs == null) {
+            return select(DocValues.emptySortedSet());
+        }
+
         final SortedDocValues selectedValues = select(values);
         return new SortedDocValues() {
+
+            int lastSeenRootDoc = -1;
+            int lastEmittedOrd;
 
             @Override
             public BytesRef lookupOrd(int ord) {
@@ -730,22 +791,31 @@ public enum MultiValueMode {
                     return -1;
                 }
 
-                final int prevRootDoc = rootDocs.prevSetBit(rootDoc - 1);
-                final int firstNestedDoc = innerDocs.nextSetBit(prevRootDoc + 1);
-                int ord = -1;
-
-                for (int doc = firstNestedDoc; doc != -1 && doc < rootDoc; doc = innerDocs.nextSetBit(doc + 1)) {
-                    final int innerOrd = selectedValues.getOrd(doc);
-                    if (innerOrd != -1) {
-                        if (ord == -1) {
-                            ord = innerOrd;
-                        } else {
-                            ord = applyOrd(ord, innerOrd);
-                        }
-                    }
+                if (rootDoc == lastSeenRootDoc) {
+                    return lastEmittedOrd;
                 }
 
-                return ord;
+                try {
+                    final int prevRootDoc = rootDocs.prevSetBit(rootDoc - 1);
+                    final int firstNestedDoc = innerDocs.advance(prevRootDoc + 1);
+                    int ord = -1;
+
+                    for (int doc = firstNestedDoc; doc > prevRootDoc && doc < rootDoc; doc = innerDocs.advance(doc + 1)) {
+                        final int innerOrd = selectedValues.getOrd(doc);
+                        if (innerOrd != -1) {
+                            if (ord == -1) {
+                                ord = innerOrd;
+                            } else {
+                                ord = applyOrd(ord, innerOrd);
+                            }
+                        }
+                    }
+
+                    lastSeenRootDoc = rootDoc;
+                    return lastEmittedOrd = ord;
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
             }
         };
     }

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/TopHitsContext.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/TopHitsContext.java
@@ -638,4 +638,14 @@ public class TopHitsContext extends SearchContext {
     public Counter timeEstimateCounter() {
         throw new UnsupportedOperationException("Not supported");
     }
+
+    @Override
+    public boolean requireDocsCollectedInOrder() {
+        return context.requireDocsCollectedInOrder();
+    }
+
+    @Override
+    public void setRequireDocsCollectedInOrder(boolean docsInOrder) {
+        throw new UnsupportedOperationException("Not supported");
+    }
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/TopHitsContext.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/TopHitsContext.java
@@ -645,7 +645,7 @@ public class TopHitsContext extends SearchContext {
     }
 
     @Override
-    public void setRequireDocsCollectedInOrder(boolean docsInOrder) {
+    public void setRequireDocsCollectedInOrder() {
         throw new UnsupportedOperationException("Not supported");
     }
 }

--- a/src/main/java/org/elasticsearch/search/internal/DefaultSearchContext.java
+++ b/src/main/java/org/elasticsearch/search/internal/DefaultSearchContext.java
@@ -185,6 +185,8 @@ public class DefaultSearchContext extends SearchContext {
 
     private volatile boolean useSlowScroll;
 
+    private boolean executeDocsInOrder;
+
     public DefaultSearchContext(long id, ShardSearchRequest request, SearchShardTarget shardTarget,
                          Engine.Searcher engineSearcher, IndexService indexService, IndexShard indexShard,
                          ScriptService scriptService, CacheRecycler cacheRecycler, PageCacheRecycler pageCacheRecycler,
@@ -737,5 +739,15 @@ public class DefaultSearchContext extends SearchContext {
     @Override
     public Counter timeEstimateCounter() {
         return timeEstimateCounter;
+    }
+
+    @Override
+    public boolean requireDocsCollectedInOrder() {
+        return executeDocsInOrder;
+    }
+
+    @Override
+    public void setRequireDocsCollectedInOrder(boolean docsInOrder) {
+        this.executeDocsInOrder = docsInOrder;
     }
 }

--- a/src/main/java/org/elasticsearch/search/internal/DefaultSearchContext.java
+++ b/src/main/java/org/elasticsearch/search/internal/DefaultSearchContext.java
@@ -747,7 +747,7 @@ public class DefaultSearchContext extends SearchContext {
     }
 
     @Override
-    public void setRequireDocsCollectedInOrder(boolean docsInOrder) {
-        this.executeDocsInOrder = docsInOrder;
+    public void setRequireDocsCollectedInOrder() {
+        this.executeDocsInOrder = true;
     }
 }

--- a/src/main/java/org/elasticsearch/search/internal/SearchContext.java
+++ b/src/main/java/org/elasticsearch/search/internal/SearchContext.java
@@ -368,6 +368,10 @@ public abstract class SearchContext implements Releasable {
 
     public abstract Counter timeEstimateCounter();
 
+    public abstract boolean requireDocsCollectedInOrder();
+
+    public abstract void setRequireDocsCollectedInOrder(boolean docsInOrder);
+
     /**
      * The life time of an object that is used during search execution.
      */

--- a/src/main/java/org/elasticsearch/search/internal/SearchContext.java
+++ b/src/main/java/org/elasticsearch/search/internal/SearchContext.java
@@ -370,7 +370,7 @@ public abstract class SearchContext implements Releasable {
 
     public abstract boolean requireDocsCollectedInOrder();
 
-    public abstract void setRequireDocsCollectedInOrder(boolean docsInOrder);
+    public abstract void setRequireDocsCollectedInOrder();
 
     /**
      * The life time of an object that is used during search execution.

--- a/src/main/java/org/elasticsearch/search/sort/ScriptSortParser.java
+++ b/src/main/java/org/elasticsearch/search/sort/ScriptSortParser.java
@@ -138,11 +138,11 @@ public class ScriptSortParser implements SortParser {
             }
 
             FixedBitSetFilter rootDocumentsFilter = context.fixedBitSetFilterCache().getFixedBitSetFilter(NonNestedDocsFilter.INSTANCE);
-            FixedBitSetFilter innerDocumentsFilter;
+            Filter innerDocumentsFilter;
             if (nestedFilter != null) {
-                innerDocumentsFilter = context.fixedBitSetFilterCache().getFixedBitSetFilter(nestedFilter);
+                innerDocumentsFilter = context.filterCache().cache(nestedFilter);
             } else {
-                innerDocumentsFilter = context.fixedBitSetFilterCache().getFixedBitSetFilter(objectMapper.nestedTypeFilter());
+                innerDocumentsFilter = context.filterCache().cache(objectMapper.nestedTypeFilter());
             }
             nested = new Nested(rootDocumentsFilter, innerDocumentsFilter);
         } else {

--- a/src/main/java/org/elasticsearch/search/sort/SortParseElement.java
+++ b/src/main/java/org/elasticsearch/search/sort/SortParseElement.java
@@ -248,7 +248,7 @@ public class SortParseElement implements SearchParseElement {
             }
             final Nested nested;
             if (objectMapper != null && objectMapper.nested().isNested()) {
-                context.setRequireDocsCollectedInOrder(true);
+                context.setRequireDocsCollectedInOrder();
                 FixedBitSetFilter rootDocumentsFilter = context.fixedBitSetFilterCache().getFixedBitSetFilter(NonNestedDocsFilter.INSTANCE);
                 Filter innerDocumentsFilter;
                 if (nestedFilter != null) {

--- a/src/main/java/org/elasticsearch/search/sort/SortParseElement.java
+++ b/src/main/java/org/elasticsearch/search/sort/SortParseElement.java
@@ -248,12 +248,13 @@ public class SortParseElement implements SearchParseElement {
             }
             final Nested nested;
             if (objectMapper != null && objectMapper.nested().isNested()) {
+                context.setRequireDocsCollectedInOrder(true);
                 FixedBitSetFilter rootDocumentsFilter = context.fixedBitSetFilterCache().getFixedBitSetFilter(NonNestedDocsFilter.INSTANCE);
-                FixedBitSetFilter innerDocumentsFilter;
+                Filter innerDocumentsFilter;
                 if (nestedFilter != null) {
-                    innerDocumentsFilter = context.fixedBitSetFilterCache().getFixedBitSetFilter(nestedFilter);
+                    innerDocumentsFilter = context.filterCache().cache(nestedFilter);
                 } else {
-                    innerDocumentsFilter = context.fixedBitSetFilterCache().getFixedBitSetFilter(objectMapper.nestedTypeFilter());
+                    innerDocumentsFilter = context.filterCache().cache(objectMapper.nestedTypeFilter());
                 }
                 nested = new Nested(rootDocumentsFilter, innerDocumentsFilter);
             } else {

--- a/src/test/java/org/elasticsearch/search/MultiValueModeTests.java
+++ b/src/test/java/org/elasticsearch/search/MultiValueModeTests.java
@@ -21,6 +21,8 @@ package org.elasticsearch.search;
 
 import com.carrotsearch.randomizedtesting.generators.RandomStrings;
 import org.apache.lucene.index.*;
+import org.apache.lucene.search.DocIdSet;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.FixedBitSet;
 import org.elasticsearch.index.fielddata.FieldData;
@@ -29,6 +31,7 @@ import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 import org.elasticsearch.test.ElasticsearchTestCase;
 
+import java.io.IOException;
 import java.util.Arrays;
 
 public class MultiValueModeTests extends ElasticsearchTestCase {
@@ -55,7 +58,7 @@ public class MultiValueModeTests extends ElasticsearchTestCase {
         return innerDocs;
     }
 
-    public void testSingleValuedLongs() {
+    public void testSingleValuedLongs() throws Exception {
         final int numDocs = scaledRandomIntBetween(1, 100);
         final long[] array = new long[numDocs];
         final FixedBitSet docsWithValue = randomBoolean() ? null : new FixedBitSet(numDocs);
@@ -82,7 +85,7 @@ public class MultiValueModeTests extends ElasticsearchTestCase {
         verify(multiValues, numDocs, rootDocs, innerDocs);
     }
 
-    public void testMultiValuedLongs() {
+    public void testMultiValuedLongs() throws Exception  {
         final int numDocs = scaledRandomIntBetween(1, 100);
         final long[][] array = new long[numDocs][];
         for (int i = 0; i < numDocs; ++i) {
@@ -142,20 +145,24 @@ public class MultiValueModeTests extends ElasticsearchTestCase {
         }
     }
 
-    private void verify(SortedNumericDocValues values, int maxDoc, FixedBitSet rootDocs, FixedBitSet innerDocs) {
+    private void verify(SortedNumericDocValues values, int maxDoc, FixedBitSet rootDocs, DocIdSet innerDocSet) throws IOException {
         for (long missingValue : new long[] { 0, randomLong() }) {
             for (MultiValueMode mode : MultiValueMode.values()) {
-                final NumericDocValues selected = mode.select(values, missingValue, rootDocs, innerDocs, maxDoc);
+                final NumericDocValues selected = mode.select(values, missingValue, rootDocs, innerDocSet, maxDoc);
                 int prevRoot = -1;
                 for (int root = rootDocs.nextSetBit(0); root != -1; root = root + 1 < maxDoc ? rootDocs.nextSetBit(root + 1) : -1) {
                     final long actual = selected.get(root);
                     long expected = mode.startLong();
                     int numValues = 0;
-                    for (int child = innerDocs.nextSetBit(prevRoot + 1); child != -1 && child < root; child = innerDocs.nextSetBit(child + 1)) {
-                        values.setDocument(child);
-                        for (int j = 0; j < values.count(); ++j) {
-                            expected = mode.apply(expected, values.valueAt(j));
-                            ++numValues;
+
+                    DocIdSetIterator innerDocs = innerDocSet.iterator();
+                    if (innerDocs != null) {
+                        for (int child = innerDocs.advance(prevRoot + 1); child != -1 && child < root; child = innerDocs.advance(child + 1)) {
+                            values.setDocument(child);
+                            for (int j = 0; j < values.count(); ++j) {
+                                expected = mode.apply(expected, values.valueAt(j));
+                                ++numValues;
+                            }
                         }
                     }
                     if (numValues == 0) {
@@ -172,7 +179,7 @@ public class MultiValueModeTests extends ElasticsearchTestCase {
         }
     }
 
-    public void testSingleValuedDoubles() {
+    public void testSingleValuedDoubles() throws Exception  {
         final int numDocs = scaledRandomIntBetween(1, 100);
         final double[] array = new double[numDocs];
         final FixedBitSet docsWithValue = randomBoolean() ? null : new FixedBitSet(numDocs);
@@ -199,7 +206,7 @@ public class MultiValueModeTests extends ElasticsearchTestCase {
         verify(multiValues, numDocs, rootDocs, innerDocs);
     }
 
-    public void testMultiValuedDoubles() {
+    public void testMultiValuedDoubles() throws Exception  {
         final int numDocs = scaledRandomIntBetween(1, 100);
         final double[][] array = new double[numDocs][];
         for (int i = 0; i < numDocs; ++i) {
@@ -259,7 +266,7 @@ public class MultiValueModeTests extends ElasticsearchTestCase {
         }
     }
 
-    private void verify(SortedNumericDoubleValues values, int maxDoc, FixedBitSet rootDocs, FixedBitSet innerDocs) {
+    private void verify(SortedNumericDoubleValues values, int maxDoc, FixedBitSet rootDocs, FixedBitSet innerDocs) throws IOException {
         for (long missingValue : new long[] { 0, randomLong() }) {
             for (MultiValueMode mode : MultiValueMode.values()) {
                 final NumericDoubleValues selected = mode.select(values, missingValue, rootDocs, innerDocs, maxDoc);
@@ -289,7 +296,7 @@ public class MultiValueModeTests extends ElasticsearchTestCase {
         }
     }
 
-    public void testSingleValuedStrings() {
+    public void testSingleValuedStrings() throws Exception  {
         final int numDocs = scaledRandomIntBetween(1, 100);
         final BytesRef[] array = new BytesRef[numDocs];
         final FixedBitSet docsWithValue = randomBoolean() ? null : new FixedBitSet(numDocs);
@@ -319,7 +326,7 @@ public class MultiValueModeTests extends ElasticsearchTestCase {
         verify(multiValues, numDocs, rootDocs, innerDocs);
     }
 
-    public void testMultiValuedStrings() {
+    public void testMultiValuedStrings() throws Exception  {
         final int numDocs = scaledRandomIntBetween(1, 100);
         final BytesRef[][] array = new BytesRef[numDocs][];
         for (int i = 0; i < numDocs; ++i) {
@@ -384,7 +391,7 @@ public class MultiValueModeTests extends ElasticsearchTestCase {
         }
     }
 
-    private void verify(SortedBinaryDocValues values, int maxDoc, FixedBitSet rootDocs, FixedBitSet innerDocs) {
+    private void verify(SortedBinaryDocValues values, int maxDoc, FixedBitSet rootDocs, FixedBitSet innerDocs) throws IOException {
         for (BytesRef missingValue : new BytesRef[] { new BytesRef(), new BytesRef(RandomStrings.randomAsciiOfLength(getRandom(), 8)) }) {
             for (MultiValueMode mode : new MultiValueMode[] {MultiValueMode.MIN, MultiValueMode.MAX}) {
                 final BinaryDocValues selected = mode.select(values, missingValue, rootDocs, innerDocs, maxDoc);
@@ -416,7 +423,7 @@ public class MultiValueModeTests extends ElasticsearchTestCase {
     }
 
 
-    public void testSingleValuedOrds() {
+    public void testSingleValuedOrds() throws Exception  {
         final int numDocs = scaledRandomIntBetween(1, 100);
         final int[] array = new int[numDocs];
         for (int i = 0; i < array.length; ++i) {
@@ -449,7 +456,7 @@ public class MultiValueModeTests extends ElasticsearchTestCase {
         verify(multiValues, numDocs, rootDocs, innerDocs);
     }
 
-    public void testMultiValuedOrds() {
+    public void testMultiValuedOrds() throws Exception  {
         final int numDocs = scaledRandomIntBetween(1, 100);
         final long[][] array = new long[numDocs][];
         for (int i = 0; i < numDocs; ++i) {
@@ -518,7 +525,7 @@ public class MultiValueModeTests extends ElasticsearchTestCase {
         }
     }
 
-    private void verify(RandomAccessOrds values, int maxDoc, FixedBitSet rootDocs, FixedBitSet innerDocs) {
+    private void verify(RandomAccessOrds values, int maxDoc, FixedBitSet rootDocs, FixedBitSet innerDocs) throws IOException {
         for (MultiValueMode mode : new MultiValueMode[] {MultiValueMode.MIN, MultiValueMode.MAX}) {
             final SortedDocValues selected = mode.select(values, rootDocs, innerDocs);
             int prevRoot = -1;

--- a/src/test/java/org/elasticsearch/test/TestSearchContext.java
+++ b/src/test/java/org/elasticsearch/test/TestSearchContext.java
@@ -636,7 +636,7 @@ public class TestSearchContext extends SearchContext {
     }
 
     @Override
-    public void setRequireDocsCollectedInOrder(boolean docsInOrder) {
+    public void setRequireDocsCollectedInOrder() {
         throw new UnsupportedOperationException();
     }
 }

--- a/src/test/java/org/elasticsearch/test/TestSearchContext.java
+++ b/src/test/java/org/elasticsearch/test/TestSearchContext.java
@@ -629,4 +629,14 @@ public class TestSearchContext extends SearchContext {
     public Counter timeEstimateCounter() {
         throw new UnsupportedOperationException();
     }
+
+    @Override
+    public boolean requireDocsCollectedInOrder() {
+        return false;
+    }
+
+    @Override
+    public void setRequireDocsCollectedInOrder(boolean docsInOrder) {
+        throw new UnsupportedOperationException();
+    }
 }


### PR DESCRIPTION
By executing in docid order the nested sorting doesn't need two random access bitsets, but just one (the parent bitset). In practise for mappings with only single level nested fields this means that only one bitset needs to be put in the bitset cache.

Because FieldComparator can't tell the IndexSearcher to not execute out of order like a Collector, this PR adds a setting the SearchContext that enforces in order docid execution, which the sort parsing enables if it encounters nested sorting. This was the cleanest way I could find in order for nested sorting to not use many bitsets which get cached by the bitset cache.

PR for #8810
