### PR TITLE
FileSystemUtils: Only create backup copies if files differ

### DIFF
--- a/src/test/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
+++ b/src/test/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
@@ -797,6 +797,13 @@ public class ElasticsearchAssertions {
     }
 
     /**
+     * Check if a file does not exist
+     */
+    public static void assertFileNotExists(Path file) {
+        assertThat("file/dir [" + file + "] should not exist.", Files.exists(file), is(false));
+    }
+
+    /**
      * Check if a directory exists
      */
     public static void assertDirectoryExists(Path dir) {


### PR DESCRIPTION
The FileSystemUtils class has a helper method to create files with
a .new suffix, in case the file, which should be created already
exists. If you install plugins and those have configuration files,
even without changes, you will end up with tons of .new files.

This commit checks the file size and sha-256 sum, and only if those
differ, a .new file is actually being created.
