### PR TITLE
The parent option on update request should be used for upsert only.

### DIFF
--- a/docs/reference/docs/update.asciidoc
+++ b/docs/reference/docs/update.asciidoc
@@ -197,10 +197,15 @@ The update operation supports similar parameters as the index API,
 including:
 
 [horizontal]
-`routing`::     Sets the routing that will be used to route the 
-                document to the relevant shard.
+`routing`::     Routing is used to route the update request to the right shard
+                and sets the routing for the upsert request if the document being
+                updated doesn't exist. Can't be used to update the routing of an
+                existing document.
 
-`parent`::      Simply sets the routing.
+`parent`::      Parent is used to route the update request to the right shard
+                and sets the parent for the upsert request if the document being
+                updated doesn't exist. Can't be used to update the `parent` of an
+                existing document.
 
 `timeout`::     Timeout waiting for a shard to become available.
 

--- a/docs/reference/docs/update.asciidoc
+++ b/docs/reference/docs/update.asciidoc
@@ -200,6 +200,8 @@ including:
 `routing`::     Sets the routing that will be used to route the 
                 document to the relevant shard.
 
+`parent`::      Simply sets the routing.
+
 `timeout`::     Timeout waiting for a shard to become available.
 
 `consistency`:: The write consistency of the index/delete operation.

--- a/docs/reference/migration/migrate_2_0.asciidoc
+++ b/docs/reference/migration/migrate_2_0.asciidoc
@@ -153,7 +153,7 @@ The `parent` parameter has been removed from the update request. Before 2.x it j
 `routing` setting should be used instead. The `parent` setting was confusing, because it had the impression that the parent
 a child documents points to can be changed but this is not true.
 
-=== Delete by query
+==== Delete by query
 
 The meaning of the `_shards` headers in the delete by query response has changed. Before version 2.0 the `total`,
 `successful` and `failed` fields in the header are based on the number of primary shards. The failures on replica

--- a/rest-api-spec/api/update.json
+++ b/rest-api-spec/api/update.json
@@ -38,7 +38,7 @@
         },
         "parent": {
           "type": "string",
-          "description": "ID of the parent document"
+          "description": "ID of the parent document. Is is only used for routing and when for the upsert request"
         },
         "refresh": {
           "type": "boolean",

--- a/rest-api-spec/api/update.json
+++ b/rest-api-spec/api/update.json
@@ -36,6 +36,10 @@
           "type": "string",
           "description": "The script language (default: groovy)"
         },
