### PR TITLE
Increase default xlog flush size from 200mb to 512 mb

### DIFF
--- a/docs/reference/index-modules/translog.asciidoc
+++ b/docs/reference/index-modules/translog.asciidoc
@@ -13,7 +13,7 @@ After how many operations to flush. Defaults to `unlimited`.
 
 `index.translog.flush_threshold_size`:: 
 
-Once the translog hits this size, a flush will happen. Defaults to `200mb`.
+Once the translog hits this size, a flush will happen. Defaults to `512mb`.
 
 `index.translog.flush_threshold_period`:: 
 

--- a/src/main/java/org/elasticsearch/index/translog/TranslogService.java
+++ b/src/main/java/org/elasticsearch/index/translog/TranslogService.java
@@ -81,7 +81,7 @@ public class TranslogService extends AbstractIndexShardComponent implements Clos
         this.indexShard = indexShard;
         this.translog = translog;
         this.flushThresholdOperations = componentSettings.getAsInt(FLUSH_THRESHOLD_OPS_KEY, componentSettings.getAsInt("flush_threshold", Integer.MAX_VALUE));
-        this.flushThresholdSize = componentSettings.getAsBytesSize(FLUSH_THRESHOLD_SIZE_KEY, new ByteSizeValue(200, ByteSizeUnit.MB));
+        this.flushThresholdSize = componentSettings.getAsBytesSize(FLUSH_THRESHOLD_SIZE_KEY, new ByteSizeValue(512, ByteSizeUnit.MB));
         this.flushThresholdPeriod = componentSettings.getAsTime(FLUSH_THRESHOLD_PERIOD_KEY, TimeValue.timeValueMinutes(30));
         this.interval = componentSettings.getAsTime(FLUSH_THRESHOLD_INTERVAL_KEY, timeValueMillis(5000));
         this.disableFlush = componentSettings.getAsBoolean(FLUSH_THRESHOLD_DISABLE_FLUSH_KEY, false);


### PR DESCRIPTION
Closes #9265
