### PR TITLE
Prevent negative intervals in date_histogram

### DIFF
--- a/src/main/java/org/elasticsearch/common/rounding/TimeZoneRounding.java
+++ b/src/main/java/org/elasticsearch/common/rounding/TimeZoneRounding.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.common.rounding;
 
+import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.unit.TimeValue;
@@ -63,6 +64,8 @@ public abstract class TimeZoneRounding extends Rounding {
 
         public Builder(TimeValue interval) {
             this.unit = null;
+            if (interval.millis() < 1)
+                throw new ElasticsearchIllegalArgumentException("Zero or negative time interval not supported");
             this.interval = interval.millis();
         }
 
@@ -309,6 +312,8 @@ public abstract class TimeZoneRounding extends Rounding {
         }
 
         UTCIntervalTimeZoneRounding(long interval) {
+            if (interval < 1)
+                throw new ElasticsearchIllegalArgumentException("Zero or negative time interval not supported");
             this.interval = interval;
         }
 
@@ -356,6 +361,8 @@ public abstract class TimeZoneRounding extends Rounding {
         }
 
         TimeIntervalTimeZoneRounding(long interval, DateTimeZone preTz, DateTimeZone postTz) {
+            if (interval < 1)
+                throw new ElasticsearchIllegalArgumentException("Zero or negative time interval not supported");
             this.interval = interval;
             this.preTz = preTz;
             this.postTz = postTz;
@@ -414,6 +421,8 @@ public abstract class TimeZoneRounding extends Rounding {
         }
 
         DayIntervalTimeZoneRounding(long interval, DateTimeZone preTz, DateTimeZone postTz) {
+            if (interval < 1)
+                throw new ElasticsearchIllegalArgumentException("Zero or negative time interval not supported");
             this.interval = interval;
             this.preTz = preTz;
             this.postTz = postTz;

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/HistogramParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/HistogramParser.java
@@ -118,7 +118,7 @@ public class HistogramParser implements Aggregator.Parser {
             }
         }
 
-        if (interval < 0) {
+        if (interval < 1) {
             throw new SearchParseException(context, "Missing required field [interval] for histogram aggregation [" + aggregationName + "]");
         }
         


### PR DESCRIPTION
Negative settings for `interval` in `date_histogram` could lead to OOM errors in conjunction with `min_doc_count`=0. This fix raises exceptions in the histogram builder and the TimeZoneRounding classes so that the query fails before this can happen.

Closes #9634
