### PR TITLE
Add `beforeIndexAddedToCluster` callback

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
@@ -65,10 +65,7 @@ import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.IndexQueryParserService;
 import org.elasticsearch.index.IndexService;
-import org.elasticsearch.indices.IndexAlreadyExistsException;
-import org.elasticsearch.indices.IndexCreationException;
-import org.elasticsearch.indices.IndicesService;
-import org.elasticsearch.indices.InvalidIndexNameException;
+import org.elasticsearch.indices.*;
 import org.elasticsearch.river.RiverIndexName;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -452,6 +449,9 @@ public class MetaDataCreateIndexService extends AbstractComponent {
                         removalReason = "failed to build index metadata";
                         throw e;
                     }
+
+                    indexService.indicesLifecycle().beforeIndexAddedToCluster(new Index(request.index()),
+                            indexMetaData.settings());
 
                     MetaData newMetaData = MetaData.builder(currentState.metaData())
                             .put(indexMetaData, false)

--- a/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/src/main/java/org/elasticsearch/index/IndexService.java
@@ -162,6 +162,10 @@ public class IndexService extends AbstractIndexComponent implements IndexCompone
         return shards.size();
     }
 
+    public InternalIndicesLifecycle indicesLifecycle() {
+        return this.indicesLifecycle;
+    }
+
     @Override
     public Iterator<IndexShard> iterator() {
         return Iterators.transform(shards.values().iterator(), new Function<Tuple<IndexShard, Injector>, IndexShard>() {

--- a/src/main/java/org/elasticsearch/indices/IndicesLifecycle.java
+++ b/src/main/java/org/elasticsearch/indices/IndicesLifecycle.java
@@ -62,7 +62,15 @@ public interface IndicesLifecycle {
         }
 
         /**
-         * Called before the index gets created.
+         * Called on the Master node only before the index is created
+         */
+        public void beforeIndexAddedToCluster(Index index, @IndexSettings Settings indexSettings) {
+
+        }
+
+        /**
+         * Called before the index gets created. Note that this is also called
+         * when the index is created on data nodes
          */
         public void beforeIndexCreated(Index index, @IndexSettings Settings indexSettings) {
 

--- a/src/main/java/org/elasticsearch/indices/InternalIndicesLifecycle.java
+++ b/src/main/java/org/elasticsearch/indices/InternalIndicesLifecycle.java
@@ -65,6 +65,17 @@ public class InternalIndicesLifecycle extends AbstractComponent implements Indic
         }
     }
 
+    public void beforeIndexAddedToCluster(Index index, @IndexSettings Settings indexSettings) {
+        for (Listener listener : listeners) {
+            try {
+                listener.beforeIndexAddedToCluster(index, indexSettings);
+            } catch (Throwable t) {
+                logger.warn("[{}] failed to invoke before index added to cluster callback", t, index.name());
+                throw t;
+            }
+        }
+    }
+
     public void beforeIndexCreated(Index index, @IndexSettings Settings indexSettings) {
         for (Listener listener : listeners) {
             try {

--- a/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -220,6 +220,10 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent<Indic
         // handle closed indices, since they are not allocated on a node once they are closed
         // so applyDeletedIndices might not take them into account
         for (IndexService indexService : indicesService) {
+            if (indexService == null) {
+                // already deleted on us, ignore it
+                continue;
+            }
             String index = indexService.index().getName();
             IndexMetaData indexMetaData = event.state().metaData().index(index);
             if (indexMetaData != null && indexMetaData.state() == IndexMetaData.State.CLOSE) {
@@ -247,6 +251,10 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent<Indic
 
     private void applyDeletedIndices(final ClusterChangedEvent event) {
         for (IndexService indexService : indicesService) {
+            if (indexService == null) {
+                // got deleted already on us, skip
+                continue;
+            }
             final String index = indexService.index().name();
             if (!event.state().metaData().hasIndex(index)) {
                 if (logger.isDebugEnabled()) {
@@ -264,6 +272,10 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent<Indic
         }
         IntOpenHashSet newShardIds = new IntOpenHashSet();
         for (IndexService indexService : indicesService) {
+            if (indexService == null) {
+                // already deleted on us
+                continue;
+            }
             String index = indexService.index().name();
             IndexMetaData indexMetaData = event.state().metaData().index(index);
             if (indexMetaData == null) {
@@ -308,7 +320,11 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent<Indic
                 if (logger.isDebugEnabled()) {
                     logger.debug("[{}] creating index", indexMetaData.index());
                 }
-                indicesService.createIndex(indexMetaData.index(), indexMetaData.settings(), event.state().nodes().localNode().id());
+                try {
+                    indicesService.createIndex(indexMetaData.index(), indexMetaData.settings(), event.state().nodes().localNode().id());
+                } catch (Exception e) {
+                    logger.warn("failed to create index [{}]", e, indexMetaData.index());
+                }
             }
         }
     }
@@ -328,6 +344,10 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent<Indic
             }
             String index = indexMetaData.index();
             IndexService indexService = indicesService.indexServiceSafe(index);
+            if (indexService == null) {
+                // already deleted on us, ignore it
+                continue;
+            }
             IndexSettingsService indexSettingsService = indexService.injector().getInstance(IndexSettingsService.class);
             indexSettingsService.refreshSettings(indexMetaData.settings());
         }


### PR DESCRIPTION
This callback is executed only once, on the master node during an
index's creation. An exception thrown during this listener will cancel
the index creation.

This also adds checks in `IndicesClusterStateService` for the
indexService being null as well as if the `indicesService.createIndex`
throws an exception on data nodes after an index has already been
created.
