### PR TITLE
Flush immediately after a remote recovery finishes (unless there are ongoing ones)

### DIFF
--- a/src/main/java/org/elasticsearch/common/xcontent/XContentHelper.java
+++ b/src/main/java/org/elasticsearch/common/xcontent/XContentHelper.java
@@ -204,7 +204,10 @@ public class XContentHelper {
      */
     public static String toString(ToXContent toXContent, Params params) {
         try {
-            XContentBuilder builder = XContentFactory.jsonBuilder().prettyPrint();
+            XContentBuilder builder = XContentFactory.jsonBuilder();
+            if (params.paramAsBoolean("pretty", true)) {
+                builder.prettyPrint();
+            }
             builder.startObject();
             toXContent.toXContent(builder, params);
             builder.endObject();

--- a/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
+++ b/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
@@ -1685,7 +1685,7 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
             assert onGoingRecoveries.get() >= 0 : "ongoingRecoveries must be >= 0 but was: " + onGoingRecoveries.get();
             if (left == 0) {
                 try {
-                    logger.info("flushing post replication");
+                    logger.info("flushing post recovery");
                     flush(new Engine.Flush());
                 } catch (IllegalIndexShardStateException e) {
                     // we are being closed, or in created state, ignore

--- a/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
+++ b/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
@@ -36,7 +36,6 @@ import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.cluster.routing.operation.hash.djb.DjbHashFunction;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Preconditions;
-import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.lease.Releasables;
@@ -69,6 +68,7 @@ import org.elasticsearch.index.search.nested.IncludeNestedDocsQuery;
 import org.elasticsearch.index.settings.IndexSettings;
 import org.elasticsearch.index.settings.IndexSettingsService;
 import org.elasticsearch.index.shard.AbstractIndexShardComponent;
+import org.elasticsearch.index.shard.IllegalIndexShardStateException;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.similarity.SimilarityService;
 import org.elasticsearch.index.store.Store;
@@ -282,7 +282,7 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
                         indexWriter = null;
                         pending.rollback();
                     } catch (IOException e1) {
-                       e.addSuppressed(e1);
+                        e.addSuppressed(e1);
                     }
                 }
                 throw new EngineCreationFailureException(shardId, "failed to create engine", e);
@@ -1019,7 +1019,7 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
 
         lastDeleteVersionPruneTimeMSec = timeMSec;
     }
-    
+
     @Override
     public void maybeMerge() throws EngineException {
         if (!possibleMergeNeeded()) {
@@ -1033,7 +1033,7 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
             throw new OptimizeFailedEngineException(shardId, t);
         }
     }
-    
+
     private void waitForMerges(boolean flushAfter, boolean upgrade) {
         try {
             currentIndexWriter().waitForMerges();
@@ -1065,9 +1065,9 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
                 assert mp instanceof ElasticsearchMergePolicy : "MergePolicy is " + mp.getClass().getName();
                 if (optimize.upgrade()) {
                     logger.info("Starting upgrade of " + shardId);
-                    ((ElasticsearchMergePolicy)mp).setUpgradeInProgress(true);
+                    ((ElasticsearchMergePolicy) mp).setUpgradeInProgress(true);
                 }
-                
+
                 if (optimize.onlyExpungeDeletes()) {
                     writer.forceMergeDeletes(false);
                 } else if (optimize.maxNumSegments() <= 0) {
@@ -1083,7 +1083,7 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
                 optimizeMutex.set(false);
             }
         }
-        
+
         // wait for the merges outside of the read lock
         if (optimize.waitForMerge()) {
             waitForMerges(optimize.flush(), optimize.upgrade());
@@ -1186,7 +1186,7 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
             } else {
                 logger.warn("corrupt file detected source: [{}] but [{}] is set to [{}]", t, source, INDEX_FAIL_ON_CORRUPTION, this.failEngineOnCorruption);
             }
-        }else if (ExceptionsHelper.isOOM(t)) {
+        } else if (ExceptionsHelper.isOOM(t)) {
             failEngine("out of memory", t);
             return true;
         }
@@ -1217,7 +1217,7 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
             }
             stats.addVersionMapMemoryInBytes(versionMap.ramBytesUsed());
             stats.addIndexWriterMemoryInBytes(indexWriter.ramBytesUsed());
-            stats.addIndexWriterMaxMemoryInBytes((long) (indexWriter.getConfig().getRAMBufferSizeMB()*1024*1024));
+            stats.addIndexWriterMaxMemoryInBytes((long) (indexWriter.getConfig().getRAMBufferSizeMB() * 1024 * 1024));
             return stats;
         }
     }
