### PR TITLE
[nrt_suggester] New Lookup API

### DIFF
--- a/src/main/java/org/apache/lucene/search/suggest/analyzing/ContextAwareScorer.java
+++ b/src/main/java/org/apache/lucene/search/suggest/analyzing/ContextAwareScorer.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.lucene.search.suggest.analyzing;
+
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.fst.ByteSequenceOutputs;
+import org.apache.lucene.util.fst.Outputs;
+import org.apache.lucene.util.fst.PositiveIntOutputs;
+
+import java.util.Comparator;
+
+/**
+ * Pluggable scorer for {@link org.apache.lucene.search.suggest.analyzing.NRTSuggester}
+ *
+ * TODO: documentation and simplify
+ * @param <T>
+ */
+public abstract class ContextAwareScorer<T extends Comparable<T>> {
+
+    /**
+     * A unique name to identify this instance
+     */
+    protected abstract String name();
+
+    /**
+     * @return configuration for the weight output
+     */
+    protected abstract OutputConfiguration<T> getOutputConfiguration();
+
+    /**
+     *
+     * @param context provided score for the current search
+     * @param pathCost partial path cost
+     * @return true if the path should be pruned, false otherwise
+     */
+    protected abstract boolean prune(T context, T pathCost);
+
+    /**
+     *
+     * @param context provided score for the current search
+     * @return a comparator used to sort paths
+     */
+    protected abstract Comparator<T> comparator(T context);
+
+    /**
+     *
+     * @param context provided score for the current search
+     * @param result score of a record
+     * @return The score of the result
+     */
+    protected abstract T score(T context, T result);
+
+    /**
+     * TODO
+     * @param <T>
+     */
+    public static interface OutputConfiguration<T extends Comparable<T>> {
+
+        Outputs<T> outputSingleton();
+
+        T encode(T input);
+
+        T decode(T output);
+    }
+
+    /**
+     * Long based ContextAwareScorer
+     */
+    public static abstract class LongBased extends ContextAwareScorer<Long> {
+
+        @Override
+        protected OutputConfiguration<Long> getOutputConfiguration() {
+            return new OutputConfiguration<Long>() {
+                @Override
+                public Outputs<Long> outputSingleton() {
+                    return PositiveIntOutputs.getSingleton();
+                }
+
+                @Override
+                public Long encode(Long input) {
+                    if (input < 0 || input > Integer.MAX_VALUE) {
+                        throw new UnsupportedOperationException("cannot encode value: " + input);
+                    }
+                    return Integer.MAX_VALUE - input;
+                }
+
+                @Override
+                public Long decode(Long output) {
+                    return (Integer.MAX_VALUE - output);
+                }
+            };
+        }
+    }
+
+    /**
+     * BytesRef based ContextAwareScorer
+     */
+    public static abstract class BytesBased extends ContextAwareScorer<BytesRef> {
+
+        @Override
+        protected OutputConfiguration<BytesRef> getOutputConfiguration() {
+            return new OutputConfiguration<BytesRef>() {
+                @Override
+                public Outputs<BytesRef> outputSingleton() {
+                    return ByteSequenceOutputs.getSingleton();
+                }
+
+                @Override
+                public BytesRef encode(BytesRef input) {
+                    return input;
+                }
+
+                @Override
+                public BytesRef decode(BytesRef output) {
+                    return output;
+                }
+            };
+        }
+    }
+
+    public static final ContextAwareScorer<Long> DEFAULT = new LongBased() {
+        @Override
+        protected String name() {
+            return "default";
+        }
+
+        @Override
+        protected boolean prune(Long currentContext, Long pathCost) {
+            return false;
+        }
+
+        @Override
+        protected Comparator<Long> comparator(Long context) {
+            return new Comparator<Long>() {
+                @Override
+                public int compare(Long left, Long right) {
+                    return left.compareTo(right);
+                }
+            };
+        }
+
+        @Override
+        protected Long score(Long context, Long result) {
+            return result;
+        }
+    };
+}

--- a/src/main/java/org/apache/lucene/search/suggest/analyzing/DefaultCollector.java
+++ b/src/main/java/org/apache/lucene/search/suggest/analyzing/DefaultCollector.java
@@ -409,6 +409,8 @@ public class DefaultCollector<W> implements SegmentLookup.Collector<W> {
                     } else {
                         addDocValues(fieldInfo.getDocValuesType(), field);
                     }
+                } else {
+                    throw new IllegalArgumentException(field + " does not exist");
                 }
             }
         }

--- a/src/main/java/org/apache/lucene/search/suggest/analyzing/DefaultCollector.java
+++ b/src/main/java/org/apache/lucene/search/suggest/analyzing/DefaultCollector.java
@@ -20,36 +20,38 @@
 package org.apache.lucene.search.suggest.analyzing;
 
 import org.apache.lucene.document.Document;
-import org.apache.lucene.index.DocValuesType;
-import org.apache.lucene.index.FieldInfo;
-import org.apache.lucene.index.IndexableField;
-import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.*;
 import org.apache.lucene.util.BytesRef;
 
 import java.io.IOException;
 import java.util.*;
