### PR TITLE
Add logging around gateway shard allocation

### DIFF
--- a/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesOperationAction.java
+++ b/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesOperationAction.java
@@ -203,7 +203,7 @@ public abstract class TransportNodesOperationAction<Request extends NodesOperati
                 logger.debug("failed to execute on node [{}]", t, nodeId);
             }
             if (accumulateExceptions()) {
-                responses.set(idx, new FailedNodeException(nodeId, "Failed node [" + nodeId + "][" + t.getMessage() + "]", t));
+                responses.set(idx, new FailedNodeException(nodeId, "Failed node [" + nodeId + "]", t));
             }
             if (counter.incrementAndGet() == responses.length()) {
                 finishHim();

--- a/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesOperationAction.java
+++ b/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesOperationAction.java
@@ -203,7 +203,7 @@ public abstract class TransportNodesOperationAction<Request extends NodesOperati
                 logger.debug("failed to execute on node [{}]", t, nodeId);
             }
             if (accumulateExceptions()) {
-                responses.set(idx, new FailedNodeException(nodeId, "Failed node [" + nodeId + "]", t));
+                responses.set(idx, new FailedNodeException(nodeId, "Failed node [" + nodeId + "][" + t.getMessage() + "]", t));
             }
             if (counter.incrementAndGet() == responses.length()) {
                 finishHim();

--- a/src/main/java/org/elasticsearch/gateway/local/LocalGatewayAllocator.java
+++ b/src/main/java/org/elasticsearch/gateway/local/LocalGatewayAllocator.java
@@ -414,21 +414,13 @@ public class LocalGatewayAllocator extends AbstractComponent implements GatewayA
     }
 
     private void logListActionFailures(MutableShardRouting shard, String actionType, FailedNodeException[] failures) {
-        if (failures == null || failures.length == 0) {
-            return;
-        }
-        int totalWarnFailures = 0;
         for (final FailedNodeException failure : failures) {
             Throwable cause = ExceptionsHelper.unwrapCause(failure);
             if (cause instanceof ConnectTransportException) {
                 continue;
             }
             // we log warn here. debug logs with full stack traces will be logged if debug logging is turned on for TransportNodeListGatewayStartedShards
-            logger.warn("{}: failed to list shard {} on node [{}], reason [{}]", shard.shardId(), actionType, failure.nodeId(), failure.getMessage());
-            totalWarnFailures++;
-        }
-        if (totalWarnFailures > 0) {
-            logger.warn("{}: [{}] failures when trying to list shard {} on nodes.", shard.shardId(), totalWarnFailures, actionType);
+            logger.warn("{}: failed to list shard {} on node [{}]", failure, shard.shardId(), actionType, failure.nodeId());
         }
     }
 

--- a/src/main/java/org/elasticsearch/gateway/local/state/shards/ShardStateInfo.java
+++ b/src/main/java/org/elasticsearch/gateway/local/state/shards/ShardStateInfo.java
@@ -35,4 +35,9 @@ public class ShardStateInfo {
         this.version = version;
         this.primary = primary;
     }
+
+    @Override
+    public String toString() {
+        return "version [" + version + "], primary [" + primary + "]";
+    }
 }

