### PR TITLE
Fail node startup if shards index format is too old / new

### DIFF
--- a/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -461,7 +461,7 @@ public class NodeEnvironment extends AbstractComponent implements Closeable{
         return shardLocations;
     }
 
-    public Set<String> findAllIndices() throws Exception {
+    public Set<String> findAllIndices() throws IOException {
         if (nodePaths == null || locks == null) {
             throw new ElasticsearchIllegalStateException("node is not configured to store local location");
         }

--- a/src/test/java/org/elasticsearch/bwcompat/OldIndexBackwardsCompatibilityTests.java
+++ b/src/test/java/org/elasticsearch/bwcompat/OldIndexBackwardsCompatibilityTests.java
@@ -93,7 +93,7 @@ public class OldIndexBackwardsCompatibilityTests extends StaticIndexBackwardComp
         "index-1.4.1.zip",
         "index-1.4.2.zip"
     );
-    
+
     public void testAllVersionsTested() throws Exception {
         SortedSet<String> expectedVersions = new TreeSet<>();
         for (java.lang.reflect.Field field : Version.class.getDeclaredFields()) {
@@ -213,5 +213,15 @@ public class OldIndexBackwardsCompatibilityTests extends StaticIndexBackwardComp
         }
         UpgradeTest.runUpgrade(httpClient, "test", "wait_for_completion", "true");
         UpgradeTest.assertUpgraded(httpClient, "test");
+    }
+
+    public void testUnsupportedVersionDoesNotStart() throws Exception {
+        String unsupportedIndex = "index-0.20.6.zip";
+        try {
+            loadIndex(unsupportedIndex, ImmutableSettings.EMPTY);
+            fail();
+        } catch (Exception ex) {
+            logger.info("Failed = all is well", ex);
+        }
     }
 }


### PR DESCRIPTION
Today if a shard contains a segment that is from Lucene 3.x and
therefore throws an `IndexFormatTooOldException` the node goes into
a wild allocation loop if the index is directly recovered from the gateway.
If the problematic shard is allocated later due to other reasons the shard
will fail allocation and downgrading the cluster might be impossible since
new segments in other indices have already been written.

This commit adds sanity checks to the `GatewayMetaState` that tries to read
the `SegmentsInfo` for every shard on the node and fails if a shard is corrupted
or the index is too new etc.

With the new data_path per index feature nodes might not have enough information
unless they are master eligible since we used to not persist the index and global
state on nodes that are not master eligible. This commit changes this behavior and
writes the state on all nodes that hold data. This in an enhancement itself since
data nodes that are not master eligible are not self-contained today.

This change also fixes the issue see in #8823 since metadata is written on all
data nodes now.

Closes #8823
