### PR TITLE
Remove FlushType and make resources final in InternalEngine

### DIFF
--- a/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -92,9 +92,20 @@ public interface Engine extends Closeable {
     void refresh(String source) throws EngineException;
 
     /**
-     * Flushes the state of the engine, clearing memory.
+     * Flushes the state of the engine including the transaction log, clearing memory.
+     * @param force if <code>true</code> a lucene commit is executed even if no changes need to be committed.
+     * @param waitIfOngoing if <code>true</code> this call will block until all currently running flushes have finished.
+     *                      Otherwise this call will return without blocking.
      */
-    void flush(FlushType type, boolean force, boolean waitIfOngoing) throws EngineException;
+    void flush(boolean force, boolean waitIfOngoing) throws EngineException;
+
+    /**
+     * Flushes the state of the engine including the transaction log, clearing memory and persisting
+     * documents in the lucene index to disk including a potentially heavy and durable fsync operation.
+     * This operation is not going to block if another flush operation is currently running and won't write
+     * a lucene commit if nothing needs to be committed.
+     */
+    void flush() throws EngineException;
 
     /**
      * Optimizes to 1 segment
@@ -185,17 +196,6 @@ public interface Engine extends Closeable {
         public void close() throws ElasticsearchException {
             // nothing to release here...
         }
-    }
-
-    public static enum FlushType {
-        /**
-         * A flush that just commits the writer, without cleaning the translog.
-         */
-        COMMIT,
-        /**
-         * A flush that does a commit, as well as clears the translog.
-         */
-        COMMIT_TRANSLOG
     }
 
     static interface Operation {

--- a/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -615,7 +615,7 @@ public class IndexShard extends AbstractIndexShardComponent {
             logger.trace("flush with {}", request);
         }
         long time = System.nanoTime();
-        engine().flush(Engine.FlushType.COMMIT_TRANSLOG, request.force(), request.waitIfOngoing());
+        engine().flush(request.force(), request.waitIfOngoing());
         flushMetric.inc(System.nanoTime() - time);
     }
 
