### PR TITLE
query-string-query.asciidoc: multi field logic bug

### DIFF
--- a/docs/reference/query-dsl/queries/query-string-query.asciidoc
+++ b/docs/reference/query-dsl/queries/query-string-query.asciidoc
@@ -125,7 +125,7 @@ matches the same words as
 --------------------------------------------------
 {
     "query_string": {
-      "query": "(content:this OR content:that) AND (name:this OR name:that)"
+      "query": "(content:this AND content:that) OR (name:this AND name:that)"
     }
 }
 --------------------------------------------------


### PR DESCRIPTION
It seems that the AND/OR were swapped in the description of multi field; I propose swapping them back.
