### PR TITLE
Consolidate index / shard deletion in IndicesService

### DIFF
--- a/src/main/java/org/elasticsearch/index/store/IndexStore.java
+++ b/src/main/java/org/elasticsearch/index/store/IndexStore.java
@@ -45,17 +45,6 @@ public interface IndexStore extends Closeable {
     Class<? extends DirectoryService> shardDirectory();
 
     /**
-     * Returns <tt>true</tt> if this shard is allocated on this node. Allocated means
-     * that it has storage files that can be deleted using {@code deleteUnallocated(ShardId, Settings)}.
-     */
-    boolean canDeleteUnallocated(ShardId shardId, @IndexSettings Settings indexSettings);
-
-    /**
-     * Deletes this shard store since its no longer allocated.
-     */
-    void deleteUnallocated(ShardId shardId, @IndexSettings Settings indexSettings) throws IOException;
-
-    /**
      * Return an array of all index folder locations for a given shard
      */
     Path[] shardIndexLocations(ShardId shardId);

--- a/src/main/java/org/elasticsearch/index/store/support/AbstractIndexStore.java
+++ b/src/main/java/org/elasticsearch/index/store/support/AbstractIndexStore.java
@@ -126,33 +126,6 @@ public abstract class AbstractIndexStore extends AbstractIndexComponent implemen
         return nodeRateLimiting ? indicesStore.rateLimiting() : this.rateLimiting;
     }
 
