### PR TITLE
Remove dirty flag and force boolean for refresh

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/indices/refresh/RefreshRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/refresh/RefreshRequest.java
@@ -37,7 +37,6 @@ import java.io.IOException;
  */
 public class RefreshRequest extends BroadcastOperationRequest<RefreshRequest> {
 
-    private boolean force = true;
 
     RefreshRequest() {
     }
@@ -54,26 +53,4 @@ public class RefreshRequest extends BroadcastOperationRequest<RefreshRequest> {
         super(indices);
     }
 
-    public boolean force() {
-        return force;
-    }
-
-    /**
-     * Forces calling refresh, overriding the check that dirty operations even happened. Defaults
-     * to true (note, still lightweight if no refresh is needed).
-     */
-    public RefreshRequest force(boolean force) {
-        this.force = force;
-        return this;
-    }
-
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        force = in.readBoolean();
-    }
-
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
-        out.writeBoolean(force);
-    }
 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/refresh/RefreshRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/refresh/RefreshRequestBuilder.java
@@ -34,15 +34,6 @@ public class RefreshRequestBuilder extends BroadcastOperationRequestBuilder<Refr
         super(indicesClient, new RefreshRequest());
     }
 
-    /**
-     * Forces calling refresh, overriding the check that dirty operations even happened. Defaults
-     * to true (note, still lightweight if no refresh is needed).
-     */
-    public RefreshRequestBuilder setForce(boolean force) {
-        request.force(force);
-        return this;
-    }
-
     @Override
     protected void doExecute(ActionListener<RefreshResponse> listener) {
         client.refresh(request, listener);

--- a/src/main/java/org/elasticsearch/action/admin/indices/refresh/ShardRefreshRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/refresh/ShardRefreshRequest.java
@@ -31,29 +31,11 @@ import java.io.IOException;
  */
 class ShardRefreshRequest extends BroadcastShardOperationRequest {
 
-    private boolean force = true;
-
     ShardRefreshRequest() {
     }
 
     ShardRefreshRequest(ShardId shardId, RefreshRequest request) {
         super(shardId, request);
-        force = request.force();
     }
 
-    public boolean force() {
-        return force;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        force = in.readBoolean();
-    }
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
-        out.writeBoolean(force);
-    }
 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportRefreshAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportRefreshAction.java
@@ -107,8 +107,8 @@ public class TransportRefreshAction extends TransportBroadcastOperationAction<Re
     @Override
     protected ShardRefreshResponse shardOperation(ShardRefreshRequest request) throws ElasticsearchException {
         IndexShard indexShard = indicesService.indexServiceSafe(request.shardId().getIndex()).shardSafe(request.shardId().id());
-        indexShard.refresh("api", request.force());
-        logger.trace("{} refresh request executed, force: [{}]", indexShard.shardId(), request.force());
+        indexShard.refresh("api");
+        logger.trace("{} refresh request executed, force: [{}]", indexShard.shardId());
         return new ShardRefreshResponse(request.shardId());
     }
 

--- a/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
+++ b/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
@@ -355,7 +355,7 @@ public class TransportShardBulkAction extends TransportShardReplicationOperation
 
         if (request.refresh()) {
             try {
-                indexShard.refresh("refresh_flag_bulk", false);
+                indexShard.refresh("refresh_flag_bulk");
             } catch (Throwable e) {
                 // ignore
             }
@@ -620,7 +620,7 @@ public class TransportShardBulkAction extends TransportShardReplicationOperation
 
         if (request.refresh()) {
             try {
-                indexShard.refresh("refresh_flag_bulk", false);
+                indexShard.refresh("refresh_flag_bulk");
             } catch (Throwable e) {
                 // ignore
             }

--- a/src/main/java/org/elasticsearch/action/delete/TransportDeleteAction.java
+++ b/src/main/java/org/elasticsearch/action/delete/TransportDeleteAction.java
@@ -182,7 +182,7 @@ public class TransportDeleteAction extends TransportShardReplicationOperationAct
 
         if (request.refresh()) {
             try {
-                indexShard.refresh("refresh_flag_delete", false);
+                indexShard.refresh("refresh_flag_delete");
             } catch (Exception e) {
                 // ignore
             }
@@ -202,7 +202,7 @@ public class TransportDeleteAction extends TransportShardReplicationOperationAct
 
         if (request.refresh()) {
             try {
-                indexShard.refresh("refresh_flag_delete", false);
+                indexShard.refresh("refresh_flag_delete");
             } catch (Exception e) {
                 // ignore
             }

--- a/src/main/java/org/elasticsearch/action/delete/TransportShardDeleteAction.java
+++ b/src/main/java/org/elasticsearch/action/delete/TransportShardDeleteAction.java
@@ -92,7 +92,7 @@ public class TransportShardDeleteAction extends TransportShardReplicationOperati
 
         if (request.refresh()) {
             try {
-                indexShard.refresh("refresh_flag_delete", false);
+                indexShard.refresh("refresh_flag_delete");
             } catch (Exception e) {
                 // ignore
             }
@@ -117,7 +117,7 @@ public class TransportShardDeleteAction extends TransportShardReplicationOperati
 
         if (request.refresh()) {
             try {
-                indexShard.refresh("refresh_flag_delete", false);
+                indexShard.refresh("refresh_flag_delete");
             } catch (Exception e) {
                 // ignore
             }

--- a/src/main/java/org/elasticsearch/action/get/TransportGetAction.java
+++ b/src/main/java/org/elasticsearch/action/get/TransportGetAction.java
@@ -41,8 +41,6 @@ import org.elasticsearch.transport.TransportService;
  */
 public class TransportGetAction extends TransportShardSingleOperationAction<GetRequest, GetResponse> {
 
-    public static final boolean REFRESH_FORCE = false;
-
     private final IndicesService indicesService;
     private final boolean realtime;
 
@@ -90,7 +88,7 @@ public class TransportGetAction extends TransportShardSingleOperationAction<GetR
         IndexShard indexShard = indexService.shardSafe(shardId.id());
 
         if (request.refresh() && !request.realtime()) {
-            indexShard.refresh("refresh_flag_get", REFRESH_FORCE);
+            indexShard.refresh("refresh_flag_get");
         }
 
         GetResult result = indexShard.getService().get(request.type(), request.id(), request.fields(),

--- a/src/main/java/org/elasticsearch/action/get/TransportShardMultiGetAction.java
+++ b/src/main/java/org/elasticsearch/action/get/TransportShardMultiGetAction.java
@@ -98,7 +98,7 @@ public class TransportShardMultiGetAction extends TransportShardSingleOperationA
         IndexShard indexShard = indexService.shardSafe(shardId.id());
 
         if (request.refresh() && !request.realtime()) {
-            indexShard.refresh("refresh_flag_mget", TransportGetAction.REFRESH_FORCE);
+            indexShard.refresh("refresh_flag_mget");
         }
 
         MultiGetShardResponse response = new MultiGetShardResponse();

--- a/src/main/java/org/elasticsearch/action/index/TransportIndexAction.java
+++ b/src/main/java/org/elasticsearch/action/index/TransportIndexAction.java
@@ -205,7 +205,7 @@ public class TransportIndexAction extends TransportShardReplicationOperationActi
         }
         if (request.refresh()) {
             try {
-                indexShard.refresh("refresh_flag_index", false);
+                indexShard.refresh("refresh_flag_index");
             } catch (Throwable e) {
                 // ignore
             }
@@ -236,7 +236,7 @@ public class TransportIndexAction extends TransportShardReplicationOperationActi
         }
         if (request.refresh()) {
             try {
-                indexShard.refresh("refresh_flag_index", false);
+                indexShard.refresh("refresh_flag_index");
             } catch (Exception e) {
                 // ignore
             }

--- a/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -88,10 +88,9 @@ public interface Engine extends Closeable {
 
     /**
      * Refreshes the engine for new search operations to reflect the latest
-     * changes. Pass <tt>true</tt> if the refresh operation should include
-     * all the operations performed up to this call.
+     * changes.
      */
-    void refresh(String source, boolean force) throws EngineException;
+    void refresh(String source) throws EngineException;
 
     /**
      * Flushes the state of the engine, clearing memory.

--- a/src/main/java/org/elasticsearch/index/gateway/IndexShardGatewayService.java
+++ b/src/main/java/org/elasticsearch/index/gateway/IndexShardGatewayService.java
@@ -143,7 +143,7 @@ public class IndexShardGatewayService extends AbstractIndexShardComponent implem
                         indexShard.postRecovery("post recovery from gateway");
                     }
                     // refresh the shard
-                    indexShard.refresh("post_gateway", true);
+                    indexShard.refresh("post_gateway");
 
                     recoveryState.getTimer().time(System.currentTimeMillis() - recoveryState.getTimer().startTime());
                     recoveryState.setStage(RecoveryState.Stage.DONE);

--- a/src/main/java/org/elasticsearch/index/percolator/PercolatorQueriesRegistry.java
+++ b/src/main/java/org/elasticsearch/index/percolator/PercolatorQueriesRegistry.java
@@ -275,7 +275,7 @@ public class PercolatorQueriesRegistry extends AbstractIndexShardComponent imple
         }
 
         private int loadQueries(IndexShard shard) {
-            shard.refresh("percolator_load_queries", true);
+            shard.refresh("percolator_load_queries");
             // Maybe add a mode load? This isn't really a write. We need write b/c state=post_recovery
             try (Engine.Searcher searcher = shard.acquireSearcher("percolator_load_queries", true)) {
                 Query query = new ConstantScoreQuery(

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/refresh/RestRefreshAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/refresh/RestRefreshAction.java
@@ -54,7 +54,6 @@ public class RestRefreshAction extends BaseRestHandler {
     public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         RefreshRequest refreshRequest = new RefreshRequest(Strings.splitStringByCommaToArray(request.param("index")));
         refreshRequest.listenerThreaded(false);
-        refreshRequest.force(request.paramAsBoolean("force", refreshRequest.force()));
         refreshRequest.indicesOptions(IndicesOptions.fromRequest(request, refreshRequest.indicesOptions()));
         client.admin().indices().refresh(refreshRequest, new RestBuilderListener<RefreshResponse>(channel) {
             @Override

--- a/src/test/java/org/elasticsearch/index/engine/internal/InternalEngineTests.java
+++ b/src/test/java/org/elasticsearch/index/engine/internal/InternalEngineTests.java
@@ -265,7 +265,7 @@ public class InternalEngineTests extends ElasticsearchLuceneTestCase {
 
         ParsedDocument doc2 = testParsedDocument("2", "2", "test", null, -1, -1, testDocumentWithTextField(), B_2, false);
         engine.create(new Engine.Create(null, analyzer, newUid("2"), doc2));
-        engine.refresh("test", false);
+        engine.refresh("test");
 
         segments = engine.segments(false);
         assertThat(segments.size(), equalTo(1));
@@ -298,7 +298,7 @@ public class InternalEngineTests extends ElasticsearchLuceneTestCase {
 
         ParsedDocument doc3 = testParsedDocument("3", "3", "test", null, -1, -1, testDocumentWithTextField(), B_3, false);
         engine.create(new Engine.Create(null, analyzer, newUid("3"), doc3));
-        engine.refresh("test", false);
+        engine.refresh("test");
 
         segments = engine.segments(false);
         assertThat(segments.size(), equalTo(2));
@@ -324,7 +324,7 @@ public class InternalEngineTests extends ElasticsearchLuceneTestCase {
 
 
         engine.delete(new Engine.Delete("test", "1", newUid("1")));
-        engine.refresh("test", false);
+        engine.refresh("test");
 
         segments = engine.segments(false);
         assertThat(segments.size(), equalTo(2));
@@ -345,7 +345,7 @@ public class InternalEngineTests extends ElasticsearchLuceneTestCase {
         engineSettingsService.refreshSettings(ImmutableSettings.builder().put(EngineConfig.INDEX_COMPOUND_ON_FLUSH, true).build());
         ParsedDocument doc4 = testParsedDocument("4", "4", "test", null, -1, -1, testDocumentWithTextField(), B_3, false);
         engine.create(new Engine.Create(null, analyzer, newUid("4"), doc4));
-        engine.refresh("test", false);
+        engine.refresh("test");
 
         segments = engine.segments(false);
         assertThat(segments.size(), equalTo(3));
@@ -376,7 +376,7 @@ public class InternalEngineTests extends ElasticsearchLuceneTestCase {
         
         ParsedDocument doc = testParsedDocument("1", "1", "test", null, -1, -1, testDocumentWithTextField(), B_1, false);
         engine.create(new Engine.Create(null, analyzer, newUid("1"), doc));
-        engine.refresh("test", false);
+        engine.refresh("test");
 
         segments = engine.segments(true);
         assertThat(segments.size(), equalTo(1));
@@ -384,10 +384,10 @@ public class InternalEngineTests extends ElasticsearchLuceneTestCase {
         
         ParsedDocument doc2 = testParsedDocument("2", "2", "test", null, -1, -1, testDocumentWithTextField(), B_2, false);
         engine.create(new Engine.Create(null, analyzer, newUid("2"), doc2));
-        engine.refresh("test", false);
+        engine.refresh("test");
         ParsedDocument doc3 = testParsedDocument("3", "3", "test", null, -1, -1, testDocumentWithTextField(), B_3, false);
         engine.create(new Engine.Create(null, analyzer, newUid("3"), doc3));
-        engine.refresh("test", false);
+        engine.refresh("test");
 
         segments = engine.segments(true);
         assertThat(segments.size(), equalTo(3));
@@ -528,7 +528,7 @@ public class InternalEngineTests extends ElasticsearchLuceneTestCase {
         assertThat(getResult.exists(), equalTo(false));
         getResult.release();
         // refresh and it should be there
-        engine.refresh("test", false);
+        engine.refresh("test");
 
         // now its there...
         searchResult = engine.acquireSearcher("test");
@@ -564,7 +564,7 @@ public class InternalEngineTests extends ElasticsearchLuceneTestCase {
         getResult.release();
 
         // refresh and it should be updated
-        engine.refresh("test", false);
+        engine.refresh("test");
 
         searchResult = engine.acquireSearcher("test");
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(1));
@@ -588,7 +588,7 @@ public class InternalEngineTests extends ElasticsearchLuceneTestCase {
         getResult.release();
 
         // refresh and it should be deleted
-        engine.refresh("test", false);
+        engine.refresh("test");
 
         searchResult = engine.acquireSearcher("test");
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(0));
@@ -610,7 +610,7 @@ public class InternalEngineTests extends ElasticsearchLuceneTestCase {
         searchResult.close();
 
         // refresh and it should be there
-        engine.refresh("test", false);
+        engine.refresh("test");
 
         // now its there...
         searchResult = engine.acquireSearcher("test");
@@ -644,7 +644,7 @@ public class InternalEngineTests extends ElasticsearchLuceneTestCase {
         searchResult.close();
 
         // refresh and it should be updated
-        engine.refresh("test", false);
+        engine.refresh("test");
 
         searchResult = engine.acquireSearcher("test");
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(1));
@@ -672,7 +672,7 @@ public class InternalEngineTests extends ElasticsearchLuceneTestCase {
         searchResult.close();
 
         // refresh and it should be there
-        engine.refresh("test", false);
+        engine.refresh("test");
 
         // now its there...
         searchResult = engine.acquireSearcher("test");
@@ -682,7 +682,7 @@ public class InternalEngineTests extends ElasticsearchLuceneTestCase {
 
         // delete, refresh and do a new search, it should not be there
         engine.delete(new Engine.Delete("test", "1", newUid("1")));
-        engine.refresh("test", false);
+        engine.refresh("test");
         Engine.Searcher updateSearchResult = engine.acquireSearcher("test");
         MatcherAssert.assertThat(updateSearchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(0));
         updateSearchResult.close();
@@ -735,7 +735,7 @@ public class InternalEngineTests extends ElasticsearchLuceneTestCase {
 
             ParsedDocument doc2 = testParsedDocument("2", "2", "test", null, -1, -1, testDocumentWithTextField(), B_2, false);
             engine.create(new Engine.Create(null, analyzer, newUid("2"), doc2));
-            engine.refresh("foo", false);
+            engine.refresh("foo");
 
             searchResult = engine.acquireSearcher("test");
             MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(new TermQuery(new Term("value", "test")), 2));
@@ -1407,7 +1407,7 @@ public class InternalEngineTests extends ElasticsearchLuceneTestCase {
         Thread.sleep(1000);
 
         if (randomBoolean()) {
-            engine.refresh("test", false);
+            engine.refresh("test");
         }
 
         // Delete non-existent document


### PR DESCRIPTION
Today we have a dirty flag indicating that a refresh must
be executed. We also allow users to bypass this by setting
a force=true boolean on the refresh request / command. All
these flags are unneeded since the SearcherManager has all
the information to do the right thing if it's dirty or not.
