### PR TITLE
Remove fieldSearchAnalyzer and fieldSearchQuoteAnalyzer from MapperService.

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -905,15 +905,6 @@ public class MapperService extends AbstractIndexComponent  {
         return this.searchQuoteAnalyzer;
     }
 
-    public Analyzer fieldSearchAnalyzer(String field) {
-        return this.searchAnalyzer.getWrappedAnalyzer(field);
-    }
-
-    public Analyzer fieldSearchQuoteAnalyzer(String field) {
-        return this.searchQuoteAnalyzer.getWrappedAnalyzer(field);
-    }
-
-
     /**
      * Resolves the closest inherited {@link ObjectMapper} that is nested.
      */


### PR DESCRIPTION
Instead, get the FieldMapper for the field and check the analyzer there.  There was only one use of `fieldSearchAnalyzer` and no uses of the quoted version.
