### PR TITLE
Core: Fix Store.checkIntegrity() for lucene 3.x index files.

### DIFF
--- a/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/src/main/java/org/elasticsearch/index/store/Store.java
@@ -393,6 +393,29 @@ public class Store extends AbstractIndexShardComponent implements CloseableIndex
         }
         return MetadataSnapshot.EMPTY;
     }
+    
+    /** 
+     * Returns true if the legacy checksum cannot be relied upon, because the file was not
+     * append only. This only impacts Lucene 3.x files for elasticsearch.
+     */
+    static boolean isUnreliableLegacyChecksum(StoreFileMetaData metadata) {
+        if (metadata.hasLegacyChecksum()) {
+            // Lucene's .tii and .tis files (3.x) were not actually append-only.
+            // this means the adler32 in ES 0.20.x releases is actually wrong, we can't use it.
+            boolean badTermInfo = metadata.name().endsWith(".tii") || metadata.name().endsWith(".tis");
+            // Lucene's .cfs (3.0-3.3) was not append-only, so old ES checksums (pre-0.18.x) are wrong.
+            // NOTE: if we don't know the version, then we don't trust the checksum. 
+            boolean badCFS = metadata.name().endsWith(".cfs") && 
+                    (metadata.writtenBy() == null || metadata.writtenBy().onOrAfter(Version.LUCENE_34) == false);
+            // Lucene's segments_N always had a checksum, and reasonably old versions of ES never added
+            // their own metadata for it. But it wasn't append-only, so be defensive and don't rely upon
+            // old versions omitting the checksum. NOTE: This logic also excludes segments.gen for the same reason.
+            boolean badCommit = metadata.name().startsWith(IndexFileNames.SEGMENTS);
+            
+            return badTermInfo || badCFS || badCommit;
+        }
+        return false;
+    }
 
     /**
      * The returned IndexOutput might validate the files checksum if the file has been written with a newer lucene version
@@ -407,19 +430,7 @@ public class Store extends AbstractIndexShardComponent implements CloseableIndex
         boolean success = false;
         try {
             if (metadata.hasLegacyChecksum()) {
-                // Lucene's .tii and .tis files (3.x) were not actually append-only.
-                // this means the adler32 in ES 0.20.x releases is actually wrong, we can't use it.
-                boolean badTermInfo = metadata.name().endsWith(".tii") || metadata.name().endsWith(".tis");
-                // Lucene's .cfs (3.0-3.3) was not append-only, so old ES checksums (pre-0.18.x) are wrong.
-                // NOTE: if we don't know the version, then we don't trust the checksum. 
-                boolean badCFS = metadata.name().endsWith(".cfs") && 
-                                 (metadata.writtenBy() == null || metadata.writtenBy().onOrAfter(Version.LUCENE_34) == false);
-                // Lucene's segments_N always had a checksum, and reasonably old versions of ES never added
-                // their own metadata for it. But it wasn't append-only, so be defensive and don't rely upon
-                // old versions omitting the checksum. NOTE: This logic also excludes segments.gen for the same reason.
-                boolean badCommit = metadata.name().startsWith(IndexFileNames.SEGMENTS);
-                        
-                if (badTermInfo || badCFS || badCommit) {
+                if (isUnreliableLegacyChecksum(metadata)) {
                     logger.debug("create legacy length-only output for non-write-once file {}", fileName);
                     output = new LegacyVerification.LengthVerifyingIndexOutput(output, metadata.length());
                 } else {
@@ -479,7 +490,7 @@ public class Store extends AbstractIndexShardComponent implements CloseableIndex
             }
             if (md.writtenBy() != null && md.writtenBy().onOrAfter(Version.LUCENE_48)) {
                 return Store.digestToString(CodecUtil.checksumEntireFile(input)).equals(md.checksum());
-            } else if (md.hasLegacyChecksum()) {
+            } else if (md.hasLegacyChecksum() && !isUnreliableLegacyChecksum(md)) {
                 // legacy checksum verification - no footer that we need to omit in the checksum!
                 final Checksum checksum = new Adler32();
                 final byte[] buffer = new byte[md.length() > 4096 ? 4096 : (int) md.length()];

--- a/src/test/java/org/elasticsearch/index/store/StoreTest.java
+++ b/src/test/java/org/elasticsearch/index/store/StoreTest.java
@@ -448,6 +448,7 @@ public class StoreTest extends ElasticsearchLuceneTestCase {
 
         // .tii: no version specified
         StoreFileMetaData tii = new StoreFileMetaData("foo.tii", 20, "boguschecksum", null);
+        assertTrue(Store.isUnreliableLegacyChecksum(tii));
         try (VerifyingIndexOutput output = (VerifyingIndexOutput) store.createVerifyingOutput("foo.temp", tii, IOContext.DEFAULT)) {
             output.writeBytes(new byte[20], 20);
             output.verify();
@@ -455,10 +456,20 @@ public class StoreTest extends ElasticsearchLuceneTestCase {
         
         // .tii: old version
         tii = new StoreFileMetaData("foo.tii", 20, "boguschecksum", Version.LUCENE_36);
+        assertTrue(Store.isUnreliableLegacyChecksum(tii));
         try (VerifyingIndexOutput output = (VerifyingIndexOutput) store.createVerifyingOutput("foo.temp2", tii, IOContext.DEFAULT)) {
             output.writeBytes(new byte[20], 20);
             output.verify();
         }
+        
+        // .tii: checkIntegrity
+        tii = new StoreFileMetaData("foo.tii", 20, "boguschecksum", Version.LUCENE_36);
+        assertTrue(Store.isUnreliableLegacyChecksum(tii));
+        try (VerifyingIndexOutput output = (VerifyingIndexOutput) store.createVerifyingOutput("foo.tii", tii, IOContext.DEFAULT)) {
+            output.writeBytes(new byte[20], 20);
+            output.verify();
+        }
+        assertTrue(store.checkIntegrity(tii));
         store.close();
     }
 
@@ -470,6 +481,7 @@ public class StoreTest extends ElasticsearchLuceneTestCase {
 
         // .tis: no version specified
         StoreFileMetaData tis = new StoreFileMetaData("foo.tis", 20, "boguschecksum", null);
+        assertTrue(Store.isUnreliableLegacyChecksum(tis));
         try (VerifyingIndexOutput output = (VerifyingIndexOutput) store.createVerifyingOutput("foo.temp", tis, IOContext.DEFAULT)) {
             output.writeBytes(new byte[20], 20);
             output.verify();
@@ -477,10 +489,20 @@ public class StoreTest extends ElasticsearchLuceneTestCase {
 
         // .tis: old version
         tis = new StoreFileMetaData("foo.tis", 20, "boguschecksum", Version.LUCENE_36);
+        assertTrue(Store.isUnreliableLegacyChecksum(tis));
         try (VerifyingIndexOutput output = (VerifyingIndexOutput) store.createVerifyingOutput("foo.temp", tis, IOContext.DEFAULT)) {
             output.writeBytes(new byte[20], 20);
             output.verify();
         };
+        
+        // .tis: checkIntegrity
+        tis = new StoreFileMetaData("foo.tis", 20, "boguschecksum", Version.LUCENE_36);
+        assertTrue(Store.isUnreliableLegacyChecksum(tis));
+        try (VerifyingIndexOutput output = (VerifyingIndexOutput) store.createVerifyingOutput("foo.tis", tis, IOContext.DEFAULT)) {
+            output.writeBytes(new byte[20], 20);
+            output.verify();
+        };
+        assertTrue(store.checkIntegrity(tis));
 
         store.close();
     }
@@ -493,6 +515,7 @@ public class StoreTest extends ElasticsearchLuceneTestCase {
 
         // .cfs: unspecified version
         StoreFileMetaData cfs = new StoreFileMetaData("foo.cfs", 20, "boguschecksum", null);
+        assertTrue(Store.isUnreliableLegacyChecksum(cfs));
         try (VerifyingIndexOutput output = (VerifyingIndexOutput) store.createVerifyingOutput("foo.temp", cfs, IOContext.DEFAULT)) {
             output.writeBytes(new byte[20], 20);
             output.verify();
@@ -500,6 +523,7 @@ public class StoreTest extends ElasticsearchLuceneTestCase {
 
         // .cfs: ancient affected version
         cfs = new StoreFileMetaData("foo.cfs", 20, "boguschecksum", Version.LUCENE_33);
+        assertTrue(Store.isUnreliableLegacyChecksum(cfs));
         try (VerifyingIndexOutput output = (VerifyingIndexOutput) store.createVerifyingOutput("foo.temp2", cfs, IOContext.DEFAULT)) {
             output.writeBytes(new byte[20], 20);
             output.verify();
@@ -507,6 +531,7 @@ public class StoreTest extends ElasticsearchLuceneTestCase {
 
         // .cfs: should still be checksummed for an ok version
         cfs = new StoreFileMetaData("foo.cfs", 20, "boguschecksum", Version.LUCENE_34);
+        assertFalse(Store.isUnreliableLegacyChecksum(cfs));
         try (VerifyingIndexOutput output = (VerifyingIndexOutput) store.createVerifyingOutput("foo.temp3", cfs, IOContext.DEFAULT)) {
             output.writeBytes(new byte[20], 20);
             output.verify();
@@ -514,6 +539,15 @@ public class StoreTest extends ElasticsearchLuceneTestCase {
         } catch (CorruptIndexException expected) {
             assertTrue(expected.getMessage().startsWith("checksum failed"));
         }
+        
+        // .cfs: checkIntegrity
+        cfs = new StoreFileMetaData("foo.cfs", 20, "boguschecksum", Version.LUCENE_33);
+        assertTrue(Store.isUnreliableLegacyChecksum(cfs));
+        try (VerifyingIndexOutput output = (VerifyingIndexOutput) store.createVerifyingOutput("foo.cfs", cfs, IOContext.DEFAULT)) {
+            output.writeBytes(new byte[20], 20);
+            output.verify();
+        }
+        assertTrue(store.checkIntegrity(cfs));
 
         store.close();
     }
@@ -526,6 +560,7 @@ public class StoreTest extends ElasticsearchLuceneTestCase {
 
         // segments_N: unspecified version
         StoreFileMetaData segments = new StoreFileMetaData("segments_1", 20, "boguschecksum", null);
+        assertTrue(Store.isUnreliableLegacyChecksum(segments));
         try (VerifyingIndexOutput output = (VerifyingIndexOutput) store.createVerifyingOutput("foo.temp", segments, IOContext.DEFAULT)) {
             output.writeBytes(new byte[20], 20);
             output.verify();
@@ -533,6 +568,7 @@ public class StoreTest extends ElasticsearchLuceneTestCase {
 
         // segments_N: specified old version
         segments = new StoreFileMetaData("segments_2", 20, "boguschecksum", Version.LUCENE_33);
+        assertTrue(Store.isUnreliableLegacyChecksum(segments));
         try (VerifyingIndexOutput output = (VerifyingIndexOutput) store.createVerifyingOutput("foo.temp2", segments, IOContext.DEFAULT)) {
             output.writeBytes(new byte[20], 20);
             output.verify();
@@ -540,6 +576,7 @@ public class StoreTest extends ElasticsearchLuceneTestCase {
 
         // segments_N: should still be checksummed for an ok version (lucene checksum)
         segments = new StoreFileMetaData("segments_3", 20, "boguschecksum", Version.LUCENE_48);
+        assertFalse(Store.isUnreliableLegacyChecksum(segments));
         try (VerifyingIndexOutput output = (VerifyingIndexOutput) store.createVerifyingOutput("foo.temp3", segments, IOContext.DEFAULT)) {
             output.writeBytes(new byte[20], 20);
             output.verify();
@@ -559,6 +596,7 @@ public class StoreTest extends ElasticsearchLuceneTestCase {
 
         // segments.gen: unspecified version
         StoreFileMetaData segmentsGen = new StoreFileMetaData("segments.gen", 20, "boguschecksum", null);
+        assertTrue(Store.isUnreliableLegacyChecksum(segmentsGen));
         try (VerifyingIndexOutput output = (VerifyingIndexOutput) store.createVerifyingOutput("foo.temp", segmentsGen, IOContext.DEFAULT)) {
             output.writeBytes(new byte[20], 20);
             output.verify();
@@ -566,6 +604,7 @@ public class StoreTest extends ElasticsearchLuceneTestCase {
 
         // segments.gen: specified old version
         segmentsGen = new StoreFileMetaData("segments.gen", 20, "boguschecksum", Version.LUCENE_33);
+        assertTrue(Store.isUnreliableLegacyChecksum(segmentsGen));
         try (VerifyingIndexOutput output = (VerifyingIndexOutput) store.createVerifyingOutput("foo.temp2", segmentsGen, IOContext.DEFAULT)) {
             output.writeBytes(new byte[20], 20);
             output.verify();
@@ -573,6 +612,7 @@ public class StoreTest extends ElasticsearchLuceneTestCase {
 
         // segments.gen: should still be checksummed for an ok version (lucene checksum)
         segmentsGen = new StoreFileMetaData("segments.gen", 20, "boguschecksum", Version.LUCENE_48);
+        assertFalse(Store.isUnreliableLegacyChecksum(segmentsGen));
         try (VerifyingIndexOutput output = (VerifyingIndexOutput) store.createVerifyingOutput("foo.temp3", segmentsGen, IOContext.DEFAULT)) {
             output.writeBytes(new byte[20], 20);
             output.verify();


### PR DESCRIPTION
We fixed createVerifyingOutput, but we should use the same logic
for checkIntegrity as well.
