### PR TITLE
Enforce _parent field resolution to be strict

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/HasChildFilterBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/HasChildFilterBuilder.java
@@ -73,21 +73,6 @@ public class HasChildFilterBuilder extends BaseFilterBuilder {
         return this;
     }
 
-
-    /**
-     * This is a noop since has_child can't be cached.
-     */
-    public HasChildFilterBuilder cache(boolean cache) {
-        return this;
-    }
-
-    /**
-     * This is a noop since has_child can't be cached.
-     */
-    public HasChildFilterBuilder cacheKey(String cacheKey) {
-        return this;
-    }
-
     /**
      * Configures at what cut off point only to evaluate parent documents that contain the matching parent id terms
      * instead of evaluating all parent docs.

--- a/src/main/java/org/elasticsearch/index/query/HasChildFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/HasChildFilterParser.java
@@ -104,10 +104,6 @@ public class HasChildFilterParser implements FilterParser {
                     childType = parser.text();
                 } else if ("_name".equals(currentFieldName)) {
                     filterName = parser.text();
-                } else if ("_cache".equals(currentFieldName)) {
-                    // noop to be backwards compatible
-                } else if ("_cache_key".equals(currentFieldName) || "_cacheKey".equals(currentFieldName)) {
-                    // noop to be backwards compatible
                 } else if ("short_circuit_cutoff".equals(currentFieldName)) {
                     shortCircuitParentDocSet = parser.intValue();
                 } else if ("min_children".equals(currentFieldName) || "minChildren".equals(currentFieldName)) {

--- a/src/main/java/org/elasticsearch/index/query/HasParentFilterBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/HasParentFilterBuilder.java
@@ -63,20 +63,6 @@ public class HasParentFilterBuilder extends BaseFilterBuilder {
     }
 
     /**
-     * This is a noop since has_parent can't be cached.
-     */
-    public HasParentFilterBuilder cache(boolean cache) {
-        return this;
-    }
-
-    /**
-     * This is a noop since has_parent can't be cached.
-     */
-    public HasParentFilterBuilder cacheKey(String cacheKey) {
-        return this;
-    }
-
-    /**
      * Sets inner hit definition in the scope of this filter and reusing the defined type and query.
      */
     public HasParentFilterBuilder innerHit(QueryInnerHitBuilder innerHit) {

--- a/src/main/java/org/elasticsearch/index/query/HasParentFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/HasParentFilterParser.java
@@ -92,10 +92,6 @@ public class HasParentFilterParser implements FilterParser {
                     parentType = parser.text();
                 } else if ("_name".equals(currentFieldName)) {
                     filterName = parser.text();
-                } else if ("_cache".equals(currentFieldName)) {
-                    // noop to be backwards compatible
-                } else if ("_cache_key".equals(currentFieldName) || "_cacheKey".equals(currentFieldName)) {
-                    // noop to be backwards compatible
                 } else {
                     throw new QueryParsingException(parseContext.index(), "[has_parent] filter does not support [" + currentFieldName + "]");
                 }

--- a/src/test/java/org/elasticsearch/search/child/SimpleChildQuerySearchTests.java
+++ b/src/test/java/org/elasticsearch/search/child/SimpleChildQuerySearchTests.java
@@ -1371,7 +1371,7 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
         client().admin().indices().prepareRefresh("test").get();
 
         SearchResponse searchResponse = client().prepareSearch("test")
-                .setQuery(constantScoreQuery(hasChildFilter("child", termQuery("c_field", "blue")).cache(true)))
+                .setQuery(constantScoreQuery(hasChildFilter("child", termQuery("c_field", "blue"))))
                 .get();
         assertNoFailures(searchResponse);
         assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
@@ -1380,7 +1380,7 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
         client().admin().indices().prepareRefresh("test").get();
 
         searchResponse = client().prepareSearch("test")
-                .setQuery(constantScoreQuery(hasChildFilter("child", termQuery("c_field", "blue")).cache(true)))
+                .setQuery(constantScoreQuery(hasChildFilter("child", termQuery("c_field", "blue"))))
                 .get();
         assertNoFailures(searchResponse);
         assertThat(searchResponse.getHits().totalHits(), equalTo(2l));
@@ -2039,7 +2039,7 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
         long initialCacheSize = statsResponse.getIndex("test").getTotal().getFilterCache().getMemorySizeInBytes();
 
         searchResponse = client().prepareSearch("test")
-                .setQuery(QueryBuilders.filteredQuery(matchAllQuery(), FilterBuilders.hasChildFilter("child", matchAllQuery()).cache(true)))
+                .setQuery(QueryBuilders.filteredQuery(matchAllQuery(), FilterBuilders.hasChildFilter("child", matchAllQuery())))
                 .get();
         assertHitCount(searchResponse, 1l);
 
@@ -2047,7 +2047,7 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
         assertThat(statsResponse.getIndex("test").getTotal().getFilterCache().getMemorySizeInBytes(), equalTo(initialCacheSize));
 
         searchResponse = client().prepareSearch("test")
-                .setQuery(QueryBuilders.filteredQuery(matchAllQuery(), FilterBuilders.hasParentFilter("parent", matchAllQuery()).cache(true)))
+                .setQuery(QueryBuilders.filteredQuery(matchAllQuery(), FilterBuilders.hasParentFilter("parent", matchAllQuery())))
                 .get();
         assertHitCount(searchResponse, 1l);
 
@@ -2060,7 +2060,7 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
                         matchAllQuery(),
                         FilterBuilders.boolFilter().cache(true)
                                 .must(FilterBuilders.matchAllFilter())
-                                .must(FilterBuilders.hasChildFilter("child", matchAllQuery()).cache(true))
+                                .must(FilterBuilders.hasChildFilter("child", matchAllQuery()))
                 ))
                 .get();
         assertHitCount(searchResponse, 1l);
@@ -2070,7 +2070,7 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
                         matchAllQuery(),
                         FilterBuilders.boolFilter().cache(true)
                                 .must(FilterBuilders.matchAllFilter())
-                                .must(FilterBuilders.hasParentFilter("parent", matchAllQuery()).cache(true))
+                                .must(FilterBuilders.hasParentFilter("parent", matchAllQuery()))
                 ))
                 .get();
         assertHitCount(searchResponse, 1l);
@@ -2084,7 +2084,7 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
                         matchAllQuery(),
                         FilterBuilders.boolFilter().cache(true)
                                 .must(FilterBuilders.termFilter("field", "value").cache(true))
-                                .must(FilterBuilders.hasChildFilter("child", matchAllQuery()).cache(true))
+                                .must(FilterBuilders.hasChildFilter("child", matchAllQuery()))
                 ))
                 .get();
         assertHitCount(searchResponse, 1l);
@@ -2094,7 +2094,7 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
                         matchAllQuery(),
                         FilterBuilders.boolFilter().cache(true)
                                 .must(FilterBuilders.termFilter("field", "value").cache(true))
-                                .must(FilterBuilders.hasParentFilter("parent", matchAllQuery()).cache(true))
+                                .must(FilterBuilders.hasParentFilter("parent", matchAllQuery()))
                 ))
                 .get();
         assertHitCount(searchResponse, 1l);


### PR DESCRIPTION
A type defined in a has_child query must have a _parent field.
A type defined in a has_parent query must have child type with a _parent field pointing to it.

PR fixes #9461 too. The query parsing failed sometimes with a unexpected NPE, because the `_parent` field is pointing to a non existing type. The consistent strict _parent field resolution makes sure the NPE can't occur any more.

This PR also includes a commit that removes the old and used `_cache` and `_cache_key` options. (master only)
