### PR TITLE
Tests: Add upgrade step to static bwc tests

### DIFF
--- a/src/test/java/org/elasticsearch/bwcompat/StaticIndexBackwardCompatibilityTest.java
+++ b/src/test/java/org/elasticsearch/bwcompat/StaticIndexBackwardCompatibilityTest.java
@@ -81,7 +81,7 @@ public class StaticIndexBackwardCompatibilityTest extends ElasticsearchIntegrati
     static NodeInfo nodeInfo(final Client client) {
         final NodesInfoResponse nodeInfos = client.admin().cluster().prepareNodesInfo().get();
         final NodeInfo[] nodes = nodeInfos.getNodes();
-        assertEquals(1, nodes.length);
+        assertTrue(nodes.length > 0);
         return nodes[0];
     }
 }

--- a/src/test/java/org/elasticsearch/rest/action/admin/indices/upgrade/UpgradeTest.java
+++ b/src/test/java/org/elasticsearch/rest/action/admin/indices/upgrade/UpgradeTest.java
@@ -174,7 +174,7 @@ public class UpgradeTest extends ElasticsearchBackwardsCompatIntegrationTest {
         return path;
     }
     
-    static void assertNotUpgraded(HttpRequestBuilder httpClient, String index) throws Exception {
+    public static void assertNotUpgraded(HttpRequestBuilder httpClient, String index) throws Exception {
         for (UpgradeStatus status : getUpgradeStatus(httpClient, upgradePath(index))) {
             assertTrue("index " + status.indexName + " should not be zero sized", status.totalBytes != 0);
             // TODO: it would be better for this to be strictly greater, but sometimes an extra flush
@@ -185,7 +185,7 @@ public class UpgradeTest extends ElasticsearchBackwardsCompatIntegrationTest {
         }
     }
 
-    static void assertUpgraded(HttpRequestBuilder httpClient, String index) throws Exception {
+    public static void assertUpgraded(HttpRequestBuilder httpClient, String index) throws Exception {
         for (UpgradeStatus status : getUpgradeStatus(httpClient, upgradePath(index))) {
             assertTrue("index " + status.indexName + " should not be zero sized", status.totalBytes != 0);
             assertEquals("index " + status.indexName + " should be upgraded",
@@ -233,7 +233,7 @@ public class UpgradeTest extends ElasticsearchBackwardsCompatIntegrationTest {
         }
     }
     
-    static void runUpgrade(HttpRequestBuilder httpClient, String index, String... params) throws Exception {
+    public static void runUpgrade(HttpRequestBuilder httpClient, String index, String... params) throws Exception {
         assert params.length % 2 == 0;
         HttpRequestBuilder builder = httpClient.method("POST").path(upgradePath(index));
         for (int i = 0; i < params.length; i += 2) {


### PR DESCRIPTION
This used to happen just for 0.20 in 1.x, but now this will check upgrade works against all static indexes we have.
