### PR TITLE
Updates the command to add the repo

### DIFF
--- a/docs/reference/setup/repositories.asciidoc
+++ b/docs/reference/setup/repositories.asciidoc
@@ -11,23 +11,23 @@ Elasticsearch Signing Key, with fingerprint
 
     4609 5ACC 8548 582C 1A26 99A9 D27D 666C D88E 42B4
 
-to sign all our packages.  It is available from http://pgp.mit.edu.
+to sign all our packages. It is available from http://pgp.mit.edu.
 
 [float]
 === APT
 
-Download and install the Public Signing Key
+Download and install the Public Signing Key:
 
 [source,sh]
 --------------------------------------------------
 wget -qO - https://packages.elasticsearch.org/GPG-KEY-elasticsearch | sudo apt-key add -
 --------------------------------------------------
 
-Add the following to your /etc/apt/sources.list to enable the repository
+Add the repository definition to your `/etc/apt/sources.list` file:
 
 ["source","sh",subs="attributes,callouts"]
 --------------------------------------------------
-sudo add-apt-repository "deb http://packages.elasticsearch.org/elasticsearch/{branch}/debian stable main"
+echo "deb http://packages.elasticsearch.org/elasticsearch/{branch}/debian stable main" | sudo tee -a /etc/apt/sources.list
 --------------------------------------------------
 
 Run apt-get update and the repository is ready for use. You can install it with :


### PR DESCRIPTION
The example command in the 'Setup Repositories' section has been updated to not use add-apt-repository, which automatically adds a non-working deb-src line to sources.list. Command now uses echo to write the correct line to sources.list instead.
