### PR TITLE
Use correct number of bytes in query cache accounting

### DIFF
--- a/src/main/java/org/elasticsearch/common/io/stream/BytesStreamOutput.java
+++ b/src/main/java/org/elasticsearch/common/io/stream/BytesStreamOutput.java
@@ -150,6 +150,14 @@ public class BytesStreamOutput extends StreamOutput implements BytesStream {
         return new PagedBytesReference(bigarrays, bytes, count);
     }
 
+    /**
+     * Returns the number of bytes used by the underlying {@link org.elasticsearch.common.util.ByteArray}
+     * @see org.elasticsearch.common.util.ByteArray#ramBytesUsed()
+     */
+    public long ramBytesUsed() {
+        return bytes.ramBytesUsed();
+    }
+
     private void ensureCapacity(int offset) {
         bytes = bigarrays.grow(bytes, offset);
     }

--- a/src/main/java/org/elasticsearch/index/cache/query/ShardQueryCache.java
+++ b/src/main/java/org/elasticsearch/index/cache/query/ShardQueryCache.java
@@ -36,7 +36,7 @@ import org.elasticsearch.indices.cache.query.IndicesQueryCache;
 
 /**
  */
-public class ShardQueryCache extends AbstractIndexShardComponent implements RemovalListener<IndicesQueryCache.Key, BytesReference> {
+public class ShardQueryCache extends AbstractIndexShardComponent implements RemovalListener<IndicesQueryCache.Key, IndicesQueryCache.Value> {
 
     final CounterMetric evictionsMetric = new CounterMetric();
     final CounterMetric totalMetric = new CounterMetric();
@@ -60,12 +60,12 @@ public class ShardQueryCache extends AbstractIndexShardComponent implements Remo
         missCount.inc();
     }
 
-    public void onCached(IndicesQueryCache.Key key, BytesReference value) {
-        totalMetric.inc(key.ramBytesUsed() + value.length());
+    public void onCached(IndicesQueryCache.Key key, IndicesQueryCache.Value value) {
+        totalMetric.inc(key.ramBytesUsed() + value.ramBytesUsed());
     }
 
     @Override
-    public void onRemoval(RemovalNotification<IndicesQueryCache.Key, BytesReference> removalNotification) {
+    public void onRemoval(RemovalNotification<IndicesQueryCache.Key, IndicesQueryCache.Value> removalNotification) {
         if (removalNotification.wasEvicted()) {
             evictionsMetric.inc();
         }
@@ -74,7 +74,7 @@ public class ShardQueryCache extends AbstractIndexShardComponent implements Remo
             dec += removalNotification.getKey().ramBytesUsed();
         }
         if (removalNotification.getValue() != null) {
-            dec += removalNotification.getValue().length();
+            dec += removalNotification.getValue().ramBytesUsed();
         }
         totalMetric.dec(dec);
     }


### PR DESCRIPTION
today we use the length of the BytesReference which is misleading since
the reference is paged such that the length != ramBytesUsed. This can lead
to a way higher memory consuption than expected if query results are tiny
since each query result requires at least 16kb. Yet, we should rethink this
strategy for query results that are very small ie. less than 20% of the ramBytesUsed
but this commit first tries to make the acocunting correct.