@@ -744,7 +744,7 @@ public class IndexShard extends AbstractIndexShardComponent {
 
     public void performRecoveryFinalization(boolean withFlush) throws ElasticsearchException {
         if (withFlush) {
-            engine().flush(Engine.FlushType.COMMIT_TRANSLOG, false, false);
+            engine().flush();
         }
         // clear unreferenced files
         translog.clearUnreferenced();

--- a/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -734,7 +734,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent<Indic
                 RecoveryState.Type type = shardRouting.primary() ? RecoveryState.Type.RELOCATION : RecoveryState.Type.REPLICA;
                 recoveryTarget.startRecovery(indexShard, type, sourceNode, new PeerRecoveryListener(shardRouting, indexService, indexMetaData));
             } catch (Throwable e) {
-                indexShard.engine().failEngine("corrupted preexisting index", e);
+                indexShard.failShard("corrupted preexisting index", e);
                 handleRecoveryFailure(indexService, indexMetaData, shardRouting, true, e);
             }
         } else {

--- a/src/test/java/org/elasticsearch/index/engine/internal/InternalEngineSettingsTest.java
+++ b/src/test/java/org/elasticsearch/index/engine/internal/InternalEngineSettingsTest.java
@@ -31,11 +31,11 @@ public class InternalEngineSettingsTest extends ElasticsearchSingleNodeTest {
         final IndexService service = createIndex("foo");
         // INDEX_COMPOUND_ON_FLUSH
         InternalEngine engine = ((InternalEngine)engine(service));
-        assertThat(engine.currentIndexWriterConfig().getUseCompoundFile(), is(true));
+        assertThat(engine.getCurrentIndexWriterConfig().getUseCompoundFile(), is(true));
         client().admin().indices().prepareUpdateSettings("foo").setSettings(ImmutableSettings.builder().put(EngineConfig.INDEX_COMPOUND_ON_FLUSH, false).build()).get();
-        assertThat(engine.currentIndexWriterConfig().getUseCompoundFile(), is(false));
+        assertThat(engine.getCurrentIndexWriterConfig().getUseCompoundFile(), is(false));
         client().admin().indices().prepareUpdateSettings("foo").setSettings(ImmutableSettings.builder().put(EngineConfig.INDEX_COMPOUND_ON_FLUSH, true).build()).get();
-        assertThat(engine.currentIndexWriterConfig().getUseCompoundFile(), is(true));
+        assertThat(engine.getCurrentIndexWriterConfig().getUseCompoundFile(), is(true));
     }
 
 

--- a/src/test/java/org/elasticsearch/index/engine/internal/InternalEngineTests.java
+++ b/src/test/java/org/elasticsearch/index/engine/internal/InternalEngineTests.java
@@ -308,7 +308,7 @@ public class InternalEngineTests extends ElasticsearchLuceneTestCase {
         assertThat(segments.get(0).isCompound(), equalTo(defaultCompound));
         assertThat(segments.get(0).ramTree, nullValue());
 
-        engine.flush(Engine.FlushType.COMMIT_TRANSLOG, false, false);
+        engine.flush();
 
         segments = engine.segments(false);
         assertThat(segments.size(), equalTo(1));
@@ -453,11 +453,11 @@ public class InternalEngineTests extends ElasticsearchLuceneTestCase {
         ParsedDocument doc = testParsedDocument("1", "1", "test", null, -1, -1, testDocument(), B_1, false);
         Engine.Index index = new Engine.Index(null, newUid("1"), doc);
         engine.index(index);
-        engine.flush(Engine.FlushType.COMMIT_TRANSLOG, false, false);
+        engine.flush();
         assertThat(engine.segments(false).size(), equalTo(1));
         index = new Engine.Index(null, newUid("2"), doc);
         engine.index(index);
-        engine.flush(Engine.FlushType.COMMIT_TRANSLOG, false, false);
+        engine.flush();
         List<Segment> segments = engine.segments(false);
         assertThat(segments.size(), equalTo(2));
         for (Segment segment : segments) {
@@ -465,7 +465,7 @@ public class InternalEngineTests extends ElasticsearchLuceneTestCase {
         }
         index = new Engine.Index(null, newUid("3"), doc);
         engine.index(index);
-        engine.flush(Engine.FlushType.COMMIT_TRANSLOG, false, false);
+        engine.flush();
         segments = engine.segments(false);
         assertThat(segments.size(), equalTo(3));
         for (Segment segment : segments) {
@@ -485,7 +485,7 @@ public class InternalEngineTests extends ElasticsearchLuceneTestCase {
 
         index = new Engine.Index(null, newUid("4"), doc);
         engine.index(index);
-        engine.flush(Engine.FlushType.COMMIT_TRANSLOG, false, false);
+        engine.flush();
         final long gen1 = store.readLastCommittedSegmentsInfo().getGeneration();
         // now, optimize and wait for merges, see that we have no merge flag
         engine.forceMerge(true, true);
@@ -645,7 +645,7 @@ public class InternalEngineTests extends ElasticsearchLuceneTestCase {
         searchResult.close();
 
         // now flush
-        engine.flush(Engine.FlushType.COMMIT_TRANSLOG, false, false);
+        engine.flush();
 
         // and, verify get (in real time)
         getResult = engine.get(new Engine.Get(true, newUid("1")));
@@ -722,7 +722,7 @@ public class InternalEngineTests extends ElasticsearchLuceneTestCase {
     public void testFailEngineOnCorruption() {
         ParsedDocument doc = testParsedDocument("1", "1", "test", null, -1, -1, testDocumentWithTextField(), B_1, false);
         engine.create(new Engine.Create(null, newUid("1"), doc));
-        engine.flush(Engine.FlushType.COMMIT_TRANSLOG, false, false);
+        engine.flush();
         final boolean failEngine = defaultSettings.getAsBoolean(EngineConfig.INDEX_FAIL_ON_CORRUPTION_SETTING, false);
         final int failInPhase = randomIntBetween(1, 3);
         try {
@@ -777,13 +777,13 @@ public class InternalEngineTests extends ElasticsearchLuceneTestCase {
     public void testSimpleRecover() throws Exception {
         final ParsedDocument doc = testParsedDocument("1", "1", "test", null, -1, -1, testDocumentWithTextField(), B_1, false);
         engine.create(new Engine.Create(null, newUid("1"), doc));
-        engine.flush(Engine.FlushType.COMMIT_TRANSLOG, false, false);
+        engine.flush();
 
         engine.recover(new Engine.RecoveryHandler() {
             @Override
             public void phase1(SnapshotIndexCommit snapshot) throws EngineException {
                 try {
-                    engine.flush(Engine.FlushType.COMMIT_TRANSLOG, false, false);
+                    engine.flush();
                     assertThat("flush is not allowed in phase 1", false, equalTo(true));
                 } catch (FlushNotAllowedEngineException e) {
                     // all is well
@@ -794,7 +794,7 @@ public class InternalEngineTests extends ElasticsearchLuceneTestCase {
             public void phase2(Translog.Snapshot snapshot) throws EngineException {
                 MatcherAssert.assertThat(snapshot, TranslogSizeMatcher.translogSize(0));
                 try {
-                    engine.flush(Engine.FlushType.COMMIT_TRANSLOG, false, false);
+                    engine.flush();
                     assertThat("flush is not allowed in phase 2", false, equalTo(true));
                 } catch (FlushNotAllowedEngineException e) {
                     // all is well
@@ -809,7 +809,7 @@ public class InternalEngineTests extends ElasticsearchLuceneTestCase {
                 MatcherAssert.assertThat(snapshot, TranslogSizeMatcher.translogSize(1));
                 try {
                     // we can do this here since we are on the same thread
-                    engine.flush(Engine.FlushType.COMMIT_TRANSLOG, false, false);
+                    engine.flush();
                     assertThat("flush is not allowed in phase 3", false, equalTo(true));
                 } catch (FlushNotAllowedEngineException e) {
                     // all is well
@@ -819,7 +819,7 @@ public class InternalEngineTests extends ElasticsearchLuceneTestCase {
         // post recovery should flush the translog
         MatcherAssert.assertThat(translog.snapshot(), TranslogSizeMatcher.translogSize(0));
 
-        engine.flush(Engine.FlushType.COMMIT_TRANSLOG, false, false);
+        engine.flush();
         engine.close();
     }
 
@@ -827,7 +827,7 @@ public class InternalEngineTests extends ElasticsearchLuceneTestCase {
     public void testRecoverWithOperationsBetweenPhase1AndPhase2() throws Exception {
         ParsedDocument doc1 = testParsedDocument("1", "1", "test", null, -1, -1, testDocumentWithTextField(), B_1, false);
         engine.create(new Engine.Create(null, newUid("1"), doc1));
-        engine.flush(Engine.FlushType.COMMIT_TRANSLOG, false, false);
+        engine.flush();
         ParsedDocument doc2 = testParsedDocument("2", "2", "test", null, -1, -1, testDocumentWithTextField(), B_2, false);
         engine.create(new Engine.Create(null, newUid("2"), doc2));
 
@@ -850,7 +850,7 @@ public class InternalEngineTests extends ElasticsearchLuceneTestCase {
             }
         });
 
-        engine.flush(Engine.FlushType.COMMIT_TRANSLOG, false, false);
+        engine.flush();
         engine.close();
     }
 
@@ -858,7 +858,7 @@ public class InternalEngineTests extends ElasticsearchLuceneTestCase {
     public void testRecoverWithOperationsBetweenPhase1AndPhase2AndPhase3() throws Exception {
         ParsedDocument doc1 = testParsedDocument("1", "1", "test", null, -1, -1, testDocumentWithTextField(), B_1, false);
         engine.create(new Engine.Create(null, newUid("1"), doc1));
-        engine.flush(Engine.FlushType.COMMIT_TRANSLOG, false, false);
+        engine.flush();
         ParsedDocument doc2 = testParsedDocument("2", "2", "test", null, -1, -1, testDocumentWithTextField(), B_2, false);
         engine.create(new Engine.Create(null, newUid("2"), doc2));
 
@@ -888,7 +888,7 @@ public class InternalEngineTests extends ElasticsearchLuceneTestCase {
             }
         });
 
-        engine.flush(Engine.FlushType.COMMIT_TRANSLOG, false, false);
+        engine.flush();
         engine.close();
     }
 
@@ -1000,7 +1000,7 @@ public class InternalEngineTests extends ElasticsearchLuceneTestCase {
         engine.index(index);
         assertThat(index.version(), equalTo(2l));
 
-        engine.flush(Engine.FlushType.COMMIT_TRANSLOG, false, false);
+        engine.flush();
 
         index = new Engine.Index(null, newUid("1"), doc, 1l, VersionType.INTERNAL, PRIMARY, 0);
         try {
@@ -1031,7 +1031,7 @@ public class InternalEngineTests extends ElasticsearchLuceneTestCase {
         engine.index(index);
         assertThat(index.version(), equalTo(14l));
 
-        engine.flush(Engine.FlushType.COMMIT_TRANSLOG, false, false);
+        engine.flush();
 
         index = new Engine.Index(null, newUid("1"), doc, 13, VersionType.EXTERNAL, PRIMARY, 0);
         try {
@@ -1104,7 +1104,7 @@ public class InternalEngineTests extends ElasticsearchLuceneTestCase {
         engine.index(index);
         assertThat(index.version(), equalTo(2l));
 
-        engine.flush(Engine.FlushType.COMMIT_TRANSLOG, false, false);
+        engine.flush();
 
         Engine.Delete delete = new Engine.Delete("test", "1", newUid("1"), 1l, VersionType.INTERNAL, PRIMARY, 0, false);
         try {
@@ -1123,14 +1123,14 @@ public class InternalEngineTests extends ElasticsearchLuceneTestCase {
             // all is well
         }
 
-        engine.flush(Engine.FlushType.COMMIT_TRANSLOG, false, false);
+        engine.flush();
 
         // now actually delete
         delete = new Engine.Delete("test", "1", newUid("1"), 2l, VersionType.INTERNAL, PRIMARY, 0, false);
         engine.delete(delete);
         assertThat(delete.version(), equalTo(3l));
 
-        engine.flush(Engine.FlushType.COMMIT_TRANSLOG, false, false);
+        engine.flush();
 
         // now check if we can index to a delete doc with version
         index = new Engine.Index(null, newUid("1"), doc, 2l, VersionType.INTERNAL, PRIMARY, 0);
@@ -1173,7 +1173,7 @@ public class InternalEngineTests extends ElasticsearchLuceneTestCase {
         engine.create(create);
         assertThat(create.version(), equalTo(1l));
 
-        engine.flush(Engine.FlushType.COMMIT_TRANSLOG, false, false);
+        engine.flush();
 
         create = new Engine.Create(null, newUid("1"), doc, Versions.MATCH_ANY, VersionType.INTERNAL, PRIMARY, 0);
         try {
@@ -1297,7 +1297,7 @@ public class InternalEngineTests extends ElasticsearchLuceneTestCase {
 
         engine.delete(new Engine.Delete(null, "1", newUid("1")));
 
-        engine.flush(Engine.FlushType.COMMIT_TRANSLOG, false, false);
+        engine.flush();
 
         index = new Engine.Index(null, newUid("1"), doc);
         engine.index(index);
@@ -1348,13 +1348,13 @@ public class InternalEngineTests extends ElasticsearchLuceneTestCase {
             // First, with DEBUG, which should NOT log IndexWriter output:
             ParsedDocument doc = testParsedDocument("1", "1", "test", null, -1, -1, testDocumentWithTextField(), B_1, false);
             engine.create(new Engine.Create(null, newUid("1"), doc));
-            engine.flush(Engine.FlushType.COMMIT_TRANSLOG, false, false);
+            engine.flush();
             assertFalse(mockAppender.sawIndexWriterMessage);
 
             // Again, with TRACE, which should log IndexWriter output:
             rootLogger.setLevel(Level.TRACE);
             engine.create(new Engine.Create(null, newUid("2"), doc));
-            engine.flush(Engine.FlushType.COMMIT_TRANSLOG, false, false);
+            engine.flush();
             assertTrue(mockAppender.sawIndexWriterMessage);
 
         } finally {
@@ -1383,14 +1383,14 @@ public class InternalEngineTests extends ElasticsearchLuceneTestCase {
             // First, with DEBUG, which should NOT log IndexWriter output:
             ParsedDocument doc = testParsedDocument("1", "1", "test", null, -1, -1, testDocumentWithTextField(), B_1, false);
             engine.create(new Engine.Create(null, newUid("1"), doc));
-            engine.flush(Engine.FlushType.COMMIT_TRANSLOG, false, false);
+            engine.flush();
             assertFalse(mockAppender.sawIndexWriterMessage);
             assertFalse(mockAppender.sawIndexWriterIFDMessage);
 
             // Again, with TRACE, which should only log IndexWriter IFD output:
             iwIFDLogger.setLevel(Level.TRACE);
             engine.create(new Engine.Create(null, newUid("2"), doc));
-            engine.flush(Engine.FlushType.COMMIT_TRANSLOG, false, false);
+            engine.flush();
             assertFalse(mockAppender.sawIndexWriterMessage);
             assertTrue(mockAppender.sawIndexWriterIFDMessage);
 

--- a/src/test/java/org/elasticsearch/test/store/MockFSDirectoryService.java
+++ b/src/test/java/org/elasticsearch/test/store/MockFSDirectoryService.java
@@ -86,7 +86,7 @@ public class MockFSDirectoryService extends FsDirectoryService {
                             // When the the internal engine closes we do a rollback, which removes uncommitted segments
                             // By doing a commit flush we perform a Lucene commit, but don't clear the translog,
                             // so that even in tests where don't flush we can check the integrity of the Lucene index
-                            indexShard.engine().flush(Engine.FlushType.COMMIT, false, true); // Keep translog for tests that rely on replaying it
+                            indexShard.engine().snapshotIndex(); // Keep translog for tests that rely on replaying it
                             logger.info("flush finished in beforeIndexShardClosed");
                         }
                     }


### PR DESCRIPTION
This commit removes the FlushType entirely and replaces it in the most places with
a simple `Engine#flush()` call. Flushing without committing the translog is now
entirely private to the engine and is only called in one place.
