### PR TITLE
Clean up time zone options for `date_histogram`

### DIFF
--- a/docs/reference/migration/migrate_2_0.asciidoc
+++ b/docs/reference/migration/migrate_2_0.asciidoc
@@ -125,11 +125,10 @@ The `histogram` and the `date_histogram` aggregation now support a simplified `o
 `post_offset` rounding options. Instead of having to specify two separate offset shifts of the underlying buckets, the `offset` option
 moves the bucket boundaries in positive or negative direction depending on its argument.
 
-The `date_histogram` options for `pre_zone` and `post_zone` are replaced by the `time_zone` option. So far the `time_zone` option was
-equivalent to `pre_zone`. The time zone conversion was performed before rounding the date values to be put inside the aggregation buckets.
-This could lead to cases where bucket keys were not in UTC. This behavior is unified. Setting `time_zone` to a value like
-"+01:00" now will lead to the bucket boundary calculations being applied in the specified time zone but the results are returned in UTC.
-In addition to this, also the `pre_zone_adjust_large_interval` is removed because we now always return dates in UTC.
+The `date_histogram` options for `pre_zone` and `post_zone` are replaced by the `time_zone` option. The behavior of `time_zone` is
+equivalent to the former `pre_zone` option. Setting `time_zone` to a value like "+01:00" now will lead to the bucket calculations
+being applied in the specified time zone but In addition to this, also the `pre_zone_adjust_large_interval` is removed because we
+now always return dates and bucket keys in UTC.
 
 === Terms filter lookup caching
 

--- a/docs/reference/migration/migrate_2_0.asciidoc
+++ b/docs/reference/migration/migrate_2_0.asciidoc
@@ -6,9 +6,9 @@ your application to Elasticsearch 2.0.
 
 === Indices API
 
-The <<alias-retrieving, get alias api>> will, by default produce an error response 
-if a requested index does not exist. This change brings the defaults for this API in 
-line with the other Indices APIs. The <<multi-index>> options can be used on a request 
+The <<alias-retrieving, get alias api>> will, by default produce an error response
+if a requested index does not exist. This change brings the defaults for this API in
+line with the other Indices APIs. The <<multi-index>> options can be used on a request
 to change this behavior
 
 `GetIndexRequest.features()` now returns an array of Feature Enums instead of an array of String values.
@@ -109,13 +109,13 @@ Some query builders have been removed or renamed:
 
 ==== Aggregations
 
-The `date_histogram` aggregation now returns a `Histogram` object in the response, and the `DateHistogram` class has been removed. Similarly 
-the `date_range`, `ipv4_range`, and `geo_distance` aggregations all return a `Range` object in the response, and the `IPV4Range`, `DateRange`, 
-and `GeoDistance` classes have been removed. The motivation for this is to have a single response API for the Range and Histogram aggregations 
-regardless of the type of data being queried.  To support this some changes were made in the `MultiBucketAggregation` interface which applies 
+The `date_histogram` aggregation now returns a `Histogram` object in the response, and the `DateHistogram` class has been removed. Similarly
+the `date_range`, `ipv4_range`, and `geo_distance` aggregations all return a `Range` object in the response, and the `IPV4Range`, `DateRange`,
+and `GeoDistance` classes have been removed. The motivation for this is to have a single response API for the Range and Histogram aggregations
+regardless of the type of data being queried.  To support this some changes were made in the `MultiBucketAggregation` interface which applies
 to all bucket aggregations:
 
-* The `getKey()` method now returns `Object` instead of `String`. The actual object type returned depends on the type of aggregation requested 
+* The `getKey()` method now returns `Object` instead of `String`. The actual object type returned depends on the type of aggregation requested
 (e.g. the `date_histogram` will return a `DateTime` object for this method whereas a `histogram` will return a `Number`).
 * A `getKeyAsString()` method has been added to return the String representation of the key.
 * All other `getKeyAsX()` methods have been removed.
@@ -124,6 +124,12 @@ to all bucket aggregations:
 The `histogram` and the `date_histogram` aggregation now support a simplified `offset` option that replaces the previous `pre_offset` and
 `post_offset` rounding options. Instead of having to specify two separate offset shifts of the underlying buckets, the `offset` option
 moves the bucket boundaries in positive or negative direction depending on its argument.
+
+The `date_histogram` options for `pre_zone` and `post_zone` are replaced by the `time_zone` option. So far the `time_zone` option was
+equivalent to `pre_zone`. The time zone conversion was performed before rounding the date values to be put inside the aggregation buckets.
+This could lead to cases where bucket keys were not in UTC. This behavior is unified. Setting `time_zone` to a value like
+"+01:00" now will lead to the bucket boundary calculations being applied in the specified time zone but the results are returned in UTC.
+In addition to this, also the `pre_zone_adjust_large_interval` is removed because we now always return dates in UTC.
 
 === Terms filter lookup caching
 

--- a/docs/reference/search/aggregations/bucket/datehistogram-aggregation.asciidoc
+++ b/docs/reference/search/aggregations/bucket/datehistogram-aggregation.asciidoc
@@ -48,29 +48,17 @@ See <<time-units>> for accepted abbreviations.
 ==== Time Zone
 
 By default, times are stored as UTC milliseconds since the epoch. Thus, all computation and "bucketing" / "rounding" is
-done on UTC. It is possible to provide a time zone (both pre rounding, and post rounding) value, which will cause all
-computations to take the relevant zone into account. The time returned for each bucket/entry is milliseconds since the
-epoch of the provided time zone.
+done on UTC. It is possible to provide a time zone value, which will cause all bucket
+computations to take place in the specified zone. The time returned for each bucket/entry is milliseconds since the
+epoch in UTC. The parameters is called `time_zone`. It accepts either a numeric value for the hours offset, for example:
+`"time_zone" : -2`. It also accepts a format of hours and minutes, like `"time_zone" : "-02:30"`.
+Another option is to provide a time zone accepted as one of the values listed here.
 
-The parameters are `pre_zone` (pre rounding based on interval) and `post_zone` (post rounding based on interval). The
-`time_zone` parameter simply sets the `pre_zone` parameter. By default, those are set to `UTC`.
-
-The zone value accepts either a numeric value for the hours offset, for example: `"time_zone" : -2`. It also accepts a
-format of hours and minutes, like `"time_zone" : "-02:30"`. Another option is to provide a time zone accepted as one of
-the values listed here.
-
-Lets take an example. For `2012-04-01T04:15:30Z`, with a `pre_zone` of `-08:00`. For day interval, the actual time by
+Lets take an example. For `2012-04-01T04:15:30Z` (UTC), with a `time_zone` of `"-08:00"`. For day interval, the actual time by
 applying the time zone and rounding falls under `2012-03-31`, so the returned value will be (in millis) of
-`2012-03-31T00:00:00Z` (UTC). For hour interval, applying the time zone results in `2012-03-31T20:15:30`, rounding it
-results in `2012-03-31T20:00:00`, but, we want to return it in UTC (`post_zone` is not set), so we convert it back to
-UTC: `2012-04-01T04:00:00Z`. Note, we are consistent in the results, returning the rounded value in UTC.
-
-`post_zone` simply takes the result, and adds the relevant offset.
-
-Sometimes, we want to apply the same conversion to UTC we did above for hour also for day (and up) intervals. We can
-set `pre_zone_adjust_large_interval` to `true`, which will apply the same conversion done for hour interval in the
-example, to day and above intervals (it can be set regardless of the interval, but only kick in when using day and
-higher intervals).
+`2012-03-31T08:00:00Z` (UTC). For hour interval, internally applying the time zone results in `2012-03-31T20:15:30`, so rounding it
+in the time zone results in `2012-03-31T20:00:00`, but we return that rounded value converted back in UTC so be consistent as
+`2012-04-01T04:00:00Z` (UTC).
 
 ==== Offset
 

--- a/src/main/java/org/elasticsearch/common/rounding/Rounding.java
+++ b/src/main/java/org/elasticsearch/common/rounding/Rounding.java
@@ -19,7 +19,6 @@
 package org.elasticsearch.common.rounding;
 
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
@@ -239,12 +238,8 @@ public abstract class Rounding implements Streamable {
             byte id = in.readByte();
             switch (id) {
                 case Interval.ID: rounding = new Interval(); break;
-                case TimeZoneRounding.TimeTimeZoneRoundingFloor.ID: rounding = new TimeZoneRounding.TimeTimeZoneRoundingFloor(); break;
-                case TimeZoneRounding.UTCTimeZoneRoundingFloor.ID: rounding = new TimeZoneRounding.UTCTimeZoneRoundingFloor(); break;
-                case TimeZoneRounding.DayTimeZoneRoundingFloor.ID: rounding = new TimeZoneRounding.DayTimeZoneRoundingFloor(); break;
-                case TimeZoneRounding.UTCIntervalTimeZoneRounding.ID: rounding = new TimeZoneRounding.UTCIntervalTimeZoneRounding(); break;
-                case TimeZoneRounding.TimeIntervalTimeZoneRounding.ID: rounding = new TimeZoneRounding.TimeIntervalTimeZoneRounding(); break;
-                case TimeZoneRounding.DayIntervalTimeZoneRounding.ID: rounding = new TimeZoneRounding.DayIntervalTimeZoneRounding(); break;
+                case TimeZoneRounding.TimeUnitRounding.ID: rounding = new TimeZoneRounding.TimeUnitRounding(); break;
+                case TimeZoneRounding.TimeIntervalRounding.ID: rounding = new TimeZoneRounding.TimeIntervalRounding(); break;
                 case TimeZoneRounding.FactorRounding.ID: rounding = new FactorRounding(); break;
                 case OffsetRounding.ID: rounding = new OffsetRounding(); break;
                 default: throw new ElasticsearchException("unknown rounding id [" + id + "]");

--- a/src/main/java/org/elasticsearch/common/rounding/TimeZoneRounding.java
+++ b/src/main/java/org/elasticsearch/common/rounding/TimeZoneRounding.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.common.rounding;
 
+import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.unit.TimeValue;
@@ -282,6 +283,8 @@ public abstract class TimeZoneRounding extends Rounding {
         }
 
         UTCIntervalTimeZoneRounding(long interval) {
+            if (interval < 1)
+                throw new ElasticsearchIllegalArgumentException("Negative time interval not supported");
             this.interval = interval;
         }
 
@@ -328,6 +331,8 @@ public abstract class TimeZoneRounding extends Rounding {
         }
 
         TimeIntervalTimeZoneRounding(long interval, DateTimeZone timeZone) {
+            if (interval < 1)
+                throw new ElasticsearchIllegalArgumentException("Negative time interval not supported");
             this.interval = interval;
             this.timeZone = timeZone;
         }
@@ -380,6 +385,8 @@ public abstract class TimeZoneRounding extends Rounding {
         }
 
         DayIntervalTimeZoneRounding(long interval, DateTimeZone timeZone) {
+            if (interval < 1)
+                throw new ElasticsearchIllegalArgumentException("Negative time interval not supported");
             this.interval = interval;
             this.timeZone = timeZone;
         }

--- a/src/main/java/org/elasticsearch/common/rounding/TimeZoneRounding.java
+++ b/src/main/java/org/elasticsearch/common/rounding/TimeZoneRounding.java
@@ -134,13 +134,13 @@ public abstract class TimeZoneRounding extends Rounding {
         @Override
         public long roundKey(long utcMillis) {
             long timeLocal = timeZone.convertUTCToLocal(utcMillis);
-            return field.roundFloor(timeLocal);
+            return timeZone.convertLocalToUTC(field.roundFloor(timeLocal), true, utcMillis);
         }
 
         @Override
         public long valueForKey(long time) {
-            assert field.roundFloor(time) == time;
-            return timeZone.convertLocalToUTC(time, true);
+            assert roundKey(time) == time;
+            return time;
         }
 
         @Override

--- a/src/main/java/org/elasticsearch/common/rounding/TimeZoneRounding.java
+++ b/src/main/java/org/elasticsearch/common/rounding/TimeZoneRounding.java
@@ -46,8 +46,7 @@ public abstract class TimeZoneRounding extends Rounding {
         private DateTimeUnit unit;
         private long interval = -1;
 
-        private DateTimeZone preTz = DateTimeZone.UTC;
-        private DateTimeZone postTz = DateTimeZone.UTC;
+        private DateTimeZone timeZone = DateTimeZone.UTC;
 
         private float factor = 1.0f;
 
@@ -65,8 +64,8 @@ public abstract class TimeZoneRounding extends Rounding {
             this.interval = interval.millis();
         }
 
-        public Builder preZone(DateTimeZone preTz) {
-            this.preTz = preTz;
+        public Builder timeZone(DateTimeZone timeZone) {
+            this.timeZone = timeZone;
             return this;
         }
 
@@ -75,10 +74,10 @@ public abstract class TimeZoneRounding extends Rounding {
             return this;
         }
 
-        public Builder postZone(DateTimeZone postTz) {
-            this.postTz = postTz;
-            return this;
-        }
+//        public Builder postZone(DateTimeZone postTz) {
+//            this.postTz = postTz;
+//            return this;
+//        }
 
         public Builder offset(long offset) {
             this.offset = offset;
@@ -93,20 +92,20 @@ public abstract class TimeZoneRounding extends Rounding {
         public Rounding build() {
             Rounding timeZoneRounding;
             if (unit != null) {
-                if (preTz.equals(DateTimeZone.UTC) && postTz.equals(DateTimeZone.UTC)) {
+                if (timeZone.equals(DateTimeZone.UTC)) {
                     timeZoneRounding = new UTCTimeZoneRoundingFloor(unit);
                 } else if (preZoneAdjustLargeInterval || unit.field().getDurationField().getUnitMillis() < DateTimeConstants.MILLIS_PER_HOUR * 12) {
-                    timeZoneRounding = new TimeTimeZoneRoundingFloor(unit, preTz, postTz);
+                    timeZoneRounding = new TimeTimeZoneRoundingFloor(unit, timeZone, timeZone);
                 } else {
-                    timeZoneRounding = new DayTimeZoneRoundingFloor(unit, preTz, postTz);
+                    timeZoneRounding = new DayTimeZoneRoundingFloor(unit, timeZone, timeZone);
                 }
             } else {
-                if (preTz.equals(DateTimeZone.UTC) && postTz.equals(DateTimeZone.UTC)) {
+                if (timeZone.equals(DateTimeZone.UTC)) {
                     timeZoneRounding = new UTCIntervalTimeZoneRounding(interval);
                 } else if (preZoneAdjustLargeInterval || interval < DateTimeConstants.MILLIS_PER_HOUR * 12) {
-                    timeZoneRounding = new TimeIntervalTimeZoneRounding(interval, preTz, postTz);
+                    timeZoneRounding = new TimeIntervalTimeZoneRounding(interval, timeZone, timeZone);
                 } else {
-                    timeZoneRounding = new DayIntervalTimeZoneRounding(interval, preTz, postTz);
+                    timeZoneRounding = new DayIntervalTimeZoneRounding(interval, timeZone, timeZone);
                 }
             }
             if (offset != 0) {
@@ -155,7 +154,7 @@ public abstract class TimeZoneRounding extends Rounding {
         @Override
         public long valueForKey(long time) {
             // now apply post Tz
-            time = time + postTz.getOffset(time);
+//            time = time + postTz.getOffset(time);
             return time;
         }
 
@@ -267,7 +266,7 @@ public abstract class TimeZoneRounding extends Rounding {
         public long valueForKey(long time) {
             // after rounding, since its day level (and above), its actually UTC!
             // now apply post Tz
-            time = time + postTz.getOffset(time);
+            time = time - postTz.getOffset(time);
             return time;
         }
 
@@ -372,7 +371,7 @@ public abstract class TimeZoneRounding extends Rounding {
             // now, time is still in local, move it to UTC
             time = time - preTz.getOffset(time);
             // now apply post Tz
-            time = time + postTz.getOffset(time);
+            //time = time - postTz.getOffset(time);
             return time;
         }
 
@@ -429,7 +428,7 @@ public abstract class TimeZoneRounding extends Rounding {
             long time = Rounding.Interval.roundValue(key, interval);
             // after rounding, since its day level (and above), its actually UTC!
             // now apply post Tz
-            time = time + postTz.getOffset(time);
+            time = time - postTz.getOffset(time);
             return time;
         }
 

--- a/src/main/java/org/elasticsearch/common/rounding/TimeZoneRounding.java
+++ b/src/main/java/org/elasticsearch/common/rounding/TimeZoneRounding.java
@@ -23,7 +23,6 @@ import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.unit.TimeValue;
-import org.joda.time.DateTimeConstants;
 import org.joda.time.DateTimeField;
 import org.joda.time.DateTimeZone;
 import org.joda.time.DurationField;
@@ -81,21 +80,9 @@ public abstract class TimeZoneRounding extends Rounding {
         public Rounding build() {
             Rounding timeZoneRounding;
             if (unit != null) {
-                if (timeZone.equals(DateTimeZone.UTC)) {
-                    timeZoneRounding = new UTCTimeZoneRoundingFloor(unit);
-                } else if (unit.field().getDurationField().getUnitMillis() < DateTimeConstants.MILLIS_PER_HOUR * 12) {
-                    timeZoneRounding = new TimeTimeZoneRoundingFloor(unit, timeZone);
-                } else {
-                    timeZoneRounding = new DayTimeZoneRoundingFloor(unit, timeZone);
-                }
+                    timeZoneRounding = new TimeUnitRounding(unit, timeZone);
             } else {
-                if (timeZone.equals(DateTimeZone.UTC)) {
-                    timeZoneRounding = new UTCIntervalTimeZoneRounding(interval);
-                } else if (interval < DateTimeConstants.MILLIS_PER_HOUR * 12) {
-                    timeZoneRounding = new TimeIntervalTimeZoneRounding(interval, timeZone);
-                } else {
-                    timeZoneRounding = new DayIntervalTimeZoneRounding(interval, timeZone);
-                }
+                    timeZoneRounding = new TimeIntervalRounding(interval, timeZone);
             }
             if (offset != 0) {
                 timeZoneRounding = new OffsetRounding(timeZoneRounding, offset);
@@ -107,7 +94,7 @@ public abstract class TimeZoneRounding extends Rounding {
         }
     }
 
-    static class TimeTimeZoneRoundingFloor extends TimeZoneRounding {
+    static class TimeUnitRounding extends TimeZoneRounding {
 
         static final byte ID = 1;
 
@@ -115,15 +102,17 @@ public abstract class TimeZoneRounding extends Rounding {
         private DateTimeField field;
         private DurationField durationField;
         private DateTimeZone timeZone;
+        private boolean isUtc;
 
-        TimeTimeZoneRoundingFloor() { // for serialization
+        TimeUnitRounding() { // for serialization
         }
 
-        TimeTimeZoneRoundingFloor(DateTimeUnit unit, DateTimeZone timeZone) {
+        TimeUnitRounding(DateTimeUnit unit, DateTimeZone timeZone) {
             this.unit = unit;
-            field = unit.field();
-            durationField = field.getDurationField();
+            this.field = unit.field();
+            this.durationField = field.getDurationField();
             this.timeZone = timeZone;
+            this.isUtc = timeZone.equals(DateTimeZone.UTC);
         }
 
         @Override
@@ -133,8 +122,16 @@ public abstract class TimeZoneRounding extends Rounding {
 
         @Override
         public long roundKey(long utcMillis) {
-            long timeLocal = timeZone.convertUTCToLocal(utcMillis);
-            return timeZone.convertLocalToUTC(field.roundFloor(timeLocal), true, utcMillis);
+            long timeLocal = utcMillis;
+            if (!isUtc) {
+                timeLocal = timeZone.convertUTCToLocal(utcMillis);
+            }
+            long rounded = field.roundFloor(timeLocal);
+            if (!isUtc) {
+                return timeZone.convertLocalToUTC(rounded, true, utcMillis);
+            } else {
+                return rounded;
+            }
         }
 
         @Override
@@ -145,9 +142,16 @@ public abstract class TimeZoneRounding extends Rounding {
 
         @Override
         public long nextRoundingValue(long time) {
-            long timeUtc = timeZone.convertUTCToLocal(time);
-            long nextInLocalTime = durationField.add(timeUtc, 1);
-            return timeZone.convertLocalToUTC(nextInLocalTime, true);
+            long timeLocal = time;
+            if (!isUtc) {
+                timeLocal = timeZone.convertUTCToLocal(time);
+            }
+            long nextInLocalTime = durationField.add(timeLocal, 1);
+            if (!isUtc) {
+                return timeZone.convertLocalToUTC(nextInLocalTime, true);
+            } else {
+                return nextInLocalTime;
+            }
         }
 
         @Override
@@ -156,6 +160,7 @@ public abstract class TimeZoneRounding extends Rounding {
             field = unit.field();
             durationField = field.getDurationField();
             timeZone = DateTimeZone.forID(in.readString());
+            isUtc = timeZone.equals(DateTimeZone.UTC);
         }
 
         @Override
@@ -165,176 +170,23 @@ public abstract class TimeZoneRounding extends Rounding {
         }
     }
 
-    static class UTCTimeZoneRoundingFloor extends TimeZoneRounding {
+    static class TimeIntervalRounding extends TimeZoneRounding {
 
         final static byte ID = 2;
 
-        private DateTimeUnit unit;
-        private DateTimeField field;
-        private DurationField durationField;
-
-        UTCTimeZoneRoundingFloor() { // for serialization
-        }
-
-        UTCTimeZoneRoundingFloor(DateTimeUnit unit) {
-            this.unit = unit;
-            field = unit.field();
-            durationField = field.getDurationField();
-        }
-
-        @Override
-        public byte id() {
-            return ID;
-        }
-
-        @Override
-        public long roundKey(long utcMillis) {
-            return field.roundFloor(utcMillis);
-        }
-
-        @Override
-        public long valueForKey(long key) {
-            return key;
-        }
-
-        @Override
-        public long nextRoundingValue(long value) {
-            return durationField.add(value, 1);
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            unit = DateTimeUnit.resolve(in.readByte());
-            field = unit.field();
-            durationField = field.getDurationField();
-        }
-
-        @Override
-        public void writeTo(StreamOutput out) throws IOException {
-            out.writeByte(unit.id());
-        }
-    }
-
-    static class DayTimeZoneRoundingFloor extends TimeZoneRounding {
-
-        final static byte ID = 3;
-
-        private DateTimeUnit unit;
-        private DateTimeField field;
-        private DurationField durationField;
-        private DateTimeZone timeZone;
-
-        DayTimeZoneRoundingFloor() { // for serialization
-        }
-
-        DayTimeZoneRoundingFloor(DateTimeUnit unit, DateTimeZone timeZone) {
-            this.unit = unit;
-            field = unit.field();
-            durationField = field.getDurationField();
-            this.timeZone = timeZone;
-        }
-
-        @Override
-        public byte id() {
-            return ID;
-        }
-
-        @Override
-        public long roundKey(long utcMillis) {
-            long timeLocal = timeZone.convertUTCToLocal(utcMillis);
-            return field.roundFloor(timeLocal);
-        }
-
-        @Override
-        public long valueForKey(long time) {
-            assert field.roundFloor(time) == time;
-            return timeZone.convertLocalToUTC(time, true);
-        }
-
-        @Override
-        public long nextRoundingValue(long time) {
-            long timeUtc = timeZone.convertUTCToLocal(time);
-            long nextInLocalTime = durationField.add(timeUtc, 1);
-            return timeZone.convertLocalToUTC(nextInLocalTime, true);
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            unit = DateTimeUnit.resolve(in.readByte());
-            field = unit.field();
-            durationField = field.getDurationField();
-            timeZone = DateTimeZone.forID(in.readString());
-        }
-
-        @Override
-        public void writeTo(StreamOutput out) throws IOException {
-            out.writeByte(unit.id());
-            out.writeString(timeZone.getID());
-        }
-    }
-
-    static class UTCIntervalTimeZoneRounding extends TimeZoneRounding {
-
-        final static byte ID = 4;
-
-        private long interval;
-
-        UTCIntervalTimeZoneRounding() { // for serialization
-        }
-
-        UTCIntervalTimeZoneRounding(long interval) {
-            if (interval < 1)
-                throw new ElasticsearchIllegalArgumentException("Negative time interval not supported");
-            this.interval = interval;
-        }
-
-        @Override
-        public byte id() {
-            return ID;
-        }
-
-        @Override
-        public long roundKey(long utcMillis) {
-            return Rounding.Interval.roundKey(utcMillis, interval);
-        }
-
-        @Override
-        public long valueForKey(long key) {
-            return Rounding.Interval.roundValue(key, interval);
-        }
-
-        @Override
-        public long nextRoundingValue(long value) {
-            return value + interval;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            interval = in.readVLong();
-        }
-
-        @Override
-        public void writeTo(StreamOutput out) throws IOException {
-            out.writeVLong(interval);
-        }
-    }
-
-
-    static class TimeIntervalTimeZoneRounding extends TimeZoneRounding {
-
-        final static byte ID = 5;
-
         private long interval;
         private DateTimeZone timeZone;
+        private boolean isUtc;
 
-        TimeIntervalTimeZoneRounding() { // for serialization
+        TimeIntervalRounding() { // for serialization
         }
 
-        TimeIntervalTimeZoneRounding(long interval, DateTimeZone timeZone) {
+        TimeIntervalRounding(long interval, DateTimeZone timeZone) {
             if (interval < 1)
                 throw new ElasticsearchIllegalArgumentException("Negative time interval not supported");
             this.interval = interval;
             this.timeZone = timeZone;
+            this.isUtc = timeZone.equals(DateTimeZone.UTC);
         }
 
         @Override
@@ -344,81 +196,42 @@ public abstract class TimeZoneRounding extends Rounding {
 
         @Override
         public long roundKey(long utcMillis) {
-            long timeLocal = timeZone.convertUTCToLocal(utcMillis);
+            long timeLocal = utcMillis;
+            if (!isUtc) {
+                timeLocal = timeZone.convertUTCToLocal(utcMillis);
+            }
             return Rounding.Interval.roundKey(timeLocal, interval);
         }
 
         @Override
         public long valueForKey(long key) {
             long localTime = Rounding.Interval.roundValue(key, interval);
-            return timeZone.convertLocalToUTC(localTime, true);
+            if (!isUtc) {
+                return timeZone.convertLocalToUTC(localTime, true);
+            } else {
+                return localTime;
+            }
         }
 
         @Override
-        public long nextRoundingValue(long value) {
-            long timeLocal = timeZone.convertUTCToLocal(value);
+        public long nextRoundingValue(long time) {
+            long timeLocal = time;
+            if (!isUtc) {
+                timeLocal = timeZone.convertUTCToLocal(time);
+            }
             long next = timeLocal + interval;
-            return timeZone.convertLocalToUTC(next, true);
+            if (!isUtc){
+                return timeZone.convertLocalToUTC(next, true);
+            } else {
+                return next;
+            }
         }
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
             interval = in.readVLong();
             timeZone = DateTimeZone.forID(in.readString());
-        }
-
-        @Override
-        public void writeTo(StreamOutput out) throws IOException {
-            out.writeVLong(interval);
-            out.writeString(timeZone.getID());
-        }
-    }
-
-    static class DayIntervalTimeZoneRounding extends TimeZoneRounding {
-
-        final static byte ID = 6;
-
-        private long interval;
-        private DateTimeZone timeZone;
-
-        DayIntervalTimeZoneRounding() { // for serialization
-        }
-
-        DayIntervalTimeZoneRounding(long interval, DateTimeZone timeZone) {
-            if (interval < 1)
-                throw new ElasticsearchIllegalArgumentException("Negative time interval not supported");
-            this.interval = interval;
-            this.timeZone = timeZone;
-        }
-
-        @Override
-        public byte id() {
-            return ID;
-        }
-
-        @Override
-        public long roundKey(long utcMillis) {
-            long time = utcMillis + timeZone.getOffset(utcMillis);
-            return Rounding.Interval.roundKey(time, interval);
-        }
-
-        @Override
-        public long valueForKey(long key) {
-            long localTime = Rounding.Interval.roundValue(key, interval);
-            return timeZone.convertLocalToUTC(localTime, true);
-        }
-
-        @Override
-        public long nextRoundingValue(long value) {
-            long timeLocal = timeZone.convertUTCToLocal(value);
-            long next = timeLocal + interval;
-            return timeZone.convertLocalToUTC(next, true);
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            interval = in.readVLong();
-            timeZone = DateTimeZone.forID(in.readString());
+            isUtc = timeZone.equals(DateTimeZone.UTC);
         }
 
         @Override

--- a/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
@@ -402,8 +402,8 @@ public class RangeQueryBuilder extends BaseQueryBuilder implements MultiTermQuer
     /**
      * In case of date field, we can adjust the from/to fields using a timezone
      */
-    public RangeQueryBuilder timeZone(String preZone) {
-        this.timeZone = preZone;
+    public RangeQueryBuilder timeZone(String timezone) {
+        this.timeZone = timezone;
         return this;
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramBuilder.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramBuilder.java
@@ -38,7 +38,6 @@ public class DateHistogramBuilder extends ValuesSourceAggregationBuilder<DateHis
     private Object extendedBoundsMin;
     private Object extendedBoundsMax;
     private String timeZone;
-    private boolean preZoneAdjustLargeInterval;
     private String format;
     private String offset;
     private float factor = 1.0f;
@@ -88,14 +87,6 @@ public class DateHistogramBuilder extends ValuesSourceAggregationBuilder<DateHis
      */
     public DateHistogramBuilder timeZone(String timeZone) {
         this.timeZone = timeZone;
-        return this;
-    }
-
-    /**
-     * Set whether to adjust large intervals, when using days or larger intervals.
-     */
-    public DateHistogramBuilder preZoneAdjustLargeInterval(boolean preZoneAdjustLargeInterval) {
-        this.preZoneAdjustLargeInterval = preZoneAdjustLargeInterval;
         return this;
     }
 
@@ -179,10 +170,6 @@ public class DateHistogramBuilder extends ValuesSourceAggregationBuilder<DateHis
 
         if (timeZone != null) {
             builder.field("time_zone", timeZone);
-        }
-
-        if (preZoneAdjustLargeInterval) {
-            builder.field("pre_zone_adjust_large_interval", true);
         }
 
         if (offset != null) {

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramBuilder.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramBuilder.java
@@ -37,8 +37,7 @@ public class DateHistogramBuilder extends ValuesSourceAggregationBuilder<DateHis
     private Long minDocCount;
     private Object extendedBoundsMin;
     private Object extendedBoundsMax;
-    private String preZone;
-    private String postZone;
+    private String timeZone;
     private boolean preZoneAdjustLargeInterval;
     private String format;
     private String offset;
@@ -87,16 +86,8 @@ public class DateHistogramBuilder extends ValuesSourceAggregationBuilder<DateHis
     /**
      * Set the timezone in which to translate dates before computing buckets.
      */
-    public DateHistogramBuilder preZone(String preZone) {
-        this.preZone = preZone;
-        return this;
-    }
-
-    /**
-     * Set the timezone in which to translate dates after having computed buckets.
-     */
-    public DateHistogramBuilder postZone(String postZone) {
-        this.postZone = postZone;
+    public DateHistogramBuilder timeZone(String timeZone) {
+        this.timeZone = timeZone;
         return this;
     }
 
@@ -186,12 +177,8 @@ public class DateHistogramBuilder extends ValuesSourceAggregationBuilder<DateHis
             order.toXContent(builder, params);
         }
 
-        if (preZone != null) {
-            builder.field("pre_zone", preZone);
-        }
-
-        if (postZone != null) {
-            builder.field("post_zone", postZone);
+        if (timeZone != null) {
+            builder.field("time_zone", timeZone);
         }
 
         if (preZoneAdjustLargeInterval) {

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramParser.java
@@ -86,8 +86,7 @@ public class DateHistogramParser implements Aggregator.Parser {
         InternalOrder order = (InternalOrder) Histogram.Order.KEY_ASC;
         String interval = null;
         boolean preZoneAdjustLargeInterval = false;
-        DateTimeZone preZone = DateTimeZone.UTC;
-        DateTimeZone postZone = DateTimeZone.UTC;
+        DateTimeZone timeZone = DateTimeZone.UTC;
         long offset = 0;
 
         XContentParser.Token token;
@@ -99,11 +98,7 @@ public class DateHistogramParser implements Aggregator.Parser {
                 continue;
             } else if (token == XContentParser.Token.VALUE_STRING) {
                 if ("time_zone".equals(currentFieldName) || "timeZone".equals(currentFieldName)) {
-                    preZone = DateTimeZone.forID(parser.text());
-                } else if ("pre_zone".equals(currentFieldName) || "preZone".equals(currentFieldName)) {
-                    preZone = DateTimeZone.forID(parser.text());
-                } else if ("post_zone".equals(currentFieldName) || "postZone".equals(currentFieldName)) {
-                    postZone = DateTimeZone.forID(parser.text());
+                    timeZone = DateTimeZone.forID(parser.text());
                 } else if ("offset".equals(currentFieldName)) {
                     offset = parseOffset(parser.text());
                 } else if ("interval".equals(currentFieldName)) {
@@ -123,11 +118,7 @@ public class DateHistogramParser implements Aggregator.Parser {
                 if ("min_doc_count".equals(currentFieldName) || "minDocCount".equals(currentFieldName)) {
                     minDocCount = parser.longValue();
                 } else if ("time_zone".equals(currentFieldName) || "timeZone".equals(currentFieldName)) {
-                    preZone = DateTimeZone.forOffsetHours(parser.intValue());
-                } else if ("pre_zone".equals(currentFieldName) || "preZone".equals(currentFieldName)) {
-                    preZone = DateTimeZone.forOffsetHours(parser.intValue());
-                } else if ("post_zone".equals(currentFieldName) || "postZone".equals(currentFieldName)) {
-                    postZone = DateTimeZone.forOffsetHours(parser.intValue());
+                    timeZone = DateTimeZone.forOffsetHours(parser.intValue());
                 } else {
                     throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
                 }
@@ -191,7 +182,7 @@ public class DateHistogramParser implements Aggregator.Parser {
         }
 
         Rounding rounding = tzRoundingBuilder
-                .preZone(preZone).postZone(postZone)
+                .timeZone(timeZone)
                 .preZoneAdjustLargeInterval(preZoneAdjustLargeInterval)
                 .offset(offset).build();
 

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramParser.java
@@ -43,6 +43,9 @@ import java.io.IOException;
 public class DateHistogramParser implements Aggregator.Parser {
 
     static final ParseField EXTENDED_BOUNDS = new ParseField("extended_bounds");
+    static final ParseField TIME_ZONE = new ParseField("time_zone");
+    static final ParseField OFFSET = new ParseField("offset");
+    static final ParseField INTERVAL = new ParseField("interval");
 
     private final ImmutableMap<String, DateTimeUnit> dateFieldUnits;
 
@@ -96,11 +99,11 @@ public class DateHistogramParser implements Aggregator.Parser {
             } else if (vsParser.token(currentFieldName, token, parser)) {
                 continue;
             } else if (token == XContentParser.Token.VALUE_STRING) {
-                if ("time_zone".equals(currentFieldName) || "timeZone".equals(currentFieldName)) {
+                if (TIME_ZONE.match(currentFieldName)) {
                     timeZone = DateTimeZone.forID(parser.text());
-                } else if ("offset".equals(currentFieldName)) {
+                } else if (OFFSET.match(currentFieldName)) {
                     offset = parseOffset(parser.text());
-                } else if ("interval".equals(currentFieldName)) {
+                } else if (INTERVAL.match(currentFieldName)) {
                     interval = parser.text();
                 } else {
                     throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramParser.java
@@ -85,7 +85,6 @@ public class DateHistogramParser implements Aggregator.Parser {
         ExtendedBounds extendedBounds = null;
         InternalOrder order = (InternalOrder) Histogram.Order.KEY_ASC;
         String interval = null;
-        boolean preZoneAdjustLargeInterval = false;
         DateTimeZone timeZone = DateTimeZone.UTC;
         long offset = 0;
 
@@ -109,8 +108,6 @@ public class DateHistogramParser implements Aggregator.Parser {
             } else if (token == XContentParser.Token.VALUE_BOOLEAN) {
                 if ("keyed".equals(currentFieldName)) {
                     keyed = parser.booleanValue();
-                } else if ("pre_zone_adjust_large_interval".equals(currentFieldName) || "preZoneAdjustLargeInterval".equals(currentFieldName)) {
-                    preZoneAdjustLargeInterval = parser.booleanValue();
                 } else {
                     throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
                 }
@@ -183,7 +180,6 @@ public class DateHistogramParser implements Aggregator.Parser {
 
         Rounding rounding = tzRoundingBuilder
                 .timeZone(timeZone)
-                .preZoneAdjustLargeInterval(preZoneAdjustLargeInterval)
                 .offset(offset).build();
 
         return new HistogramAggregator.Factory(aggregationName, vsParser.config(), rounding, order, keyed, minDocCount, extendedBounds,

--- a/src/test/java/org/elasticsearch/common/rounding/TimeZoneRoundingTests.java
+++ b/src/test/java/org/elasticsearch/common/rounding/TimeZoneRoundingTests.java
@@ -104,17 +104,21 @@ public class TimeZoneRoundingTests extends ElasticsearchTestCase {
     @Test
     public void testDayTimeZoneRounding() {
         int timezoneOffset = -2;
-        Rounding tzRounding = TimeZoneRounding.builder(DateTimeUnit.DAY_OF_MONTH).timeZone(DateTimeZone.forOffsetHours(timezoneOffset)).build();
+        Rounding tzRounding = TimeZoneRounding.builder(DateTimeUnit.DAY_OF_MONTH).timeZone(DateTimeZone.forOffsetHours(timezoneOffset))
+                .build();
         assertThat(tzRounding.round(0), equalTo(0l - TimeValue.timeValueHours(24 + timezoneOffset).millis()));
-        assertThat(tzRounding.nextRoundingValue(0l - TimeValue.timeValueHours(24 + timezoneOffset).millis()), equalTo(0l - TimeValue.timeValueHours(timezoneOffset).millis()));
+        assertThat(tzRounding.nextRoundingValue(0l - TimeValue.timeValueHours(24 + timezoneOffset).millis()), equalTo(0l - TimeValue
+                .timeValueHours(timezoneOffset).millis()));
 
         tzRounding = TimeZoneRounding.builder(DateTimeUnit.DAY_OF_MONTH).timeZone(DateTimeZone.forID("-08:00")).build();
         assertThat(tzRounding.round(utc("2012-04-01T04:15:30Z")), equalTo(utc("2012-03-31T08:00:00Z")));
-        assertThat(toUTCDateString(tzRounding.nextRoundingValue(utc("2012-03-31T08:00:00Z"))), equalTo(toUTCDateString(utc("2012-04-01T08:0:00Z"))));
+        assertThat(toUTCDateString(tzRounding.nextRoundingValue(utc("2012-03-31T08:00:00Z"))),
+                equalTo(toUTCDateString(utc("2012-04-01T08:0:00Z"))));
 
         tzRounding = TimeZoneRounding.builder(DateTimeUnit.MONTH_OF_YEAR).timeZone(DateTimeZone.forID("-08:00")).build();
         assertThat(tzRounding.round(utc("2012-04-01T04:15:30Z")), equalTo(utc("2012-03-01T08:00:00Z")));
-        assertThat(toUTCDateString(tzRounding.nextRoundingValue(utc("2012-03-01T08:00:00Z"))), equalTo(toUTCDateString(utc("2012-04-01T08:0:00Z"))));
+        assertThat(toUTCDateString(tzRounding.nextRoundingValue(utc("2012-03-01T08:00:00Z"))),
+                equalTo(toUTCDateString(utc("2012-04-01T08:0:00Z"))));
 
         // date in Feb-3rd, but still in Feb-2nd in -02:00 timezone
         tzRounding = TimeZoneRounding.builder(DateTimeUnit.DAY_OF_MONTH).timeZone(DateTimeZone.forID("-02:00")).build();
@@ -150,42 +154,53 @@ public class TimeZoneRoundingTests extends ElasticsearchTestCase {
         Rounding tzRounding;
         // testing savings to non savings switch
         tzRounding = TimeZoneRounding.builder(DateTimeUnit.HOUR_OF_DAY).timeZone(DateTimeZone.forID("UTC")).build();
-        assertThat(tzRounding.round(time("2014-10-26T01:01:01", DateTimeZone.forID("CET"))), equalTo(time("2014-10-26T01:00:00", DateTimeZone.forID("CET"))));
+        assertThat(tzRounding.round(time("2014-10-26T01:01:01", DateTimeZone.forID("CET"))),
+                equalTo(time("2014-10-26T01:00:00", DateTimeZone.forID("CET"))));
 
         tzRounding = TimeZoneRounding.builder(DateTimeUnit.HOUR_OF_DAY).timeZone(DateTimeZone.forID("CET")).build();
-        assertThat(tzRounding.round(time("2014-10-26T01:01:01", DateTimeZone.forID("CET"))), equalTo(time("2014-10-26T01:00:00", DateTimeZone.forID("CET"))));
+        assertThat(tzRounding.round(time("2014-10-26T01:01:01", DateTimeZone.forID("CET"))),
+                equalTo(time("2014-10-26T01:00:00", DateTimeZone.forID("CET"))));
 
         // testing non savings to savings switch
         tzRounding = TimeZoneRounding.builder(DateTimeUnit.HOUR_OF_DAY).timeZone(DateTimeZone.forID("UTC")).build();
-        assertThat(tzRounding.round(time("2014-03-30T01:01:01", DateTimeZone.forID("CET"))), equalTo(time("2014-03-30T01:00:00", DateTimeZone.forID("CET"))));
+        assertThat(tzRounding.round(time("2014-03-30T01:01:01", DateTimeZone.forID("CET"))),
+                equalTo(time("2014-03-30T01:00:00", DateTimeZone.forID("CET"))));
 
         tzRounding = TimeZoneRounding.builder(DateTimeUnit.HOUR_OF_DAY).timeZone(DateTimeZone.forID("CET")).build();
-        assertThat(tzRounding.round(time("2014-03-30T01:01:01", DateTimeZone.forID("CET"))), equalTo(time("2014-03-30T01:00:00", DateTimeZone.forID("CET"))));
+        assertThat(tzRounding.round(time("2014-03-30T01:01:01", DateTimeZone.forID("CET"))),
+                equalTo(time("2014-03-30T01:00:00", DateTimeZone.forID("CET"))));
 
         // testing non savings to savings switch (America/Chicago)
         tzRounding = TimeZoneRounding.builder(DateTimeUnit.HOUR_OF_DAY).timeZone(DateTimeZone.forID("UTC")).build();
-        assertThat(tzRounding.round(time("2014-03-09T03:01:01", DateTimeZone.forID("America/Chicago"))), equalTo(time("2014-03-09T03:00:00", DateTimeZone.forID("America/Chicago"))));
+        assertThat(tzRounding.round(time("2014-03-09T03:01:01", DateTimeZone.forID("America/Chicago"))),
+                equalTo(time("2014-03-09T03:00:00", DateTimeZone.forID("America/Chicago"))));
 
         tzRounding = TimeZoneRounding.builder(DateTimeUnit.HOUR_OF_DAY).timeZone(DateTimeZone.forID("America/Chicago")).build();
-        assertThat(tzRounding.round(time("2014-03-09T03:01:01", DateTimeZone.forID("America/Chicago"))), equalTo(time("2014-03-09T03:00:00", DateTimeZone.forID("America/Chicago"))));
+        assertThat(tzRounding.round(time("2014-03-09T03:01:01", DateTimeZone.forID("America/Chicago"))),
+                equalTo(time("2014-03-09T03:00:00", DateTimeZone.forID("America/Chicago"))));
 
         // testing savings to non savings switch 2013 (America/Chicago)
         tzRounding = TimeZoneRounding.builder(DateTimeUnit.HOUR_OF_DAY).timeZone(DateTimeZone.forID("UTC")).build();
-        assertThat(tzRounding.round(time("2013-11-03T06:01:01", DateTimeZone.forID("America/Chicago"))), equalTo(time("2013-11-03T06:00:00", DateTimeZone.forID("America/Chicago"))));
+        assertThat(tzRounding.round(time("2013-11-03T06:01:01", DateTimeZone.forID("America/Chicago"))),
+                equalTo(time("2013-11-03T06:00:00", DateTimeZone.forID("America/Chicago"))));
 
         tzRounding = TimeZoneRounding.builder(DateTimeUnit.HOUR_OF_DAY).timeZone(DateTimeZone.forID("America/Chicago")).build();
-        assertThat(tzRounding.round(time("2013-11-03T06:01:01", DateTimeZone.forID("America/Chicago"))), equalTo(time("2013-11-03T06:00:00", DateTimeZone.forID("America/Chicago"))));
+        assertThat(tzRounding.round(time("2013-11-03T06:01:01", DateTimeZone.forID("America/Chicago"))),
+                equalTo(time("2013-11-03T06:00:00", DateTimeZone.forID("America/Chicago"))));
 
         // testing savings to non savings switch 2014 (America/Chicago)
         tzRounding = TimeZoneRounding.builder(DateTimeUnit.HOUR_OF_DAY).timeZone(DateTimeZone.forID("UTC")).build();
-        assertThat(tzRounding.round(time("2014-11-02T06:01:01", DateTimeZone.forID("America/Chicago"))), equalTo(time("2014-11-02T06:00:00", DateTimeZone.forID("America/Chicago"))));
+        assertThat(tzRounding.round(time("2014-11-02T06:01:01", DateTimeZone.forID("America/Chicago"))),
+                equalTo(time("2014-11-02T06:00:00", DateTimeZone.forID("America/Chicago"))));
 
         tzRounding = TimeZoneRounding.builder(DateTimeUnit.HOUR_OF_DAY).timeZone(DateTimeZone.forID("America/Chicago")).build();
-        assertThat(tzRounding.round(time("2014-11-02T06:01:01", DateTimeZone.forID("America/Chicago"))), equalTo(time("2014-11-02T06:00:00", DateTimeZone.forID("America/Chicago"))));
+        assertThat(tzRounding.round(time("2014-11-02T06:01:01", DateTimeZone.forID("America/Chicago"))),
+                equalTo(time("2014-11-02T06:00:00", DateTimeZone.forID("America/Chicago"))));
     }
 
     /**
-     * randomized test on UTC/Day/TimeTimeZoneRoundingFloor with random time units and time zone offsets
+     * randomized test on UTC/Day/TimeTimeZoneRoundingFloor with random time
+     * units and time zone offsets
      */
     @Test
     public void testTimeZoneRoundingRandom() {
@@ -193,15 +208,7 @@ public class TimeZoneRoundingTests extends ElasticsearchTestCase {
             DateTimeUnit timeUnit = randomTimeUnit();
             TimeZoneRounding rounding;
             int timezoneOffset = randomIntBetween(-23, 23);
-            if (timezoneOffset==0) {
-                rounding = new TimeZoneRounding.UTCTimeZoneRoundingFloor(timeUnit);
-            } else {
-                if (randomBoolean()) {
-                    rounding = new TimeZoneRounding.DayTimeZoneRoundingFloor(timeUnit, DateTimeZone.forOffsetHours(timezoneOffset));
-                } else {
-                    rounding = new TimeZoneRounding.TimeTimeZoneRoundingFloor(timeUnit, DateTimeZone.forOffsetHours(timezoneOffset));
-                }
-            }
+            rounding = new TimeZoneRounding.TimeUnitRounding(timeUnit, DateTimeZone.forOffsetHours(timezoneOffset));
             long date = Math.abs(randomLong() % ((long) 10e11));
             final long roundedDate = rounding.round(date);
             final long nextRoundingValue = rounding.nextRoundingValue(roundedDate);
@@ -213,7 +220,8 @@ public class TimeZoneRoundingTests extends ElasticsearchTestCase {
     }
 
     /**
-     * randomized test on UTC/Day/TimeIntervalTimeZoneRounding with random interval and time zone offsets
+     * randomized test on UTC/Day/TimeIntervalTimeZoneRounding with random
+     * interval and time zone offsets
      */
     @Test
     public void testIntervalRoundingRandom() {
@@ -222,15 +230,7 @@ public class TimeZoneRoundingTests extends ElasticsearchTestCase {
             long interval = Math.abs(randomLong() % (TimeUnit.DAYS.toMillis(365)));
             TimeZoneRounding rounding;
             int timezoneOffset = randomIntBetween(-23, 23);
-            if (timezoneOffset==0) {
-                rounding = new TimeZoneRounding.UTCIntervalTimeZoneRounding(interval);
-            } else {
-                if (randomBoolean()) {
-                    rounding = new TimeZoneRounding.DayIntervalTimeZoneRounding(interval, DateTimeZone.forOffsetHours(timezoneOffset));
-                } else {
-                    rounding = new TimeZoneRounding.TimeIntervalTimeZoneRounding(interval, DateTimeZone.forOffsetHours(timezoneOffset));
-                }
-            }
+            rounding = new TimeZoneRounding.TimeIntervalRounding(interval, DateTimeZone.forOffsetHours(timezoneOffset));
             long date = Math.abs(randomLong() % ((long) 10e11));
             final long roundedDate = rounding.round(date);
             final long nextRoundingValue = rounding.nextRoundingValue(roundedDate);
@@ -238,8 +238,7 @@ public class TimeZoneRoundingTests extends ElasticsearchTestCase {
             assertThat("Rounded value smaller or equal than unrounded, regardless of timezone", roundedDate, lessThanOrEqualTo(date));
             assertThat("NextRounding value should be greater than date", nextRoundingValue, greaterThan(roundedDate));
             assertThat("NextRounding value should be interval from rounded value", nextRoundingValue - roundedDate, equalTo(interval));
-            assertThat("NextRounding value should be a rounded date", nextRoundingValue,
-                    equalTo(rounding.round(nextRoundingValue)));
+            assertThat("NextRounding value should be a rounded date", nextRoundingValue, equalTo(rounding.round(nextRoundingValue)));
         }
     }
 
@@ -249,8 +248,7 @@ public class TimeZoneRoundingTests extends ElasticsearchTestCase {
     @Test
     public void testAmbiguousHoursAfterDSTSwitch() {
         Rounding tzRounding;
-        tzRounding = TimeZoneRounding.builder(DateTimeUnit.HOUR_OF_DAY).timeZone(DateTimeZone.forID("Asia/Jerusalem"))
-                .build();
+        tzRounding = TimeZoneRounding.builder(DateTimeUnit.HOUR_OF_DAY).timeZone(DateTimeZone.forID("Asia/Jerusalem")).build();
         assertThat(tzRounding.round(time("2014-10-25T22:30:00", DateTimeZone.UTC)), equalTo(time("2014-10-25T22:00:00", DateTimeZone.UTC)));
         assertThat(tzRounding.round(time("2014-10-25T23:30:00", DateTimeZone.UTC)), equalTo(time("2014-10-25T23:00:00", DateTimeZone.UTC)));
     }
@@ -259,8 +257,7 @@ public class TimeZoneRoundingTests extends ElasticsearchTestCase {
     public void testAdjustPreTimeZone() {
         Rounding tzRounding;
         // Day interval
-        tzRounding = TimeZoneRounding.builder(DateTimeUnit.DAY_OF_MONTH).timeZone(DateTimeZone.forID("Asia/Jerusalem"))
-                .build();
+        tzRounding = TimeZoneRounding.builder(DateTimeUnit.DAY_OF_MONTH).timeZone(DateTimeZone.forID("Asia/Jerusalem")).build();
         assertThat(tzRounding.round(time("2014-11-11T17:00:00", DateTimeZone.forID("Asia/Jerusalem"))),
                 equalTo(time("2014-11-11T00:00:00", DateTimeZone.forID("Asia/Jerusalem"))));
         // DST on
@@ -273,21 +270,18 @@ public class TimeZoneRoundingTests extends ElasticsearchTestCase {
         assertThat(tzRounding.round(time("2015-03-27T17:00:00", DateTimeZone.forID("Asia/Jerusalem"))),
                 equalTo(time("2015-03-27T00:00:00", DateTimeZone.forID("Asia/Jerusalem"))));
         // Month interval
-        tzRounding = TimeZoneRounding.builder(DateTimeUnit.MONTH_OF_YEAR).timeZone(DateTimeZone.forID("Asia/Jerusalem"))
-                .build();
+        tzRounding = TimeZoneRounding.builder(DateTimeUnit.MONTH_OF_YEAR).timeZone(DateTimeZone.forID("Asia/Jerusalem")).build();
         assertThat(tzRounding.round(time("2014-11-11T17:00:00", DateTimeZone.forID("Asia/Jerusalem"))),
                 equalTo(time("2014-11-01T00:00:00", DateTimeZone.forID("Asia/Jerusalem"))));
         // DST on
         assertThat(tzRounding.round(time("2014-10-10T17:00:00", DateTimeZone.forID("Asia/Jerusalem"))),
                 equalTo(time("2014-10-01T00:00:00", DateTimeZone.forID("Asia/Jerusalem"))));
         // Year interval
-        tzRounding = TimeZoneRounding.builder(DateTimeUnit.YEAR_OF_CENTURY).timeZone(DateTimeZone.forID("Asia/Jerusalem"))
-                .build();
+        tzRounding = TimeZoneRounding.builder(DateTimeUnit.YEAR_OF_CENTURY).timeZone(DateTimeZone.forID("Asia/Jerusalem")).build();
         assertThat(tzRounding.round(time("2014-11-11T17:00:00", DateTimeZone.forID("Asia/Jerusalem"))),
                 equalTo(time("2014-01-01T00:00:00", DateTimeZone.forID("Asia/Jerusalem"))));
         // Two time stamps in same year ("Double buckets" bug in 1.3.7)
-        tzRounding = TimeZoneRounding.builder(DateTimeUnit.YEAR_OF_CENTURY).timeZone(DateTimeZone.forID("Asia/Jerusalem"))
-                .build();
+        tzRounding = TimeZoneRounding.builder(DateTimeUnit.YEAR_OF_CENTURY).timeZone(DateTimeZone.forID("Asia/Jerusalem")).build();
         assertThat(tzRounding.round(time("2014-11-11T17:00:00", DateTimeZone.forID("Asia/Jerusalem"))),
                 equalTo(tzRounding.round(time("2014-08-11T17:00:00", DateTimeZone.forID("Asia/Jerusalem")))));
     }

--- a/src/test/java/org/elasticsearch/common/rounding/TimeZoneRoundingTests.java
+++ b/src/test/java/org/elasticsearch/common/rounding/TimeZoneRoundingTests.java
@@ -45,81 +45,129 @@ public class TimeZoneRoundingTests extends ElasticsearchTestCase {
         assertThat(tzRounding.round(utc("2012-01-10T01:01:01")), equalTo(utc("2012-01-08T00:00:00.000Z")));
         assertThat(tzRounding.nextRoundingValue(utc("2012-01-08T00:00:00.000Z")), equalTo(utc("2012-01-15T00:00:00.000Z")));
     }
+    
+    @Test
+    public void testUTCIntervalRounding() {
+        Rounding tzRounding = TimeZoneRounding.builder(TimeValue.timeValueHours(12)).build();
+        assertThat(tzRounding.round(utc("2009-02-03T01:01:01")), equalTo(utc("2009-02-03T00:00:00.000Z")));
+        long roundKey = tzRounding.roundKey(utc("2009-02-03T01:01:01"));
+        assertThat(roundKey, equalTo(tzRounding.roundKey(utc("2009-02-03T00:00:00.000Z"))));
+        assertThat(tzRounding.valueForKey(roundKey), equalTo(utc("2009-02-03T00:00:00.000Z")));
+        assertThat(tzRounding.nextRoundingValue(utc("2009-02-03T00:00:00.000Z")), equalTo(utc("2009-02-03T12:00:00.000Z")));
+        assertThat(tzRounding.round(utc("2009-02-03T13:01:01")), equalTo(utc("2009-02-03T12:00:00.000Z")));
+        assertThat(tzRounding.nextRoundingValue(utc("2009-02-03T12:00:00.000Z")), equalTo(utc("2009-02-04T00:00:00.000Z")));
+        
+        tzRounding = TimeZoneRounding.builder(TimeValue.timeValueHours(48)).build();
+        assertThat(tzRounding.round(utc("2009-02-03T01:01:01")), equalTo(utc("2009-02-03T00:00:00.000Z")));
+        assertThat(tzRounding.nextRoundingValue(utc("2009-02-03T00:00:00.000Z")), equalTo(utc("2009-02-05T00:00:00.000Z")));
+        assertThat(tzRounding.round(utc("2009-02-05T13:01:01")), equalTo(utc("2009-02-05T00:00:00.000Z")));
+        assertThat(tzRounding.nextRoundingValue(utc("2009-02-05T00:00:00.000Z")), equalTo(utc("2009-02-07T00:00:00.000Z")));
+    }
+    
+    /**
+     * test TimeIntervalTimeZoneRounding, (interval < 12h) with time zone shift
+     */
+    @Test
+    public void testTimeIntervalTimeZoneRounding() {
+        Rounding tzRounding = TimeZoneRounding.builder(TimeValue.timeValueHours(6)).timeZone(DateTimeZone.forOffsetHours(-1)).build();
+        assertThat(tzRounding.round(utc("2009-02-03T00:01:01")), equalTo(utc("2009-02-02T19:00:00.000Z")));
+        long roundKey = tzRounding.roundKey(utc("2009-02-03T00:01:01"));
+        assertThat(roundKey, equalTo(tzRounding.roundKey(utc("2009-02-02T19:00:00.000Z"))));
+        assertThat(tzRounding.valueForKey(roundKey), equalTo(utc("2009-02-02T19:00:00.000Z")));
+        assertThat(tzRounding.nextRoundingValue(utc("2009-02-02T19:00:00.000Z")), equalTo(utc("2009-02-03T01:00:00.000Z")));
+        
+        assertThat(tzRounding.round(utc("2009-02-03T13:01:01")), equalTo(utc("2009-02-03T13:00:00.000Z")));
+        assertThat(tzRounding.nextRoundingValue(utc("2009-02-03T13:00:00.000Z")), equalTo(utc("2009-02-03T19:00:00.000Z")));
+    }
+
+    /**
+     * test DayIntervalTimeZoneRounding, (interval >= 12h) with time zone shift
+     */
+    @Test
+    public void testDayIntervalTimeZoneRounding() {
+        Rounding tzRounding = TimeZoneRounding.builder(TimeValue.timeValueHours(12)).timeZone(DateTimeZone.forOffsetHours(-8)).preZoneAdjustLargeInterval(false).build();
+        assertThat(tzRounding.round(utc("2009-02-03T00:01:01")), equalTo(utc("2009-02-02T20:00:00.000Z")));
+        long roundKey = tzRounding.roundKey(utc("2009-02-03T00:01:01"));
+        assertThat(roundKey, equalTo(tzRounding.roundKey(utc("2009-02-02T20:00:00.000Z"))));
+        assertThat(tzRounding.valueForKey(roundKey), equalTo(utc("2009-02-02T20:00:00.000Z")));
+        assertThat(tzRounding.nextRoundingValue(utc("2009-02-02T20:00:00.000Z")), equalTo(utc("2009-02-03T08:00:00.000Z")));
+        
+        assertThat(tzRounding.round(utc("2009-02-03T13:01:01")), equalTo(utc("2009-02-03T08:00:00.000Z")));
+        assertThat(tzRounding.nextRoundingValue(utc("2009-02-03T08:00:00.000Z")), equalTo(utc("2009-02-03T20:00:00.000Z")));
+    }
 
     @Test
     public void testDayTimeZoneRounding() {
-        Rounding tzRounding = TimeZoneRounding.builder(DateTimeUnit.DAY_OF_MONTH).preZone(DateTimeZone.forOffsetHours(-2)).build();
-        assertThat(tzRounding.round(0), equalTo(0l - TimeValue.timeValueHours(24).millis()));
-        assertThat(tzRounding.nextRoundingValue(0l - TimeValue.timeValueHours(24).millis()), equalTo(0l));
+        int timezoneOffset = -2;
+        Rounding tzRounding = TimeZoneRounding.builder(DateTimeUnit.DAY_OF_MONTH).timeZone(DateTimeZone.forOffsetHours(timezoneOffset)).build();
+        assertThat(tzRounding.round(0), equalTo(0l - TimeValue.timeValueHours(24 + timezoneOffset).millis()));
+        assertThat(tzRounding.nextRoundingValue(0l - TimeValue.timeValueHours(24 + timezoneOffset).millis()), equalTo(0l - TimeValue.timeValueHours(timezoneOffset).millis()));
 
-        tzRounding = TimeZoneRounding.builder(DateTimeUnit.DAY_OF_MONTH).preZone(DateTimeZone.forOffsetHours(-2)).postZone(DateTimeZone.forOffsetHours(-2)).build();
-        assertThat(tzRounding.round(0), equalTo(0l - TimeValue.timeValueHours(26).millis()));
-        assertThat(tzRounding.nextRoundingValue(0l - TimeValue.timeValueHours(26).millis()), equalTo(-TimeValue.timeValueHours(2).millis()));
-
-        tzRounding = TimeZoneRounding.builder(DateTimeUnit.DAY_OF_MONTH).preZone(DateTimeZone.forOffsetHours(-2)).build();
-        assertThat(tzRounding.round(utc("2009-02-03T01:01:01")), equalTo(utc("2009-02-02T00:00:00")));
-        assertThat(tzRounding.nextRoundingValue(utc("2009-02-02T00:00:00")), equalTo(utc("2009-02-03T00:00:00")));
-
-        tzRounding = TimeZoneRounding.builder(DateTimeUnit.DAY_OF_MONTH).preZone(DateTimeZone.forOffsetHours(-2)).postZone(DateTimeZone.forOffsetHours(-2)).build();
-        assertThat(tzRounding.round(utc("2009-02-03T01:01:01")), equalTo(time("2009-02-02T00:00:00", DateTimeZone.forOffsetHours(+2))));
-        assertThat(tzRounding.nextRoundingValue(time("2009-02-02T00:00:00", DateTimeZone.forOffsetHours(+2))), equalTo(time("2009-02-03T00:00:00", DateTimeZone.forOffsetHours(+2))));
+        // date in Feb-3rd, but still in Feb-2nd in -02:00 timezone
+        tzRounding = TimeZoneRounding.builder(DateTimeUnit.DAY_OF_MONTH).timeZone(DateTimeZone.forOffsetHours(-2)).build();
+        assertThat(tzRounding.round(utc("2009-02-03T01:01:01")), equalTo(utc("2009-02-02T02:00:00")));
+        long roundKey = tzRounding.roundKey(utc("2009-02-03T01:01:01"));
+        assertThat(roundKey, equalTo(tzRounding.roundKey(utc("2009-02-02T02:00:00.000Z"))));
+        assertThat(tzRounding.valueForKey(roundKey), equalTo(utc("2009-02-02T02:00:00.000Z")));
+        assertThat(tzRounding.nextRoundingValue(utc("2009-02-02T02:00:00")), equalTo(utc("2009-02-03T02:00:00")));
+        
+        // date in Feb-3rd, also in -02:00 timezone
+        tzRounding = TimeZoneRounding.builder(DateTimeUnit.DAY_OF_MONTH).timeZone(DateTimeZone.forOffsetHours(-2)).build();
+        assertThat(tzRounding.round(utc("2009-02-03T02:01:01")), equalTo(utc("2009-02-03T02:00:00")));
+        roundKey = tzRounding.roundKey(utc("2009-02-03T02:01:01"));
+        assertThat(roundKey, equalTo(tzRounding.roundKey(utc("2009-02-03T02:00:00.000Z"))));
+        assertThat(tzRounding.valueForKey(roundKey), equalTo(utc("2009-02-03T02:00:00.000Z")));
+        assertThat(tzRounding.nextRoundingValue(utc("2009-02-03T02:00:00")), equalTo(utc("2009-02-04T02:00:00")));
     }
 
     @Test
     public void testTimeTimeZoneRounding() {
-        Rounding tzRounding = TimeZoneRounding.builder(DateTimeUnit.HOUR_OF_DAY).preZone(DateTimeZone.forOffsetHours(-2)).build();
+        // hour unit        
+        Rounding tzRounding = TimeZoneRounding.builder(DateTimeUnit.HOUR_OF_DAY).timeZone(DateTimeZone.forOffsetHours(-2)).build();
         assertThat(tzRounding.round(0), equalTo(0l));
         assertThat(tzRounding.nextRoundingValue(0l), equalTo(TimeValue.timeValueHours(1l).getMillis()));
 
-        tzRounding = TimeZoneRounding.builder(DateTimeUnit.HOUR_OF_DAY).preZone(DateTimeZone.forOffsetHours(-2)).postZone(DateTimeZone.forOffsetHours(-2)).build();
-        assertThat(tzRounding.round(0), equalTo(0l - TimeValue.timeValueHours(2).millis()));
-        assertThat(tzRounding.nextRoundingValue(0l - TimeValue.timeValueHours(2).millis()), equalTo(0l - TimeValue.timeValueHours(1).millis()));
-
-        tzRounding = TimeZoneRounding.builder(DateTimeUnit.HOUR_OF_DAY).preZone(DateTimeZone.forOffsetHours(-2)).build();
+        tzRounding = TimeZoneRounding.builder(DateTimeUnit.HOUR_OF_DAY).timeZone(DateTimeZone.forOffsetHours(-2)).build();
         assertThat(tzRounding.round(utc("2009-02-03T01:01:01")), equalTo(utc("2009-02-03T01:00:00")));
         assertThat(tzRounding.nextRoundingValue(utc("2009-02-03T01:00:00")), equalTo(utc("2009-02-03T02:00:00")));
-
-        tzRounding = TimeZoneRounding.builder(DateTimeUnit.HOUR_OF_DAY).preZone(DateTimeZone.forOffsetHours(-2)).postZone(DateTimeZone.forOffsetHours(-2)).build();
-        assertThat(tzRounding.round(utc("2009-02-03T01:01:01")), equalTo(time("2009-02-03T01:00:00", DateTimeZone.forOffsetHours(+2))));
-        assertThat(tzRounding.nextRoundingValue(time("2009-02-03T01:00:00", DateTimeZone.forOffsetHours(+2))), equalTo(time("2009-02-03T02:00:00", DateTimeZone.forOffsetHours(+2))));
     }
-    
+
     @Test
     public void testTimeTimeZoneRoundingDST() {
         Rounding tzRounding;
         // testing savings to non savings switch 
-        tzRounding = TimeZoneRounding.builder(DateTimeUnit.HOUR_OF_DAY).preZone(DateTimeZone.forID("UTC")).build();
+        tzRounding = TimeZoneRounding.builder(DateTimeUnit.HOUR_OF_DAY).timeZone(DateTimeZone.forID("UTC")).build();
         assertThat(tzRounding.round(time("2014-10-26T01:01:01", DateTimeZone.forID("CET"))), equalTo(time("2014-10-26T01:00:00", DateTimeZone.forID("CET"))));
         
-        tzRounding = TimeZoneRounding.builder(DateTimeUnit.HOUR_OF_DAY).preZone(DateTimeZone.forID("CET")).build();
+        tzRounding = TimeZoneRounding.builder(DateTimeUnit.HOUR_OF_DAY).timeZone(DateTimeZone.forID("CET")).build();
         assertThat(tzRounding.round(time("2014-10-26T01:01:01", DateTimeZone.forID("CET"))), equalTo(time("2014-10-26T01:00:00", DateTimeZone.forID("CET"))));
         
         // testing non savings to savings switch
-        tzRounding = TimeZoneRounding.builder(DateTimeUnit.HOUR_OF_DAY).preZone(DateTimeZone.forID("UTC")).build();
+        tzRounding = TimeZoneRounding.builder(DateTimeUnit.HOUR_OF_DAY).timeZone(DateTimeZone.forID("UTC")).build();
         assertThat(tzRounding.round(time("2014-03-30T01:01:01", DateTimeZone.forID("CET"))), equalTo(time("2014-03-30T01:00:00", DateTimeZone.forID("CET"))));
         
-        tzRounding = TimeZoneRounding.builder(DateTimeUnit.HOUR_OF_DAY).preZone(DateTimeZone.forID("CET")).build();
+        tzRounding = TimeZoneRounding.builder(DateTimeUnit.HOUR_OF_DAY).timeZone(DateTimeZone.forID("CET")).build();
         assertThat(tzRounding.round(time("2014-03-30T01:01:01", DateTimeZone.forID("CET"))), equalTo(time("2014-03-30T01:00:00", DateTimeZone.forID("CET"))));
         
         // testing non savings to savings switch (America/Chicago)
-        tzRounding = TimeZoneRounding.builder(DateTimeUnit.HOUR_OF_DAY).preZone(DateTimeZone.forID("UTC")).build();
+        tzRounding = TimeZoneRounding.builder(DateTimeUnit.HOUR_OF_DAY).timeZone(DateTimeZone.forID("UTC")).build();
         assertThat(tzRounding.round(time("2014-03-09T03:01:01", DateTimeZone.forID("America/Chicago"))), equalTo(time("2014-03-09T03:00:00", DateTimeZone.forID("America/Chicago"))));
         
-        tzRounding = TimeZoneRounding.builder(DateTimeUnit.HOUR_OF_DAY).preZone(DateTimeZone.forID("America/Chicago")).build();
+        tzRounding = TimeZoneRounding.builder(DateTimeUnit.HOUR_OF_DAY).timeZone(DateTimeZone.forID("America/Chicago")).build();
         assertThat(tzRounding.round(time("2014-03-09T03:01:01", DateTimeZone.forID("America/Chicago"))), equalTo(time("2014-03-09T03:00:00", DateTimeZone.forID("America/Chicago"))));
         
         // testing savings to non savings switch 2013 (America/Chicago)
-        tzRounding = TimeZoneRounding.builder(DateTimeUnit.HOUR_OF_DAY).preZone(DateTimeZone.forID("UTC")).build();
+        tzRounding = TimeZoneRounding.builder(DateTimeUnit.HOUR_OF_DAY).timeZone(DateTimeZone.forID("UTC")).build();
         assertThat(tzRounding.round(time("2013-11-03T06:01:01", DateTimeZone.forID("America/Chicago"))), equalTo(time("2013-11-03T06:00:00", DateTimeZone.forID("America/Chicago"))));
         
-        tzRounding = TimeZoneRounding.builder(DateTimeUnit.HOUR_OF_DAY).preZone(DateTimeZone.forID("America/Chicago")).build();
+        tzRounding = TimeZoneRounding.builder(DateTimeUnit.HOUR_OF_DAY).timeZone(DateTimeZone.forID("America/Chicago")).build();
         assertThat(tzRounding.round(time("2013-11-03T06:01:01", DateTimeZone.forID("America/Chicago"))), equalTo(time("2013-11-03T06:00:00", DateTimeZone.forID("America/Chicago"))));
         
         // testing savings to non savings switch 2014 (America/Chicago)
-        tzRounding = TimeZoneRounding.builder(DateTimeUnit.HOUR_OF_DAY).preZone(DateTimeZone.forID("UTC")).build();
+        tzRounding = TimeZoneRounding.builder(DateTimeUnit.HOUR_OF_DAY).timeZone(DateTimeZone.forID("UTC")).build();
         assertThat(tzRounding.round(time("2014-11-02T06:01:01", DateTimeZone.forID("America/Chicago"))), equalTo(time("2014-11-02T06:00:00", DateTimeZone.forID("America/Chicago"))));
         
-        tzRounding = TimeZoneRounding.builder(DateTimeUnit.HOUR_OF_DAY).preZone(DateTimeZone.forID("America/Chicago")).build();
+        tzRounding = TimeZoneRounding.builder(DateTimeUnit.HOUR_OF_DAY).timeZone(DateTimeZone.forID("America/Chicago")).build();
         assertThat(tzRounding.round(time("2014-11-02T06:01:01", DateTimeZone.forID("America/Chicago"))), equalTo(time("2014-11-02T06:00:00", DateTimeZone.forID("America/Chicago"))));
     }
 

--- a/src/test/java/org/elasticsearch/common/rounding/TimeZoneRoundingTests.java
+++ b/src/test/java/org/elasticsearch/common/rounding/TimeZoneRoundingTests.java
@@ -21,10 +21,13 @@ package org.elasticsearch.common.rounding;
 
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.test.ElasticsearchTestCase;
+import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.format.ISODateTimeFormat;
 import org.junit.Test;
 
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.equalTo;
 
 /**
@@ -45,7 +48,7 @@ public class TimeZoneRoundingTests extends ElasticsearchTestCase {
         assertThat(tzRounding.round(utc("2012-01-10T01:01:01")), equalTo(utc("2012-01-08T00:00:00.000Z")));
         assertThat(tzRounding.nextRoundingValue(utc("2012-01-08T00:00:00.000Z")), equalTo(utc("2012-01-15T00:00:00.000Z")));
     }
-    
+
     @Test
     public void testUTCIntervalRounding() {
         Rounding tzRounding = TimeZoneRounding.builder(TimeValue.timeValueHours(12)).build();
@@ -56,14 +59,14 @@ public class TimeZoneRoundingTests extends ElasticsearchTestCase {
         assertThat(tzRounding.nextRoundingValue(utc("2009-02-03T00:00:00.000Z")), equalTo(utc("2009-02-03T12:00:00.000Z")));
         assertThat(tzRounding.round(utc("2009-02-03T13:01:01")), equalTo(utc("2009-02-03T12:00:00.000Z")));
         assertThat(tzRounding.nextRoundingValue(utc("2009-02-03T12:00:00.000Z")), equalTo(utc("2009-02-04T00:00:00.000Z")));
-        
+
         tzRounding = TimeZoneRounding.builder(TimeValue.timeValueHours(48)).build();
         assertThat(tzRounding.round(utc("2009-02-03T01:01:01")), equalTo(utc("2009-02-03T00:00:00.000Z")));
         assertThat(tzRounding.nextRoundingValue(utc("2009-02-03T00:00:00.000Z")), equalTo(utc("2009-02-05T00:00:00.000Z")));
         assertThat(tzRounding.round(utc("2009-02-05T13:01:01")), equalTo(utc("2009-02-05T00:00:00.000Z")));
         assertThat(tzRounding.nextRoundingValue(utc("2009-02-05T00:00:00.000Z")), equalTo(utc("2009-02-07T00:00:00.000Z")));
     }
-    
+
     /**
      * test TimeIntervalTimeZoneRounding, (interval < 12h) with time zone shift
      */
@@ -75,7 +78,7 @@ public class TimeZoneRoundingTests extends ElasticsearchTestCase {
         assertThat(roundKey, equalTo(tzRounding.roundKey(utc("2009-02-02T19:00:00.000Z"))));
         assertThat(tzRounding.valueForKey(roundKey), equalTo(utc("2009-02-02T19:00:00.000Z")));
         assertThat(tzRounding.nextRoundingValue(utc("2009-02-02T19:00:00.000Z")), equalTo(utc("2009-02-03T01:00:00.000Z")));
-        
+
         assertThat(tzRounding.round(utc("2009-02-03T13:01:01")), equalTo(utc("2009-02-03T13:00:00.000Z")));
         assertThat(tzRounding.nextRoundingValue(utc("2009-02-03T13:00:00.000Z")), equalTo(utc("2009-02-03T19:00:00.000Z")));
     }
@@ -85,13 +88,13 @@ public class TimeZoneRoundingTests extends ElasticsearchTestCase {
      */
     @Test
     public void testDayIntervalTimeZoneRounding() {
-        Rounding tzRounding = TimeZoneRounding.builder(TimeValue.timeValueHours(12)).timeZone(DateTimeZone.forOffsetHours(-8)).preZoneAdjustLargeInterval(false).build();
+        Rounding tzRounding = TimeZoneRounding.builder(TimeValue.timeValueHours(12)).timeZone(DateTimeZone.forOffsetHours(-8)).build();
         assertThat(tzRounding.round(utc("2009-02-03T00:01:01")), equalTo(utc("2009-02-02T20:00:00.000Z")));
         long roundKey = tzRounding.roundKey(utc("2009-02-03T00:01:01"));
         assertThat(roundKey, equalTo(tzRounding.roundKey(utc("2009-02-02T20:00:00.000Z"))));
         assertThat(tzRounding.valueForKey(roundKey), equalTo(utc("2009-02-02T20:00:00.000Z")));
         assertThat(tzRounding.nextRoundingValue(utc("2009-02-02T20:00:00.000Z")), equalTo(utc("2009-02-03T08:00:00.000Z")));
-        
+
         assertThat(tzRounding.round(utc("2009-02-03T13:01:01")), equalTo(utc("2009-02-03T08:00:00.000Z")));
         assertThat(tzRounding.nextRoundingValue(utc("2009-02-03T08:00:00.000Z")), equalTo(utc("2009-02-03T20:00:00.000Z")));
     }
@@ -110,7 +113,7 @@ public class TimeZoneRoundingTests extends ElasticsearchTestCase {
         assertThat(roundKey, equalTo(tzRounding.roundKey(utc("2009-02-02T02:00:00.000Z"))));
         assertThat(tzRounding.valueForKey(roundKey), equalTo(utc("2009-02-02T02:00:00.000Z")));
         assertThat(tzRounding.nextRoundingValue(utc("2009-02-02T02:00:00")), equalTo(utc("2009-02-03T02:00:00")));
-        
+
         // date in Feb-3rd, also in -02:00 timezone
         tzRounding = TimeZoneRounding.builder(DateTimeUnit.DAY_OF_MONTH).timeZone(DateTimeZone.forOffsetHours(-2)).build();
         assertThat(tzRounding.round(utc("2009-02-03T02:01:01")), equalTo(utc("2009-02-03T02:00:00")));
@@ -122,7 +125,7 @@ public class TimeZoneRoundingTests extends ElasticsearchTestCase {
 
     @Test
     public void testTimeTimeZoneRounding() {
-        // hour unit        
+        // hour unit
         Rounding tzRounding = TimeZoneRounding.builder(DateTimeUnit.HOUR_OF_DAY).timeZone(DateTimeZone.forOffsetHours(-2)).build();
         assertThat(tzRounding.round(0), equalTo(0l));
         assertThat(tzRounding.nextRoundingValue(0l), equalTo(TimeValue.timeValueHours(1l).getMillis()));
@@ -135,40 +138,77 @@ public class TimeZoneRoundingTests extends ElasticsearchTestCase {
     @Test
     public void testTimeTimeZoneRoundingDST() {
         Rounding tzRounding;
-        // testing savings to non savings switch 
+        // testing savings to non savings switch
         tzRounding = TimeZoneRounding.builder(DateTimeUnit.HOUR_OF_DAY).timeZone(DateTimeZone.forID("UTC")).build();
         assertThat(tzRounding.round(time("2014-10-26T01:01:01", DateTimeZone.forID("CET"))), equalTo(time("2014-10-26T01:00:00", DateTimeZone.forID("CET"))));
-        
+
         tzRounding = TimeZoneRounding.builder(DateTimeUnit.HOUR_OF_DAY).timeZone(DateTimeZone.forID("CET")).build();
         assertThat(tzRounding.round(time("2014-10-26T01:01:01", DateTimeZone.forID("CET"))), equalTo(time("2014-10-26T01:00:00", DateTimeZone.forID("CET"))));
-        
+
         // testing non savings to savings switch
         tzRounding = TimeZoneRounding.builder(DateTimeUnit.HOUR_OF_DAY).timeZone(DateTimeZone.forID("UTC")).build();
         assertThat(tzRounding.round(time("2014-03-30T01:01:01", DateTimeZone.forID("CET"))), equalTo(time("2014-03-30T01:00:00", DateTimeZone.forID("CET"))));
-        
+
         tzRounding = TimeZoneRounding.builder(DateTimeUnit.HOUR_OF_DAY).timeZone(DateTimeZone.forID("CET")).build();
         assertThat(tzRounding.round(time("2014-03-30T01:01:01", DateTimeZone.forID("CET"))), equalTo(time("2014-03-30T01:00:00", DateTimeZone.forID("CET"))));
-        
+
         // testing non savings to savings switch (America/Chicago)
         tzRounding = TimeZoneRounding.builder(DateTimeUnit.HOUR_OF_DAY).timeZone(DateTimeZone.forID("UTC")).build();
         assertThat(tzRounding.round(time("2014-03-09T03:01:01", DateTimeZone.forID("America/Chicago"))), equalTo(time("2014-03-09T03:00:00", DateTimeZone.forID("America/Chicago"))));
-        
+
         tzRounding = TimeZoneRounding.builder(DateTimeUnit.HOUR_OF_DAY).timeZone(DateTimeZone.forID("America/Chicago")).build();
         assertThat(tzRounding.round(time("2014-03-09T03:01:01", DateTimeZone.forID("America/Chicago"))), equalTo(time("2014-03-09T03:00:00", DateTimeZone.forID("America/Chicago"))));
-        
+
         // testing savings to non savings switch 2013 (America/Chicago)
         tzRounding = TimeZoneRounding.builder(DateTimeUnit.HOUR_OF_DAY).timeZone(DateTimeZone.forID("UTC")).build();
         assertThat(tzRounding.round(time("2013-11-03T06:01:01", DateTimeZone.forID("America/Chicago"))), equalTo(time("2013-11-03T06:00:00", DateTimeZone.forID("America/Chicago"))));
-        
+
         tzRounding = TimeZoneRounding.builder(DateTimeUnit.HOUR_OF_DAY).timeZone(DateTimeZone.forID("America/Chicago")).build();
         assertThat(tzRounding.round(time("2013-11-03T06:01:01", DateTimeZone.forID("America/Chicago"))), equalTo(time("2013-11-03T06:00:00", DateTimeZone.forID("America/Chicago"))));
-        
+
         // testing savings to non savings switch 2014 (America/Chicago)
         tzRounding = TimeZoneRounding.builder(DateTimeUnit.HOUR_OF_DAY).timeZone(DateTimeZone.forID("UTC")).build();
         assertThat(tzRounding.round(time("2014-11-02T06:01:01", DateTimeZone.forID("America/Chicago"))), equalTo(time("2014-11-02T06:00:00", DateTimeZone.forID("America/Chicago"))));
-        
+
         tzRounding = TimeZoneRounding.builder(DateTimeUnit.HOUR_OF_DAY).timeZone(DateTimeZone.forID("America/Chicago")).build();
         assertThat(tzRounding.round(time("2014-11-02T06:01:01", DateTimeZone.forID("America/Chicago"))), equalTo(time("2014-11-02T06:00:00", DateTimeZone.forID("America/Chicago"))));
+    }
+
+    /**
+     * randomized test on UTC/Day/TimeTimeZoneRoundingFloor with random time units and time zone offsets
+     */
+    @Test
+    public void testTimeZoneRoundingRandom() {
+        for (int i = 0; i < 1000; ++i) {
+            DateTimeUnit timeUnit = randomTimeUnit();
+            TimeZoneRounding rounding;
+            int timezoneOffset = randomIntBetween(-23, 23);
+            if (timezoneOffset==0) {
+                rounding = new TimeZoneRounding.UTCTimeZoneRoundingFloor(timeUnit);
+            } else {
+                if (randomBoolean()) {
+                    rounding = new TimeZoneRounding.DayTimeZoneRoundingFloor(timeUnit, DateTimeZone.forOffsetHours(timezoneOffset));
+                } else {
+                    rounding = new TimeZoneRounding.TimeTimeZoneRoundingFloor(timeUnit, DateTimeZone.forOffsetHours(timezoneOffset));
+                }
+            }
+            long date = Math.abs(randomLong() % ((long) 10e11));
+            final long roundedDate = rounding.round(date);
+            final long nextRoundingValue = rounding.nextRoundingValue(roundedDate);
+            assertThat("Rounding should be idempotent", roundedDate, equalTo(rounding.round(roundedDate)));
+            assertThat("Rounded value smaller or equal than unrounded, regardless of timezone", roundedDate, lessThanOrEqualTo(date));
+            assertThat("NextRounding value should be greater than date", nextRoundingValue, greaterThan(roundedDate));
+            assertThat("NextRounding value should be a rounded date", nextRoundingValue, equalTo(rounding.round(nextRoundingValue)));
+        }
+    }
+
+    private DateTimeUnit randomTimeUnit() {
+        byte id = (byte) randomIntBetween(1, 8);
+        return DateTimeUnit.resolve(id);
+    }
+
+    private String toUTCDateString(long time) {
+        return new DateTime(time, DateTimeZone.UTC).toString();
     }
 
     private long utc(String time) {

--- a/src/test/java/org/elasticsearch/common/rounding/TimeZoneRoundingTests.java
+++ b/src/test/java/org/elasticsearch/common/rounding/TimeZoneRoundingTests.java
@@ -243,6 +243,55 @@ public class TimeZoneRoundingTests extends ElasticsearchTestCase {
         }
     }
 
+    /**
+     * special test for DST switch from #9491
+     */
+    @Test
+    public void testAmbiguousHoursAfterDSTSwitch() {
+        Rounding tzRounding;
+        tzRounding = TimeZoneRounding.builder(DateTimeUnit.HOUR_OF_DAY).timeZone(DateTimeZone.forID("Asia/Jerusalem"))
+                .build();
+        assertThat(tzRounding.round(time("2014-10-25T22:30:00", DateTimeZone.UTC)), equalTo(time("2014-10-25T22:00:00", DateTimeZone.UTC)));
+        assertThat(tzRounding.round(time("2014-10-25T23:30:00", DateTimeZone.UTC)), equalTo(time("2014-10-25T23:00:00", DateTimeZone.UTC)));
+    }
+
+    @Test
+    public void testAdjustPreTimeZone() {
+        Rounding tzRounding;
+        // Day interval
+        tzRounding = TimeZoneRounding.builder(DateTimeUnit.DAY_OF_MONTH).timeZone(DateTimeZone.forID("Asia/Jerusalem"))
+                .build();
+        assertThat(tzRounding.round(time("2014-11-11T17:00:00", DateTimeZone.forID("Asia/Jerusalem"))),
+                equalTo(time("2014-11-11T00:00:00", DateTimeZone.forID("Asia/Jerusalem"))));
+        // DST on
+        assertThat(tzRounding.round(time("2014-08-11T17:00:00", DateTimeZone.forID("Asia/Jerusalem"))),
+                equalTo(time("2014-08-11T00:00:00", DateTimeZone.forID("Asia/Jerusalem"))));
+        // Day of switching DST on -> off
+        assertThat(tzRounding.round(time("2014-10-26T17:00:00", DateTimeZone.forID("Asia/Jerusalem"))),
+                equalTo(time("2014-10-26T00:00:00", DateTimeZone.forID("Asia/Jerusalem"))));
+        // Day of switching DST off -> on
+        assertThat(tzRounding.round(time("2015-03-27T17:00:00", DateTimeZone.forID("Asia/Jerusalem"))),
+                equalTo(time("2015-03-27T00:00:00", DateTimeZone.forID("Asia/Jerusalem"))));
+        // Month interval
+        tzRounding = TimeZoneRounding.builder(DateTimeUnit.MONTH_OF_YEAR).timeZone(DateTimeZone.forID("Asia/Jerusalem"))
+                .build();
+        assertThat(tzRounding.round(time("2014-11-11T17:00:00", DateTimeZone.forID("Asia/Jerusalem"))),
+                equalTo(time("2014-11-01T00:00:00", DateTimeZone.forID("Asia/Jerusalem"))));
+        // DST on
+        assertThat(tzRounding.round(time("2014-10-10T17:00:00", DateTimeZone.forID("Asia/Jerusalem"))),
+                equalTo(time("2014-10-01T00:00:00", DateTimeZone.forID("Asia/Jerusalem"))));
+        // Year interval
+        tzRounding = TimeZoneRounding.builder(DateTimeUnit.YEAR_OF_CENTURY).timeZone(DateTimeZone.forID("Asia/Jerusalem"))
+                .build();
+        assertThat(tzRounding.round(time("2014-11-11T17:00:00", DateTimeZone.forID("Asia/Jerusalem"))),
+                equalTo(time("2014-01-01T00:00:00", DateTimeZone.forID("Asia/Jerusalem"))));
+        // Two time stamps in same year ("Double buckets" bug in 1.3.7)
+        tzRounding = TimeZoneRounding.builder(DateTimeUnit.YEAR_OF_CENTURY).timeZone(DateTimeZone.forID("Asia/Jerusalem"))
+                .build();
+        assertThat(tzRounding.round(time("2014-11-11T17:00:00", DateTimeZone.forID("Asia/Jerusalem"))),
+                equalTo(tzRounding.round(time("2014-08-11T17:00:00", DateTimeZone.forID("Asia/Jerusalem")))));
+    }
+
     private DateTimeUnit randomTimeUnit() {
         byte id = (byte) randomIntBetween(1, 8);
         return DateTimeUnit.resolve(id);

--- a/src/test/java/org/elasticsearch/common/rounding/TimeZoneRoundingTests.java
+++ b/src/test/java/org/elasticsearch/common/rounding/TimeZoneRoundingTests.java
@@ -37,7 +37,7 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 public class TimeZoneRoundingTests extends ElasticsearchTestCase {
 
     @Test
-    public void testUTCMonthRounding() {
+    public void testUTCTimeUnitRounding() {
         Rounding tzRounding = TimeZoneRounding.builder(DateTimeUnit.MONTH_OF_YEAR).build();
         assertThat(tzRounding.round(utc("2009-02-03T01:01:01")), equalTo(utc("2009-02-01T00:00:00.000Z")));
         assertThat(tzRounding.nextRoundingValue(utc("2009-02-01T00:00:00.000Z")), equalTo(utc("2009-03-01T00:00:00.000Z")));
@@ -150,7 +150,7 @@ public class TimeZoneRoundingTests extends ElasticsearchTestCase {
     }
 
     @Test
-    public void testTimeTimeZoneRoundingDST() {
+    public void testTimeUnitRoundingDST() {
         Rounding tzRounding;
         // testing savings to non savings switch
         tzRounding = TimeZoneRounding.builder(DateTimeUnit.HOUR_OF_DAY).timeZone(DateTimeZone.forID("UTC")).build();
@@ -199,8 +199,7 @@ public class TimeZoneRoundingTests extends ElasticsearchTestCase {
     }
 
     /**
-     * randomized test on UTC/Day/TimeTimeZoneRoundingFloor with random time
-     * units and time zone offsets
+     * randomized test on TimeUnitRounding with random time units and time zone offsets
      */
     @Test
     public void testTimeZoneRoundingRandom() {
@@ -220,8 +219,7 @@ public class TimeZoneRoundingTests extends ElasticsearchTestCase {
     }
 
     /**
-     * randomized test on UTC/Day/TimeIntervalTimeZoneRounding with random
-     * interval and time zone offsets
+     * randomized test on TimeIntervalRounding with random interval and time zone offsets
      */
     @Test
     public void testIntervalRoundingRandom() {
@@ -251,11 +249,7 @@ public class TimeZoneRoundingTests extends ElasticsearchTestCase {
         tzRounding = TimeZoneRounding.builder(DateTimeUnit.HOUR_OF_DAY).timeZone(DateTimeZone.forID("Asia/Jerusalem")).build();
         assertThat(tzRounding.round(time("2014-10-25T22:30:00", DateTimeZone.UTC)), equalTo(time("2014-10-25T22:00:00", DateTimeZone.UTC)));
         assertThat(tzRounding.round(time("2014-10-25T23:30:00", DateTimeZone.UTC)), equalTo(time("2014-10-25T23:00:00", DateTimeZone.UTC)));
-    }
 
-    @Test
-    public void testAdjustPreTimeZone() {
-        Rounding tzRounding;
         // Day interval
         tzRounding = TimeZoneRounding.builder(DateTimeUnit.DAY_OF_MONTH).timeZone(DateTimeZone.forID("Asia/Jerusalem")).build();
         assertThat(tzRounding.round(time("2014-11-11T17:00:00", DateTimeZone.forID("Asia/Jerusalem"))),

--- a/src/test/java/org/elasticsearch/common/rounding/TimeZoneRoundingTests.java
+++ b/src/test/java/org/elasticsearch/common/rounding/TimeZoneRoundingTests.java
@@ -28,9 +28,9 @@ import org.junit.Test;
 
 import java.util.concurrent.TimeUnit;
 
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
-import static org.hamcrest.Matchers.equalTo;
 
 /**
  */
@@ -108,8 +108,16 @@ public class TimeZoneRoundingTests extends ElasticsearchTestCase {
         assertThat(tzRounding.round(0), equalTo(0l - TimeValue.timeValueHours(24 + timezoneOffset).millis()));
         assertThat(tzRounding.nextRoundingValue(0l - TimeValue.timeValueHours(24 + timezoneOffset).millis()), equalTo(0l - TimeValue.timeValueHours(timezoneOffset).millis()));
 
+        tzRounding = TimeZoneRounding.builder(DateTimeUnit.DAY_OF_MONTH).timeZone(DateTimeZone.forID("-08:00")).build();
+        assertThat(tzRounding.round(utc("2012-04-01T04:15:30Z")), equalTo(utc("2012-03-31T08:00:00Z")));
+        assertThat(toUTCDateString(tzRounding.nextRoundingValue(utc("2012-03-31T08:00:00Z"))), equalTo(toUTCDateString(utc("2012-04-01T08:0:00Z"))));
+
+        tzRounding = TimeZoneRounding.builder(DateTimeUnit.MONTH_OF_YEAR).timeZone(DateTimeZone.forID("-08:00")).build();
+        assertThat(tzRounding.round(utc("2012-04-01T04:15:30Z")), equalTo(utc("2012-03-01T08:00:00Z")));
+        assertThat(toUTCDateString(tzRounding.nextRoundingValue(utc("2012-03-01T08:00:00Z"))), equalTo(toUTCDateString(utc("2012-04-01T08:0:00Z"))));
+
         // date in Feb-3rd, but still in Feb-2nd in -02:00 timezone
-        tzRounding = TimeZoneRounding.builder(DateTimeUnit.DAY_OF_MONTH).timeZone(DateTimeZone.forOffsetHours(-2)).build();
+        tzRounding = TimeZoneRounding.builder(DateTimeUnit.DAY_OF_MONTH).timeZone(DateTimeZone.forID("-02:00")).build();
         assertThat(tzRounding.round(utc("2009-02-03T01:01:01")), equalTo(utc("2009-02-02T02:00:00")));
         long roundKey = tzRounding.roundKey(utc("2009-02-03T01:01:01"));
         assertThat(roundKey, equalTo(tzRounding.roundKey(utc("2009-02-02T02:00:00.000Z"))));
@@ -117,7 +125,7 @@ public class TimeZoneRoundingTests extends ElasticsearchTestCase {
         assertThat(tzRounding.nextRoundingValue(utc("2009-02-02T02:00:00")), equalTo(utc("2009-02-03T02:00:00")));
 
         // date in Feb-3rd, also in -02:00 timezone
-        tzRounding = TimeZoneRounding.builder(DateTimeUnit.DAY_OF_MONTH).timeZone(DateTimeZone.forOffsetHours(-2)).build();
+        tzRounding = TimeZoneRounding.builder(DateTimeUnit.DAY_OF_MONTH).timeZone(DateTimeZone.forID("-02:00")).build();
         assertThat(tzRounding.round(utc("2009-02-03T02:01:01")), equalTo(utc("2009-02-03T02:00:00")));
         roundKey = tzRounding.roundKey(utc("2009-02-03T02:01:01"));
         assertThat(roundKey, equalTo(tzRounding.roundKey(utc("2009-02-03T02:00:00.000Z"))));

--- a/src/test/java/org/elasticsearch/indices/cache/query/IndicesQueryCacheTests.java
+++ b/src/test/java/org/elasticsearch/indices/cache/query/IndicesQueryCacheTests.java
@@ -49,7 +49,7 @@ public class IndicesQueryCacheTests extends ElasticsearchIntegrationTest {
         // which used to not work well with the query cache because of the handles stream output
         // see #9500
         final SearchResponse r1 = client().prepareSearch("index").setSearchType(SearchType.COUNT)
-            .addAggregation(dateHistogram("histo").field("f").preZone("+01:00").minDocCount(0).interval(DateHistogramInterval.MONTH)).get();
+            .addAggregation(dateHistogram("histo").field("f").timeZone("+01:00").minDocCount(0).interval(DateHistogramInterval.MONTH)).get();
         assertSearchResponse(r1);
 
         // The cached is actually used
@@ -57,7 +57,7 @@ public class IndicesQueryCacheTests extends ElasticsearchIntegrationTest {
 
         for (int i = 0; i < 10; ++i) {
             final SearchResponse r2 = client().prepareSearch("index").setSearchType(SearchType.COUNT)
-                    .addAggregation(dateHistogram("histo").field("f").preZone("+01:00").minDocCount(0).interval(DateHistogramInterval.MONTH)).get();
+                    .addAggregation(dateHistogram("histo").field("f").timeZone("+01:00").minDocCount(0).interval(DateHistogramInterval.MONTH)).get();
             assertSearchResponse(r2);
             Histogram h1 = r1.getAggregations().get("histo");
             Histogram h2 = r2.getAggregations().get("histo");

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/DateHistogramOffsetTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/DateHistogramOffsetTests.java
@@ -53,7 +53,7 @@ import static org.hamcrest.core.IsNull.notNullValue;
 @ElasticsearchIntegrationTest.ClusterScope(scope=ElasticsearchIntegrationTest.Scope.SUITE)
 public class DateHistogramOffsetTests extends ElasticsearchIntegrationTest {
 
-    private static final String DATE_FORMAT = "YY-MM-DD:hh-mm-ss";
+    private static final String DATE_FORMAT = "yyyy-MM-dd:hh-mm-ss";
 
     private DateTime date(String date) {
         return DateFieldMapper.Defaults.DATE_TIME_FORMATTER.parser().parseDateTime(date);

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/DateHistogramTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/DateHistogramTests.java
@@ -1028,13 +1028,11 @@ public class DateHistogramTests extends ElasticsearchIntegrationTest {
         List<? extends Histogram.Bucket> buckets = histo.getBuckets();
         assertThat(buckets.size(), equalTo(2));
 
-        DateTime key = new DateTime(2014, 3, 10, 2, 0, DateTimeZone.UTC);
         Histogram.Bucket bucket = buckets.get(0);
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo("2014-03-10:02-00-00"));
         assertThat(bucket.getDocCount(), equalTo(2l));
 
-        key = new DateTime(2014, 3, 11, 2, 0, DateTimeZone.UTC);
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo("2014-03-11:02-00-00"));

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/DateHistogramTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/DateHistogramTests.java
@@ -43,6 +43,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
@@ -55,6 +56,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSear
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsNull.notNullValue;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 
 /**
  *
@@ -75,21 +77,15 @@ public class DateHistogramTests extends ElasticsearchIntegrationTest {
     }
 
     private IndexRequestBuilder indexDoc(String idx, DateTime date, int value) throws Exception {
-        return client().prepareIndex(idx, "type").setSource(jsonBuilder()
-                .startObject()
-                .field("date", date)
-                .field("value", value)
-                .startArray("dates").value(date).value(date.plusMonths(1).plusDays(1)).endArray()
-                .endObject());
+        return client().prepareIndex(idx, "type").setSource(
+                jsonBuilder().startObject().field("date", date).field("value", value).startArray("dates").value(date)
+                        .value(date.plusMonths(1).plusDays(1)).endArray().endObject());
     }
 
     private IndexRequestBuilder indexDoc(int month, int day, int value) throws Exception {
-        return client().prepareIndex("idx", "type").setSource(jsonBuilder()
-                .startObject()
-                .field("value", value)
-                .field("date", date(month, day))
-                .startArray("dates").value(date(month, day)).value(date(month + 1, day + 1)).endArray()
-                .endObject());
+        return client().prepareIndex("idx", "type").setSource(
+                jsonBuilder().startObject().field("value", value).field("date", date(month, day)).startArray("dates")
+                        .value(date(month, day)).value(date(month + 1, day + 1)).endArray().endObject());
     }
 
     @Override
@@ -100,16 +96,14 @@ public class DateHistogramTests extends ElasticsearchIntegrationTest {
         prepareCreate("empty_bucket_idx").addMapping("type", "value", "type=integer").execute().actionGet();
         List<IndexRequestBuilder> builders = new ArrayList<>();
         for (int i = 0; i < 2; i++) {
-            builders.add(client().prepareIndex("empty_bucket_idx", "type", ""+i).setSource(jsonBuilder()
-                    .startObject()
-                    .field("value", i*2)
-                    .endObject()));
+            builders.add(client().prepareIndex("empty_bucket_idx", "type", "" + i).setSource(
+                    jsonBuilder().startObject().field("value", i * 2).endObject()));
         }
-        builders.addAll(Arrays.asList(
-                indexDoc(1, 2, 1),  // date: Jan 2, dates: Jan 2, Feb 3
-                indexDoc(2, 2, 2),  // date: Feb 2, dates: Feb 2, Mar 3
+        builders.addAll(Arrays.asList(indexDoc(1, 2, 1), // date: Jan 2, dates:
+                                                         // Jan 2, Feb 3
+                indexDoc(2, 2, 2), // date: Feb 2, dates: Feb 2, Mar 3
                 indexDoc(2, 15, 3), // date: Feb 15, dates: Feb 15, Mar 16
-                indexDoc(3, 2, 4),  // date: Mar 2, dates: Mar 2, Apr 3
+                indexDoc(3, 2, 4), // date: Mar 2, dates: Mar 2, Apr 3
                 indexDoc(3, 15, 5), // date: Mar 15, dates: Mar 15, Apr 16
                 indexDoc(3, 23, 6))); // date: Mar 23, dates: Mar 23, Apr 24
         indexRandom(true, builders);
@@ -128,11 +122,9 @@ public class DateHistogramTests extends ElasticsearchIntegrationTest {
     @Test
     public void singleValuedField() throws Exception {
         SearchResponse response = client().prepareSearch("idx")
-                .addAggregation(dateHistogram("histo").field("date").interval(DateHistogramInterval.MONTH))
-                .execute().actionGet();
+                .addAggregation(dateHistogram("histo").field("date").interval(DateHistogramInterval.MONTH)).execute().actionGet();
 
         assertSearchResponse(response);
-
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -167,28 +159,20 @@ public class DateHistogramTests extends ElasticsearchIntegrationTest {
         SearchResponse response;
         if (randomBoolean()) {
             response = client().prepareSearch("idx")
-                .addAggregation(dateHistogram("histo").field("date").interval(DateHistogramInterval.DAY).timeZone("+01:00"))
-                .execute().actionGet();
+                    .addAggregation(dateHistogram("histo").field("date").interval(DateHistogramInterval.DAY).timeZone("+01:00")).execute()
+                    .actionGet();
         } else {
             // checking time_zone setting as an int
-            response = client().prepareSearch("idx")
-                .addAggregation(new AbstractAggregationBuilder("histo", "date_histogram") {
-                    @Override
-                    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-                        return builder.startObject(getName())
-                                .startObject(type)
-                                    .field("field", "date")
-                                    .field("interval", "1d")
-                                    .field("time_zone", +1)
-                                .endObject()
-                            .endObject();
-                    }
-                })
-                .execute().actionGet();
+            response = client().prepareSearch("idx").addAggregation(new AbstractAggregationBuilder("histo", "date_histogram") {
+                @Override
+                public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+                    return builder.startObject(getName()).startObject(type).field("field", "date").field("interval", "1d")
+                            .field("time_zone", +1).endObject().endObject();
+                }
+            }).execute().actionGet();
         }
 
         assertSearchResponse(response);
-
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -242,14 +226,10 @@ public class DateHistogramTests extends ElasticsearchIntegrationTest {
     @Test
     public void singleValuedField_OrderedByKeyAsc() throws Exception {
         SearchResponse response = client().prepareSearch("idx")
-                .addAggregation(dateHistogram("histo")
-                        .field("date")
-                        .interval(DateHistogramInterval.MONTH)
-.order(Histogram.Order.KEY_ASC))
+                .addAggregation(dateHistogram("histo").field("date").interval(DateHistogramInterval.MONTH).order(Histogram.Order.KEY_ASC))
                 .execute().actionGet();
 
         assertSearchResponse(response);
-
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -267,14 +247,10 @@ public class DateHistogramTests extends ElasticsearchIntegrationTest {
     @Test
     public void singleValuedField_OrderedByKeyDesc() throws Exception {
         SearchResponse response = client().prepareSearch("idx")
-                .addAggregation(dateHistogram("histo")
-                        .field("date")
-                        .interval(DateHistogramInterval.MONTH)
-.order(Histogram.Order.KEY_DESC))
+                .addAggregation(dateHistogram("histo").field("date").interval(DateHistogramInterval.MONTH).order(Histogram.Order.KEY_DESC))
                 .execute().actionGet();
 
         assertSearchResponse(response);
-
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -290,15 +266,12 @@ public class DateHistogramTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void singleValuedField_OrderedByCountAsc() throws Exception {
-        SearchResponse response = client().prepareSearch("idx")
-                .addAggregation(dateHistogram("histo")
-                        .field("date")
-                        .interval(DateHistogramInterval.MONTH)
-.order(Histogram.Order.COUNT_ASC))
+        SearchResponse response = client()
+                .prepareSearch("idx")
+                .addAggregation(dateHistogram("histo").field("date").interval(DateHistogramInterval.MONTH).order(Histogram.Order.COUNT_ASC))
                 .execute().actionGet();
 
         assertSearchResponse(response);
-
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -314,15 +287,13 @@ public class DateHistogramTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void singleValuedField_OrderedByCountDesc() throws Exception {
-        SearchResponse response = client().prepareSearch("idx")
-                .addAggregation(dateHistogram("histo")
-                        .field("date")
-                        .interval(DateHistogramInterval.MONTH)
-.order(Histogram.Order.COUNT_DESC))
+        SearchResponse response = client()
+                .prepareSearch("idx")
+                .addAggregation(
+                        dateHistogram("histo").field("date").interval(DateHistogramInterval.MONTH).order(Histogram.Order.COUNT_DESC))
                 .execute().actionGet();
 
         assertSearchResponse(response);
-
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -338,13 +309,13 @@ public class DateHistogramTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void singleValuedField_WithSubAggregation() throws Exception {
-        SearchResponse response = client().prepareSearch("idx")
-                .addAggregation(dateHistogram("histo").field("date").interval(DateHistogramInterval.MONTH)
-                    .subAggregation(sum("sum").field("value")))
-                .execute().actionGet();
+        SearchResponse response = client()
+                .prepareSearch("idx")
+                .addAggregation(
+                        dateHistogram("histo").field("date").interval(DateHistogramInterval.MONTH)
+                                .subAggregation(sum("sum").field("value"))).execute().actionGet();
 
         assertSearchResponse(response);
-
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -398,12 +369,10 @@ public class DateHistogramTests extends ElasticsearchIntegrationTest {
     @Test
     public void singleValuedField_WithSubAggregation_Inherited() throws Exception {
         SearchResponse response = client().prepareSearch("idx")
-                .addAggregation(dateHistogram("histo").field("date").interval(DateHistogramInterval.MONTH)
-                        .subAggregation(max("max")))
+                .addAggregation(dateHistogram("histo").field("date").interval(DateHistogramInterval.MONTH).subAggregation(max("max")))
                 .execute().actionGet();
 
         assertSearchResponse(response);
-
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -444,16 +413,14 @@ public class DateHistogramTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void singleValuedField_OrderedBySubAggregationAsc() throws Exception {
-        SearchResponse response = client().prepareSearch("idx")
-                .addAggregation(dateHistogram("histo")
-                        .field("date")
-                        .interval(DateHistogramInterval.MONTH)
-                                .order(Histogram.Order.aggregation("sum", true))
-                        .subAggregation(max("sum").field("value")))
-                .execute().actionGet();
+        SearchResponse response = client()
+                .prepareSearch("idx")
+                .addAggregation(
+                        dateHistogram("histo").field("date").interval(DateHistogramInterval.MONTH)
+                                .order(Histogram.Order.aggregation("sum", true)).subAggregation(max("sum").field("value"))).execute()
+                .actionGet();
 
         assertSearchResponse(response);
-
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -469,16 +436,14 @@ public class DateHistogramTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void singleValuedField_OrderedBySubAggregationDesc() throws Exception {
-        SearchResponse response = client().prepareSearch("idx")
-                .addAggregation(dateHistogram("histo")
-                        .field("date")
-                        .interval(DateHistogramInterval.MONTH)
-                                .order(Histogram.Order.aggregation("sum", false))
-                        .subAggregation(max("sum").field("value")))
-                .execute().actionGet();
+        SearchResponse response = client()
+                .prepareSearch("idx")
+                .addAggregation(
+                        dateHistogram("histo").field("date").interval(DateHistogramInterval.MONTH)
+                                .order(Histogram.Order.aggregation("sum", false)).subAggregation(max("sum").field("value"))).execute()
+                .actionGet();
 
         assertSearchResponse(response);
-
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -494,12 +459,11 @@ public class DateHistogramTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void singleValuedField_OrderedByMultiValuedSubAggregationAsc_Inherited() throws Exception {
-        SearchResponse response = client().prepareSearch("idx")
-                .addAggregation(dateHistogram("histo")
-                        .field("date")
-                        .interval(DateHistogramInterval.MONTH)
-                                .order(Histogram.Order.aggregation("stats", "sum", true))
-                        .subAggregation(stats("stats").field("value")))
+        SearchResponse response = client()
+                .prepareSearch("idx")
+                .addAggregation(
+                        dateHistogram("histo").field("date").interval(DateHistogramInterval.MONTH)
+                                .order(Histogram.Order.aggregation("stats", "sum", true)).subAggregation(stats("stats").field("value")))
                 .execute().actionGet();
 
         assertSearchResponse(response);
@@ -518,16 +482,14 @@ public class DateHistogramTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void singleValuedField_OrderedByMultiValuedSubAggregationDesc() throws Exception {
-        SearchResponse response = client().prepareSearch("idx")
-                .addAggregation(dateHistogram("histo")
-                        .field("date")
-                        .interval(DateHistogramInterval.MONTH)
-                                .order(Histogram.Order.aggregation("stats", "sum", false))
-                        .subAggregation(stats("stats").field("value")))
+        SearchResponse response = client()
+                .prepareSearch("idx")
+                .addAggregation(
+                        dateHistogram("histo").field("date").interval(DateHistogramInterval.MONTH)
+                                .order(Histogram.Order.aggregation("stats", "sum", false)).subAggregation(stats("stats").field("value")))
                 .execute().actionGet();
 
         assertSearchResponse(response);
-
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -543,15 +505,13 @@ public class DateHistogramTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void singleValuedField_WithValueScript() throws Exception {
-        SearchResponse response = client().prepareSearch("idx")
-                .addAggregation(dateHistogram("histo")
-                        .field("date")
-                        .script("new DateTime(_value).plusMonths(1).getMillis()")
-                        .interval(DateHistogramInterval.MONTH))
-                .execute().actionGet();
+        SearchResponse response = client()
+                .prepareSearch("idx")
+                .addAggregation(
+                        dateHistogram("histo").field("date").script("new DateTime(_value).plusMonths(1).getMillis()")
+                                .interval(DateHistogramInterval.MONTH)).execute().actionGet();
 
         assertSearchResponse(response);
-
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -583,22 +543,16 @@ public class DateHistogramTests extends ElasticsearchIntegrationTest {
     }
 
     /*
-    [ Jan 2, Feb 3]
-    [ Feb 2, Mar 3]
-    [ Feb 15, Mar 16]
-    [ Mar 2, Apr 3]
-    [ Mar 15, Apr 16]
-    [ Mar 23, Apr 24]
+     * [ Jan 2, Feb 3] [ Feb 2, Mar 3] [ Feb 15, Mar 16] [ Mar 2, Apr 3] [ Mar
+     * 15, Apr 16] [ Mar 23, Apr 24]
      */
 
     @Test
     public void multiValuedField() throws Exception {
         SearchResponse response = client().prepareSearch("idx")
-                .addAggregation(dateHistogram("histo").field("dates").interval(DateHistogramInterval.MONTH))
-                .execute().actionGet();
+                .addAggregation(dateHistogram("histo").field("dates").interval(DateHistogramInterval.MONTH)).execute().actionGet();
 
         assertSearchResponse(response);
-
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -637,15 +591,13 @@ public class DateHistogramTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void multiValuedField_OrderedByKeyDesc() throws Exception {
-        SearchResponse response = client().prepareSearch("idx")
-                .addAggregation(dateHistogram("histo")
-                        .field("dates")
-                        .interval(DateHistogramInterval.MONTH)
-.order(Histogram.Order.COUNT_DESC))
+        SearchResponse response = client()
+                .prepareSearch("idx")
+                .addAggregation(
+                        dateHistogram("histo").field("dates").interval(DateHistogramInterval.MONTH).order(Histogram.Order.COUNT_DESC))
                 .execute().actionGet();
 
         assertSearchResponse(response);
-
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -671,28 +623,21 @@ public class DateHistogramTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getDocCount(), equalTo(1l));
     }
 
-
     /**
      * The script will change to document date values to the following:
      *
-     * doc 1: [ Feb 2, Mar 3]
-     * doc 2: [ Mar 2, Apr 3]
-     * doc 3: [ Mar 15, Apr 16]
-     * doc 4: [ Apr 2, May 3]
-     * doc 5: [ Apr 15, May 16]
-     * doc 6: [ Apr 23, May 24]
+     * doc 1: [ Feb 2, Mar 3] doc 2: [ Mar 2, Apr 3] doc 3: [ Mar 15, Apr 16]
+     * doc 4: [ Apr 2, May 3] doc 5: [ Apr 15, May 16] doc 6: [ Apr 23, May 24]
      */
     @Test
     public void multiValuedField_WithValueScript() throws Exception {
-        SearchResponse response = client().prepareSearch("idx")
-                .addAggregation(dateHistogram("histo")
-                        .field("dates")
-                        .script("new DateTime(_value, DateTimeZone.UTC).plusMonths(1).getMillis()")
-                        .interval(DateHistogramInterval.MONTH))
-                .execute().actionGet();
+        SearchResponse response = client()
+                .prepareSearch("idx")
+                .addAggregation(
+                        dateHistogram("histo").field("dates").script("new DateTime(_value, DateTimeZone.UTC).plusMonths(1).getMillis()")
+                                .interval(DateHistogramInterval.MONTH)).execute().actionGet();
 
         assertSearchResponse(response);
-
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -732,26 +677,20 @@ public class DateHistogramTests extends ElasticsearchIntegrationTest {
     /**
      * The script will change to document date values to the following:
      *
-     * doc 1: [ Feb 2, Mar 3]
-     * doc 2: [ Mar 2, Apr 3]
-     * doc 3: [ Mar 15, Apr 16]
-     * doc 4: [ Apr 2, May 3]
-     * doc 5: [ Apr 15, May 16]
-     * doc 6: [ Apr 23, May 24]
+     * doc 1: [ Feb 2, Mar 3] doc 2: [ Mar 2, Apr 3] doc 3: [ Mar 15, Apr 16]
+     * doc 4: [ Apr 2, May 3] doc 5: [ Apr 15, May 16] doc 6: [ Apr 23, May 24]
      *
      */
     @Test
     public void multiValuedField_WithValueScript_WithInheritedSubAggregator() throws Exception {
-        SearchResponse response = client().prepareSearch("idx")
-                .addAggregation(dateHistogram("histo")
-                        .field("dates")
-                        .script("new DateTime((long)_value, DateTimeZone.UTC).plusMonths(1).getMillis()")
-                        .interval(DateHistogramInterval.MONTH)
-                        .subAggregation(max("max")))
-                .execute().actionGet();
+        SearchResponse response = client()
+                .prepareSearch("idx")
+                .addAggregation(
+                        dateHistogram("histo").field("dates")
+                                .script("new DateTime((long)_value, DateTimeZone.UTC).plusMonths(1).getMillis()")
+                                .interval(DateHistogramInterval.MONTH).subAggregation(max("max"))).execute().actionGet();
 
         assertSearchResponse(response);
-
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -801,21 +740,15 @@ public class DateHistogramTests extends ElasticsearchIntegrationTest {
     }
 
     /**
-     * Jan 2
-     * Feb 2
-     * Feb 15
-     * Mar 2
-     * Mar 15
-     * Mar 23
+     * Jan 2 Feb 2 Feb 15 Mar 2 Mar 15 Mar 23
      */
     @Test
     public void script_SingleValue() throws Exception {
         SearchResponse response = client().prepareSearch("idx")
-                .addAggregation(dateHistogram("histo").script("doc['date'].value").interval(DateHistogramInterval.MONTH))
-                .execute().actionGet();
+                .addAggregation(dateHistogram("histo").script("doc['date'].value").interval(DateHistogramInterval.MONTH)).execute()
+                .actionGet();
 
         assertSearchResponse(response);
-
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -847,15 +780,13 @@ public class DateHistogramTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void script_SingleValue_WithSubAggregator_Inherited() throws Exception {
-        SearchResponse response = client().prepareSearch("idx")
-                .addAggregation(dateHistogram("histo")
-                        .script("doc['date'].value")
-                        .interval(DateHistogramInterval.MONTH)
-                        .subAggregation(max("max")))
+        SearchResponse response = client()
+                .prepareSearch("idx")
+                .addAggregation(
+                        dateHistogram("histo").script("doc['date'].value").interval(DateHistogramInterval.MONTH).subAggregation(max("max")))
                 .execute().actionGet();
 
         assertSearchResponse(response);
-
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -897,11 +828,10 @@ public class DateHistogramTests extends ElasticsearchIntegrationTest {
     @Test
     public void script_MultiValued() throws Exception {
         SearchResponse response = client().prepareSearch("idx")
-                .addAggregation(dateHistogram("histo").script("doc['dates'].values").interval(DateHistogramInterval.MONTH))
-                .execute().actionGet();
+                .addAggregation(dateHistogram("histo").script("doc['dates'].values").interval(DateHistogramInterval.MONTH)).execute()
+                .actionGet();
 
         assertSearchResponse(response);
-
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -938,26 +868,20 @@ public class DateHistogramTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getDocCount(), equalTo(3l));
     }
 
-      /*
-    [ Jan 2, Feb 3]
-    [ Feb 2, Mar 3]
-    [ Feb 15, Mar 16]
-    [ Mar 2, Apr 3]
-    [ Mar 15, Apr 16]
-    [ Mar 23, Apr 24]
+    /*
+     * [ Jan 2, Feb 3] [ Feb 2, Mar 3] [ Feb 15, Mar 16] [ Mar 2, Apr 3] [ Mar
+     * 15, Apr 16] [ Mar 23, Apr 24]
      */
 
     @Test
     public void script_MultiValued_WithAggregatorInherited() throws Exception {
-        SearchResponse response = client().prepareSearch("idx")
-                .addAggregation(dateHistogram("histo")
-                        .script("doc['dates'].values")
-                        .interval(DateHistogramInterval.MONTH)
-                        .subAggregation(max("max")))
-                .execute().actionGet();
+        SearchResponse response = client()
+                .prepareSearch("idx")
+                .addAggregation(
+                        dateHistogram("histo").script("doc['dates'].values").interval(DateHistogramInterval.MONTH)
+                                .subAggregation(max("max"))).execute().actionGet();
 
         assertSearchResponse(response);
-
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -1009,11 +933,9 @@ public class DateHistogramTests extends ElasticsearchIntegrationTest {
     @Test
     public void unmapped() throws Exception {
         SearchResponse response = client().prepareSearch("idx_unmapped")
-                .addAggregation(dateHistogram("histo").field("date").interval(DateHistogramInterval.MONTH))
-                .execute().actionGet();
+                .addAggregation(dateHistogram("histo").field("date").interval(DateHistogramInterval.MONTH)).execute().actionGet();
 
         assertSearchResponse(response);
-
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -1024,11 +946,9 @@ public class DateHistogramTests extends ElasticsearchIntegrationTest {
     @Test
     public void partiallyUnmapped() throws Exception {
         SearchResponse response = client().prepareSearch("idx", "idx_unmapped")
-                .addAggregation(dateHistogram("histo").field("date").interval(DateHistogramInterval.MONTH))
-                .execute().actionGet();
+                .addAggregation(dateHistogram("histo").field("date").interval(DateHistogramInterval.MONTH)).execute().actionGet();
 
         assertSearchResponse(response);
-
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -1060,10 +980,12 @@ public class DateHistogramTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void emptyAggregation() throws Exception {
-        SearchResponse searchResponse = client().prepareSearch("empty_bucket_idx")
+        SearchResponse searchResponse = client()
+                .prepareSearch("empty_bucket_idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(histogram("histo").field("value").interval(1l).minDocCount(0).subAggregation(dateHistogram("date_histo").interval(1)))
-                .execute().actionGet();
+                .addAggregation(
+                        histogram("histo").field("value").interval(1l).minDocCount(0)
+                                .subAggregation(dateHistogram("date_histo").interval(1))).execute().actionGet();
 
         assertThat(searchResponse.getHits().getTotalHits(), equalTo(2l));
         Histogram histo = searchResponse.getAggregations().get("histo");
@@ -1093,14 +1015,12 @@ public class DateHistogramTests extends ElasticsearchIntegrationTest {
         }
         indexRandom(true, reqs);
 
-        SearchResponse response = client().prepareSearch("idx2")
+        SearchResponse response = client()
+                .prepareSearch("idx2")
                 .setQuery(matchAllQuery())
-                .addAggregation(dateHistogram("date_histo")
-                        .field("date")
-                        .timeZone("-02:00")
-                        .interval(DateHistogramInterval.DAY)
-                        .format("yyyy-MM-dd:HH-mm-ss"))
-                .execute().actionGet();
+                .addAggregation(
+                        dateHistogram("date_histo").field("date").timeZone("-02:00").interval(DateHistogramInterval.DAY)
+                                .format("yyyy-MM-dd:HH-mm-ss")).execute().actionGet();
 
         assertThat(response.getHits().getTotalHits(), equalTo(5l));
 
@@ -1140,7 +1060,10 @@ public class DateHistogramTests extends ElasticsearchIntegrationTest {
 
         createIndex("idx2");
         int numOfBuckets = randomIntBetween(3, 6);
-        int emptyBucketIndex = randomIntBetween(1, numOfBuckets - 2); // should be in the middle
+        int emptyBucketIndex = randomIntBetween(1, numOfBuckets - 2); // should
+                                                                      // be in
+                                                                      // the
+                                                                      // middle
 
         long[] docCounts = new long[numOfBuckets];
         List<IndexRequestBuilder> builders = new ArrayList<>();
@@ -1162,7 +1085,8 @@ public class DateHistogramTests extends ElasticsearchIntegrationTest {
         DateTime lastDataBucketKey = baseKey.plusDays((numOfBuckets - 1) * interval);
 
         // randomizing the number of buckets on the min bound
-        // (can sometimes fall within the data range, but more frequently will fall before the data range)
+        // (can sometimes fall within the data range, but more frequently will
+        // fall before the data range)
         int addedBucketsLeft = randomIntBetween(0, numOfBuckets);
         DateTime boundsMinKey;
         if (frequently()) {
@@ -1174,7 +1098,8 @@ public class DateHistogramTests extends ElasticsearchIntegrationTest {
         DateTime boundsMin = boundsMinKey.plusDays(randomIntBetween(0, interval - 1));
 
         // randomizing the number of buckets on the max bound
-        // (can sometimes fall within the data range, but more frequently will fall after the data range)
+        // (can sometimes fall within the data range, but more frequently will
+        // fall after the data range)
         int addedBucketsRight = randomIntBetween(0, numOfBuckets);
         int boundsMaxKeyDelta = addedBucketsRight * interval;
         if (rarely()) {
@@ -1184,7 +1109,8 @@ public class DateHistogramTests extends ElasticsearchIntegrationTest {
         DateTime boundsMaxKey = lastDataBucketKey.plusDays(boundsMaxKeyDelta);
         DateTime boundsMax = boundsMaxKey.plusDays(randomIntBetween(0, interval - 1));
 
-        // it could be that the random bounds.min we chose ended up greater than bounds.max - this should
+        // it could be that the random bounds.min we chose ended up greater than
+        // bounds.max - this should
         // trigger an error
         boolean invalidBoundsError = boundsMin.isAfter(boundsMax);
 
@@ -1196,14 +1122,10 @@ public class DateHistogramTests extends ElasticsearchIntegrationTest {
         SearchResponse response = null;
         try {
             response = client().prepareSearch("idx2")
-                    .addAggregation(dateHistogram("histo")
-                            .field("date")
-                            .interval(DateHistogramInterval.days(interval))
-                            .minDocCount(0)
-                            // when explicitly specifying a format, the extended bounds should be defined by the same format
-                            .extendedBounds(format(boundsMin, pattern), format(boundsMax, pattern))
-                            .format(pattern))
-                    .execute().actionGet();
+                    .addAggregation(dateHistogram("histo").field("date").interval(DateHistogramInterval.days(interval)).minDocCount(0)
+                    // when explicitly specifying a format, the extended bounds
+                    // should be defined by the same format
+                            .extendedBounds(format(boundsMin, pattern), format(boundsMax, pattern)).format(pattern)).execute().actionGet();
 
             if (invalidBoundsError) {
                 fail("Expected an exception to be thrown when bounds.min is greater than bounds.max");
@@ -1240,20 +1162,19 @@ public class DateHistogramTests extends ElasticsearchIntegrationTest {
     @Test
     public void singleValue_WithMultipleDateFormatsFromMapping() throws Exception {
 
-        String mappingJson = jsonBuilder().startObject().startObject("type").startObject("properties").startObject("date").field("type", "date").field("format", "dateOptionalTime||dd-MM-yyyy").endObject().endObject().endObject().endObject().string();
+        String mappingJson = jsonBuilder().startObject().startObject("type").startObject("properties").startObject("date")
+                .field("type", "date").field("format", "dateOptionalTime||dd-MM-yyyy").endObject().endObject().endObject().endObject()
+                .string();
         prepareCreate("idx2").addMapping("type", mappingJson).execute().actionGet();
         IndexRequestBuilder[] reqs = new IndexRequestBuilder[5];
         for (int i = 0; i < reqs.length; i++) {
-            reqs[i] = client().prepareIndex("idx2", "type", "" + i).setSource(jsonBuilder().startObject().field("date", "10-03-2014").endObject());
+            reqs[i] = client().prepareIndex("idx2", "type", "" + i).setSource(
+                    jsonBuilder().startObject().field("date", "10-03-2014").endObject());
         }
         indexRandom(true, reqs);
 
-        SearchResponse response = client().prepareSearch("idx2")
-                .setQuery(matchAllQuery())
-                .addAggregation(dateHistogram("date_histo")
-                        .field("date")
-                        .interval(DateHistogramInterval.DAY))
-                .execute().actionGet();
+        SearchResponse response = client().prepareSearch("idx2").setQuery(matchAllQuery())
+                .addAggregation(dateHistogram("date_histo").field("date").interval(DateHistogramInterval.DAY)).execute().actionGet();
 
         assertThat(response.getHits().getTotalHits(), equalTo(5l));
 
@@ -1270,8 +1191,10 @@ public class DateHistogramTests extends ElasticsearchIntegrationTest {
     }
 
     public void testIssue6965() {
-        SearchResponse response = client().prepareSearch("idx")
-                .addAggregation(dateHistogram("histo").field("date").timeZone("+01:00").interval(DateHistogramInterval.MONTH).minDocCount(0))
+        SearchResponse response = client()
+                .prepareSearch("idx")
+                .addAggregation(
+                        dateHistogram("histo").field("date").timeZone("+01:00").interval(DateHistogramInterval.MONTH).minDocCount(0))
                 .execute().actionGet();
 
         assertSearchResponse(response);
@@ -1302,5 +1225,19 @@ public class DateHistogramTests extends ElasticsearchIntegrationTest {
         assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
         assertThat(((DateTime) bucket.getKey()), equalTo(key));
         assertThat(bucket.getDocCount(), equalTo(3l));
+    }
+
+    public void testDSTBoundaryIssue9491() throws InterruptedException, ExecutionException {
+        assertAcked(client().admin().indices().prepareCreate("test9491").addMapping("type", "d", "type=date").get());
+        indexRandom(true, client().prepareIndex("test9491", "type").setSource("d", "2014-10-08T13:00:00Z"),
+                client().prepareIndex("test9491", "type").setSource("d", "2014-11-08T13:00:00Z"));
+        ensureSearchable("test9491");
+        SearchResponse response = client().prepareSearch("test9491")
+                .addAggregation(dateHistogram("histo").field("d").interval(DateHistogramInterval.YEAR).timeZone("Asia/Jerusalem"))
+                .execute().actionGet();
+        assertSearchResponse(response);
+        Histogram histo = response.getAggregations().get("histo");
+        assertThat(histo.getBuckets().size(), equalTo(1));
+        assertThat(histo.getBuckets().get(0).getKeyAsString(), equalTo("2013-12-31T22:00:00.000Z"));
     }
 }


### PR DESCRIPTION
Remove the current time zone options `pre_zone` and `post_zone` in favor of a simplified `time_zone` option.
The former were hard to understand and made it possible to return dates that are not in UTC. The `time_zone` parameter can be used to compute the buckets in the specified time zone and the buckets are returned in UTC.
Also the `pre_zone_adjust_large_interval` parameter is removed because now buckets are always returned in UTC.

Closes #9062
