### PR TITLE
Add AliasesRequest interface to mark requests that manage aliases

### DIFF
--- a/src/main/java/org/elasticsearch/action/AliasesRequest.java
+++ b/src/main/java/org/elasticsearch/action/AliasesRequest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action;
+
+/**
+ * Needs to be implemented by all {@link org.elasticsearch.action.ActionRequest} subclasses that relate to
+ * one or more indices and one or more aliases. Meant to be used for aliases management requests (e.g. add/remove alias,
+ * get aliases) that hold aliases and indices in separate fields.
+ * Allows to retrieve which indices and aliases the action relates to.
+ */
+public interface AliasesRequest extends IndicesRequest.Replaceable {
+
+    /**
+     * Returns the array of aliases that the action relates to
+     */
+    String[] aliases();
+
+    /**
+     * Sets the array of aliases that the action relates to
+     */
+    AliasesRequest aliases(String[] aliases);
+
+    /**
+     * Returns true if wildcards expressions among aliases should be resolved, false otherwise
+     */
+    boolean expandAliasesWildcards();
+}

--- a/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequestBuilder.java
@@ -51,7 +51,7 @@ public class IndicesAliasesRequestBuilder extends AcknowledgedRequestBuilder<Ind
     /**
      * Adds an alias to the index.
      *
-     * @param index The indices
+     * @param indices The indices
      * @param alias The alias
      */
     public IndicesAliasesRequestBuilder addAlias(String[] indices, String alias) {
@@ -184,13 +184,10 @@ public class IndicesAliasesRequestBuilder extends AcknowledgedRequestBuilder<Ind
     /**
      * Adds an alias action to the request.
      *
-     * @param aliasAction The alias action
+     * @param action The alias action
      */
-    public IndicesAliasesRequestBuilder addAliasAction(
-            AliasActions action) {
+    public IndicesAliasesRequestBuilder addAliasAction(AliasActions action) {
         request.addAliasAction(action);
         return this;
     }
-
-   
 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/alias/TransportIndicesAliasesAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/alias/TransportIndicesAliasesAction.java
@@ -38,10 +38,7 @@ import org.elasticsearch.rest.action.admin.indices.alias.delete.AliasesMissingEx
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 /**
  * Add/remove aliases action
@@ -96,9 +93,7 @@ public class TransportIndicesAliasesAction extends TransportMasterNodeOperationA
             //expand indices
             String[] concreteIndices = state.metaData().concreteIndices(request.indicesOptions(), action.indices());
             //collect the aliases
-            for (String alias : action.aliases()) {
-                aliases.add(alias);
-            }
+            Collections.addAll(aliases, action.aliases());
             for (String index : concreteIndices) {
                 for (String alias : action.concreteAliases(state.metaData(), index)) { 
                     AliasAction finalAction = new AliasAction(action.aliasAction());

--- a/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesRequest.java
@@ -20,7 +20,7 @@ package org.elasticsearch.action.admin.indices.alias.get;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
-import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.AliasesRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.MasterNodeReadOperationRequest;
 import org.elasticsearch.common.Strings;
@@ -31,7 +31,7 @@ import java.io.IOException;
 
 /**
  */
-public class GetAliasesRequest extends MasterNodeReadOperationRequest<GetAliasesRequest> implements IndicesRequest.Replaceable {
+public class GetAliasesRequest extends MasterNodeReadOperationRequest<GetAliasesRequest> implements AliasesRequest {
 
     private String[] indices = Strings.EMPTY_ARRAY;
     private String[] aliases = Strings.EMPTY_ARRAY;
@@ -55,6 +55,7 @@ public class GetAliasesRequest extends MasterNodeReadOperationRequest<GetAliases
         return this;
     }
 
+    @Override
     public GetAliasesRequest aliases(String... aliases) {
         this.aliases = aliases;
         return this;
@@ -70,8 +71,14 @@ public class GetAliasesRequest extends MasterNodeReadOperationRequest<GetAliases
         return indices;
     }
 
+    @Override
     public String[] aliases() {
         return aliases;
+    }
+
+    @Override
+    public boolean expandAliasesWildcards() {
+        return true;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
@@ -320,9 +320,9 @@ public class MetaData implements Iterable<IndexMetaData> {
         return mapBuilder.build();
     }
 
-    private boolean matchAllAliases(final String[] aliases) {
+    private static boolean matchAllAliases(final String[] aliases) {
         for (String alias : aliases) {
-            if (alias.equals("_all")) {
+            if (alias.equals(ALL)) {
                 return true;
             }
         }

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/put/RestIndexPutAliasAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/put/RestIndexPutAliasAction.java
@@ -29,7 +29,10 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.rest.*;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.support.AcknowledgedRestListener;
 
 import java.util.Map;

--- a/src/test/java/org/elasticsearch/aliases/IndexAliasesTests.java
+++ b/src/test/java/org/elasticsearch/aliases/IndexAliasesTests.java
@@ -752,11 +752,9 @@ public class IndexAliasesTests extends ElasticsearchIntegrationTest {
             assertAcked(admin().indices().prepareAliases().addAliasAction(AliasAction.newAddAliasAction(null, "alias1")));
             fail("create alias should have failed due to null index");
         } catch (ElasticsearchIllegalArgumentException e) {
-            assertThat("Exception text does not contain \"Property [index] was either missing or null\"",
-                    e.getMessage().contains("Property [index] was either missing or null"),
-                    equalTo(true));
+            assertThat("Exception text does not contain \"Alias action [add]: [index] may not be empty string\"",
+                    e.getMessage(), containsString("Alias action [add]: [index] may not be empty string"));
         }
-
     }
 
     @Test
@@ -771,9 +769,8 @@ public class IndexAliasesTests extends ElasticsearchIntegrationTest {
             assertAcked(admin().indices().prepareAliases().addAlias((String) null, "empty-alias"));
             fail("create alias should have failed due to null index");
         } catch (ElasticsearchIllegalArgumentException e) {
-            assertThat("Exception text does not contain \"Property [index] was either missing or null\"",
-                    e.getMessage().contains("Property [index] was either missing or null"),
-                    equalTo(true));
+            assertThat("Exception text does not contain \"Alias action [add]: [index] may not be empty string\"",
+                    e.getMessage(), containsString("Alias action [add]: [index] may not be empty string"));
         }
     }
 


### PR DESCRIPTION
We currently have the IndicesRequest interface to mark indices related requests and be able to retrieve the indices they relate to in a generic way. This commit introduces a similar abstraction for requests that manage aliases, to be able to retrieve/replace the aliases they relate to.

Also, IndicesAliasesRequest becomes a CompositeIndicesRequest, as it allows to perform multiple operations (e.g. add/remote multiple aliases). Each single operation (AliasActions) implements now the newly introduced AliasesRequest.

AliasesRequest is also implemented by GetAliasesRequest, which allows to retrieve aliases information.
