### PR TITLE
Package private getters to become public if there have corresponding public setters

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/cluster/settings/ClusterUpdateSettingsRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/settings/ClusterUpdateSettingsRequest.java
@@ -58,11 +58,11 @@ public class ClusterUpdateSettingsRequest extends AcknowledgedRequest<ClusterUpd
         return validationException;
     }
 
-    Settings transientSettings() {
+    public Settings transientSettings() {
         return transientSettings;
     }
 
-    Settings persistentSettings() {
+    public Settings persistentSettings() {
         return persistentSettings;
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequest.java
@@ -24,7 +24,6 @@ import com.google.common.collect.Sets;
 import org.elasticsearch.ElasticsearchGenerationException;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.ElasticsearchParseException;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.IndicesRequest;
@@ -131,7 +130,7 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
     /**
      * The index name to create.
      */
-    String index() {
+    public String index() {
         return index;
     }
 
@@ -143,14 +142,14 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
     /**
      * The settings to create the index with.
      */
-    Settings settings() {
+    public Settings settings() {
         return settings;
     }
 
     /**
      * The cause for this index creation.
      */
-    String cause() {
+    public String cause() {
         return cause;
     }
 
@@ -424,11 +423,11 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
         return this;
     }
 
-    Map<String, String> mappings() {
+    public Map<String, String> mappings() {
         return this.mappings;
     }
 
-    Set<Alias> aliases() {
+    public Set<Alias> aliases() {
         return this.aliases;
     }
 
@@ -440,7 +439,7 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
         return this;
     }
 
-    Map<String, IndexMetaData.Custom> customs() {
+    public Map<String, IndexMetaData.Custom> customs() {
         return this.customs;
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequest.java
@@ -21,7 +21,6 @@ package org.elasticsearch.action.admin.indices.template.put;
 import org.elasticsearch.ElasticsearchGenerationException;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.ElasticsearchParseException;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.admin.indices.alias.Alias;
@@ -179,7 +178,7 @@ public class PutIndexTemplateRequest extends MasterNodeOperationRequest<PutIndex
         return this;
     }
 
-    Settings settings() {
+    public Settings settings() {
         return this.settings;
     }
 
@@ -250,7 +249,7 @@ public class PutIndexTemplateRequest extends MasterNodeOperationRequest<PutIndex
         return this;
     }
 
-    Map<String, String> mappings() {
+    public Map<String, String> mappings() {
         return this.mappings;
     }
 
@@ -352,11 +351,11 @@ public class PutIndexTemplateRequest extends MasterNodeOperationRequest<PutIndex
         return this;
     }
 
-    Map<String, IndexMetaData.Custom> customs() {
+    public Map<String, IndexMetaData.Custom> customs() {
         return this.customs;
     }
        
-    Set<Alias> aliases() {
+    public Set<Alias> aliases() {
         return this.aliases;
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryRequest.java
@@ -85,7 +85,7 @@ public class ValidateQueryRequest extends BroadcastOperationRequest<ValidateQuer
     /**
      * The source to execute.
      */
-    BytesReference source() {
+    public BytesReference source() {
         return source;
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/warmer/delete/DeleteWarmerRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/warmer/delete/DeleteWarmerRequest.java
@@ -87,7 +87,7 @@ public class DeleteWarmerRequest extends AcknowledgedRequest<DeleteWarmerRequest
      * The name to delete.
      */
     @Nullable
-    String[] names() {
+    public String[] names() {
         return names;
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/warmer/put/PutWarmerRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/warmer/put/PutWarmerRequest.java
@@ -64,7 +64,7 @@ public class PutWarmerRequest extends AcknowledgedRequest<PutWarmerRequest> impl
         return this;
     }
 
-    String name() {
+    public String name() {
         return this.name;
     }
 
@@ -84,7 +84,7 @@ public class PutWarmerRequest extends AcknowledgedRequest<PutWarmerRequest> impl
         return this;
     }
 
-    SearchRequest searchRequest() {
+    public SearchRequest searchRequest() {
         return this.searchRequest;
     }
 

--- a/src/main/java/org/elasticsearch/action/count/CountRequest.java
+++ b/src/main/java/org/elasticsearch/action/count/CountRequest.java
@@ -21,7 +21,6 @@ package org.elasticsearch.action.count;
 
 import org.elasticsearch.ElasticsearchGenerationException;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.QuerySourceBuilder;
 import org.elasticsearch.action.support.broadcast.BroadcastOperationRequest;
@@ -36,11 +35,11 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentHelper;
 
-import static org.elasticsearch.search.internal.SearchContext.DEFAULT_TERMINATE_AFTER;
-
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Map;
+
+import static org.elasticsearch.search.internal.SearchContext.DEFAULT_TERMINATE_AFTER;
 
 /**
  * A request to count the number of documents matching a specific query. Best created with
@@ -101,7 +100,7 @@ public class CountRequest extends BroadcastOperationRequest<CountRequest> {
     /**
      * The minimum score of the documents to include in the count.
      */
-    float minScore() {
+    public float minScore() {
         return minScore;
     }
 
@@ -117,7 +116,7 @@ public class CountRequest extends BroadcastOperationRequest<CountRequest> {
     /**
      * The source to execute.
      */
-    BytesReference source() {
+    public BytesReference source() {
         return source;
     }
 

--- a/src/main/java/org/elasticsearch/action/deletebyquery/DeleteByQueryRequest.java
+++ b/src/main/java/org/elasticsearch/action/deletebyquery/DeleteByQueryRequest.java
@@ -93,7 +93,7 @@ public class DeleteByQueryRequest extends IndicesReplicationOperationRequest<Del
     /**
      * The source to execute.
      */
-    BytesReference source() {
+    public BytesReference source() {
         if (sourceUnsafe) {
             source = source.copyBytesArray();
         }
@@ -164,7 +164,7 @@ public class DeleteByQueryRequest extends IndicesReplicationOperationRequest<Del
     /**
      * The types of documents the query will run against. Defaults to all types.
      */
-    String[] types() {
+    public String[] types() {
         return this.types;
     }
 

--- a/src/main/java/org/elasticsearch/action/exists/ExistsRequest.java
+++ b/src/main/java/org/elasticsearch/action/exists/ExistsRequest.java
@@ -85,7 +85,7 @@ public class ExistsRequest extends BroadcastOperationRequest<ExistsRequest> {
     /**
      * The minimum score of the documents to include in the count.
      */
-    float minScore() {
+    public float minScore() {
         return minScore;
     }
 
@@ -136,7 +136,7 @@ public class ExistsRequest extends BroadcastOperationRequest<ExistsRequest> {
     /**
      * The source to execute.
      */
-    BytesReference source() {
+    public BytesReference source() {
         return source;
     }
 

--- a/src/main/java/org/elasticsearch/action/suggest/SuggestRequest.java
+++ b/src/main/java/org/elasticsearch/action/suggest/SuggestRequest.java
@@ -19,9 +19,6 @@
 
 package org.elasticsearch.action.suggest;
 
-import java.io.IOException;
-import java.util.Arrays;
-
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.broadcast.BroadcastOperationRequest;
 import org.elasticsearch.client.Requests;
@@ -33,6 +30,9 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.search.suggest.SuggestBuilder;
+
+import java.io.IOException;
+import java.util.Arrays;
 
 /**
  * A request to get suggestions for corrections of phrases. Best created with
@@ -86,7 +86,7 @@ public final class SuggestRequest extends BroadcastOperationRequest<SuggestReque
     /**
      * The Phrase to get correction suggestions for 
      */
-    BytesReference suggest() {
+    public BytesReference suggest() {
         return suggestSource;
     }
     


### PR DESCRIPTION
Some of our Java API requests have public setters but their corresponding getters are package private only, which doesn't make much sense as anybody can set their values but it is not possible to read those same values.

This PR addresses this by making existing package private getters public when they have a corresponding public setter.
