### PR TITLE
Lenient default parameters

### DIFF
--- a/docs/reference/migration/migrate_2_0.asciidoc
+++ b/docs/reference/migration/migrate_2_0.asciidoc
@@ -6,9 +6,9 @@ your application to Elasticsearch 2.0.
 
 === Indices API
 
-The <<alias-retrieving, get alias api>> will, by default produce an error response 
-if a requested index does not exist. This change brings the defaults for this API in 
-line with the other Indices APIs. The <<multi-index>> options can be used on a request 
+The <<alias-retrieving, get alias api>> will, by default produce an error response
+if a requested index does not exist. This change brings the defaults for this API in
+line with the other Indices APIs. The <<multi-index>> options can be used on a request
 to change this behavior
 
 `GetIndexRequest.features()` now returns an array of Feature Enums instrad of an array of String values.
@@ -22,10 +22,14 @@ The following deprecated methods have been removed:
 
 Partial fields were deprecated since 1.0.0beta1 in favor of <<search-request-source-filtering,source filtering>>.
 
-=== More Like This Field
+=== More Like This
 
-The More Like This Field query has been removed in favor of the <<query-dsl-mlt-query, More Like This Query>>
+* The More Like This Field query has been removed in favor of the <<query-dsl-mlt-query, More Like This Query>>
 restrained set to a specific `field`.
+
+* The default parameters of the MLT Query have been changed to be as lenient
+  as possible, to ensure results are always returned. This change affects the
+  defaults for `min_term_freq`, `min_doc_freq` and `minimum_should_match`.
 
 === Routing
 

--- a/docs/reference/query-dsl/queries/mlt-query.asciidoc
+++ b/docs/reference/query-dsl/queries/mlt-query.asciidoc
@@ -188,11 +188,11 @@ gives greater accuracy at the expense of query execution speed. Defaults to
 
 `min_term_freq`::
 The minimum term frequency below which the terms will be ignored from the
-input document. Defaults to `2`.
+input document. Defaults to `1`.
 
 `min_doc_freq`::
 The minimum document frequency below which the terms will be ignored from the
-input document. Defaults to `5`.
+input document. Defaults to `1`.
 
 `max_doc_freq`::
 The maximum document frequency above which the terms will be ignored from the
@@ -225,7 +225,7 @@ analyzer associated with the first field in `fields`.
 After the disjunctive query has been formed, this parameter controls the
 number of terms that must match.
 The syntax is the same as the <<query-dsl-minimum-should-match,minimum should match>>.
-(Defaults to `"30%"`).
+(Defaults to `"0%"`).
 
 `boost_terms`::
 Each term in the formed query could be further boosted by their tf-idf score.

--- a/docs/reference/query-dsl/queries/mlt-query.asciidoc
+++ b/docs/reference/query-dsl/queries/mlt-query.asciidoc
@@ -239,3 +239,10 @@ results returned. Defaults to `false`.
 
 `boost`::
 Sets the boost value of the whole query. Defaults to `1.0`.
+
+[NOTE]
+The goal here is to maximize the tf-idf score, so depending on your
+application increasing the value of `min_term_freq` or `min_word_length` may
+yield greater speed without compromising accuracy. Another parameter to play
+with is `max_query_terms`. Depending on your application, only a few terms may
+already return fairly good results.

--- a/src/main/java/org/elasticsearch/common/lucene/search/MoreLikeThisQuery.java
+++ b/src/main/java/org/elasticsearch/common/lucene/search/MoreLikeThisQuery.java
@@ -45,7 +45,7 @@ import java.util.Set;
  */
 public class MoreLikeThisQuery extends Query {
 
-    public static final String DEFAULT_MINIMUM_SHOULD_MATCH = "30%";
+    public static final String DEFAULT_MINIMUM_SHOULD_MATCH = "0%";
 
     private TFIDFSimilarity similarity;
 

--- a/src/main/java/org/elasticsearch/common/lucene/search/XMoreLikeThis.java
+++ b/src/main/java/org/elasticsearch/common/lucene/search/XMoreLikeThis.java
@@ -171,7 +171,7 @@ public final class XMoreLikeThis {
      * @see #getMinTermFreq
      * @see #setMinTermFreq
      */
-    public static final int DEFAULT_MIN_TERM_FREQ = 2;
+    public static final int DEFAULT_MIN_TERM_FREQ = 1;
 
     /**
      * Ignore words which do not occur in at least this many docs.
@@ -179,7 +179,7 @@ public final class XMoreLikeThis {
      * @see #getMinDocFreq
      * @see #setMinDocFreq
      */
-    public static final int DEFAULT_MIN_DOC_FREQ = 5;
+    public static final int DEFAULT_MIN_DOC_FREQ = 1;
 
     /**
      * Ignore words which occur in more than this many docs.


### PR DESCRIPTION
The default parameters of the MLT query are set to be as lenient as possible
to ensure results are always returned. For example, in the common case of MLT
on a tag field (unique keywords per document), the default of `min_term_freq`
set to `2` would return no result. This change affects the defaults for
`min_term_freq`, `min_doc_freq` and `minimum_should_match`.
