### PR TITLE
Internal: Change snapshot state for unreleased versions and add validation tests for constants

### DIFF
--- a/src/main/java/org/elasticsearch/Version.java
+++ b/src/main/java/org/elasticsearch/Version.java
@@ -156,73 +156,73 @@ public class Version {
     public static final int V_0_90_14_ID = /*00*/901499;
     public static final Version V_0_90_14 = new Version(V_0_90_14_ID, false, org.apache.lucene.util.Version.LUCENE_4_6);
 
-    public static final int V_1_0_0_Beta1_ID = /*00*/1000001;
+    public static final int V_1_0_0_Beta1_ID = 1000001;
     public static final Version V_1_0_0_Beta1 = new Version(V_1_0_0_Beta1_ID, false, org.apache.lucene.util.Version.LUCENE_4_5);
-    public static final int V_1_0_0_Beta2_ID = /*00*/1000002;
+    public static final int V_1_0_0_Beta2_ID = 1000002;
     public static final Version V_1_0_0_Beta2 = new Version(V_1_0_0_Beta2_ID, false, org.apache.lucene.util.Version.LUCENE_4_6);
-    public static final int V_1_0_0_RC1_ID = /*00*/1000051;
+    public static final int V_1_0_0_RC1_ID = 1000051;
     public static final Version V_1_0_0_RC1 = new Version(V_1_0_0_RC1_ID, false, org.apache.lucene.util.Version.LUCENE_4_6);
-    public static final int V_1_0_0_RC2_ID = /*00*/1000052;
+    public static final int V_1_0_0_RC2_ID = 1000052;
     public static final Version V_1_0_0_RC2 = new Version(V_1_0_0_RC2_ID, false, org.apache.lucene.util.Version.LUCENE_4_6);
-    public static final int V_1_0_0_ID = /*00*/1000099;
+    public static final int V_1_0_0_ID = 1000099;
     public static final Version V_1_0_0 = new Version(V_1_0_0_ID, false, org.apache.lucene.util.Version.LUCENE_4_6);
-    public static final int V_1_0_1_ID = /*00*/1000199;
+    public static final int V_1_0_1_ID = 1000199;
     public static final Version V_1_0_1 = new Version(V_1_0_1_ID, false, org.apache.lucene.util.Version.LUCENE_4_6);
-    public static final int V_1_0_2_ID = /*00*/1000299;
+    public static final int V_1_0_2_ID = 1000299;
     public static final Version V_1_0_2 = new Version(V_1_0_2_ID, false, org.apache.lucene.util.Version.LUCENE_4_6);
-    public static final int V_1_0_3_ID = /*00*/1000399;
+    public static final int V_1_0_3_ID = 1000399;
     public static final Version V_1_0_3 = new Version(V_1_0_3_ID, false, org.apache.lucene.util.Version.LUCENE_4_6);
-    public static final int V_1_0_4_ID = /*00*/1000499;
-    public static final Version V_1_0_4 = new Version(V_1_0_3_ID, false, org.apache.lucene.util.Version.LUCENE_4_6);
-    public static final int V_1_1_0_ID = /*00*/1010099;
+    public static final int V_1_0_4_ID = 1000499;
+    public static final Version V_1_0_4 = new Version(V_1_0_4_ID, false, org.apache.lucene.util.Version.LUCENE_4_6);
+    public static final int V_1_1_0_ID = 1010099;
     public static final Version V_1_1_0 = new Version(V_1_1_0_ID, false, org.apache.lucene.util.Version.LUCENE_4_7);
-    public static final int V_1_1_1_ID = /*00*/1010199;
+    public static final int V_1_1_1_ID = 1010199;
     public static final Version V_1_1_1 = new Version(V_1_1_1_ID, false, org.apache.lucene.util.Version.LUCENE_4_7);
-    public static final int V_1_1_2_ID = /*00*/1010299;
-    public static final Version V_1_1_2 = new Version(V_1_1_2_ID, false, org.apache.lucene.util.Version.LUCENE_4_7);
-    public static final int V_1_2_0_ID = /*00*/1020099;
+    public static final int V_1_1_2_ID = 1010299;
+    public static final Version V_1_1_2 = new Version(V_1_1_2_ID, true, org.apache.lucene.util.Version.LUCENE_4_7);
+    public static final int V_1_2_0_ID = 1020099;
     public static final Version V_1_2_0 = new Version(V_1_2_0_ID, false, org.apache.lucene.util.Version.LUCENE_4_8);
-    public static final int V_1_2_1_ID = /*00*/1020199;
+    public static final int V_1_2_1_ID = 1020199;
     public static final Version V_1_2_1 = new Version(V_1_2_1_ID, false, org.apache.lucene.util.Version.LUCENE_4_8);
-    public static final int V_1_2_2_ID = /*00*/1020299;
+    public static final int V_1_2_2_ID = 1020299;
     public static final Version V_1_2_2 = new Version(V_1_2_2_ID, false, org.apache.lucene.util.Version.LUCENE_4_8);
-    public static final int V_1_2_3_ID = /*00*/1020399;
+    public static final int V_1_2_3_ID = 1020399;
     public static final Version V_1_2_3 = new Version(V_1_2_3_ID, false, org.apache.lucene.util.Version.LUCENE_4_8);
-    public static final int V_1_2_4_ID = /*00*/1020499;
+    public static final int V_1_2_4_ID = 1020499;
     public static final Version V_1_2_4 = new Version(V_1_2_4_ID, false, org.apache.lucene.util.Version.LUCENE_4_8);
-    public static final int V_1_2_5_ID = /*00*/1020599;
-    public static final Version V_1_2_5 = new Version(V_1_2_5_ID, false, org.apache.lucene.util.Version.LUCENE_4_8);
-    public static final int V_1_3_0_ID = /*00*/1030099;
+    public static final int V_1_2_5_ID = 1020599;
+    public static final Version V_1_2_5 = new Version(V_1_2_5_ID, true, org.apache.lucene.util.Version.LUCENE_4_8);
+    public static final int V_1_3_0_ID = 1030099;
     public static final Version V_1_3_0 = new Version(V_1_3_0_ID, false, org.apache.lucene.util.Version.LUCENE_4_9);
-    public static final int V_1_3_1_ID = /*00*/1030199;
+    public static final int V_1_3_1_ID = 1030199;
     public static final Version V_1_3_1 = new Version(V_1_3_1_ID, false, org.apache.lucene.util.Version.LUCENE_4_9);
-    public static final int V_1_3_2_ID = /*00*/1030299;
+    public static final int V_1_3_2_ID = 1030299;
     public static final Version V_1_3_2 = new Version(V_1_3_2_ID, false, org.apache.lucene.util.Version.LUCENE_4_9);
-    public static final int V_1_3_3_ID = /*00*/1030399;
+    public static final int V_1_3_3_ID = 1030399;
     public static final Version V_1_3_3 = new Version(V_1_3_3_ID, false, org.apache.lucene.util.Version.LUCENE_4_9);
-    public static final int V_1_3_4_ID = /*00*/1030499;
+    public static final int V_1_3_4_ID = 1030499;
     public static final Version V_1_3_4 = new Version(V_1_3_4_ID, false, org.apache.lucene.util.Version.LUCENE_4_9);
-    public static final int V_1_3_5_ID = /*00*/1030599;
+    public static final int V_1_3_5_ID = 1030599;
     public static final Version V_1_3_5 = new Version(V_1_3_5_ID, false, org.apache.lucene.util.Version.LUCENE_4_9);
-    public static final int V_1_3_6_ID = /*00*/1030699;
+    public static final int V_1_3_6_ID = 1030699;
     public static final Version V_1_3_6 = new Version(V_1_3_6_ID, false, org.apache.lucene.util.Version.LUCENE_4_9);
-    public static final int V_1_3_7_ID = /*00*/1030799;
+    public static final int V_1_3_7_ID = 1030799;
     public static final Version V_1_3_7 = new Version(V_1_3_7_ID, false, org.apache.lucene.util.Version.LUCENE_4_9);
-    public static final int V_1_3_8_ID = /*00*/1030899;
-    public static final Version V_1_3_8 = new Version(V_1_3_8_ID, false, org.apache.lucene.util.Version.LUCENE_4_9);
-    public static final int V_1_4_0_Beta1_ID = /*00*/1040001;
+    public static final int V_1_3_8_ID = 1030899;
+    public static final Version V_1_3_8 = new Version(V_1_3_8_ID, true, org.apache.lucene.util.Version.LUCENE_4_9);
+    public static final int V_1_4_0_Beta1_ID = 1040001;
     public static final Version V_1_4_0_Beta1 = new Version(V_1_4_0_Beta1_ID, false, org.apache.lucene.util.Version.LUCENE_4_10_1);
-    public static final int V_1_4_0_ID = /*00*/1040099;
+    public static final int V_1_4_0_ID = 1040099;
     public static final Version V_1_4_0 = new Version(V_1_4_0_ID, false, org.apache.lucene.util.Version.LUCENE_4_10_2);
-    public static final int V_1_4_1_ID = /*00*/1040199;
+    public static final int V_1_4_1_ID = 1040199;
     public static final Version V_1_4_1 = new Version(V_1_4_1_ID, false, org.apache.lucene.util.Version.LUCENE_4_10_2);
-    public static final int V_1_4_2_ID = /*00*/1040299;
+    public static final int V_1_4_2_ID = 1040299;
     public static final Version V_1_4_2 = new Version(V_1_4_2_ID, false, org.apache.lucene.util.Version.LUCENE_4_10_2);
-    public static final int V_1_4_3_ID = /*00*/1040399;
+    public static final int V_1_4_3_ID = 1040399;
     public static final Version V_1_4_3 = new Version(V_1_4_3_ID, false, org.apache.lucene.util.Version.LUCENE_4_10_2);
-    public static final int V_1_5_0_ID = /*00*/1050099;
-    public static final Version V_1_5_0 = new Version(V_1_5_0_ID, false, org.apache.lucene.util.Version.LUCENE_4_10_3);
-    public static final int V_2_0_0_ID = /*00*/2000099;
+    public static final int V_1_5_0_ID = 1050099;
+    public static final Version V_1_5_0 = new Version(V_1_5_0_ID, true, org.apache.lucene.util.Version.LUCENE_4_10_3);
+    public static final int V_2_0_0_ID = 2000099;
     public static final Version V_2_0_0 = new Version(V_2_0_0_ID, true, org.apache.lucene.util.Version.LUCENE_5_0_0);
 
     public static final Version CURRENT = V_2_0_0;
@@ -416,7 +416,7 @@ public class Version {
                 return V_0_18_8;
 
             default:
-                return new Version(id, null, Lucene.VERSION);
+                return new Version(id, false, Lucene.VERSION);
         }
     }
 