@@ -1500,7 +1500,7 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
                 InternalEngine.this.compoundOnFlush = compoundOnFlush;
                 indexWriter.getConfig().setUseCompoundFile(compoundOnFlush);
             }
-            
+
             final boolean checksumOnMerge = settings.getAsBoolean(INDEX_CHECKSUM_ON_MERGE, InternalEngine.this.checksumOnMerge);
             if (checksumOnMerge != InternalEngine.this.checksumOnMerge) {
                 logger.info("updating {} from [{}] to [{}]", InternalEngine.INDEX_CHECKSUM_ON_MERGE, InternalEngine.this.checksumOnMerge, checksumOnMerge);
@@ -1681,8 +1681,20 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
 
         public void endRecovery() throws ElasticsearchException {
             store.decRef();
-            onGoingRecoveries.decrementAndGet();
+            int left = onGoingRecoveries.decrementAndGet();
             assert onGoingRecoveries.get() >= 0 : "ongoingRecoveries must be >= 0 but was: " + onGoingRecoveries.get();
+            if (left == 0) {
+                try {
+                    logger.info("flushing post replication");
+                    flush(new Engine.Flush());
+                } catch (IllegalIndexShardStateException e) {
+                    // we are being closed, or in created state, ignore
+                } catch (FlushNotAllowedEngineException e) {
+                    // ignore this exception, we are not allowed to perform flush
+                } catch (Throwable e) {
+                    logger.warn("failed to flush shard post recovery", e);
+                }
+            }
         }
 
         @Override
@@ -1738,7 +1750,6 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
             return count != null && count.get() > 0;
         }
     }
