### PR TITLE
Change logging from debug to warning

### DIFF
--- a/src/main/java/org/elasticsearch/discovery/zen/publish/PublishClusterStateAction.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/publish/PublishClusterStateAction.java
@@ -198,7 +198,7 @@ public class PublishClusterStateAction extends AbstractComponent {
                     try {
                         channel.sendResponse(TransportResponse.Empty.INSTANCE);
                     } catch (Throwable e) {
-                        logger.debug("failed to send response on cluster state processed", e);
+                        logger.warn("failed to send response on cluster state processed", e);
                     }
                 }
 
@@ -207,7 +207,7 @@ public class PublishClusterStateAction extends AbstractComponent {
                     try {
                         channel.sendResponse(t);
                     } catch (Throwable e) {
-                        logger.debug("failed to send response on cluster state processed", e);
+                        logger.warn("failed to send response on cluster state processed", e);
                     }
                 }
             });


### PR DESCRIPTION
I tool I am developing detected the logging message here should be a warning instead of a debug.

Some examples of the pattern:
org.elasticsearch.action.support.master.TransportMasterNodeOperationAction.java Lines 255 to 260
org.elasticsearch.action.support.replication.TransportIndicesReplicationOperationAction.java Lines 157 to 162
org.elasticsearch.discovery.zen.membership.MembershipAction.java Lines 197 to 162
