### PR TITLE
Queries are never cached when date math expressions are used (including exact dates)

### DIFF
--- a/src/main/java/org/elasticsearch/common/joda/DateMathParser.java
+++ b/src/main/java/org/elasticsearch/common/joda/DateMathParser.java
@@ -25,6 +25,7 @@ import org.joda.time.DateTimeZone;
 import org.joda.time.MutableDateTime;
 import org.joda.time.format.DateTimeFormatter;
 
+import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -46,15 +47,22 @@ public class DateMathParser {
         this.timeUnit = timeUnit;
     }
 
-    public long parse(String text, long now) {
+    public long parse(String text, Callable<Long> now) {
         return parse(text, now, false, null);
     }
 
-    public long parse(String text, long now, boolean roundUp, DateTimeZone timeZone) {
+    // Note: we take a callable here for the timestamp in order to be able to figure out
+    // if it has been used. For instance, the query cache does not cache queries that make
+    // use of `now`.
+    public long parse(String text, Callable<Long> now, boolean roundUp, DateTimeZone timeZone) {
         long time;
         String mathString;
         if (text.startsWith("now")) {
-            time = now;
+            try {
+                time = now.call();
+            } catch (Exception e) {
+                throw new ElasticsearchParseException("Could not read the current timestamp", e);
+            }
             mathString = text.substring("now".length());
         } else {
             int index = text.indexOf("||");

--- a/src/main/java/org/elasticsearch/search/aggregations/support/format/ValueParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/support/format/ValueParser.java
@@ -31,6 +31,7 @@ import java.text.DecimalFormatSymbols;
 import java.text.NumberFormat;
 import java.text.ParseException;
 import java.util.Locale;
+import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -92,8 +93,14 @@ public interface ValueParser {
         }
 
         @Override
-        public long parseLong(String value, SearchContext searchContext) {
-            return parser.parse(value, searchContext.nowInMillis());
+        public long parseLong(String value, final SearchContext searchContext) {
+            final Callable<Long> now = new Callable<Long>() {
+                @Override
+                public Long call() throws Exception {
+                    return searchContext.nowInMillis();
+                }
+            };
+            return parser.parse(value, now);
         }
 
         @Override


### PR DESCRIPTION
The query cache has a mechanism that disables it automatically when
SearchContext.nowInMillis() is used. One issue with that is that the date math
parser always evaluates the current timestamp when parsing a date, even if it
is not needed. As a consequence, whenever you use a date expression in your
queries, the query cache would not be used.

Close #9225