+        "parent": {
+          "type": "string",
+          "description": "ID of the parent document"
+        },
         "refresh": {
           "type": "boolean",
           "description": "Refresh the index after performing the operation"

--- a/rest-api-spec/test/update/50_parent.yaml
+++ b/rest-api-spec/test/update/50_parent.yaml
@@ -29,10 +29,10 @@ setup:
           index:   test_1
           type:    test
           id:      1
-          routing:  5
+          parent:  5
           body:
             doc:        { foo: baz }
-            upsert:     { foo: bar, _parent: 5 }
+            upsert:     { foo: bar }
 
  - do:
       get:
@@ -50,7 +50,7 @@ setup:
           index:   test_1
           type:    test
           id:      1
-          routing:  5
+          parent:  5
           fields:  foo
           body:
             doc:        { foo: baz }

--- a/rest-api-spec/test/update/55_parent_with_routing.yaml
+++ b/rest-api-spec/test/update/55_parent_with_routing.yaml
@@ -21,10 +21,11 @@
           index:   test_1
           type:    test
           id:      1
+          parent:  5
           routing: 4
           body:
             doc:        { foo: baz }
-            upsert:     { foo: bar, _parent: 5 }
+            upsert:     { foo: bar }
 
  - do:
       get:
@@ -44,7 +45,7 @@
           index:   test_1
           type:    test
           id:      1
-          routing:  5
+          parent:  5
           body:
             doc:        { foo: baz }
 
@@ -53,6 +54,7 @@
           index:   test_1
           type:    test
           id:      1
+          parent:  5
           routing: 4
           fields:  foo
           body:

--- a/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
+++ b/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
@@ -353,12 +353,12 @@ public class BulkRequest extends ActionRequest<BulkRequest> implements Composite
                     } else if ("update".equals(action)) {
                         UpdateRequest updateRequest = new UpdateRequest(index, type, id).routing(routing).parent(parent).retryOnConflict(retryOnConflict)
                                 .version(version).versionType(versionType)
+                                .routing(routing)
+                                .parent(parent)
                                 .source(data.slice(from, nextMarker - from));
 
                         IndexRequest upsertRequest = updateRequest.upsertRequest();
                         if (upsertRequest != null) {
-                            upsertRequest.routing(routing);
-                            upsertRequest.parent(parent); // order is important, set it after routing, so it will set the routing
                             upsertRequest.timestamp(timestamp);
                             upsertRequest.ttl(ttl);
                             upsertRequest.version(version);
@@ -366,8 +366,6 @@ public class BulkRequest extends ActionRequest<BulkRequest> implements Composite
                         }
                         IndexRequest doc = updateRequest.doc();
                         if (doc != null) {
-                            doc.routing(routing);
-                            doc.parent(parent); // order is important, set it after routing, so it will set the routing
                             doc.timestamp(timestamp);
                             doc.ttl(ttl);
                             doc.version(version);

--- a/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
+++ b/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
@@ -351,13 +351,14 @@ public class BulkRequest extends ActionRequest<BulkRequest> implements Composite
                                 .create(true)
                                 .source(data.slice(from, nextMarker - from), contentUnsafe), payload);
                     } else if ("update".equals(action)) {
-                        UpdateRequest updateRequest = new UpdateRequest(index, type, id).routing(routing).retryOnConflict(retryOnConflict)
+                        UpdateRequest updateRequest = new UpdateRequest(index, type, id).routing(routing).parent(parent).retryOnConflict(retryOnConflict)
                                 .version(version).versionType(versionType)
                                 .source(data.slice(from, nextMarker - from));
 
                         IndexRequest upsertRequest = updateRequest.upsertRequest();
                         if (upsertRequest != null) {
                             upsertRequest.routing(routing);
+                            upsertRequest.parent(parent); // order is important, set it after routing, so it will set the routing
                             upsertRequest.timestamp(timestamp);
                             upsertRequest.ttl(ttl);
                             upsertRequest.version(version);
@@ -366,6 +367,7 @@ public class BulkRequest extends ActionRequest<BulkRequest> implements Composite
                         IndexRequest doc = updateRequest.doc();
                         if (doc != null) {
                             doc.routing(routing);
+                            doc.parent(parent); // order is important, set it after routing, so it will set the routing
                             doc.timestamp(timestamp);
                             doc.ttl(ttl);
                             doc.version(version);

--- a/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
+++ b/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
@@ -118,15 +118,16 @@ public class UpdateHelper extends AbstractComponent {
                     update.setGetResult(getResult);
                     return new Result(update, Operation.NONE, upsertDoc, XContentType.JSON);
                 }
-                indexRequest.source((Map)ctx.get("_source"));
+                indexRequest.source((Map) ctx.get("_source"));
             }
 
             indexRequest.index(request.index()).type(request.type()).id(request.id())
                     // it has to be a "create!"
                     .create(true)                    
-                    .routing(request.routing())
                     .ttl(ttl)
                     .refresh(request.refresh())
+                    .routing(request.routing())
+                    .parent(request.parent())
                     .consistencyLevel(request.consistencyLevel());
             indexRequest.operationThreaded(false);
             if (request.versionType() != VersionType.INTERNAL) {

--- a/src/main/java/org/elasticsearch/action/update/UpdateRequest.java
+++ b/src/main/java/org/elasticsearch/action/update/UpdateRequest.java
@@ -175,6 +175,17 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest> 
     }
 
     /**
+     * Sets the parent id of this document. Will simply set the routing to this value, as it is only
+     * used for routing with delete requests.
+     */
+    public UpdateRequest parent(String parent) {
+        if (routing == null) {
+            routing = parent;
+        }
+        return this;
+    }
+
+    /**
      * Controls the shard routing of the request. Using this value to hash the shard
      * and not the id.
      */

--- a/src/main/java/org/elasticsearch/action/update/UpdateRequest.java
+++ b/src/main/java/org/elasticsearch/action/update/UpdateRequest.java
@@ -56,6 +56,9 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest> 
     private String routing;
 
     @Nullable
+    private String parent;
+
+    @Nullable
     String script;
     @Nullable
     ScriptService.ScriptType scriptType;
@@ -175,23 +178,27 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest> 
     }
 
     /**
-     * Sets the parent id of this document. Will simply set the routing to this value, as it is only
-     * used for routing with delete requests.
-     */
-    public UpdateRequest parent(String parent) {
-        if (routing == null) {
-            routing = parent;
-        }
-        return this;
-    }
-
-    /**
      * Controls the shard routing of the request. Using this value to hash the shard
      * and not the id.
      */
     @Override
     public String routing() {
         return this.routing;
+    }
+
+    /**
+     * The parent id is used for the upsert request and also implicitely sets the routing if not already set.
+     */
+    public UpdateRequest parent(String parent) {
+        this.parent = parent;
+        if (routing == null) {
+            routing = parent;
+        }
+        return this;
+    }
+
+    public String parent() {
+        return parent;
     }
 
     int shardId() {
@@ -631,6 +638,7 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest> 
         type = in.readString();
         id = in.readString();
         routing = in.readOptionalString();
+        parent = in.readOptionalString();
         script = in.readOptionalString();
         if(Strings.hasLength(script)) {
             scriptType = ScriptService.ScriptType.readFrom(in);
@@ -668,6 +676,7 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest> 
         out.writeString(type);
         out.writeString(id);
         out.writeOptionalString(routing);
+        out.writeOptionalString(parent);
         out.writeOptionalString(script);
         if (Strings.hasLength(script)) {
             ScriptService.ScriptType.writeTo(scriptType, out);

--- a/src/main/java/org/elasticsearch/action/update/UpdateRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/update/UpdateRequestBuilder.java
@@ -69,6 +69,11 @@ public class UpdateRequestBuilder extends InstanceShardOperationRequestBuilder<U
         return this;
     }
 
+    public UpdateRequestBuilder setParent(String parent) {
+        request.parent(parent);
+        return this;
+    }
+
     /**
      * The script to execute. Note, make sure not to send different script each times and instead
      * use script params if possible with the same (automatically compiled) script.

--- a/src/main/java/org/elasticsearch/rest/action/update/RestUpdateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/update/RestUpdateAction.java
@@ -57,7 +57,7 @@ public class RestUpdateAction extends BaseRestHandler {
         UpdateRequest updateRequest = new UpdateRequest(request.param("index"), request.param("type"), request.param("id"));
         updateRequest.listenerThreaded(false);
         updateRequest.routing(request.param("routing"));
-        updateRequest.parent(request.param("parent")); // order is important, set it after routing, so it will set the routing
+        updateRequest.parent(request.param("parent"));
         updateRequest.timeout(request.paramAsTime("timeout", updateRequest.timeout()));
         updateRequest.refresh(request.paramAsBoolean("refresh", updateRequest.refresh()));
         String consistencyLevel = request.param("consistency");

--- a/src/main/java/org/elasticsearch/rest/action/update/RestUpdateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/update/RestUpdateAction.java
@@ -57,6 +57,7 @@ public class RestUpdateAction extends BaseRestHandler {
         UpdateRequest updateRequest = new UpdateRequest(request.param("index"), request.param("type"), request.param("id"));
         updateRequest.listenerThreaded(false);
         updateRequest.routing(request.param("routing"));
+        updateRequest.parent(request.param("parent")); // order is important, set it after routing, so it will set the routing
         updateRequest.timeout(request.paramAsTime("timeout", updateRequest.timeout()));
         updateRequest.refresh(request.paramAsBoolean("refresh", updateRequest.refresh()));
         String consistencyLevel = request.param("consistency");

--- a/src/test/java/org/elasticsearch/document/BulkTests.java
+++ b/src/test/java/org/elasticsearch/document/BulkTests.java
@@ -427,8 +427,8 @@ public class BulkTests extends ElasticsearchIntegrationTest {
         byte[] addParent = new BytesArray("{\"index\" : { \"_index\" : \"test\", \"_type\" : \"parent\", \"_id\" : \"parent1\"}}\n" +
                 "{\"field1\" : \"value1\"}\n").array();
 
-        byte[] addChild = new BytesArray("{ \"update\" : { \"_index\" : \"test\", \"_type\" : \"child\", \"_id\" : \"child1\", \"routing\" : \"parent1\"}}\n" +
-                "{\"doc\" : { \"field1\" : \"value1\", \"_parent\" : \"parent1\"}, \"doc_as_upsert\" : \"true\"}\n").array();
+        byte[] addChild = new BytesArray("{ \"update\" : { \"_index\" : \"test\", \"_type\" : \"child\", \"_id\" : \"child1\", \"parent\" : \"parent1\"}}\n" +
+                "{\"doc\" : { \"field1\" : \"value1\"}, \"doc_as_upsert\" : \"true\"}\n").array();
 
         builder.add(addParent, 0, addParent.length, false);
         builder.add(addChild, 0, addChild.length, false);
@@ -464,8 +464,8 @@ public class BulkTests extends ElasticsearchIntegrationTest {
         byte[] addParent = new BytesArray("{\"index\" : { \"_index\" : \"test\", \"_type\" : \"parent\", \"_id\" : \"parent1\"}}\n" +
                 "{\"field1\" : \"value1\"}\n").array();
 
-        byte[] addChild = new BytesArray("{\"update\" : { \"_id\" : \"child1\", \"_type\" : \"child\", \"_index\" : \"test\", \"routing\" : \"parent1\"} }\n" +
-                "{ \"script\" : \"ctx._source.field2 = 'value2'\", \"upsert\" : {\"field1\" : \"value1\", \"_parent\" : \"parent1\"}}\n").array();
+        byte[] addChild = new BytesArray("{\"update\" : { \"_id\" : \"child1\", \"_type\" : \"child\", \"_index\" : \"test\", \"parent\" : \"parent1\"} }\n" +
+                "{ \"script\" : \"ctx._source.field2 = 'value2'\", \"upsert\" : {\"field1\" : \"value1\"}}\n").array();
 
         builder.add(addParent, 0, addParent.length, false);
         builder.add(addChild, 0, addChild.length, false);

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/ChildrenTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/ChildrenTests.java
@@ -256,7 +256,7 @@ public class ChildrenTests extends ElasticsearchIntegrationTest {
 
             String idToUpdate = Integer.toString(randomInt(3));
             UpdateResponse updateResponse = client().prepareUpdate(indexName, "child", idToUpdate)
-                    .setRouting("1")
+                    .setParent("1")
                     .setDoc("count", 1)
                     .get();
             assertThat(updateResponse.getVersion(), greaterThan(1l));


### PR DESCRIPTION
PR for #4538 and consists out of two parts:
- Revert of the removal of the `parent` option on update
- Let the parent option on the update request to be used only for upsert requests.
