### PR TITLE
Fix equality check of timevalue after serialization

### DIFF
--- a/src/main/java/org/elasticsearch/common/unit/TimeValue.java
+++ b/src/main/java/org/elasticsearch/common/unit/TimeValue.java
@@ -268,6 +268,9 @@ public class TimeValue implements Serializable, Streamable {
         return timeValue;
     }
 
+    /**
+     * serialization converts TimeValue internally to NANOSECONDS
+     */
     @Override
     public void readFrom(StreamInput in) throws IOException {
         duration = in.readLong();
@@ -285,17 +288,12 @@ public class TimeValue implements Serializable, Streamable {
         if (o == null || getClass() != o.getClass()) return false;
 
         TimeValue timeValue = (TimeValue) o;
-
-        if (duration != timeValue.duration) return false;
-        if (timeUnit != timeValue.timeUnit) return false;
-
-        return true;
+        return timeUnit.toNanos(duration) == timeValue.timeUnit.toNanos(timeValue.duration);
     }
 
     @Override
     public int hashCode() {
-        int result = (int) (duration ^ (duration >>> 32));
-        result = 31 * result + (timeUnit != null ? timeUnit.hashCode() : 0);
-        return result;
+        long normalized = timeUnit.toNanos(duration);
+        return (int) (normalized ^ (normalized >>> 32));
     }
 }

--- a/src/test/java/org/elasticsearch/common/unit/TimeValueTests.java
+++ b/src/test/java/org/elasticsearch/common/unit/TimeValueTests.java
@@ -19,13 +19,15 @@
 
 package org.elasticsearch.common.unit;
 
+import org.elasticsearch.common.io.stream.BytesStreamInput;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.joda.time.PeriodType;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.lessThan;
 
@@ -65,5 +67,23 @@ public class TimeValueTests extends ElasticsearchTestCase {
     @Test
     public void testMinusOne() {
         assertThat(new TimeValue(-1).nanos(), lessThan(0l));
+    }
+
+    private void assertEqualityAfterSerialize(TimeValue value) throws IOException {
+        BytesStreamOutput out = new BytesStreamOutput();
+        value.writeTo(out);
+
+        BytesStreamInput in = new BytesStreamInput(out.bytes());
+        TimeValue inValue = TimeValue.readTimeValue(in);
+
+        assertThat(inValue, equalTo(value));
+    }
+
+    @Test
+    public void testSerialize() throws Exception {
+        assertEqualityAfterSerialize(new TimeValue(100, TimeUnit.DAYS));
+        assertEqualityAfterSerialize(new TimeValue(-1));
+        assertEqualityAfterSerialize(new TimeValue(1, TimeUnit.NANOSECONDS));
+
     }
 }


### PR DESCRIPTION
`TimeValue` serialization changes `timeUnit` to `NANOSECONDS` and converts `duration` accordingly.
As `.equals()` and `.hashCode()` blindly compare those properties, equality is not conserved during serialization.
