### PR TITLE
Pass through all exceptions in IndicesLifecycleListeners

### DIFF
--- a/src/main/java/org/elasticsearch/indices/InternalIndicesLifecycle.java
+++ b/src/main/java/org/elasticsearch/indices/InternalIndicesLifecycle.java
@@ -34,7 +34,9 @@ import org.elasticsearch.index.shard.ShardId;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
- *
+ * InternalIndicesLifecycle handles invoking each listener for the Index. All
+ * exceptions thrown by listeners are logged and then re-thrown to stop further
+ * index action.
  */
 public class InternalIndicesLifecycle extends AbstractComponent implements IndicesLifecycle {
 
@@ -69,6 +71,7 @@ public class InternalIndicesLifecycle extends AbstractComponent implements Indic
                 listener.beforeIndexCreated(index, indexSettings);
             } catch (Throwable t) {
                 logger.warn("[{}] failed to invoke before index created callback", t, index.name());
+                throw t;
             }
         }
     }
@@ -79,6 +82,7 @@ public class InternalIndicesLifecycle extends AbstractComponent implements Indic
                 listener.afterIndexCreated(indexService);
             } catch (Throwable t) {
                 logger.warn("[{}] failed to invoke after index created callback", t, indexService.index().name());
+                throw t;
             }
         }
     }
@@ -89,6 +93,7 @@ public class InternalIndicesLifecycle extends AbstractComponent implements Indic
                 listener.beforeIndexShardCreated(shardId, indexSettings);
             } catch (Throwable t) {
                 logger.warn("{} failed to invoke before shard created callback", t, shardId);
+                throw t;
             }
         }
     }
@@ -99,6 +104,7 @@ public class InternalIndicesLifecycle extends AbstractComponent implements Indic
                 listener.afterIndexShardCreated(indexShard);
             } catch (Throwable t) {
                 logger.warn("{} failed to invoke after shard created callback", t, indexShard.shardId());
+                throw t;
             }
         }
     }
@@ -109,6 +115,7 @@ public class InternalIndicesLifecycle extends AbstractComponent implements Indic
                 listener.afterIndexShardPostRecovery(indexShard);
             } catch (Throwable t) {
                 logger.warn("{} failed to invoke after shard post recovery callback", t, indexShard.shardId());
+                throw t;
             }
         }
     }
@@ -119,6 +126,7 @@ public class InternalIndicesLifecycle extends AbstractComponent implements Indic
                 listener.afterIndexShardStarted(indexShard);
             } catch (Throwable t) {
                 logger.warn("{} failed to invoke after shard started callback", t, indexShard.shardId());
+                throw t;
             }
         }
     }
@@ -129,6 +137,7 @@ public class InternalIndicesLifecycle extends AbstractComponent implements Indic
                 listener.beforeIndexClosed(indexService);
             } catch (Throwable t) {
                 logger.warn("[{}] failed to invoke before index closed callback", t, indexService.index().name());
+                throw t;
             }
         }
     }
@@ -139,6 +148,7 @@ public class InternalIndicesLifecycle extends AbstractComponent implements Indic
                 listener.beforeIndexDeleted(indexService);
             } catch (Throwable t) {
                 logger.warn("[{}] failed to invoke before index deleted callback", t, indexService.index().name());
+                throw t;
             }
         }
     }
@@ -149,6 +159,7 @@ public class InternalIndicesLifecycle extends AbstractComponent implements Indic
                 listener.afterIndexDeleted(index, indexSettings);
             } catch (Throwable t) {
                 logger.warn("[{}] failed to invoke after index deleted callback", t, index.name());
+                throw t;
             }
         }
     }
@@ -159,6 +170,7 @@ public class InternalIndicesLifecycle extends AbstractComponent implements Indic
                 listener.afterIndexClosed(index, indexSettings);
             } catch (Throwable t) {
                 logger.warn("[{}] failed to invoke after index closed callback", t, index.name());
+                throw t;
             }
         }
     }
@@ -170,6 +182,7 @@ public class InternalIndicesLifecycle extends AbstractComponent implements Indic
                 listener.beforeIndexShardClosed(shardId, indexShard, indexSettings);
             } catch (Throwable t) {
                 logger.warn("{} failed to invoke before shard closed callback", t, shardId);
+                throw t;
             }
         }
     }
@@ -181,6 +194,7 @@ public class InternalIndicesLifecycle extends AbstractComponent implements Indic
                 listener.afterIndexShardClosed(shardId, indexShard, indexSettings);
             } catch (Throwable t) {
                 logger.warn("{} failed to invoke after shard closed callback", t, shardId);
+                throw t;
             }
         }
     }
@@ -191,6 +205,7 @@ public class InternalIndicesLifecycle extends AbstractComponent implements Indic
                 listener.indexShardStateChanged(indexShard, previousState, indexShard.state(), reason);
             } catch (Throwable t) {
                 logger.warn("{} failed to invoke index shard state changed callback", t, indexShard.shardId());
+                throw t;
             }
         }
     }


### PR DESCRIPTION
This allows a plugin or user that registers a listener to be able to
stop actions like creating an index or starting a shard by throwing an
exception. Previously all exceptions were logged without being rethrown.
