### PR TITLE
Add `fielddata_fields` to the REST spec

### DIFF
--- a/rest-api-spec/api/search.json
+++ b/rest-api-spec/api/search.json
@@ -42,6 +42,10 @@
           "type" : "list",
           "description" : "A comma-separated list of fields to return as part of a hit"
         },
+        "fielddata_fields": {
+          "type" : "list",
+          "description" : "A comma-separated list of fields to return as the field data representation of a field for each hit"
+        },
         "from": {
           "type" : "number",
           "description" : "Starting offset (default: 0)"


### PR DESCRIPTION
#4492 added the ability to specify fields to pull field values from fielddata from but wasn't added to the rest-api

Closes #9398 
