### PR TITLE
[Java API] Scrolling .setSource does not respect the source query

### DIFF
--- a/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
@@ -1021,7 +1021,7 @@ public class SearchRequestBuilder extends ActionRequestBuilder<SearchRequest, Se
 
     @Override
     protected void doExecute(ActionListener<SearchResponse> listener) {
-        if (sourceBuilder != null) {
+        if (sourceBuilder != null && request.source() == null) {
             request.source(sourceBuilder());
         }
         client.search(request, listener);

--- a/src/test/java/org/elasticsearch/search/rescore/QueryRescorerTests.java
+++ b/src/test/java/org/elasticsearch/search/rescore/QueryRescorerTests.java
@@ -674,6 +674,7 @@ public class QueryRescorerTests extends ElasticsearchIntegrationTest {
         assertSecondHit(response, hasId("8"));
 
         // Now squash the second rescore window so it never gets to see a seven
+        request = client().prepareSearch().setRescoreWindow(numDocs);
         response = request.setSize(1).clearRescorers().addRescorer(eightIsGreat).addRescorer(sevenIsBetter, 1).get();
         assertFirstHit(response, hasId("8"));
         // We have no idea what the second hit will be because we didn't get a chance to look for seven
@@ -685,6 +686,8 @@ public class QueryRescorerTests extends ElasticsearchIntegrationTest {
         QueryRescorer oneToo = RescoreBuilder.queryRescorer(
                 QueryBuilders.functionScoreQuery(QueryBuilders.queryStringQuery("*one*")).boostMode(CombineFunction.REPLACE)
                 .add(ScoreFunctionBuilders.scriptFunction("1000.0f"))).setScoreMode("total");
+        
+        request = client().prepareSearch().setRescoreWindow(numDocs);
         request.clearRescorers().addRescorer(ninetyIsGood).addRescorer(oneToo, 10);
         response = request.setSize(2).get();
         assertFirstHit(response, hasId("91"));


### PR DESCRIPTION
`doExecute` was completely ignoring that request's source may have been set through `setSource` earlier.

Not sure though why this happens only while scrolling. a simple prepare search works correctly.