-
 
 
     static final class IndexThrottle implements MergeSchedulerProvider.Listener {

--- a/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
+++ b/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
@@ -1685,8 +1685,7 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
             assert onGoingRecoveries.get() >= 0 : "ongoingRecoveries must be >= 0 but was: " + onGoingRecoveries.get();
             if (left == 0) {
                 try {
-                    logger.info("flushing post recovery");
-                    flush(new Engine.Flush());
+                    flush(new Engine.Flush().type(Flush.Type.COMMIT_TRANSLOG));
                 } catch (IllegalIndexShardStateException e) {
                     // we are being closed, or in created state, ignore
                 } catch (FlushNotAllowedEngineException e) {

--- a/src/test/java/org/elasticsearch/benchmark/recovery/ReplicaRecoveryBenchmark.java
+++ b/src/test/java/org/elasticsearch/benchmark/recovery/ReplicaRecoveryBenchmark.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.benchmark.recovery;
+
+import org.elasticsearch.action.admin.indices.recovery.RecoveryResponse;
+import org.elasticsearch.action.admin.indices.recovery.ShardRecoveryResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.routing.allocation.decider.DiskThresholdDecider;
+import org.elasticsearch.common.jna.Natives;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.ESLoggerFactory;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.SizeValue;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.indices.IndexMissingException;
+import org.elasticsearch.node.Node;
+import org.elasticsearch.test.BackgroundIndexer;
+import org.elasticsearch.transport.TransportModule;
+
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_REPLICAS;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
+import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.elasticsearch.node.NodeBuilder.nodeBuilder;
+
+/**
+ *
+ */
+public class ReplicaRecoveryBenchmark {
+
+    private static final String INDEX_NAME = "index";
+    private static final String TYPE_NAME = "type";
+
+
+    static int DOC_COUNT = (int) SizeValue.parseSizeValue("40k").singles();
+    static int CONCURRENT_INDEXERS = 2;
+
+    public static void main(String[] args) throws Exception {
+        System.setProperty("es.logger.prefix", "");
+        Natives.tryMlockall();
+
+        Settings settings = settingsBuilder()
+                .put("gateway.type", "local")
+                .put(DiskThresholdDecider.CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED, "false")
+                .put(SETTING_NUMBER_OF_SHARDS, 1)
+                .put(SETTING_NUMBER_OF_REPLICAS, 0)
+                .put(TransportModule.TRANSPORT_TYPE_KEY, "local")
+                .build();
+
+        String clusterName = ReplicaRecoveryBenchmark.class.getSimpleName();
+        Node node1 = nodeBuilder().clusterName(clusterName)
+                .settings(settingsBuilder().put(settings))
+                .node();
+
+        final ESLogger logger = ESLoggerFactory.getLogger("benchmark");
+
+        final Client client1 = node1.client();
+        client1.admin().cluster().prepareUpdateSettings().setPersistentSettings("logger.indices.recovery: TRACE").get();
+        final BackgroundIndexer indexer = new BackgroundIndexer(INDEX_NAME, TYPE_NAME, client1, 0, CONCURRENT_INDEXERS, false, new Random());
+        indexer.setMinFieldSize(10);
+        indexer.setMaxFieldSize(150);
+        try {
+            client1.admin().indices().prepareDelete(INDEX_NAME).get();
+        } catch (IndexMissingException e) {
+        }
+        client1.admin().indices().prepareCreate(INDEX_NAME).get();
+        indexer.start(DOC_COUNT / 2);
+        while (indexer.totalIndexedDocs() < DOC_COUNT / 2) {
+            Thread.sleep(5000);
+            logger.info("--> indexed {} of {}", indexer.totalIndexedDocs(), DOC_COUNT);
+        }
+        client1.admin().indices().prepareFlush().get();
+        indexer.continueIndexing(DOC_COUNT / 2);
+        while (indexer.totalIndexedDocs() < DOC_COUNT) {
+            Thread.sleep(5000);
+            logger.info("--> indexed {} of {}", indexer.totalIndexedDocs(), DOC_COUNT);
+        }
+
+
+        logger.info("--> starting another node and allocating a shard on it");
+
+        Node node2 = nodeBuilder().clusterName(clusterName)
+                .settings(settingsBuilder().put(settings))
+                .node();
+
+        client1.admin().indices().prepareUpdateSettings(INDEX_NAME).setSettings(IndexMetaData.SETTING_NUMBER_OF_REPLICAS + ": 1").get();
+
+        final AtomicBoolean end = new AtomicBoolean(false);
+
+        final Thread backgroundLogger = new Thread(new Runnable() {
+
+            long lastTime = System.currentTimeMillis();
+            long lastDocs = indexer.totalIndexedDocs();
+            long lastBytes = 0;
+            long lastTranslogOps = 0;
+
+            @Override
+            public void run() {
+                while (true) {
+                    try {
+                        Thread.sleep(5000);
+                    } catch (InterruptedException e) {
+
+                    }
+                    if (end.get()) {
+                        return;
+                    }
+                    long currentTime = System.currentTimeMillis();
+                    long currentDocs = indexer.totalIndexedDocs();
+                    RecoveryResponse recoveryResponse = client1.admin().indices().prepareRecoveries(INDEX_NAME).setActiveOnly(true).get();
+                    List<ShardRecoveryResponse> indexRecoveries = recoveryResponse.shardResponses().get(INDEX_NAME);
+                    long translogOps;
+                    long bytes;
+                    if (indexRecoveries.size() > 0) {
+                        translogOps = indexRecoveries.get(0).recoveryState().getTranslog().currentTranslogOperations();
+                        bytes = recoveryResponse.shardResponses().get(INDEX_NAME).get(0).recoveryState().getIndex().recoveredByteCount();
+                    } else {
+                        bytes = lastBytes = 0;
+                        translogOps = lastTranslogOps = 0;
+                    }
+                    float seconds = (currentTime - lastTime) / 1000.0F;
+                    logger.info("--> indexed [{}];[{}] doc/s, recovered [{}] MB/s , translog ops [{}]/s ",
+                            currentDocs, (currentDocs - lastDocs) / seconds,
+                            (bytes - lastBytes) / 1024.0F / 1024F / seconds, (translogOps - lastTranslogOps) / seconds);
+                    lastBytes = bytes;
+                    lastTranslogOps = translogOps;
+                    lastTime = currentTime;
+                    lastDocs = currentDocs;
+                }
+            }
+        });
+
+        backgroundLogger.start();
+
+        client1.admin().cluster().prepareHealth().setWaitForGreenStatus().get();
+
+        logger.info("--> green. starting relocation cycles");
+
+        long startDocIndexed = indexer.totalIndexedDocs();
+        indexer.continueIndexing(DOC_COUNT * 50);
+
+        long totalRecoveryTime = 0;
+        long startTime = System.currentTimeMillis();
+        for (int iteration = 0; iteration < 3; iteration++) {
+            logger.info("--> removing replicas");
+            client1.admin().indices().prepareUpdateSettings(INDEX_NAME).setSettings(IndexMetaData.SETTING_NUMBER_OF_REPLICAS + ": 0").get();
+            logger.info("--> adding replica again");
+            long recoveryStart = System.currentTimeMillis();
+            client1.admin().indices().prepareUpdateSettings(INDEX_NAME).setSettings(IndexMetaData.SETTING_NUMBER_OF_REPLICAS + ": 1").get();
+            client1.admin().cluster().prepareHealth(INDEX_NAME).setWaitForGreenStatus().setTimeout("15m").get();
+            long recoveryTime = System.currentTimeMillis() - recoveryStart;
+            totalRecoveryTime += recoveryTime;
+            logger.info("--> recovery done in [{}]", new TimeValue(recoveryTime));
+            // sleep some to let things clean up
+            Thread.sleep(10000);
+        }
+
+        long endDocIndexed = indexer.totalIndexedDocs();
+        long totalTime = System.currentTimeMillis() - startTime;
+        indexer.stop();
+
+        end.set(true);
+
+        backgroundLogger.interrupt();
+
+        backgroundLogger.join();
+
+        logger.info("average doc/s [{}], average relocation time [{}]", (endDocIndexed - startDocIndexed) * 1000.0 / totalTime, new TimeValue(totalRecoveryTime / 3));
+
+        client1.close();
+        node1.close();
+        node2.close();
+    }
+}

--- a/src/test/java/org/elasticsearch/index/engine/internal/InternalEngineTests.java
+++ b/src/test/java/org/elasticsearch/index/engine/internal/InternalEngineTests.java
@@ -30,10 +30,8 @@ import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.TextField;
 import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.IndexDeletionPolicy;
-import org.apache.lucene.index.SegmentInfos;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.TermQuery;
-import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.util.LuceneTestCase.Slow;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.Version;
@@ -106,6 +104,9 @@ public class InternalEngineTests extends ElasticsearchTestCase {
     private Store store;
     private Store storeReplica;
 
+    protected Translog translog;
+    protected Translog replicaTranslog;
+
     protected Engine engine;
     protected Engine replicaEngine;
 
@@ -130,13 +131,15 @@ public class InternalEngineTests extends ElasticsearchTestCase {
         storeReplica = createStoreReplica();
         storeReplica.deleteContent();
         engineSettingsService = new IndexSettingsService(shardId.index(), ImmutableSettings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT).build());
-        engine = createEngine(engineSettingsService, store, createTranslog());
+        translog = createTranslog();
+        engine = createEngine(engineSettingsService, store, translog);
         if (randomBoolean()) {
             engine.enableGcDeletes(false);
         }
         engine.start();
         replicaSettingsService = new IndexSettingsService(shardId.index(), ImmutableSettings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT).build());
-        replicaEngine = createEngine(replicaSettingsService, storeReplica, createTranslogReplica());
+        replicaTranslog = createTranslogReplica();
+        replicaEngine = createEngine(replicaSettingsService, storeReplica, replicaTranslog);
         if (randomBoolean()) {
             replicaEngine.enableGcDeletes(false);
         }
@@ -708,7 +711,7 @@ public class InternalEngineTests extends ElasticsearchTestCase {
 
     @Test
     public void testSimpleRecover() throws Exception {
-        ParsedDocument doc = testParsedDocument("1", "1", "test", null, -1, -1, testDocumentWithTextField(), Lucene.STANDARD_ANALYZER, B_1, false);
+        final ParsedDocument doc = testParsedDocument("1", "1", "test", null, -1, -1, testDocumentWithTextField(), Lucene.STANDARD_ANALYZER, B_1, false);
         engine.create(new Engine.Create(null, newUid("1"), doc));
         engine.flush(new Engine.Flush());
 
@@ -732,11 +735,14 @@ public class InternalEngineTests extends ElasticsearchTestCase {
                 } catch (FlushNotAllowedEngineException e) {
                     // all is well
                 }
+
+                // but we can index
+                engine.index(new Engine.Index(null, newUid("1"), doc));
             }
 
             @Override
             public void phase3(Translog.Snapshot snapshot) throws EngineException {
-                MatcherAssert.assertThat(snapshot, TranslogSizeMatcher.translogSize(0));
+                MatcherAssert.assertThat(snapshot, TranslogSizeMatcher.translogSize(1));
                 try {
                     // we can do this here since we are on the same thread
                     engine.flush(new Engine.Flush());
@@ -746,6 +752,8 @@ public class InternalEngineTests extends ElasticsearchTestCase {
                 }
             }
         });
+        // post recovery should flush the translog
+        MatcherAssert.assertThat(translog.snapshot(), TranslogSizeMatcher.translogSize(0));
 
         engine.flush(new Engine.Flush());
         engine.close();


### PR DESCRIPTION
To properly replicate, we currently stop flushing during recovery so we can repay the translog once copying files are done. Once recovery is done, the translog will be flushed by a background thread that, by default, kicks in every 5s. In case of a recovery failure and a quick re-assignment of a new shard copy, we may fail to flush before starting a new recovery, causing it to deal with potentially even longer translog. This commit makes sure we flush immediately when the ongoing recovery count goes to 0.

I also added a simple recovery benchmark.
