### PR TITLE
Aggregations: Add 'offset' option to date_histogram

### DIFF
--- a/docs/reference/migration/migrate_1_5.asciidoc
+++ b/docs/reference/migration/migrate_1_5.asciidoc
@@ -1,0 +1,12 @@
+[[breaking-changes-1.5]]
+== Breaking changes in 1.5
+
+This section discusses the changes that you need to be aware of when migrating
+your application from Elasticsearch 1.x to Elasticsearch 1.5.
+
+[float]
+==== Aggregations
+
+The `date_histogram` aggregation now support a simplified `offset` option that replaces the previous `pre_offset` and
+`post_offset` which are deprecated in 1.5. Instead of having to specify two separate offset shifts of the underlying buckets, the `offset` option
+moves the bucket boundaries in positive or negative direction depending on its argument.

--- a/docs/reference/search/aggregations/bucket/datehistogram-aggregation.asciidoc
+++ b/docs/reference/search/aggregations/bucket/datehistogram-aggregation.asciidoc
@@ -72,10 +72,14 @@ set `pre_zone_adjust_large_interval` to `true`, which will apply the same conver
 example, to day and above intervals (it can be set regardless of the interval, but only kick in when using day and
 higher intervals).
 
-==== Pre/Post Offset
+==== Offset
 
-Specific offsets can be provided for pre rounding and post rounding. The `pre_offset` for pre rounding, and
-`post_offset` for post rounding. The format is the date time format (`1h`, `1d`, etc...).
+The `offset` option can be provided for shifting the date bucket intervals boundaries after any other shifts because of
+time zones are applies. This for example makes it possible that daily buckets go from 6AM to 6AM the next day instead of starting at 12AM
+or that monthly buckets go from the 10th of the month to the 10th of the next month instead of the 1st.
+
+The `offset` option accepts positive or negative time durations like "1h" for an hour or "1M" for a Month. See <<time-units>> for more
+possible time duration options.
 
 ==== Keys
 

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramBuilder.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramBuilder.java
@@ -43,6 +43,7 @@ public class DateHistogramBuilder extends ValuesSourceAggregationBuilder<DateHis
     private String format;
     private String preOffset;
     private String postOffset;
+    private String offset;
     private float factor = 1.0f;
 
     /**
@@ -111,7 +112,9 @@ public class DateHistogramBuilder extends ValuesSourceAggregationBuilder<DateHis
 
     /**
      * Set the offset to apply prior to computing buckets.
+     * @deprecated the preOffset option will be replaced by offset in future version.
      */
