### PR TITLE
Added nested scope to parse context that keeps track the current nested level during search request parsing

### DIFF
--- a/src/main/java/org/elasticsearch/index/cache/bitset/BitsetFilterCache.java
+++ b/src/main/java/org/elasticsearch/index/cache/bitset/BitsetFilterCache.java
@@ -26,6 +26,7 @@ import com.google.common.cache.RemovalNotification;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.DocIdSet;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.Filter;
 import org.apache.lucene.search.join.BitDocIdSetFilter;
 import org.apache.lucene.util.BitDocIdSet;
@@ -142,7 +143,11 @@ public class BitsetFilterCache extends AbstractIndexComponent implements LeafRea
                 } else {
                     BitDocIdSet.Builder builder = new BitDocIdSet.Builder(context.reader().maxDoc());
                     if (docIdSet != null && docIdSet != DocIdSet.EMPTY) {
-                        builder.or(docIdSet.iterator());
+                        DocIdSetIterator iterator = docIdSet.iterator();
+                        // some filters (QueryWrapperFilter) return not null or DocIdSet.EMPTY if there no matching docs
+                        if (iterator != null) {
+                            builder.or(iterator);
+                        }
                     }
                     BitDocIdSet bits = builder.build();
                     // code expects this to be non-null

--- a/src/main/java/org/elasticsearch/index/query/NestedFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/NestedFilterParser.java
@@ -19,26 +19,15 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.Filter;
-import org.apache.lucene.search.FilteredQuery;
-import org.apache.lucene.search.Query;
-import org.apache.lucene.search.join.BitDocIdSetFilter;
 import org.apache.lucene.search.join.ScoreMode;
 import org.apache.lucene.search.join.ToParentBlockJoinQuery;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.lucene.HashedBytesRef;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.mapper.DocumentMapper;
-import org.elasticsearch.index.mapper.MapperService;
-import org.elasticsearch.index.mapper.object.ObjectMapper;
 import org.elasticsearch.index.query.support.InnerHitsQueryParserHelper;
-import org.elasticsearch.index.search.nested.NonNestedDocsFilter;
-import org.elasticsearch.search.fetch.innerhits.InnerHitsContext;
-import org.elasticsearch.search.internal.SubSearchContext;
 
 import java.io.IOException;
 
@@ -61,113 +50,49 @@ public class NestedFilterParser implements FilterParser {
     @Override
     public Filter parse(QueryParseContext parseContext) throws IOException, QueryParsingException {
         XContentParser parser = parseContext.parser();
+        final NestedQueryParser.ToBlockJoinQueryBuilder builder = new NestedQueryParser.ToBlockJoinQueryBuilder(parseContext);
 
-        Query query = null;
-        boolean queryFound = false;
-        Filter filter = null;
-        boolean filterFound = false;
         float boost = 1.0f;
-        String path = null;
         boolean cache = false;
         HashedBytesRef cacheKey = null;
         String filterName = null;
-        Tuple<String, SubSearchContext> innerHits = null;
 
-        // we need a late binding filter so we can inject a parent nested filter inner nested queries
-        NestedQueryParser.LateBindingParentFilter currentParentFilterContext = NestedQueryParser.parentFilterContext.get();
-
-        NestedQueryParser.LateBindingParentFilter usAsParentFilter = new NestedQueryParser.LateBindingParentFilter();
-        NestedQueryParser.parentFilterContext.set(usAsParentFilter);
-
-        try {
-            String currentFieldName = null;
-            XContentParser.Token token;
-            while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
-                if (token == XContentParser.Token.FIELD_NAME) {
-                    currentFieldName = parser.currentName();
-                } else if (token == XContentParser.Token.START_OBJECT) {
-                    if ("query".equals(currentFieldName)) {
-                        queryFound = true;
-                        query = parseContext.parseInnerQuery();
-                    } else if ("filter".equals(currentFieldName)) {
-                        filterFound = true;
-                        filter = parseContext.parseInnerFilter();
-                    } else if ("inner_hits".equals(currentFieldName)) {
-                        innerHits = innerHitsQueryParserHelper.parse(parseContext);
-                    } else {
-                        throw new QueryParsingException(parseContext.index(), "[nested] filter does not support [" + currentFieldName + "]");
-                    }
-                } else if (token.isValue()) {
-                    if ("path".equals(currentFieldName)) {
-                        path = parser.text();
-                    } else if ("boost".equals(currentFieldName)) {
-                        boost = parser.floatValue();
-                    } else if ("_name".equals(currentFieldName)) {
-                        filterName = parser.text();
-                    } else if ("_cache".equals(currentFieldName)) {
-                        cache = parser.booleanValue();
-                    } else if ("_cache_key".equals(currentFieldName) || "_cacheKey".equals(currentFieldName)) {
-                        cacheKey = new HashedBytesRef(parser.text());
-                    } else {
-                        throw new QueryParsingException(parseContext.index(), "[nested] filter does not support [" + currentFieldName + "]");
-                    }
+        String currentFieldName = null;
+        XContentParser.Token token;
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                currentFieldName = parser.currentName();
+            } else if (token == XContentParser.Token.START_OBJECT) {
+                if ("query".equals(currentFieldName)) {
+                    builder.query();
+                } else if ("filter".equals(currentFieldName)) {
+                    builder.filter();
+                } else if ("inner_hits".equals(currentFieldName)) {
+                    builder.setInnerHits(innerHitsQueryParserHelper.parse(parseContext));
+                } else {
+                    throw new QueryParsingException(parseContext.index(), "[nested] filter does not support [" + currentFieldName + "]");
+                }
+            } else if (token.isValue()) {
+                if ("path".equals(currentFieldName)) {
+                    builder.setPath(parser.text());
+                } else if ("boost".equals(currentFieldName)) {
+                    boost = parser.floatValue();
+                } else if ("_name".equals(currentFieldName)) {
+                    filterName = parser.text();
+                } else if ("_cache".equals(currentFieldName)) {
+                    cache = parser.booleanValue();
+                } else if ("_cache_key".equals(currentFieldName) || "_cacheKey".equals(currentFieldName)) {
+                    cacheKey = new HashedBytesRef(parser.text());
+                } else {
+                    throw new QueryParsingException(parseContext.index(), "[nested] filter does not support [" + currentFieldName + "]");
                 }
             }
-            if (!queryFound && !filterFound) {
-                throw new QueryParsingException(parseContext.index(), "[nested] requires either 'query' or 'filter' field");
-            }
-            if (path == null) {
-                throw new QueryParsingException(parseContext.index(), "[nested] requires 'path' field");
-            }
-
-            if (query == null && filter == null) {
-                return null;
-            }
-
-            if (filter != null) {
-                query = new ConstantScoreQuery(filter);
-            }
-
-            query.setBoost(boost);
-
-            MapperService.SmartNameObjectMapper mapper = parseContext.smartObjectMapper(path);
-            if (mapper == null) {
-                throw new QueryParsingException(parseContext.index(), "[nested] failed to find nested object under path [" + path + "]");
-            }
-            ObjectMapper objectMapper = mapper.mapper();
-            if (objectMapper == null) {
-                throw new QueryParsingException(parseContext.index(), "[nested] failed to find nested object under path [" + path + "]");
-            }
-            if (!objectMapper.nested().isNested()) {
-                throw new QueryParsingException(parseContext.index(), "[nested] nested object under path [" + path + "] is not of nested type");
-            }
-
-            BitDocIdSetFilter childFilter = parseContext.bitsetFilter(objectMapper.nestedTypeFilter());
-            usAsParentFilter.filter = childFilter;
-            // wrap the child query to only work on the nested path type
-            query = new FilteredQuery(query, childFilter);
-            if (innerHits != null) {
-                DocumentMapper childDocumentMapper = mapper.docMapper();
-                ObjectMapper parentObjectMapper = childDocumentMapper.findParentObjectMapper(objectMapper);
-                InnerHitsContext.NestedInnerHits nestedInnerHits = new InnerHitsContext.NestedInnerHits(innerHits.v2(), query, null, parentObjectMapper, objectMapper);
-                String name = innerHits.v1() != null ? innerHits.v1() : path;
-                parseContext.addInnerHits(name, nestedInnerHits);
-            }
-
-            BitDocIdSetFilter parentFilter = currentParentFilterContext;
-            if (parentFilter == null) {
-                parentFilter = parseContext.bitsetFilter(NonNestedDocsFilter.INSTANCE);
-                // don't do special parent filtering, since we might have same nested mapping on two different types
-                //if (mapper.hasDocMapper()) {
-                //    // filter based on the type...
-                //    parentFilter = mapper.docMapper().typeFilter();
-                //}
-            } else {
-                parentFilter = parseContext.bitsetFilter(parentFilter);
-            }
-
-            Filter nestedFilter = Queries.wrap(new ToParentBlockJoinQuery(query, parentFilter, ScoreMode.None), parseContext);
-
+        }
+        builder.setScoreMode(ScoreMode.None);
+        ToParentBlockJoinQuery joinQuery = builder.build();
+        if (joinQuery != null) {
+            joinQuery.getChildQuery().setBoost(boost);
+            Filter nestedFilter = Queries.wrap(joinQuery, parseContext);
             if (cache) {
                 nestedFilter = parseContext.cacheFilter(nestedFilter, cacheKey, parseContext.autoFilterCachePolicy());
             }
@@ -175,9 +100,8 @@ public class NestedFilterParser implements FilterParser {
                 parseContext.addNamedFilter(filterName, nestedFilter);
             }
             return nestedFilter;
-        } finally {
-            // restore the thread local one...
-            NestedQueryParser.parentFilterContext.set(currentParentFilterContext);
+        } else {
+            return null;
         }
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/NestedQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/NestedQueryParser.java
@@ -19,25 +19,21 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.Filter;
 import org.apache.lucene.search.FilteredQuery;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.search.join.BitDocIdSetFilter;
 import org.apache.lucene.search.join.ScoreMode;
 import org.apache.lucene.search.join.ToParentBlockJoinQuery;
-import org.apache.lucene.util.BitDocIdSet;
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.mapper.DocumentMapper;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.object.ObjectMapper;
 import org.elasticsearch.index.query.support.InnerHitsQueryParserHelper;
-import org.elasticsearch.index.search.nested.NonNestedDocsFilter;
-import org.elasticsearch.search.fetch.innerhits.InnerHitsContext.NestedInnerHits;
+import org.elasticsearch.index.query.support.NestedInnerQueryParseSupport;
+import org.elasticsearch.search.fetch.innerhits.InnerHitsContext;
 import org.elasticsearch.search.internal.SubSearchContext;
 
 import java.io.IOException;
@@ -61,155 +57,110 @@ public class NestedQueryParser implements QueryParser {
     @Override
     public Query parse(QueryParseContext parseContext) throws IOException, QueryParsingException {
         XContentParser parser = parseContext.parser();
+        final ToBlockJoinQueryBuilder builder = new ToBlockJoinQueryBuilder(parseContext);
 
-        Query query = null;
-        boolean queryFound = false;
-        Filter filter = null;
-        boolean filterFound = false;
         float boost = 1.0f;
-        String path = null;
         ScoreMode scoreMode = ScoreMode.Avg;
         String queryName = null;
-        Tuple<String, SubSearchContext> innerHits = null;
 
-        // we need a late binding filter so we can inject a parent nested filter inner nested queries
-        LateBindingParentFilter currentParentFilterContext = parentFilterContext.get();
-
-        LateBindingParentFilter usAsParentFilter = new LateBindingParentFilter();
-        parentFilterContext.set(usAsParentFilter);
-
-        try {
-            String currentFieldName = null;
-            XContentParser.Token token;
-            while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
-                if (token == XContentParser.Token.FIELD_NAME) {
-                    currentFieldName = parser.currentName();
-                } else if (token == XContentParser.Token.START_OBJECT) {
-                    if ("query".equals(currentFieldName)) {
-                        queryFound = true;
-                        query = parseContext.parseInnerQuery();
-                    } else if ("filter".equals(currentFieldName)) {
-                        filterFound = true;
-                        filter = parseContext.parseInnerFilter();
-                    } else if ("inner_hits".equals(currentFieldName)) {
-                        innerHits = innerHitsQueryParserHelper.parse(parseContext);
+        String currentFieldName = null;
+        XContentParser.Token token;
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                currentFieldName = parser.currentName();
+            } else if (token == XContentParser.Token.START_OBJECT) {
+                if ("query".equals(currentFieldName)) {
+                    builder.query();
+                } else if ("filter".equals(currentFieldName)) {
+                    builder.filter();
+                } else if ("inner_hits".equals(currentFieldName)) {
+                    builder.setInnerHits(innerHitsQueryParserHelper.parse(parseContext));
+                } else {
+                    throw new QueryParsingException(parseContext.index(), "[nested] query does not support [" + currentFieldName + "]");
+                }
+            } else if (token.isValue()) {
+                if ("path".equals(currentFieldName)) {
+                    builder.setPath(parser.text());
+                } else if ("boost".equals(currentFieldName)) {
+                    boost = parser.floatValue();
+                } else if ("score_mode".equals(currentFieldName) || "scoreMode".equals(currentFieldName)) {
+                    String sScoreMode = parser.text();
+                    if ("avg".equals(sScoreMode)) {
+                        scoreMode = ScoreMode.Avg;
+                    } else if ("max".equals(sScoreMode)) {
+                        scoreMode = ScoreMode.Max;
+                    } else if ("total".equals(sScoreMode) || "sum".equals(sScoreMode)) {
+                        scoreMode = ScoreMode.Total;
+                    } else if ("none".equals(sScoreMode)) {
+                        scoreMode = ScoreMode.None;
                     } else {
-                        throw new QueryParsingException(parseContext.index(), "[nested] query does not support [" + currentFieldName + "]");
+                        throw new QueryParsingException(parseContext.index(), "illegal score_mode for nested query [" + sScoreMode + "]");
                     }
-                } else if (token.isValue()) {
-                    if ("path".equals(currentFieldName)) {
-                        path = parser.text();
-                    } else if ("boost".equals(currentFieldName)) {
-                        boost = parser.floatValue();
-                    } else if ("score_mode".equals(currentFieldName) || "scoreMode".equals(currentFieldName)) {
-                        String sScoreMode = parser.text();
-                        if ("avg".equals(sScoreMode)) {
-                            scoreMode = ScoreMode.Avg;
-                        } else if ("max".equals(sScoreMode)) {
-                            scoreMode = ScoreMode.Max;
-                        } else if ("total".equals(sScoreMode) || "sum".equals(sScoreMode)) {
-                            scoreMode = ScoreMode.Total;
-                        } else if ("none".equals(sScoreMode)) {
-                            scoreMode = ScoreMode.None;
-                        } else {
-                            throw new QueryParsingException(parseContext.index(), "illegal score_mode for nested query [" + sScoreMode + "]");
-                        }
-                    } else if ("_name".equals(currentFieldName)) {
-                        queryName = parser.text();
-                    } else {
-                        throw new QueryParsingException(parseContext.index(), "[nested] query does not support [" + currentFieldName + "]");
-                    }
+                } else if ("_name".equals(currentFieldName)) {
+                    queryName = parser.text();
+                } else {
+                    throw new QueryParsingException(parseContext.index(), "[nested] query does not support [" + currentFieldName + "]");
                 }
             }
-            if (!queryFound && !filterFound) {
-                throw new QueryParsingException(parseContext.index(), "[nested] requires either 'query' or 'filter' field");
-            }
-            if (path == null) {
-                throw new QueryParsingException(parseContext.index(), "[nested] requires 'path' field");
-            }
+        }
 
-            if (query == null && filter == null) {
-                return null;
-            }
-
-            if (filter != null) {
-                query = new ConstantScoreQuery(filter);
-            }
-
-            MapperService.SmartNameObjectMapper mapper = parseContext.smartObjectMapper(path);
-            if (mapper == null) {
-                throw new QueryParsingException(parseContext.index(), "[nested] failed to find nested object under path [" + path + "]");
-            }
-            ObjectMapper objectMapper = mapper.mapper();
-            if (objectMapper == null) {
-                throw new QueryParsingException(parseContext.index(), "[nested] failed to find nested object under path [" + path + "]");
-            }
-            if (!objectMapper.nested().isNested()) {
-                throw new QueryParsingException(parseContext.index(), "[nested] nested object under path [" + path + "] is not of nested type");
-            }
-
-            BitDocIdSetFilter childFilter = parseContext.bitsetFilter(objectMapper.nestedTypeFilter());
-            usAsParentFilter.filter = childFilter;
-            // wrap the child query to only work on the nested path type
-            query = new FilteredQuery(query, childFilter);
-            if (innerHits != null) {
-                DocumentMapper childDocumentMapper = mapper.docMapper();
-                ObjectMapper parentObjectMapper = childDocumentMapper.findParentObjectMapper(objectMapper);
-                NestedInnerHits nestedInnerHits = new NestedInnerHits(innerHits.v2(), query, null, parentObjectMapper, objectMapper);
-                String name = innerHits.v1() != null ? innerHits.v1() : path;
-                parseContext.addInnerHits(name, nestedInnerHits);
-            }
-
-            BitDocIdSetFilter parentFilter = currentParentFilterContext;
-            if (parentFilter == null) {
-                parentFilter = parseContext.bitsetFilter(NonNestedDocsFilter.INSTANCE);
-                // don't do special parent filtering, since we might have same nested mapping on two different types
-                //if (mapper.hasDocMapper()) {
-                //    // filter based on the type...
-                //    parentFilter = mapper.docMapper().typeFilter();
-                //}
-            } else {
-                parentFilter = parseContext.bitsetFilter(parentFilter);
-            }
-            ToParentBlockJoinQuery joinQuery = new ToParentBlockJoinQuery(query, parentFilter, scoreMode);
+        builder.setScoreMode(scoreMode);
+        ToParentBlockJoinQuery joinQuery = builder.build();
+        if (joinQuery != null) {
             joinQuery.setBoost(boost);
             if (queryName != null) {
                 parseContext.addNamedQuery(queryName, joinQuery);
             }
-            return joinQuery;
-        } finally {
-            // restore the thread local one...
-            parentFilterContext.set(currentParentFilterContext);
         }
+        return joinQuery;
     }
 
-    // TODO: Change this mechanism in favour of how parent nested object type is resolved in nested and reverse_nested agg
-    // with this also proper validation can be performed on what is a valid nested child nested object type to be used
-    public static ThreadLocal<LateBindingParentFilter> parentFilterContext = new ThreadLocal<>();
+    public static class ToBlockJoinQueryBuilder extends NestedInnerQueryParseSupport {
 
-    public static class LateBindingParentFilter extends BitDocIdSetFilter {
+        private ScoreMode scoreMode;
+        private Tuple<String, SubSearchContext> innerHits;
 
-        public BitDocIdSetFilter filter;
-
-        @Override
-        public int hashCode() {
-            return filter.hashCode();
+        public ToBlockJoinQueryBuilder(QueryParseContext parseContext) throws IOException {
+            super(parseContext);
         }
 
-        @Override
-        public boolean equals(Object obj) {
-            if (!(obj instanceof LateBindingParentFilter)) return false;
-            return filter.equals(((LateBindingParentFilter) obj).filter);
+        public void setScoreMode(ScoreMode scoreMode) {
+            this.scoreMode = scoreMode;
         }
 
-        @Override
-        public String toString() {
-            return filter.toString();
+        public void setInnerHits(Tuple<String, SubSearchContext> innerHits) {
+            this.innerHits = innerHits;
         }
 
-        @Override
-        public BitDocIdSet getDocIdSet(LeafReaderContext ctx) throws IOException {
-            return filter.getDocIdSet(ctx);
+        @Nullable
+        public ToParentBlockJoinQuery build() throws IOException {
+            Query innerQuery;
+            if (queryFound) {
+                innerQuery = getInnerQuery();
+            } else if (filterFound) {
+                Filter innerFilter = getInnerFilter();
+                if (innerFilter != null) {
+                    innerQuery = new ConstantScoreQuery(getInnerFilter());
+                } else {
+                    innerQuery = null;
+                }
+            } else {
+                throw new QueryParsingException(parseContext.index(), "[nested] requires either 'query' or 'filter' field");
+            }
+
+            if (innerHits != null) {
+                ObjectMapper parentObjectMapper = childDocumentMapper.findParentObjectMapper(nestedObjectMapper);
+                InnerHitsContext.NestedInnerHits nestedInnerHits = new InnerHitsContext.NestedInnerHits(innerHits.v2(), getInnerQuery(), null, parentObjectMapper, nestedObjectMapper);
+                String name = innerHits.v1() != null ? innerHits.v1() : path;
+                parseContext.addInnerHits(name, nestedInnerHits);
+            }
+
+            if (innerQuery != null) {
+                return new ToParentBlockJoinQuery(new FilteredQuery(innerQuery, childFilter), parentFilter, scoreMode);
+            } else {
+                return null;
+            }
         }
+
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/QueryParseContext.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryParseContext.java
@@ -54,6 +54,7 @@ import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.MapperBuilders;
 import org.elasticsearch.index.mapper.ContentPath;
 import org.elasticsearch.index.mapper.core.StringFieldMapper;
+import org.elasticsearch.index.query.support.NestedScope;
 import org.elasticsearch.index.search.child.CustomQueryWrappingFilter;
 import org.elasticsearch.index.similarity.SimilarityService;
 import org.elasticsearch.script.ScriptService;
@@ -111,6 +112,8 @@ public class QueryParseContext {
 
     private boolean mapUnmappedFieldAsString;
 
+    private NestedScope nestedScope;
+
     public QueryParseContext(Index index, IndexQueryParserService indexQueryParser) {
         this(index, indexQueryParser, false);
     }
@@ -138,6 +141,7 @@ public class QueryParseContext {
         this.namedFilters.clear();
         this.requireCustomQueryWrappingFilter = false;
         this.propagateNoCache = false;
+        this.nestedScope = new NestedScope();
     }
 
     public Index index() {
@@ -466,5 +470,9 @@ public class QueryParseContext {
 
     public boolean requireCustomQueryWrappingFilter() {
         return requireCustomQueryWrappingFilter;
+    }
+
+    public NestedScope nestedScope() {
+        return nestedScope;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/support/NestedInnerQueryParseSupport.java
+++ b/src/main/java/org/elasticsearch/index/query/support/NestedInnerQueryParseSupport.java
@@ -1,0 +1,205 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query.support;
+
+import org.apache.lucene.search.Filter;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.join.BitDocIdSetFilter;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.mapper.DocumentMapper;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.object.ObjectMapper;
+import org.elasticsearch.index.query.QueryParseContext;
+import org.elasticsearch.index.query.QueryParsingException;
+import org.elasticsearch.index.search.nested.NonNestedDocsFilter;
+import org.elasticsearch.search.internal.SearchContext;
+
+import java.io.IOException;
+
+/**
+ * A helper that helps with parsing inner queries of the nested query.
+ * 1) Takes into account that type nested path can appear before or after the inner query
+ * 2) Updates the {@link NestedScope} when parsing the inner query.
+ */
+public class NestedInnerQueryParseSupport {
+
+    protected final QueryParseContext parseContext;
+
+    private BytesReference source;
+    private Query innerQuery;
+    private Filter innerFilter;
+    protected String path;
+
+    private boolean filterParsed = false;
+    private boolean queryParsed = false;
+    protected boolean queryFound = false;
+    protected boolean filterFound = false;
+
+    protected BitDocIdSetFilter parentFilter;
+    protected BitDocIdSetFilter childFilter;
+
+    protected DocumentMapper childDocumentMapper;
+    protected ObjectMapper nestedObjectMapper;
+
+    public NestedInnerQueryParseSupport(XContentParser parser, SearchContext searchContext) {
+        parseContext = searchContext.queryParserService().getParseContext();
+        parseContext.reset(parser);
+    }
+
+    public NestedInnerQueryParseSupport(QueryParseContext parseContext) {
+        this.parseContext = parseContext;
+    }
+
+    public void query() throws IOException {
+        if (path != null) {
+            setPathLevel();
+            try {
+                innerQuery = parseContext.parseInnerQuery();
+            } finally {
+                resetPathLevel();
+            }
+            queryParsed = true;
+        } else {
+            source = XContentFactory.smileBuilder().copyCurrentStructure(parseContext.parser()).bytes();
+        }
+        queryFound = true;
+    }
+
+    public void filter() throws IOException {
+        if (path != null) {
+            setPathLevel();
+            try {
+                innerFilter = parseContext.parseInnerFilter();
+            } finally {
+                resetPathLevel();
+            }
+            filterParsed = true;
+        } else {
+            source = XContentFactory.smileBuilder().copyCurrentStructure(parseContext.parser()).bytes();
+        }
+        filterFound = true;
+    }
+
+    public Query getInnerQuery() throws IOException {
+        if (queryParsed) {
+            return innerQuery;
+        } else {
+            if (path == null) {
+                throw new QueryParsingException(parseContext.index(), "[nested] requires 'path' field");
+            }
+            if (!queryFound) {
+                throw new QueryParsingException(parseContext.index(), "[nested] requires either 'query' or 'filter' field");
+            }
+
+            XContentParser old = parseContext.parser();
+            try {
+                XContentParser innerParser = XContentHelper.createParser(source);
+                parseContext.parser(innerParser);
+                setPathLevel();
+                try {
+                    innerQuery = parseContext.parseInnerQuery();
+                } finally {
+                    resetPathLevel();
+                }
+                queryParsed = true;
+                return innerQuery;
+            } finally {
+                parseContext.parser(old);
+            }
+        }
+    }
+
+    public Filter getInnerFilter() throws IOException {
+        if (filterParsed) {
+            return innerFilter;
+        } else {
+            if (path == null) {
+                throw new QueryParsingException(parseContext.index(), "[nested] requires 'path' field");
+            }
+            if (!filterFound) {
+                throw new QueryParsingException(parseContext.index(), "[nested] requires either 'query' or 'filter' field");
+            }
+
+            setPathLevel();
+            XContentParser old = parseContext.parser();
+            try {
+                XContentParser innerParser = XContentHelper.createParser(source);
+                parseContext.parser(innerParser);
+                innerFilter = parseContext.parseInnerFilter();
+                filterParsed = true;
+                return innerFilter;
+            } finally {
+                resetPathLevel();
+                parseContext.parser(old);
+            }
+        }
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+        MapperService.SmartNameObjectMapper smart = parseContext.smartObjectMapper(path);
+        if (smart == null) {
+            throw new QueryParsingException(parseContext.index(), "[nested] failed to find nested object under path [" + path + "]");
+        }
+        childDocumentMapper = smart.docMapper();
+        nestedObjectMapper = smart.mapper();
+        if (nestedObjectMapper == null) {
+            throw new QueryParsingException(parseContext.index(), "[nested] failed to find nested object under path [" + path + "]");
+        }
+        if (!nestedObjectMapper.nested().isNested()) {
+            throw new QueryParsingException(parseContext.index(), "[nested] nested object under path [" + path + "] is not of nested type");
+        }
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public ObjectMapper getNestedObjectMapper() {
+        return nestedObjectMapper;
+    }
+
+    public boolean queryFound() {
+        return queryFound;
+    }
+
+    public boolean filterFound() {
+        return filterFound;
+    }
+
+    private void setPathLevel() {
+        ObjectMapper objectMapper = parseContext.nestedScope().getObjectMapper();
+        if (objectMapper == null) {
+            parentFilter = parseContext.bitsetFilter(NonNestedDocsFilter.INSTANCE);
+        } else {
+            parentFilter = parseContext.bitsetFilter(objectMapper.nestedTypeFilter());
+        }
+        childFilter = parseContext.bitsetFilter(nestedObjectMapper.nestedTypeFilter());
+        parseContext.nestedScope().nextLevel(nestedObjectMapper);
+    }
+
+    private void resetPathLevel() {
+        parseContext.nestedScope().previousLevel();
+    }
+
+}

--- a/src/main/java/org/elasticsearch/index/query/support/NestedScope.java
+++ b/src/main/java/org/elasticsearch/index/query/support/NestedScope.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query.support;
+
+import org.elasticsearch.index.mapper.object.ObjectMapper;
+
+import java.util.Deque;
+import java.util.LinkedList;
+
+/**
+ * During query parsing this keeps track of the current nested level.
+ */
+public final class NestedScope {
+
+    private final Deque<ObjectMapper> levelStack = new LinkedList<>();
+
+    /**
+     * @return For the current nested level returns the object mapper that belongs to that
+     */
+    public ObjectMapper getObjectMapper() {
+        return levelStack.peek();
+    }
+
+    /**
+     * Sets the new current nested level and moves old current nested level down
+     */
+    public void nextLevel(ObjectMapper level) {
+        levelStack.push(level);
+    }
+
+    /**
+     * Sets the previous nested level as current nested level and removes the current nested level.
+     */
+    public void previousLevel() {
+        ObjectMapper level = levelStack.pop();
+    }
+
+}

--- a/src/main/java/org/elasticsearch/percolator/PercolateContext.java
+++ b/src/main/java/org/elasticsearch/percolator/PercolateContext.java
@@ -19,9 +19,9 @@
 package org.elasticsearch.percolator;
 
 import com.google.common.collect.ImmutableList;
-import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.*;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.Counter;
@@ -31,6 +31,7 @@ import org.elasticsearch.cache.recycler.PageCacheRecycler;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.text.StringText;
 import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.analysis.AnalysisService;
 import org.elasticsearch.index.cache.bitset.BitsetFilterCache;
 import org.elasticsearch.index.cache.filter.FilterCache;
@@ -43,7 +44,6 @@ import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.index.query.IndexQueryParserService;
 import org.elasticsearch.index.query.ParsedFilter;
 import org.elasticsearch.index.query.ParsedQuery;
-import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.similarity.SimilarityService;
 import org.elasticsearch.script.ScriptService;
@@ -687,4 +687,5 @@ public class PercolateContext extends SearchContext {
     public InnerHitsContext innerHits() {
         throw new UnsupportedOperationException();
     }
+
 }

--- a/src/main/java/org/elasticsearch/search/fetch/innerhits/InnerHitsParseElement.java
+++ b/src/main/java/org/elasticsearch/search/fetch/innerhits/InnerHitsParseElement.java
@@ -26,7 +26,7 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.object.ObjectMapper;
-import org.elasticsearch.index.query.NestedQueryParser;
+import org.elasticsearch.index.query.QueryParseContext;
 import org.elasticsearch.search.SearchParseElement;
 import org.elasticsearch.search.fetch.fielddata.FieldDataFieldsParseElement;
 import org.elasticsearch.search.fetch.script.ScriptFieldsParseElement;
@@ -60,14 +60,16 @@ public class InnerHitsParseElement implements SearchParseElement {
     }
 
     @Override
-    public void parse(XContentParser parser, SearchContext context) throws Exception {
-        Map<String, InnerHitsContext.BaseInnerHits> innerHitsMap = parseInnerHits(parser, context);
+    public void parse(XContentParser parser, SearchContext searchContext) throws Exception {
+        QueryParseContext parseContext = searchContext.queryParserService().getParseContext();
+        parseContext.reset(parser);
+        Map<String, InnerHitsContext.BaseInnerHits> innerHitsMap = parseInnerHits(parser, parseContext, searchContext);
         if (innerHitsMap != null) {
-            context.innerHits(new InnerHitsContext(innerHitsMap));
+            searchContext.innerHits(new InnerHitsContext(innerHitsMap));
         }
     }
 
-    private Map<String, InnerHitsContext.BaseInnerHits> parseInnerHits(XContentParser parser, SearchContext context) throws Exception {
+    private Map<String, InnerHitsContext.BaseInnerHits> parseInnerHits(XContentParser parser, QueryParseContext parseContext, SearchContext searchContext) throws Exception {
         XContentParser.Token token;
         Map<String, InnerHitsContext.BaseInnerHits> innerHitsMap = null;
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
@@ -79,7 +81,7 @@ public class InnerHitsParseElement implements SearchParseElement {
             if (token != XContentParser.Token.START_OBJECT) {
                 throw new ElasticsearchIllegalArgumentException("Inner hit definition for [" + innerHitName + " starts with a [" + token + "], expected a [" + XContentParser.Token.START_OBJECT + "].");
             }
-            InnerHitsContext.BaseInnerHits innerHits = parseInnerHit(parser, context, innerHitName);
+            InnerHitsContext.BaseInnerHits innerHits = parseInnerHit(parser, parseContext, searchContext, innerHitName);
             if (innerHitsMap == null) {
                 innerHitsMap = new HashMap<>();
             }
@@ -88,7 +90,7 @@ public class InnerHitsParseElement implements SearchParseElement {
         return innerHitsMap;
     }
 
-    private InnerHitsContext.BaseInnerHits parseInnerHit(XContentParser parser, SearchContext context, String innerHitName) throws Exception {
+    private InnerHitsContext.BaseInnerHits parseInnerHit(XContentParser parser, QueryParseContext parseContext, SearchContext searchContext, String innerHitName) throws Exception {
         XContentParser.Token token = parser.nextToken();
         if (token != XContentParser.Token.FIELD_NAME) {
             throw new ElasticsearchIllegalArgumentException("Unexpected token " + token + " inside inner hit definition. Either specify [path] or [type] object");
@@ -98,13 +100,15 @@ public class InnerHitsParseElement implements SearchParseElement {
         if (token != XContentParser.Token.START_OBJECT) {
             throw new ElasticsearchIllegalArgumentException("Inner hit definition for [" + innerHitName + " starts with a [" + token + "], expected a [" + XContentParser.Token.START_OBJECT + "].");
         }
-        final boolean nested;
+
+        String nestedPath = null;
+        String type = null;
         switch (fieldName) {
             case "path":
-                nested = true;
+                nestedPath = parser.currentName();
                 break;
             case "type":
-                nested = false;
+                type = parser.currentName();
                 break;
             default:
                 throw new ElasticsearchIllegalArgumentException("Either path or type object must be defined");
@@ -119,38 +123,13 @@ public class InnerHitsParseElement implements SearchParseElement {
             throw new ElasticsearchIllegalArgumentException("Inner hit definition for [" + innerHitName + " starts with a [" + token + "], expected a [" + XContentParser.Token.START_OBJECT + "].");
         }
 
-        NestedQueryParser.LateBindingParentFilter parentFilter = null;
-        NestedQueryParser.LateBindingParentFilter currentFilter = null;
-
-
-        String nestedPath = null;
-        String type = null;
-        if (nested) {
-            nestedPath = fieldName;
-            currentFilter = new NestedQueryParser.LateBindingParentFilter();
-            parentFilter = NestedQueryParser.parentFilterContext.get();
-            NestedQueryParser.parentFilterContext.set(currentFilter);
+        final InnerHitsContext.BaseInnerHits innerHits;
+        if (nestedPath != null) {
+            innerHits = parseNested(parser, parseContext, searchContext, fieldName);
+        } else if (type != null) {
+            innerHits = parseParentChild(parser, parseContext, searchContext, fieldName);
         } else {
-            type = fieldName;
-        }
-
-        Query query = null;
-        Map<String, InnerHitsContext.BaseInnerHits> childInnerHits = null;
-        SubSearchContext subSearchContext = new SubSearchContext(context);
-        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
-            if (token == XContentParser.Token.FIELD_NAME) {
-                fieldName = parser.currentName();
-            } else if (token == XContentParser.Token.START_OBJECT) {
-                if ("query".equals(fieldName)) {
-                    query = context.queryParserService().parse(parser).query();
-                } else if ("inner_hits".equals(fieldName)) {
-                    childInnerHits = parseInnerHits(parser, context);
-                } else {
-                    parseCommonInnerHitOptions(parser, token, fieldName, subSearchContext, sortParseElement, sourceParseElement, highlighterParseElement, scriptFieldsParseElement, fieldDataFieldsParseElement);
-                }
-            } else {
-                parseCommonInnerHitOptions(parser, token, fieldName, subSearchContext, sortParseElement, sourceParseElement, highlighterParseElement, scriptFieldsParseElement, fieldDataFieldsParseElement);
-            }
+            throw new ElasticsearchIllegalArgumentException("Either [path] or [type] must be defined");
         }
 
         // Completely consume all json objects:
@@ -163,37 +142,86 @@ public class InnerHitsParseElement implements SearchParseElement {
             throw new ElasticsearchIllegalArgumentException("Expected [" + XContentParser.Token.END_OBJECT + "] token, but got a [" + token + "] token.");
         }
 
+        return innerHits;
+    }
+
+    private InnerHitsContext.ParentChildInnerHits parseParentChild(XContentParser parser, QueryParseContext parseContext, SearchContext searchContext, String type) throws Exception {
+        ParseResult parseResult = parseSubSearchContext(searchContext, parseContext, parser);
+        DocumentMapper documentMapper = searchContext.mapperService().documentMapper(type);
+        if (documentMapper == null) {
+            throw new ElasticsearchIllegalArgumentException("type [" + type + "] doesn't exist");
+        }
+        return new InnerHitsContext.ParentChildInnerHits(parseResult.context(), parseResult.query(), parseResult.childInnerHits(), documentMapper);
+    }
+
+    private InnerHitsContext.NestedInnerHits parseNested(XContentParser parser, QueryParseContext parseContext, SearchContext searchContext, String nestedPath) throws Exception {
+        MapperService.SmartNameObjectMapper smartNameObjectMapper = searchContext.smartNameObjectMapper(nestedPath);
+        if (smartNameObjectMapper == null || !smartNameObjectMapper.hasMapper()) {
+            throw new ElasticsearchIllegalArgumentException("path [" + nestedPath +"] doesn't exist");
+        }
+        ObjectMapper childObjectMapper = smartNameObjectMapper.mapper();
+        if (!childObjectMapper.nested().isNested()) {
+            throw new ElasticsearchIllegalArgumentException("path [" + nestedPath +"] isn't nested");
+        }
+        DocumentMapper childDocumentMapper = smartNameObjectMapper.docMapper();
+        parseContext.nestedScope().nextLevel(childObjectMapper);
+        ParseResult parseResult = parseSubSearchContext(searchContext, parseContext, parser);
+        parseContext.nestedScope().previousLevel();
+
+        ObjectMapper parentObjectMapper = childDocumentMapper.findParentObjectMapper(childObjectMapper);
+        return new InnerHitsContext.NestedInnerHits(parseResult.context(), parseResult.query(), parseResult.childInnerHits(), parentObjectMapper, childObjectMapper);
+    }
+
+    private ParseResult parseSubSearchContext(SearchContext searchContext, QueryParseContext parseContext, XContentParser parser) throws Exception {
+        Query query = null;
+        Map<String, InnerHitsContext.BaseInnerHits> childInnerHits = null;
+        SubSearchContext subSearchContext = new SubSearchContext(searchContext);
+        String fieldName = null;
+        XContentParser.Token token;
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                fieldName = parser.currentName();
+            } else if (token == XContentParser.Token.START_OBJECT) {
+                if ("query".equals(fieldName)) {
+                    query = searchContext.queryParserService().parseInnerQuery(parseContext);
+                } else if ("inner_hits".equals(fieldName)) {
+                    childInnerHits = parseInnerHits(parser, parseContext, searchContext);
+                } else {
+                    parseCommonInnerHitOptions(parser, token, fieldName, subSearchContext, sortParseElement, sourceParseElement, highlighterParseElement, scriptFieldsParseElement, fieldDataFieldsParseElement);
+                }
+            } else {
+                parseCommonInnerHitOptions(parser, token, fieldName, subSearchContext, sortParseElement, sourceParseElement, highlighterParseElement, scriptFieldsParseElement, fieldDataFieldsParseElement);
+            }
+        }
+
         if (query == null) {
             query = new MatchAllDocsQuery();
         }
+        return new ParseResult(subSearchContext, query, childInnerHits);
+    }
 
-        if (nestedPath != null && type != null) {
-            throw new ElasticsearchIllegalArgumentException("Either [path] or [type] can be defined not both");
-        } else if (nestedPath != null) {
-            MapperService.SmartNameObjectMapper smartNameObjectMapper = context.smartNameObjectMapper(nestedPath);
-            if (smartNameObjectMapper == null || !smartNameObjectMapper.hasMapper()) {
-                throw new ElasticsearchIllegalArgumentException("path [" + nestedPath +"] doesn't exist");
-            }
-            ObjectMapper childObjectMapper = smartNameObjectMapper.mapper();
-            if (!childObjectMapper.nested().isNested()) {
-                throw new ElasticsearchIllegalArgumentException("path [" + nestedPath +"] isn't nested");
-            }
-            DocumentMapper childDocumentMapper = smartNameObjectMapper.docMapper();
-            if (currentFilter != null && childDocumentMapper != null) {
-                currentFilter.filter = context.bitsetFilterCache().getBitDocIdSetFilter(childObjectMapper.nestedTypeFilter());
-                NestedQueryParser.parentFilterContext.set(parentFilter);
-            }
+    private static final class ParseResult {
 
-            ObjectMapper parentObjectMapper = childDocumentMapper.findParentObjectMapper(childObjectMapper);
-            return new InnerHitsContext.NestedInnerHits(subSearchContext, query, childInnerHits, parentObjectMapper, childObjectMapper);
-        } else if (type != null) {
-            DocumentMapper documentMapper = context.mapperService().documentMapper(type);
-            if (documentMapper == null) {
-                throw new ElasticsearchIllegalArgumentException("type [" + type + "] doesn't exist");
-            }
-            return new InnerHitsContext.ParentChildInnerHits(subSearchContext, query, childInnerHits, documentMapper);
-        } else {
-            throw new ElasticsearchIllegalArgumentException("Either [path] or [type] must be defined");
+        private final SubSearchContext context;
+        private final Query query;
+        private final Map<String, InnerHitsContext.BaseInnerHits> childInnerHits;
+
+        private ParseResult(SubSearchContext context, Query query, Map<String, InnerHitsContext.BaseInnerHits> childInnerHits) {
+            this.context = context;
+            this.query = query;
+            this.childInnerHits = childInnerHits;
+        }
+
+        public SubSearchContext context() {
+            return context;
+        }
+
+        public Query query() {
+            return query;
+        }
+
+        public Map<String, InnerHitsContext.BaseInnerHits> childInnerHits() {
+            return childInnerHits;
         }
     }
 }

--- a/src/main/java/org/elasticsearch/search/internal/DefaultSearchContext.java
+++ b/src/main/java/org/elasticsearch/search/internal/DefaultSearchContext.java
@@ -50,6 +50,7 @@ import org.elasticsearch.index.query.IndexQueryParserService;
 import org.elasticsearch.index.query.ParsedFilter;
 import org.elasticsearch.index.query.ParsedQuery;
 import org.elasticsearch.index.IndexService;
+import org.elasticsearch.index.query.support.NestedScope;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.similarity.SimilarityService;
 import org.elasticsearch.script.ScriptService;

--- a/src/main/java/org/elasticsearch/search/internal/FilteredSearchContext.java
+++ b/src/main/java/org/elasticsearch/search/internal/FilteredSearchContext.java
@@ -562,4 +562,5 @@ public abstract class FilteredSearchContext extends SearchContext {
     public Counter timeEstimateCounter() {
         return in.timeEstimateCounter();
     }
+
 }

--- a/src/main/java/org/elasticsearch/search/internal/SearchContext.java
+++ b/src/main/java/org/elasticsearch/search/internal/SearchContext.java
@@ -43,6 +43,7 @@ import org.elasticsearch.index.query.IndexQueryParserService;
 import org.elasticsearch.index.query.ParsedFilter;
 import org.elasticsearch.index.query.ParsedQuery;
 import org.elasticsearch.index.query.QueryParseContext;
+import org.elasticsearch.index.query.support.NestedScope;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.similarity.SimilarityService;
 import org.elasticsearch.script.ScriptService;

--- a/src/main/java/org/elasticsearch/search/internal/SubSearchContext.java
+++ b/src/main/java/org/elasticsearch/search/internal/SubSearchContext.java
@@ -71,6 +71,8 @@ public class SubSearchContext extends FilteredSearchContext {
     private boolean trackScores;
     private boolean version;
 
+    private InnerHitsContext innerHitsContext;
+
     public SubSearchContext(SearchContext context) {
         super(context);
         this.fetchSearchResult = new FetchSearchResult();
@@ -349,8 +351,6 @@ public class SubSearchContext extends FilteredSearchContext {
     public Counter timeEstimateCounter() {
         throw new UnsupportedOperationException("Not supported");
     }
-
-    private InnerHitsContext innerHitsContext;
 
     @Override
     public void innerHits(InnerHitsContext innerHitsContext) {

--- a/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortParser.java
+++ b/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortParser.java
@@ -19,10 +19,9 @@
 
 package org.elasticsearch.search.sort;
 
-import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.search.FieldComparator;
-import org.apache.lucene.search.Filter;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.join.BitDocIdSetFilter;
 import org.apache.lucene.util.BitSet;
@@ -37,9 +36,8 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.fielddata.*;
 import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource.Nested;
 import org.elasticsearch.index.mapper.FieldMapper;
-import org.elasticsearch.index.mapper.ObjectMappers;
 import org.elasticsearch.index.mapper.object.ObjectMapper;
-import org.elasticsearch.index.query.ParsedFilter;
+import org.elasticsearch.index.query.support.NestedInnerQueryParseSupport;
 import org.elasticsearch.index.search.nested.NonNestedDocsFilter;
 import org.elasticsearch.search.MultiValueMode;
 import org.elasticsearch.search.internal.SearchContext;
@@ -66,8 +64,7 @@ public class GeoDistanceSortParser implements SortParser {
         GeoDistance geoDistance = GeoDistance.DEFAULT;
         boolean reverse = false;
         MultiValueMode sortMode = null;
-        String nestedPath = null;
-        Filter nestedFilter = null;
+        NestedInnerQueryParseSupport nestedHelper = null;
 
         boolean normalizeLon = true;
         boolean normalizeLat = true;
@@ -84,8 +81,10 @@ public class GeoDistanceSortParser implements SortParser {
             } else if (token == XContentParser.Token.START_OBJECT) {
                 // the json in the format of -> field : { lat : 30, lon : 12 }
                 if ("nested_filter".equals(currentName) || "nestedFilter".equals(currentName)) {
-                    ParsedFilter parsedFilter = context.queryParserService().parseInnerFilter(parser);
-                    nestedFilter = parsedFilter == null ? null : parsedFilter.filter();
+                    if (nestedHelper == null) {
+                        nestedHelper = new NestedInnerQueryParseSupport(parser, context);
+                    }
+                    nestedHelper.filter();
                 } else {
                     fieldName = currentName;
                     GeoPoint point = new GeoPoint();
@@ -107,7 +106,10 @@ public class GeoDistanceSortParser implements SortParser {
                 } else if ("sort_mode".equals(currentName) || "sortMode".equals(currentName) || "mode".equals(currentName)) {
                     sortMode = MultiValueMode.fromString(parser.text());
                 } else if ("nested_path".equals(currentName) || "nestedPath".equals(currentName)) {
-                    nestedPath = parser.text();
+                    if (nestedHelper == null) {
+                        nestedHelper = new NestedInnerQueryParseSupport(parser, context);
+                    }
+                    nestedHelper.setPath(parser.text());
                 } else {
                     GeoPoint point = new GeoPoint();
                     point.resetFromString(parser.text());
@@ -141,27 +143,26 @@ public class GeoDistanceSortParser implements SortParser {
         for (int i = 0; i< geoPoints.size(); i++) {
             distances[i] = geoDistance.fixedSourceDistance(geoPoints.get(i).lat(), geoPoints.get(i).lon(), unit);
         }
-        ObjectMapper objectMapper;
-        if (nestedPath != null) {
-            ObjectMappers objectMappers = context.mapperService().objectMapper(nestedPath);
-            if (objectMappers == null) {
-                throw new ElasticsearchIllegalArgumentException("failed to find nested object mapping for explicit nested path [" + nestedPath + "]");
+
+        // TODO: remove this in master, we should be explicit when we want to sort on nested fields and don't do anything automatically
+        if (nestedHelper == null || nestedHelper.getNestedObjectMapper() == null) {
+            ObjectMapper objectMapper = context.mapperService().resolveClosestNestedObjectMapper(fieldName);
+            if (objectMapper != null && objectMapper.nested().isNested()) {
+                if (nestedHelper == null) {
+                    nestedHelper = new NestedInnerQueryParseSupport(context.queryParserService().getParseContext());
+                }
+                nestedHelper.setPath(objectMapper.fullPath());
             }
-            objectMapper = objectMappers.mapper();
-            if (!objectMapper.nested().isNested()) {
-                throw new ElasticsearchIllegalArgumentException("mapping for explicit nested path is not mapped as nested: [" + nestedPath + "]");
-            }
-        } else {
-            objectMapper = context.mapperService().resolveClosestNestedObjectMapper(fieldName);
         }
+
         final Nested nested;
-        if (objectMapper != null && objectMapper.nested().isNested()) {
+        if (nestedHelper != null && nestedHelper.getPath() != null) {
             BitDocIdSetFilter rootDocumentsFilter = context.bitsetFilterCache().getBitDocIdSetFilter(NonNestedDocsFilter.INSTANCE);
             BitDocIdSetFilter innerDocumentsFilter;
-            if (nestedFilter != null) {
-                innerDocumentsFilter = context.bitsetFilterCache().getBitDocIdSetFilter(nestedFilter);
+            if (nestedHelper.filterFound()) {
+                innerDocumentsFilter = context.bitsetFilterCache().getBitDocIdSetFilter(nestedHelper.getInnerFilter());
             } else {
-                innerDocumentsFilter = context.bitsetFilterCache().getBitDocIdSetFilter(objectMapper.nestedTypeFilter());
+                innerDocumentsFilter = context.bitsetFilterCache().getBitDocIdSetFilter(nestedHelper.getNestedObjectMapper().nestedTypeFilter());
             }
             nested = new Nested(rootDocumentsFilter, innerDocumentsFilter);
         } else {

--- a/src/main/java/org/elasticsearch/search/sort/ScriptSortParser.java
+++ b/src/main/java/org/elasticsearch/search/sort/ScriptSortParser.java
@@ -19,23 +19,20 @@
 
 package org.elasticsearch.search.sort;
 
-import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.BinaryDocValues;
-import org.apache.lucene.search.Filter;
+import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.join.BitDocIdSetFilter;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
-import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.fielddata.*;
 import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource.Nested;
 import org.elasticsearch.index.fielddata.fieldcomparator.BytesRefFieldComparatorSource;
 import org.elasticsearch.index.fielddata.fieldcomparator.DoubleValuesComparatorSource;
-import org.elasticsearch.index.mapper.ObjectMappers;
 import org.elasticsearch.index.mapper.object.ObjectMapper;
-import org.elasticsearch.index.query.ParsedFilter;
+import org.elasticsearch.index.query.support.NestedInnerQueryParseSupport;
 import org.elasticsearch.index.search.nested.NonNestedDocsFilter;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.script.SearchScript;
@@ -67,8 +64,7 @@ public class ScriptSortParser implements SortParser {
         Map<String, Object> params = null;
         boolean reverse = false;
         MultiValueMode sortMode = null;
-        String nestedPath = null;
-        Filter nestedFilter = null;
+        NestedInnerQueryParseSupport nestedHelper = null;
 
         XContentParser.Token token;
         String currentName = parser.currentName();
@@ -80,8 +76,10 @@ public class ScriptSortParser implements SortParser {
                 if ("params".equals(currentName)) {
                     params = parser.map();
                 } else if ("nested_filter".equals(currentName) || "nestedFilter".equals(currentName)) {
-                    ParsedFilter parsedFilter = context.queryParserService().parseInnerFilter(parser);
-                    nestedFilter = parsedFilter == null ? null : parsedFilter.filter();
+                    if (nestedHelper == null) {
+                        nestedHelper = new NestedInnerQueryParseSupport(parser, context);
+                    }
+                    nestedHelper.filter();
                 }
             } else if (token.isValue()) {
                 if ("reverse".equals(currentName)) {
@@ -104,7 +102,10 @@ public class ScriptSortParser implements SortParser {
                 } else if ("mode".equals(currentName)) {
                     sortMode = MultiValueMode.fromString(parser.text());
                 } else if ("nested_path".equals(currentName) || "nestedPath".equals(currentName)) {
-                    nestedPath = parser.text();
+                    if (nestedHelper == null) {
+                        nestedHelper = new NestedInnerQueryParseSupport(parser, context);
+                    }
+                    nestedHelper.setPath(parser.text());
                 }
             }
         }
@@ -128,22 +129,13 @@ public class ScriptSortParser implements SortParser {
         // If nested_path is specified, then wrap the `fieldComparatorSource` in a `NestedFieldComparatorSource`
         ObjectMapper objectMapper;
         final Nested nested;
-        if (nestedPath != null) {
-            ObjectMappers objectMappers = context.mapperService().objectMapper(nestedPath);
-            if (objectMappers == null) {
-                throw new ElasticsearchIllegalArgumentException("failed to find nested object mapping for explicit nested path [" + nestedPath + "]");
-            }
-            objectMapper = objectMappers.mapper();
-            if (!objectMapper.nested().isNested()) {
-                throw new ElasticsearchIllegalArgumentException("mapping for explicit nested path is not mapped as nested: [" + nestedPath + "]");
-            }
-
+        if (nestedHelper != null && nestedHelper.getPath() != null) {
             BitDocIdSetFilter rootDocumentsFilter = context.bitsetFilterCache().getBitDocIdSetFilter(NonNestedDocsFilter.INSTANCE);
             BitDocIdSetFilter innerDocumentsFilter;
-            if (nestedFilter != null) {
-                innerDocumentsFilter = context.bitsetFilterCache().getBitDocIdSetFilter(nestedFilter);
+            if (nestedHelper.filterFound()) {
+                innerDocumentsFilter = context.bitsetFilterCache().getBitDocIdSetFilter(nestedHelper.getInnerFilter());
             } else {
-                innerDocumentsFilter = context.bitsetFilterCache().getBitDocIdSetFilter(objectMapper.nestedTypeFilter());
+                innerDocumentsFilter = context.bitsetFilterCache().getBitDocIdSetFilter(nestedHelper.getNestedObjectMapper().nestedTypeFilter());
             }
             nested = new Nested(rootDocumentsFilter, innerDocumentsFilter);
         } else {

--- a/src/test/java/org/elasticsearch/test/TestSearchContext.java
+++ b/src/test/java/org/elasticsearch/test/TestSearchContext.java
@@ -38,6 +38,7 @@ import org.elasticsearch.index.query.IndexQueryParserService;
 import org.elasticsearch.index.query.ParsedFilter;
 import org.elasticsearch.index.query.ParsedQuery;
 import org.elasticsearch.index.IndexService;
+import org.elasticsearch.index.query.support.NestedScope;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.similarity.SimilarityService;
 import org.elasticsearch.script.ScriptService;
@@ -606,4 +607,5 @@ public class TestSearchContext extends SearchContext {
     public InnerHitsContext innerHits() {
         throw new UnsupportedOperationException();
     }
+
 }


### PR DESCRIPTION
The nested scope is set by any nested feature, so that sub nested queries and filters know about their context and these sub nested queries and filters can construct the right parent filter.

Removed the LateBindingParentFilter workaround in the nested query parser in favour of the nested scope maintained in the parse context.

Due to this change nested queries and filters can now also be included in nested sorting and inner hits, because those features also now use the nested scope.

This change doesn't fix the usage of nested filters in nested and reverse_nested aggregations. The `nested` filter shouldn't be used inside these aggregations and instead the `nested` and `reverse_nested` aggs should be used to query on the right level. In a different change `nested` inside a `nested` and `reverse_nested` aggregation should result in a parse error.

Also fixes #9305
