### PR TITLE
Mapping: Explicit _timestamp default null is set to now

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/metadata/MappingMetaData.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MappingMetaData.java
@@ -354,8 +354,8 @@ public class MappingMetaData {
                     path = fieldNode.toString();
                 } else if (fieldName.equals("format")) {
                     format = fieldNode.toString();
-                } else if (fieldName.equals("default") && fieldNode != null) {
-                    defaultTimestamp = fieldNode.toString();
+                } else if (fieldName.equals("default")) {
+                    defaultTimestamp = fieldNode == null ? null : fieldNode.toString();
                 }
             }
             this.timestamp = new Timestamp(enabled, path, format, defaultTimestamp);

--- a/src/test/java/org/elasticsearch/index/mapper/timestamp/TimestampMappingTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/timestamp/TimestampMappingTests.java
@@ -624,7 +624,9 @@ public class TimestampMappingTests extends ElasticsearchSingleNodeTest {
                     .endObject()
                 .endObject().endObject().string();
         // This was causing a NPE
-        new MappingMetaData(new CompressedString(mapping));
+        MappingMetaData mappingMetaData = new MappingMetaData(new CompressedString(mapping));
+        String defaultTimestamp = mappingMetaData.timestamp().defaultTimestamp();
+        assertThat(defaultTimestamp, is(nullValue()));
     }
 
     @Test


### PR DESCRIPTION
When creating an index with:

```
PUT new_index
{
    "mappings": {
        "power": {
            "_timestamp" : {
                "enabled" : true,
                "default": null
            }
        }
    }
}
```

When restarting the cluster, `now` is applied instead of `null`. So index become:

```
{
    "mappings": {
        "power": {
            "_timestamp" : {
                "enabled" : true,
                "default": "now"
            }
        }
    }
}
```

This PR fix that and applies `null` when it was explicitly set.

Note that this won't happen anymore in 1.5 as `null` is not allowed anymore as a `default` value. See #9104.

See also:
- #7036
- #9049
- #9426#issuecomment-71534871
