### PR TITLE
Expose `master_timeout` flag on `GET _template` & `HEAD _template`

### DIFF
--- a/rest-api-spec/api/indices.exists_template.json
+++ b/rest-api-spec/api/indices.exists_template.json
@@ -7,12 +7,16 @@
       "paths": ["/_template/{name}"],
       "parts": {
         "name": {
-          "type" : "string",
-          "required" : true,
-          "description" : "The name of the template"
+          "type": "string",
+          "required": true,
+          "description": "The name of the template"
         }
       },
       "params": {
+        "master_timeout": {
+          "type": "time",
+          "description": "Explicit operation timeout for connection to master node"
+        },
         "local": {
           "type": "boolean",
           "description": "Return local information, do not retrieve the state from master node (default: false)"

--- a/rest-api-spec/api/indices.get_template.json
+++ b/rest-api-spec/api/indices.get_template.json
@@ -4,23 +4,30 @@
     "methods": ["GET"],
     "url": {
       "path": "/_template/{name}",
-      "paths": ["/_template", "/_template/{name}"],
+      "paths": [
+        "/_template",
+        "/_template/{name}"
+      ],
       "parts": {
         "name": {
-          "type" : "string",
-          "required" : false,
-          "description" : "The name of the template"
+          "type": "string",
+          "required": false,
+          "description": "The name of the template"
         }
       },
       "params": {
-          "flat_settings": {
-              "type": "boolean",
-              "description": "Return settings in flat format (default: false)"
-          },
-          "local": {
-              "type": "boolean",
-              "description": "Return local information, do not retrieve the state from master node (default: false)"
-          }
+        "flat_settings": {
+          "type": "boolean",
+          "description": "Return settings in flat format (default: false)"
+        },
+        "master_timeout": {
+          "type": "time",
+          "description": "Explicit operation timeout for connection to master node"
+        },
+        "local": {
+          "type": "boolean",
+          "description": "Return local information, do not retrieve the state from master node (default: false)"
+        }
       }
     },
     "body": null

--- a/rest-api-spec/test/indices.exists_template/10_basic.yaml
+++ b/rest-api-spec/test/indices.exists_template/10_basic.yaml
@@ -24,6 +24,7 @@ setup:
   - do:
       indices.exists_template:
         name: test
+        master_timeout: 1m
 
   - is_true: ''
 

--- a/rest-api-spec/test/indices.get_template/10_basic.yaml
+++ b/rest-api-spec/test/indices.get_template/10_basic.yaml
@@ -46,11 +46,12 @@ setup:
   - is_true: test
 
 ---
-"Get template with non flat settings":
+"Get template with non flat settings and master timeout":
 
   - do:
       indices.get_template:
         name: test
         flat_settings: false
+        master_timeout: 1m
 
   - match: {test.settings: {index: {number_of_shards: '1', number_of_replicas: '0'}}}

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/template/get/RestGetIndexTemplateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/template/get/RestGetIndexTemplateAction.java
@@ -56,6 +56,8 @@ public class RestGetIndexTemplateAction extends BaseRestHandler {
 
         GetIndexTemplatesRequest getIndexTemplatesRequest = new GetIndexTemplatesRequest(names);
         getIndexTemplatesRequest.local(request.paramAsBoolean("local", getIndexTemplatesRequest.local()));
+        getIndexTemplatesRequest.masterNodeTimeout(request.paramAsTime("master_timeout", getIndexTemplatesRequest.masterNodeTimeout()));
+
         getIndexTemplatesRequest.listenerThreaded(false);
 
         final boolean implicitAll = getIndexTemplatesRequest.names().length == 0;

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/template/head/RestHeadIndexTemplateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/template/head/RestHeadIndexTemplateAction.java
@@ -46,6 +46,7 @@ public class RestHeadIndexTemplateAction extends BaseRestHandler {
     public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         GetIndexTemplatesRequest getIndexTemplatesRequest = new GetIndexTemplatesRequest(request.param("name"));
         getIndexTemplatesRequest.local(request.paramAsBoolean("local", getIndexTemplatesRequest.local()));
+        getIndexTemplatesRequest.masterNodeTimeout(request.paramAsTime("master_timeout", getIndexTemplatesRequest.masterNodeTimeout()));
         client.admin().indices().getTemplates(getIndexTemplatesRequest, new RestResponseListener<GetIndexTemplatesResponse>(channel) {
             @Override
             public RestResponse buildResponse(GetIndexTemplatesResponse getIndexTemplatesResponse) {


### PR DESCRIPTION
These are master level operation but we currently don't expose this parameter
