### PR TITLE
Better handling of index deletion during snapshot

### DIFF
--- a/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreTests.java
+++ b/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreTests.java
@@ -1558,6 +1558,59 @@ public class SharedClusterSnapshotRestoreTests extends AbstractSnapshotTests {
 
     }
 
+    @Test
+    public void deleteIndexDuringSnapshotTest() throws Exception {
+        Client client = client();
+
+        boolean allowPartial = randomBoolean();
+
+        logger.info("-->  creating repository");
+        assertAcked(client.admin().cluster().preparePutRepository("test-repo")
+                .setType(MockRepositoryModule.class.getCanonicalName()).setSettings(ImmutableSettings.settingsBuilder()
+                        .put("location", newTempDirPath())
+                        .put("compress", randomBoolean())
+                        .put("chunk_size", randomIntBetween(100, 1000))
+                        .put("block_on_init", true)
+                ));
+
+        createIndex("test-idx-1", "test-idx-2", "test-idx-3");
+        ensureGreen();
+
+        logger.info("--> indexing some data");
+        for (int i = 0; i < 100; i++) {
+            index("test-idx-1", "doc", Integer.toString(i), "foo", "bar" + i);
+            index("test-idx-2", "doc", Integer.toString(i), "foo", "baz" + i);
+            index("test-idx-3", "doc", Integer.toString(i), "foo", "baz" + i);
+        }
+        refresh();
+        assertThat(client.prepareCount("test-idx-1").get().getCount(), equalTo(100L));
+        assertThat(client.prepareCount("test-idx-2").get().getCount(), equalTo(100L));
+        assertThat(client.prepareCount("test-idx-3").get().getCount(), equalTo(100L));
+
+        logger.info("--> snapshot allow partial {}", allowPartial);
+        ListenableActionFuture<CreateSnapshotResponse> future = client.admin().cluster().prepareCreateSnapshot("test-repo", "test-snap")
+                .setIndices("test-idx-*").setWaitForCompletion(true).setPartial(allowPartial).execute();
+        logger.info("--> wait for block to kick in");
+        waitForBlock(internalCluster().getMasterName(), "test-repo", TimeValue.timeValueMinutes(1));
+        logger.info("--> delete some indices while snapshot is running");
+        client.admin().indices().prepareDelete("test-idx-1", "test-idx-2").get();
+        logger.info("--> unblock running master node");
+        unblockNode(internalCluster().getMasterName());
+        logger.info("--> waiting for snapshot to finish");
+        CreateSnapshotResponse createSnapshotResponse = future.get();
+
+        if (allowPartial) {
+            logger.info("Deleted index during snapshot, but allow partial");
+            assertThat(createSnapshotResponse.getSnapshotInfo().state(), equalTo((SnapshotState.PARTIAL)));
+            assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(), greaterThan(0));
+            assertThat(createSnapshotResponse.getSnapshotInfo().failedShards(), greaterThan(0));
+            assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(), lessThan(createSnapshotResponse.getSnapshotInfo().totalShards()));
+        } else {
+            logger.info("Deleted index during snapshot and doesn't allow partial");
+            assertThat(createSnapshotResponse.getSnapshotInfo().state(), equalTo((SnapshotState.FAILED)));
+        }
+    }
+
     private boolean waitForIndex(final String index, TimeValue timeout) throws InterruptedException {
         return awaitBusy(new Predicate<Object>() {
             @Override

--- a/src/test/java/org/elasticsearch/snapshots/mockstore/MockRepository.java
+++ b/src/test/java/org/elasticsearch/snapshots/mockstore/MockRepository.java
@@ -19,10 +19,13 @@
 
 package org.elasticsearch.snapshots.mockstore;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.cluster.metadata.SnapshotId;
 import org.elasticsearch.common.blobstore.BlobMetaData;
 import org.elasticsearch.common.blobstore.BlobPath;
 import org.elasticsearch.common.blobstore.BlobStore;
@@ -46,6 +49,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static com.carrotsearch.randomizedtesting.RandomizedTest.randomAsciiOfLength;
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 
 /**
@@ -68,6 +72,8 @@ public class MockRepository extends FsRepository {
 
     private final String randomPrefix;
 
+    private volatile boolean blockOnInitialization;
+
     private volatile boolean blockOnControlFiles;
 
     private volatile boolean blockOnDataFiles;
@@ -81,10 +87,19 @@ public class MockRepository extends FsRepository {
         randomDataFileIOExceptionRate = repositorySettings.settings().getAsDouble("random_data_file_io_exception_rate", 0.0);
         blockOnControlFiles = repositorySettings.settings().getAsBoolean("block_on_control", false);
         blockOnDataFiles = repositorySettings.settings().getAsBoolean("block_on_data", false);
-        randomPrefix = repositorySettings.settings().get("random");
+        blockOnInitialization = repositorySettings.settings().getAsBoolean("block_on_init", false);
+        randomPrefix = repositorySettings.settings().get("random", "default");
         waitAfterUnblock = repositorySettings.settings().getAsLong("wait_after_unblock", 0L);
         logger.info("starting mock repository with random prefix " + randomPrefix);
         mockBlobStore = new MockBlobStore(super.blobStore());
+    }
+
+    @Override
+    public void initializeSnapshot(SnapshotId snapshotId, ImmutableList<String> indices, MetaData metaData) {
+        if (blockOnInitialization ) {
+            blockExecution();
+        }
+        super.initializeSnapshot(snapshotId, indices, metaData);
     }
 
     private static RepositorySettings overrideSettings(RepositorySettings repositorySettings, ClusterService clusterService) {
@@ -118,12 +133,8 @@ public class MockRepository extends FsRepository {
         return mockBlobStore;
     }
 
-    public boolean blocked() {
-        return mockBlobStore.blocked();
-    }
-
     public void unblock() {
-        mockBlobStore.unblockExecution();
+        unblockExecution();
     }
 
     public void blockOnDataFiles(boolean blocked) {
@@ -132,6 +143,37 @@ public class MockRepository extends FsRepository {
 
     public void blockOnControlFiles(boolean blocked) {
         blockOnControlFiles = blocked;
+    }
+
+    public synchronized void unblockExecution() {
+        if (blocked) {
+            blocked = false;
+            // Clean blocking flags, so we wouldn't try to block again
+            blockOnDataFiles = false;
+            blockOnControlFiles = false;
+            blockOnInitialization = false;
+            this.notifyAll();
+        }
+    }
+
+    public boolean blocked() {
+        return blocked;
+    }
+
+    private synchronized boolean blockExecution() {
+        logger.debug("Blocking execution");
+        boolean wasBlocked = false;
+        try {
+            while (blockOnDataFiles || blockOnControlFiles || blockOnInitialization) {
+                blocked = true;
+                this.wait();
+                wasBlocked = true;
+            }
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+        }
+        logger.debug("Unblocking execution");
+        return wasBlocked;
     }
 
     public class MockBlobStore extends BlobStoreWrapper {
@@ -155,34 +197,6 @@ public class MockRepository extends FsRepository {
         @Override
         public BlobContainer blobContainer(BlobPath path) {
             return new MockBlobContainer(super.blobContainer(path));
-        }
-
-        public synchronized void unblockExecution() {
-            if (blocked) {
-                blocked = false;
-                // Clean blocking flags, so we wouldn't try to block again
-                blockOnDataFiles = false;
-                blockOnControlFiles = false;
-                this.notifyAll();
-            }
-        }
-
-        public boolean blocked() {
-            return blocked;
-        }
-
-        private synchronized boolean blockExecution() {
-            boolean wasBlocked = false;
-            try {
-                while (blockOnDataFiles || blockOnControlFiles) {
-                    blocked = true;
-                    this.wait();
-                    wasBlocked = true;
-                }
-            } catch (InterruptedException ex) {
-                Thread.currentThread().interrupt();
-            }
-            return wasBlocked;
         }
 
         private class MockBlobContainer extends BlobContainerWrapper {


### PR DESCRIPTION
If an index is deleted during initial state of the snapshot operation, the entire snapshot can fail with NPE. This commit improves handling of this situation and allows snapshot to continue if partial snapshots are allowed.

Closes #9024
