### PR TITLE
Add antlr and asm dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -948,7 +948,7 @@
                                 </data>
                                 <data>
                                     <src>${project.build.directory}/lib</src>
-                                    <includes>lucene*, *log4j*, jna*, spatial4j*, jts*, groovy*</includes>
+                                    <includes>lucene*, *log4j*, jna*, spatial4j*, jts*, groovy*, antlr-runtime*, asm*</includes>
                                     <type>directory</type>
                                     <mapper>
                                         <type>perm</type>
@@ -1154,6 +1154,8 @@
                                         <include>spatial4j*</include>
                                         <include>jts*</include>
                                         <include>groovy*</include>
+                                        <include>antlr-runtime*</include>
+                                        <include>asm*</include>
                                     </includes>
                                 </source>
                                 <source>


### PR DESCRIPTION
rpm and deb packages are missing required dependencies for the Lucene expression scripting engine
