### PR TITLE
Change logging to warning to match pattern

### DIFF
--- a/src/main/java/org/elasticsearch/gateway/LocalAllocateDangledIndices.java
+++ b/src/main/java/org/elasticsearch/gateway/LocalAllocateDangledIndices.java
@@ -158,7 +158,7 @@ public class LocalAllocateDangledIndices extends AbstractComponent {
                     try {
                         channel.sendResponse(t);
                     } catch (Exception e) {
-                        logger.error("failed send response for allocating dangled", e);
+                        logger.warn("failed send response for allocating dangled", e);
                     }
                 }
 
@@ -167,7 +167,7 @@ public class LocalAllocateDangledIndices extends AbstractComponent {
                     try {
                         channel.sendResponse(new AllocateDangledResponse(true));
                     } catch (IOException e) {
-                        logger.error("failed send response for allocating dangled", e);
+                        logger.warn("failed send response for allocating dangled", e);
                     }
                 }
             });


### PR DESCRIPTION
I tool I am developing detected the logging message here should be a warning instead of an error.

Some examples of the pattern:
org.elasticsearch.action.support.master.TransportMasterNodeOperationAction.java Lines 255 to 260
org.elasticsearch.action.support.replication.TransportIndicesReplicationOperationAction.java Lines 157 to 162
org.elasticsearch.discovery.zen.membership.MembershipAction.java Lines 197 to 162
