### PR TITLE
Correct bounding box logic for GeometryCollection type

### DIFF
--- a/src/main/java/org/elasticsearch/common/geo/XShapeCollection.java
+++ b/src/main/java/org/elasticsearch/common/geo/XShapeCollection.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.geo;
+
+import com.spatial4j.core.context.SpatialContext;
+import com.spatial4j.core.shape.Rectangle;
+import com.spatial4j.core.shape.Shape;
+import com.spatial4j.core.shape.ShapeCollection;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Overrides bounding box logic in ShapeCollection base class to comply with
+ * OGC OpenGIS Abstract Specification: An Object Model for Interoperable Geoprocessing.
+ *
+ * This class also overrides the 'relate' method to leverage the updated bbox logic.
+ * NOTE: This algorithm is O(N) and can possibly be improved O(log n) using an internal R*-Tree
+ * data structure for a collection of bounding boxes
+ */
+public class XShapeCollection<S extends Shape> extends ShapeCollection<S> {
+
+  public XShapeCollection(List<S> shapes, SpatialContext ctx) {
+    super(shapes, ctx);
+  }
+
+  @Override
+  protected Rectangle computeBoundingBox(Collection<? extends Shape> shapes, SpatialContext ctx) {
+    Rectangle retBox = shapes.iterator().next().getBoundingBox();
+    for (Shape geom : shapes) {
+      retBox = expandBBox(retBox, geom.getBoundingBox());
+    }
+    return retBox;
+  }
+
+  /**
+   * Spatial4J shapes have no knowledge of directed edges. For this reason, a bounding box
+   * that wraps the dateline can have a min longitude that is mathematically > than the
+   * Rectangles' minX value.  This is an issue for geometric collections (e.g., MultiPolygon
+   * and ShapeCollection) Until geometry logic can be cleaned up in Spatial4J, ES provides
+   * the following expansion algorithm for GeometryCollections
+   */
+  private Rectangle expandBBox(Rectangle bbox, Rectangle expand) {
+    if (bbox.equals(expand) || bbox.equals(SpatialContext.GEO.getWorldBounds())) {
+      return bbox;
+    }
+
+    double minX = bbox.getMinX();
+    double eMinX = expand.getMinX();
+    double maxX = bbox.getMaxX();
+    double eMaxX = expand.getMaxX();
+    double minY = bbox.getMinY();
+    double eMinY = expand.getMinY();
+    double maxY = bbox.getMaxY();
+    double eMaxY = expand.getMaxY();
+
+    bbox.reset(Math.min(Math.min(minX, maxX), Math.min(eMinX, eMaxX)),
+            Math.max(Math.max(minX, maxX), Math.max(eMinX, eMaxX)),
+            Math.min(Math.min(minY, maxY), Math.min(eMinY, eMaxY)),
+            Math.max(Math.max(minY, maxY), Math.max(eMinY, eMaxY)));
+
+    return bbox;
+  }
+}

--- a/src/main/java/org/elasticsearch/common/geo/builders/GeometryCollectionBuilder.java
+++ b/src/main/java/org/elasticsearch/common/geo/builders/GeometryCollectionBuilder.java
@@ -20,7 +20,7 @@
 package org.elasticsearch.common.geo.builders;
 
 import com.spatial4j.core.shape.Shape;
-import com.spatial4j.core.shape.ShapeCollection;
+import org.elasticsearch.common.geo.XShapeCollection;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -115,7 +115,7 @@ public class GeometryCollectionBuilder extends ShapeBuilder {
         if (shapes.size() == 1)
             return shapes.get(0);
         else
-            return new ShapeCollection<>(shapes, SPATIAL_CONTEXT);
+            return new XShapeCollection<>(shapes, SPATIAL_CONTEXT);
         //note: ShapeCollection is probably faster than a Multi* geom.
     }
 

--- a/src/main/java/org/elasticsearch/common/geo/builders/MultiPointBuilder.java
+++ b/src/main/java/org/elasticsearch/common/geo/builders/MultiPointBuilder.java
@@ -21,8 +21,8 @@ package org.elasticsearch.common.geo.builders;
 
 import com.spatial4j.core.shape.Point;
 import com.spatial4j.core.shape.Shape;
-import com.spatial4j.core.shape.ShapeCollection;
 import com.vividsolutions.jts.geom.Coordinate;
+import org.elasticsearch.common.geo.XShapeCollection;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -51,7 +51,7 @@ public class MultiPointBuilder extends PointCollection<MultiPointBuilder> {
         for (Coordinate coord : points) {
             shapes.add(SPATIAL_CONTEXT.makePoint(coord.x, coord.y));
         }
-        return new ShapeCollection<>(shapes, SPATIAL_CONTEXT);
+        return new XShapeCollection<>(shapes, SPATIAL_CONTEXT);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/common/geo/builders/MultiPolygonBuilder.java
+++ b/src/main/java/org/elasticsearch/common/geo/builders/MultiPolygonBuilder.java
@@ -23,7 +23,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.spatial4j.core.shape.ShapeCollection;
+import org.elasticsearch.common.geo.XShapeCollection;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import com.spatial4j.core.shape.Shape;
@@ -96,7 +96,7 @@ public class MultiPolygonBuilder extends ShapeBuilder {
         if (shapes.size() == 1)
             return shapes.get(0);
         else
-            return new ShapeCollection<>(shapes, SPATIAL_CONTEXT);
+            return new XShapeCollection<>(shapes, SPATIAL_CONTEXT);
         //note: ShapeCollection is probably faster than a Multi* geom.
     }
 


### PR DESCRIPTION
"The OpenGIS Abstract Specification: An Object Model for Interoperable Geoprocessing" published by the OGC defines "The boundary of a geometric object is a set of geometric objects of the next lower dimension." The bounding box of a GeometryCollection is therefore the set of bounding rectangles derived from the geometric objects of the next lower dimension. This commit updates the computeBoundingBox and relate methods for the ShapeCollection base class to correctly determine the prefixTree detail level used in Lucene's FilterCellIterator.

closes #9360
