### PR TITLE
Take filters from aliases into account

### DIFF
--- a/src/main/java/org/elasticsearch/percolator/PercolateContext.java
+++ b/src/main/java/org/elasticsearch/percolator/PercolateContext.java
@@ -36,8 +36,8 @@ import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.analysis.AnalysisService;
 import org.elasticsearch.index.cache.docset.DocSetCache;
 import org.elasticsearch.index.cache.filter.FilterCache;
-import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.cache.fixedbitset.FixedBitSetFilterCache;
+import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.fielddata.IndexFieldDataService;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.FieldMappers;
@@ -95,6 +95,7 @@ public class PercolateContext extends SearchContext {
     private final ScriptService scriptService;
     private final ConcurrentMap<BytesRef, Query> percolateQueries;
     private final int numberOfShards;
+    private final Filter aliasFilter;
     private String[] types;
 
     private Engine.Searcher docSearcher;
@@ -115,7 +116,7 @@ public class PercolateContext extends SearchContext {
 
     public PercolateContext(PercolateShardRequest request, SearchShardTarget searchShardTarget, IndexShard indexShard,
                             IndexService indexService, CacheRecycler cacheRecycler, PageCacheRecycler pageCacheRecycler,
-                            BigArrays bigArrays, ScriptService scriptService) {
+                            BigArrays bigArrays, ScriptService scriptService, Filter aliasFilter) {
         this.indexShard = indexShard;
         this.indexService = indexService;
         this.fieldDataService = indexService.fieldData();
@@ -130,6 +131,7 @@ public class PercolateContext extends SearchContext {
         this.searcher = new ContextIndexSearcher(this, engineSearcher);
         this.scriptService = scriptService;
         this.numberOfShards = request.getNumberOfShards();
+        this.aliasFilter = aliasFilter;
     }
 
     public IndexSearcher docSearcher() {
@@ -294,7 +296,7 @@ public class PercolateContext extends SearchContext {
 
     @Override
     public Filter searchFilter(String[] types) {
-        throw new UnsupportedOperationException();
+        return aliasFilter();
     }
 
     @Override
@@ -546,7 +548,7 @@ public class PercolateContext extends SearchContext {
 
     @Override
     public Filter aliasFilter() {
-        throw new UnsupportedOperationException();
+        return aliasFilter;
     }
 
     @Override

--- a/src/test/java/org/elasticsearch/percolator/PercolatorTests.java
+++ b/src/test/java/org/elasticsearch/percolator/PercolatorTests.java
@@ -22,6 +22,7 @@ import com.google.common.base.Predicate;
 import org.elasticsearch.action.ShardOperationFailedException;
 import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
 import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsResponse;
+import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesResponse;
 import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsResponse;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
@@ -50,7 +51,6 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.highlight.HighlightBuilder;
 import org.elasticsearch.search.sort.SortBuilders;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
-import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -917,7 +917,84 @@ public class PercolatorTests extends ElasticsearchIntegrationTest {
         for (PercolateResponse.Match match : response) {
             assertThat(match.getIndex().string(), equalTo("test2"));
         }
+    }
 
+    @Test
+    public void testPercolateWithAliasFilter() throws Exception {
+        assertAcked(prepareCreate("my-index")
+                        .addMapping(PercolatorService.TYPE_NAME, "a", "type=string,index=not_analyzed")
+                        .addAlias(new Alias("a").filter(FilterBuilders.termFilter("a", "a")))
+                        .addAlias(new Alias("b").filter(FilterBuilders.termFilter("a", "b")))
+                        .addAlias(new Alias("c").filter(FilterBuilders.termFilter("a", "c")))
+        );
+        client().prepareIndex("my-index", PercolatorService.TYPE_NAME, "1")
+                .setSource(jsonBuilder().startObject().field("query", matchAllQuery()).field("a", "a").endObject())
+                .get();
+        client().prepareIndex("my-index", PercolatorService.TYPE_NAME, "2")
+                .setSource(jsonBuilder().startObject().field("query", matchAllQuery()).field("a", "b").endObject())
+                .get();
+        refresh();
+
+        // Specifying only the document to percolate and no filter, sorting or aggs, the queries are retrieved from
+        // memory directly. Otherwise we need to retrieve those queries from lucene to be able to execute filters,
+        // aggregations and sorting on top of them. So this test a different code execution path.
+        PercolateResponse response = client().preparePercolate()
+                .setIndices("a")
+                .setDocumentType("my-type")
+                .setPercolateDoc(new PercolateSourceBuilder.DocBuilder().setDoc("{}"))
+                .get();
+        assertNoFailures(response);
+        assertThat(response.getCount(), equalTo(1l));
+        assertThat(response.getMatches()[0].getId().string(), equalTo("1"));
+
+        response = client().preparePercolate()
+                .setIndices("b")
+                .setDocumentType("my-type")
+                .setPercolateDoc(new PercolateSourceBuilder.DocBuilder().setDoc("{}"))
+                .get();
+        assertNoFailures(response);
+        assertThat(response.getCount(), equalTo(1l));
+        assertThat(response.getMatches()[0].getId().string(), equalTo("2"));
+
+
+        response = client().preparePercolate()
+                .setIndices("c")
+                .setDocumentType("my-type")
+                .setPercolateDoc(new PercolateSourceBuilder.DocBuilder().setDoc("{}"))
+                .get();
+        assertNoFailures(response);
+        assertThat(response.getCount(), equalTo(0l));
+
+        // Testing that the alias filter and the filter specified while percolating are both taken into account.
+        response = client().preparePercolate()
+                .setIndices("a")
+                .setDocumentType("my-type")
+                .setPercolateDoc(new PercolateSourceBuilder.DocBuilder().setDoc("{}"))
+                .setPercolateFilter(FilterBuilders.matchAllFilter())
+                .get();
+        assertNoFailures(response);
+        assertThat(response.getCount(), equalTo(1l));
+        assertThat(response.getMatches()[0].getId().string(), equalTo("1"));
+
+        response = client().preparePercolate()
+                .setIndices("b")
+                .setDocumentType("my-type")
+                .setPercolateDoc(new PercolateSourceBuilder.DocBuilder().setDoc("{}"))
+                .setPercolateFilter(FilterBuilders.matchAllFilter())
+                .get();
+        assertNoFailures(response);
+        assertThat(response.getCount(), equalTo(1l));
+        assertThat(response.getMatches()[0].getId().string(), equalTo("2"));
+
+
+        response = client().preparePercolate()
+                .setIndices("c")
+                .setDocumentType("my-type")
+                .setPercolateDoc(new PercolateSourceBuilder.DocBuilder().setDoc("{}"))
+                .setPercolateFilter(FilterBuilders.matchAllFilter())
+                .get();
+        assertNoFailures(response);
+        assertThat(response.getCount(), equalTo(0l));
     }
 
     @Test


### PR DESCRIPTION
Take filters from index aliases into account when selecting queries to run on a document.

The filter from an indexed alias is as if you would filter on the metadata of a percolator query, but then the filter is defined in the index alias instead of the percolate request.

PR for #6241