-
-    @Override
-    public boolean canDeleteUnallocated(ShardId shardId, @IndexSettings Settings indexSettings) {
-        if (locations == null) {
-            return false;
-        }
-        if (indexService.hasShard(shardId.id())) {
-            return false;
-        }
-        return FileSystemUtils.exists(nodeEnv.shardPaths(shardId));
-    }
-
-    @Override
-    public void deleteUnallocated(ShardId shardId, @IndexSettings Settings indexSettings) throws IOException {
-        if (locations == null) {
-            return;
-        }
-        if (indexService.hasShard(shardId.id())) {
-            throw new ElasticsearchIllegalStateException(shardId + " allocated, can't be deleted");
-        }
-        try {
-            nodeEnv.deleteShardDirectorySafe(shardId, indexSettings);
-        } catch (Exception ex) {
-            logger.debug("failed to delete shard locations", ex);
-        }
-    }
-
     /**
      * Return an array of all index folder locations for a given shard. Uses
      * the index settings to determine if a custom data path is set for the

--- a/src/main/java/org/elasticsearch/indices/IndicesModule.java
+++ b/src/main/java/org/elasticsearch/indices/IndicesModule.java
@@ -66,7 +66,6 @@ public class IndicesModule extends AbstractModule implements SpawnModules {
         bind(RecoverySettings.class).asEagerSingleton();
         bind(RecoveryTarget.class).asEagerSingleton();
         bind(RecoverySource.class).asEagerSingleton();
-
         bind(IndicesStore.class).asEagerSingleton();
         bind(IndicesClusterStateService.class).asEagerSingleton();
         bind(IndexingMemoryController.class).asEagerSingleton();

--- a/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -28,6 +28,7 @@ import org.elasticsearch.ElasticsearchIllegalStateException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateListener;
 import org.elasticsearch.cluster.action.index.NodeIndexDeletedAction;
 import org.elasticsearch.cluster.action.index.NodeMappingRefreshAction;
@@ -177,42 +178,15 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent<Indic
             }
 
             cleanFailedShards(event);
-            cleanMismatchedIndexUUIDs(event);
+
+            applyDeletedIndices(event);
             applyNewIndices(event);
             applyMappings(event);
             applyAliases(event);
             applyNewOrUpdatedShards(event);
-            applyDeletedIndices(event);
             applyDeletedShards(event);
             applyCleanedIndices(event);
             applySettings(event);
-            sendIndexLifecycleEvents(event);
-        }
-    }
-
-    private void sendIndexLifecycleEvents(final ClusterChangedEvent event) {
-        String localNodeId = event.state().nodes().localNodeId();
-        assert localNodeId != null;
-        for (String index : event.indicesDeleted()) {
-            try {
-                nodeIndexDeletedAction.nodeIndexDeleted(event.state(), index, localNodeId);
-            } catch (Throwable e) {
-                logger.debug("failed to send to master index {} deleted event", e, index);
-            }
-        }
-    }
-
-    private void cleanMismatchedIndexUUIDs(final ClusterChangedEvent event) {
-        for (IndexService indexService : indicesService) {
-            IndexMetaData indexMetaData = event.state().metaData().index(indexService.index().name());
-            if (indexMetaData == null) {
-                // got deleted on us, will be deleted later
-                continue;
-            }
-            if (!indexMetaData.isSameUUID(indexService.indexUUID())) {
-                logger.debug("[{}] mismatch on index UUIDs between cluster state and local state, cleaning the index so it will be recreated", indexMetaData.index());
-                removeIndex(indexMetaData.index(), "mismatch on index UUIDs between cluster state and local state, cleaning the index so it will be recreated");
-            }
         }
     }
 
@@ -246,15 +220,39 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent<Indic
     }
 
     private void applyDeletedIndices(final ClusterChangedEvent event) {
+        final ClusterState previousState = event.previousState();
+        final String localNodeId = event.state().nodes().localNodeId();
+        assert localNodeId != null;
+
         for (IndexService indexService : indicesService) {
-            final String index = indexService.index().name();
-            if (!event.state().metaData().hasIndex(index)) {
-                if (logger.isDebugEnabled()) {
-                    logger.debug("[{}] cleaning index, no longer part of the metadata", index);
+            IndexMetaData indexMetaData = event.state().metaData().index(indexService.index().name());
+            if (indexMetaData != null) {
+                if (!indexMetaData.isSameUUID(indexService.indexUUID())) {
+                    logger.debug("[{}] mismatch on index UUIDs between cluster state and local state, cleaning the index so it will be recreated", indexMetaData.index());
+                    deleteIndex(indexMetaData.index(), "mismatch on index UUIDs between cluster state and local state, cleaning the index so it will be recreated");
                 }
-                deleteIndex(index, "index no longer part of the metadata");
             }
         }
+
+        for (String index : event.indicesDeleted()) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("[{}] cleaning index, no longer part of the metadata", index);
+            }
+            if (indicesService.hasIndex(index)) {
+                deleteIndex(index, "index no longer part of the metadata");
+            } else {
+                IndexMetaData metaData = previousState.metaData().index(index);
+                assert metaData != null;
+                indicesService.deleteClosedIndex("closed index no longer part of the metadata", metaData);
+            }
+            try {
+                nodeIndexDeletedAction.nodeIndexDeleted(event.state(), index, localNodeId);
+            } catch (Throwable e) {
+                logger.debug("failed to send to master index {} deleted event", e, index);
+            }
+        }
+
+
     }
 
     private void applyDeletedShards(final ClusterChangedEvent event) {
@@ -872,6 +870,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent<Indic
         }
         // clear seen mappings as well
         clearSeenMappings(index);
+
     }
 
     private class FailedEngineHandler implements Engine.FailedEngineListener {

--- a/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
+++ b/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.indices.store;
 
 import org.apache.lucene.store.StoreRateLimiting;
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.*;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -30,7 +29,6 @@ import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.io.FileSystemUtils;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.ImmutableSettings;
@@ -49,7 +47,6 @@ import org.elasticsearch.transport.*;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
@@ -160,20 +157,8 @@ public class IndicesStore extends AbstractComponent implements ClusterStateListe
             for (IndexShardRoutingTable indexShardRoutingTable : indexRoutingTable) {
                 if (shardCanBeDeleted(event.state(), indexShardRoutingTable)) {
                     ShardId shardId = indexShardRoutingTable.shardId();
-                    IndexService indexService = indicesService.indexService(shardId.getIndex());
-                    if (indexService == null) {
-                        if (nodeEnv.hasNodeFile()) {
-                            Path[] shardLocations = nodeEnv.shardPaths(shardId);
-                            if (FileSystemUtils.exists(shardLocations)) {
-                                deleteShardIfExistElseWhere(event.state(), indexShardRoutingTable);
-                            }
-                        }
-                    } else {
-                        if (!indexService.hasShard(shardId.id())) {
-                            if (indexService.store().canDeleteUnallocated(shardId, indexService.settingsService().getSettings())) {
-                                deleteShardIfExistElseWhere(event.state(), indexShardRoutingTable);
-                            }
-                        }
+                    if (indicesService.canDeleteShardContent(shardId, event.state().getMetaData().index(shardId.getIndex()))) {
+                        deleteShardIfExistElseWhere(event.state(), indexShardRoutingTable);
                     }
                 }
             }
@@ -201,19 +186,9 @@ public class IndicesStore extends AbstractComponent implements ClusterStateListe
             if (node == null) {
                 return false;
             }
-            // If all nodes have been upgraded to >= 1.3.0 at some point we get back here and have the chance to
-            // run this api. (when cluster state is then updated)
-            if (node.getVersion().before(Version.V_1_3_0)) {
-                logger.debug("Skip deleting deleting shard instance [{}], a node holding a shard instance is < 1.3.0", shardRouting);
-                return false;
-            }
             if (shardRouting.relocatingNodeId() != null) {
                 node = state.nodes().get(shardRouting.relocatingNodeId());
                 if (node == null) {
-                    return false;
-                }
-                if (node.getVersion().before(Version.V_1_3_0)) {
-                    logger.debug("Skip deleting deleting shard instance [{}], a node holding a shard instance is < 1.3.0", shardRouting);
                     return false;
                 }
             }
@@ -318,38 +293,11 @@ public class IndicesStore extends AbstractComponent implements ClusterStateListe
                         logger.trace("not deleting shard {}, the update task state version[{}] is not equal to cluster state before shard active api call [{}]", shardId, currentState.getVersion(), clusterState.getVersion());
                         return currentState;
                     }
-
-                    IndexService indexService = indicesService.indexService(shardId.getIndex());
                     IndexMetaData indexMeta = clusterState.getMetaData().indices().get(shardId.getIndex());
-                    if (indexService == null) {
-                        // not physical allocation of the index, delete it from the file system if applicable
-                        if (nodeEnv.hasNodeFile()) {
-                            Path[] shardLocations = nodeEnv.shardPaths(shardId);
-                            if (FileSystemUtils.exists(shardLocations)) {
-                                logger.debug("{} deleting shard that is no longer used", shardId);
-                                try {
-                                    nodeEnv.deleteShardDirectorySafe(shardId, indexMeta.settings());
-                                } catch (Exception ex) {
-                                    logger.debug("failed to delete shard locations", ex);
-                                }
-                            }
-                        }
-                    } else {
-                        if (!indexService.hasShard(shardId.id())) {
-                            if (indexService.store().canDeleteUnallocated(shardId, indexMeta.settings())) {
-                                logger.debug("{} deleting shard that is no longer used", shardId);
-                                try {
-                                    indexService.store().deleteUnallocated(shardId, indexMeta.settings());
-                                } catch (Exception e) {
-                                    logger.debug("{} failed to delete unallocated shard, ignoring", e, shardId);
-                                }
-                            }
-                        } else {
-                            // this state is weird, should we log?
-                            // basically, it means that the shard is not allocated on this node using the routing
-                            // but its still physically exists on an IndexService
-                            // Note, this listener should run after IndicesClusterStateService...
-                        }
+                    try {
+                        indicesService.deleteShardStore("no longer used", shardId, indexMeta);
+                    } catch (Exception ex) {
+                        logger.debug("{} failed to delete unallocated shard, ignoring", ex, shardId);
                     }
                     return currentState;
                 }

--- a/src/test/java/org/elasticsearch/indices/IndicesServiceTest.java
+++ b/src/test/java/org/elasticsearch/indices/IndicesServiceTest.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.indices;
+
+import org.elasticsearch.ElasticsearchIllegalStateException;
+import org.elasticsearch.Version;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthStatus;
+import org.elasticsearch.client.Requests;
+import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.common.Priority;
+import org.elasticsearch.env.NodeEnvironment;
+import org.elasticsearch.gateway.GatewayMetaState;
+import org.elasticsearch.index.IndexService;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.test.ElasticsearchSingleNodeTest;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+
+public class IndicesServiceTest extends ElasticsearchSingleNodeTest {
+
+    public IndicesService getIndicesService() {
+        return getInstanceFromNode(IndicesService.class);
+    }
+
+    protected boolean resetNodeAfterTest() {
+        return true;
+    }
+
+    public void testCanDeleteShardContent() {
+        IndicesService indicesService = getIndicesService();
+        IndexMetaData meta = IndexMetaData.builder("test").settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(
+                1).build();
+        assertFalse("no shard location", indicesService.canDeleteShardContent(new ShardId("test", 0), meta));
+        IndexService test = createIndex("test");
+        assertTrue(test.hasShard(0));
+        assertFalse("shard is allocated", indicesService.canDeleteShardContent(new ShardId("test", 0), meta));
+        test.removeShard(0, "boom");
+        assertTrue("shard is removed", indicesService.canDeleteShardContent(new ShardId("test", 0), meta));
+    }
+
+    public void testDeleteIndexStore() throws Exception {
+        IndicesService indicesService = getIndicesService();
+        IndexService test = createIndex("test");
+        ClusterService clusterService = getInstanceFromNode(ClusterService.class);
+        IndexMetaData firstMetaData = clusterService.state().metaData().index("test");
+        assertTrue(test.hasShard(0));
+
+        try {
+            indicesService.deleteIndexStore("boom", firstMetaData);
+            fail();
+        } catch (ElasticsearchIllegalStateException ex) {
+            // all good
+        }
+
+        GatewayMetaState gwMetaState = getInstanceFromNode(GatewayMetaState.class);
+        MetaData meta = gwMetaState.loadMetaState();
+        assertNotNull(meta);
+        assertNotNull(meta.index("test"));
+        assertAcked(client().admin().indices().prepareDelete("test"));
+
+        meta = gwMetaState.loadMetaState();
+        assertNotNull(meta);
+        assertNull(meta.index("test"));
+
+
+        createIndex("test");
+        client().prepareIndex("test", "type", "1").setSource("field", "value").setRefresh(true).get();
+        client().admin().indices().prepareFlush("test").get();
+        assertHitCount(client().prepareSearch("test").get(), 1);
+        IndexMetaData secondMetaData = clusterService.state().metaData().index("test");
+        assertAcked(client().admin().indices().prepareClose("test"));
+        NodeEnvironment nodeEnv = getInstanceFromNode(NodeEnvironment.class);
+        Path[] paths = nodeEnv.shardDataPaths(new ShardId("test", 0), clusterService.state().getMetaData().index("test").getSettings());
+        for (Path path : paths) {
+            assertTrue(Files.exists(path));
+        }
+
+        try {
+            indicesService.deleteIndexStore("boom", secondMetaData);
+            fail();
+        } catch (ElasticsearchIllegalStateException ex) {
+            // all good
+        }
+
+        for (Path path : paths) {
+            assertTrue(Files.exists(path));
+        }
+
+        // now delete the old one and make sure we resolve against the name
+        try {
+            indicesService.deleteIndexStore("boom", firstMetaData);
+            fail();
+        } catch (ElasticsearchIllegalStateException ex) {
+            // all good
+        }
+        assertAcked(client().admin().indices().prepareOpen("test"));
+        ensureGreen("test");
+    }
+}

--- a/src/test/java/org/elasticsearch/indices/store/IndicesStoreTests.java
+++ b/src/test/java/org/elasticsearch/indices/store/IndicesStoreTests.java
@@ -161,15 +161,8 @@ public class IndicesStoreTests extends ElasticsearchTestCase {
             }
         }
 
-        final boolean canBeDeleted;
-        if (nodeVersion.before(Version.V_1_3_0)) {
-            canBeDeleted = false;
-        } else {
-            canBeDeleted = true;
-        }
-
         // shard exist on other node (abc)
-        assertThat(indicesStore.shardCanBeDeleted(clusterState.build(), routingTable.build()), is(canBeDeleted));
+        assertTrue(indicesStore.shardCanBeDeleted(clusterState.build(), routingTable.build()));
     }
 
     @Test
@@ -194,14 +187,8 @@ public class IndicesStoreTests extends ElasticsearchTestCase {
             }
         }
 
-        final boolean canBeDeleted;
-        if (nodeVersion.before(Version.V_1_3_0)) {
-            canBeDeleted = false;
-        } else {
-            canBeDeleted = true;
-        }
         // shard exist on other node (abc and def)
-        assertThat(indicesStore.shardCanBeDeleted(clusterState.build(), routingTable.build()), is(canBeDeleted));
+        assertTrue(indicesStore.shardCanBeDeleted(clusterState.build(), routingTable.build()));
     }
 
 }

--- a/src/test/java/org/elasticsearch/transport/netty/NettyTransportMultiPortTests.java
+++ b/src/test/java/org/elasticsearch/transport/netty/NettyTransportMultiPortTests.java
@@ -136,7 +136,7 @@ public class NettyTransportMultiPortTests extends ElasticsearchTestCase {
     public void testThatBindingOnDifferentHostsWorks() throws Exception {
         int[] ports = getRandomPorts(2);
         InetAddress firstNonLoopbackAddress = NetworkUtils.getFirstNonLoopbackAddress(NetworkUtils.StackType.IPv4);
-
+        assumeTrue("No IP-v4 non-loopback address available - are you on a plane?", firstNonLoopbackAddress != null);
         Settings settings = settingsBuilder()
                 .put("network.host", "127.0.0.1")
                 .put("transport.tcp.port", ports[0])


### PR DESCRIPTION
Today the logic related to deleting an index is spread across several
classes which makes changes to this rather delicate part of the code-base
very difficult. This commit consolidates this logic into the IndicesService
and moves the handling of ack-ing the delete to the master entirely into
`IndicesClusterStateService`.
