### PR TITLE
Startup script does not allow us to use LD_PRELOAD

### DIFF
--- a/bin/elasticsearch
+++ b/bin/elasticsearch
@@ -52,7 +52,22 @@
 # ensuring that no include files exist in the aforementioned search list.
 # Be aware that you will be entirely responsible for populating the needed
 # environment variables.
-
+#
+# In some use cases, it may be beneficial to set environment variables
+# to be used when executing Java -- or to specify the path to the Java
+# executable itself. There are two environment variables that can be
+# set to achieve this:
+#
+# JAVA_BIN -- Path to Java executable
+# JAVA_ENV -- Environment variables to be passed into Java's execution
+#             environment
+#
+# For example, on 64-bit platforms you may wish to specify a combination of:
+#
+# JAVA_BIN=/opt/local/java/bin/amd64/java
+# JAVA_ENV="LD_PRELOAD=/usr/lib/64/libmtmalloc.so"
+#
+# for highly concurrent ES deployments.
 
 # Maven will replace the project.name with elasticsearch below. If that
 # hasn't been done, we assume that this is not a packaged version and the
@@ -108,10 +123,16 @@ elif [ -r "$ES_INCLUDE" ]; then
     . "$ES_INCLUDE"
 fi
 
-if [ -x "$JAVA_HOME/bin/java" ]; then
-    JAVA="$JAVA_HOME/bin/java"
-else
-    JAVA=`which java`
+if [ ! -z "$JAVA_BIN" ]; then
+  JAVA="$JAVA_BIN"
+fi
+
+if [ -z "$JAVA" ]; then
+  if [ -x "$JAVA_HOME/bin/java" ]; then
+      JAVA="$JAVA_HOME/bin/java"
+  else
+      JAVA=`which java`
+  fi
 fi
 
 if [ ! -x "$JAVA" ]; then
@@ -151,11 +172,13 @@ launch_service()
     # The es-foreground option will tell Elasticsearch not to close stdout/stderr, but it's up to us not to daemonize.
     if [ "x$daemonized" = "x" ]; then
         es_parms="$es_parms -Des.foreground=yes"
+        eval "export $JAVA_ENV" > /dev/null
         exec "$JAVA" $JAVA_OPTS $ES_JAVA_OPTS $es_parms -Des.path.home="$ES_HOME" -cp "$ES_CLASSPATH" $props \
                 org.elasticsearch.bootstrap.Elasticsearch
         # exec without running it in the background, makes it replace this shell, we'll never get here...
         # no need to return something
     else
+        eval "export $JAVA_ENV" > /dev/null
         # Startup Elasticsearch, background it, and write the pid.
         exec "$JAVA" $JAVA_OPTS $ES_JAVA_OPTS $es_parms -Des.path.home="$ES_HOME" -cp "$ES_CLASSPATH" $props \
                     org.elasticsearch.bootstrap.Elasticsearch <&- &
@@ -207,6 +230,7 @@ eval set -- "$args"
 while true; do
     case $1 in
         -v)
+            eval "export $JAVA_ENV" > /dev/null
             "$JAVA" $JAVA_OPTS $ES_JAVA_OPTS $es_parms -Des.path.home="$ES_HOME" -cp "$ES_CLASSPATH" $props \
                     org.elasticsearch.Version
             exit 0


### PR DESCRIPTION
In cases where a user wishes to use a different malloc library than that which is linked to the Java binary, LD_PRELOAD would be extremely useful. With the way `bin/elasticsearch` is written, this is not readily possible. The script's use of exec() means that we cannot influence Java's environment by prepending the JAVA variable with our environment.

The proposed change is what we are currently using in production to test malloc in libc, libumem, and libmtmalloc. It is flexible enough to fit our needs as well as introduces the ability to arbitrarily influence the Java execution environment with environment variables. The only criticism of our work that I currently have is that it could potentially influence the execution of the startup script -- which is why we eval the JAVA_ENV variable as late as possible.

Currently, our Chef cookbook is overwriting the startup script provided by the Elasticsearch package. It would be nice if we did not have to do that. :kiss:

Any feedback is, of course, greatly appreciated. Thank you.