@@ -498,7 +498,7 @@ public class Version {
     public final Boolean snapshot;
     public final org.apache.lucene.util.Version luceneVersion;
 
-    Version(int id, @Nullable Boolean snapshot, org.apache.lucene.util.Version luceneVersion) {
+    Version(int id, boolean snapshot, org.apache.lucene.util.Version luceneVersion) {
         this.id = id;
         this.major = (byte) ((id / 1000000) % 100);
         this.minor = (byte) ((id / 10000) % 100);
@@ -509,7 +509,7 @@ public class Version {
     }
 
     public boolean snapshot() {
-        return snapshot != null && snapshot;
+        return snapshot;
     }
 
     public boolean after(Version version) {

--- a/src/test/java/org/elasticsearch/VersionTests.java
+++ b/src/test/java/org/elasticsearch/VersionTests.java
@@ -26,7 +26,10 @@ import org.elasticsearch.test.ElasticsearchTestCase;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
 import java.util.Locale;
+import java.util.Map;
 
 import static org.elasticsearch.Version.V_0_20_0;
 import static org.elasticsearch.Version.V_0_90_0;
@@ -35,8 +38,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
 
 public class VersionTests extends ElasticsearchTestCase {
-
-    @Test
+    
     public void testMavenVersion() {
         // maven sets this property to ensure that the latest version
         // we use here is the version that is actually set to the project.version
@@ -45,9 +47,8 @@ public class VersionTests extends ElasticsearchTestCase {
         assumeNotNull(property);
         assertEquals(property, Version.CURRENT.toString());
     }
-
-    @Test
-    public void testVersions() throws Exception {
+    
+    public void testVersionComparison() throws Exception {
         assertThat(V_0_20_0.before(V_0_90_0), is(true));
         assertThat(V_0_20_0.before(V_0_20_0), is(false));
         assertThat(V_0_90_0.before(V_0_20_0), is(false));
@@ -64,8 +65,7 @@ public class VersionTests extends ElasticsearchTestCase {
         assertThat(V_0_20_0.onOrAfter(V_0_20_0), is(true));
         assertThat(V_0_90_0.onOrAfter(V_0_20_0), is(true));
     }
-
-    @Test
+    
     public void testVersionConstantPresent() {
         assertThat(Version.CURRENT, sameInstance(Version.fromId(Version.CURRENT.id)));
         assertThat(Version.CURRENT.luceneVersion, equalTo(org.apache.lucene.util.Version.LATEST));
@@ -77,7 +77,6 @@ public class VersionTests extends ElasticsearchTestCase {
         }
     }
 
-    @Test
     public void testCURRENTIsLatest() {
         final int iters = scaledRandomIntBetween(100, 1000);
         for (int i = 0; i < iters; i++) {
@@ -87,8 +86,7 @@ public class VersionTests extends ElasticsearchTestCase {
             }
         }
     }
-
-    @Test
+    
     public void testVersionFromString() {
         final int iters = scaledRandomIntBetween(100, 1000);
         for (int i = 0; i < iters; i++) {
@@ -122,13 +120,12 @@ public class VersionTests extends ElasticsearchTestCase {
         Version.indexCreated(ImmutableSettings.builder().build());
     }
 
-    public void testVersion() {
+    public void testIndexCreatedVersion() {
         // an actual index has a IndexMetaData.SETTING_UUID
         final Version version = randomFrom(Version.V_0_18_0, Version.V_0_90_13, Version.V_1_3_0);
         assertEquals(version, Version.indexCreated(ImmutableSettings.builder().put(IndexMetaData.SETTING_UUID, "foo").put(IndexMetaData.SETTING_VERSION_CREATED, version).build()));
     }
-
-    @Test
+    
     public void testMinCompatVersion() {
         assertThat(Version.V_2_0_0.minimumCompatibilityVersion(), equalTo(Version.V_2_0_0));
         assertThat(Version.V_1_3_0.minimumCompatibilityVersion(), equalTo(Version.V_1_0_0));
@@ -136,8 +133,7 @@ public class VersionTests extends ElasticsearchTestCase {
         assertThat(Version.V_1_2_3.minimumCompatibilityVersion(), equalTo(Version.V_1_0_0));
         assertThat(Version.V_1_0_0_RC2.minimumCompatibilityVersion(), equalTo(Version.V_1_0_0_RC2));
     }
-
-    @Test
+    
     public void testParseVersion() {
         final int iters = scaledRandomIntBetween(100, 1000);
         for (int i = 0; i < iters; i++) {
@@ -151,15 +147,46 @@ public class VersionTests extends ElasticsearchTestCase {
             assertEquals(version.snapshot(), parsedVersion.snapshot());
         }
     }
-
-    @Test
-    public void parseLenient() {
+    
+    public void testParseLenient() {
         // note this is just a silly sanity check, we test it in lucene
         for (Version version : allVersions()) {
             org.apache.lucene.util.Version luceneVersion = version.luceneVersion;
             String string = luceneVersion.toString().toUpperCase(Locale.ROOT)
                     .replaceFirst("^LUCENE_(\\d+)_(\\d+)$", "$1.$2");
             assertThat(luceneVersion, Matchers.equalTo(Lucene.parseVersionLenient(string, null)));
+        }
+    }
+    
+    public void testAllVersionsMatchId() throws Exception {
+        Map<String, Version> maxBranchVersions = new HashMap<>();
+        for (java.lang.reflect.Field field : Version.class.getDeclaredFields()) {
+            if (field.getName().endsWith("_ID")) {
+                assertTrue(field.getName() + " should be static", Modifier.isStatic(field.getModifiers()));
+                assertTrue(field.getName() + " should be final", Modifier.isFinal(field.getModifiers()));
+                int versionId = (Integer)field.get(Version.class);
+                
+                String constantName = field.getName().substring(0, field.getName().length() - 3);
+                java.lang.reflect.Field versionConstant = Version.class.getField(constantName);
+                assertTrue(constantName + " should be static", Modifier.isStatic(versionConstant.getModifiers()));
+                assertTrue(constantName + " should be final", Modifier.isFinal(versionConstant.getModifiers()));
+           
+                Version v = (Version) versionConstant.get(Version.class);
+                logger.info("Checking " + v);
+                assertEquals("Version id " + field.getName() + " does not point to " + constantName, v, Version.fromId(versionId));
+                assertEquals("Version " + constantName + " does not have correct id", versionId, v.id);
+                assertEquals("V_" + v.number().replace('.', '_'), constantName);
+                
+                // only the latest version for a branch should be a snapshot (ie unreleased)
+                String branchName = "" + v.major + "." + v.minor;
+                Version maxBranchVersion = maxBranchVersions.get(branchName);
+                if (maxBranchVersion == null) {
+                    maxBranchVersions.put(branchName, v);
+                } else if (v.after(maxBranchVersion)) {
+                    assertFalse("Version " + maxBranchVersion + " cannot be a snapshot because version " + v + " exists", maxBranchVersion.snapshot());
+                    maxBranchVersions.put(branchName, v);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Currently the snapshot flag for Version constants is only set to true
for CURRENT.  However, this means that the snapshot state changes from
branch to branch.  Instead, snapshot should be "is this version
released?".  This change also adds a validation test checking that
ID -> constant and vice versa are correct, and fixes one bug found there
(for an unreleased version).