--- a/src/main/java/org/elasticsearch/gateway/local/state/shards/TransportNodesListGatewayStartedShards.java
+++ b/src/main/java/org/elasticsearch/gateway/local/state/shards/TransportNodesListGatewayStartedShards.java
@@ -117,10 +117,13 @@ public class TransportNodesListGatewayStartedShards extends TransportNodesOperat
     @Override
     protected NodeLocalGatewayStartedShards nodeOperation(NodeRequest request) throws ElasticsearchException {
         try {
+            logger.trace("loading shard state info for {}", request.shardId);
             ShardStateInfo shardStateInfo = shardsState.loadShardInfo(request.shardId);
             if (shardStateInfo != null) {
+                logger.debug("{} shard state info found: [{}]", request.shardId, shardStateInfo);
                 return new NodeLocalGatewayStartedShards(clusterService.localNode(), shardStateInfo.version);
             }
+            logger.trace("no shard info found for {}", request.shardId);
             return new NodeLocalGatewayStartedShards(clusterService.localNode(), -1);
         } catch (Exception e) {
             throw new ElasticsearchException("failed to load started shards", e);

--- a/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/src/main/java/org/elasticsearch/index/store/Store.java
@@ -630,6 +630,7 @@ public class Store extends AbstractIndexShardComponent implements CloseableIndex
                     // Lucene checks the checksum after it tries to lookup the codec etc.
                     // in that case we might get only IAE or similar exceptions while we are really corrupt...
                     // TODO we should check the checksum in lucene if we hit an exception
+                    logger.warn("checking segment info integrity (reason [{}])", ex.getMessage());
                     Lucene.checkSegmentInfoIntegrity(directory);
                 } catch (CorruptIndexException cex) {
                   cex.addSuppressed(ex);

--- a/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/src/main/java/org/elasticsearch/index/store/Store.java
@@ -623,7 +623,8 @@ public class Store extends AbstractIndexShardComponent implements CloseableIndex
                 } else {
                     builder.put(segmentsFile, new StoreFileMetaData(segmentsFile, directory.fileLength(segmentsFile), legacyChecksum, null));
                 }
-            } catch (CorruptIndexException ex) {
+            } catch (CorruptIndexException | IndexNotFoundException ex) {
+                // we either know the index is corrupted or it's just not there
                 throw ex;
             } catch (Throwable ex) {
                 try {

--- a/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/src/main/java/org/elasticsearch/index/store/Store.java
@@ -630,8 +630,8 @@ public class Store extends AbstractIndexShardComponent implements CloseableIndex
                     // Lucene checks the checksum after it tries to lookup the codec etc.
                     // in that case we might get only IAE or similar exceptions while we are really corrupt...
                     // TODO we should check the checksum in lucene if we hit an exception
-                    logger.warn("failed to build store metadata. checking segment info integrity (with commit [{}], reason [{}])",
-                            ex, commit == null ? "no" : "yes", ex.getMessage());
+                    logger.warn("failed to build store metadata. checking segment info integrity (with commit [{}])",
+                            ex, commit == null ? "no" : "yes");
                     Lucene.checkSegmentInfoIntegrity(directory);
                 } catch (CorruptIndexException cex) {
                   cex.addSuppressed(ex);

--- a/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/src/main/java/org/elasticsearch/index/store/Store.java
@@ -630,7 +630,8 @@ public class Store extends AbstractIndexShardComponent implements CloseableIndex
                     // Lucene checks the checksum after it tries to lookup the codec etc.
                     // in that case we might get only IAE or similar exceptions while we are really corrupt...
                     // TODO we should check the checksum in lucene if we hit an exception
-                    logger.warn("checking segment info integrity (reason [{}])", ex.getMessage());
+                    logger.warn("failed to build store metadata. checking segment info integrity (with commit [{}], reason [{}])",
+                            ex, commit == null ? "no" : "yes", ex.getMessage());
                     Lucene.checkSegmentInfoIntegrity(directory);
                 } catch (CorruptIndexException cex) {
                   cex.addSuppressed(ex);

--- a/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetaData.java
+++ b/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetaData.java
@@ -50,7 +50,10 @@ import org.elasticsearch.transport.TransportService;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.*;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 
 /**
@@ -142,44 +145,56 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesOperatio
     }
 
     private StoreFilesMetaData listStoreMetaData(ShardId shardId) throws IOException {
-        IndexService indexService = indicesService.indexService(shardId.index().name());
-        if (indexService != null) {
-            InternalIndexShard indexShard = (InternalIndexShard) indexService.shard(shardId.id());
-            if (indexShard != null) {
-                final Store store = indexShard.store();
-                store.incRef();
-                try {
-                    return new StoreFilesMetaData(true, shardId, store.getMetadataOrEmpty().asMap());
-                } finally {
-                    store.decRef();
+        logger.trace("listing store meta data for {}", shardId);
+        long startTime = System.currentTimeMillis();
+        boolean exists = false;
+        try {
+            IndexService indexService = indicesService.indexService(shardId.index().name());
+            if (indexService != null) {
+                InternalIndexShard indexShard = (InternalIndexShard) indexService.shard(shardId.id());
+                if (indexShard != null) {
+                    final Store store = indexShard.store();
+                    store.incRef();
+                    try {
+                        exists = true;
+                        return new StoreFilesMetaData(true, shardId, store.getMetadataOrEmpty().asMap());
+                    } finally {
+                        store.decRef();
+                    }
                 }
             }
-        }
-        // try and see if we an list unallocated
-        IndexMetaData metaData = clusterService.state().metaData().index(shardId.index().name());
-        if (metaData == null) {
-            return new StoreFilesMetaData(false, shardId, ImmutableMap.<String, StoreFileMetaData>of());
-        }
-        String storeType = metaData.settings().get("index.store.type", "fs");
-        if (!storeType.contains("fs")) {
-            return new StoreFilesMetaData(false, shardId, ImmutableMap.<String, StoreFileMetaData>of());
-        }
-        File[] shardLocations = nodeEnv.shardLocations(shardId);
-        File[] shardIndexLocations = new File[shardLocations.length];
-        for (int i = 0; i < shardLocations.length; i++) {
-            shardIndexLocations[i] = new File(shardLocations[i], "index");
-        }
-        boolean exists = false;
-        for (File shardIndexLocation : shardIndexLocations) {
-            if (shardIndexLocation.exists()) {
-                exists = true;
-                break;
+            // try and see if we an list unallocated
+            IndexMetaData metaData = clusterService.state().metaData().index(shardId.index().name());
+            if (metaData == null) {
+                return new StoreFilesMetaData(false, shardId, ImmutableMap.<String, StoreFileMetaData>of());
+            }
+            String storeType = metaData.settings().get("index.store.type", "fs");
+            if (!storeType.contains("fs")) {
+                return new StoreFilesMetaData(false, shardId, ImmutableMap.<String, StoreFileMetaData>of());
+            }
+            File[] shardLocations = nodeEnv.shardLocations(shardId);
+            File[] shardIndexLocations = new File[shardLocations.length];
+            for (int i = 0; i < shardLocations.length; i++) {
+                shardIndexLocations[i] = new File(shardLocations[i], "index");
+            }
+            for (File shardIndexLocation : shardIndexLocations) {
+                if (shardIndexLocation.exists()) {
+                    exists = true;
+                    break;
+                }
+            }
+            if (!exists) {
+                return new StoreFilesMetaData(false, shardId, ImmutableMap.<String, StoreFileMetaData>of());
+            }
+            return new StoreFilesMetaData(false, shardId, Store.readMetadataSnapshot(shardIndexLocations, logger).asMap());
+        } finally {
+            TimeValue took = new TimeValue(System.currentTimeMillis() - startTime);
+            if (exists) {
+                logger.debug("loaded store meta data for {} (took [{}])", shardId, took);
+            } else {
+                logger.trace("loaded store meta data for {} (took [{}])", shardId, took);
             }
         }
-        if (!exists) {
-            return new StoreFilesMetaData(false, shardId, ImmutableMap.<String, StoreFileMetaData>of());
-        }
-        return new StoreFilesMetaData(false, shardId, Store.readMetadataSnapshot(shardIndexLocations, logger).asMap());
     }
 
     @Override


### PR DESCRIPTION
This commit adds more logs around the gateway shard allocation. Any errors while reaching out to nodes to list the local shards are logged in `WARN`. Shard info loading time is logged under DEBUG. Also, we log a `WARN` message if an exception forces a full checksum check during reading the store metadata.

Examples:

```
[2015-02-04 17:15:31,632][WARN ][gateway.local            ] [Danger] [index][0]: failed to list shard state on node [9tAoCoTLTIiXfJz88S6Sqg], reason [Failed node [9tAoCoTLTIiXfJz88S6Sqg][[Tiger Shark][inet[/192.168.1.248:9301]][internal:gateway/local/started_shards[n]] request_id [14] timed out after [30003ms]]]
[2015-02-04 17:15:31,632][WARN ][gateway.local            ] [Danger] [index][0]: [1] failures when trying to list shard state on nodes.
```

```
[2015-02-04 15:13:42,183][DEBUG][indices.store             ] [Fault Zone] loaded store meta data for [index][0] (took [28ms])
```

```
[2015-02-04 15:13:31,358][DEBUG][gateway.local.state.shards] [Edwin Jarvis] [index][0] shard state info found: [version [18], primary [true]]
```
