### PR TITLE
Upgrade: Change wait_for_completion to default to true

### DIFF
--- a/docs/reference/indices/upgrade.asciidoc
+++ b/docs/reference/indices/upgrade.asciidoc
@@ -25,7 +25,7 @@ The `upgrade` API accepts the following request parameters:
 
 [horizontal]
 `wait_for_completion`:: Should the request wait for the upgrade to complete. Defaults
-to `false`.
+to `true`.
 
 [float]
 === Check upgrade status

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/upgrade/RestUpgradeAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/upgrade/RestUpgradeAction.java
@@ -90,7 +90,7 @@ public class RestUpgradeAction extends BaseRestHandler {
     
     void handlePost(RestRequest request, RestChannel channel, Client client) {
         OptimizeRequest optimizeReq = new OptimizeRequest(Strings.splitStringByCommaToArray(request.param("index")));
-        optimizeReq.waitForMerge(request.paramAsBoolean("wait_for_completion", false));
+        optimizeReq.waitForMerge(request.paramAsBoolean("wait_for_completion", true));
         optimizeReq.flush(true);
         optimizeReq.upgrade(true);
         optimizeReq.maxNumSegments(Integer.MAX_VALUE); // we just want to upgrade the segments, not actually optimize to a single segment


### PR DESCRIPTION
This has ended up being very trappy.  Most people don't realize the
parameter is there, and using a wildcard on index names for upgrade
will end up essentially bypassing the optimize concurrency controls
through its threadpool.

See #9638
