### PR TITLE
[TEST] Introduce basic validation of our REST spec

### DIFF
--- a/rest-api-spec/api/count_percolate.json
+++ b/rest-api-spec/api/count_percolate.json
@@ -23,6 +23,10 @@
         }
       },
       "params": {
+        "source": {
+          "type" : "string",
+          "description" : "The URL-encoded request definition"
+        },
         "routing": {
           "type": "list",
           "description": "A comma-separated list of specific routing values"

--- a/rest-api-spec/api/indices.analyze.json
+++ b/rest-api-spec/api/indices.analyze.json
@@ -12,6 +12,10 @@
         }
       },
       "params": {
+        "source": {
+          "type" : "string",
+          "description" : "The URL-encoded request definition"
+        },
         "analyzer": {
           "type" : "string",
           "description" : "The name of the analyzer to use"

--- a/rest-api-spec/api/mget.json
+++ b/rest-api-spec/api/mget.json
@@ -16,6 +16,10 @@
         }
       },
       "params": {
+        "source": {
+          "type" : "string",
+          "description" : "The URL-encoded request definition"
+        },
         "fields": {
           "type": "list",
           "description" : "A comma-separated list of fields to return in the response"

--- a/rest-api-spec/api/mlt.json
+++ b/rest-api-spec/api/mlt.json
@@ -23,6 +23,10 @@
         }
       },
       "params": {
+        "source": {
+          "type" : "string",
+          "description" : "The URL-encoded request definition"
+        },
         "boost_terms": {
           "type" : "number",
           "description" : "The boost factor"

--- a/rest-api-spec/api/mpercolate.json
+++ b/rest-api-spec/api/mpercolate.json
@@ -16,6 +16,10 @@
         }
       },
       "params": {
+        "source": {
+          "type" : "string",
+          "description" : "The URL-encoded request definition"
+        },
         "ignore_unavailable": {
           "type": "boolean",
           "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)"

--- a/rest-api-spec/api/msearch.json
+++ b/rest-api-spec/api/msearch.json
@@ -16,6 +16,10 @@
         }
       },
       "params": {
+        "source": {
+          "type" : "string",
+          "description" : "The URL-encoded request definition"
+        },
         "search_type": {
           "type" : "enum",
           "options" : ["query_then_fetch", "query_and_fetch", "dfs_query_then_fetch", "dfs_query_and_fetch", "count", "scan"],

--- a/rest-api-spec/api/mtermvectors.json
+++ b/rest-api-spec/api/mtermvectors.json
@@ -16,6 +16,10 @@
         }
       },
       "params" : {
+        "source": {
+          "type" : "string",
+          "description" : "The URL-encoded request definition"
+        },
         "ids" : {
           "type" : "list",
           "description" : "A comma-separated list of documents ids. You must define ids as parameter or set \"ids\" or \"docs\" in the request body",

--- a/rest-api-spec/api/percolate.json
+++ b/rest-api-spec/api/percolate.json
@@ -23,6 +23,10 @@
         }
       },
       "params": {
+        "source": {
+          "type" : "string",
+          "description" : "The URL-encoded request definition"
+        },
         "routing": {
           "type" : "list",
           "description" : "A comma-separated list of specific routing values"

--- a/rest-api-spec/api/scroll.json
+++ b/rest-api-spec/api/scroll.json
@@ -12,6 +12,10 @@
         }
       },
       "params": {
+        "source": {
+          "type" : "string",
+          "description" : "The URL-encoded request definition"
+        },
         "scroll": {
           "type" : "duration",
           "description" : "Specify how long a consistent view of the index should be maintained for scrolled search"

--- a/rest-api-spec/api/search_template.json
+++ b/rest-api-spec/api/search_template.json
@@ -16,6 +16,10 @@
         }
       },
       "params" : {
+        "source": {
+          "type" : "string",
+          "description" : "The URL-encoded request definition"
+        },
         "ignore_unavailable": {
             "type" : "boolean",
             "description" : "Whether specified concrete indices should be ignored when unavailable (missing or closed)"

--- a/rest-api-spec/api/termvectors.json
+++ b/rest-api-spec/api/termvectors.json
@@ -22,6 +22,10 @@
          }
       },
       "params": {
+        "source": {
+          "type" : "string",
+          "description" : "The URL-encoded request definition"
+        },
         "term_statistics" : {
           "type" : "boolean",
           "description" : "Specifies if total term frequency and document frequency should be returned.",

--- a/src/test/java/org/elasticsearch/test/rest/spec/RestSpec.java
+++ b/src/test/java/org/elasticsearch/test/rest/spec/RestSpec.java
@@ -19,13 +19,10 @@
 package org.elasticsearch.test.rest.spec;
 
 import com.google.common.collect.Maps;
-
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.test.rest.support.FileUtils;
 
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -59,6 +56,14 @@ public class RestSpec {
                 try (InputStream stream = Files.newInputStream(jsonFile)) {
                     XContentParser parser = JsonXContent.jsonXContent.createParser(stream);
                     RestApi restApi = new RestApiParser().parse(parser);
+                    if (restApi.getMethods().contains("GET") && restApi.isBodySupported()) {
+                        if (!restApi.getMethods().contains("POST")) {
+                            throw new IllegalArgumentException(restApi.getName() + " supports GET with a body but doesn't support POST");
+                        }
+                        if (!restApi.getParams().contains("source")) {
+                            throw new IllegalArgumentException(restApi.getName() + " supports GET with a body but doesn't support the source query string parameter");
+                        }
+                    }
                     restSpec.addApi(restApi);
                 } catch (Throwable ex) {
                     throw new IOException("Can't parse rest spec file: [" + jsonFile + "]", ex);


### PR DESCRIPTION
Whenever we have an api that supports GET with a body, we always support the POST method too, as well as providing the body as a query_string parameter called `source`. Our REST spec should reflect this convention. Fixed them and introduced a hard check at parse time in our Java REST tests runner, which will cause the tests to fail if spec are not compliant.
