### PR TITLE
Ensure that we don't pass negative `timeInQueue` to writeVLong

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/service/PendingClusterTask.java
+++ b/src/main/java/org/elasticsearch/cluster/service/PendingClusterTask.java
@@ -98,8 +98,8 @@ public class PendingClusterTask implements Streamable {
             // timeInQueue is set to -1 when unknown and can be negative if time goes backwards
             out.writeLong(timeInQueue);
         } else {
-            out.writeVLong(timeInQueue);
-        }
+            out.writeVLong(Math.max(0, timeInQueue));
+            }
         if (out.getVersion().onOrAfter(Version.V_1_3_0)) {
             out.writeBoolean(executing);
         }


### PR DESCRIPTION
`#writeVLong` can only serialize positive values, yet this BWC code
in `PendingClusterTask` passes occational `-1` causing assertions to trip.
It also yields completely wrong values ie. if `-1` is deserialized it yields
`9223372036854775807`. This commit ensure that `timeInQueue` is positive ie.
at least `0`

Relates to #8077

Note this PR is against `1.x`
