### PR TITLE
upgrade to lucene r1657571

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <lucene.version>5.1.0</lucene.version>
-        <lucene.maven.version>5.1.0-snapshot-1656366</lucene.maven.version>
+        <lucene.maven.version>5.1.0-snapshot-1657571</lucene.maven.version>
         <tests.jvms>auto</tests.jvms>
         <tests.shuffle>true</tests.shuffle>
         <tests.output>onerror</tests.output>
@@ -54,7 +54,7 @@
         </repository>
         <repository>
             <id>Lucene snapshots</id>
-            <url>https://download.elasticsearch.org/lucenesnapshots/1656366</url>
+            <url>https://download.elasticsearch.org/lucenesnapshots/1657571</url>
         </repository>
     </repositories>
 

--- a/src/main/java/org/elasticsearch/common/lucene/Lucene.java
+++ b/src/main/java/org/elasticsearch/common/lucene/Lucene.java
@@ -536,6 +536,11 @@ public class Lucene {
         public void doSetNextReader(LeafReaderContext atomicReaderContext) throws IOException {
             leafCollector = delegate.getLeafCollector(atomicReaderContext);
         }
+
+        @Override
+        public boolean needsScores() {
+            return delegate.needsScores();
+        }
     }
 
     private Lucene() {

--- a/src/main/java/org/elasticsearch/common/lucene/MinimumScoreCollector.java
+++ b/src/main/java/org/elasticsearch/common/lucene/MinimumScoreCollector.java
@@ -60,4 +60,9 @@ public class MinimumScoreCollector extends SimpleCollector {
     public void doSetNextReader(LeafReaderContext context) throws IOException {
         leafCollector = collector.getLeafCollector(context);
     }
+
+    @Override
+    public boolean needsScores() {
+        return true;
+    }
 }

--- a/src/main/java/org/elasticsearch/common/lucene/all/AllTermQuery.java
+++ b/src/main/java/org/elasticsearch/common/lucene/all/AllTermQuery.java
@@ -62,7 +62,7 @@ public class AllTermQuery extends SpanTermQuery {
         }
 
         @Override
-        public AllTermSpanScorer scorer(LeafReaderContext context, Bits acceptDocs) throws IOException {
+        public AllTermSpanScorer scorer(LeafReaderContext context, Bits acceptDocs, boolean needsScores) throws IOException {
             if (this.stats == null) {
                 return null;
             }
@@ -146,7 +146,7 @@ public class AllTermQuery extends SpanTermQuery {
         
         @Override
         public Explanation explain(LeafReaderContext context, int doc) throws IOException{
-            AllTermSpanScorer scorer = scorer(context, context.reader().getLiveDocs());
+            AllTermSpanScorer scorer = scorer(context, context.reader().getLiveDocs(), true);
             if (scorer != null) {
               int newDoc = scorer.advance(doc);
               if (newDoc == doc) {

--- a/src/main/java/org/elasticsearch/common/lucene/search/FilteredCollector.java
+++ b/src/main/java/org/elasticsearch/common/lucene/search/FilteredCollector.java
@@ -97,4 +97,8 @@ public class FilteredCollector implements XCollector {
         };
     }
 
+    @Override
+    public boolean needsScores() {
+        return collector.needsScores();
+    }
 }

--- a/src/main/java/org/elasticsearch/common/lucene/search/MatchNoDocsQuery.java
+++ b/src/main/java/org/elasticsearch/common/lucene/search/MatchNoDocsQuery.java
@@ -57,7 +57,7 @@ public final class MatchNoDocsQuery extends Query {
         }
 
         @Override
-        public Scorer scorer(LeafReaderContext context, Bits acceptDocs) throws IOException {
+        public Scorer scorer(LeafReaderContext context, Bits acceptDocs, boolean needsScores) throws IOException {
             return null;
         }
 

--- a/src/main/java/org/elasticsearch/common/lucene/search/NoopCollector.java
+++ b/src/main/java/org/elasticsearch/common/lucene/search/NoopCollector.java
@@ -43,4 +43,9 @@ public class NoopCollector extends SimpleCollector {
     @Override
     protected void doSetNextReader(LeafReaderContext context) throws IOException {
     }
+
+    @Override
+    public boolean needsScores() {
+        return false;
+    }
 }

--- a/src/main/java/org/elasticsearch/common/lucene/search/function/FiltersFunctionScoreQuery.java
+++ b/src/main/java/org/elasticsearch/common/lucene/search/function/FiltersFunctionScoreQuery.java
@@ -152,11 +152,11 @@ public class FiltersFunctionScoreQuery extends Query {
         }
 
         @Override
-        public Scorer scorer(LeafReaderContext context, Bits acceptDocs) throws IOException {
+        public Scorer scorer(LeafReaderContext context, Bits acceptDocs, boolean needsScores) throws IOException {
             // we ignore scoreDocsInOrder parameter, because we need to score in
             // order if documents are scored with a script. The
             // ShardLookup depends on in order scoring.
-            Scorer subQueryScorer = subQueryWeight.scorer(context, acceptDocs);
+            Scorer subQueryScorer = subQueryWeight.scorer(context, acceptDocs, needsScores);
             if (subQueryScorer == null) {
                 return null;
             }

--- a/src/main/java/org/elasticsearch/common/lucene/search/function/FunctionScoreQuery.java
+++ b/src/main/java/org/elasticsearch/common/lucene/search/function/FunctionScoreQuery.java
@@ -120,11 +120,11 @@ public class FunctionScoreQuery extends Query {
         }
 
         @Override
-        public Scorer scorer(LeafReaderContext context, Bits acceptDocs) throws IOException {
+        public Scorer scorer(LeafReaderContext context, Bits acceptDocs, boolean needsScores) throws IOException {
             // we ignore scoreDocsInOrder parameter, because we need to score in
             // order if documents are scored with a script. The
             // ShardLookup depends on in order scoring.
-            Scorer subQueryScorer = subQueryWeight.scorer(context, acceptDocs);
+            Scorer subQueryScorer = subQueryWeight.scorer(context, acceptDocs, needsScores);
             if (subQueryScorer == null) {
                 return null;
             }

--- a/src/main/java/org/elasticsearch/index/percolator/QueriesLoaderCollector.java
+++ b/src/main/java/org/elasticsearch/index/percolator/QueriesLoaderCollector.java
@@ -96,4 +96,9 @@ final class QueriesLoaderCollector extends SimpleCollector {
     @Override
     public void setScorer(Scorer scorer) throws IOException {
     }
+
+    @Override
+    public boolean needsScores() {
+        return false;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/FilteredQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/FilteredQueryParser.java
@@ -75,14 +75,14 @@ public class FilteredQueryParser implements QueryParser {
         }
 
         @Override
-        public Scorer filteredScorer(LeafReaderContext context, Weight weight, DocIdSet docIdSet) throws IOException {
+        public Scorer filteredScorer(LeafReaderContext context, Weight weight, DocIdSet docIdSet, boolean needsScores) throws IOException {
             // CHANGE: If threshold is 0, always pass down the accept docs, don't pay the price of calling nextDoc even...
             final Bits filterAcceptDocs = docIdSet.bits();
             if (threshold == 0) {
                 if (filterAcceptDocs != null) {
-                    return weight.scorer(context, filterAcceptDocs);
+                    return weight.scorer(context, filterAcceptDocs, needsScores);
                 } else {
-                    return FilteredQuery.LEAP_FROG_QUERY_FIRST_STRATEGY.filteredScorer(context, weight, docIdSet);
+                    return FilteredQuery.LEAP_FROG_QUERY_FIRST_STRATEGY.filteredScorer(context, weight, docIdSet, needsScores);
                 }
             }
 
@@ -91,11 +91,11 @@ public class FilteredQueryParser implements QueryParser {
                 // default  value, don't iterate on only apply filter after query if its not a "fast" docIdSet
                 // TODO: is there a way we could avoid creating an iterator here?
                 if (filterAcceptDocs != null && DocIdSets.isBroken(docIdSet.iterator())) {
-                    return FilteredQuery.QUERY_FIRST_FILTER_STRATEGY.filteredScorer(context, weight, docIdSet);
+                    return FilteredQuery.QUERY_FIRST_FILTER_STRATEGY.filteredScorer(context, weight, docIdSet, needsScores);
                 }
             }
 
-            return super.filteredScorer(context, weight, docIdSet);
+            return super.filteredScorer(context, weight, docIdSet, needsScores);
         }
 
         @Override

--- a/src/main/java/org/elasticsearch/index/search/child/ChildrenConstantScoreQuery.java
+++ b/src/main/java/org/elasticsearch/index/search/child/ChildrenConstantScoreQuery.java
@@ -51,6 +51,7 @@ import java.util.Set;
 /**
  *
  */
+// TODO: Remove me and move the logic to ChildrenQuery when needsScore=false
 public class ChildrenConstantScoreQuery extends Query {
 
     private final IndexParentChildFieldData parentChildIndexFieldData;
@@ -221,7 +222,7 @@ public class ChildrenConstantScoreQuery extends Query {
         }
 
         @Override
-        public Scorer scorer(LeafReaderContext context, Bits acceptDocs) throws IOException {
+        public Scorer scorer(LeafReaderContext context, Bits acceptDocs, boolean needsScores) throws IOException {
             if (remaining == 0) {
                 return null;
             }

--- a/src/main/java/org/elasticsearch/index/search/child/ChildrenQuery.java
+++ b/src/main/java/org/elasticsearch/index/search/child/ChildrenQuery.java
@@ -288,7 +288,7 @@ public class ChildrenQuery extends Query {
         }
 
         @Override
-        public Scorer scorer(LeafReaderContext context, Bits acceptDocs) throws IOException {
+        public Scorer scorer(LeafReaderContext context, Bits acceptDocs, boolean needsScores) throws IOException {
             DocIdSet parentsSet = parentFilter.getDocIdSet(context, acceptDocs);
             if (DocIdSets.isEmpty(parentsSet) || remaining == 0) {
                 return null;

--- a/src/main/java/org/elasticsearch/index/search/child/CustomQueryWrappingFilter.java
+++ b/src/main/java/org/elasticsearch/index/search/child/CustomQueryWrappingFilter.java
@@ -73,7 +73,7 @@ public class CustomQueryWrappingFilter extends NoCacheFilter implements Releasab
                 final DocIdSet set = new DocIdSet() {
                     @Override
                     public DocIdSetIterator iterator() throws IOException {
-                        return weight.scorer(leaf, null);
+                        return weight.scorer(leaf, null, false);
                     }
                     @Override
                     public boolean isCacheable() { return false; }

--- a/src/main/java/org/elasticsearch/index/search/child/ParentConstantScoreQuery.java
+++ b/src/main/java/org/elasticsearch/index/search/child/ParentConstantScoreQuery.java
@@ -187,7 +187,7 @@ public class ParentConstantScoreQuery extends Query {
         }
 
         @Override
-        public Scorer scorer(LeafReaderContext context, Bits acceptDocs) throws IOException {
+        public Scorer scorer(LeafReaderContext context, Bits acceptDocs, boolean needsScores) throws IOException {
             DocIdSet childrenDocIdSet = childrenFilter.getDocIdSet(context, acceptDocs);
             if (DocIdSets.isEmpty(childrenDocIdSet)) {
                 return null;

--- a/src/main/java/org/elasticsearch/index/search/child/ParentQuery.java
+++ b/src/main/java/org/elasticsearch/index/search/child/ParentQuery.java
@@ -251,7 +251,7 @@ public class ParentQuery extends Query {
         }
 
         @Override
-        public Scorer scorer(LeafReaderContext context, Bits acceptDocs) throws IOException {
+        public Scorer scorer(LeafReaderContext context, Bits acceptDocs, boolean needsScores) throws IOException {
             DocIdSet childrenDocSet = childrenFilter.getDocIdSet(context, acceptDocs);
             if (DocIdSets.isEmpty(childrenDocSet)) {
                 return null;

--- a/src/main/java/org/elasticsearch/index/search/child/TopChildrenQuery.java
+++ b/src/main/java/org/elasticsearch/index/search/child/TopChildrenQuery.java
@@ -323,8 +323,11 @@ public class TopChildrenQuery extends Query {
         }
 
         @Override
-        public Scorer scorer(LeafReaderContext context, Bits acceptDocs) throws IOException {
+        public Scorer scorer(LeafReaderContext context, Bits acceptDocs, boolean needsScores) throws IOException {
             ParentDoc[] readerParentDocs = parentDocs.get(context.reader().getCoreCacheKey());
+            // We ignore the needsScores parameter here because there isn't really anything that we
+            // can improve by ignoring scores. Actually this query does not really make sense
+            // with needsScores=false...
             if (readerParentDocs != null) {
                 if (scoreType == ScoreType.MIN) {
                     return new ParentScorer(this, readerParentDocs) {

--- a/src/main/java/org/elasticsearch/index/search/nested/IncludeNestedDocsQuery.java
+++ b/src/main/java/org/elasticsearch/index/search/nested/IncludeNestedDocsQuery.java
@@ -105,8 +105,8 @@ public class IncludeNestedDocsQuery extends Query {
         }
 
         @Override
-        public Scorer scorer(LeafReaderContext context, Bits acceptDocs) throws IOException {
-            final Scorer parentScorer = parentWeight.scorer(context, acceptDocs);
+        public Scorer scorer(LeafReaderContext context, Bits acceptDocs, boolean needsScores) throws IOException {
+            final Scorer parentScorer = parentWeight.scorer(context, acceptDocs, needsScores);
 
             // no matches
             if (parentScorer == null) {

--- a/src/main/java/org/elasticsearch/indices/ttl/IndicesTTLService.java
+++ b/src/main/java/org/elasticsearch/indices/ttl/IndicesTTLService.java
@@ -247,8 +247,9 @@ public class IndicesTTLService extends AbstractLifecycleComponent<IndicesTTLServ
         public void setScorer(Scorer scorer) {
         }
 
-        public boolean acceptsDocsOutOfOrder() {
-            return true;
+        @Override
+        public boolean needsScores() {
+            return false;
         }
 
         public void collect(int doc) {

--- a/src/main/java/org/elasticsearch/percolator/QueryCollector.java
+++ b/src/main/java/org/elasticsearch/percolator/QueryCollector.java
@@ -111,6 +111,16 @@ abstract class QueryCollector extends SimpleCollector {
     }
 
     @Override
+    public boolean needsScores() {
+        for (Collector collector : aggregatorCollector) {
+            if (collector.needsScores()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
     public void doSetNextReader(LeafReaderContext context) throws IOException {
         // we use the UID because id might not be indexed
         values = idFieldData.load(context).getBytesValues();

--- a/src/main/java/org/elasticsearch/search/aggregations/AggregationPhase.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/AggregationPhase.java
@@ -94,7 +94,7 @@ public class AggregationPhase implements SearchPhase {
             }
             context.aggregations().aggregators(aggregators);
             if (!collectors.isEmpty()) {
-                context.searcher().addMainQueryCollector(new AggregationsCollector(collectors, aggregationContext));
+                context.searcher().queryCollectors().put(AggregationPhase.class, new AggregationsCollector(collectors, aggregationContext));
             }
             aggregationContext.setNextReader(context.searcher().getIndexReader().getContext());
         }
@@ -148,6 +148,7 @@ public class AggregationPhase implements SearchPhase {
 
         // disable aggregations so that they don't run on next pages in case of scrolling
         context.aggregations(null);
+        context.searcher().queryCollectors().remove(AggregationPhase.class);
     }
 
 
@@ -168,11 +169,7 @@ public class AggregationPhase implements SearchPhase {
 
         @Override
         public boolean needsScores() {
-            // TODO: we currently have no way to know if aggregations need scores
-            // since almost any aggregation can use the _score special variable
-            // in scripts which will poll the current scorer and compute the
-            // score.
-            return true;
+            return aggregationContext.needsScores();
         }
 
         @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/AggregationPhase.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/AggregationPhase.java
@@ -167,6 +167,15 @@ public class AggregationPhase implements SearchPhase {
         }
 
         @Override
+        public boolean needsScores() {
+            // TODO: we currently have no way to know if aggregations need scores
+            // since almost any aggregation can use the _score special variable
+            // in scripts which will poll the current scorer and compute the
+            // score.
+            return true;
+        }
+
+        @Override
         public void collect(int doc) throws IOException {
             for (Aggregator collector : collectors) {
                 collector.collect(doc, 0);

--- a/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactories.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactories.java
@@ -99,6 +99,15 @@ public class AggregatorFactories {
         }
     }
 
+    public boolean needsScores() {
+        for (AggregatorFactory factory : factories) {
+            if (factory.needsScores()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private final static class Empty extends AggregatorFactories {
 
         private static final AggregatorFactory[] EMPTY_FACTORIES = new AggregatorFactory[0];

--- a/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactory.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactory.java
@@ -101,6 +101,10 @@ public abstract class AggregatorFactory {
         this.metaData = metaData;
     }
 
+    public boolean needsScores() {
+        return factories.needsScores();
+    }
+
     /**
      * Utility method. Given an {@link AggregatorFactory} that creates {@link Aggregator}s that only know how
      * to collect bucket <tt>0</tt>, this returns an aggregator that can collect any bucket.

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/TopHitsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/TopHitsAggregator.java
@@ -176,5 +176,15 @@ public class TopHitsAggregator extends MetricsAggregator implements ScorerAware 
             throw new AggregationInitializationException("Aggregator [" + name + "] of type [" + type + "] cannot accept sub-aggregations");
         }
 
+        @Override
+        public boolean needsScores() {
+            Sort sort = subSearchContext.sort();
+            if (sort != null) {
+                return sort.needsScores() || subSearchContext.trackScores();
+            } else {
+                // sort by score
+                return true;
+            }
+        }
     }
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/support/AggregationContext.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/support/AggregationContext.java
@@ -63,6 +63,13 @@ public class AggregationContext implements ReaderContextAware, ScorerAware {
         this.searchContext = searchContext;
     }
 
+    /**
+     * Whether aggregators which are attached to this context need scores.
+     */
+    public boolean needsScores() {
+        return searchContext.aggregations().factories().needsScores();
+    }
+
     public SearchContext searchContext() {
         return searchContext;
     }

--- a/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceAggregatorFactory.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceAggregatorFactory.java
@@ -64,6 +64,15 @@ public abstract class ValuesSourceAggregatorFactory<VS extends ValuesSource> ext
         }
     }
 
+    @Override
+    public boolean needsScores() {
+        // TODO: we have no way to know whether scripts use the score so
+        // for now we assume that they do but in the future it would be
+        // nice to be able to know if they need scores so that the query
+        // would only provuce scores if required.
+        return config.script != null || super.needsScores();
+    }
+
     protected abstract Aggregator createUnmapped(AggregationContext aggregationContext, Aggregator parent, Map<String, Object> metaData) throws IOException;
 
     protected abstract Aggregator doCreateInternal(VS valuesSource, AggregationContext aggregationContext, Aggregator parent, boolean collectsFromSingleBucket, Map<String, Object> metaData) throws IOException;

--- a/src/main/java/org/elasticsearch/search/scan/ScanContext.java
+++ b/src/main/java/org/elasticsearch/search/scan/ScanContext.java
@@ -101,6 +101,11 @@ public class ScanContext {
         }
 
         @Override
+        public boolean needsScores() {
+            return trackScores;
+        }
+
+        @Override
         public void setScorer(Scorer scorer) throws IOException {
             this.scorer = scorer;
         }

--- a/src/test/java/org/elasticsearch/search/aggregations/AggregationCollectorTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/AggregationCollectorTests.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations;
+
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.index.IndexService;
+import org.elasticsearch.test.ElasticsearchSingleNodeTest;
+
+import java.io.IOException;
+
+public class AggregationCollectorTests extends ElasticsearchSingleNodeTest {
+
+    public void testNeedsScores() throws Exception {
+        IndexService index = createIndex("idx");
+        client().prepareIndex("idx", "type", "1").setSource("f", 5).execute().get();
+        client().admin().indices().prepareRefresh("idx").get();
+        
+        // simple field aggregation, no scores needed
+        String fieldAgg = "{ \"my_terms\": {\"terms\": {\"field\": \"f\"}}}";
+        assertFalse(needsScores(index, fieldAgg));
+
+        // agg on a script => scores are needed
+        String scriptAgg = "{ \"my_terms\": {\"terms\": {\"script\": \"doc['f'].value\"}}}";
+        assertTrue(needsScores(index, scriptAgg));
+
+        // make sure the information is propagated to sub aggregations
+        String subFieldAgg = "{ \"my_outer_terms\": { \"terms\": { \"field\": \"f\" }, \"aggs\": " + fieldAgg + "}}";
+        assertFalse(needsScores(index, subFieldAgg));
+
+        String subScriptAgg = "{ \"my_outer_terms\": { \"terms\": { \"field\": \"f\" }, \"aggs\": " + scriptAgg + "}}";
+        assertTrue(needsScores(index, subScriptAgg));
+
+        // top_hits is a particular example of an aggregation that needs scores
+        String topHitsAgg = "{ \"my_hits\": {\"top_hits\": {}}}";
+        assertTrue(needsScores(index, topHitsAgg));
+    }
+
+    private boolean needsScores(IndexService index, String agg) throws IOException {
+        AggregatorParsers parser = getInstanceFromNode(AggregatorParsers.class);
+        XContentParser aggParser = JsonXContent.jsonXContent.createParser(agg);
+        aggParser.nextToken();
+        final AggregatorFactories factories = parser.parseAggregators(aggParser, createSearchContext(index));
+        return factories.needsScores();
+    }
+
+}

--- a/src/test/java/org/elasticsearch/test/TestSearchContext.java
+++ b/src/test/java/org/elasticsearch/test/TestSearchContext.java
@@ -77,6 +77,7 @@ public class TestSearchContext extends SearchContext {
     int size;
     private int terminateAfter = DEFAULT_TERMINATE_AFTER;
     private String[] types;
+    private SearchContextAggregations aggregations;
 
     public TestSearchContext(ThreadPool threadPool,PageCacheRecycler pageCacheRecycler, BigArrays bigArrays, IndexService indexService, FilterCache filterCache, IndexFieldDataService indexFieldDataService) {
         this.pageCacheRecycler = pageCacheRecycler;
@@ -143,7 +144,7 @@ public class TestSearchContext extends SearchContext {
 
     @Override
     public int numberOfShards() {
-        return 0;
+        return 1;
     }
 
     @Override
@@ -183,12 +184,13 @@ public class TestSearchContext extends SearchContext {
 
     @Override
     public SearchContextAggregations aggregations() {
-        return null;
+        return aggregations;
     }
 
     @Override
     public SearchContext aggregations(SearchContextAggregations aggregations) {
-        return null;
+        this.aggregations = aggregations;
+        return this;
     }
 
     @Override
@@ -297,7 +299,7 @@ public class TestSearchContext extends SearchContext {
 
     @Override
     public ScriptService scriptService() {
-        return null;
+        return indexService.injector().getInstance(ScriptService.class);
     }
 
     @Override
@@ -529,7 +531,7 @@ public class TestSearchContext extends SearchContext {
 
     @Override
     public SearchLookup lookup() {
-        return null;
+        return new SearchLookup(mapperService(), fieldData(), null);
     }
 
     @Override


### PR DESCRIPTION
This is mainly to deal with api changes for https://issues.apache.org/jira/browse/LUCENE-6218

Collector and Weight.scorer() have a parameter if scores are needed. In many cases they are not, for example in the case of an uncached filter, when sorting by a field like price, when the clause is a boolean MUST_NOT, constant-score queries, etc. 

In these cases knowing that we will never need the score means some queries can execute faster: terms don't need to decode frequency blocks, phrases can stop after the first match, booleanquery can sometimes drop optional clauses, etc.
