### PR TITLE
Test: use local gateway by default

### DIFF
--- a/src/test/java/org/elasticsearch/cluster/MinimumMasterNodesTests.java
+++ b/src/test/java/org/elasticsearch/cluster/MinimumMasterNodesTests.java
@@ -32,7 +32,6 @@ import org.elasticsearch.discovery.zen.elect.ElectMasterService;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
-import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -43,7 +42,6 @@ import static org.elasticsearch.client.Requests.clusterHealthRequest;
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 import static org.elasticsearch.test.ElasticsearchIntegrationTest.Scope;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertThrows;
 import static org.hamcrest.Matchers.*;
 
 @ClusterScope(scope = Scope.TEST, numDataNodes = 0)
@@ -57,7 +55,6 @@ public class MinimumMasterNodesTests extends ElasticsearchIntegrationTest {
                 .put("discovery.zen.minimum_master_nodes", 2)
                 .put("discovery.zen.ping_timeout", "200ms")
                 .put("discovery.initial_state_timeout", "500ms")
-                .put("gateway.type", "local")
                 .build();
 
         logger.info("--> start first node");
@@ -175,7 +172,6 @@ public class MinimumMasterNodesTests extends ElasticsearchIntegrationTest {
                 .put("discovery.zen.minimum_master_nodes", 3)
                 .put("discovery.zen.ping_timeout", "1s")
                 .put("discovery.initial_state_timeout", "500ms")
-                .put("gateway.type", "local")
                 .build();
 
         logger.info("--> start first 2 nodes");
@@ -265,7 +261,6 @@ public class MinimumMasterNodesTests extends ElasticsearchIntegrationTest {
                 .put("discovery.type", "zen")
                 .put("discovery.zen.ping_timeout", "400ms")
                 .put("discovery.initial_state_timeout", "500ms")
-                .put("gateway.type", "local")
                 .build();
 
         logger.info("--> start 2 nodes");
@@ -318,8 +313,7 @@ public class MinimumMasterNodesTests extends ElasticsearchIntegrationTest {
         ImmutableSettings.Builder settings = settingsBuilder()
                 .put("discovery.type", "zen")
                 .put("discovery.zen.ping_timeout", "200ms")
-                .put("discovery.initial_state_timeout", "500ms")
-                .put("gateway.type", "local");
+                .put("discovery.initial_state_timeout", "500ms");
 
         // set an initial value which is at least quorum to avoid split brains during initial startup
         int initialMinMasterNodes = randomIntBetween(nodeCount / 2 + 1, nodeCount);

--- a/src/test/java/org/elasticsearch/cluster/allocation/ClusterRerouteTests.java
+++ b/src/test/java/org/elasticsearch/cluster/allocation/ClusterRerouteTests.java
@@ -70,7 +70,6 @@ public class ClusterRerouteTests extends ElasticsearchIntegrationTest {
     public void rerouteWithCommands_enableAllocationSettings() throws Exception {
         Settings commonSettings = settingsBuilder()
                 .put(EnableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ENABLE, EnableAllocationDecider.Allocation.NONE.name())
-                .put("gateway.type", "local")
                 .build();
         rerouteWithCommands(commonSettings);
     }
@@ -141,7 +140,6 @@ public class ClusterRerouteTests extends ElasticsearchIntegrationTest {
         Settings commonSettings = settingsBuilder()
                 .put(DisableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_DISABLE_NEW_ALLOCATION, true)
                 .put(DisableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_DISABLE_ALLOCATION, true)
-                .put("gateway.type", "local")
                 .build();
         rerouteWithAllocateLocalGateway(commonSettings);
     }
@@ -150,7 +148,6 @@ public class ClusterRerouteTests extends ElasticsearchIntegrationTest {
     public void rerouteWithAllocateLocalGateway_enableAllocationSettings() throws Exception {
         Settings commonSettings = settingsBuilder()
                 .put(EnableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ENABLE, EnableAllocationDecider.Allocation.NONE.name())
-                .put("gateway.type", "local")
                 .build();
         rerouteWithAllocateLocalGateway(commonSettings);
     }

--- a/src/test/java/org/elasticsearch/gateway/local/LocalGatewayIndexStateTests.java
+++ b/src/test/java/org/elasticsearch/gateway/local/LocalGatewayIndexStateTests.java
@@ -38,7 +38,6 @@ import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
 import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.test.InternalTestCluster.RestartCallback;
-import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.junit.Test;
 
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
@@ -62,7 +61,7 @@ public class LocalGatewayIndexStateTests extends ElasticsearchIntegrationTest {
     public void testMappingMetaDataParsed() throws Exception {
 
         logger.info("--> starting 1 nodes");
-        internalCluster().startNode(settingsBuilder().put("gateway.type", "local"));
+        internalCluster().startNode();
 
         logger.info("--> creating test index, with meta routing");
         client().admin().indices().prepareCreate("test")
@@ -91,7 +90,7 @@ public class LocalGatewayIndexStateTests extends ElasticsearchIntegrationTest {
     public void testSimpleOpenClose() throws Exception {
 
         logger.info("--> starting 2 nodes");
-        internalCluster().startNodesAsync(2, settingsBuilder().put("gateway.type", "local").build()).get();
+        internalCluster().startNodesAsync(2).get();
 
         logger.info("--> creating test index");
         createIndex("test");
@@ -194,7 +193,7 @@ public class LocalGatewayIndexStateTests extends ElasticsearchIntegrationTest {
         logger.info("--> cleaning nodes");
 
         logger.info("--> starting 1 master node non data");
-        internalCluster().startNode(settingsBuilder().put("node.data", false).put("gateway.type", "local").build());
+        internalCluster().startNode(settingsBuilder().put("node.data", false).build());
 
         logger.info("--> create an index");
         client().admin().indices().prepareCreate("test").execute().actionGet();
@@ -203,7 +202,7 @@ public class LocalGatewayIndexStateTests extends ElasticsearchIntegrationTest {
         internalCluster().closeNonSharedNodes(false);
 
         logger.info("--> starting 1 master node non data again");
-        internalCluster().startNode(settingsBuilder().put("node.data", false).put("gateway.type", "local").build());
+        internalCluster().startNode(settingsBuilder().put("node.data", false).build());
 
         logger.info("--> waiting for test index to be created");
         ClusterHealthResponse health = client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setIndices("test").execute().actionGet();
@@ -219,8 +218,8 @@ public class LocalGatewayIndexStateTests extends ElasticsearchIntegrationTest {
         logger.info("--> cleaning nodes");
 
         logger.info("--> starting 1 master node non data");
-        internalCluster().startNode(settingsBuilder().put("node.data", false).put("gateway.type", "local").build());
-        internalCluster().startNode(settingsBuilder().put("node.master", false).put("gateway.type", "local").build());
+        internalCluster().startNode(settingsBuilder().put("node.data", false).build());
+        internalCluster().startNode(settingsBuilder().put("node.master", false).build());
 
         logger.info("--> create an index");
         client().admin().indices().prepareCreate("test").execute().actionGet();
@@ -236,8 +235,8 @@ public class LocalGatewayIndexStateTests extends ElasticsearchIntegrationTest {
         logger.info("--> cleaning nodes");
 
         logger.info("--> starting 2 nodes");
-        internalCluster().startNode(settingsBuilder().put("gateway.type", "local").build());
-        internalCluster().startNode(settingsBuilder().put("gateway.type", "local").build());
+        internalCluster().startNode();
+        internalCluster().startNode();
 
         logger.info("--> indexing a simple document");
         client().prepareIndex("test", "type1", "1").setSource("field1", "value1").setRefresh(true).execute().actionGet();
@@ -274,9 +273,8 @@ public class LocalGatewayIndexStateTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testDanglingIndicesConflictWithAlias() throws Exception {
-        Settings settings = settingsBuilder().put("gateway.type", "local").build();
         logger.info("--> starting two nodes");
-        internalCluster().startNodesAsync(2, settings).get();
+        internalCluster().startNodesAsync(2).get();
 
         logger.info("--> indexing a simple document");
         client().prepareIndex("test", "type1", "1").setSource("field1", "value1").setRefresh(true).execute().actionGet();
@@ -304,7 +302,7 @@ public class LocalGatewayIndexStateTests extends ElasticsearchIntegrationTest {
         assertAcked(client().admin().indices().prepareAliases().addAlias("test2", "test"));
 
         logger.info("--> starting node back up");
-        internalCluster().startNode(settings);
+        internalCluster().startNode();
 
         ensureGreen();
 
@@ -337,7 +335,7 @@ public class LocalGatewayIndexStateTests extends ElasticsearchIntegrationTest {
     @Test
     public void testDanglingIndicesAutoImportYes() throws Exception {
         Settings settings = settingsBuilder()
-                .put("gateway.type", "local").put("gateway.local.auto_import_dangled", "yes")
+                .put("gateway.local.auto_import_dangled", "yes")
                 .put("gateway.local.dangling_timeout", randomIntBetween(0, 120))
                 .build();
         logger.info("--> starting two nodes");
@@ -393,7 +391,7 @@ public class LocalGatewayIndexStateTests extends ElasticsearchIntegrationTest {
     @Test
     public void testDanglingIndicesAutoImportClose() throws Exception {
         Settings settings = settingsBuilder()
-                .put("gateway.type", "local").put("gateway.local.auto_import_dangled", "closed")
+                .put("gateway.local.auto_import_dangled", "closed")
                 .build();
 
 
@@ -456,7 +454,7 @@ public class LocalGatewayIndexStateTests extends ElasticsearchIntegrationTest {
     @Test
     public void testDanglingIndicesNoAutoImport() throws Exception {
         Settings settings = settingsBuilder()
-                .put("gateway.type", "local").put("gateway.local.auto_import_dangled", "no")
+                .put("gateway.local.auto_import_dangled", "no")
                 .build();
         logger.info("--> starting two nodes");
         final String node_1 = internalCluster().startNodesAsync(2, settings).get().get(0);
@@ -518,7 +516,7 @@ public class LocalGatewayIndexStateTests extends ElasticsearchIntegrationTest {
     @Test
     public void testDanglingIndicesNoAutoImportStillDanglingAndCreatingSameIndex() throws Exception {
         Settings settings = settingsBuilder()
-                .put("gateway.type", "local").put("gateway.local.auto_import_dangled", "no")
+                .put("gateway.local.auto_import_dangled", "no")
                 .build();
 
         logger.info("--> starting two nodes");

--- a/src/test/java/org/elasticsearch/gateway/local/QuorumLocalGatewayTests.java
+++ b/src/test/java/org/elasticsearch/gateway/local/QuorumLocalGatewayTests.java
@@ -37,7 +37,7 @@ import static org.elasticsearch.client.Requests.clusterHealthRequest;
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
-import static org.elasticsearch.test.ElasticsearchIntegrationTest.*;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.Scope;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.*;
@@ -57,7 +57,7 @@ public class QuorumLocalGatewayTests extends ElasticsearchIntegrationTest {
     @Slow
     public void testChangeInitialShardsRecovery() throws Exception {
         logger.info("--> starting 3 nodes");
-        final String[] nodes = internalCluster().startNodesAsync(3, settingsBuilder().put("gateway.type", "local").build()).get().toArray(new String[0]);
+        final String[] nodes = internalCluster().startNodesAsync(3).get().toArray(new String[0]);
 
         createIndex("test");
         ensureGreen();
@@ -78,11 +78,6 @@ public class QuorumLocalGatewayTests extends ElasticsearchIntegrationTest {
         final String nodeToRemove = nodes[between(0,2)];
         logger.info("--> restarting 1 nodes -- kill 2");
         internalCluster().fullRestart(new RestartCallback() {
-            @Override
-            public Settings onNodeStopped(String nodeName) throws Exception {
-                return settingsBuilder().put("gateway.type", "local").build();
-            }
-            
             @Override
             public boolean doRestart(String nodeName) {
                 return nodeToRemove.equals(nodeName);
@@ -123,7 +118,7 @@ public class QuorumLocalGatewayTests extends ElasticsearchIntegrationTest {
     public void testQuorumRecovery() throws Exception {
 
         logger.info("--> starting 3 nodes");
-        internalCluster().startNodesAsync(3, settingsBuilder().put("gateway.type", "local").build()).get();
+        internalCluster().startNodesAsync(3).get();
         // we are shutting down nodes - make sure we don't have 2 clusters if we test network
         setMinimumMasterNodes(2);
 

--- a/src/test/java/org/elasticsearch/gateway/local/SimpleRecoveryLocalGatewayTests.java
+++ b/src/test/java/org/elasticsearch/gateway/local/SimpleRecoveryLocalGatewayTests.java
@@ -56,15 +56,11 @@ import static org.hamcrest.Matchers.*;
 @Slow
 public class SimpleRecoveryLocalGatewayTests extends ElasticsearchIntegrationTest {
 
-    private ImmutableSettings.Builder settingsBuilder() {
-        return ImmutableSettings.settingsBuilder().put("gateway.type", "local");
-    }
-
     @Test
     @Slow
     public void testOneNodeRecoverFromGateway() throws Exception {
 
-        internalCluster().startNode(settingsBuilder().build());
+        internalCluster().startNode();
 
         String mapping = XContentFactory.jsonBuilder().startObject().startObject("type1")
                 .startObject("properties").startObject("appAccountIds").field("type", "string").endObject().endObject()
@@ -113,7 +109,7 @@ public class SimpleRecoveryLocalGatewayTests extends ElasticsearchIntegrationTes
     @Slow
     public void testSingleNodeNoFlush() throws Exception {
 
-        internalCluster().startNode(settingsBuilder().build());
+        internalCluster().startNode();
 
         String mapping = XContentFactory.jsonBuilder().startObject().startObject("type1")
                 .startObject("properties").startObject("field").field("type", "string").endObject().startObject("num").field("type", "integer").endObject().endObject()
@@ -201,7 +197,7 @@ public class SimpleRecoveryLocalGatewayTests extends ElasticsearchIntegrationTes
     @Slow
     public void testSingleNodeWithFlush() throws Exception {
 
-        internalCluster().startNode(settingsBuilder().build());
+        internalCluster().startNode();
         client().prepareIndex("test", "type1", "1").setSource(jsonBuilder().startObject().field("field", "value1").endObject()).execute().actionGet();
         flush();
         client().prepareIndex("test", "type1", "2").setSource(jsonBuilder().startObject().field("field", "value2").endObject()).execute().actionGet();
@@ -235,8 +231,8 @@ public class SimpleRecoveryLocalGatewayTests extends ElasticsearchIntegrationTes
     @Slow
     public void testTwoNodeFirstNodeCleared() throws Exception {
 
-        final String firstNode = internalCluster().startNode(settingsBuilder().build());
-        internalCluster().startNode(settingsBuilder().build());
+        final String firstNode = internalCluster().startNode();
+        internalCluster().startNode();
 
         client().prepareIndex("test", "type1", "1").setSource(jsonBuilder().startObject().field("field", "value1").endObject()).execute().actionGet();
         flush();
@@ -253,7 +249,7 @@ public class SimpleRecoveryLocalGatewayTests extends ElasticsearchIntegrationTes
         internalCluster().fullRestart(new RestartCallback() {
             @Override
             public Settings onNodeStopped(String nodeName) throws Exception {
-                return settingsBuilder().put("gateway.recover_after_nodes", 2).build();
+                return ImmutableSettings.settingsBuilder().put("gateway.recover_after_nodes", 2).build();
             }
 
             @Override
@@ -275,7 +271,7 @@ public class SimpleRecoveryLocalGatewayTests extends ElasticsearchIntegrationTes
     @Slow
     public void testLatestVersionLoaded() throws Exception {
         // clean two nodes
-        internalCluster().startNodesAsync(2, settingsBuilder().put("gateway.recover_after_nodes", 2).build()).get();
+        internalCluster().startNodesAsync(2, ImmutableSettings.settingsBuilder().put("gateway.recover_after_nodes", 2).build()).get();
 
         client().prepareIndex("test", "type1", "1").setSource(jsonBuilder().startObject().field("field", "value1").endObject()).execute().actionGet();
         client().admin().indices().prepareFlush().execute().actionGet();
@@ -345,7 +341,7 @@ public class SimpleRecoveryLocalGatewayTests extends ElasticsearchIntegrationTes
     @Test
     @Slow
     public void testReusePeerRecovery() throws Exception {
-        ImmutableSettings.Builder settings = settingsBuilder()
+        ImmutableSettings.Builder settings = ImmutableSettings.settingsBuilder()
                 .put("action.admin.cluster.node.shutdown.delay", "10ms")
                 .put(MockFSDirectoryService.CHECK_INDEX_ON_CLOSE, false)
                 .put("gateway.recover_after_nodes", 4)
@@ -373,10 +369,10 @@ public class SimpleRecoveryLocalGatewayTests extends ElasticsearchIntegrationTes
         // if we run into a relocation the reuse count will be 0 and this fails the test. We are testing here if
         // we reuse the files on disk after full restarts for replicas.
         client().admin().cluster().prepareUpdateSettings()
-                .setPersistentSettings(settingsBuilder().put(BalancedShardsAllocator.SETTING_THRESHOLD, 100.0f)).get();
+                .setPersistentSettings(ImmutableSettings.settingsBuilder().put(BalancedShardsAllocator.SETTING_THRESHOLD, 100.0f)).get();
         // Disable allocations while we are closing nodes
         client().admin().cluster().prepareUpdateSettings()
-                .setTransientSettings(settingsBuilder()
+                .setTransientSettings(ImmutableSettings.settingsBuilder()
                         .put(EnableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ENABLE, EnableAllocationDecider.Allocation.NONE))
                 .get();
         logger.info("--> full cluster restart");
@@ -388,7 +384,7 @@ public class SimpleRecoveryLocalGatewayTests extends ElasticsearchIntegrationTes
         logger.info("--> shutting down the nodes");
         // Disable allocations while we are closing nodes
         client().admin().cluster().prepareUpdateSettings()
-                .setTransientSettings(settingsBuilder()
+                .setTransientSettings(ImmutableSettings.settingsBuilder()
                         .put(EnableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ENABLE, EnableAllocationDecider.Allocation.NONE))
                 .get();
         logger.info("--> full cluster restart");
@@ -424,11 +420,11 @@ public class SimpleRecoveryLocalGatewayTests extends ElasticsearchIntegrationTes
     public void testRecoveryDifferentNodeOrderStartup() throws Exception {
         // we need different data paths so we make sure we start the second node fresh
 
-        final String node_1 = internalCluster().startNode(settingsBuilder().put("path.data", "data/data1").build());
+        final String node_1 = internalCluster().startNode(ImmutableSettings.settingsBuilder().put("path.data", "data/data1").build());
 
         client().prepareIndex("test", "type1", "1").setSource("field", "value").execute().actionGet();
 
-        internalCluster().startNode(settingsBuilder().put("path.data", "data/data2").build());
+        internalCluster().startNode(ImmutableSettings.settingsBuilder().put("path.data", "data/data2").build());
 
         ensureGreen();
 

--- a/src/test/java/org/elasticsearch/index/store/CorruptedFileTest.java
+++ b/src/test/java/org/elasticsearch/index/store/CorruptedFileTest.java
@@ -89,7 +89,7 @@ public class CorruptedFileTest extends ElasticsearchIntegrationTest {
         return ImmutableSettings.builder()
                 // we really need local GW here since this also checks for corruption etc.
                 // and we need to make sure primaries are not just trashed if we don't have replicas
-                .put(super.nodeSettings(nodeOrdinal)).put("gateway.type", "local")
+                .put(super.nodeSettings(nodeOrdinal))
                 .put(TransportModule.TRANSPORT_SERVICE_TYPE_KEY, MockTransportService.class.getName())
                         // speed up recoveries
                 .put(RecoverySettings.INDICES_RECOVERY_CONCURRENT_STREAMS, 10)

--- a/src/test/java/org/elasticsearch/index/store/CorruptedTranslogTests.java
+++ b/src/test/java/org/elasticsearch/index/store/CorruptedTranslogTests.java
@@ -60,7 +60,7 @@ public class CorruptedTranslogTests extends ElasticsearchIntegrationTest {
         return ImmutableSettings.builder()
                 // we really need local GW here since this also checks for corruption etc.
                 // and we need to make sure primaries are not just trashed if we don't have replicas
-                .put(super.nodeSettings(nodeOrdinal)).put("gateway.type", "local")
+                .put(super.nodeSettings(nodeOrdinal))
                 .put(TransportModule.TRANSPORT_SERVICE_TYPE_KEY, MockTransportService.class.getName()).build();
     }
 

--- a/src/test/java/org/elasticsearch/index/store/ExceptionRetryTests.java
+++ b/src/test/java/org/elasticsearch/index/store/ExceptionRetryTests.java
@@ -18,8 +18,6 @@
  */
 package org.elasticsearch.index.store;
 
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
 import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsResponse;
@@ -40,7 +38,8 @@ import org.elasticsearch.transport.*;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -56,7 +55,7 @@ public class ExceptionRetryTests extends ElasticsearchIntegrationTest {
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {
         return ImmutableSettings.builder()
-                .put(super.nodeSettings(nodeOrdinal)).put("gateway.type", "local")
+                .put(super.nodeSettings(nodeOrdinal))
                 .put(TransportModule.TRANSPORT_SERVICE_TYPE_KEY, MockTransportService.class.getName())
                 .build();
     }

--- a/src/test/java/org/elasticsearch/indices/IndicesCustomDataPathTests.java
+++ b/src/test/java/org/elasticsearch/indices/IndicesCustomDataPathTests.java
@@ -70,12 +70,12 @@ public class IndicesCustomDataPathTests extends ElasticsearchIntegrationTest {
                 .put(IndexMetaData.SETTING_DATA_PATH, startDir.toAbsolutePath().toString())
                         // Don't allow a RAM store or a "none" gateway
                 .put("index.store.type", "default")
-                .put("gateway.type", "local");
+                .put("index.gateway.type", "local");
         ImmutableSettings.Builder sb2 = ImmutableSettings.builder()
                 .put(IndexMetaData.SETTING_DATA_PATH, endDir.toAbsolutePath().toString())
                         // Don't allow a RAM store or a "none" gateway
                 .put("index.store.type", "default")
-                .put("gateway.type", "local");
+                .put("index.gateway.type", "local");
 
         logger.info("--> creating an index with data_path [{}]", startDir.toAbsolutePath().toString());
         client().admin().indices().prepareCreate(INDEX).setSettings(sb).get();

--- a/src/test/java/org/elasticsearch/indices/recovery/IndexRecoveryTests.java
+++ b/src/test/java/org/elasticsearch/indices/recovery/IndexRecoveryTests.java
@@ -140,7 +140,7 @@ public class IndexRecoveryTests extends ElasticsearchIntegrationTest {
     @Test
     public void gatewayRecoveryTest() throws Exception {
         logger.info("--> start nodes");
-        String node = internalCluster().startNode(settingsBuilder().put("gateway.type", "local"));
+        String node = internalCluster().startNode();
 
         createAndPopulateIndex(INDEX_NAME, 1, SHARD_COUNT, REPLICA_COUNT);
 
@@ -167,7 +167,7 @@ public class IndexRecoveryTests extends ElasticsearchIntegrationTest {
     @Test
     public void gatewayRecoveryTestActiveOnly() throws Exception {
         logger.info("--> start nodes");
-        internalCluster().startNode(settingsBuilder().put("gateway.type", "local"));
+        internalCluster().startNode();
 
         createAndPopulateIndex(INDEX_NAME, 1, SHARD_COUNT, REPLICA_COUNT);
 
@@ -185,13 +185,13 @@ public class IndexRecoveryTests extends ElasticsearchIntegrationTest {
     @Test
     public void replicaRecoveryTest() throws Exception {
         logger.info("--> start node A");
-        String nodeA = internalCluster().startNode(settingsBuilder().put("gateway.type", "local"));
+        String nodeA = internalCluster().startNode();
 
         logger.info("--> create index on node: {}", nodeA);
         createAndPopulateIndex(INDEX_NAME, 1, SHARD_COUNT, REPLICA_COUNT);
 
         logger.info("--> start node B");
-        String nodeB = internalCluster().startNode(settingsBuilder().put("gateway.type", "local"));
+        String nodeB = internalCluster().startNode();
         ensureGreen();
 
         // force a shard recovery from nodeA to nodeB
@@ -227,13 +227,13 @@ public class IndexRecoveryTests extends ElasticsearchIntegrationTest {
     @TestLogging("indices.recovery:TRACE")
     public void rerouteRecoveryTest() throws Exception {
         logger.info("--> start node A");
-        String nodeA = internalCluster().startNode(settingsBuilder().put("gateway.type", "local"));
+        String nodeA = internalCluster().startNode();
 
         logger.info("--> create index on node: {}", nodeA);
         ByteSizeValue shardSize = createAndPopulateIndex(INDEX_NAME, 1, SHARD_COUNT, REPLICA_COUNT).getShards()[0].getStats().getStore().size();
 
         logger.info("--> start node B");
-        String nodeB = internalCluster().startNode(settingsBuilder().put("gateway.type", "local"));
+        String nodeB = internalCluster().startNode();
 
         ensureGreen();
 
@@ -281,7 +281,7 @@ public class IndexRecoveryTests extends ElasticsearchIntegrationTest {
         ensureGreen();
 
         logger.info("--> start node C");
-        String nodeC = internalCluster().startNode(settingsBuilder().put("gateway.type", "local"));
+        String nodeC = internalCluster().startNode();
         assertFalse(client().admin().cluster().prepareHealth().setWaitForNodes("3").get().isTimedOut());
 
         logger.info("--> slowing down recoveries");
@@ -337,7 +337,7 @@ public class IndexRecoveryTests extends ElasticsearchIntegrationTest {
     @Test
     public void snapshotRecoveryTest() throws Exception {
         logger.info("--> start node A");
-        String nodeA = internalCluster().startNode(settingsBuilder().put("gateway.type", "local"));
+        String nodeA = internalCluster().startNode();
 
         logger.info("--> create repository");
         assertAcked(client().admin().cluster().preparePutRepository(REPO_NAME)

--- a/src/test/java/org/elasticsearch/indices/state/RareClusterStateTests.java
+++ b/src/test/java/org/elasticsearch/indices/state/RareClusterStateTests.java
@@ -54,7 +54,6 @@ public class RareClusterStateTests extends ElasticsearchIntegrationTest {
     protected Settings nodeSettings(int nodeOrdinal) {
         return ImmutableSettings.builder()
                 .put(super.nodeSettings(nodeOrdinal))
-                .put("gateway.type", "local")
                 .build();
     }
 

--- a/src/test/java/org/elasticsearch/indices/store/IndicesStoreIntegrationTests.java
+++ b/src/test/java/org/elasticsearch/indices/store/IndicesStoreIntegrationTests.java
@@ -29,7 +29,6 @@ import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.routing.*;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.settings.ImmutableSettings;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.discovery.DiscoveryService;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.index.shard.ShardId;
@@ -41,7 +40,6 @@ import org.junit.Test;
 import java.io.File;
 import java.util.Arrays;
 
-import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 import static org.elasticsearch.test.ElasticsearchIntegrationTest.Scope;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.equalTo;
@@ -51,12 +49,11 @@ import static org.hamcrest.Matchers.equalTo;
  */
 @ClusterScope(scope= Scope.TEST, numDataNodes = 0)
 public class IndicesStoreIntegrationTests extends ElasticsearchIntegrationTest {
-    private static final Settings SETTINGS = settingsBuilder().put("gateway.type", "local").build();
 
     @Test
     public void shardsCleanup() throws Exception {
-        final String node_1 = internalCluster().startNode(SETTINGS);
-        final String node_2 = internalCluster().startNode(SETTINGS);
+        final String node_1 = internalCluster().startNode();
+        final String node_2 = internalCluster().startNode();
         logger.info("--> creating index [test] with one shard and on replica");
         assertAcked(prepareCreate("test").setSettings(
                         ImmutableSettings.builder().put(indexSettings())
@@ -70,7 +67,7 @@ public class IndicesStoreIntegrationTests extends ElasticsearchIntegrationTest {
         assertThat(shardDirectory(node_2, "test", 0).exists(), equalTo(true));
 
         logger.info("--> starting node server3");
-        String node_3 = internalCluster().startNode(SETTINGS);
+        String node_3 = internalCluster().startNode();
         logger.info("--> running cluster_health");
         ClusterHealthResponse clusterHealth = client().admin().cluster().prepareHealth()
                 .setWaitForNodes("3")
@@ -102,7 +99,7 @@ public class IndicesStoreIntegrationTests extends ElasticsearchIntegrationTest {
         assertThat(shardDirectory(node_3, "test", 0).exists(), equalTo(true));
 
         logger.info("--> starting node node_4");
-        final String node_4 = internalCluster().startNode(SETTINGS);
+        final String node_4 = internalCluster().startNode();
 
         logger.info("--> running cluster_health");
         ensureGreen();
@@ -115,8 +112,8 @@ public class IndicesStoreIntegrationTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testShardActiveElseWhere() throws Exception {
-        String node_1 = internalCluster().startNode(SETTINGS);
-        String node_2 = internalCluster().startNode(SETTINGS);
+        String node_1 = internalCluster().startNode();
+        String node_2 = internalCluster().startNode();
         final String node_1_id = internalCluster().getInstance(DiscoveryService.class, node_1).localNode().getId();
         final String node_2_id = internalCluster().getInstance(DiscoveryService.class, node_2).localNode().getId();
 

--- a/src/test/java/org/elasticsearch/indices/warmer/LocalGatewayIndicesWarmerTests.java
+++ b/src/test/java/org/elasticsearch/indices/warmer/LocalGatewayIndicesWarmerTests.java
@@ -23,17 +23,14 @@ import org.elasticsearch.action.admin.indices.warmer.delete.DeleteWarmerResponse
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.warmer.IndexWarmersMetaData;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
-import org.elasticsearch.test.InternalTestCluster.RestartCallback;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
-import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
-import static org.elasticsearch.test.ElasticsearchIntegrationTest.*;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.Scope;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -48,7 +45,7 @@ public class LocalGatewayIndicesWarmerTests extends ElasticsearchIntegrationTest
     public void testStatePersistence() throws Exception {
 
         logger.info("--> starting 1 nodes");
-        internalCluster().startNode(settingsBuilder().put("gateway.type", "local"));
+        internalCluster().startNode();
 
         logger.info("--> putting two templates");
         createIndex("test");
@@ -89,12 +86,7 @@ public class LocalGatewayIndicesWarmerTests extends ElasticsearchIntegrationTest
         assertThat(templateWarmers.entries().size(), equalTo(1));
 
         logger.info("--> restarting the node");
-        internalCluster().fullRestart(new RestartCallback() {
-            @Override
-            public Settings onNodeStopped(String nodeName) throws Exception {
-                return settingsBuilder().put("gateway.type", "local").build();
-            }
-        });
+        internalCluster().fullRestart();
 
         ensureYellow();
 
@@ -127,12 +119,7 @@ public class LocalGatewayIndicesWarmerTests extends ElasticsearchIntegrationTest
         assertThat(warmersMetaData.entries().size(), equalTo(1));
 
         logger.info("--> restarting the node");
-        internalCluster().fullRestart(new RestartCallback() {
-            @Override
-            public Settings onNodeStopped(String nodeName) throws Exception {
-                return settingsBuilder().put("gateway.type", "local").build();
-            }
-        });
+        internalCluster().fullRestart();
 
         ensureYellow();
 

--- a/src/test/java/org/elasticsearch/percolator/RecoveryPercolatorTests.java
+++ b/src/test/java/org/elasticsearch/percolator/RecoveryPercolatorTests.java
@@ -36,7 +36,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
-import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.junit.Test;
 
 import java.util.concurrent.CountDownLatch;
@@ -45,7 +44,6 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.elasticsearch.action.percolate.PercolateSourceBuilder.docBuilder;
 import static org.elasticsearch.client.Requests.clusterHealthRequest;
-import static org.elasticsearch.common.settings.ImmutableSettings.builder;
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.*;
@@ -61,11 +59,6 @@ public class RecoveryPercolatorTests extends ElasticsearchIntegrationTest {
     @Override
     protected int numberOfShards() {
         return 1;
-    }
-
-    @Override
-    protected Settings nodeSettings(int nodeOrdinal) {
-        return builder().put(super.nodeSettings(nodeOrdinal)).put("gateway.type", "local").build();
     }
 
     @Test

--- a/src/test/java/org/elasticsearch/search/basic/SearchWithRandomExceptionsTests.java
+++ b/src/test/java/org/elasticsearch/search/basic/SearchWithRandomExceptionsTests.java
@@ -91,9 +91,7 @@ public class SearchWithRandomExceptionsTests extends ElasticsearchIntegrationTes
         int numInitialDocs = 0;
 
         if (createIndexWithoutErrors) {
-            Builder settings = settingsBuilder()
-                    .put("index.number_of_replicas", randomIntBetween(0, 1))
-                    .put("gateway.type", "local");
+            Builder settings = settingsBuilder().put("index.number_of_replicas", randomIntBetween(0, 1));
             logger.info("creating index: [test] using settings: [{}]", settings.build().getAsMap());
             client().admin().indices().prepareCreate("test")
                     .setSettings(settings)

--- a/src/test/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreTests.java
+++ b/src/test/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreTests.java
@@ -145,7 +145,7 @@ public class DedicatedClusterSnapshotRestoreTests extends AbstractSnapshotTests 
         File tempDir = newTempDir();
 
         logger.info("--> start node");
-        internalCluster().startNode(settingsBuilder().put("gateway.type", "local"));
+        internalCluster().startNode();
         Client client = client();
         createIndex("test-idx");
         ensureYellow();
@@ -379,8 +379,8 @@ public class DedicatedClusterSnapshotRestoreTests extends AbstractSnapshotTests 
     @Test
     public void restoreIndexWithMissingShards() throws Exception {
         logger.info("--> start 2 nodes");
-        internalCluster().startNode(settingsBuilder().put("gateway.type", "local"));
-        internalCluster().startNode(settingsBuilder().put("gateway.type", "local"));
+        internalCluster().startNode();
+        internalCluster().startNode();
         cluster().wipeIndices("_all");
 
         logger.info("--> create an index that will have some unallocated shards");
@@ -516,8 +516,8 @@ public class DedicatedClusterSnapshotRestoreTests extends AbstractSnapshotTests 
     @Test
     public void restoreIndexWithShardsMissingInLocalGateway() throws Exception {
         logger.info("--> start 2 nodes");
-        internalCluster().startNode(settingsBuilder().put("gateway.type", "local"));
-        internalCluster().startNode(settingsBuilder().put("gateway.type", "local"));
+        internalCluster().startNode();
+        internalCluster().startNode();
         cluster().wipeIndices("_all");
 
         logger.info("--> create repository");

--- a/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
@@ -1874,7 +1874,6 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
         assertTrue(dest.exists());
         ImmutableSettings.Builder builder = ImmutableSettings.builder()
                 .put(settings)
-                .put("gateway.type", "local") // this is important we need to recover from gateway
                 .put("path.data", dataDir.getPath());
 
         File configDir = new File(indexDir, "config");

--- a/src/test/java/org/elasticsearch/test/ElasticsearchSingleNodeTest.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchSingleNodeTest.java
@@ -102,8 +102,8 @@ public abstract class ElasticsearchSingleNodeTest extends ElasticsearchTestCase 
                 .put(EsExecutors.PROCESSORS, 1) // limit the number of threads created
                 .put("http.enabled", false)
                 .put("index.store.type", "ram")
-                .put("config.ignore_system_properties", true) // make sure we get what we set :)
-                .put("gateway.type", "none")).build();
+                .put("config.ignore_system_properties", true)  // make sure we get what we set :)
+        ).build();
         build.start();
         assertThat(DiscoveryNode.localNode(build.settings()), is(true));
         return build;

--- a/src/test/java/org/elasticsearch/test/ExternalNode.java
+++ b/src/test/java/org/elasticsearch/test/ExternalNode.java
@@ -43,7 +43,6 @@ import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
-import static junit.framework.Assert.assertFalse;
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 
 /**
@@ -55,7 +54,7 @@ final class ExternalNode implements Closeable {
             .put("config.ignore_system_properties", true)
             .put(DiscoveryModule.DISCOVERY_TYPE_KEY, "zen")
             .put("node.mode", "network") // we need network mode for this
-            .put("gateway.type", "local").build(); // we require local gateway to mimic upgrades of nodes
+            .build();
 
     private final File path;
     private final Random random;

--- a/src/test/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/src/test/java/org/elasticsearch/test/InternalTestCluster.java
@@ -18,8 +18,6 @@
  */
 package org.elasticsearch.test;
 
-import org.elasticsearch.cache.recycler.PageCacheRecycler;
-
 import com.carrotsearch.randomizedtesting.RandomizedTest;
 import com.carrotsearch.randomizedtesting.SeedUtils;
 import com.carrotsearch.randomizedtesting.generators.RandomInts;
@@ -39,6 +37,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
 import org.elasticsearch.action.admin.indices.stats.CommonStatsFlags;
 import org.elasticsearch.cache.recycler.CacheRecycler;
+import org.elasticsearch.cache.recycler.PageCacheRecycler;
 import org.elasticsearch.cache.recycler.PageCacheRecyclerModule;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.transport.TransportClient;
@@ -69,7 +68,6 @@ import org.elasticsearch.common.util.BigArraysModule;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.http.HttpServerTransport;
-import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.cache.filter.FilterCacheModule;
 import org.elasticsearch.index.cache.filter.none.NoneFilterCache;
 import org.elasticsearch.index.cache.filter.weighted.WeightedFilterCache;
@@ -115,7 +113,7 @@ import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilde
 import static org.elasticsearch.node.NodeBuilder.nodeBuilder;
 import static org.elasticsearch.test.ElasticsearchTestCase.assertBusy;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoTimeout;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 
@@ -364,8 +362,6 @@ public final class InternalTestCluster extends TestCluster {
                 //.put("index.store.type", random.nextInt(10) == 0 ? MockRamIndexStoreModule.class.getName() : MockFSIndexStoreModule.class.getName())
                 // decrease the routing schedule so new nodes will be added quickly - some random value between 30 and 80 ms
                 .put("cluster.routing.schedule", (30 + random.nextInt(50)) + "ms")
-                        // default to non gateway
-                .put("gateway.type", "none")
                 .put(SETTING_CLUSTER_NODE_SEED, seed);
         if (ENABLE_MOCK_MODULES && usually(random)) {
             builder.put("index.store.type", MockFSIndexStoreModule.class.getName()); // no RAM dir for now!

--- a/src/test/java/org/elasticsearch/test/discovery/ClusterDiscoveryConfiguration.java
+++ b/src/test/java/org/elasticsearch/test/discovery/ClusterDiscoveryConfiguration.java
@@ -34,7 +34,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class ClusterDiscoveryConfiguration extends SettingsSource {
 
     static Settings DEFAULT_NODE_SETTINGS = ImmutableSettings.settingsBuilder()
-            .put("gateway.type", "local")
             .put("discovery.type", "zen").build();
 
     final int numOfNodes;


### PR DESCRIPTION
The LocalGateway contains important functionality for the correct behavior of elasticsearch. As an optimization, it was replaced with the NoneGateway as a default for testing. However, this has proven to cause nasty-to-trace build failures which are not worth the extra speed up. The NoneGateway was already removed from master. This commit doesn't remove it due to bwc but changes the default to the local gateway.