+import java.util.Map.Entry;
 
 /**
  * Default collector implementation
  *
- * TODO: add storedField and docValues lookup support support
- * NOTE: WIP
  */
 public class DefaultCollector<W> implements SegmentLookup.Collector<W> {
 
     private final List<Result<W>> results;
-    private final LeafReader reader;
-    private final Set<FieldInfo> fieldInfos;
-    private final Set<String> storedFields;
+    private final FieldValues fieldValues;
 
+    /**
+     * Default collector to collect only output, score and docId for every inner result
+     */
     public DefaultCollector() {
         this.results = new ArrayList<>();
-        this.reader = null;
-        this.fieldInfos = null;
-        this.storedFields = null;
+        this.fieldValues = null;
     }
 
-    public DefaultCollector(LeafReader reader, Set<String> fields) {
+    /**
+     * Default collector to collect output, score, docId and <code>fields</code>
+     * from the index for every inner result
+     * @param reader to be used to retrieve field values
+     * @param fields set of field names (fields can be stored fields or doc values)
+     * @throws IOException
+     */
+    public DefaultCollector(LeafReader reader, Set<String> fields) throws IOException {
         if (reader == null) {
             throw new IllegalArgumentException("reader can not be null");
         }
@@ -57,32 +59,17 @@ public class DefaultCollector<W> implements SegmentLookup.Collector<W> {
             throw new IllegalArgumentException("fields can not be null");
         }
         this.results = new ArrayList<>();
-        this.reader = reader;
-        this.storedFields = new HashSet<>(fields.size());
-        this.fieldInfos = new HashSet<>(fields.size());
-        //TODO: figure out what field name is a docValue/storedField from FieldInfo
-        for (String field : fields) {
-            FieldInfo fieldInfo = reader.getFieldInfos().fieldInfo(field);
-            if (fieldInfo.getDocValuesType() == DocValuesType.NONE) {
-                storedFields.add(field);
-            }
-            fieldInfos.add(fieldInfo);
-        }
+        this.fieldValues = new FieldValues(reader, fields);
     }
 
     @Override
     public void collect(CharSequence key, List<ResultMetaData<W>> resultMetaDataList) throws IOException {
-        List<Map.Entry<ResultMetaData<W>, List<StoredField>>> innerResults = new ArrayList<>(resultMetaDataList.size());
+        List<Result.InnerResult<W>> innerResults = new ArrayList<>(resultMetaDataList.size());
         for (ResultMetaData<W> resultMetaData : resultMetaDataList) {
-            if (reader == null || fieldInfos == null) {
-                innerResults.add(new AbstractMap.SimpleEntry<ResultMetaData<W>, List<StoredField>>(resultMetaData, null));
+            if (fieldValues == null) {
+                innerResults.add(new Result.InnerResult<>(resultMetaData));
             } else {
-                Document document = reader.document(resultMetaData.docId(), storedFields);
-                List<StoredField> storedFieldValues = new ArrayList<>(storedFields.size());
-                for (String field : storedFields) {
-                    storedFieldValues.add(new StoredField(field, document.getFields(field)));
-                }
-                innerResults.add(new AbstractMap.SimpleEntry<>(resultMetaData, storedFieldValues));
+                innerResults.add(new Result.InnerResult<>(resultMetaData, fieldValues.get(resultMetaData.docId())));
             }
         }
         this.results.add(new Result<>(key, innerResults));
@@ -92,33 +79,181 @@ public class DefaultCollector<W> implements SegmentLookup.Collector<W> {
         return results;
     }
 
-    public class Result<W> {
-        private final CharSequence key;
-        private final List<Map.Entry<ResultMetaData<W>, List<StoredField>>> innerResults;
 
-        public Result(CharSequence key, List<Map.Entry<ResultMetaData<W>, List<StoredField>>> innerResults) {
+    public static class Result<W> {
+        private final CharSequence key;
+        private final List<InnerResult<W>> innerResults;
+
+        public static final class InnerResult<W> {
+            final ResultMetaData<W> resultMetaData;
+            final List<FieldValue> fieldValues;
+
+            InnerResult(ResultMetaData<W> resultMetaData, List<FieldValue> fieldValues) {
+                this.resultMetaData = resultMetaData;
+                this.fieldValues = fieldValues;
+            }
+
+            InnerResult(ResultMetaData<W> resultMetaData) {
+                this.resultMetaData = resultMetaData;
+                this.fieldValues = null;
+            }
+
+            public List<FieldValue> fieldValues() {
+                return fieldValues;
+            }
+
+            public W score() {
+                return resultMetaData.score();
+            }
+
+            public CharSequence output() {
+                return resultMetaData.output();
+            }
+
+            public int docID() {
+                return resultMetaData.docId();
+            }
+        }
+
+        Result(CharSequence key, List<InnerResult<W>> innerResults) {
             this.key = key;
             this.innerResults = innerResults;
         }
 
+        /**
+         * Returns the analyzed form of the lookup field value
+         */
         public CharSequence key() {
             return key;
         }
 
-        public List<ResultMetaData<W>> resultMetaDataList() {
-            List<ResultMetaData<W>> results = new ArrayList<>(innerResults.size());
-            for (Map.Entry<ResultMetaData<W>, List<StoredField>> innerResult : innerResults) {
-                results.add(innerResult.getKey());
-            }
-            return results;
-        }
-
-        public List<Map.Entry<ResultMetaData<W>, List<StoredField>>> innerResults() {
+        /**
+         * Returns a list of (output (lookup field value), score and weight)
+         * along with {@link org.apache.lucene.search.suggest.analyzing.DefaultCollector.FieldValue}s
+         * of any field(s) if specified
+         * for the current key ordered by the specified score
+         */
+        public List<InnerResult<W>> innerResults() {
             return innerResults;
         }
+
     }
-    // TODO:: add stored field support + docValues support
-    public final class StoredField {
+
+    /**
+     * Generic interface for accessing field values (can be from stored fields or doc values)
+     */
+    public interface FieldValue {
+
+        /**
+         * Name of the field
+         */
+        public String name();
+
+        /**
+         * True if any of the field value(s) is {@link java.lang.Number}
+         * can be int, float, long or double
+         */
+        public boolean isNumeric();
+
+        /**
+         * True if any of the field value(s) is {@link org.apache.lucene.util.BytesRef}
+         */
+        public boolean isBinary();
+
+        /**
+         * True if any of the field value(s) is {@link java.lang.String}
+         */
+        public boolean isString();
+
+        /**
+         * Returns a List of {@link org.apache.lucene.util.BytesRef} for a field
+         * or <code>null</code> if the field has no binary values
+         */
+        public List<BytesRef> binaryValues();
+
+        /**
+         * Returns a List of {@link String} for a field
+         * or <code>null</code> if the field has no string values
+         */
+        public List<String> stringValues();
+
+        /**
+         * Returns a List of {@link Number} for a field
+         * or <code>null</code> if the field has no numeric values
+         */
+        public List<Number> numericValues();
+    }
+
+    /**
+     * {@link org.apache.lucene.search.suggest.analyzing.DefaultCollector.FieldValue} implementation for doc values
+     */
+    private final class DocValueField implements FieldValue {
+        final String name;
+        final BytesRef[] bytesValues;
+        final Number[] longValues;
+
+        public DocValueField(String name, Number... values) {
+            this(name, values, null);
+        }
+
+        public DocValueField(String name, BytesRef... values) {
+            this(name, null, values);
+        }
+
+        private DocValueField(String name, Number[] longValues, BytesRef[] bytesValues) {
+            this.name = name;
+            this.longValues = longValues;
+            this.bytesValues = bytesValues;
+            assert (longValues != null && bytesValues == null) || (longValues == null && bytesValues != null) : "only one of long value or bytes value should be set";
+        }
+
+        @Override
+        public String name() {
+            return name;
+        }
+
+        @Override
+        public boolean isNumeric() {
+            return longValues != null;
+        }
+
+        @Override
+        public boolean isBinary() {
+            return bytesValues != null;
+        }
+
+        @Override
+        public boolean isString() {
+            return false;
+        }
+
+        @Override
+        public List<BytesRef> binaryValues() {
+            if (bytesValues == null) {
+                throw new IllegalStateException("field: "+ name + "does not contain any bytesRef values");
+            }
+            return Arrays.asList(bytesValues);
+        }
+
+        @Override
+        public List<String> stringValues() {
+            return null;
+        }
+
+        @Override
+        public List<Number> numericValues() {
+            if (longValues == null) {
+                throw new IllegalStateException("field: "+ name + "does not contain any number values");
+            }
+            return Arrays.asList(longValues);
+        }
+    }
+
+    /**
+     * {@link org.apache.lucene.search.suggest.analyzing.DefaultCollector.FieldValue} implementation
+     * for stored fields
+     */
+    private final class StoredField implements FieldValue {
 
         Object[] values;
         final int numValues;
@@ -151,58 +286,6 @@ public class DefaultCollector<W> implements SegmentLookup.Collector<W> {
         }
 
         /**
-         * Returns a List of {@link Number} for a stored field
-         * or <code>null</code> if the stored field has no numeric values
-         */
-        public List<Number> getNumericValues() {
-            List<Number> numericValues = null;
-            for (Object value : values) {
-                if (value instanceof Number) {
-                    if (numericValues == null) {
-                        numericValues = new ArrayList<>(numValues);
-                    }
-                    numericValues.add((Number) value);
-                }
-            }
-            return numericValues;
-        }
-
-        /**
-         * Returns a List of {@link String} for a stored field
-         * or <code>null</code> if the stored field has no string values
-         */
-        public List<String> getStringValues() {
-            List<String> stringValues = null;
-            for (Object value : values) {
-                if (value instanceof String) {
-                    if (stringValues == null) {
-                        stringValues = new ArrayList<>(numValues);
-                    }
-                    stringValues.add((String) value);
-                }
-            }
-            return stringValues;
-        }
-
-        /**
-         * Returns a List of {@link org.apache.lucene.util.BytesRef} for a stored field
-         * or <code>null</code> if the stored field has no binary values
-         */
-        public List<BytesRef> getBinaryValues() {
-            List<BytesRef> binaryValues = null;
-            for (Object value : values) {
-                if (value instanceof BytesRef) {
-                    if (binaryValues == null) {
-                        binaryValues = new ArrayList<>(numValues);
-                    }
-                    binaryValues.add((BytesRef) value);
-                }
-            }
-            return binaryValues;
-        }
-
-
-        /**
          * Returns a List of {@link Object} for a stored field
          */
         public Object[] getValues() {
@@ -221,6 +304,220 @@ public class DefaultCollector<W> implements SegmentLookup.Collector<W> {
             }
             stringBuilder.append("]");
             return stringBuilder.toString();
+        }
+
+        @Override
+        public String name() {
+            return name;
+        }
+
+        @Override
+        public boolean isNumeric() {
+            for (int i = 0; i < numValues; i++) {
+                if (values[i] instanceof Number) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public boolean isBinary() {
+            for (int i = 0; i < numValues; i++) {
+                if (values[i] instanceof BytesRef) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public boolean isString() {
+            for (int i = 0; i < numValues; i++) {
+                if (values[i] instanceof String) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public List<BytesRef> binaryValues() {
+            List<BytesRef> binaryValues = null;
+            for (Object value : values) {
+                if (value instanceof BytesRef) {
+                    if (binaryValues == null) {
+                        binaryValues = new ArrayList<>(numValues);
+                    }
+                    binaryValues.add((BytesRef) value);
+                }
+            }
+            return binaryValues;
+        }
+
+        @Override
+        public List<String> stringValues() {
+            List<String> stringValues = null;
+            for (Object value : values) {
+                if (value instanceof String) {
+                    if (stringValues == null) {
+                        stringValues = new ArrayList<>(numValues);
+                    }
+                    stringValues.add((String) value);
+                }
+            }
+            return stringValues;
+        }
+
+        @Override
+        public List<Number> numericValues() {
+            List<Number> numericValues = null;
+            for (Object value : values) {
+                if (value instanceof Number) {
+                    if (numericValues == null) {
+                        numericValues = new ArrayList<>(numValues);
+                    }
+                    numericValues.add((Number) value);
+                }
+            }
+            return numericValues;
+        }
+    }
+
+    private class FieldValues {
+        private final LeafReader reader;
+
+        // lazy load
+        private Set<String> storedFields;
+        private List<Entry<String, NumericDocValues>> numericDocValues;
+        private List<Entry<String, BinaryDocValues>> binaryDocValues;
+        private List<Entry<String, SortedDocValues>> sortedDocValues;
+        private List<Entry<String, SortedNumericDocValues>> sortedNumericDocValues;
+        private List<Entry<String, SortedSetDocValues>> sortedSetDocValues;
+
+        public FieldValues(LeafReader reader, Set<String> fields) throws IOException {
+            this.reader = reader;
+            FieldInfos fieldInfos = reader.getFieldInfos();
+            for (String field : fields) {
+                FieldInfo fieldInfo = fieldInfos.fieldInfo(field);
+                if (fieldInfo != null) {
+                    if (fieldInfo.getDocValuesType() == DocValuesType.NONE) {
+                        if (storedFields == null) {
+                            storedFields = new HashSet<>(fields.size());
+                        }
+                        storedFields.add(field);
+                    } else {
+                        addDocValues(fieldInfo.getDocValuesType(), field);
+                    }
+                }
+            }
+        }
+
+        private void addDocValues(DocValuesType type, String field) throws IOException {
+            switch (type) {
+                case NONE:
+                    break;
+                case NUMERIC:
+                    if (numericDocValues == null) {
+                        numericDocValues = new ArrayList<>();
+                    }
+                    numericDocValues.add(new AbstractMap.SimpleEntry<>(field, DocValues.getNumeric(reader, field)));
+                    break;
+                case BINARY:
+                    if (binaryDocValues == null) {
+                        binaryDocValues = new ArrayList<>();
+                    }
+                    binaryDocValues.add(new AbstractMap.SimpleEntry<>(field, DocValues.getBinary(reader, field)));
+                    break;
+                case SORTED:
+                    if (sortedDocValues == null) {
+                        sortedDocValues = new ArrayList<>();
+                    }
+                    sortedDocValues.add(new AbstractMap.SimpleEntry<>(field, DocValues.getSorted(reader, field)));
+                    break;
+                case SORTED_NUMERIC:
+                    if (sortedNumericDocValues == null) {
+                        sortedNumericDocValues = new ArrayList<>();
+                    }
+                    sortedNumericDocValues.add(new AbstractMap.SimpleEntry<>(field, DocValues.getSortedNumeric(reader, field)));
+                    break;
+                case SORTED_SET:
+                    if (sortedSetDocValues == null) {
+                        sortedSetDocValues = new ArrayList<>();
+                    }
+                    sortedSetDocValues.add(new AbstractMap.SimpleEntry<>(field, DocValues.getSortedSet(reader, field)));
+                    break;
+            }
+        }
+
+        public List<List<FieldValue>> get(int[] docIDs) throws IOException {
+            List<List<FieldValue>> results = new ArrayList<>(docIDs.length);
+            for (int docID : docIDs) {
+                results.add(get(docID));
+            }
+            return results;
+        }
+
+        private List<FieldValue> get(int docID) throws IOException {
+            List<FieldValue> resultForDocID = new ArrayList<>();
+            if (storedFields != null) {
+                Document document = reader.document(docID, storedFields);
+                for (String storedField : storedFields) {
+                    resultForDocID.add(new StoredField(storedField, document.getFields(storedField)));
+                }
+            }
+
+            if (numericDocValues != null) {
+                for (Entry<String, NumericDocValues> numericDocValue : numericDocValues) {
+                    String field = numericDocValue.getKey();
+                    NumericDocValues value = numericDocValue.getValue();
+                    resultForDocID.add(new DocValueField(field, value.get(docID)));
+                }
+            }
+
+            if (binaryDocValues != null) {
+                for (Entry<String, BinaryDocValues> binaryDocValue : binaryDocValues) {
+                    String field = binaryDocValue.getKey();
+                    BinaryDocValues value = binaryDocValue.getValue();
+                    resultForDocID.add(new DocValueField(field, BytesRef.deepCopyOf(value.get(docID))));
+                }
+            }
+
+            if (sortedDocValues != null) {
+                for (Entry<String, SortedDocValues> sortedDocValue : sortedDocValues) {
+                    String field = sortedDocValue.getKey();
+                    SortedDocValues value = sortedDocValue.getValue();
+                    resultForDocID.add(new DocValueField(field, BytesRef.deepCopyOf(value.get(docID))));
+                }
+            }
+
+            if (sortedNumericDocValues != null) {
+                for (Entry<String, SortedNumericDocValues> sortedNumericDocValue : sortedNumericDocValues) {
+                    String field = sortedNumericDocValue.getKey();
+                    SortedNumericDocValues value = sortedNumericDocValue.getValue();
+                    value.setDocument(docID);
+                    Number[] fieldValues = new Number[value.count()];
+                    for (int i = 0; i < value.count(); i++) {
+                        fieldValues[i] = value.valueAt(i);
+                    }
+                    resultForDocID.add(new DocValueField(field, fieldValues));
+                }
+            }
+
+            if (sortedSetDocValues != null) {
+                for (Entry<String, SortedSetDocValues> sortedSetDocValue : sortedSetDocValues) {
+                    String field = sortedSetDocValue.getKey();
+                    SortedSetDocValues value = sortedSetDocValue.getValue();
+                    List<BytesRef> fieldValues = new ArrayList<>();
+                    value.setDocument(docID);
+                    long ord;
+                    while ((ord = value.nextOrd()) != SortedSetDocValues.NO_MORE_ORDS) {
+                        fieldValues.add(BytesRef.deepCopyOf(value.lookupOrd(ord))) ;
+                    }
+                    resultForDocID.add(new DocValueField(field, fieldValues.toArray(new BytesRef[fieldValues.size()])));
+                }
+            }
+            return resultForDocID;
         }
     }
 }

--- a/src/main/java/org/apache/lucene/search/suggest/analyzing/DefaultCollector.java
+++ b/src/main/java/org/apache/lucene/search/suggest/analyzing/DefaultCollector.java
@@ -1,0 +1,226 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.lucene.search.suggest.analyzing;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.util.BytesRef;
+
+import java.io.IOException;
+import java.util.*;
+
+/**
+ * Default collector implementation
+ *
+ * TODO: add storedField and docValues lookup support support
+ * NOTE: WIP
+ */
+public class DefaultCollector<W> implements SegmentLookup.Collector<W> {
+
+    private final List<Result<W>> results;
+    private final LeafReader reader;
+    private final Set<FieldInfo> fieldInfos;
+    private final Set<String> storedFields;
+
+    public DefaultCollector() {
+        this.results = new ArrayList<>();
+        this.reader = null;
+        this.fieldInfos = null;
+        this.storedFields = null;
+    }
+
+    public DefaultCollector(LeafReader reader, Set<String> fields) {
+        if (reader == null) {
+            throw new IllegalArgumentException("reader can not be null");
+        }
+        if (fields == null) {
+            throw new IllegalArgumentException("fields can not be null");
+        }
+        this.results = new ArrayList<>();
+        this.reader = reader;
+        this.storedFields = new HashSet<>(fields.size());
+        this.fieldInfos = new HashSet<>(fields.size());
+        //TODO: figure out what field name is a docValue/storedField from FieldInfo
+        for (String field : fields) {
+            FieldInfo fieldInfo = reader.getFieldInfos().fieldInfo(field);
+            if (fieldInfo.getDocValuesType() == DocValuesType.NONE) {
+                storedFields.add(field);
+            }
+            fieldInfos.add(fieldInfo);
+        }
+    }
+
+    @Override
+    public void collect(CharSequence key, List<ResultMetaData<W>> resultMetaDataList) throws IOException {
+        List<Map.Entry<ResultMetaData<W>, List<StoredField>>> innerResults = new ArrayList<>(resultMetaDataList.size());
+        for (ResultMetaData<W> resultMetaData : resultMetaDataList) {
+            if (reader == null || fieldInfos == null) {
+                innerResults.add(new AbstractMap.SimpleEntry<ResultMetaData<W>, List<StoredField>>(resultMetaData, null));
+            } else {
+                Document document = reader.document(resultMetaData.docId(), storedFields);
+                List<StoredField> storedFieldValues = new ArrayList<>(storedFields.size());
+                for (String field : storedFields) {
+                    storedFieldValues.add(new StoredField(field, document.getFields(field)));
+                }
+                innerResults.add(new AbstractMap.SimpleEntry<>(resultMetaData, storedFieldValues));
+            }
+        }
+        this.results.add(new Result<>(key, innerResults));
+    }
+
+    public List<Result<W>> get() {
+        return results;
+    }
+
+    public class Result<W> {
+        private final CharSequence key;
+        private final List<Map.Entry<ResultMetaData<W>, List<StoredField>>> innerResults;
+
+        public Result(CharSequence key, List<Map.Entry<ResultMetaData<W>, List<StoredField>>> innerResults) {
+            this.key = key;
+            this.innerResults = innerResults;
+        }
+
+        public CharSequence key() {
+            return key;
+        }
+
+        public List<ResultMetaData<W>> resultMetaDataList() {
+            List<ResultMetaData<W>> results = new ArrayList<>(innerResults.size());
+            for (Map.Entry<ResultMetaData<W>, List<StoredField>> innerResult : innerResults) {
+                results.add(innerResult.getKey());
+            }
+            return results;
+        }
+
+        public List<Map.Entry<ResultMetaData<W>, List<StoredField>>> innerResults() {
+            return innerResults;
+        }
+    }
+    // TODO:: add stored field support + docValues support
+    public final class StoredField {
+
+        Object[] values;
+        final int numValues;
+        int index = -1;
+        public final String name;
+
+        StoredField(String name, IndexableField[] fields) {
+            this.name = name;
+            this.numValues = fields.length;
+            this.values = new Object[numValues];
+
+            for (IndexableField field : fields) {
+                boolean valueAdded = add(field.numericValue()) || add(field.binaryValue()) || add(field.stringValue());
+                if (!valueAdded) {
+                    throw new UnsupportedOperationException("Field: " + name + " has to be of string or binary or number type");
+                }
+            }
+        }
+
+        private boolean add(Object value) {
+            if (value == null) {
+                return false;
+            }
+            if (++index < numValues) {
+                this.values[index] = value;
+            } else {
+                assert false : "Object array size=" + numValues + " attempting to add " + index + " items";
+            }
+            return true;
+        }
+
+        /**
+         * Returns a List of {@link Number} for a stored field
+         * or <code>null</code> if the stored field has no numeric values
+         */
+        public List<Number> getNumericValues() {
+            List<Number> numericValues = null;
+            for (Object value : values) {
+                if (value instanceof Number) {
+                    if (numericValues == null) {
+                        numericValues = new ArrayList<>(numValues);
+                    }
+                    numericValues.add((Number) value);
+                }
+            }
+            return numericValues;
+        }
+
+        /**
+         * Returns a List of {@link String} for a stored field
+         * or <code>null</code> if the stored field has no string values
+         */
+        public List<String> getStringValues() {
+            List<String> stringValues = null;
+            for (Object value : values) {
+                if (value instanceof String) {
+                    if (stringValues == null) {
+                        stringValues = new ArrayList<>(numValues);
+                    }
+                    stringValues.add((String) value);
+                }
+            }
+            return stringValues;
+        }
+
+        /**
+         * Returns a List of {@link org.apache.lucene.util.BytesRef} for a stored field
+         * or <code>null</code> if the stored field has no binary values
+         */
+        public List<BytesRef> getBinaryValues() {
+            List<BytesRef> binaryValues = null;
+            for (Object value : values) {
+                if (value instanceof BytesRef) {
+                    if (binaryValues == null) {
+                        binaryValues = new ArrayList<>(numValues);
+                    }
+                    binaryValues.add((BytesRef) value);
+                }
+            }
+            return binaryValues;
+        }
+
+
+        /**
+         * Returns a List of {@link Object} for a stored field
+         */
+        public Object[] getValues() {
+            assert index == numValues - 1;
+            return values;
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder stringBuilder = new StringBuilder("<" + name + ":[");
+            for (int i=0; i < values.length; i++) {
+                stringBuilder.append(values[i].toString());
+                if (i != values.length-1) {
+                    stringBuilder.append(", ");
+                }
+            }
+            stringBuilder.append("]");
+            return stringBuilder.toString();
+        }
+    }
+}

--- a/src/main/java/org/apache/lucene/search/suggest/analyzing/LookupFieldGenerator.java
+++ b/src/main/java/org/apache/lucene/search/suggest/analyzing/LookupFieldGenerator.java
@@ -1,0 +1,236 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.lucene.search.suggest.analyzing;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.search.suggest.analyzing.LookupPostingsFormat.LookupBuildConfiguration;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.IntsRef;
+
+import java.io.IOException;
+import java.util.Set;
+
+/**
+ * Class responsible for initialing and generating lookup fields
+ * Usage:
+ * LookupFieldGenerator generator = LookupFieldGenerator.create(name, ..)
+ * generator.generate(value, weight)
+ *
+ */
+public class LookupFieldGenerator {
+
+    private final String name;
+    private final LookupTokenStream.ToFiniteStrings toFiniteStrings;
+    private final PayloadProcessor payloadProcessor;
+    private final Analyzer indexAnalyzer;
+    private final String type;
+    private static final FieldType FIELD_TYPE = new FieldType();
+
+    static {
+        FIELD_TYPE.setTokenized(true);
+        FIELD_TYPE.setStored(false);
+        FIELD_TYPE.setStoreTermVectors(false);
+        FIELD_TYPE.setOmitNorms(false);
+        FIELD_TYPE.setIndexOptions(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS);
+        FIELD_TYPE.freeze();
+    }
+
+    /**
+     * Creates a lookup field generator
+     * @param name of the lookup field
+     * @param indexAnalyzer used to analyze tokens at index time
+     * @param queryAnalyzer used to analyze the query prefix
+     * @param scorer to be used to score the results
+     * @param preserveSep configuration to preserve seperators at lookup and index time
+     * @param preservePositionIncrements configuration to preserve position holes at lookup and index time
+     */
+    private LookupFieldGenerator(String name, Analyzer indexAnalyzer, Analyzer queryAnalyzer, final ContextAwareScorer scorer,
+                                 final boolean preserveSep, final boolean preservePositionIncrements) {
+        this.name = name;
+        this.indexAnalyzer = indexAnalyzer;
+        this.toFiniteStrings = new LookupTokenStream.ToFiniteStrings() {
+            @Override
+            public Set<IntsRef> toFiniteStrings(TokenStream stream) throws IOException {
+                return NRTSuggester.TokenUtils.toFiniteStrings(stream, preserveSep, preservePositionIncrements);
+            }
+        };
+
+        if (scorer instanceof ContextAwareScorer.LongBased) {
+            payloadProcessor = new PayloadProcessor.LongPayloadProcessor();
+            this.type = Long.class.getName();
+        } else if (scorer instanceof ContextAwareScorer.BytesBased) {
+            payloadProcessor = new PayloadProcessor.BytesRefPayloadProcessor();
+            this.type = BytesRef.class.getName();
+        } else {
+            throw new IllegalArgumentException("scorer has to be type ContextAwareScorer.LongBased or ContextAwareScorer.BytesBased");
+        }
+
+        LookupPostingsFormat.register(name,
+                new LookupBuildConfiguration(scorer, queryAnalyzer, preserveSep, preservePositionIncrements, payloadProcessor));
+    }
+
+    /**
+     * @return index analyzer for the lookup field
+     * TODO: this indexAnalyzer should be enforced
+     */
+    public Analyzer indexAnalyzer() {
+        return indexAnalyzer;
+    }
+
+    /**
+     * Generates a lookup field
+     * @param value of the field
+     * @param weight associated with the field
+     * @return a lookup field
+     */
+    public Field generate(String value, Long weight) {
+        if (!type.equals(Long.class.getName())) {
+            throw new IllegalArgumentException("weight can not be of type Long");
+        }
+        if (value == null) {
+            throw new IllegalArgumentException("value can not be null");
+        }
+        if (weight == null) {
+            throw new IllegalArgumentException("weight value can not be null");
+        }
+        return new LookupField<Long>(name, value, FIELD_TYPE, weight, toFiniteStrings, payloadProcessor);
+    }
+
+    /**
+     * Generates a lookup field
+     * @param value of the field
+     * @param weight associated with the field
+     * @return a lookup field
+     */
+    public Field generate(String value, BytesRef weight) {
+        if (!type.equals(BytesRef.class.getName())) {
+            throw new IllegalArgumentException("weight can not be of type BytesRef");
+        }
+        if (value == null) {
+            throw new IllegalArgumentException("value can not be null");
+        }
+        if (weight == null) {
+            throw new IllegalArgumentException("weight value can not be null");
+        }
+        return new LookupField<BytesRef>(name, value, FIELD_TYPE, weight, toFiniteStrings, payloadProcessor);
+    }
+
+    /**
+     * Creates a {@link LookupFieldGenerator} with a default long scorer
+     *
+     * @param name unique lookup name
+     * @param indexAnalyzer used to analyze tokens at index time
+     * @param queryAnalyzer used to analyze the query prefix
+     * @param preserveSep configuration to preserve seperators at lookup and index time
+     * @param preservePositionIncrements configuration to preserve position holes at lookup and index time
+     */
+    public static LookupFieldGenerator create(String name, Analyzer indexAnalyzer, Analyzer queryAnalyzer, boolean preserveSep, boolean preservePositionIncrements) {
+        return LookupFieldGenerator.create(name, indexAnalyzer, queryAnalyzer, preserveSep, preservePositionIncrements, ContextAwareScorer.DEFAULT);
+    }
+
+    /**
+     * Creates a {@link LookupFieldGenerator} preserving seperators and position increments at index and query time
+     * with a default long scorer
+     *
+     * @param name unique lookup name
+     * @param analyzer used at index and query time
+     */
+    public static LookupFieldGenerator create(String name, Analyzer analyzer) {
+        return LookupFieldGenerator.create(name, analyzer, analyzer, true, true);
+    }
+
+    /**
+     * Creates a {@link LookupFieldGenerator} with a default long scorer
+     *
+     * @param name unique lookup name
+     * @param analyzer analyzer used at index and query time
+     * @param preserveSep configuration to preserve seperators at lookup and index time
+     * @param preservePositionIncrements configuration to preserve position holes at lookup and index time
+     */
+    public static LookupFieldGenerator create(String name, Analyzer analyzer, boolean preserveSep, boolean preservePositionIncrements) {
+        return LookupFieldGenerator.create(name, analyzer, analyzer, preserveSep, preservePositionIncrements);
+    }
+
+    /**
+     * Creates a {@link LookupFieldGenerator} preserving seperators and position increments at index and query time
+     * with a default long scorer
+     *
+     * @param name unique lookup name
+     * @param indexAnalyzer used to analyze tokens at index time
+     * @param queryAnalyzer used to analyze the query prefix
+     */
+    public static LookupFieldGenerator create(String name, Analyzer indexAnalyzer, Analyzer queryAnalyzer) {
+        return LookupFieldGenerator.create(name, indexAnalyzer, queryAnalyzer, true, true);
+    }
+
+    /**
+     * Creates a {@link LookupFieldGenerator} instance
+     *
+     * @param name unique lookup name
+     * @param indexAnalyzer used to analyze tokens at index time
+     * @param queryAnalyzer used to analyze the query prefix
+     * @param preserveSep configuration to preserve seperators at lookup and index time
+     * @param preservePositionIncrements configuration to preserve position holes at lookup and index time
+     * @param scorer to configure score output and scoring
+     */
+    public static LookupFieldGenerator create(String name, Analyzer indexAnalyzer, Analyzer queryAnalyzer,
+                                              final boolean preserveSep, final boolean preservePositionIncrements,
+                                              final ContextAwareScorer scorer) {
+        return new LookupFieldGenerator(name, indexAnalyzer, queryAnalyzer, scorer, preserveSep, preservePositionIncrements);
+    }
+
+    private static final class LookupField<T> extends Field {
+        public static final char UNIT_SEPARATOR = '\u001f';
+
+        private final BytesRef surfaceForm;
+        private final T weight;
+
+        private final LookupTokenStream.ToFiniteStrings toFiniteStrings;
+        private final PayloadProcessor<T> payloadProcessor;
+
+        LookupField(String name, String value, FieldType type, T weight, LookupTokenStream.ToFiniteStrings toFiniteStrings, PayloadProcessor<T> payloadProcessor) {
+            super(name, value, type);
+            this.surfaceForm = new BytesRef(value);
+            this.weight = weight;
+            this.payloadProcessor = payloadProcessor;
+            this.toFiniteStrings = toFiniteStrings;
+        }
+
+        @Override
+        public TokenStream tokenStream(Analyzer analyzer, TokenStream previous) throws IOException {
+            BytesRef suggestPayload = buildSuggestPayload(surfaceForm, weight);
+            return new LookupTokenStream(super.tokenStream(analyzer, previous), suggestPayload, toFiniteStrings);
+        }
+
+        private BytesRef buildSuggestPayload(BytesRef surfaceForm, T weight) throws IOException {
+            for (int i = 0; i < surfaceForm.length; i++) {
+                if (surfaceForm.bytes[i] == UNIT_SEPARATOR) {
+                    throw new IllegalArgumentException(
+                            "surface form cannot contain unit separator character U+001F; this character is reserved");
+                }
+            }
+            return payloadProcessor.build(surfaceForm, weight);
+        }
+    }
+}

--- a/src/main/java/org/apache/lucene/search/suggest/analyzing/LookupPostingsFormat.java
+++ b/src/main/java/org/apache/lucene/search/suggest/analyzing/LookupPostingsFormat.java
@@ -1,0 +1,454 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.lucene.search.suggest.analyzing;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.codecs.FieldsConsumer;
+import org.apache.lucene.codecs.FieldsProducer;
+import org.apache.lucene.codecs.PostingsFormat;
+import org.apache.lucene.index.*;
+import org.apache.lucene.index.FilterLeafReader.FilterTerms;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.suggest.analyzing.LookupPostingsFormat.LookupBuildConfiguration.LOOKUP_TYPE;
+import org.apache.lucene.search.suggest.analyzing.SegmentLookup.SegmentLookupWrapper;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.IOUtils;
+
+import java.io.IOException;
+import java.util.*;
+
+/**
+ * Responsible for configuration, creation and retrieval of lookup fields
+ * associated with the index.
+ *
+ * Configuration:
+ *   use {@link #register(String, LookupBuildConfiguration)} to register build configuration
+ *   for a lookup field
+ *
+ * Creation:
+ *   see {@link LookupFieldsConsumer}
+ *
+ * Retrieval:
+ *   see {@link LookupFieldsProducer}
+ *
+ */
+public class LookupPostingsFormat extends PostingsFormat {
+
+    /**
+     * Holds build configuration for a single lookup field
+     */
+    final static class LookupBuildConfiguration {
+        final ContextAwareScorer scorer;
+        final Analyzer queryAnalyzer;
+        final boolean preserveSep;
+        final boolean preservePositionIncrements;
+        final PayloadProcessor payloadProcessor;
+
+        LookupBuildConfiguration(ContextAwareScorer scorer, Analyzer queryAnalyzer, boolean preserveSep,
+                                 boolean preservePositionIncrements, PayloadProcessor payloadProcessor) {
+            this.scorer = scorer;
+            this.queryAnalyzer = queryAnalyzer;
+            this.preserveSep = preserveSep;
+            this.preservePositionIncrements = preservePositionIncrements;
+            this.payloadProcessor = payloadProcessor;
+        }
+
+        private LOOKUP_TYPE type() {
+            if (scorer instanceof ContextAwareScorer.BytesBased) {
+                return LOOKUP_TYPE.BYTES;
+            } else if (scorer instanceof ContextAwareScorer.LongBased) {
+                return LOOKUP_TYPE.LONG;
+            } else {
+                // should never happen
+                throw new IllegalStateException("lookup is not long or bytes based");
+            }
+
+        }
+
+        static enum LOOKUP_TYPE {
+            LONG((byte) 0),
+            BYTES((byte) 1);
+
+            private byte id;
+
+            LOOKUP_TYPE(byte id) {
+                this.id = id;
+            }
+
+            public static LOOKUP_TYPE fromId(byte id) {
+                switch (id) {
+                    case 0:
+                        return LONG;
+                    case 1:
+                        return BYTES;
+                    default:
+                        throw new IllegalArgumentException("undefined type id " + id);
+                }
+            }
+        }
+    }
+
+    private static Map<String, LookupBuildConfiguration> buildConfigurationMap = new HashMap<>();
+
+    /**
+     * Registers a build configuration for a particular lookup field
+     *
+     * @param name of the lookup field
+     * @param lookupBuildConfiguration associated configuration
+     */
+    public static void register(String name, LookupBuildConfiguration lookupBuildConfiguration) {
+        buildConfigurationMap.put(name, lookupBuildConfiguration);
+    }
+
+    private static LookupBuildConfiguration buildConfiguration(String name) {
+        return buildConfigurationMap.get(name);
+    }
+
+    public static final String CODEC_NAME = "lookup";
+    public static final int LOOKUP_CODEC_VERSION = 1;
+    public static final int LOOKUP_VERSION_CURRENT = LOOKUP_CODEC_VERSION;
+    public static final String EXTENSION = "cmp";
+
+    /**
+     */
+    public LookupPostingsFormat() {
+        super(CODEC_NAME);
+    }
+
+    private PostingsFormat delegatePostingsFormat;
+
+    public LookupPostingsFormat(PostingsFormat delegatePostingsFormat) {
+        super(CODEC_NAME);
+        this.delegatePostingsFormat = delegatePostingsFormat;
+    }
+
+    @Override
+    public FieldsConsumer fieldsConsumer(SegmentWriteState state) throws IOException {
+        if (delegatePostingsFormat == null) {
+            throw new UnsupportedOperationException("Error - " + getClass().getName()
+                    + " has been constructed without a choice of PostingsFormat");
+        }
+        return new LookupFieldsConsumer(state);
+    }
+
+    @Override
+    public FieldsProducer fieldsProducer(SegmentReadState state) throws IOException {
+        return new LookupFieldsProducer(state);
+    }
+
+    /**
+     * Builds Lookup Index with {@link NRTSuggesterBuilder} using {@link LookupBuildConfiguration}
+     * for the associated lookup field.
+     * NOTE: the merging of the delegate field is used to build a merged lookup index
+     *
+     * TODO: the implementation should be pluggable, so we can support other implementations of SegmentLookup
+     *
+     * Lookup Index format:
+     * - Header
+     * - Delegate postings format name
+     * - FST + configuration for each lookup field built with {@link NRTSuggesterBuilder}
+     * - Map of lookup field names to lookup index and its type
+     *    - maps a lookup field name to the lookup index file offset and a byte (representing lookup type)
+     * -
+     */
+    private class LookupFieldsConsumer extends FieldsConsumer {
+
+        private final FieldsConsumer delegateFieldsConsumer;
+        private IndexOutput output = null;
+        private final Map<String, Map.Entry<Long, Byte>> fieldOffsets;
+
+        public LookupFieldsConsumer(SegmentWriteState state) throws IOException {
+            this.delegateFieldsConsumer = delegatePostingsFormat.fieldsConsumer(state);
+            fieldOffsets = new HashMap<>();
+            String suggestFSTFile = IndexFileNames.segmentFileName(state.segmentInfo.name, state.segmentSuffix, EXTENSION);
+            boolean success = false;
+            try {
+                output = state.directory.createOutput(suggestFSTFile, state.context);
+                CodecUtil.writeHeader(output, CODEC_NAME, LOOKUP_VERSION_CURRENT);
+                /*
+                 * we write the delegate postings format name so we can load it
+                 * without getting an instance in the ctor
+                 */
+                output.writeString(delegatePostingsFormat.getName());
+                success = true;
+            } finally {
+                if (!success) {
+                    IOUtils.closeWhileHandlingException(output);
+                }
+            }
+        }
+
+        @Override
+        public void write(Fields fields) throws IOException {
+            delegateFieldsConsumer.write(fields);
+            if (output != null) {
+                for (String field : fields) {
+                    Terms terms = fields.terms(field);
+                    if (terms == null) {
+                        continue;
+                    }
+                    LookupBuildConfiguration buildConfiguration = buildConfiguration(field);
+                    if (buildConfiguration == null) {
+                        continue;
+                    }
+                    TermsEnum termsEnum = terms.iterator(null);
+                    DocsAndPositionsEnum docsEnum = null;
+                    final NRTSuggesterBuilder builder = NRTSuggesterBuilder.fromConfiguration(buildConfiguration);
+                    int docCount = 0;
+
+                    while (true) {
+                        BytesRef term = termsEnum.next();
+                        if (term == null) {
+                            break;
+                        }
+                        docsEnum = termsEnum.docsAndPositions(null, docsEnum, DocsAndPositionsEnum.FLAG_PAYLOADS);
+                        builder.startTerm(term);
+                        int docFreq = 0;
+                        while (docsEnum.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
+                            int docID = docsEnum.docID();
+                            for (int i = 0; i < docsEnum.freq(); i++) {
+                                docsEnum.nextPosition();
+                                builder.addEntry(docID, docsEnum.getPayload());
+                            }
+                            docFreq++;
+                            docCount = Math.max(docCount, docsEnum.docID() + 1);
+                        }
+                        builder.finishTerm();
+                    }
+
+                    /*
+                     * Here we are done processing the field and we can
+                     * buid the FST and write it to disk.
+                     */
+                    final long suggesterFilePointer = output.getFilePointer();
+                    if (builder.store(output)) {
+                        byte type = buildConfiguration.type().id;
+                        Map.Entry<Long, Byte> entry = new AbstractMap.SimpleEntry<>(suggesterFilePointer, type);
+                        fieldOffsets.put(field, entry);
+                    } else {
+                        assert docCount == 0 : "the FST is null but docCount is != 0 actual value: [" + docCount + "]";
+                    }
+                }
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            delegateFieldsConsumer.close();
+            try {
+                  /*
+                   * write the offsets per field such that we know where
+                   * we need to load the FSTs from
+                   */
+                long pointer = output.getFilePointer();
+                output.writeVInt(fieldOffsets.size());
+                for (Map.Entry<String, Map.Entry<Long, Byte>> entry : fieldOffsets.entrySet()) {
+                    output.writeString(entry.getKey());
+                    output.writeByte(entry.getValue().getValue());
+                    output.writeVLong(entry.getValue().getKey());
+                }
+                output.writeLong(pointer);
+                CodecUtil.writeFooter(output);
+            } finally {
+                IOUtils.close(output);
+            }
+        }
+    }
+
+    /**
+     * Produces a lookup for a particular lookup field
+     *
+     * On initialization loads the lookup index mapping (field name -> (file offset, type))
+     * Exposes the lookup through {@link #terms(String)}
+     *
+     * On merge, none of the lookup indexes are loaded
+     *
+     * Note: the lookup index for a field is only loaded the first time {@link #terms(String)} is
+     * called on a lookup field
+     */
+    private static class LookupFieldsProducer extends FieldsProducer {
+        private FieldsProducer delegateFieldsProducer;
+        private final int version;
+        private final IndexInput input;
+        private final LookupFactory lookupFactory;
+        private Map<String, Map.Entry<Long, Byte>> fieldOffsets;
+
+        public LookupFieldsProducer(SegmentReadState state) throws IOException {
+            String suggestFSTFile = IndexFileNames.segmentFileName(state.segmentInfo.name, state.segmentSuffix, EXTENSION);
+            input = state.directory.openInput(suggestFSTFile, state.context);
+            version = CodecUtil.checkHeader(input, CODEC_NAME, LOOKUP_CODEC_VERSION, LOOKUP_VERSION_CURRENT);
+            delegateFieldsProducer = null;
+            fieldOffsets = null;
+            boolean success = false;
+            try {
+                PostingsFormat delegatePostingsFormat = PostingsFormat.forName(input.readString());
+                delegateFieldsProducer = delegatePostingsFormat.fieldsProducer(state);
+                CodecUtil.checksumEntireFile(input);
+                final long metaPointerPosition = input.length() - (8 + CodecUtil.footerLength());
+                input.seek(metaPointerPosition);
+                long metaPointer = input.readLong();
+                input.seek(metaPointer);
+                int numFields = input.readVInt();
+
+                fieldOffsets = new HashMap<>();
+                for (int i = 0; i < numFields; i++) {
+                    String name = input.readString();
+                    byte type = input.readByte();
+                    long offset = input.readVLong();
+                    fieldOffsets.put(name, new AbstractMap.SimpleEntry<>(offset, type));
+                }
+                lookupFactory = new LookupFactory(fieldOffsets, input);
+                success = true;
+            } finally {
+                if (!success) {
+                    IOUtils.closeWhileHandlingException(delegateFieldsProducer, input);
+                }
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            this.delegateFieldsProducer.close();
+            IOUtils.close(input);
+        }
+
+        @Override
+        public void checkIntegrity() throws IOException {
+            this.delegateFieldsProducer.checkIntegrity();
+        }
+
+        @Override
+        public long ramBytesUsed() {
+            return this.delegateFieldsProducer.ramBytesUsed() + lookupFactory.ramBytesUsed();
+        }
+
+        @Override
+        public Collection<Accountable> getChildResources() {
+            List<Accountable> accountables = new ArrayList<>(delegateFieldsProducer.getChildResources());
+            accountables.addAll(lookupFactory.getChildResources());
+            return accountables;
+        }
+
+        @Override
+        public Iterator<String> iterator() {
+            return delegateFieldsProducer.iterator();
+        }
+
+        @Override
+        public Terms terms(String field) throws IOException {
+            return new LookupTerms(delegateFieldsProducer.terms(field), lookupFactory.get(field));
+        }
+
+        @Override
+        public FieldsProducer getMergeInstance() throws IOException {
+            return delegateFieldsProducer.getMergeInstance();
+        }
+
+        @Override
+        public int size() {
+            return delegateFieldsProducer.size();
+        }
+    }
+
+    public static class LookupTerms extends FilterTerms {
+        private final SegmentLookupWrapper lookup;
+
+        public LookupTerms(Terms in, SegmentLookupWrapper lookup) {
+            super(in);
+            this.lookup = lookup;
+        }
+
+        public SegmentLookup.LongBased longScoreLookup() {
+            if (lookup instanceof SegmentLookup.LongBased) {
+                return (SegmentLookup.LongBased) lookup;
+            }
+            throw new IllegalStateException("the lookup is not long based");
+        }
+
+        public SegmentLookup.BytesBased bytesScoreLookup() {
+            if (lookup instanceof SegmentLookup.BytesBased) {
+                return (SegmentLookup.BytesBased) lookup;
+            }
+            throw new IllegalStateException("the lookup is not bytes based");
+        }
+    }
+
+
+    private static class LookupFactory implements Accountable {
+        private final Map<String, Map.Entry<Long, Byte>> fieldOffsets;
+        private final IndexInput input;
+        private final Map<String, SegmentLookupWrapper> lookupMap;
+
+        LookupFactory(Map<String, Map.Entry<Long, Byte>> fieldOffsets, IndexInput input) {
+            this.fieldOffsets = fieldOffsets;
+            this.input = input;
+            this.lookupMap = new HashMap<>(fieldOffsets.size());
+        }
+
+        SegmentLookupWrapper get(String field) throws IOException {
+            if (fieldOffsets.containsKey(field)) {
+                if (!lookupMap.containsKey(field)) {
+                    final Map.Entry<Long, Byte> offsetAndTypeEntry = fieldOffsets.get(field);
+                    LookupBuildConfiguration buildConfiguration = buildConfiguration(field);
+                    input.seek(offsetAndTypeEntry.getKey());
+                    switch (LOOKUP_TYPE.fromId(offsetAndTypeEntry.getValue())) {
+                        case LONG:
+                            lookupMap.put(field, new SegmentLookup.LongBased(NRTSuggester.<Long>load(input), buildConfiguration.queryAnalyzer));
+                            break;
+                        case BYTES:
+                            lookupMap.put(field, new SegmentLookup.BytesBased(NRTSuggester.<BytesRef>load(input), buildConfiguration.queryAnalyzer));
+                            break;
+                    }
+                }
+                return lookupMap.get(field);
+            } else {
+                throw new IllegalArgumentException("no Lookup found for field: " + field);
+            }
+        }
+
+        Set<String> fields() {
+            return fieldOffsets.keySet();
+        }
+
+        @Override
+        public long ramBytesUsed() {
+            long ramBytesUsed = 0;
+            for (SegmentLookup segmentLookup : lookupMap.values()) {
+                ramBytesUsed += segmentLookup.ramBytesUsed();
+            }
+            return ramBytesUsed;
+        }
+
+        @Override
+        public Collection<Accountable> getChildResources() {
+            List<Accountable> accountables = new ArrayList<>();
+            for (SegmentLookup segmentLookup : lookupMap.values()) {
+                accountables.addAll(segmentLookup.getChildResources());
+            }
+            return accountables;
+        }
+
+
+    }
+}

--- a/src/main/java/org/apache/lucene/search/suggest/analyzing/LookupTokenStream.java
+++ b/src/main/java/org/apache/lucene/search/suggest/analyzing/LookupTokenStream.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.lucene.search.suggest.analyzing;
+
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.apache.lucene.analysis.tokenattributes.PayloadAttribute;
+import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
+import org.apache.lucene.analysis.tokenattributes.TermToBytesRefAttribute;
+import org.apache.lucene.util.*;
+import org.apache.lucene.util.fst.Util;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Set;
+
+/**
+ * Copied from org.elasticsearch.search.suggest.completion.CompletionTokenStream
+ */
+public final class LookupTokenStream extends TokenStream {
+
+    private final PayloadAttribute payloadAttr = addAttribute(PayloadAttribute.class);
+    private final PositionIncrementAttribute posAttr = addAttribute(PositionIncrementAttribute.class);
+    private final ByteTermAttribute bytesAtt = addAttribute(ByteTermAttribute.class);
+
+
+    private final TokenStream input;
+    private BytesRef payload;
+    private Iterator<IntsRef> finiteStrings;
+    private ToFiniteStrings toFiniteStrings;
+    private int posInc = -1;
+    private static final int MAX_PATHS = 256;
+    private CharTermAttribute charTermAttribute;
+
+    public LookupTokenStream(TokenStream input, BytesRef payload, ToFiniteStrings toFiniteStrings) throws IOException {
+        // Don't call the super(input) ctor - this is a true delegate and has a new attribute source since we consume
+        // the input stream entirely in toFiniteStrings(input)
+        this.input = input;
+        this.payload = payload;
+        this.toFiniteStrings = toFiniteStrings;
+    }
+
+    @Override
+    public boolean incrementToken() throws IOException {
+        clearAttributes();
+        if (finiteStrings == null) {
+            Set<IntsRef> strings = toFiniteStrings.toFiniteStrings(input);
+
+            if (strings.size() > MAX_PATHS) {
+                throw new IllegalArgumentException("TokenStream expanded to " + strings.size() + " finite strings. Only <= " + MAX_PATHS
+                        + " finite strings are supported");
+            }
+            posInc = strings.size();
+            finiteStrings = strings.iterator();
+        }
+        if (finiteStrings.hasNext()) {
+            posAttr.setPositionIncrement(posInc);
+            /*
+             * this posInc encodes the number of paths that this surface form
+             * produced. Multi Fields have the same surface form and therefore sum up
+             */
+            posInc = 0;
+            Util.toBytesRef(finiteStrings.next(), bytesAtt.builder()); // now we have UTF-8
+            if (charTermAttribute != null) {
+                charTermAttribute.setLength(0);
+                charTermAttribute.append(bytesAtt.toUTF16());
+            }
+            if (payload != null) {
+                payloadAttr.setPayload(this.payload);
+            }
+            return true;
+        }
+
+        return false;
+    }
+
+    @Override
+    public void end() throws IOException {
+        super.end();
+        if (posInc == -1) {
+            input.end();
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (posInc == -1) {
+            input.close();
+        }
+    }
+
+    public static interface ToFiniteStrings {
+        public Set<IntsRef> toFiniteStrings(TokenStream stream) throws IOException;
+    }
+
+    @Override
+    public void reset() throws IOException {
+        super.reset();
+        if (hasAttribute(CharTermAttribute.class)) {
+            // we only create this if we really need it to safe the UTF-8 to UTF-16 conversion
+            charTermAttribute = getAttribute(CharTermAttribute.class);
+        }
+        finiteStrings = null;
+        posInc = -1;
+    }
+
+    public interface ByteTermAttribute extends TermToBytesRefAttribute {
+        // marker interface
+
+        /**
+         * Return the builder from which the term is derived.
+         */
+        public BytesRefBuilder builder();
+
+        public CharSequence toUTF16();
+    }
+
+    public static final class ByteTermAttributeImpl extends AttributeImpl implements ByteTermAttribute, TermToBytesRefAttribute {
+        private final BytesRefBuilder bytes = new BytesRefBuilder();
+        private CharsRefBuilder charsRef;
+
+        @Override
+        public void fillBytesRef() {
+            // does nothing - we change in place
+        }
+
+        @Override
+        public BytesRefBuilder builder() {
+            return bytes;
+        }
+
+        @Override
+        public BytesRef getBytesRef() {
+            return bytes.get();
+        }
+
+        @Override
+        public void clear() {
+            bytes.clear();
+        }
+
+        @Override
+        public void copyTo(AttributeImpl target) {
+            ByteTermAttributeImpl other = (ByteTermAttributeImpl) target;
+            other.bytes.copyBytes(bytes);
+        }
+
+        @Override
+        public CharSequence toUTF16() {
+            if (charsRef == null) {
+                charsRef = new CharsRefBuilder();
+            }
+            charsRef.copyUTF8Bytes(getBytesRef());
+            return charsRef.get();
+        }
+    }
+}

--- a/src/main/java/org/apache/lucene/search/suggest/analyzing/NRTSuggester.java
+++ b/src/main/java/org/apache/lucene/search/suggest/analyzing/NRTSuggester.java
@@ -1,0 +1,577 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.lucene.search.suggest.analyzing;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.TokenStreamToAutomaton;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.search.suggest.analyzing.ContextAwareScorer.OutputConfiguration;
+import org.apache.lucene.search.suggest.analyzing.SegmentLookup.Context.Filter;
+import org.apache.lucene.store.*;
+import org.apache.lucene.util.*;
+import org.apache.lucene.util.automaton.*;
+import org.apache.lucene.util.fst.*;
+import org.apache.lucene.util.fst.PairOutputs.Pair;
+
+import java.io.IOException;
+import java.util.*;
+
+import static org.apache.lucene.search.suggest.analyzing.NRTSuggester.PayLoadProcessor.parseDocID;
+import static org.apache.lucene.search.suggest.analyzing.NRTSuggester.PayLoadProcessor.parseSurfaceForm;
+
+/**
+ *
+ * NRTSuggester:
+ * Performs lookup on an FST returning the top <code>num</code> analyzed forms with the top acceptable <code>nLeaf</code> docIDs
+ * for a given prefix scored according to the provided {@link ContextAwareScorer}.
+ * The lookup filters out results that correspond to deleted documents in near-real time.
+ * see {@link #lookup(LeafReader, Analyzer, CharSequence, int, int, Context, Collector)}.
+ *
+ * FST Format:
+ * Input: analyzed forms of input terms
+ * Output: raw input value, weight and docID
+ * Score: configurable through {@link ContextAwareScorer} (currently supported scores: Long and BytesRef)
+ * @lucene.experimental
+ */
+public class NRTSuggester<W extends Comparable<W>> extends SegmentLookup<W> {
+
+    static final Map<String, ContextAwareScorer<?>> scoreProvider = new HashMap<>();
+
+    /**
+     * Registers a {@link ContextAwareScorer}
+     * @param name unique name for the scorer
+     * @param scorer the instance
+     * @return true if the scorer has been registered, false if the scorer was already registered
+     */
+    static boolean registerScorer(String name, ContextAwareScorer<?> scorer) {
+        if (!scoreProvider.containsKey(name)) {
+            scoreProvider.put(name, scorer);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * FST<Weight,Surface>:
+     * input is the analyzed form, with a null byte between terms
+     * and a {@link NRTSuggesterBuilder#END_BYTE} to denote the
+     * end of the input
+     * weight is encoded according to {@link ContextAwareScorer#getOutputConfiguration()}
+     * surface is the original, unanalyzed form followed by the docID
+     */
+    private final FST<Pair<W, BytesRef>> fst;
+
+    /**
+     * Highest number of analyzed paths we saw for any single
+     * input surface form.  For analyzers that never create
+     * graphs this will always be 1.
+     */
+    private final int maxAnalyzedPathsPerLeaf;
+
+    /**
+     * Represents the separation between tokens, if
+     * {@link #preserveSep} was specified
+     */
+    private final int sepLabel;
+
+    /**
+     * Seperator used between surface form and its docID in the FST output
+     */
+    private final int payloadSep;
+
+    /**
+     * Maximum graph paths to index for a single analyzed
+     * surface form.  This only matters if your analyzer
+     * makes lots of alternate paths (e.g. contains
+     * SynonymFilter).
+     */
+    private final int endByte;
+
+    private final int holeCharacter;
+
+
+    /**
+     * True if separator between tokens should be preserved.
+     */
+    private final boolean preserveSep;
+
+    /**
+     * Whether position holes should appear in the automaton.
+     */
+    private final boolean preservePositionIncrements;
+
+    /**
+     * Maximum queue depth for {@link TopNSearcher}
+     */
+    private static final int MAX_TOP_N_QUEUE_SIZE = 1000;
+
+    private static final int MAX_GRAPH_EXPANSIONS = -1;
+
+    private final Scorer scorer;
+
+    private NRTSuggester(ContextAwareScorer<W> contextAwareScorer, FST<Pair<W, BytesRef>> fst,
+                         int maxAnalyzedPathsPerLeaf,
+                         boolean preserveSep, boolean preservePositionIncrements,
+                         int sepLabel, int payloadSep, int endByte, int holeCharacter) {
+        this.fst = fst;
+        this.maxAnalyzedPathsPerLeaf = maxAnalyzedPathsPerLeaf;
+        this.sepLabel = sepLabel;
+        this.payloadSep = payloadSep;
+        this.endByte = endByte;
+        this.holeCharacter = holeCharacter;
+        this.preserveSep = preserveSep;
+        this.preservePositionIncrements = preservePositionIncrements;
+        this.scorer = new Scorer(contextAwareScorer);
+        if (sepLabel != NRTSuggesterBuilder.SEP_LABEL) {
+            throw new IllegalArgumentException("sepLabel must be " + NRTSuggesterBuilder.SEP_LABEL);
+        }
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        return fst == null ? 0 : fst.ramBytesUsed();
+    }
+
+    @Override
+    public Collection<Accountable> getChildResources() {
+        return Collections.emptyList();
+    }
+
+    private static double calculateLiveDocRatio(int numDocs, int maxDocs) {
+        return (numDocs > 0) ? ((double) numDocs / maxDocs) : -1;
+    }
+
+    private class Scorer {
+        final ContextAwareScorer<W> contextAwareScorer;
+        final OutputConfiguration<W> outputConfiguration;
+
+        public Scorer(ContextAwareScorer<W> scorer) {
+            this.contextAwareScorer = scorer;
+            this.outputConfiguration = scorer.getOutputConfiguration();
+        }
+
+        public boolean prune(W currentContext, Pair<W, BytesRef> pathCost) {
+            //TODO: we can add a strict mode, where the surfaceform/input will have to have the same prefix as the key/analyzed query
+            return contextAwareScorer.prune(currentContext, outputConfiguration.decode(pathCost.output1));
+        }
+
+        public Comparator<Pair<W, BytesRef>> getComparator(W currentContext) {
+            final Comparator<W> comparator = contextAwareScorer.comparator(currentContext);
+            return new Comparator<Pair<W, BytesRef>>() {
+                @Override
+                public int compare(Pair<W, BytesRef> o1, Pair<W, BytesRef> o2) {
+                    //TODO: we can also sort by the surface form here (for more relevant result w.r.t. input key)
+                    return comparator.compare(o1.output1, o2.output1);
+                }
+            };
+        }
+
+        public W score(W currentContext, W result) {
+            return contextAwareScorer.score(currentContext, outputConfiguration.decode(result));
+        }
+    }
+
+    @Override
+    public void lookup(final LeafReader reader, final Analyzer queryAnalyzer, final CharSequence key, final int num, final int nLeaf, final Context<W> context, final Collector<W> collector) {
+
+        /* DEBUG
+        try {
+            PrintWriter pw = new PrintWriter("/tmp/out.dot");
+            Util.toDot(fst, pw, true, true);
+            pw.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        */
+
+        assert num > 0 : "num must be > 0, found num="+num;
+        if (fst == null) {
+            return;
+        }
+
+        if (reader == null) {
+            throw new IllegalArgumentException("reader can not be null");
+        }
+
+        for (int i = 0; i < key.length(); i++) {
+            if (key.charAt(i) == holeCharacter) {
+                throw new IllegalArgumentException("lookup key cannot contain HOLE character U+001E; this character is reserved");
+            }
+            if (key.charAt(i) == sepLabel) {
+                throw new IllegalArgumentException("lookup key cannot contain unit separator character U+001F; this character is reserved");
+            }
+        }
+
+        final double liveDocsRatio = calculateLiveDocRatio(reader.numDocs(), reader.maxDoc());
+        if (liveDocsRatio == -1) {
+            return;
+        }
+        final W scoreContext;
+        final Filter filter;
+
+        if (context == null) {
+            scoreContext = null;
+            filter = null;
+        } else {
+            scoreContext = context.scoreContext;
+            filter = context.filter;
+        }
+
+        final Bits liveDocs = reader.getLiveDocs();
+        try {
+
+            Automaton lookupAutomaton = toLookupAutomaton(queryAnalyzer, key);
+            final List<FSTUtil.Path<Pair<W, BytesRef>>> prefixPaths = FSTUtil.intersectPrefixPaths(lookupAutomaton, fst);
+
+            TopNSearcher<Pair<W,BytesRef>> searcher = new TopNSearcher<Pair<W, BytesRef>>(fst,
+                                                                   num, nLeaf, endByte,
+                                                                    // TODO: take into account filter cardinality
+                                                                   getMaxTopNSearcherQueueSize(num, liveDocsRatio),
+                                                                   scorer.getComparator(scoreContext)) {
+                private final CharsRefBuilder spare = new CharsRefBuilder();
+                private final BytesRefBuilder currentKeyBuilder = new BytesRefBuilder();
+                private final List<Collector.ResultMetaData<W>> currentResultMetaDataList = new ArrayList<>(nLeaf);
+                private final Set<Integer> seenDocIds = new HashSet<>(nLeaf);
+
+                @Override
+                protected boolean prune(Pair<W, BytesRef> pathCost) {
+                    return scorer.prune(scoreContext, pathCost);
+                }
+
+                @Override
+                protected void onLeafNode(IntsRef input, Pair<W, BytesRef> output) {
+                    Util.toBytesRef(input, currentKeyBuilder);
+                }
+
+                @Override
+                protected boolean collectOutput(Pair<W, BytesRef> output) throws IOException {
+                    int payloadSepIndex = parseSurfaceForm(output.output2, payloadSep, spare);
+                    int docID = parseDocID(output.output2, payloadSepIndex);
+
+                    // filter out deleted docs
+                    if (liveDocs != null && !liveDocs.get(docID)) {
+                        return false;
+                    }
+
+                    // filter by filter context
+                    if (filter != null && !filter.bits().get(docID)) {
+                        return false;
+                    }
+
+                    // compute score
+                    // add new surface form
+                    if (!seenDocIds.contains(docID)) {
+                        W score = scorer.score(scoreContext, output.output1);
+                        currentResultMetaDataList.add(new Collector.ResultMetaData<>(spare.toCharsRef(), score, docID));
+                        seenDocIds.add(docID);
+                        return true;
+                    }  else {
+                        return false;
+                    }
+                }
+
+                @Override
+                protected void onFinishNode() throws IOException {
+                    if (currentResultMetaDataList.size() > 0) {
+                        collector.collect(currentKeyBuilder.get().utf8ToString(), new ArrayList<>(currentResultMetaDataList));
+                        currentResultMetaDataList.clear();
+                    }
+                    seenDocIds.clear();
+                }
+
+            };
+
+            // TODO: add fuzzy support
+            for (FSTUtil.Path<Pair<W,BytesRef>> path : getFullPrefixPaths(prefixPaths, lookupAutomaton, fst)) {
+                searcher.addStartPaths(path.fstNode, path.output, true, path.input);
+            }
+
+            boolean isComplete = searcher.search();
+            // search admissibility is not guaranteed
+            // see comment on getMaxTopNSearcherQueueSize
+            //assert isComplete;
+
+        } catch (IOException bogus) {
+            throw new RuntimeException(bogus);
+        }
+    }
+
+    /**
+     * Simple heuristics to try to avoid over-pruning potential suggestions by the
+     * TopNSearcher. Since suggestion entries can be rejected if they belong
+     * to a deleted document, the length of the TopNSearcher queue has to
+     * be increased by some factor, to account for the filtered out suggestions.
+     * This heuristic will try to make the searcher admissible, but the search
+     * can still lead to over-pruning
+     */
+    private int getMaxTopNSearcherQueueSize(int num, final double liveDocRatio) {
+        // TODO: we can get away with just num instead, as the leaves of an input are managed by another queue
+        int maxQueueSize = num * maxAnalyzedPathsPerLeaf;
+        // liveDocRatio can be at most 1.0 (if no docs were deleted)
+        assert liveDocRatio <= 1.0d;
+        return Math.min(MAX_TOP_N_QUEUE_SIZE, (int) (maxQueueSize / liveDocRatio));
+    }
+
+    /**
+     * Returns all completion paths to initialize the search.
+     */
+    protected List<FSTUtil.Path<Pair<W, BytesRef>>> getFullPrefixPaths(List<FSTUtil.Path<Pair<W, BytesRef>>> prefixPaths,
+                                                                          Automaton lookupAutomaton,
+                                                                          FST<Pair<W, BytesRef>> fst)
+            throws IOException {
+        return prefixPaths;
+    }
+
+
+    final Automaton toLookupAutomaton(final Analyzer queryAnalyzer, final CharSequence key) throws IOException {
+        // TODO: is there a Reader from a CharSequence?
+        // Turn tokenstream into automaton:
+        Automaton automaton = null;
+        TokenStream ts = queryAnalyzer.tokenStream("", key.toString());
+        try {
+            automaton = TokenUtils.getTokenStreamToAutomaton(preserveSep, preservePositionIncrements, sepLabel).toAutomaton(ts);
+        } finally {
+            IOUtils.closeWhileHandlingException(ts);
+        }
+
+        automaton = replaceSep(automaton, preserveSep, sepLabel);
+
+        // TODO: we can optimize this somewhat by determinizing
+        // while we convert
+
+        // This automaton should not blow up during determinize:
+        automaton = Operations.determinize(automaton, Integer.MAX_VALUE);
+        return automaton;
+    }
+
+    /**
+     * Loads a {@link NRTSuggester} from {@link org.apache.lucene.store.IndexInput}
+     */
+    public static <W extends Comparable<W>> NRTSuggester<W> load(IndexInput input) throws IOException {
+        final ContextAwareScorer<W> contextAwareScorer = (ContextAwareScorer<W>) scoreProvider.get(input.readString());
+        OutputConfiguration<W> outputConfiguration = contextAwareScorer.getOutputConfiguration();
+        final FST<Pair<W, BytesRef>> fst = new FST<>(input, new PairOutputs<>(
+                outputConfiguration.outputSingleton(), ByteSequenceOutputs.getSingleton()));
+        int maxAnalyzedPathsPerLeaf = input.readVInt();
+        int options = input.readVInt();
+        boolean preserveSep = (options & NRTSuggesterBuilder.SERIALIZE_PRESERVE_SEPARATORS) != 0;
+        boolean preservePositionIncrements = (options & NRTSuggesterBuilder.SERIALIZE_PRESERVE_POSITION_INCREMENTS) != 0;
+        int sepLabel = input.readVInt();
+        int endByte = input.readVInt();
+        int payloadSep = input.readVInt();
+        int holeCharacter = input.readVInt();
+
+        return new NRTSuggester<>(contextAwareScorer, fst, maxAnalyzedPathsPerLeaf, preserveSep,
+                preservePositionIncrements, sepLabel, payloadSep, endByte, holeCharacter);
+
+    }
+
+    // Replaces SEP with epsilon or remaps them if
+    // we were asked to preserve them:
+    private static Automaton replaceSep(Automaton a, boolean preserveSep, int sepLabel) {
+
+        Automaton result = new Automaton();
+
+        // Copy all states over
+        int numStates = a.getNumStates();
+        for(int s=0;s<numStates;s++) {
+            result.createState();
+            result.setAccept(s, a.isAccept(s));
+        }
+
+        // Go in reverse topo sort so we know we only have to
+        // make one pass:
+        Transition t = new Transition();
+        int[] topoSortStates = topoSortStates(a);
+        for(int i=0;i<topoSortStates.length;i++) {
+            int state = topoSortStates[topoSortStates.length-1-i];
+            int count = a.initTransition(state, t);
+            for(int j=0;j<count;j++) {
+                a.getNextTransition(t);
+                if (t.min == TokenStreamToAutomaton.POS_SEP) {
+                    assert t.max == TokenStreamToAutomaton.POS_SEP;
+                    if (preserveSep) {
+                        // Remap to SEP_LABEL:
+                        result.addTransition(state, t.dest, sepLabel);
+                    } else {
+                        result.addEpsilon(state, t.dest);
+                    }
+                } else if (t.min == TokenStreamToAutomaton.HOLE) {
+                    assert t.max == TokenStreamToAutomaton.HOLE;
+
+                    // Just remove the hole: there will then be two
+                    // SEP tokens next to each other, which will only
+                    // match another hole at search time.  Note that
+                    // it will also match an empty-string token ... if
+                    // that's somehow a problem we can always map HOLE
+                    // to a dedicated byte (and escape it in the
+                    // input).
+                    result.addEpsilon(state, t.dest);
+                } else {
+                    result.addTransition(state, t.dest, t.min, t.max);
+                }
+            }
+        }
+
+        result.finishState();
+
+        return result;
+    }
+
+    private static int[] topoSortStates(Automaton a) {
+        int[] states = new int[a.getNumStates()];
+        final Set<Integer> visited = new HashSet<>();
+        final LinkedList<Integer> worklist = new LinkedList<>();
+        worklist.add(0);
+        visited.add(0);
+        int upto = 0;
+        states[upto] = 0;
+        upto++;
+        Transition t = new Transition();
+        while (worklist.size() > 0) {
+            int s = worklist.removeFirst();
+            int count = a.initTransition(s, t);
+            for (int i=0;i<count;i++) {
+                a.getNextTransition(t);
+                if (!visited.contains(t.dest)) {
+                    visited.add(t.dest);
+                    worklist.add(t.dest);
+                    states[upto++] = t.dest;
+                }
+            }
+        }
+        return states;
+    }
+
+    /**
+     * TODO: think of a better name
+     */
+    public static class TokenUtils {
+
+        public static Set<IntsRef> toFiniteStrings(TokenStream ts, boolean preserveSep, boolean preservePositionIncrements) throws IOException {
+            Automaton automaton = null;
+            try {
+
+                // Create corresponding automaton: labels are bytes
+                // from each analyzed token, with byte 0 used as
+                // separator between tokens:
+                automaton = getTokenStreamToAutomaton(preserveSep, preservePositionIncrements, NRTSuggesterBuilder.SEP_LABEL).toAutomaton(ts);
+            } finally {
+                IOUtils.closeWhileHandlingException(ts);
+            }
+
+            automaton = replaceSep(automaton, preserveSep, NRTSuggesterBuilder.SEP_LABEL);
+
+            // TODO: LUCENE-5660 re-enable this once we disallow massive suggestion strings
+            // assert SpecialOperations.isFinite(automaton);
+
+            // Get all paths from the automaton (there can be
+            // more than one path, eg if the analyzer created a
+            // graph using SynFilter or WDF):
+
+            // TODO: we could walk & add simultaneously, so we
+            // don't have to alloc [possibly biggish]
+            // intermediate HashSet in RAM:
+
+            return Operations.getFiniteStrings(automaton, MAX_GRAPH_EXPANSIONS);
+        }
+
+
+        /**
+         * Just escapes the 0xff byte (which we still for SEP).
+         */
+        private static final class EscapingTokenStreamToAutomaton extends TokenStreamToAutomaton {
+
+            final BytesRefBuilder spare = new BytesRefBuilder();
+            private char sepLabel;
+
+            public EscapingTokenStreamToAutomaton(char sepLabel) {
+                this.sepLabel = sepLabel;
+            }
+
+            @Override
+            protected BytesRef changeToken(BytesRef in) {
+                int upto = 0;
+                for(int i=0;i<in.length;i++) {
+                    byte b = in.bytes[in.offset+i];
+                    if (b == (byte) sepLabel) {
+                        spare.grow(upto+2);
+                        spare.setByteAt(upto++, (byte) sepLabel);
+                        spare.setByteAt(upto++, b);
+                    } else {
+                        spare.grow(upto+1);
+                        spare.setByteAt(upto++, b);
+                    }
+                }
+                spare.setLength(upto);
+                return spare.get();
+            }
+        }
+
+        public static TokenStreamToAutomaton getTokenStreamToAutomaton(boolean preserveSep, boolean preservePositionIncrements, int sepLabel) {
+            final TokenStreamToAutomaton tsta;
+            if (preserveSep) {
+                tsta = new EscapingTokenStreamToAutomaton((char) sepLabel);
+            } else {
+                // When we're not preserving sep, we don't steal 0xff
+                // byte, so we don't need to do any escaping:
+                tsta = new TokenStreamToAutomaton();
+            }
+            tsta.setPreservePositionIncrements(preservePositionIncrements);
+            return tsta;
+        }
+    }
+
+    /**
+     * Helper to encode/decode payload with surface + PAYLOAD_SEP + docID
+     */
+    static final class PayLoadProcessor {
+        final static private int MAX_DOC_ID_LEN_WITH_SEP = 6; // vint takes at most 5 bytes
+
+        static int parseSurfaceForm(final BytesRef output, int payloadSep, CharsRefBuilder spare) {
+            int surfaceFormLen = -1;
+            for (int i = 0; i < output.length; i++) {
+                if (output.bytes[output.offset + i] == payloadSep) {
+                    surfaceFormLen = i;
+                    break;
+                }
+            }
+            assert surfaceFormLen != -1 : "no payloadSep found, unable to determine surface form";
+            spare.copyUTF8Bytes(output.bytes, output.offset, surfaceFormLen);
+            return surfaceFormLen;
+        }
+
+        static int parseDocID(final BytesRef output, int payloadSepIndex) {
+            assert payloadSepIndex != -1 : "payload sep index can not be -1";
+            ByteArrayDataInput input = new ByteArrayDataInput(output.bytes, payloadSepIndex + output.offset + 1, output.length - (payloadSepIndex + output.offset));
+            return input.readVInt();
+        }
+
+        static BytesRef make(final BytesRef surface, int docID, int payloadSep) throws IOException {
+            int len = surface.length + MAX_DOC_ID_LEN_WITH_SEP;
+            byte[] buffer = new byte[len];
+            ByteArrayDataOutput output = new ByteArrayDataOutput(buffer);
+            output.writeBytes(surface.bytes, surface.length - surface.offset);
+            output.writeByte((byte) payloadSep);
+            output.writeVInt(docID);
+            return new BytesRef(buffer, 0, output.getPosition());
+        }
+    }
+}

--- a/src/main/java/org/apache/lucene/search/suggest/analyzing/NRTSuggesterBuilder.java
+++ b/src/main/java/org/apache/lucene/search/suggest/analyzing/NRTSuggesterBuilder.java
@@ -1,0 +1,221 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.lucene.search.suggest.analyzing;
+
+import org.apache.lucene.search.suggest.analyzing.ContextAwareScorer.OutputConfiguration;
+import org.apache.lucene.search.suggest.analyzing.LookupPostingsFormat.LookupBuildConfiguration;
+import org.apache.lucene.store.DataOutput;
+import org.apache.lucene.util.*;
+import org.apache.lucene.util.fst.*;
+
+import java.io.IOException;
+import java.util.PriorityQueue;
+
+/**
+ * Builder for {@link org.apache.lucene.search.suggest.analyzing.NRTSuggester}
+ *
+ * @param <W> score type
+ */
+public class NRTSuggesterBuilder<W extends Comparable<W>> {
+    public static final int SERIALIZE_PRESERVE_SEPARATORS = 1;
+    public static final int SERIALIZE_PRESERVE_POSITION_INCREMENTS = 2;
+
+
+    public static final int PAYLOAD_SEP = '\u001F';
+    public static final int HOLE_CHARACTER = '\u001E';
+    /**
+     * Represents the separation between tokens, if
+     * PRESERVE_SEP was specified
+     */
+    public static final int SEP_LABEL = '\u001F';
+
+    /**
+     * Marks end of the analyzed input and start of dedup
+     * byte.
+     */
+    public static final int END_BYTE = 0x0;
+
+    private int payloadSep = PAYLOAD_SEP;
+    private int sepLabel = SEP_LABEL;
+    private int endByte = END_BYTE;
+    private int holeCharacter = HOLE_CHARACTER;
+
+    private FSTBuilder<W> builder;
+    private final PayloadProcessor<W> payloadProcessor;
+    private final String scorerName;
+    private final boolean preserveSep;
+    private final boolean preservePositionIncrements;
+    private int maxAnalyzedPathsPerLeaf = 0;
+
+    private NRTSuggesterBuilder(ContextAwareScorer<W> contextAwareScorer, boolean preserveSep, boolean preservePositionIncrements, PayloadProcessor<W> payloadProcessor) {
+        this.scorerName = contextAwareScorer.name();
+        this.preserveSep = preserveSep;
+        this.preservePositionIncrements = preservePositionIncrements;
+        this.payloadProcessor = payloadProcessor;
+        this.builder = new FSTBuilder<>(contextAwareScorer.getOutputConfiguration(), payloadSep, endByte);
+        NRTSuggester.registerScorer(scorerName, contextAwareScorer);
+
+    }
+
+    /**
+     * Constructs a {@code NRTSuggesterBuilder} from {@link LookupBuildConfiguration}
+     */
+    public static <W extends Comparable<W>> NRTSuggesterBuilder<W> fromConfiguration(LookupBuildConfiguration lookupBuildConfiguration) {
+        return new NRTSuggesterBuilder<>(lookupBuildConfiguration.scorer,
+                lookupBuildConfiguration.preserveSep,
+                lookupBuildConfiguration.preservePositionIncrements,
+                lookupBuildConfiguration.payloadProcessor);
+    }
+
+    /**
+     * Initializes an FST input term to add entries against
+     */
+    public void startTerm(BytesRef term) {
+        builder.startTerm(term);
+    }
+
+    /**
+     * Adds an entry for the latest input term, should be called after
+     * {@link #startTerm(org.apache.lucene.util.BytesRef)} on the desired input
+     */
+    public void addEntry(int docID, BytesRef payload) throws IOException {
+        payloadProcessor.parse(payload);
+        builder.addEntry(docID, payloadProcessor.surfaceForm(), payloadProcessor.weight());
+    }
+
+    /**
+     * Writes all the entries for the FST input term
+     */
+    public void finishTerm() throws IOException {
+        maxAnalyzedPathsPerLeaf = Math.max(maxAnalyzedPathsPerLeaf, builder.finishTerm());
+    }
+
+    /**
+     * Builds and stores a FST that can be loaded with
+     * {@link NRTSuggester#load(org.apache.lucene.store.IndexInput)}
+     */
+    public boolean store(DataOutput output) throws IOException {
+        final FST<? extends PairOutputs.Pair<W, BytesRef>> build = builder.build();
+        if (build == null) {
+            return false;
+        }
+        output.writeString(scorerName);
+        build.save(output);
+
+        /* write some more meta-info */
+        assert maxAnalyzedPathsPerLeaf > 0;
+        output.writeVInt(maxAnalyzedPathsPerLeaf);
+        int options = 0;
+        options |= preserveSep ? SERIALIZE_PRESERVE_SEPARATORS : 0;
+        options |= preservePositionIncrements ? SERIALIZE_PRESERVE_POSITION_INCREMENTS : 0;
+        output.writeVInt(options);
+        output.writeVInt(sepLabel);
+        output.writeVInt(endByte);
+        output.writeVInt(payloadSep);
+        output.writeVInt(holeCharacter);
+        return true;
+    }
+
+    final static class FSTBuilder<W extends Comparable<W>> {
+        private PairOutputs<W, BytesRef> outputs;
+        private Builder<PairOutputs.Pair<W, BytesRef>> builder;
+        private final OutputConfiguration<W> outputConfiguration;
+        private final IntsRefBuilder scratchInts = new IntsRefBuilder();
+        private final BytesRefBuilder analyzed = new BytesRefBuilder();
+        private final PriorityQueue<Entry<W>> entries;
+        private final int payloadSep;
+        private final int endByte;
+
+        FSTBuilder(OutputConfiguration<W> outputConfiguration, int payloadSep, int endByte) {
+            this.payloadSep = payloadSep;
+            this.endByte = endByte;
+            this.outputs = new PairOutputs<>(outputConfiguration.outputSingleton(), ByteSequenceOutputs.getSingleton());
+            this.outputConfiguration = outputConfiguration;
+            this.entries = new PriorityQueue<>();
+            this.builder = new Builder<>(FST.INPUT_TYPE.BYTE1, outputs);
+        }
+
+
+        void startTerm(BytesRef analyzed) {
+            this.analyzed.copyBytes(analyzed);
+            this.analyzed.append((byte) endByte);
+        }
+
+        void addEntry(int docID, BytesRef surface, W weight) throws IOException {
+            BytesRef payloadRef = NRTSuggester.PayLoadProcessor.make(surface, docID, payloadSep);
+            entries.add(new Entry<>(payloadRef, outputConfiguration.encode(weight)));
+        }
+
+        int finishTerm() throws IOException {
+            int numArcs = 0;
+            int numDedupBytes = 1;
+            int entryCount = entries.size();
+            analyzed.grow(analyzed.length() + 1);
+            analyzed.setLength(analyzed.length() + 1);
+            for (Entry<W> entry : entries) {
+                //TODO: make this a balanced tree for context-aware scoring
+                if (numArcs == maxNumArcsForDedupByte(numDedupBytes)) {
+                    analyzed.setByteAt(analyzed.length() - 1, (byte) (numArcs));
+                    analyzed.grow(analyzed.length() + 1);
+                    analyzed.setLength(analyzed.length() + 1);
+                    numArcs = 0;
+                    numDedupBytes++;
+                }
+                analyzed.setByteAt(analyzed.length() - 1, (byte) numArcs++);
+                Util.toIntsRef(analyzed.get(), scratchInts);
+                builder.add(scratchInts.get(), outputs.newPair(entry.weight, entry.payload));
+            }
+            entries.clear();
+            return entryCount;
+        }
+
+        /**
+         * Num arcs for nth dedup byte:
+         *  if n <= 5: 1 + (2 * n)
+         *  else: (1 + (2 * n)) * n
+         */
+        private static int maxNumArcsForDedupByte(int currentNumDedupBytes) {
+            int maxArcs = 1 + (2 * currentNumDedupBytes);
+            if (currentNumDedupBytes > 5) {
+                maxArcs *= currentNumDedupBytes;
+            }
+            return Math.min(maxArcs, 255);
+        }
+
+        FST<PairOutputs.Pair<W, BytesRef>> build() throws IOException {
+            return builder.finish();
+        }
+
+        private final static class Entry<W extends Comparable<W>> implements Comparable<Entry<W>> {
+            final BytesRef payload;
+            final W weight;
+
+            public Entry(BytesRef payload, W weight) {
+                this.payload = payload;
+                this.weight = weight;
+            }
+
+            @Override
+            public int compareTo(Entry<W> o) {
+                return weight.compareTo(o.weight);
+            }
+        }
+    }
+}

--- a/src/main/java/org/apache/lucene/search/suggest/analyzing/PayloadProcessor.java
+++ b/src/main/java/org/apache/lucene/search/suggest/analyzing/PayloadProcessor.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.lucene.search.suggest.analyzing;
+
+import org.apache.lucene.store.InputStreamDataInput;
+import org.apache.lucene.store.OutputStreamDataOutput;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.BytesRefBuilder;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+public abstract class PayloadProcessor<W> {
+
+    private final BytesRefBuilder scratch = new BytesRefBuilder();
+
+    private BytesRef surfaceForm = null;
+    private W weight = null;
+
+    public void parse(BytesRef payload) throws IOException {
+        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(payload.bytes, payload.offset, payload.length);
+        InputStreamDataInput input = new InputStreamDataInput(byteArrayInputStream);
+        int len = input.readVInt();
+        scratch.grow(len);
+        scratch.setLength(len);
+        input.readBytes(scratch.bytes(), 0, scratch.length());
+        surfaceForm = scratch.get();
+        weight = parseWeight(input);
+        input.close();
+    }
+
+    public BytesRef build(BytesRef surfaceForm, W weight) throws IOException {
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        OutputStreamDataOutput output = new OutputStreamDataOutput(byteArrayOutputStream);
+        output.writeVInt(surfaceForm.length);
+        output.writeBytes(surfaceForm.bytes, surfaceForm.offset, surfaceForm.length);
+        writeWeight(output, weight);
+        output.close();
+        return new BytesRef(byteArrayOutputStream.toByteArray());
+    }
+
+    public W weight() {
+        return weight;
+    }
+
+    public BytesRef surfaceForm() {
+        return surfaceForm;
+    }
+
+    abstract W parseWeight(InputStreamDataInput input) throws IOException;
+
+    abstract void writeWeight(OutputStreamDataOutput output, W weight) throws IOException;
+
+    public final static class BytesRefPayloadProcessor extends PayloadProcessor<BytesRef> {
+        private final BytesRefBuilder scratch = new BytesRefBuilder();
+
+        @Override
+        BytesRef parseWeight(InputStreamDataInput input) throws IOException {
+            int len = input.readVInt();
+            scratch.grow(len);
+            scratch.setLength(len);
+            input.readBytes(scratch.bytes(), 0, scratch.length());
+            return scratch.get();
+        }
+
+        @Override
+        void writeWeight(OutputStreamDataOutput output, BytesRef weight) throws IOException {
+            output.writeVInt(weight.length);
+            output.writeBytes(weight.bytes, weight.offset, weight.length);
+        }
+    }
+
+    public final static class LongPayloadProcessor extends PayloadProcessor<Long> {
+
+        @Override
+        Long parseWeight(InputStreamDataInput input) throws IOException {
+            return input.readVLong() - 1;
+        }
+
+        @Override
+        void writeWeight(OutputStreamDataOutput output, Long weight) throws IOException {
+            if (weight < -1 || weight > Integer.MAX_VALUE) {
+                throw new IllegalArgumentException("weight must be >= -1 && <= Integer.MAX_VALUE");
+            }
+            output.writeVLong(weight + 1);
+        }
+
+    }
+}

--- a/src/main/java/org/apache/lucene/search/suggest/analyzing/SegmentLookup.java
+++ b/src/main/java/org/apache/lucene/search/suggest/analyzing/SegmentLookup.java
@@ -55,7 +55,7 @@ public abstract class SegmentLookup<W> implements Accountable {
          * Called every time an analyzed form is collected in order specified by the configured scorer
          *
          * @param key the matched analyzed form
-         * @param results a list of surface form, score and docID of the matched documents
+         * @param results a list of output, score and docID of the matched documents
          * @throws IOException
          */
         void collect(CharSequence key, List<ResultMetaData<W>> results) throws IOException;
@@ -71,7 +71,7 @@ public abstract class SegmentLookup<W> implements Accountable {
                 this.docId = docId;
             }
 
-            public CharSequence outputForm() {
+            public CharSequence output() {
                 return outputForm;
             }
 
@@ -202,7 +202,7 @@ public abstract class SegmentLookup<W> implements Accountable {
         /**
          * long score based lookup with {@link DefaultCollector}
          */
-        public List<DefaultCollector<Long>.Result<Long>> lookup(LeafReader reader, CharSequence key, int num, int nLeaf, Context<Long> context) {
+        public List<DefaultCollector.Result<Long>> lookup(LeafReader reader, CharSequence key, int num, int nLeaf, Context<Long> context) {
             DefaultCollector<Long> defaultLongCollector = new DefaultCollector<>();
             this.lookup(reader, key, num, nLeaf, context, defaultLongCollector);
             return defaultLongCollector.get();
@@ -211,14 +211,14 @@ public abstract class SegmentLookup<W> implements Accountable {
         /**
          * long score based lookup with {@link DefaultCollector} and no context
          */
-        public List<DefaultCollector<Long>.Result<Long>> lookup(LeafReader reader, CharSequence key, int num, int nLeaf) {
+        public List<DefaultCollector.Result<Long>> lookup(LeafReader reader, CharSequence key, int num, int nLeaf) {
             return lookup(reader, key, num, nLeaf, null);
         }
 
         /**
          * long score based lookup with {@link DefaultCollector} and no context and <code>nLeaf = 1</code>
          */
-        public List<DefaultCollector<Long>.Result<Long>> lookup(LeafReader reader, CharSequence key, int num) {
+        public List<DefaultCollector.Result<Long>> lookup(LeafReader reader, CharSequence key, int num) {
             return lookup(reader, key, num, 1);
         }
     }

--- a/src/main/java/org/apache/lucene/search/suggest/analyzing/SegmentLookup.java
+++ b/src/main/java/org/apache/lucene/search/suggest/analyzing/SegmentLookup.java
@@ -1,0 +1,234 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.lucene.search.suggest.analyzing;
+
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.BytesRef;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Simple Lookup interface for {@link CharSequence} suggestions.
+ * @lucene.experimental
+ */
+public abstract class SegmentLookup<W> implements Accountable {
+
+    /**
+     * Sole constructor. (For invocation by subclass
+     * constructors, typically implicit.)
+     */
+    public SegmentLookup() {
+    }
+
+
+    /**
+     * Collects Lookup results
+     * @param <W> type of score
+     */
+    public static interface Collector<W> {
+
+        /**
+         * Called every time an analyzed form is collected in order specified by the configured scorer
+         *
+         * @param key the matched analyzed form
+         * @param results a list of surface form, score and docID of the matched documents
+         * @throws IOException
+         */
+        void collect(CharSequence key, List<ResultMetaData<W>> results) throws IOException;
+
+        public static final class ResultMetaData<W> {
+            private final CharSequence outputForm;
+            private final W score;
+            private final int docId;
+
+            public ResultMetaData(CharSequence outputForm, W score, int docId) {
+                this.outputForm = outputForm;
+                this.score = score;
+                this.docId = docId;
+            }
+
+            public CharSequence outputForm() {
+                return outputForm;
+            }
+
+            public W score() {
+                return score;
+            }
+            public int docId() {
+                return docId;
+            }
+        }
+    }
+
+
+    /**
+     * Context holds a <code>filter</code> to filter docIds by
+     * and <code>scoreContext</code> for context aware lookup
+     * @param <W> score type
+     */
+    public static class Context<W> {
+
+        final W scoreContext;
+        final Filter filter;
+
+        public static interface Filter {
+            Bits bits();
+            int size();
+            int cardinality();
+        }
+
+        /**
+         * Context with only context aware score
+         */
+        public Context(W scoreContext) {
+            this(scoreContext, null);
+        }
+
+        /**
+         * Context with only context filter
+         */
+        public Context(Filter filter) {
+            this(null, filter);
+        }
+
+        /**
+         * Context with <code>scoreContext</code> and <code>filter</code>
+         */
+        public Context(W scoreContext, Filter filter) {
+            this.scoreContext = scoreContext;
+            this.filter = filter;
+        }
+    }
+
+    /**
+     * Calls {@link #lookup(LeafReader, Analyzer, CharSequence, int, int, Context, Collector)}
+     * with no context
+     */
+    public void lookup(final LeafReader reader, final Analyzer queryAnalyzer, final CharSequence key, int num, int nLeaf, final Collector<W> collector) {
+        lookup(reader, queryAnalyzer, key, num, nLeaf, null, collector);
+    }
+
+    /**
+     * Lookup a <code>key</code> and collect possible completion entries
+     *
+     * @param reader to be used for filtering deleted docs
+     * @param queryAnalyzer analyzer to be applied to provided key
+     * @param key prefix to lookup
+     * @param num number of unique analyzed forms
+     * @param nLeaf number of documents to be retrieved per analyzed form
+     * @param context query context and filter context for the lookup
+     * @param collector used to collect the results of the lookup
+     */
+    public abstract void lookup(final LeafReader reader, final Analyzer queryAnalyzer, final CharSequence key, int num, int nLeaf, Context<W> context, final Collector<W> collector);
+
+
+    /**
+     * SegmentLookup wrapper base for Long and BytesRef based scores
+     * @param <W> score type
+     */
+    public static abstract class SegmentLookupWrapper<W> extends SegmentLookup<W> {
+        private final SegmentLookup<W> segmentLookup;
+        private final Analyzer queryAnalyzer;
+
+
+        /**
+         * @param segmentLookup implementation
+         * @param queryAnalyzer analyzer used to tokenize lookup key
+         */
+        public SegmentLookupWrapper(SegmentLookup<W> segmentLookup, Analyzer queryAnalyzer) {
+            this.segmentLookup = segmentLookup;
+            this.queryAnalyzer = queryAnalyzer;
+        }
+
+        @Override
+        public long ramBytesUsed() {
+            return segmentLookup.ramBytesUsed();
+        }
+
+        @Override
+        public Collection<Accountable> getChildResources() {
+            return Collections.emptyList();
+        }
+
+        /**
+         * Calls {@link #lookup(LeafReader, Analyzer, CharSequence, int, int, Context, Collector)} with <code>queryAnalyzer</code>
+         */
+        public void lookup(LeafReader reader, CharSequence key, int num, int nLeaf, Context<W> context, Collector<W> collector) {
+            segmentLookup.lookup(reader, queryAnalyzer, key, num, nLeaf, context, collector);
+        }
+
+        @Override
+        public void lookup(LeafReader reader, Analyzer queryAnalyzer, CharSequence key, int num, int nLeaf, Context<W> context, Collector<W> collector) {
+            segmentLookup.lookup(reader, queryAnalyzer, key, num, nLeaf, context, collector);
+        }
+    }
+
+    /**
+     * SegmentLookup wrapper for long score based lookup
+     */
+    public static class LongBased extends SegmentLookupWrapper<Long> {
+
+        /**
+         * Calls {@link SegmentLookupWrapper}
+         */
+        public LongBased(SegmentLookup<Long> segmentLookup, Analyzer queryAnalyzer) {
+            super(segmentLookup, queryAnalyzer);
+        }
+
+        /**
+         * long score based lookup with {@link DefaultCollector}
+         */
+        public List<DefaultCollector<Long>.Result<Long>> lookup(LeafReader reader, CharSequence key, int num, int nLeaf, Context<Long> context) {
+            DefaultCollector<Long> defaultLongCollector = new DefaultCollector<>();
+            this.lookup(reader, key, num, nLeaf, context, defaultLongCollector);
+            return defaultLongCollector.get();
+        }
+
+        /**
+         * long score based lookup with {@link DefaultCollector} and no context
+         */
+        public List<DefaultCollector<Long>.Result<Long>> lookup(LeafReader reader, CharSequence key, int num, int nLeaf) {
+            return lookup(reader, key, num, nLeaf, null);
+        }
+
+        /**
+         * long score based lookup with {@link DefaultCollector} and no context and <code>nLeaf = 1</code>
+         */
+        public List<DefaultCollector<Long>.Result<Long>> lookup(LeafReader reader, CharSequence key, int num) {
+            return lookup(reader, key, num, 1);
+        }
+    }
+
+    public static class BytesBased extends SegmentLookupWrapper<BytesRef> {
+
+        public BytesBased(SegmentLookup<BytesRef> segmentLookup, Analyzer queryAnalyzer) {
+            super(segmentLookup, queryAnalyzer);
+        }
+    }
+
+}
+

--- a/src/main/java/org/apache/lucene/search/suggest/analyzing/TopNSearcher.java
+++ b/src/main/java/org/apache/lucene/search/suggest/analyzing/TopNSearcher.java
@@ -1,0 +1,415 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.lucene.search.suggest.analyzing;
+
+import org.apache.lucene.util.IntsRef;
+import org.apache.lucene.util.IntsRefBuilder;
+import org.apache.lucene.util.fst.FST;
+import org.apache.lucene.util.fst.Util;
+
+import java.io.IOException;
+import java.util.*;
+
+/**
+ * Generic TopNSearcher for {@link org.apache.lucene.util.fst.FST}
+ *
+ * Finds Top <code>topN</code> inputs that completes all the {@link #addStartPaths(FST.Arc, Object, boolean, IntsRefBuilder)}
+ * for each input iteratively finds the top accepted <code>nLeaf</code> outputs
+ *
+ * For every input completion that reaches its <code>leafLabel</code>
+ * {@link #onLeafNode(org.apache.lucene.util.IntsRef, Object)} is called once,
+ * followed by {@link #collectOutput(Object)} called at most <code>nLeaf</code> +
+ * number of rejected outputs. After at least <code>nLeaf</code> outputs are accepted
+ * {@link #onFinishNode()} is called
+ *
+ */
+public abstract class TopNSearcher<T> {
+
+    // debug flag for logging
+    private static final boolean DEBUG = false;
+
+    private final FST<T> fst;
+    private final FST.BytesReader bytesReader;
+    private final int topN;
+    private final int nLeaf;
+    private final int leafLabel;
+    private final int maxQueueDepth;
+
+    private final FST.Arc<T> scratchArc = new FST.Arc<>();
+
+    private final Comparator<T> comparator;
+
+    private TreeSet<Util.FSTPath<T>> queue = null;
+    private TreeSet<Util.FSTPath<T>> leafQueue = null;
+
+    /**
+     * Creates an unbounded TopNSearcher
+     *
+     * @param fst           the {@link org.apache.lucene.util.fst.FST} to search on
+     * @param topN          the number of top scoring inputs to retrieve
+     * @param nLeaf         the number of top scoring outputs to retrieve per input
+     * @param leafLabel     the input label that marks the beginning of the output leaves
+     * @param maxQueueDepth the maximum size of the queue of possible top entries
+     * @param comparator    the comparator to select the top N
+     */
+    public TopNSearcher(FST<T> fst, int topN, int nLeaf, int leafLabel, int maxQueueDepth, Comparator<T> comparator) {
+        this.fst = fst;
+        this.bytesReader = fst.getBytesReader();
+        this.topN = topN;
+        this.nLeaf = nLeaf;
+        this.leafLabel = leafLabel;
+        this.maxQueueDepth = maxQueueDepth;
+        this.comparator = comparator;
+
+        queue = new TreeSet<>(new TieBreakByInputComparator<>(comparator));
+        leafQueue = new TreeSet<>(new TieBreakByInputComparator<>(comparator));
+
+    }
+
+    //TODO: test and fix pruning (the chosen path is never put in the queue; make sure pruning works there)
+    protected boolean prune(T pathCost) {
+        return false;
+    }
+
+    // If back plus this arc is competitive then add to queue:
+    protected void addIfCompetitive(Util.FSTPath<T> path) {
+
+        assert queue != null;
+
+        T cost = fst.outputs.add(path.cost, path.arc.output);
+        if (DEBUG) {
+            System.out.println("  addIfCompetitive queue.size()=" + queue.size() + " path=" + path.arc.label + " + label=" + path.arc.label);
+        }
+
+        if (prune(cost)) {
+            return;
+        }
+
+        if (queue.size() == maxQueueDepth) {
+            Util.FSTPath<T> bottom = queue.last();
+            int comp = comparator.compare(cost, bottom.cost);
+            if (comp > 0) {
+                // Doesn't compete
+                return;
+            } else if (comp == 0) {
+                // Tie break by alpha sort on the input:
+                path.input.append(path.arc.label);
+                final int cmp = bottom.input.get().compareTo(path.input.get());
+                path.input.setLength(path.input.length() - 1);
+
+                // We should never see dups:
+                assert cmp != 0;
+
+                if (cmp < 0) {
+                    // Doesn't compete
+                    return;
+                }
+            }
+            // Competes
+        } else {
+            // Queue isn't full yet, so any path we hit competes:
+        }
+
+        // copy over the current input to the new input
+        // and add the arc.label to the end
+        IntsRefBuilder newInput = new IntsRefBuilder();
+        newInput.copyInts(path.input.get());
+        if (path.arc.label != leafLabel) {
+            newInput.append(path.arc.label);
+        }
+        final Util.FSTPath<T> newPath = new Util.FSTPath<>(cost, path.arc, newInput);
+
+        queue.add(newPath);
+
+        if (queue.size() == maxQueueDepth + 1) {
+            queue.pollLast();
+        }
+    }
+
+    protected void addLeafPath(Util.FSTPath<T> path) {
+        T cost = fst.outputs.add(path.cost, path.arc.output);
+        IntsRefBuilder newInput = new IntsRefBuilder();
+        newInput.copyInts(path.input.get());
+        newInput.append(path.arc.label);
+        final Util.FSTPath<T> newPath = new Util.FSTPath<>(cost, path.arc, newInput);
+
+        leafQueue.add(newPath);
+    }
+
+    /**
+     * Adds all leaving arcs, including 'finished' arc, if
+     * the node is final, from this node into the queue.
+     */
+    public void addStartPaths(FST.Arc<T> node, T startOutput, boolean allowEmptyString, IntsRefBuilder input) throws IOException {
+
+        // De-dup NO_OUTPUT since it must be a singleton:
+        if (startOutput.equals(fst.outputs.getNoOutput())) {
+            startOutput = fst.outputs.getNoOutput();
+        }
+
+        Util.FSTPath<T> path = new Util.FSTPath<>(startOutput, node, input);
+        fst.readFirstTargetArc(node, path.arc, bytesReader);
+
+        if (DEBUG) {
+            System.out.println("add start paths");
+        }
+
+        // Bootstrap: find the min starting arc
+        while (true) {
+            if (allowEmptyString || path.arc.label != FST.END_LABEL) {
+                addIfCompetitive(path);
+            }
+            if (path.arc.isLast()) {
+                break;
+            }
+            fst.readNextArc(path.arc, bytesReader);
+        }
+    }
+
+
+    /**
+     * The results for the search can be collected using {@link #onLeafNode(org.apache.lucene.util.IntsRef, Object)},
+     * {@link #collectOutput(Object)} and {@link #onFinishNode()}
+     *
+     * @return <code>true</code> iff this is a complete result ie. if
+     * the specified queue size was large enough to find the complete list of results. This might
+     * be <code>false</code> if the {@link TopNSearcher} rejected too many results.
+     */
+    public boolean search() throws IOException {
+
+        int resultCount = 0;
+
+        if (DEBUG) {
+            System.out.println("search topN=" + topN);
+        }
+        final FST.BytesReader fstReader = fst.getBytesReader();
+        final T NO_OUTPUT = fst.outputs.getNoOutput();
+
+        // TODO: we could enable FST to sorting arcs by weight
+        // as it freezes... can easily do this on first pass
+        // (w/o requiring rewrite)
+
+        // TODO: maybe we should make an FST.INPUT_TYPE.BYTE0.5!?
+        // (nibbles)
+        int rejectCount = 0;
+
+        // For each top N path:
+        while (resultCount < topN) {
+            if (DEBUG) {
+                System.out.println("\nfind next path: queue.size=" + queue.size());
+            }
+
+            Util.FSTPath<T> path;
+
+            if (queue == null) {
+                // Ran out of paths
+                if (DEBUG) {
+                    System.out.println("  break queue=null");
+                }
+                break;
+            }
+
+            // Remove top path since we are now going to
+            // pursue it:
+            path = queue.pollFirst();
+
+            if (path == null) {
+                // There were less than topN paths available:
+                if (DEBUG) {
+                    System.out.println("  break no more paths");
+                }
+                break;
+            }
+
+            if (path.arc.label == FST.END_LABEL) {
+                if (DEBUG) {
+                    System.out.println("    empty string!  cost=" + path.cost);
+                }
+                // Empty string!
+                //path.input.setLength(path.input.length() - 1);
+                continue;
+            }
+
+            if (resultCount == topN - 1 && maxQueueDepth == topN) {
+                // Last path -- don't bother w/ queue anymore:
+                queue = null;
+            }
+
+            if (DEBUG) {
+                System.out.println("  path: " + path.input.get());
+            }
+
+            // We take path and find its "0 output completion",
+            // ie, just keep traversing the first arc with
+            // NO_OUTPUT that we can find, since this must lead
+            // to the minimum path that completes from
+            // path.arc.
+
+            if (DEBUG) {
+                System.out.println("\n    cycle path: " + path.input.get());
+            }
+
+            boolean isLeaf = path.arc.label == leafLabel;
+            boolean inLeaf = false;
+            int acceptedLeaves = 0;
+
+            if (isLeaf) {
+                onLeafNode(path.input.get(), path.cost);
+                inLeaf = true;
+            }
+
+            // For each input letter:
+            while (true) {
+                fst.readFirstTargetArc(path.arc, path.arc, fstReader);
+                boolean foundZero = false;
+                // For each arc leaving this node:
+                while (true) {
+                    if (DEBUG) {
+                        System.out.println("      arc=" + path.input.get().toString() + " cost=" + path.arc.output);
+                    }
+                    // tricky: instead of comparing output == 0, we must
+                    // express it via the comparator compare(output, 0) == 0
+                    //TODO: generalize for bytes based scoring (no output would be if there is a exact bytes match with the current context with the right offset)
+                    if (comparator.compare(NO_OUTPUT, path.arc.output) == 0) {
+                        if (queue == null) {
+                            foundZero = true;
+                            break;
+                        } else if (!foundZero) {
+                            scratchArc.copyFrom(path.arc);
+                            foundZero = true;
+                        } else if (inLeaf) {
+                            addLeafPath(path);
+                        } else {
+                            addIfCompetitive(path);
+                        }
+                    } else if (inLeaf) {
+                        addLeafPath(path);
+                    } else if (queue != null) {
+                        addIfCompetitive(path);
+                    }
+                    if (path.arc.isLast()) {
+                        break;
+                    }
+                    fst.readNextArc(path.arc, fstReader);
+                }
+                assert foundZero;
+
+                if (queue != null) {
+                    // TODO: maybe we can save this copyFrom if we
+                    // are more clever above... eg on finding the
+                    // first NO_OUTPUT arc we'd switch to using
+                    // scratchArc
+                    path.arc.copyFrom(scratchArc);
+                }
+                if (inLeaf) {
+                    // The path with the lowest cost is final
+                    // so can scan the leafQueue for any other paths
+                    // that are already final
+                    if (path.arc.isFinal()) {
+                        T cost = fst.outputs.add(path.cost, path.arc.output);
+                        while (path != null && path.arc.isFinal()) {
+                            if (!prune(cost)) {
+                                if (collectOutput(cost)) {
+                                    if (++acceptedLeaves == nLeaf) {
+                                        break;
+                                    }
+                                }
+                            }
+                            path = leafQueue.pollFirst();
+                            if (path != null) {
+                                cost = path.cost;
+                            }
+                        }
+                        if (path == null || acceptedLeaves == nLeaf) {
+                            if (acceptedLeaves > 0) {
+                                resultCount++;
+                            } else {
+                                rejectCount++;
+                            }
+                            leafQueue.clear();
+                            onFinishNode();
+                            break;
+                        }
+                    } else {
+                        path.input.append(path.arc.label);
+                        path.cost = fst.outputs.add(path.cost, path.arc.output);
+                    }
+                } else {
+                    isLeaf = path.arc.label == leafLabel;
+                    path.cost = fst.outputs.add(path.cost, path.arc.output);
+                    if (isLeaf && !inLeaf) {
+                        onLeafNode(path.input.get(), path.cost);
+                        inLeaf = true;
+                    }
+                    path.input.append(path.arc.label);
+                }
+            }
+        }
+        return rejectCount + topN <= maxQueueDepth;
+    }
+
+    /**
+     * Called exactly once when a leaf node for a <code>input</code>
+     * is found
+     * @param input the input up to the leaf node (excluding the leafLabel)
+     * @param output the output up to the leaf node
+     */
+    protected abstract void onLeafNode(IntsRef input, T output);
+
+    /**
+     * Called on finding a leaf node output.
+     *
+     * This will be called at most <code>nLeaf</code> + number of not accepted
+     * output.
+     *
+     * @param output full output at the leaf node
+     * @return true if output is accepted, false otherwise
+     * @throws IOException
+     */
+    protected abstract boolean collectOutput(T output) throws IOException;
+
+    /**
+     * Called on finishing processing all the output(s) at a leaf node
+     * @throws IOException
+     */
+    protected abstract void onFinishNode() throws IOException;
+
+    /**
+     * Compares first by the provided comparator, and then
+     * tie breaks by path.input.
+     */
+    private static class TieBreakByInputComparator<T> implements Comparator<Util.FSTPath<T>> {
+        private final Comparator<T> comparator;
+
+        public TieBreakByInputComparator(Comparator<T> comparator) {
+            this.comparator = comparator;
+        }
+
+        @Override
+        public int compare(Util.FSTPath<T> a, Util.FSTPath<T> b) {
+            int cmp = comparator.compare(a.cost, b.cost);
+            if (cmp == 0) {
+                return a.input.get().compareTo(b.input.get());
+            } else {
+                return cmp;
+            }
+        }
+    }
+}

--- a/src/main/resources/META-INF/services/org.apache.lucene.codecs.PostingsFormat
+++ b/src/main/resources/META-INF/services/org.apache.lucene.codecs.PostingsFormat
@@ -1,3 +1,4 @@
 org.elasticsearch.index.codec.postingsformat.Elasticsearch090PostingsFormat
 org.elasticsearch.search.suggest.completion.Completion090PostingsFormat
+org.apache.lucene.search.suggest.analyzing.LookupPostingsFormat
 org.elasticsearch.index.codec.postingsformat.BloomFilterPostingsFormat

--- a/src/test/java/org/apache/lucene/search/suggest/analyzing/DefaultCollectorTest.java
+++ b/src/test/java/org/apache/lucene/search/suggest/analyzing/DefaultCollectorTest.java
@@ -1,0 +1,299 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.lucene.search.suggest.analyzing;
+
+import org.apache.lucene.document.*;
+import org.apache.lucene.index.*;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.LuceneTestCase;
+import org.apache.lucene.util.TestUtil;
+import org.junit.Test;
+
+import java.util.*;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+public class DefaultCollectorTest extends LuceneTestCase {
+
+
+    @Test
+    public void testMultiValuedFields() throws Exception {
+        Directory dir = newDirectory();
+
+        IndexWriterConfig iwc = newIndexWriterConfig(random(), null);
+        iwc.setMergePolicy(newLogMergePolicy());
+        RandomIndexWriter iw = new RandomIndexWriter(random(), dir, iwc);
+        int nValues = 10;
+        List<String> values = new ArrayList<>();
+        Set<String> fieldNames = new HashSet<>();
+        fieldNames.add("string_field");
+        Document doc = new Document();
+        for (int i = 0; i < nValues; i++) {
+            String val = TestUtil.randomUnicodeString(random(), 10);
+            values.add(val);
+            doc.add(stringField(val));
+        }
+
+        iw.addDocument(doc);
+
+        SegmentReader reader = getOnlySegmentReader(iw.getReader());
+
+        DefaultCollector<Long> defaultCollector = new DefaultCollector<>(reader, fieldNames);
+
+        defaultCollector.collect("", collect(0));
+
+        List<DefaultCollector.Result<Long>> results = defaultCollector.get();
+
+        for (DefaultCollector.Result.InnerResult<Long> longInnerResult : results.get(0).innerResults()) {
+            for (DefaultCollector.FieldValue fieldValue : longInnerResult.fieldValues) {
+                assertThat(fieldValue.name(), equalTo("string_field"));
+                assertThat(fieldValue.isString(), equalTo(true));
+                assertThat(fieldValue.stringValues().size(), equalTo(values.size()));
+                Set<String> actualValueSet = new HashSet<>(values);
+                for (String value : fieldValue.stringValues()) {
+                    assertTrue(actualValueSet.contains(value));
+                }
+            }
+        }
+
+        iw.close();
+        reader.close();
+        dir.close();
+    }
+
+    @Test
+    public void testMissingValues() throws Exception {
+        Directory dir = newDirectory();
+
+        IndexWriterConfig iwc = newIndexWriterConfig(random(), null);
+        iwc.setMergePolicy(newLogMergePolicy());
+        RandomIndexWriter iw = new RandomIndexWriter(random(), dir, iwc);
+        int nDocs = 6;
+        for (int i = 0; i < nDocs; i++) {
+            Document doc = new Document();
+            String val = TestUtil.randomUnicodeString(random(), 10);
+            doc.add(stringField(val));
+            if (i % 2 == 0) {
+                BytesRef binaryDVValue = new BytesRef(TestUtil.randomUnicodeString(random(), 10));
+                doc.add(binaryDocValuesField(binaryDVValue));
+            }
+            iw.addDocument(doc);
+        }
+
+        iw.forceMerge(1);
+        SegmentReader reader = getOnlySegmentReader(iw.getReader());
+        Set<String> fieldNames = new HashSet<>();
+        fieldNames.add("string_field");
+        fieldNames.add("binary_doc_values");
+
+
+        DefaultCollector<Long> defaultCollector = new DefaultCollector<>(reader, fieldNames);
+        defaultCollector.collect("", collect(0, 1, 2, 3, 4, 5));
+        List<DefaultCollector.Result<Long>> results = defaultCollector.get();
+
+        for (DefaultCollector.Result.InnerResult<Long> longInnerResult : results.get(0).innerResults()) {
+            assertThat(longInnerResult.fieldValues.size(), equalTo(2));
+            for (DefaultCollector.FieldValue fieldValue : longInnerResult.fieldValues) {
+                if (fieldValue.isString()) {
+                    assertThat(fieldValue.name(), equalTo("string_field"));
+                } else if (fieldValue.isBinary()) {
+                    assertThat(fieldValue.name(), equalTo("binary_doc_values"));
+                } else {
+                    fail("expected field to be either string or binary");
+                }
+            }
+        }
+        iw.close();
+        reader.close();
+        dir.close();
+    }
+
+    @Test
+    public void testNonExistentField() throws Exception {
+        Directory dir = newDirectory();
+
+        IndexWriterConfig iwc = newIndexWriterConfig(random(), null);
+        iwc.setMergePolicy(newLogMergePolicy());
+        RandomIndexWriter iw = new RandomIndexWriter(random(), dir, iwc);
+        int nValues = 10;
+        List<String> values = new ArrayList<>();
+        Document doc = new Document();
+        for (int i = 0; i < nValues; i++) {
+            String val = TestUtil.randomUnicodeString(random(), 10);
+            values.add(val);
+            doc.add(stringField(val));
+        }
+
+        iw.addDocument(doc);
+
+        SegmentReader reader = getOnlySegmentReader(iw.getReader());
+        Set<String> fieldNames = new HashSet<>();
+        fieldNames.add("string_field");
+        fieldNames.add("bogus_field");
+        try {
+            DefaultCollector<Long> defaultCollector = new DefaultCollector<>(reader, fieldNames);
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage(), containsString("bogus_field"));
+        }
+
+        iw.close();
+        reader.close();
+        dir.close();
+    }
+
+
+    private Field idField(String value) {
+        return newStringField("id", value, Field.Store.YES);
+    }
+
+    private Field stringField(String value) {
+        return newStringField("string_field", value, Field.Store.YES);
+    }
+
+    private Field binaryDocValuesField(BytesRef value) {
+        return new BinaryDocValuesField("binary_doc_values", value);
+    }
+
+    private Field numericDocValuesField(Long value) {
+        return new NumericDocValuesField("numeric_doc_values", value);
+    }
+
+    private Field sortedDocValueField(BytesRef value) {
+        return new SortedDocValuesField("sorted_doc_values", value);
+    }
+
+    private Field sortedSetDocValueField(BytesRef value) {
+        return new SortedSetDocValuesField("sorted_set_doc_values", value);
+    }
+
+    private Field sortedNumericDocValuesField(Long value) {
+        return new SortedNumericDocValuesField("sorted_num_doc_values", value);
+    }
+
+    @Test
+    public void testFieldValueRetrieval() throws Exception {
+        Directory dir = newDirectory();
+
+        IndexWriterConfig iwc = newIndexWriterConfig(random(), null);
+        iwc.setMergePolicy(newLogMergePolicy());
+        RandomIndexWriter iw = new RandomIndexWriter(random(), dir, iwc);
+        int nDocs = atLeast(100);
+
+        Set<String> fieldNames = new HashSet<>();
+        fieldNames.add("id");
+        fieldNames.add("string_field");
+        fieldNames.add("binary_doc_values");
+        fieldNames.add("numeric_doc_values");
+        fieldNames.add("sorted_doc_values");
+        fieldNames.add("sorted_num_doc_values");
+        fieldNames.add("sorted_set_doc_values");
+
+        Map<String, Map<String, String>> docFieldMap = new HashMap<>();
+
+        int[] docIds = new int[nDocs];
+        for (int i = 0; i < nDocs; i++) {
+            Document doc = new Document();
+            String id = String.valueOf(i);
+            String stringValue = TestUtil.randomUnicodeString(random(), 10);
+            BytesRef binaryDVValue = new BytesRef(TestUtil.randomUnicodeString(random(), 10));
+            BytesRef sortedDVValue = new BytesRef(TestUtil.randomUnicodeString(random(), 10));
+            BytesRef sortedSetDVValue= new BytesRef(TestUtil.randomUnicodeString(random(), 10));
+            long numericDVValue = TestUtil.nextLong(random(), 1, 1000);
+            long sortedNumericDVValue = TestUtil.nextLong(random(), 1, 1000);
+
+            Map<String, String> fieldValueMap = new HashMap<>();
+            fieldValueMap.put("string_field", stringValue);
+            fieldValueMap.put("binary_doc_values", binaryDVValue.utf8ToString());
+            fieldValueMap.put("sorted_doc_values", sortedDVValue.utf8ToString());
+            fieldValueMap.put("sorted_set_doc_values", sortedSetDVValue.utf8ToString());
+            fieldValueMap.put("numeric_doc_values", String.valueOf(numericDVValue));
+            fieldValueMap.put("sorted_num_doc_values", String.valueOf(sortedNumericDVValue));
+
+            docFieldMap.put(id, fieldValueMap);
+
+            doc.add(idField(id));
+            doc.add(stringField(stringValue));
+            doc.add(binaryDocValuesField(binaryDVValue));
+            doc.add(sortedDocValueField(sortedDVValue));
+            doc.add(sortedSetDocValueField(sortedSetDVValue));
+            doc.add(numericDocValuesField(numericDVValue));
+            doc.add(sortedNumericDocValuesField(sortedNumericDVValue));
+            iw.addDocument(doc);
+            docIds[i] = i;
+
+            if (random().nextInt(5) == 1) {
+                iw.commit();
+            }
+        }
+
+        iw.forceMerge(1);
+
+        SegmentReader reader = getOnlySegmentReader(iw.getReader());
+
+        DefaultCollector<Long> defaultCollector = new DefaultCollector<>(reader, fieldNames);
+
+        defaultCollector.collect("", collect(docIds));
+
+        List<DefaultCollector.Result<Long>> results = defaultCollector.get();
+
+        for (DefaultCollector.Result.InnerResult<Long> longInnerResult : results.get(0).innerResults()) {
+            String id = null;
+            for (DefaultCollector.FieldValue fieldValue : longInnerResult.fieldValues) {
+                if (fieldValue.name().equals("id")) {
+                    id = fieldValue.stringValues().get(0);
+                    break;
+                }
+            }
+            assertNotNull(id);
+            Map<String, String> fieldValueMap = docFieldMap.get(id);
+            assertNotNull(fieldValueMap);
+            for (DefaultCollector.FieldValue fieldValue : longInnerResult.fieldValues) {
+                if (fieldValue.name().equals("id")) {
+                    continue;
+                }
+                String value = fieldValueMap.get(fieldValue.name());
+                assertNotNull(value);
+                if (fieldValue.isBinary()) {
+                    assertThat(fieldValue.binaryValues().get(0).utf8ToString(), equalTo(value));
+                } else if (fieldValue.isNumeric()) {
+                    assertThat(String.valueOf(fieldValue.numericValues().get(0)), equalTo(value));
+                } else if (fieldValue.isString()) {
+                    assertThat(fieldValue.stringValues().get(0), equalTo(value));
+                } else {
+                    fail("fieldValue is not of binary/numeric/string type");
+                }
+            }
+        }
+
+        iw.close();
+        reader.close();
+        dir.close();
+    }
+
+    private static List<SegmentLookup.Collector.ResultMetaData<Long>> collect(int... docIDs) {
+        List<SegmentLookup.Collector.ResultMetaData<Long>> res = new ArrayList<>();
+        for (int docID : docIDs) {
+            res.add(new SegmentLookup.Collector.ResultMetaData<>("", 1l, docID));
+        }
+        return res;
+    }
+}

--- a/src/test/java/org/apache/lucene/search/suggest/analyzing/NRTLookupTest.java
+++ b/src/test/java/org/apache/lucene/search/suggest/analyzing/NRTLookupTest.java
@@ -1,0 +1,461 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.lucene.search.suggest.analyzing;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.apache.lucene.analysis.tokenattributes.OffsetAttribute;
+import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.PostingsFormat;
+import org.apache.lucene.codecs.lucene50.Lucene50Codec;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.StoredField;
+import org.apache.lucene.index.*;
+import org.apache.lucene.store.RAMDirectory;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.BytesRefBuilder;
+import org.apache.lucene.util.LuceneTestCase;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.*;
+
+import static com.carrotsearch.randomizedtesting.RandomizedTest.*;
+import static org.hamcrest.Matchers.*;
+
+public class NRTLookupTest extends LuceneTestCase {
+
+    private String generateRandomSuggestions(int len) {
+
+        char[] chars = new char[len];
+        for (int i = 0; i < len; i++) {
+            char c = randomUnicodeOfLengthBetween(1, 1).charAt(0);
+            while(isReservedChar(c)) {
+                c = randomUnicodeOfLengthBetween(1,1).charAt(0);
+            }
+            chars[i] = c;
+        }
+        return new String(chars);
+    }
+
+    private static boolean isReservedChar(char c) {
+        switch(c) {
+            case  NRTSuggesterBuilder.END_BYTE:
+            case  NRTSuggesterBuilder.SEP_LABEL:
+            case  NRTSuggesterBuilder.HOLE_CHARACTER:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    @Test
+    public void testSameAnalyzedMultipleSurfaceForm() throws Exception {
+        final StandardAnalyzer standardAnalyzer = new StandardAnalyzer();
+        CompletionProvider completionProvider = new CompletionProvider(standardAnalyzer);
+        String[] inputs = {"BMW", "BMW ", "bmw", "bmw "};
+        long[] weights = {10l, 4l, 2l, 5l};
+        completionProvider.indexCompletions(inputs, weights);
+
+        final IndexReader reader = completionProvider.getReader();
+        final Map.Entry<SegmentLookup.LongBased, LeafReader> lookup = completionProvider.getLookup(reader);
+        final SegmentLookup.LongBased segmentLookup = lookup.getKey();
+        final LeafReader leafReader = lookup.getValue();
+
+        List<DefaultCollector<Long>.Result<Long>> results = segmentLookup.lookup(leafReader, "b", 3, 4);
+
+        assertResults(results,
+                new ExpectedResult("bmw", 10l, 5l, 4l, 2l));
+
+        results = segmentLookup.lookup(leafReader, "bmw", 3, 4);
+
+        assertResults(results,
+                new ExpectedResult("bmw", 10l, 5l, 4l, 2l));
+    }
+
+    @Test
+    public void testSameSurfaceForms() throws Exception {
+        final StandardAnalyzer standardAnalyzer = new StandardAnalyzer();
+        CompletionProvider completionProvider = new CompletionProvider(standardAnalyzer);
+        String[] inputs = {"apple", "apple", "apple", "application"};
+        long[] weights = {10l, 4l, 2l, 5l};
+        completionProvider.indexCompletions(inputs, weights);
+
+        final IndexReader reader = completionProvider.getReader();
+        final Map.Entry<SegmentLookup.LongBased, LeafReader>  lookup = completionProvider.getLookup(reader);
+        final SegmentLookup.LongBased segmentLookup = lookup.getKey();
+        final LeafReader leafReader = lookup.getValue();
+
+        // lookup for 'app'
+        List<DefaultCollector<Long>.Result<Long>> results = segmentLookup.lookup(leafReader, "app", 3, 3);
+
+        assertResults(results,
+                new ExpectedResult("apple", 10l, 4l, 2l),
+                new ExpectedResult("application", 5l));
+    }
+
+    @Test
+    public void testSimple() throws Exception {
+        final StandardAnalyzer standardAnalyzer = new StandardAnalyzer();
+        CompletionProvider completionProvider = new CompletionProvider(standardAnalyzer);
+        String[] inputs = {"apple", "apeal", "apples", "application"};
+        long[] weights = {1l, 10l, 3l, 5l};
+        completionProvider.indexCompletions(inputs, weights);
+
+        final IndexReader reader = completionProvider.getReader();
+        final Map.Entry<SegmentLookup.LongBased, LeafReader>  lookup = completionProvider.getLookup(reader);
+        final SegmentLookup.LongBased segmentLookup = lookup.getKey();
+        final LeafReader leafReader = lookup.getValue();
+
+        List<DefaultCollector<Long>.Result<Long>> results = segmentLookup.lookup(leafReader, "app", 3);
+
+        assertResults(results,
+                new ExpectedResult("application", 5l),
+                new ExpectedResult("apples", 3l),
+                new ExpectedResult("apple", 1l));
+        assertThat(results.size(), equalTo(3));
+
+        results = segmentLookup.lookup(leafReader, "ap", 3);
+
+        assertResults(results,
+                new ExpectedResult("apeal", 10l),
+                new ExpectedResult("application", 5l),
+                new ExpectedResult("apples", 3l));
+    }
+
+    @Test
+    public void testMultipleLookup() throws Exception {
+        final StandardAnalyzer standardAnalyzer = new StandardAnalyzer();
+        String[] firstInput = {"food", "fun", "foobar"};
+        long[] firstWeight = {1l, 3l, 5l};
+        String[] secondInput = {"foo", "fooo", "foobar"};
+        long[] secondWeight = {1l, 10l, 3l};
+        CompletionProvider firstCompletion = new CompletionProvider(standardAnalyzer);
+        firstCompletion.indexCompletions(firstInput, firstWeight);
+        CompletionProvider secondCompletion = new CompletionProvider(standardAnalyzer);
+        secondCompletion.indexCompletions(secondInput, secondWeight);
+
+        final IndexReader firstReader = firstCompletion.getReader();
+        Map.Entry<SegmentLookup.LongBased, LeafReader>  lookup = firstCompletion.getLookup(firstReader);
+        final SegmentLookup.LongBased firstLookup = lookup.getKey();
+        final LeafReader leafReader = lookup.getValue();
+
+        final IndexReader secondReader = secondCompletion.getReader();
+        lookup = secondCompletion.getLookup(secondReader);
+        final SegmentLookup.LongBased segmentLookup = lookup.getKey();
+        final LeafReader secondleafReader = lookup.getValue();
+
+        List<DefaultCollector<Long>.Result<Long>> results = firstLookup.lookup(leafReader, "foo", 3);
+
+        assertResults(results,
+                new ExpectedResult("foobar", 5l),
+                new ExpectedResult("food", 1l));
+
+        results = segmentLookup.lookup(leafReader, "foo", 3);
+
+        assertResults(results,
+                new ExpectedResult("fooo", 10l),
+                new ExpectedResult("foobar", 3l),
+                new ExpectedResult("foo", 1l));
+    }
+    private static class ExpectedResult {
+        private final String key;
+        private final long[] weights;
+
+        public ExpectedResult(String key, long... weights) {
+            this.key = key;
+            this.weights = weights;
+        }
+
+    }
+
+    public void assertResults(List<DefaultCollector<Long>.Result<Long>> results, ExpectedResult... expectedResults) {
+        assertThat(results.size(), equalTo(expectedResults.length));
+        int i = 0;
+        for (DefaultCollector<Long>.Result<Long> result : results) {
+            ExpectedResult expectedResult = expectedResults[i];
+            assertThat(result.key().toString(), equalTo(expectedResult.key));
+            assertThat(result.resultMetaDataList().size(), equalTo(expectedResult.weights.length));
+            int count = 0;
+            for (SegmentLookup.Collector.ResultMetaData<Long> longResultMetaData : result.resultMetaDataList()) {
+                assertThat(longResultMetaData.score(), equalTo(expectedResult.weights[count]));
+                count++;
+            }
+            i++;
+        }
+    }
+
+    @Test
+    public void testDuplicateSurfaceForm() throws Exception {
+        String prefixStr = generateRandomSuggestions(randomIntBetween(4, 6));
+        int num = scaledRandomIntBetween(256, 800);
+        final String[] titles = new String[num];
+        final long[] weights = new long[num];
+        String suffix = generateRandomSuggestions(randomIntBetween(1, 2));//scaledRandomIntBetween(30, 100)));
+
+        for(int i = 0; i < num; i++) {
+            titles[i] = prefixStr + suffix;
+            weights[i] = num - i;
+        }
+
+        CompletionProvider completionProvider = new CompletionProvider(new StandardAnalyzer());
+        completionProvider.indexCompletions(titles, weights);
+
+        final IndexReader reader = completionProvider.getReader();
+        final Map.Entry<SegmentLookup.LongBased, LeafReader>  lookup = completionProvider.getLookup(reader);
+        final SegmentLookup.LongBased segmentLookup = lookup.getKey();
+        final LeafReader leafReader = lookup.getValue();
+
+        final StringBuilder builder = new StringBuilder();
+        analyze(new StandardAnalyzer().tokenStream("foo", prefixStr + suffix), new TokenConsumer() {
+            @Override
+            public void nextToken() throws IOException {
+                builder.append(this.charTermAttr.toString());
+            }
+        });
+        assertResults(segmentLookup.lookup(leafReader, prefixStr, 1, num),
+                new ExpectedResult(builder.toString(), weights));
+
+    }
+
+    @Test
+    public void testDefaultScoring() throws Exception {
+        String prefixStr = generateRandomSuggestions(randomIntBetween(4, 6));
+        int num = scaledRandomIntBetween(500, 1000);
+        final String[] titles = new String[num];
+        final long[] weights = new long[num];
+
+        String suffix = generateRandomSuggestions(randomIntBetween(4, scaledRandomIntBetween(30, 100)));
+
+        for (int i = 0; i < titles.length; i++) {
+            titles[i] = prefixStr + suffix;
+            if (rarely()) {
+                suffix = generateRandomSuggestions(randomIntBetween(4, scaledRandomIntBetween(30, 100)));
+            }
+            weights[i] = between(0, 1000);
+        }
+
+        CompletionProvider completionProvider = new CompletionProvider(new StandardAnalyzer());
+        completionProvider.indexCompletions(titles, weights);
+
+        final IndexReader reader = completionProvider.getReader();
+        final Map.Entry<SegmentLookup.LongBased, LeafReader>  lookup = completionProvider.getLookup(reader);
+        final SegmentLookup.LongBased segmentLookup = lookup.getKey();
+        final LeafReader leafReader = lookup.getValue();
+        for (String title : titles) {
+            int res = between(1, 10);
+            final StringBuilder builder = new StringBuilder();
+            analyze(new StandardAnalyzer().tokenStream("foo", title), new TokenConsumer() {
+                @Override
+                public void nextToken() throws IOException {
+                    if (builder.length() == 0) {
+                        builder.append(this.charTermAttr.toString());
+                    }
+                }
+            });
+            String firstTerm = builder.toString();
+            String prefix = firstTerm.isEmpty() ? "" : firstTerm.substring(0, between(1, firstTerm.length()));
+
+            final List<DefaultCollector<Long>.Result<Long>> results = segmentLookup.lookup(leafReader, prefix, res);
+
+            assertThat(results.size(), greaterThan(0));
+            long topScorePerKey = -1;
+            for (DefaultCollector<Long>.Result<Long> result : results) {
+                long innerTopScore = -1;
+                for (SegmentLookup.Collector.ResultMetaData<Long> longResultMetaData : result.resultMetaDataList()) {
+                    if (topScorePerKey == -1) {
+                        topScorePerKey = longResultMetaData.score();
+                    } else {
+                        assertThat(longResultMetaData.score(), lessThanOrEqualTo(topScorePerKey));
+                    }
+                    if (innerTopScore == -1) {
+                        innerTopScore = longResultMetaData.score();
+                    } else {
+                        assertThat(longResultMetaData.score(), lessThanOrEqualTo(innerTopScore));
+                        innerTopScore = longResultMetaData.score();
+                    }
+                }
+            }
+        }
+
+    }
+
+    private class CompletionProvider {
+        final IndexWriterConfig indexWriterConfig;
+        IndexWriter writer;
+        int deletedDocCounter = 0;
+        RAMDirectory dir = new RAMDirectory();
+        Map<String, List<Integer>> termsToDocID = new HashMap<>();
+        Set<Integer> docIDSet = new HashSet<>();
+        final LookupFieldGenerator fieldGenerator;
+
+
+        public CompletionProvider(final Analyzer indexAnalyzer) throws IOException {
+            fieldGenerator = LookupFieldGenerator.create("foo", indexAnalyzer, false, false);
+            Codec filterCodec = new Lucene50Codec() {
+                @Override
+                public PostingsFormat getPostingsFormatForField(String field) {
+                    if ("foo".equals(field)) {
+                        return new LookupPostingsFormat(super.getPostingsFormatForField(field));
+                    }
+                    return super.getPostingsFormatForField(field);
+                }
+            };
+            this.indexWriterConfig = new IndexWriterConfig(indexAnalyzer);
+            indexWriterConfig.setCodec(filterCodec);
+        }
+
+        private Field makeField(String name, Object value, Class type) throws Exception {
+            if (type == String.class) {
+                return new StoredField(name, (String) value);
+            } else if (type == BytesRef.class) {
+                return new StoredField(name, (BytesRef) value);
+            } else if (type == Integer.class) {
+                return new StoredField(name, (int) value);
+            } else if (type == Float.class) {
+                return new StoredField(name, (float) value);
+            } else if (type == Double.class) {
+                return new StoredField(name, (double) value);
+            } else if (type == Long.class) {
+                return new StoredField(name, (long) value);
+            }
+            throw new Exception("Unsupported Type "+ type);
+        }
+
+        private void indexCompletions(String[] terms, long[] weights, String[] storedFieldNames, Class[] types, Object[]... storedFieldValues) throws Exception {
+            writer = new IndexWriter(dir, indexWriterConfig);
+            for (int i = 0; i < weights.length; i++) {
+                Document doc = new Document();
+                doc.add(fieldGenerator.generate(terms[i], weights[i]));
+                for (int j = 0; j < storedFieldNames.length; j++) {
+                    doc.add(makeField(storedFieldNames[j], storedFieldValues[i][j], types[j]));
+                }
+                if (randomBoolean()) {
+                    writer.commit();
+                }
+                writer.addDocument(doc);
+                writer.forceMerge(1, true);
+                writer.commit();
+                DirectoryReader reader = DirectoryReader.open(writer, true);
+                for (LeafReaderContext ctx : reader.leaves()) {
+                    LeafReader atomicReader = ctx.reader();
+                    for (int docID = 0; docID < atomicReader.numDocs(); docID++) {
+                        if (!docIDSet.contains(docID + ctx.docBase)) {
+                            docIDSet.add(docID + ctx.docBase);
+                            List<Integer> docIDs = termsToDocID.get(terms[i]);
+                            if (docIDs == null) {
+                                docIDs = new ArrayList<>();
+                            }
+                            docIDs.add(docID + ctx.docBase);
+                            termsToDocID.put(terms[i], docIDs);
+                            break;
+                        }
+                    }
+                }
+                reader.close();
+            }
+            writer.commit();
+
+            assertThat(docIDSet.size(), equalTo(weights.length));
+        }
+
+        public void indexCompletions(String[] terms, long[] weights) throws Exception {
+            indexCompletions(terms, weights, new String[0], new Class[0]);
+        }
+
+        public void deleteDoc(IndexReader reader, String term) throws IOException {
+            assertThat(reader.numDeletedDocs(), equalTo(deletedDocCounter));
+            List<Integer> docIDs = termsToDocID.get(term);
+            assert docIDs != null;
+            assertThat(docIDs.size(), greaterThanOrEqualTo(1));
+            int docID = docIDs.remove(randomIntBetween(0, docIDs.size() - 1));
+            int initialNumDocs = writer.numDocs();
+            assertTrue(writer.tryDeleteDocument(reader, docID));
+            writer.commit();
+            assertThat(initialNumDocs, equalTo(writer.numDocs() + 1));
+            deletedDocCounter++;
+        }
+
+        public IndexReader getReader() throws IOException {
+            if (writer != null) {
+                return DirectoryReader.open(writer, true);
+            } else {
+                return null;
+            }
+        }
+
+        public Map.Entry<SegmentLookup.LongBased, LeafReader> getLookup(IndexReader reader) throws IOException {
+            assertThat(reader.leaves().size(), equalTo(1));
+            LeafReader atomicReader = reader.leaves().get(0).reader();
+            Terms luceneTerms = atomicReader.terms("foo");
+            SegmentLookup.LongBased lookup = null;
+            if (luceneTerms instanceof LookupPostingsFormat.LookupTerms) {
+                lookup = ((LookupPostingsFormat.LookupTerms) luceneTerms).longScoreLookup();
+            }
+            assertFalse(lookup == null);
+            return new AbstractMap.SimpleEntry<>(lookup, atomicReader);
+        }
+
+        public void close() throws IOException {
+            writer.close();
+            dir.close();
+        }
+    }
+
+
+    public static int analyze(TokenStream stream, TokenConsumer consumer) throws IOException {
+        stream.reset();
+        consumer.reset(stream);
+        int numTokens = 0;
+        while (stream.incrementToken()) {
+            consumer.nextToken();
+            numTokens++;
+        }
+        consumer.end();
+        stream.close();
+        return numTokens;
+    }
+
+
+    public static abstract class TokenConsumer {
+        protected CharTermAttribute charTermAttr;
+        protected PositionIncrementAttribute posIncAttr;
+        protected OffsetAttribute offsetAttr;
+
+        public void reset(TokenStream stream) {
+            charTermAttr = stream.addAttribute(CharTermAttribute.class);
+            posIncAttr = stream.addAttribute(PositionIncrementAttribute.class);
+            offsetAttr = stream.addAttribute(OffsetAttribute.class);
+        }
+
+        protected BytesRef fillBytesRef(BytesRefBuilder spare) {
+            spare.copyChars(charTermAttr);
+            return spare.get();
+        }
+
+        public abstract void nextToken() throws IOException;
+
+        public void end() {}
+    }
+}

--- a/src/test/java/org/apache/lucene/search/suggest/analyzing/NRTLookupTest.java
+++ b/src/test/java/org/apache/lucene/search/suggest/analyzing/NRTLookupTest.java
@@ -298,7 +298,6 @@ public class NRTLookupTest extends LuceneTestCase {
                 }
             }
         }
-
     }
 
     private class CompletionProvider {

--- a/src/test/java/org/apache/lucene/search/suggest/analyzing/TopNSearcherTest.java
+++ b/src/test/java/org/apache/lucene/search/suggest/analyzing/TopNSearcherTest.java
@@ -1,0 +1,248 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.lucene.search.suggest.analyzing;
+
+import org.apache.lucene.store.ByteArrayDataInput;
+import org.apache.lucene.util.*;
+import org.apache.lucene.util.automaton.Automata;
+import org.apache.lucene.util.automaton.Automaton;
+import org.apache.lucene.util.fst.*;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.*;
+
+public class TopNSearcherTest extends LuceneTestCase {
+
+    @Test
+    public void testSimple() throws Exception {
+        Entry[] inputs = {new Entry("term1", 1l, 1), new Entry("term1", 2l, 2), new Entry("term2", 3l, 3)};
+        Map.Entry<Integer, FST<PairOutputs.Pair<Long, BytesRef>>> build = build(outputConfiguration, inputs);
+        TestTopNSearcher testTopNSearcher = new TestTopNSearcher(build.getValue(), 2, 2, build.getKey());
+        Map<BytesRef, List<Entry>> result = query(testTopNSearcher, "term");
+        assertResults(mapByTerm(inputs), result);
+    }
+
+    @Test
+    public void testLeafPruning() throws Exception {
+        int nterms = 10;
+        int nLeaf = 10;
+        Entry[] inputs = new Entry[nterms * nLeaf];
+        for (int i = 0; i < nterms; i++) {
+            String term = "term_" + String.valueOf(i);
+            for (int l = 0; l < nLeaf; l++) {
+                inputs[(i * nterms) + l] = new Entry(term, (i * nterms) + l, (i * nterms) + l);
+            }
+        }
+        int pruneNFirstLeaves = 3;
+
+        Map.Entry<Integer, FST<PairOutputs.Pair<Long, BytesRef>>> build = build(outputConfiguration, inputs);
+        TestTopNSearcher testTopNSearcher = new TestTopNSearcher(build.getValue(), nterms, nLeaf, build.getKey(), pruneNFirstLeaves);
+        Map<BytesRef, List<Entry>> result = query(testTopNSearcher, "term");
+        Map<BytesRef, List<Entry>> stringListMap = mapByTerm(inputs);
+        for (BytesRef term : stringListMap.keySet()) {
+            List<Entry> entries = stringListMap.get(term);
+            stringListMap.put(term, entries.subList(pruneNFirstLeaves, entries.size()));
+        }
+        assertResults(stringListMap, result);
+    }
+
+    @Test
+    public void testFullTermSearch() throws Exception {
+        Entry[] inputs = {new Entry("term1", 1l, 1), new Entry("term1", 2l, 2), new Entry("term1", 3l, 3)};
+        Map.Entry<Integer, FST<PairOutputs.Pair<Long, BytesRef>>> build = build(outputConfiguration, inputs);
+        TestTopNSearcher testTopNSearcher = new TestTopNSearcher(build.getValue(), 1, 3, build.getKey());
+        Map<BytesRef, List<Entry>> result = query(testTopNSearcher, "term1");
+        assertResults(mapByTerm(inputs), result);
+    }
+
+    private void assertResults(Map<BytesRef, List<Entry>> expected, Map<BytesRef, List<Entry>> actual) {
+        assertEquals(expected.size(), actual.size());
+        for (Map.Entry<BytesRef, List<Entry>> expectedEntrySet : expected.entrySet()) {
+            List<Entry> actualEntries = actual.get(expectedEntrySet.getKey());
+            assertNotNull(actualEntries);
+            assertEquals(expectedEntrySet.getValue().size(), actualEntries.size());
+            int i = 0;
+            for (Entry expectedEntry : expectedEntrySet.getValue()) {
+                Entry actualEntry = actualEntries.get(i);
+                assertEquals(expectedEntry.term, actualEntry.term);
+                assertEquals(expectedEntry.weight, actualEntry.weight);
+                assertEquals(expectedEntry.docID, actualEntry.docID);
+                i++;
+            }
+        }
+    }
+
+    private static Map<BytesRef, List<Entry>> query(TestTopNSearcher searcher, String term) throws IOException {
+        Automaton automaton = Automata.makeString(term);
+        List<FSTUtil.Path<PairOutputs.Pair<Long, BytesRef>>> paths = FSTUtil.intersectPrefixPaths(automaton, searcher.fst);
+        for (FSTUtil.Path<PairOutputs.Pair<Long, BytesRef>> path : paths) {
+            searcher.addStartPaths(path.fstNode, path.output, false, path.input);
+        }
+        searcher.search();
+        return searcher.getResults();
+    }
+
+    ContextAwareScorer.OutputConfiguration<Long> outputConfiguration = new ContextAwareScorer.OutputConfiguration<Long>() {
+        @Override
+        public Outputs<Long> outputSingleton() {
+            return PositiveIntOutputs.getSingleton();
+        }
+
+        @Override
+        public Long encode(Long input) {
+            if (input < 0 || input > Integer.MAX_VALUE) {
+                throw new UnsupportedOperationException("cannot encode value: " + input);
+            }
+            return Integer.MAX_VALUE - input;
+        }
+
+        @Override
+        public Long decode(Long output) {
+            return (Integer.MAX_VALUE - output);
+        }
+    };
+
+    private static class Entry {
+        private final String term;
+        private final long weight;
+        private final int docID;
+
+        public Entry(String term, long weight, int docID) {
+            this.term = term;
+            this.weight = weight;
+            this.docID = docID;
+        }
+
+    }
+
+    private Map<BytesRef, List<Entry>> mapByTerm(Entry... entries) {
+        Map<BytesRef, List<Entry>> entriesByTerm = new TreeMap<>(new Comparator<BytesRef>() {
+            @Override
+            public int compare(BytesRef o1, BytesRef o2) {
+                return o1.compareTo(o2);
+            }
+        });
+        for (Entry entry : entries) {
+            final List<Entry> entryList;
+            BytesRef entryTerm = new BytesRef(entry.term);
+            if (!entriesByTerm.containsKey(entryTerm)) {
+                entryList = new ArrayList<>();
+                entriesByTerm.put(entryTerm, entryList);
+            } else {
+                entryList = entriesByTerm.get(entryTerm);
+            }
+            entryList.add(entry);
+        }
+
+        for (Map.Entry<BytesRef, List<Entry>> stringListEntry : entriesByTerm.entrySet()) {
+
+            Collections.sort(stringListEntry.getValue(), new Comparator<Entry>() {
+                @Override
+                public int compare(Entry o1, Entry o2) {
+                    return Long.compare(o2.weight, o1.weight);
+                }
+            });
+        }
+        return entriesByTerm;
+
+    }
+
+    private Map.Entry<Integer, FST<PairOutputs.Pair<Long, BytesRef>>> build(ContextAwareScorer.OutputConfiguration<Long> outputConfiguration, Entry... entries) throws IOException {
+      NRTSuggesterBuilder.FSTBuilder<Long> builder = new NRTSuggesterBuilder.FSTBuilder<>(outputConfiguration, NRTSuggesterBuilder.PAYLOAD_SEP, NRTSuggesterBuilder.END_BYTE);
+        Map<BytesRef, List<Entry>> entriesByTerm = mapByTerm(entries);
+        int maxFormPerLeaf = 0;
+        for (Map.Entry<BytesRef, List<Entry>> termEntries : entriesByTerm.entrySet()) {
+            BytesRef term = termEntries.getKey();
+            builder.startTerm(term);
+            for (Entry entry : termEntries.getValue()) {
+                builder.addEntry(entry.docID, term, entry.weight);
+            }
+            builder.finishTerm();
+            maxFormPerLeaf = Math.max(maxFormPerLeaf, termEntries.getValue().size());
+        }
+
+        return new AbstractMap.SimpleEntry<>(maxFormPerLeaf, builder.build());
+    }
+
+    private class TestTopNSearcher extends TopNSearcher<PairOutputs.Pair<Long, BytesRef>> {
+
+        private Map<BytesRef, List<Entry>> results = new HashMap<>();
+        private List<Entry> currentResults = new ArrayList<>();
+
+        private BytesRefBuilder currentKeyBuilder = new BytesRefBuilder();
+        private CharsRefBuilder spare = new CharsRefBuilder();
+        private final FST<PairOutputs.Pair<Long, BytesRef>> fst;
+        private final int pruneFirstNLeaves;
+        private int leafCount;
+
+        public TestTopNSearcher(FST<PairOutputs.Pair<Long, BytesRef>> fst, int topN, int nLeaf, int maxQueueDepth) {
+            this(fst, topN, nLeaf, maxQueueDepth, 0);
+        }
+        public TestTopNSearcher(FST<PairOutputs.Pair<Long, BytesRef>> fst, int topN, int nLeaf, int maxQueueDepth, int pruneFirstNLeaves) {
+            super(fst, topN, nLeaf, NRTSuggesterBuilder.END_BYTE, topN * maxQueueDepth, new Comparator<PairOutputs.Pair<Long, BytesRef>>() {
+                @Override
+                public int compare(PairOutputs.Pair<Long, BytesRef> o1, PairOutputs.Pair<Long, BytesRef> o2) {
+                    return o1.output1.compareTo(o2.output1);
+                }
+            });
+            this.fst = fst;
+            this.pruneFirstNLeaves = pruneFirstNLeaves;
+        }
+
+        @Override
+        protected void onLeafNode(IntsRef input, PairOutputs.Pair<Long, BytesRef> output) {
+            Util.toBytesRef(input, currentKeyBuilder);
+            leafCount = 0;
+        }
+
+        @Override
+        protected boolean collectOutput(PairOutputs.Pair<Long, BytesRef> output) throws IOException {
+            leafCount++;
+            if (leafCount <= pruneFirstNLeaves) {
+                return false;
+            }
+            long weight = outputConfiguration.decode(output.output1);
+
+            int surfaceFormLen = -1;
+            for (int i = 0; i < output.output2.length; i++) {
+                if (output.output2.bytes[output.output2.offset + i] == NRTSuggesterBuilder.PAYLOAD_SEP) {
+                    surfaceFormLen = i;
+                    break;
+                }
+            }
+            assert surfaceFormLen != -1 : "no payloadSep found, unable to determine surface form";
+            spare.copyUTF8Bytes(output.output2.bytes, output.output2.offset, surfaceFormLen);
+            ByteArrayDataInput input = new ByteArrayDataInput(output.output2.bytes, surfaceFormLen + output.output2.offset + 1, output.output2.length - (surfaceFormLen + output.output2.offset));
+            currentResults.add(new Entry(spare.toString(), weight, input.readVInt()));
+            return true;
+        }
+
+        @Override
+        protected void onFinishNode() throws IOException {
+            results.put(currentKeyBuilder.toBytesRef(), new ArrayList<>(currentResults));
+            currentResults.clear();
+        }
+
+        public Map<BytesRef, List<Entry>> getResults() {
+            return results;
+        }
+    }
+}

--- a/src/test/java/org/elasticsearch/search/suggest/completion/LookupBenchmark.java
+++ b/src/test/java/org/elasticsearch/search/suggest/completion/LookupBenchmark.java
@@ -1,0 +1,873 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.suggest.completion;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.PostingsFormat;
+import org.apache.lucene.codecs.lucene50.Lucene50Codec;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.StoredField;
+import org.apache.lucene.index.*;
+import org.apache.lucene.search.suggest.InputIterator;
+import org.apache.lucene.search.suggest.Lookup;
+import org.apache.lucene.search.suggest.analyzing.*;
+import org.apache.lucene.store.RAMDirectory;
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.LineFileDocs;
+import org.elasticsearch.index.analysis.NamedAnalyzer;
+import org.elasticsearch.index.codec.postingformat.Elasticsearch090RWPostingsFormat;
+import org.elasticsearch.index.codec.postingsformat.PostingsFormatProvider;
+import org.elasticsearch.index.codec.postingsformat.PreBuiltPostingsFormatProvider;
+import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.core.AbstractFieldMapper;
+import org.elasticsearch.index.mapper.core.CompletionFieldMapper;
+import org.elasticsearch.search.suggest.context.ContextMapping;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.*;
+import java.util.concurrent.Callable;
+
+/**
+ * WIP
+ *
+ * TODO: clean this up
+ */
+public class LookupBenchmark {
+
+    private final static int rounds = 15;
+    private final static int warmup = 5;
+
+    private int num = 7;
+
+    private final static int maxDataSize = 5000;
+
+    private final static Random random = new Random(0xdeadbeef);
+
+    private final static boolean useTopWiki = false; // for some reason Top50KWiki gives way higher QPS!
+    private final static boolean useGeoNames = true;
+
+    private static class Input {
+        private String term;
+        private int weight;
+
+        Input(String term, int weight) {
+            this.term = term;
+            this.weight = weight;
+        }
+    }
+
+    private static class StoredFieldInput {
+        private String name;
+        private BytesRef value;
+        private Class type;
+
+        private StoredFieldInput(String name, BytesRef value) {
+            this.name = name;
+            this.value = value;
+            this.type = BytesRef.class;
+        }
+    }
+
+    private static List<Input> benchmarkInput = new ArrayList<>();
+
+    private static List<Input> lookupInput = new ArrayList<>();
+
+    final Analyzer analyzer = new StandardAnalyzer();
+    final NamedAnalyzer namedAnalzyer = new NamedAnalyzer("foo", analyzer);
+    final PostingsFormatProvider provider = new PreBuiltPostingsFormatProvider(new Elasticsearch090RWPostingsFormat());
+
+    static List<String> SUGGEST_FIELD_NAMES = new ArrayList<>(2);
+    static final String SUGGEST_FIELD_NAME = "foo";
+    static final String SUGGEST_FIELD_WITH_PAYLOAD_NAME = "foo_payload";
+
+    static {
+        SUGGEST_FIELD_NAMES.add(SUGGEST_FIELD_NAME);
+        SUGGEST_FIELD_NAMES.add(SUGGEST_FIELD_WITH_PAYLOAD_NAME);
+    }
+
+
+    public static void main(String[] args) throws Exception {
+        setup();
+        LookupBenchmark lookupBenchmark = new LookupBenchmark();
+        //lookupBenchmark.testLookupDeletedDocFiltering();
+        lookupBenchmark.testLookupLeavesPerf();
+        lookupBenchmark.testStorageNeeds();
+        lookupBenchmark.testBuildPerformance();
+        //lookupBenchmark.testPerformanceOnPrefixes6_9();
+        //lookupBenchmark.testPerformanceOnFullHits();
+        //lookupBenchmark.testPerformanceOnPrefixes2_4();
+    }
+
+    public static void setup() throws Exception {
+        if (useGeoNames) {
+            List<Input> input = readAllCountries();
+            Collections.shuffle(input, random);
+            LookupBenchmark.lookupInput = input;
+            Collections.shuffle(input, random);
+            LookupBenchmark.benchmarkInput = input;
+            return;
+        }
+
+        if (useTopWiki) {
+            List<Input> input = readTop50KWiki();
+            Collections.shuffle(input, random);
+            LookupBenchmark.lookupInput = input;
+            Collections.shuffle(input, random);
+            LookupBenchmark.benchmarkInput = input;
+            return;
+        }
+
+        // data set with longer terms to suggest
+        LineFileDocs docs = new LineFileDocs(null);
+        Set<String> seen = new HashSet<>();
+        for (int i = 0; i < maxDataSize; i++) {
+            Document nextDoc = docs.nextDoc();
+            IndexableField field = nextDoc.getField("title");
+            String term = field.stringValue();
+            if (seen.contains(term)) {
+                continue;
+            } else {
+                seen.add(term);
+            }
+            int weight;
+            if ((weight = random.nextInt()) < 0) {
+                // force positive weight
+                weight *= -1;
+            }
+            Input input = new Input(term, weight);
+            LookupBenchmark.benchmarkInput.add(input);
+            LookupBenchmark.lookupInput.add(input);
+        }
+        Collections.shuffle(LookupBenchmark.lookupInput, random);
+        assert LookupBenchmark.benchmarkInput.size() == LookupBenchmark.lookupInput.size();
+        docs.close();
+    }
+
+    static final Charset UTF_8 = StandardCharsets.UTF_8;
+
+    /**
+     * Collect the multilingual input for benchmarks/ tests.
+     */
+    public static List<Input> readTop50KWiki() throws Exception {
+        List<Input> input = new ArrayList<>();
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(
+                LookupBenchmark.class.getResourceAsStream("/org/elasticsearch/search.suggest.completion/Top50KWiki.utf8"), UTF_8));
+
+        String line = null;
+        while ((line = br.readLine()) != null) {
+            int tab = line.indexOf('|');
+            assert tab >= 0 : "No | separator?: " + line;
+            int weight = Integer.parseInt(line.substring(tab + 1));
+            String key = line.substring(0, tab);
+            input.add(new Input(key, weight));
+        }
+        br.close();
+        return input;
+    }
+
+    public static List<Input> readAllCountries() throws Exception {
+        List<Input> input = new ArrayList<>();
+
+        Set<String> seen = new HashSet<>();
+        try (InputStream in = Files.newInputStream(Paths.get("/Users/areek/workspace/allCountries.txt"))) {
+            BufferedReader br = new BufferedReader(new InputStreamReader(in, UTF_8));
+
+            String line = null;
+            while ((line = br.readLine()) != null) {
+                int tab = line.indexOf('\t');
+                assert tab >= 0 : "No \t separator?: " + line;
+                int weight;
+                try {
+                    weight = Integer.parseInt(line.substring(0, tab - 1));
+                } catch (NumberFormatException e) {
+                    continue;
+                }
+                String key = line.substring(tab + 1, line.indexOf('\t', tab + 1));
+                if (key.equals("")) {
+                    continue;
+                }
+                if (!seen.contains(key)) {
+                    seen.add(key);
+                } else {
+                    input.add(new Input(key, weight));
+                }
+            }
+            br.close();
+
+        }
+        return input;
+    }
+
+    /**
+     * Test performance of lookup on full hits.
+     */
+    public void testPerformanceOnFullHits() throws Exception {
+        final int minPrefixLen = 100;
+        final int maxPrefixLen = 200;
+        runPerformanceTest(minPrefixLen, maxPrefixLen, num);
+    }
+
+    /**
+     * Test performance of lookup on longer term prefixes (6-9 letters or shorter).
+     */
+    public void testPerformanceOnPrefixes6_9() throws Exception {
+        final int minPrefixLen = 6;
+        final int maxPrefixLen = 9;
+        runPerformanceTest(minPrefixLen, maxPrefixLen, num);
+    }
+
+    /**
+     * Test performance of lookup on short term prefixes (2-4 letters or shorter).
+     */
+    public void testPerformanceOnPrefixes2_4() throws Exception {
+        final int minPrefixLen = 2;
+        final int maxPrefixLen = 4;
+        runPerformanceTest(minPrefixLen, maxPrefixLen, num);
+    }
+
+    /**
+     * Test lookup performance with varying percentage of deleted documents
+     */
+    public void testLookupDeletedDocFiltering() throws Exception {
+        System.out.println("-- Lookup performance with deleted doc filtering");
+        int[][] prefixLengths = {{2, 4}, {6,9}, {100,200}};
+        for(int[] prefixLength : prefixLengths) {
+            final int minPrefixLen = prefixLength[0];
+            final int maxPrefixLen = prefixLength[1];
+            List<String> inputs = generateInputs(minPrefixLen, maxPrefixLen, 50000);
+            System.out.println(String.format(Locale.ROOT,
+                    "  -- prefixes: %d-%d, num: %d",
+                    minPrefixLen, maxPrefixLen, num));
+            for (float delDocRatio = 0.0f; delDocRatio < 1.0f; delDocRatio += 0.1f) {
+                System.out.print(String.format(Locale.ROOT, "   [%2.0f%% deleted docs] ", delDocRatio * 100));
+                final Map.Entry<CompletionProvider, Set<Integer>> completionProviderAndReader = buildNewLookup(delDocRatio);
+                CompletionProvider completionProvider = completionProviderAndReader.getKey();
+                Set<Integer> deletedDocs = completionProviderAndReader.getValue();
+                final Map.Entry<SegmentLookup.LongBased, LeafReader> nrtLookupEntry = completionProvider.getNewLookup();
+                SegmentLookup.LongBased segmentLookup = nrtLookupEntry.getKey();
+                LeafReader reader = nrtLookupEntry.getValue();
+                runLookupPerfTest("Lookup", segmentLookup, inputs, new DeletedDocsLeafReader(reader, deletedDocs), num, 1);
+                reader.close();
+                completionProvider.close();
+            }
+        }
+    }
+
+    class DeletedDocsLeafReader extends FilterLeafReader {
+        private final Set<Integer> deletedDocIDs;
+
+        public DeletedDocsLeafReader(LeafReader in, Set<Integer> deletedDocIDs) {
+            super(in);
+            this.deletedDocIDs = deletedDocIDs;
+
+        }
+
+        @Override
+        public Bits getLiveDocs() {
+            return new Bits() {
+                @Override
+                public boolean get(int index) {
+                    return !deletedDocIDs.contains(index);
+                }
+
+                @Override
+                public int length() {
+                    return in.maxDoc();
+                }
+            };
+        }
+    }
+
+    public void testLookupLeavesPerf() throws Exception {
+        System.out.println("-- Lookup performance with leaves");
+        int[] nLeaves = {2, 4, 6, 8, 10, 12, 14};
+        int[][] prefixLengths = {{100,200}, {6,9}, {2, 4}};
+        for(int[] prefixLength : prefixLengths) {
+            final int minPrefixLen = prefixLength[0];
+            final int maxPrefixLen = prefixLength[1];
+            List<String> inputs = generateInputs(minPrefixLen, maxPrefixLen, 50000);
+            System.out.println(String.format(Locale.ROOT,
+                    "  -- prefixes: %d-%d, num: %d",
+                    minPrefixLen, maxPrefixLen, num));
+            final Map.Entry<SegmentLookup.LongBased, LeafReader> nrtLookupEntry = buildNewLookupWith(lookupInput);//lookupInputDuplicates(lookupInput, 13));
+            for (int nLeaf : nLeaves) {
+                System.out.print(String.format(Locale.ROOT, "   [%d leaves] ", nLeaf));
+                SegmentLookup.LongBased segmentLookup = nrtLookupEntry.getKey();
+                LeafReader reader = nrtLookupEntry.getValue();
+                runLookupPerfTest("Lookup", segmentLookup, inputs, reader, num, nLeaf);
+                //reader.close();
+            }
+        }
+    }
+
+    private Map.Entry<SegmentLookup.LongBased, LeafReader> buildNewLookupWith(List<Input> inputs) throws Exception {
+        CompletionProvider completionProvider = null;
+        try {
+            completionProvider = new CompletionProvider(analyzer);
+            completionProvider.indexCompletions(inputs);
+            return completionProvider.getNewLookup();
+        } finally {
+            assert completionProvider != null;
+            completionProvider.close();
+        }
+    }
+
+    /**
+     * Test RAM consumption
+     */
+    //public void testStorageNeeds() throws Exception {
+    //    System.out.println("-- RAM consumption");
+    //    final Lookup analyzingLookup = buildAnalyzingLookup(null, true);
+    //    final Lookup xAnalyzingLookup = buildXAnalyzingLookup(null);
+
+    //    runStorageNeeds("AnalyzingSuggester", analyzingLookup);
+    //    runStorageNeeds("XAnalyzingSuggester", xAnalyzingLookup);
+    //}
+
+    public void testStorageNeeds() throws Exception {
+        Map.Entry<SegmentLookup.LongBased, LeafReader> entry = buildNewLookupWith(lookupInput);
+        runStorageNeeds("Lookup", entry.getKey());
+    }
+
+
+    /**
+     * Test time to build
+     */
+    public void testBuildPerformance() throws Exception {
+        System.out.println("-- Build time");
+        BenchmarkResult result = measure(new Callable<Integer>() {
+            @Override
+            public Integer call() throws Exception {
+                Map.Entry<SegmentLookup.LongBased, LeafReader> entry = buildNewLookupWith(lookupInput);
+                return entry.hashCode();
+            }
+        });
+
+        System.out.println(
+                String.format(Locale.ROOT, "  %-15s input: %d, time[ms]: %s",
+                        "Lookup",
+                        lookupInput.size(),
+                        result.average.toString()));
+    }
+
+    public void testStoredFieldRetrievalPerformance() throws Exception {
+        System.out.println("-- Stored Field Retrieval Performance");
+        int[][] prefixLengthBounds = {{2, 4}, {3, 6}, {100, 200}};
+        final String returnFieldName = "payload";
+        Lookup analyzingLookup = null;
+        Lookup xAnalyzingLookup = null;
+        Map.Entry<Lookup, LeafReader> xNRTLookupAndReader = null;
+        Set<String> returnFieldNames = new HashSet<>(1);
+        returnFieldNames.add(returnFieldName);
+        final List<StoredFieldInput> storedFieldInputs = generateStoredFieldInputs(returnFieldName);
+        for (int[] prefixLengthBound : prefixLengthBounds) {
+            int minPrefixLength = prefixLengthBound[0];
+            int maxPrefixLength = prefixLengthBound[1];
+            final List<String> inputs = generateInputs(minPrefixLength, maxPrefixLength, benchmarkInput.size());
+            analyzingLookup = buildAnalyzingLookup(storedFieldInputs, true);
+            xAnalyzingLookup = buildXAnalyzingLookup(storedFieldInputs);
+            //xNRTLookupAndReader = buildXNRTLookup(storedFieldInputs);
+
+            for (int num : new int[]{2, 4, 6}) {
+                System.out.println(String.format(Locale.ROOT,
+                        "  -- prefixes: %d-%d, num: %d", minPrefixLength, maxPrefixLength, num));
+
+                runPerfTest("  AnalyzingSuggester", analyzingLookup, inputs, null, null, num);
+                runPerfTest("  XAnalyzingSuggester", xAnalyzingLookup, inputs, null, null, num);
+                //runPerfTest("  XNRTSuggester", xNRTLookupAndReader.getKey(), inputs, xNRTLookupAndReader.getValue(), returnFieldNames, num);
+            }
+        }
+
+        //assert xNRTLookupAndReader != null;
+        System.out.println("\n - Storage benchmark");
+        runStorageNeeds("  AnalyzingSuggester (with payload)", analyzingLookup);
+        runStorageNeeds("  XAnalyzingSuggester (with payload)", xAnalyzingLookup);
+        //runStorageNeeds("  XNRTSuggester", xNRTLookupAndReader.getKey());
+
+    }
+
+    private List<StoredFieldInput> generateStoredFieldInputs(String name) {
+        List<StoredFieldInput> storedFieldInputs = new ArrayList<>(benchmarkInput.size());
+        for (Input input : benchmarkInput) {
+            storedFieldInputs.add(new StoredFieldInput(name, new BytesRef(input.term)));
+        }
+        return storedFieldInputs;
+    }
+
+    public void runPerformanceTest(final int minPrefixLen, final int maxPrefixLen,
+                                   final int num) throws Exception {
+        System.out.println(String.format(Locale.ROOT,
+                "-- Lookup performance (prefixes: %d-%d, num: %d)",
+                minPrefixLen, maxPrefixLen, num));
+
+        final List<String> inputs = generateInputs(minPrefixLen, maxPrefixLen, benchmarkInput.size());
+        //final Lookup analyzingLookup = buildAnalyzingLookup(null, true);
+        final Lookup xAnalyzingLookup = buildXAnalyzingLookup(null);
+        //final Lookup xNRTLookup = buildXNRTLookup(null).getKey();
+
+        Map.Entry<SegmentLookup.LongBased, LeafReader> segmentLookupLeafReaderEntry = buildNewLookup(null);
+        final SegmentLookup.LongBased segmentLookup = segmentLookupLeafReaderEntry.getKey();
+        final LeafReader reader = segmentLookupLeafReaderEntry.getValue();
+
+        //runPerfTest("AnalyzingSuggester", analyzingLookup, inputs, null, null, num);
+        runPerfTest("XAnalyzingSuggester", xAnalyzingLookup, inputs, null, null, num);
+        //runPerfTest("XNRTSuggester", xNRTLookup, inputs, null, null, num);
+
+        runLookupPerfTest("Lookup", segmentLookup, inputs, reader, num, 1);
+    }
+
+    public Lookup buildLookup(String name) throws Exception {
+        switch (name) {
+            case "AnalyzingSuggester":
+                return buildAnalyzingLookup(null, false);
+            case "XAnalyzingSuggester":
+                return buildXAnalyzingLookup(null);
+            default:
+                return null;
+        }
+    }
+
+    /**
+     * Test memory required for the storage.
+     */
+    public void runStorageNeeds(String name, Accountable lookup) throws Exception {
+        long sizeInBytes = lookup.ramBytesUsed();
+        System.out.println(
+                String.format(Locale.ROOT, "  %-15s size[B]:%,13d",
+                        name,
+                        sizeInBytes));
+    }
+
+    private Lookup buildAnalyzingLookup(List<StoredFieldInput> payloads, boolean validate) throws IOException {
+        AnalyzingSuggester suggester = new AnalyzingSuggester(analyzer);
+        suggester.build(constructInputIterator(lookupInput, payloads, validate));
+        return suggester;
+    }
+
+    private InputIterator constructInputIterator(final List<Input> inputs, final List<StoredFieldInput> payloads, boolean validate) throws IOException {
+        InputIterator inputIterator = new InputIterator() {
+            int index = -1;
+
+            @Override
+            public long weight() {
+                return inputs.get(index).weight;
+            }
+
+            @Override
+            public BytesRef payload() {
+                if (payloads != null) {
+                    return payloads.get(index).value;
+                }
+                return null;
+            }
+
+            @Override
+            public boolean hasPayloads() {
+                return payloads != null;
+            }
+
+            @Override
+            public Set<BytesRef> contexts() {
+                return null;
+            }
+
+            @Override
+            public boolean hasContexts() {
+                return false;
+            }
+
+            @Override
+            public BytesRef next() throws IOException {
+                if (++index < inputs.size()) {
+                    return new BytesRef(inputs.get(index).term);
+                } else {
+                    return null;
+                }
+            }
+        };
+
+
+        if (validate) {
+            BytesRef term;
+            int count = 0;
+            Iterator<Input> listIterator = inputs.iterator();
+            while((term = inputIterator.next())!= null) {
+                Input listItem = listIterator.next();
+                assert term.utf8ToString().equals(listItem.term);
+                assert ((int) inputIterator.weight()) == listItem.weight;
+                count++;
+            }
+            assert count == inputs.size();
+            // used up constructed input iterator; construct it again without validation
+            return constructInputIterator(inputs, payloads, false);
+        }
+
+        return inputIterator;
+    }
+
+    private Lookup buildXAnalyzingLookup(final List<StoredFieldInput> storedFieldInputs) throws Exception {
+        String fieldName = (storedFieldInputs==null) ? SUGGEST_FIELD_NAME : SUGGEST_FIELD_WITH_PAYLOAD_NAME;
+        final CompletionFieldMapper analyzingCompletionFieldMapper = new CompletionFieldMapper(new FieldMapper.Names(fieldName), namedAnalzyer, namedAnalzyer, provider, null, storedFieldInputs!=null,
+                false, false, Integer.MAX_VALUE, AbstractFieldMapper.MultiFields.empty(), null, ContextMapping.EMPTY_MAPPING);
+        CompletionProvider completionProvider = null;
+        try {
+            completionProvider = new CompletionProvider(analyzingCompletionFieldMapper);
+            completionProvider.indexCompletions(lookupInput, storedFieldInputs);
+            return completionProvider.getLookup();
+        } finally {
+            assert completionProvider != null;
+            completionProvider.close();
+        }
+    }
+
+    private Map.Entry<SegmentLookup.LongBased, LeafReader> buildNewLookup(final List<StoredFieldInput> storedFieldInputs) throws Exception {
+        CompletionProvider completionProvider = null;
+        try {
+            completionProvider = new CompletionProvider(analyzer);
+            completionProvider.indexCompletions(lookupInput, storedFieldInputs);
+            return completionProvider.getNewLookup();
+        } finally {
+            assert completionProvider != null;
+            completionProvider.close();
+        }
+    }
+
+    private Map.Entry<CompletionProvider, Set<Integer>> buildNewLookup(float deletedDocRatio) throws Exception {
+        int deletedDocs = (int) (deletedDocRatio * lookupInput.size());
+        final CompletionProvider completionProvider = new CompletionProvider(analyzer);
+        completionProvider.indexCompletions(lookupInput);
+        IndexReader reader = completionProvider.getReader();
+        return new AbstractMap.SimpleEntry<>(completionProvider, completionProvider.deletedDocs(reader, deletedDocs));
+    }
+
+    private List<Input> lookupInputDuplicates(List<Input> lookupInput, int numDuplicate) {
+        List<Input> result = new ArrayList<>(lookupInput.size() * numDuplicate);
+        for (Input input : lookupInput) {
+            for (int i = 0;i < numDuplicate; i++) {
+                result.add(input);
+            }
+        }
+        return result;
+    }
+
+    private List<String> generateInputs(int minPrefixLen, int maxPrefixLen, int num) {
+        final List<String> inputs = new ArrayList<>();
+        int count = 0;
+        for (Input input : benchmarkInput) {
+            String s = input.term;
+            String sub = s.substring(0, Math.min(s.length(),
+                    minPrefixLen + random.nextInt(maxPrefixLen - minPrefixLen + 1)));
+            inputs.add(sub);
+            if (num < ++count) {
+                break;
+            }
+        }
+        return inputs;
+    }
+
+    private void runLookupPerfTest(final String name, final SegmentLookup.LongBased lookup, final List<String> inputs, final LeafReader reader, final int num, final int nLeaf) {
+        BenchmarkResult result;
+
+        result = measure(new Callable<Integer>() {
+            @Override
+            public Integer call() throws Exception {
+                int v = 0;
+                for (String term : inputs) {
+                    v += lookup.lookup(reader, term, num, nLeaf).size();
+                }
+                return v;
+            }
+        });
+        System.out.println(
+                String.format(Locale.ROOT, "  %-15s queries: %d, time[ms]: %s, ~kQPS: %.0f",
+                        name,
+                        inputs.size(),
+                        result.average.toString(),
+                        inputs.size() / result.average.avg));
+    }
+
+    private void runPerfTest(final String name, final Lookup lookup, final List<String> inputs, final LeafReader reader, final Set<String> returnStoredFields, final int num) {
+        BenchmarkResult result;
+        assert returnStoredFields == null : "returnStoredFields has to be null for non-nrt suggesters";
+        result = measure(new Callable<Integer>() {
+                         @Override
+                         public Integer call() throws Exception {
+                int v = 0;
+                for (String term : inputs) {
+                    v += lookup.lookup(term, false, num).size();
+                }
+                return v;
+                }
+        });
+        System.out.println(
+                String.format(Locale.ROOT, "  %-15s queries: %d, time[ms]: %s, ~kQPS: %.0f",
+                        name,
+                        inputs.size(),
+                        result.average.toString(),
+                        inputs.size() / result.average.avg));
+    }
+
+    /**
+     * Do the measurements.
+     */
+    private BenchmarkResult measure(Callable<Integer> callable) {
+        final double NANOS_PER_MS = 1000000;
+
+        try {
+            List<Double> times = new ArrayList<>();
+            for (int i = 0; i < warmup + rounds; i++) {
+                final long start = System.nanoTime();
+                guard = callable.call().intValue();
+                times.add((System.nanoTime() - start) / NANOS_PER_MS);
+            }
+            return new BenchmarkResult(times, warmup, rounds);
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+
+        }
+    }
+
+    /** Guard against opts. */
+    @SuppressWarnings("unused")
+    private static volatile int guard;
+
+    private static class BenchmarkResult {
+        /** Average time per round (ms). */
+        public final Average average;
+
+        public BenchmarkResult(List<Double> times, int warmup, int rounds) {
+            this.average = Average.from(times.subList(warmup, times.size()));
+        }
+    }
+
+
+    private class CompletionProvider {
+        final IndexWriterConfig indexWriterConfig;
+        final CompletionFieldMapper mapper;
+        IndexWriter writer;
+        RAMDirectory dir = new RAMDirectory();
+        final LookupFieldGenerator fieldGenerator;
+
+        public CompletionProvider(final CompletionFieldMapper mapper) throws IOException {
+            Codec filterCodec = new Lucene50Codec() {
+                @Override
+                public PostingsFormat getPostingsFormatForField(String field) {
+                    if (SUGGEST_FIELD_NAMES.contains(field)) {
+                        return mapper.postingsFormatProvider().get();
+                    }
+                    return super.getPostingsFormatForField(field);
+                }
+            };
+            this.indexWriterConfig = new IndexWriterConfig(mapper.indexAnalyzer());
+            indexWriterConfig.setCodec(filterCodec);
+            this.mapper = mapper;
+            this.fieldGenerator = null;
+        }
+
+        public CompletionProvider(Analyzer indexAnalyzer) throws IOException {
+            Codec filterCodec = new Lucene50Codec() {
+                @Override
+                public PostingsFormat getPostingsFormatForField(String field) {
+                    if (SUGGEST_FIELD_NAMES.contains(field)) {
+                        return new LookupPostingsFormat(super.getPostingsFormatForField(field));
+                    }
+                    return super.getPostingsFormatForField(field);
+                }
+            };
+
+            this.fieldGenerator = LookupFieldGenerator.create(SUGGEST_FIELD_NAME, analyzer);
+
+            this.indexWriterConfig = new IndexWriterConfig(indexAnalyzer);
+            indexWriterConfig.setCodec(filterCodec);
+            this.mapper = null;
+
+        }
+
+        public void indexCompletions(List<Input> inputs) throws Exception {
+            indexCompletions(inputs, null);
+        }
+
+        public void indexCompletions(List<Input> inputs, List<StoredFieldInput> storedFieldInputs) throws Exception {
+            writer = new IndexWriter(dir, indexWriterConfig);
+            final boolean hasStoredFieldInputs = storedFieldInputs != null;
+            if (hasStoredFieldInputs) {
+                assert storedFieldInputs.size() == inputs.size();
+            }
+            for (int i = 0; i < inputs.size(); i++) {
+                Input input = inputs.get(i);
+                Document doc = new Document();
+                if (mapper != null) {
+                    BytesRef payload = mapper.buildPayload(new BytesRef(input.term), input.weight, new BytesRef());
+                    doc.add(mapper.getCompletionField(ContextMapping.EMPTY_CONTEXT, input.term, payload));
+                } else {
+                    doc.add(fieldGenerator.generate(input.term, (long) input.weight));
+                }
+                if (hasStoredFieldInputs) {
+                    StoredFieldInput storedFieldInput = storedFieldInputs.get(i);
+                    doc.add(makeField(storedFieldInput.name, storedFieldInput.value, storedFieldInput.type));
+                }
+                writer.addDocument(doc);
+            }
+            writer.forceMerge(1, true);
+            writer.commit();
+        }
+
+        private Set<Integer> generateDocIDsToDelete(int numDocs, int numDocsToDelete) {
+            Set<Integer> docIDsToDelete = new HashSet<>(numDocsToDelete);
+            for (int i = 0; i < numDocsToDelete; i++) {
+                while (true) {
+                    int docID = random.nextInt() % numDocs;
+                    if (docID < 0) {
+                        docID += numDocs;
+                    }
+                    if (!docIDsToDelete.contains(docID)) {
+                        assert docID >= 0 && docID < numDocs :
+                                String.format(Locale.ROOT, "docID=%d, numDocs=%d", docID, numDocs);
+                        docIDsToDelete.add(docID);
+                        break;
+                    }
+                }
+            }
+            return docIDsToDelete;
+        }
+
+        public IndexReader getReader() throws IOException {
+            assert writer != null;
+            return DirectoryReader.open(writer, false);
+        }
+
+        public Set<Integer> deletedDocs(IndexReader reader, int numDocsToDelete) throws Exception {
+            assert reader.leaves().size() == 1;
+            return generateDocIDsToDelete(reader.numDocs(), numDocsToDelete);
+
+        }
+
+        public Map.Entry<SegmentLookup.LongBased, LeafReader> getNewLookup(IndexReader reader) throws Exception {
+            assert reader.leaves().size() == 1;
+            LeafReader atomicReader = reader.leaves().get(0).reader();
+            Terms luceneTerms = atomicReader.terms(SUGGEST_FIELD_NAME);
+            SegmentLookup.LongBased lookup = null;
+            if (luceneTerms instanceof LookupPostingsFormat.LookupTerms) {
+                lookup = ((LookupPostingsFormat.LookupTerms) luceneTerms).longScoreLookup();
+            }
+            assert lookup != null;
+            return new AbstractMap.SimpleEntry<>(lookup, atomicReader);
+        }
+
+        public Map.Entry<SegmentLookup.LongBased, LeafReader> getNewLookup() throws Exception {
+            return getNewLookup(getReader());
+        }
+
+
+        public Lookup getLookup() throws IOException {
+            IndexReader reader = DirectoryReader.open(writer, true);
+            assert reader.leaves().size() == 1;
+            LeafReader atomicReader = reader.leaves().get(0).reader();
+            Terms luceneTerms = atomicReader.terms(mapper.name());
+            Lookup lookup = null;
+            if (luceneTerms instanceof Completion090PostingsFormat.CompletionTerms) {
+                lookup = ((Completion090PostingsFormat.CompletionTerms) luceneTerms).getLookup(mapper, new CompletionSuggestionContext(null));
+            }
+            assert lookup != null;
+            return lookup;
+        }
+
+        public void close() throws IOException {
+            writer.close();
+            dir.close();
+        }
+
+
+        private Field makeField(String name, Object value, Class type) throws Exception {
+            if (type == String.class) {
+                return new StoredField(name, (String) value);
+            } else if (type == BytesRef.class) {
+                return new StoredField(name, (BytesRef) value);
+            } else if (type == Integer.class) {
+                return new StoredField(name, (int) value);
+            } else if (type == Float.class) {
+                return new StoredField(name, (float) value);
+            } else if (type == Double.class) {
+                return new StoredField(name, (double) value);
+            } else if (type == Long.class) {
+                return new StoredField(name, (long) value);
+            }
+            throw new Exception("Unsupported Type " + type);
+        }
+    }
+    // copied from Lucene (org/apache/lucene/search/suggest/Average.java)
+    final static class Average {
+        /**
+         * Average (in milliseconds).
+         */
+        public final double avg;
+
+        /**
+         * Standard deviation (in milliseconds).
+         */
+        public final double stddev;
+
+        /**
+         *
+         */
+        Average(double avg, double stddev)
+        {
+            this.avg = avg;
+            this.stddev = stddev;
+        }
+
+        @Override
+        public String toString()
+        {
+            return String.format(Locale.ROOT, "%.0f [+- %2.2f]",
+                    avg, stddev);
+        }
+
+        static Average from(List<Double> values) {
+            double sum = 0;
+            double sumSquares = 0;
+
+            for (double l : values)
+            {
+                sum += l;
+                sumSquares += l * l;
+            }
+
+            double avg = sum / (double) values.size();
+            return new Average(
+                    (sum / (double) values.size()),
+                    Math.sqrt(sumSquares / (double) values.size() - avg * avg));
+        }
+    }
+}


### PR DESCRIPTION
**NOTE:** Experimental! The PR will be merged to branch `feature/nrt_suggester`
# Overview

Lookup API maps a lookup field value (analyzed form) to its Lucene document id with a weight using a weighted FST. It retrieves top M documents for the top N completions (analyzed form) of a query prefix.

One or more named lookup field(s) can be added to documents to query the lookup API by the lookup field name. Adding the same lookup field(s) with the same value across different documents enables the documents to be looked up under completions of the lookup field value (e.g. multiple documents for a single entity). Adding multiple lookup field value(s) to a single document enables the document to be looked up under completions to all the lookup field value(s) (e.g. multiple names representing a single document).

Lookup API filters out deleted documents in near-real time and supports arbitrary filters on documents at query-time.
## Example

Assuming a set of documents have the following fields:
- `titles` (can be multi-valued, may be unique/document)
- `popularity` (numeric)
- `type` (many documents can have the same value)
- `location` (geohash based on BytesRef)

**Use case 1:**
 By adding a lookup field with `titles` as values and `popularity` as the weights to all documents, one can lookup most `popular` `m` documents grouped under most `popular` `n` `titles` that completes a query prefix (filtered by some criteria, if needed)

**Use case 2:**
By adding a lookup field with `type` as the value and `popularity` as the weight to all documents, one can lookup most `popular` `m` documents grouped under most `popular` `n` `type`s that completes a query prefix (filtered by some criteria, if needed)

**Use case 3:**
By adding a lookup field with `titles` as values and `location` as the weight to all documents, one can lookup the closest (to a provided query-time `location` context) `m` documents grouped under the closest `n` `titles` that completes a query prefix (filtered by some criteria, if needed). (NOTE: using a `ContextAwareScorer` for scoring with `geohash`)

**Use case 4:**
 By adding a lookup field with `titles` as values and `popularity` as the weight for a lookup field for documents with only a certain `type`, one can lookup most `popular` `m` documents with the certain `type` grouped under most `popular` `n` `titles` that completes a query prefix (filtered by some criteria, if needed)
# Usage
## Indexing

`LookupFieldGenerator` has to be created with the lookup configuration and lookup field(s) can be generated from it to be added to any document(s).

``` java
// create a named lookup field generator using `analyzer` as indexAnalyzer and queryAnalyzer
LookupFieldGenerator fieldGenerator = LookupFieldGenerator.create("movies", analyzer);

// lookup fields can be added to a document just like any other fields
// making the document available for lookup for completions to "Star Wars" and "Star Wars Episode IV: A New Hope"
Document doc = new Document();
doc.add(..);
doc.add(fieldGenerator.generate("Star Wars", 5));
doc.add(fieldGenerator.generate("Star Wars Episode IV: A New Hope", 9));
...
```

**LookupFieldGenerator options:**

`name` - unique lookup name
 `indexAnalyzer` - used to analyze tokens at index time
 `queryAnalyzer` - used to analyze the query prefix
 `preserveSep` - configuration to preserve seperators at lookup and index time
 `preservePositionIncrements` - configuration to preserve position holes at lookup and index time
 `scorer` - to configure score output and scoring

``` java
LookupFieldGenerator.create(String name, Analyzer indexAnalyzer, Analyzer queryAnalyzer, 
                                     boolean preserveSep, boolean preservePositionIncrements, 
                                     ContextAwareScorer scorer)
```
## Querying

The lookup can be accessed through a `LeafReader` just like any other field.

``` java
// get lookup terms from LeafReader
LookupTerms lookupTerms = (LookupTerms) leafReader.terms("movies");
SegmentLookup.LongBased lookup = lookupTerms.longScoreLookup();

// query the lookup for movie titles starting with 'Star' to get the 3 top completions with at most 2 top documents for each
result = lookup.lookup(leafReader, "Star", 3, 2); 

// sample result structure
{
 "starwarsepisodeivnewhope" : 
   [
     {"score": 9, "docID": .., "output": "Star Wars Episode IV: A New Hope"}
   ],
 "starwars" : 
   [
     {"score": 5, "docID": .., "output": "Star Wars"}
   ],
 "startrek" : 
   [
     {"score": 3, "docID": .., "output": ..}, 
     {"score:" 2, "docID": .., "output": ...}
   ]
}
```

**Lookup options:**
 `reader` -  to be used for filtering deleted docs
 `queryAnalyzer` - analyzer to be applied to provided key
 `key` - prefix to lookup
 `num` -  number of unique analyzed forms
 `nLeaf` - number of documents to be retrieved per analyzed form
`context` - query context (for context aware scoring) and filter context for the lookup
`collector` - used to collect the results of the lookup

``` java
public void lookup(LeafReader reader, Analyzer queryAnalyzer, 
                             CharSequence key, int num, int nLeaf, 
                             Context<W> context, Collector<W> collector)

```
# Design Overview

The Lookup API is based on a custom postings format, `LookupPostingsFormat`.
## Indexing

`LookupFieldGenerator` registers the build configuration to the posting format on creation. The configuration is used by `NRTSuggesterBuilder` to build the FST when a new lookup field is indexed (see `LookupFieldsConsumer`).

**FST format:**
- **Input:** analyzed form of the field value (using `indexAnalyzer`)
- **outputs:**
  - weight (scoring on which can be configured by `ContextAwareScorer`)
  - raw field value and docID 
- a leaf label is appended to the end of each **input**, the **outputs** for every **input** is sorted (for context-aware scoring sorted in a uniform way) before being added to the FST. Dedup bytes are used to structure the leaves to enable impact ordering of the docIds and early termination at query time.
## Querying

`LookupFieldsProducer` exposes a named lookup through the `terms(String name)` api of a `LeafReader`. `LookupFieldsProducer` loads the FST segments lazily and uses the `NRTSuggester` to perform the actual lookup. 

`NRTSuggester` uses the `TopNSearcher` for lookup. `TopNSearcher` has two modes, inLeaf (after finding the leaf label for an input) and not inLeaf. When not inLeaf mode the `TopNSearcher` behaves the same as the one used for `AnalyzingSuggester`. When inLeaf mode, the `TopNSearcher` iteratively finds the top scoring leaves and early terminates if it finds `m` acceptable leaves.
## Scoring

The lookup API has flexible scoring mechanism and allows for context-aware scoring through `ContextAwareScorer`. It provides the interfaces to customize the weight `output` of the FST and plug in external scoring schemes.

**TODO:** `ContextAwareScorer` API usage
# Benchmark

**Dataset:** http://download.geonames.org/export/dump/allCountries.zip (source: http://www.geonames.org/)
**# of Input**: 3,383,887
**NOTE:** `name` was used as the lookup field value and `geonameid` was used as the weight for the benchmark

**Benchmark showing performance for increasing number of leaf lookups (# of documents per analyzed form) for different prefix lengths**
![kqps_vs_leaf_2](https://cloud.githubusercontent.com/assets/753679/6141452/b6bdc696-b173-11e4-82bc-98e9197aa387.png)

**Benchmark showing performance for increasing % of documents to be filtered at query-time for different prefix lenghts**
![kqps_vs_filter_2](https://cloud.githubusercontent.com/assets/753679/6141454/cb7ad934-b173-11e4-8d5f-739f56260c1d.png)

**Lookup FST size:** ~50mb
**Lookup Build Performance:** ~60 seconds

**TODO:** Benchmark for stored field and doc value retrieval
# Work in progress
- [x] Fully support returning docValues and stored field values in `DefaultCollector`
- [x] test `DefaultCollector`
- [ ] Flush out `ContextAwareScorer` API for pluggable scoring
- [ ] Simplify `Context` in `NRTSuggester`
- [ ] Increase test coverage
- [ ] Implement geohash based `ContextAwareScorer`
- [ ] General cleanup
