### PR TITLE
Add ability to retrieve currently running snapshots

### DIFF
--- a/docs/reference/modules/snapshots.asciidoc
+++ b/docs/reference/modules/snapshots.asciidoc
@@ -176,6 +176,13 @@ All snapshots currently stored in the repository can be listed using the followi
 $ curl -XGET "localhost:9200/_snapshot/my_backup/_all"
 -----------------------------------
 
+coming[2.0] A currently running snapshot can be retrieved using the following command:
+
+[source,shell]
+-----------------------------------
+$ curl -XGET "localhost:9200/_snapshot/my_backup/_current"
+-----------------------------------
+
 A snapshot can be deleted from the repository using the following command:
 
 [source,shell]

--- a/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsRequest.java
@@ -34,6 +34,9 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
  */
 public class GetSnapshotsRequest extends MasterNodeOperationRequest<GetSnapshotsRequest> {
 
+    public static final String ALL_SNAPSHOTS = "_all";
+    public static final String CURRENT_SNAPSHOT = "_current";
+
     private String repository;
 
     private String[] snapshots = Strings.EMPTY_ARRAY;

--- a/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsRequestBuilder.java
@@ -71,6 +71,16 @@ public class GetSnapshotsRequestBuilder extends MasterNodeOperationRequestBuilde
     }
 
     /**
+     * Makes the request to return the current snapshot
+     *
+     * @return this builder
+     */
+    public GetSnapshotsRequestBuilder setCurrentSnapshot() {
+        request.snapshots(new String[] {GetSnapshotsRequest.CURRENT_SNAPSHOT});
+        return this;
+    }
+
+    /**
      * Adds additional snapshots to the list of snapshots to return
      *
      * @param snapshots additional snapshots

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/snapshots/get/RestGetSnapshotsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/snapshots/get/RestGetSnapshotsAction.java
@@ -47,9 +47,6 @@ public class RestGetSnapshotsAction extends BaseRestHandler {
     public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         String repository = request.param("repository");
         String[] snapshots = request.paramAsStringArray("snapshot", Strings.EMPTY_ARRAY);
-        if (snapshots.length == 1 && "_all".equalsIgnoreCase(snapshots[0])) {
-            snapshots = Strings.EMPTY_ARRAY;
-        }
         GetSnapshotsRequest getSnapshotsRequest = getSnapshotsRequest(repository).snapshots(snapshots);
         getSnapshotsRequest.masterNodeTimeout(request.paramAsTime("master_timeout", getSnapshotsRequest.masterNodeTimeout()));
         client.admin().cluster().getSnapshots(getSnapshotsRequest, new RestToXContentListener<GetSnapshotsResponse>(channel));

--- a/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -162,6 +162,22 @@ public class SnapshotsService extends AbstractLifecycleComponent<SnapshotsServic
     }
 
     /**
+     * Returns a list of currently running snapshots from repository sorted by snapshot creation date
+     *
+     * @param repositoryName repository name
+     * @return list of snapshots
+     */
+    public ImmutableList<Snapshot> currentSnapshots(String repositoryName) {
+        List<Snapshot> snapshotList = newArrayList();
+        ImmutableList<SnapshotMetaData.Entry> entries = currentSnapshots(repositoryName, null);
+        for (SnapshotMetaData.Entry entry : entries) {
+            snapshotList.add(inProgressSnapshot(entry));
+        }
+        CollectionUtil.timSort(snapshotList);
+        return ImmutableList.copyOf(snapshotList);
+    }
+
+    /**
      * Initializes the snapshotting process.
      * <p/>
      * This method is used by clients to start snapshot. It makes sure that there is no snapshots are currently running and


### PR DESCRIPTION
Together with #8782 it should help in the situations simliar to #8887 by adding an ability to get information about currently running snapshot without accessing the repository itself.

Closes #8887 and #7859
