### PR TITLE
Tests: Add type-unrestricted version of field mapper getter to SearchContext

### DIFF
--- a/src/main/java/org/elasticsearch/percolator/PercolateContext.java
+++ b/src/main/java/org/elasticsearch/percolator/PercolateContext.java
@@ -664,6 +664,11 @@ public class PercolateContext extends SearchContext {
     }
 
     @Override
+    public FieldMapper smartNameFieldMapperFromAnyType(String name) {
+        return mapperService().smartNameFieldMapper(name);
+    }
+
+    @Override
     public MapperService.SmartNameObjectMapper smartNameObjectMapper(String name) {
         throw new UnsupportedOperationException();
     }

--- a/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceParser.java
@@ -152,7 +152,7 @@ public class ValuesSourceParser<VS extends ValuesSource> {
             return config;
         }
 
-        FieldMapper<?> mapper = context.mapperService().smartNameFieldMapper(input.field);
+        FieldMapper<?> mapper = context.smartNameFieldMapperFromAnyType(input.field);
         if (mapper == null) {
             Class<VS> valuesSourceType = valueType != null ? (Class<VS>) valueType.getValuesSourceType() : this.valuesSourceType;
             ValuesSourceConfig<VS> config = new ValuesSourceConfig<>(valuesSourceType);

--- a/src/main/java/org/elasticsearch/search/internal/DefaultSearchContext.java
+++ b/src/main/java/org/elasticsearch/search/internal/DefaultSearchContext.java
@@ -671,18 +671,27 @@ public class DefaultSearchContext extends SearchContext {
         return scanContext;
     }
 
+    @Override
     public MapperService.SmartNameFieldMappers smartFieldMappers(String name) {
         return mapperService().smartName(name, request.types());
     }
 
+    @Override
     public FieldMappers smartNameFieldMappers(String name) {
         return mapperService().smartNameFieldMappers(name, request.types());
     }
 
+    @Override
     public FieldMapper smartNameFieldMapper(String name) {
         return mapperService().smartNameFieldMapper(name, request.types());
     }
 
+    @Override
+    public FieldMapper smartNameFieldMapperFromAnyType(String name) {
+        return mapperService().smartNameFieldMapper(name);
+    }
+
+    @Override
     public MapperService.SmartNameObjectMapper smartNameObjectMapper(String name) {
         return mapperService().smartNameObjectMapper(name, request.types());
     }

--- a/src/main/java/org/elasticsearch/search/internal/FilteredSearchContext.java
+++ b/src/main/java/org/elasticsearch/search/internal/FilteredSearchContext.java
@@ -549,6 +549,11 @@ public abstract class FilteredSearchContext extends SearchContext {
     }
 
     @Override
+    public FieldMapper smartNameFieldMapperFromAnyType(String name) {
+        return in.smartNameFieldMapperFromAnyType(name);
+    }
+
+    @Override
     public MapperService.SmartNameObjectMapper smartNameObjectMapper(String name) {
         return in.smartNameObjectMapper(name);
     }

--- a/src/main/java/org/elasticsearch/search/internal/SearchContext.java
+++ b/src/main/java/org/elasticsearch/search/internal/SearchContext.java
@@ -349,6 +349,11 @@ public abstract class SearchContext implements Releasable {
 
     public abstract FieldMapper smartNameFieldMapper(String name);
 
+    /**
+     * Looks up the given field, but does not restrict to fields in the types set on this context.
+     */
+    public abstract FieldMapper smartNameFieldMapperFromAnyType(String name);
+
     public abstract MapperService.SmartNameObjectMapper smartNameObjectMapper(String name);
 
     public abstract Counter timeEstimateCounter();

--- a/src/test/java/org/elasticsearch/test/TestSearchContext.java
+++ b/src/test/java/org/elasticsearch/test/TestSearchContext.java
@@ -571,8 +571,19 @@ public class TestSearchContext extends SearchContext {
     }
 
     @Override
+    public FieldMapper<?> smartNameFieldMapperFromAnyType(String name) {
+        if (mapperService() != null) {
+            return mapperService().smartNameFieldMapper(name);
+        }
+        return null;
+    }
+
+    @Override
     public MapperService.SmartNameObjectMapper smartNameObjectMapper(String name) {
-        return mapperService().smartNameObjectMapper(name, types);
+        if (mapperService() != null) {
+            return mapperService().smartNameObjectMapper(name, types);
+        }
+        return null;
     }
 
     @Override


### PR DESCRIPTION
This fixes an NPE when using TestSearchContext in SignificanceHeuristicTests.
