### PR TITLE
Add warning to settings documentation because setting number_of_replicas on a closed can lead to index beeing not openable again

### DIFF
--- a/docs/reference/indices/update-settings.asciidoc
+++ b/docs/reference/indices/update-settings.asciidoc
@@ -29,6 +29,12 @@ curl -XPUT 'localhost:9200/my_index/_settings' -d '
 }'
 --------------------------------------------------
 
+[WARNING]
+========================
+When changing the number of replicas the index needs to be open. Changing
+the number of replicas on a closed index might prevent the index to be opened correctly again.
+========================
+
 Below is the list of settings that can be changed using the update
 settings API:
 


### PR DESCRIPTION
Issue #9566 raises the point that setting the number of shards on a closed index can lead to this index not beeing able to open again. This change in documentation is ment to warn the user about this issue.
