### PR TITLE
Tests: Rename tests with the same name

### DIFF
--- a/src/test/java/org/elasticsearch/count/query/CountQueryTests.java
+++ b/src/test/java/org/elasticsearch/count/query/CountQueryTests.java
@@ -43,7 +43,7 @@ import static org.elasticsearch.index.query.QueryBuilders.*;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.*;
 import static org.hamcrest.Matchers.*;
 
-public class SimpleQueryTests extends ElasticsearchIntegrationTest {
+public class CountQueryTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void passQueryAsStringTest() throws Exception {

--- a/src/test/java/org/elasticsearch/search/query/SearchQueryTests.java
+++ b/src/test/java/org/elasticsearch/search/query/SearchQueryTests.java
@@ -62,7 +62,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.*;
 import static org.hamcrest.Matchers.*;
 
 
-public class SimpleQueryTests extends ElasticsearchIntegrationTest {
+public class SearchQueryTests extends ElasticsearchIntegrationTest {
 
     @Override
     protected int maximumNumberOfShards() {


### PR DESCRIPTION
These two tests are confusing because they have the same class name in
different packages.  This results in accidentally looking at the wrong
file when trying to open the test by class name. They are also
not "simple"..
