### PR TITLE
service.bat file should explicitly use the Windows find command.

### DIFF
--- a/bin/service.bat
+++ b/bin/service.bat
@@ -13,7 +13,7 @@ if not exist "%JAVA_HOME%\bin\java.exe" (
 echo JAVA_HOME points to an invalid Java installation (no java.exe found in "%JAVA_HOME%"^). Exiting...
 goto:eof
 )
-"%JAVA_HOME%\bin\java" -version 2>&1 | find "64-Bit" >nul:
+"%JAVA_HOME%\bin\java" -version 2>&1 | "%windir%\System32\find" "64-Bit" >nul:
 
 if errorlevel 1 goto x86
 set EXECUTABLE=%ES_HOME%\bin\elasticsearch-service-x64.exe


### PR DESCRIPTION
If `find` maps to something other than the Windows find command, the
installation will succeed, but use the incorrect Java version.

For example, I have GNU find first in my path, which uses a different syntax. So, service.bat will "successfully" install the x86 version of the service, but the service will fail on startup.

Here are the log statements when the service is attempted to be started:
    [2015-02-02 11:59:26] [info]  [28200] Running 'elasticsearch-service-x86' Service...
    [2015-02-02 11:59:26] [info]  [28124] Starting service...
    [2015-02-02 11:59:26] [error] [28124] %1 is not a valid Win32 application.
    [2015-02-02 11:59:26] [error] [28124] Failed creating java C:\Program    Files\Java\jdk1.7.0_75\jre\bin\server\jvm.dll
    [2015-02-02 11:59:26] [error] [28124] %1 is not a valid Win32 application.
    [2015-02-02 11:59:26] [error] [28124] ServiceStart returned 1
    [2015-02-02 11:59:26] [error] [28124] %1 is not a valid Win32 application.
    [2015-02-02 11:59:26] [info]  [28200] Run service finished.
    [2015-02-02 11:59:26] [info]  [28200] Commons Daemon procrun finished

By explicitly using the Windows find executable, the service installation runs as expected.
