### PR TITLE
[TEST] support stashed values within property names in our REST tests

### DIFF
--- a/src/test/java/org/elasticsearch/rest/action/admin/indices/upgrade/UpgradeTest.java
+++ b/src/test/java/org/elasticsearch/rest/action/admin/indices/upgrade/UpgradeTest.java
@@ -34,9 +34,6 @@ import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.ToXContent;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.engine.Segment;
 import org.elasticsearch.node.internal.InternalNode;
 import org.elasticsearch.test.ElasticsearchBackwardsCompatIntegrationTest;
@@ -246,6 +243,7 @@ public class UpgradeTest extends ElasticsearchBackwardsCompatIntegrationTest {
         assertEquals(200, rsp.getStatusCode());
     }
 
+    @SuppressWarnings("unchecked")
     static List<UpgradeStatus> getUpgradeStatus(HttpRequestBuilder httpClient, String path) throws Exception {
         HttpResponse rsp = httpClient.method("GET").path(path).execute();
         Map<String,Object> data = validateAndParse(rsp);
@@ -258,11 +256,12 @@ public class UpgradeTest extends ElasticsearchBackwardsCompatIntegrationTest {
             assertTrue("missing key size_to_upgrade_in_bytes for index " + index, status.containsKey("size_to_upgrade_in_bytes"));
             Object toUpgradeBytes = status.get("size_to_upgrade_in_bytes");
             assertTrue("size_to_upgrade_in_bytes for index " + index + " is not an integer", toUpgradeBytes instanceof Integer);
-            ret.add(new UpgradeStatus(index, ((Integer)totalBytes).intValue(), ((Integer)toUpgradeBytes).intValue()));
+            ret.add(new UpgradeStatus(index, (Integer)totalBytes, (Integer)toUpgradeBytes));
         }
         return ret;
     }
