### PR TITLE
Coordinates can contain more than two elements (x,y) in GeoJSON parser.

### DIFF
--- a/src/main/java/org/elasticsearch/common/geo/builders/ShapeBuilder.java
+++ b/src/main/java/org/elasticsearch/common/geo/builders/ShapeBuilder.java
@@ -240,16 +240,24 @@ public abstract class ShapeBuilder implements ToXContent {
      *             XContentParser
      */
     private static CoordinateNode parseCoordinates(XContentParser parser) throws IOException {
+        /** http://geojson.org/geojson-spec.html#positions
+         *  A position is represented by an array of numbers.
+         *  There must be at least two elements, and may be more
+         */
+
         XContentParser.Token token = parser.nextToken();
 
         // Base cases
         if (token != XContentParser.Token.START_ARRAY && 
-                token != XContentParser.Token.END_ARRAY && 
+                token != XContentParser.Token.END_ARRAY &&
                 token != XContentParser.Token.VALUE_NULL) {
             double lon = parser.doubleValue();
             token = parser.nextToken();
             double lat = parser.doubleValue();
-            token = parser.nextToken();
+            // Only lon and lat elements are parsed, others (if any) are skipped
+            while (token != XContentParser.Token.END_ARRAY) {
+                token = parser.nextToken();
+            }
             return new CoordinateNode(new Coordinate(lon, lat));
         } else if (token == XContentParser.Token.VALUE_NULL) {
             throw new ElasticsearchIllegalArgumentException("coordinates cannot contain NULL values)");

--- a/src/test/java/org/elasticsearch/common/geo/GeoJSONShapeParserTests.java
+++ b/src/test/java/org/elasticsearch/common/geo/GeoJSONShapeParserTests.java
@@ -185,6 +185,31 @@ public class GeoJSONShapeParserTests extends ElasticsearchTestCase {
         assertGeometryEquals(jtsGeom(expected), polygonGeoJson);
     }
 
+    public void testParse_polygonWithCoordinateWithMoreThanTwoElements() throws IOException {
+        String polygonGeoJson = XContentFactory.jsonBuilder().startObject().field("type", "Polygon")
+                .startArray("coordinates")
+                .startArray()
+                .startArray().value(100.0).value(1.0).endArray()
+                .startArray().value(101.0).value(1.0).value(2.0).endArray()
+                .startArray().value(101.0).value(0.0).endArray()
+                .startArray().value(100.0).value(0.0).endArray()
+                .startArray().value(100.0).value(1.0).endArray()
+                .endArray()
+                .endArray()
+                .endObject().string();
+
+        List<Coordinate> shellCoordinates = new ArrayList<>();
+        shellCoordinates.add(new Coordinate(100, 0));
+        shellCoordinates.add(new Coordinate(101, 0));
+        shellCoordinates.add(new Coordinate(101, 1));
+        shellCoordinates.add(new Coordinate(100, 1));
+        shellCoordinates.add(new Coordinate(100, 0));
+
+        LinearRing shell = GEOMETRY_FACTORY.createLinearRing(shellCoordinates.toArray(new Coordinate[shellCoordinates.size()]));
+        Polygon expected = GEOMETRY_FACTORY.createPolygon(shell, null);
+        assertGeometryEquals(jtsGeom(expected), polygonGeoJson);
+    }
+
     public void testParse_invalidPoint() throws IOException {
         // test case 1: create an invalid point object with multipoint data format
         String invalidPoint1 = XContentFactory.jsonBuilder().startObject().field("type", "point")


### PR DESCRIPTION
This pr fixes GeoJSON parsing with more than 2 elements in coordinates.

Closes #9540 
