### PR TITLE
Let init.d script to automatically repair permissions issues

### DIFF
--- a/src/deb/init.d/elasticsearch
+++ b/src/deb/init.d/elasticsearch
@@ -146,7 +146,7 @@ case "$1" in
 	fi
 
 	# Prepare environment
-	mkdir -p "$LOG_DIR" "$DATA_DIR" "$WORK_DIR" && chown "$ES_USER":"$ES_GROUP" "$LOG_DIR" "$DATA_DIR" "$WORK_DIR"
+	mkdir -p "$LOG_DIR" "$DATA_DIR" "$WORK_DIR" && chown -R "$ES_USER":"$ES_GROUP" "$LOG_DIR" "$DATA_DIR" "$WORK_DIR"
 	touch "$PID_FILE" && chown "$ES_USER":"$ES_GROUP" "$PID_FILE"
 
 	if [ -n "$MAX_OPEN_FILES" ]; then


### PR DESCRIPTION
If elasticsearch data, logs,work directory have error permission, like this case:

```
ls -lh /mnt/sdc/elasticsearch
drwxr-xr-x 3 elasticsearch elasticsearch 4.0K Dec 31 15:27 data
drwxr-xr-x 2 elasticsearch elasticsearch 4.0K Jan 14 12:05 logs
drwxr-xr-x 2 elasticsearch elasticsearch 4.0K Dec 31 15:27 work
```

```
ls -lh /mnt/sdc/elasticsearch/data
drwxr-xr-x 3 lowstz lowstz 4.0K Dec 10 19:27 Curiosity
```

The deb init.d script will not work in this case.
I edit `/etc/default/elasticsearch` and use `set -x` to debug  `/etc/init.d/elasticsearch`
