### PR TITLE
Fix shard state tranport action names

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
+++ b/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
@@ -52,8 +52,8 @@ import static org.elasticsearch.cluster.routing.ImmutableShardRouting.readShardR
  */
 public class ShardStateAction extends AbstractComponent {
 
-    public static final String SHARD_STARTED_ACTION_NAME = "internal:cluster/shard/failure";
-    public static final String SHARD_FAILED_ACTION_NAME = "internal:cluster/shard/started";
+    public static final String SHARD_STARTED_ACTION_NAME = "internal:cluster/shard/started";
+    public static final String SHARD_FAILED_ACTION_NAME = "internal:cluster/shard/failure";
 
     private final TransportService transportService;
     private final ClusterService clusterService;

--- a/src/main/java/org/elasticsearch/transport/ActionNames.java
+++ b/src/main/java/org/elasticsearch/transport/ActionNames.java
@@ -158,6 +158,17 @@ final class ActionNames {
                 return post_1_4_action;
             }
         }
+        if (version.onOrAfter(Version.V_1_4_0_Beta1) && version.before(Version.V_1_5_0)) {
+            //when we renamed the transport actions in #7105, shard started and failed were flipped around
+            //this didn't cause any actual problem as it was done in a backwards compatible manner.
+            //That said the action names were wrong and we have to fix it still maintaining backwards compatibility
+            if (action.equals(ShardStateAction.SHARD_FAILED_ACTION_NAME)) {
+                return ShardStateAction.SHARD_STARTED_ACTION_NAME;
+            }
+            if (action.equals(ShardStateAction.SHARD_STARTED_ACTION_NAME)) {
+                return ShardStateAction.SHARD_FAILED_ACTION_NAME;
+            }
+        }
         return action;
     }
 
@@ -171,6 +182,17 @@ final class ActionNames {
             //custom actions e.g. registered through plugins are not mapped, fallback to the original one
             if (pre_1_4_Action != null) {
                 return pre_1_4_Action;
+            }
+        }
+        if (version.onOrAfter(Version.V_1_4_0_Beta1) && version.before(Version.V_1_5_0)) {
+            //when we renamed the transport actions in #7105, shard started and failed were flipped around
+            //this didn't cause any actual problem as it was done in a backwards compatible manner.
+            //That said the action names were wrong and we have to fix it still maintaining backwards compatibility
+            if (action.equals(ShardStateAction.SHARD_FAILED_ACTION_NAME)) {
+                return ShardStateAction.SHARD_STARTED_ACTION_NAME;
+            }
+            if (action.equals(ShardStateAction.SHARD_STARTED_ACTION_NAME)) {
+                return ShardStateAction.SHARD_FAILED_ACTION_NAME;
             }
         }
         return action;


### PR DESCRIPTION
When we renamed all of the transport actions in #7105, shard started and failed were flipped around by mistake.
This didn't cause any actual problem as the change was made in a backwards compatible manner. That said the action names ended up being wrong (just a naming problem, meaning that started == failed and failed ==started) and we have to fix it, still maintaining backwards compatibility.
