### PR TITLE
Remove limitation on field access within aggs to the types provided in the search

### DIFF
--- a/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceParser.java
@@ -152,7 +152,7 @@ public class ValuesSourceParser<VS extends ValuesSource> {
             return config;
         }
 
-        FieldMapper<?> mapper = context.smartNameFieldMapper(input.field);
+        FieldMapper<?> mapper = context.mapperService().smartNameFieldMapper(input.field);
         if (mapper == null) {
             Class<VS> valuesSourceType = valueType != null ? (Class<VS>) valueType.getValuesSourceType() : this.valuesSourceType;
             ValuesSourceConfig<VS> config = new ValuesSourceConfig<>(valuesSourceType);

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/ChildrenTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/ChildrenTests.java
@@ -310,8 +310,8 @@ public class ChildrenTests extends ElasticsearchIntegrationTest {
                 .setQuery(hasChildQuery(childType, termQuery("color", "orange")))
                 .addAggregation(children("my-refinements")
                                 .childType(childType)
-                                .subAggregation(terms("my-colors").field(childType + ".color"))
-                                .subAggregation(terms("my-sizes").field(childType + ".size"))
+                                .subAggregation(terms("my-colors").field("color"))
+                                .subAggregation(terms("my-sizes").field("size"))
                 ).get();
         assertNoFailures(response);
         assertHitCount(response, 1);


### PR DESCRIPTION
Currently, doing a field lookup within a terms agg will restrict the
fields available to those within the types passed into the search
request.  However, when doing sub aggs within a children agg, the
fields available should not be restricted to those of the search.

This change makes the field lookup use the index level mapper service.