+    @Deprecated
     public DateHistogramBuilder preOffset(String preOffset) {
         this.preOffset = preOffset;
         return this;
@@ -119,7 +122,9 @@ public class DateHistogramBuilder extends ValuesSourceAggregationBuilder<DateHis
 
     /**
      * Set the offset to apply after having computed buckets.
+     * @deprecated the preOffset option will be replaced by offset in future version.
      */
+    @Deprecated
     public DateHistogramBuilder postOffset(String postOffset) {
         this.postOffset = postOffset;
         return this;
@@ -212,6 +217,10 @@ public class DateHistogramBuilder extends ValuesSourceAggregationBuilder<DateHis
 
         if (postOffset != null) {
             builder.field("post_offset", postOffset);
+        }
+
+        if (offset != null) {
+            builder.field("offset", offset);
         }
 
         if (factor != 1.0f) {

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramBuilder.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramBuilder.java
@@ -131,6 +131,14 @@ public class DateHistogramBuilder extends ValuesSourceAggregationBuilder<DateHis
     }
 
     /**
+     * Set the offset that is applied to computed bucket boundaries.
+     */
+    public DateHistogramBuilder offset(String offset) {
+        this.offset = offset;
+        return this;
+    }
+
+    /**
      * Set a factor to apply to values of the field, typically used if times
      * are stored in seconds instead of milliseconds.
      */

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramParser.java
@@ -43,6 +43,9 @@ import java.io.IOException;
 public class DateHistogramParser implements Aggregator.Parser {
 
     static final ParseField EXTENDED_BOUNDS = new ParseField("extended_bounds");
+    static final ParseField OFFSET = new ParseField("offset");
+    static final ParseField PRE_OFFSET = new ParseField("", "pre_offset");
+    static final ParseField POST_OFFSET = new ParseField("", "post_offset");
 
     private final ImmutableMap<String, DateTimeUnit> dateFieldUnits;
 
@@ -105,10 +108,13 @@ public class DateHistogramParser implements Aggregator.Parser {
                     preZone = DateMathParser.parseZone(parser.text());
                 } else if ("post_zone".equals(currentFieldName) || "postZone".equals(currentFieldName)) {
                     postZone = DateMathParser.parseZone(parser.text());
-                } else if ("pre_offset".equals(currentFieldName) || "preOffset".equals(currentFieldName)) {
+                } else if (PRE_OFFSET.match(currentFieldName)) {
                     preOffset = parseOffset(parser.text());
-                } else if ("post_offset".equals(currentFieldName) || "postOffset".equals(currentFieldName)) {
+                } else if (POST_OFFSET.match(currentFieldName)) {
                     postOffset = parseOffset(parser.text());
+                } else if (OFFSET.match(currentFieldName)) {
+                    postOffset = parseOffset(parser.text());
+                    preOffset = -postOffset;
                 } else if ("interval".equals(currentFieldName)) {
                     interval = parser.text();
                 } else {

--- a/src/test/java/org/elasticsearch/common/rounding/RoundingTests.java
+++ b/src/test/java/org/elasticsearch/common/rounding/RoundingTests.java
@@ -20,7 +20,9 @@
 package org.elasticsearch.common.rounding;
 
 import org.elasticsearch.test.ElasticsearchTestCase;
+import org.junit.Test;
 
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
@@ -41,4 +43,45 @@ public class RoundingTests extends ElasticsearchTestCase {
         }
     }
 
+    /**
+     * Simple test case to illustrate how Rounding.Offset works on readable input.
+     * offset shifts input value back before rounding (so here 6 - 7 -> -1)
+     * then shifts rounded Value back  (here -10 -> -3)
+     */
+    @Test
+    public void testPrePostRounding() {
+        final long interval = 10;
+        final long offset = 7;
+        Rounding.PrePostRounding rounding = new Rounding.PrePostRounding(new Rounding.Interval(interval), -offset, offset);
+        assertEquals(-1, rounding.roundKey(6));
+        assertEquals(-3, rounding.round(6));
+        assertEquals(7, rounding.nextRoundingValue(-3));
+        assertEquals(0, rounding.roundKey(7));
+        assertEquals(7, rounding.round(7));
+        assertEquals(17, rounding.nextRoundingValue(7));
+        assertEquals(0, rounding.roundKey(16));
+        assertEquals(7, rounding.round(16));
+        assertEquals(1, rounding.roundKey(17));
+        assertEquals(17, rounding.round(17));
+        assertEquals(27, rounding.nextRoundingValue(17));
+    }
+
+    @Test
+    public void testOffsetRoundingRandom() {
+        final long interval = randomIntBetween(1, 100);
+        Rounding.Interval internalRounding = new Rounding.Interval(interval);
+        final long offset = randomIntBetween(-100, 100);
+        Rounding.PrePostRounding  rounding = new Rounding.PrePostRounding(internalRounding, -offset, offset);
+        long safetyMargin = Math.abs(interval) + Math.abs(offset); // to prevent range overflow / underflow
+        for (int i = 0; i < 100000; ++i) {
+            long value = Math.max(randomLong() - safetyMargin, Long.MIN_VALUE + safetyMargin);
+            final long key = rounding.roundKey(value);
+            final long key_next = rounding.roundKey(value + interval);
+            final long r_value = rounding.round(value);
+            assertThat("Rounding should be idempotent", r_value, equalTo(rounding.round(r_value)));
+            assertThat("Rounded value smaller than unrounded, regardless of offset", r_value - offset, lessThanOrEqualTo(value - offset));
+            assertThat("Key for value to key for value+inteval should differ by one", key_next - key, equalTo(1L));
+            assertThat("Rounded value <= value < next interval start", r_value + interval, greaterThan(value));
+        }
+    }
 }


### PR DESCRIPTION
Add offset option to 'date_histogram', deprecating the previous 'pre_offset' and 'post_offset' options.
This change is part of a larger clean up task for `date_histogram` from issue #9062.