-    
+
+    @SuppressWarnings("unchecked")
     static Map<String, Object> validateAndParse(HttpResponse rsp) throws Exception {
         assertNotNull(rsp);
         assertEquals(200, rsp.getStatusCode());

--- a/src/test/java/org/elasticsearch/test/rest/RestTestExecutionContext.java
+++ b/src/test/java/org/elasticsearch/test/rest/RestTestExecutionContext.java
@@ -114,7 +114,7 @@ public class RestTestExecutionContext implements Closeable {
      * Extracts a specific value from the last saved response
      */
     public Object response(String path) throws IOException {
-        return response.evaluate(path);
+        return response.evaluate(path, stash);
     }
 
     /**

--- a/src/test/java/org/elasticsearch/test/rest/Stash.java
+++ b/src/test/java/org/elasticsearch/test/rest/Stash.java
@@ -35,6 +35,8 @@ public class Stash {
 
     private static final ESLogger logger = Loggers.getLogger(Stash.class);
 
+    public static final Stash EMPTY = new Stash();
+
     private final Map<String, Object> stash = Maps.newHashMap();
 
     /**
@@ -93,7 +95,7 @@ public class Stash {
     @SuppressWarnings("unchecked")
     private void unstashObject(Object obj) {
         if (obj instanceof List) {
-            List list = (List)obj;
+            List list = (List) obj;
             for (int i = 0; i < list.size(); i++) {
                 Object o = list.get(i);
                 if (isStashedValue(o)) {

--- a/src/test/java/org/elasticsearch/test/rest/client/RestResponse.java
+++ b/src/test/java/org/elasticsearch/test/rest/client/RestResponse.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.test.rest.client;
 
+import org.elasticsearch.test.rest.Stash;
 import org.elasticsearch.test.rest.client.http.HttpResponse;
 import org.elasticsearch.test.rest.json.JsonPath;
 
@@ -70,6 +71,13 @@ public class RestResponse {
      * Parses the response body as json and extracts a specific value from it (identified by the provided path)
      */
     public Object evaluate(String path) throws IOException {
+        return evaluate(path, Stash.EMPTY);
+    }
+
+    /**
+     * Parses the response body as json and extracts a specific value from it (identified by the provided path)
+     */
+    public Object evaluate(String path, Stash stash) throws IOException {
 
         if (response == null) {
             return null;
@@ -87,7 +95,7 @@ public class RestResponse {
             return null;
         }
 
-        return jsonPath.evaluate(path);
+        return jsonPath.evaluate(path, stash);
     }
 
     private boolean isJson() {

--- a/src/test/java/org/elasticsearch/test/rest/json/JsonPath.java
+++ b/src/test/java/org/elasticsearch/test/rest/json/JsonPath.java
@@ -20,6 +20,7 @@ package org.elasticsearch.test.rest.json;
 
 import com.google.common.collect.Lists;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.test.rest.Stash;
 
 import java.io.IOException;
 import java.util.List;
@@ -46,10 +47,17 @@ public class JsonPath {
      * Returns the object corresponding to the provided path if present, null otherwise
      */
     public Object evaluate(String path) {
+        return evaluate(path, Stash.EMPTY);
+    }
+
+    /**
+     * Returns the object corresponding to the provided path if present, null otherwise
+     */
+    public Object evaluate(String path, Stash stash) {
         String[] parts = parsePath(path);
         Object object = jsonMap;
         for (String part : parts) {
-            object = evaluate(part, object);
+            object = evaluate(part, object, stash);
             if (object == null) {
                 return null;
             }
@@ -58,7 +66,11 @@ public class JsonPath {
     }
 
     @SuppressWarnings("unchecked")
-    private Object evaluate(String key, Object object) {
+    private Object evaluate(String key, Object object, Stash stash) {
+        if (stash.isStashedValue(key)) {
+            key = stash.unstashValue(key).toString();
+        }
+
         if (object instanceof Map) {
             return ((Map<String, Object>) object).get(key);
         }

--- a/src/test/java/org/elasticsearch/test/rest/section/MatchAssertion.java
+++ b/src/test/java/org/elasticsearch/test/rest/section/MatchAssertion.java
@@ -25,6 +25,7 @@ import java.util.regex.Pattern;
 
 import static org.elasticsearch.test.hamcrest.RegexMatcher.matches;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
@@ -49,10 +50,12 @@ public class MatchAssertion extends Assertion {
         if (expectedValue instanceof String) {
             String expValue = ((String) expectedValue).trim();
             if (expValue.length() > 2 && expValue.startsWith("/") && expValue.endsWith("/")) {
+                assertThat("field [" + getField() + "] was expected to be of type String but is an instanceof [" + actualValue.getClass() + "]", actualValue, instanceOf(String.class));
+                String stringValue = (String) actualValue;
                 String regex = expValue.substring(1, expValue.length() - 1);
-                logger.trace("assert that [{}] matches [{}]", actualValue, regex);
+                logger.trace("assert that [{}] matches [{}]", stringValue, regex);
                 assertThat("field [" + getField() + "] was expected to match the provided regex but didn't",
-                        actualValue.toString(), matches(regex, Pattern.COMMENTS));
+                        stringValue, matches(regex, Pattern.COMMENTS));
                 return;
             }
         }

--- a/src/test/java/org/elasticsearch/test/rest/support/Features.java
+++ b/src/test/java/org/elasticsearch/test/rest/support/Features.java
@@ -34,7 +34,7 @@ import java.util.List;
  */
 public final class Features {
 
-    private static final List<String> SUPPORTED = Lists.newArrayList("gtelte");
+    private static final List<String> SUPPORTED = Lists.newArrayList("gtelte", "stash_in_path");
 
     private Features() {
 


### PR DESCRIPTION
Support stashed values within property names, feature that was added to the REST spec in https://github.com/elasticsearch/elasticsearch/commit/e7ac5f296e9d1239e8e9c6333a462f06b62d343f .
