### PR TITLE
Only do a single listAll from FileSwitchDir

### DIFF
--- a/src/main/java/org/elasticsearch/index/store/fs/DefaultFsDirectoryService.java
+++ b/src/main/java/org/elasticsearch/index/store/fs/DefaultFsDirectoryService.java
@@ -50,6 +50,13 @@ public class DefaultFsDirectoryService extends FsDirectoryService {
 
     @Override
     protected Directory newFSDirectory(Path location, LockFactory lockFactory) throws IOException {
-        return new FileSwitchDirectory(PRIMARY_EXTENSIONS, new MMapDirectory(location, lockFactory), new NIOFSDirectory(location, lockFactory), true);
+        final MMapDirectory mmapDir = new MMapDirectory(location, lockFactory);
+        return new FileSwitchDirectory(PRIMARY_EXTENSIONS, mmapDir, new NIOFSDirectory(location, lockFactory), true) {
+            @Override
+            public String[] listAll() throws IOException {
+                // Avoid doing listAll twice:
+                return mmapDir.listAll();
+            }
+        };
     }
 }


### PR DESCRIPTION
With #6636 listAll now calls it twice (once for the mmap dir, once for niofs dir) ... I think we should fix this to be a single call?
