### PR TITLE
Support encoded body as query string param consistently

### DIFF
--- a/rest-api-spec/test/percolate/16_existing_doc.yaml
+++ b/rest-api-spec/test/percolate/16_existing_doc.yaml
@@ -13,6 +13,7 @@
         body:
           query:
             match_all: {}
+          tag: tag1
 
   - do:
       index:
@@ -84,3 +85,28 @@
         version: 1
         percolate_index: percolator_index
         percolate_type: test_type
+
+  - do:
+      percolate:
+        index: percolator_index
+        type:  test_type
+        id: 1
+        body:
+          filter:
+            term:
+              tag: non_existing_tag
+
+  - match: {'matches': []}
+
+  - do:
+      percolate:
+        index: percolator_index
+        type:  test_type
+        id: 1
+        body:
+          filter:
+            term:
+              tag: tag1
+
+  - match: {'matches': [{_index: percolator_index, _id: test_percolator}]}
+

--- a/src/main/java/org/elasticsearch/rest/action/percolate/RestPercolateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/percolate/RestPercolateAction.java
@@ -87,7 +87,7 @@ public class RestPercolateAction extends BaseRestHandler {
         percolateRequest.getRequest(getRequest);
         percolateRequest.routing(restRequest.param("percolate_routing"));
         percolateRequest.preference(restRequest.param("percolate_preference"));
-        percolateRequest.source(restRequest.content(), restRequest.contentUnsafe());
+        percolateRequest.source(RestActions.getRestContent(restRequest), restRequest.contentUnsafe());
 
         percolateRequest.indicesOptions(IndicesOptions.fromRequest(restRequest, percolateRequest.indicesOptions()));
         executePercolate(percolateRequest, restChannel, client);


### PR DESCRIPTION
The percolate api doesn't parse the encoded body provided as `source` query string parameter, when percolating an existing document. Fixed and added REST test that would have caught this since we randomly use GET + encoded `source` param instead of GET + request body in our java runner (the perl runner does the same too).
