### PR TITLE
Fix typo in sample json of keyword marker tokenfilter

### DIFF
--- a/docs/reference/analysis/tokenfilters/keyword-marker-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/keyword-marker-tokenfilter.asciidoc
@@ -26,9 +26,9 @@ index :
             myAnalyzer :
                 type : custom
                 tokenizer : standard
-                filter : [lowercase, protwods, porter_stem]    
+                filter : [lowercase, protwords, porter_stem]    
         filter :
-            protwods :
+            protwords :
                 type : keyword_marker
                 keywords_path : analysis/protwords.txt
 --------------------------------------------------


### PR DESCRIPTION
This PR fixes a minor typo in sample json.

By correcting this filter name, readers will have less chance to get confused with `protwords` anad `protwods`
