### PR TITLE
Using `default:null` for _timestamp field creates a index loss on restart

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/metadata/MappingMetaData.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MappingMetaData.java
@@ -354,7 +354,7 @@ public class MappingMetaData {
                     path = fieldNode.toString();
                 } else if (fieldName.equals("format")) {
                     format = fieldNode.toString();
-                } else if (fieldName.equals("default")) {
+                } else if (fieldName.equals("default") && fieldNode != null) {
                     defaultTimestamp = fieldNode.toString();
                 }
             }

--- a/src/test/java/org/elasticsearch/index/mapper/timestamp/TimestampMappingTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/timestamp/TimestampMappingTests.java
@@ -606,6 +606,22 @@ public class TimestampMappingTests extends ElasticsearchSingleNodeTest {
         assertThat(mergeResult.hasConflicts(), is(true));
     }
 
+    /**
+     * Test for issue #9223
+     */
+    @Test
+    public void testInitMappers() throws IOException {
+        String mapping = XContentFactory.jsonBuilder().startObject()
+                .startObject("type")
+                    .startObject("_timestamp")
+                        .field("enabled", true)
+                        .field("default", (String) null)
+                    .endObject()
+                .endObject().endObject().string();
+        // This was causing a NPE
+        new MappingMetaData(new CompressedString(mapping));
+    }
+
     @Test
     public void testMergePaths() throws Exception {
         String[] possiblePathValues = {"some_path", "anotherPath", null};


### PR DESCRIPTION
> **Note**: this issue won't appear anymore in elasticsearch 1.5 and above because #9104 will disable support for `"default":null`. That being said, I think it would be safer to port this patch to 1.x and master branches.

Step to reproduce:
- Create new index and type.

```
DELETE new_index
PUT new_index
 {
    "mappings": {
        "power": {
            "_timestamp" : {
                "enabled" : true,
                "default": null
            }
        }
    }
}
```
- Add a document

```
PUT new_index/power/1
{
    "foo": "bar"
}
```
- Restart cluster ... and **index is missing**...

```
GET new_index
```

Gives IndexMissingException

Closes #9223.
