### PR TITLE
Change behaviour of indices segments api to allow no indices

### DIFF
--- a/rest-api-spec/test/cat.segments/10_basic.yaml
+++ b/rest-api-spec/test/cat.segments/10_basic.yaml
@@ -47,7 +47,7 @@
         refresh: true
   - do:
        cluster.health:
-         wait_for_status: yellow
+         wait_for_status: green
   - do:
       cat.segments:
         v: false
@@ -65,7 +65,7 @@
             number_of_replicas: "0"
   - do:
        cluster.health:
-         wait_for_status: yellow
+         wait_for_status: green
          wait_for_relocating_shards: 0
 
   - do:
@@ -76,7 +76,7 @@
         refresh: true
   - do:
        cluster.health:
-         wait_for_status: yellow
+         wait_for_status: green
 
 
   - do:
@@ -107,7 +107,7 @@
 
   - do:
        cluster.health:
-         wait_for_status: yellow
+         wait_for_status: green
 
   - do:
     indices.close:

--- a/rest-api-spec/test/cat.segments/10_basic.yaml
+++ b/rest-api-spec/test/cat.segments/10_basic.yaml
@@ -93,3 +93,28 @@
   - match:
       $body: |
                   /^(index2 .+ \n?)$/
+
+---
+"Test cat segments on closed index behaviour":
+
+  - do:
+      indices.create:
+        index: index1
+        body:
+          settings:
+            number_of_shards: "1"
+            number_of_replicas: "0"
+
+  - do:
+       cluster.health:
+         wait_for_status: yellow
+
+  - do:
+    indices.close:
+      index: index1
+
+  - do:
+      catch: forbidden
+      cat.segments:
+        index: index1
+        v: false

--- a/rest-api-spec/test/cat.segments/10_basic.yaml
+++ b/rest-api-spec/test/cat.segments/10_basic.yaml
@@ -25,6 +25,14 @@
 "Test cat segments output":
 
   - do:
+      cat.segments:
+        v: false
+
+  - match:
+      $body: |
+               /^$/
+
+  - do:
       indices.create:
         index: index1
         body:

--- a/rest-api-spec/test/indices.segments/10_basic.yaml
+++ b/rest-api-spec/test/indices.segments/10_basic.yaml
@@ -1,5 +1,79 @@
 ---
-"segments test":
+"no segments test":
   - do:
       indices.segments:
         allow_no_indices: true
+
+  - match:   { _shards.total: 0}
+  - match:   { indices: {}}
+
+  - do:
+      catch: missing
+      indices.segments:
+        allow_no_indices: false
+
+---
+"basic segments test":
+
+  - do:
+      indices.create:
+        index: index1
+        body:
+          settings:
+            number_of_shards: "1"
+            number_of_replicas: "0"
+  - do:
+      index:
+        index: index1
+        type: type
+        body: { foo: bar }
+        refresh: true
+
+  - do:
+       cluster.health:
+         wait_for_status: yellow
+
+  - do:
+      indices.segments:
+          index: index1
+
+  - match:   { _shards.total: 1}
+  - match:   { indices.index1.shards.0.0.routing.primary: true}
+  - match:   { indices.index1.shards.0.0.segments._0.num_docs: 1}
+
+---
+"closed segments test":
+
+  - do:
+      indices.create:
+        index: index1
+        body:
+          settings:
+            number_of_shards: "1"
+            number_of_replicas: "0"
+  - do:
+      index:
+        index: index1
+        type: type
+        body: { foo: bar }
+        refresh: true
+
+  - do:
+    indices.close:
+      index: index1
+
+  - do:
+       cluster.health:
+         wait_for_status: yellow
+
+  - do:
+      catch: forbidden
+      indices.segments:
+          index: index1
+
+  - do:
+      indices.segments:
+          index: index1
+          ignore_unavailable: true
+
+  - match:   { _shards.total: 0}

--- a/rest-api-spec/test/indices.segments/10_basic.yaml
+++ b/rest-api-spec/test/indices.segments/10_basic.yaml
@@ -31,7 +31,7 @@
 
   - do:
        cluster.health:
-         wait_for_status: yellow
+         wait_for_status: green
 
   - do:
       indices.segments:
@@ -64,7 +64,7 @@
 
   - do:
        cluster.health:
-         wait_for_status: yellow
+         wait_for_status: green
 
   - do:
       catch: forbidden

--- a/rest-api-spec/test/indices.segments/10_basic.yaml
+++ b/rest-api-spec/test/indices.segments/10_basic.yaml
@@ -63,10 +63,6 @@
       index: index1
 
   - do:
-       cluster.health:
-         wait_for_status: green
-
-  - do:
       catch: forbidden
       indices.segments:
           index: index1

--- a/src/main/java/org/elasticsearch/action/admin/indices/segments/IndicesSegmentsRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/segments/IndicesSegmentsRequest.java
@@ -37,7 +37,6 @@ public class IndicesSegmentsRequest extends BroadcastOperationRequest<IndicesSeg
 
     public IndicesSegmentsRequest(String... indices) {
         super(indices);
-        indicesOptions(IndicesOptions.fromOptions(false, true, true, false));
     }
 
     /**

--- a/src/main/java/org/elasticsearch/action/admin/indices/segments/IndicesSegmentsRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/segments/IndicesSegmentsRequest.java
@@ -37,7 +37,7 @@ public class IndicesSegmentsRequest extends BroadcastOperationRequest<IndicesSeg
 
     public IndicesSegmentsRequest(String... indices) {
         super(indices);
-        indicesOptions(IndicesOptions.fromOptions(false, false, true, false));
+        indicesOptions(IndicesOptions.fromOptions(false, true, true, false));
     }
 
     /**

--- a/src/test/java/org/elasticsearch/indices/IndicesOptionsIntegrationTests.java
+++ b/src/test/java/org/elasticsearch/indices/IndicesOptionsIntegrationTests.java
@@ -362,7 +362,7 @@ public class IndicesOptionsIntegrationTests extends ElasticsearchIntegrationTest
         verify(count(indices), false);
         verify(clearCache(indices), false);
         verify(_flush(indices),false);
-        verify(segments(indices), true);
+        verify(segments(indices), false);
         verify(stats(indices), false);
         verify(optimize(indices), false);
         verify(refresh(indices), false);
@@ -437,7 +437,7 @@ public class IndicesOptionsIntegrationTests extends ElasticsearchIntegrationTest
         verify(count(indices), false, 1);
         verify(clearCache(indices), false);
         verify(_flush(indices),false);
-        verify(segments(indices), true);
+        verify(segments(indices), false);
         verify(stats(indices), false);
         verify(optimize(indices), false);
         verify(refresh(indices), false);


### PR DESCRIPTION
Writing the test for #5856 I found that when calling '_cat/segments' on an empty cluster returns `{"error":"IndexMissingException[[_all] missing]","status":404}` where other cat-commands like "shards" return silently. Although this is an edge case it would be more consistent with the other commands if "segments" would also do this.

In order to achieve this I had to change the IndicesOptions used in creating the IndicesSegmentsRequest to include the 'allowNoIndices' flag. Not sure if this breaks any other behaviour, though.

I added this edge case in the rest-test & let the regular mvn test run on this.
