### PR TITLE
Internal: Separate version lookup failure in settings to only be when really loading an index.

### DIFF
--- a/src/main/java/org/elasticsearch/Version.java
+++ b/src/main/java/org/elasticsearch/Version.java
@@ -428,16 +428,19 @@ public class Version {
     }
 
     /**
-     * Return the {@link Version} of Elasticsearch that has been used to create an index given its settings.
-     *
-     * @throws ElasticsearchIllegalStateException if the given index settings doesn't contain a value for the key {@value IndexMetaData#SETTING_VERSION_CREATED}
+     * Return the {@link Version} of Elasticsearch that has been used to create an index given its settings, or
+     * {@link #CURRENT} if it is missing.
      */
     public static Version indexCreated(Settings indexSettings) {
-        final Version indexVersion = indexSettings.getAsVersion(IndexMetaData.SETTING_VERSION_CREATED, null);
+        final Version indexVersion = indexCreatedOrNull(indexSettings);
         if (indexVersion == null) {
-            throw new ElasticsearchIllegalStateException("[" + IndexMetaData.SETTING_VERSION_CREATED + "] is not present in the index settings for index with uuid: [" + indexSettings.get(IndexMetaData.SETTING_UUID) + "]");
+            return Version.CURRENT;
         }
         return indexVersion;
+    }
+
+    public static Version indexCreatedOrNull(Settings indexSettings) {
+        return indexSettings.getAsVersion(IndexMetaData.SETTING_VERSION_CREATED, null);
     }
 
     public static void writeVersion(Version version, StreamOutput out) throws IOException {

--- a/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
@@ -227,7 +227,10 @@ public class IndexMetaData {
         } else {
             excludeFilters = DiscoveryNodeFilters.buildFromKeyValue(OR, excludeMap);
         }
-        indexCreatedVersion = Version.indexCreated(settings);
+        indexCreatedVersion = Version.indexCreatedOrNull(settings);
+        if (indexCreatedVersion == null) {
+            throw new ElasticsearchIllegalStateException("[" + IndexMetaData.SETTING_VERSION_CREATED + "] is not present in the index settings for index with uuid: [" + settings.get(IndexMetaData.SETTING_UUID) + "]");
+        }
         final Class<? extends HashFunction> hashFunctionClass = settings.getAsClass(SETTING_LEGACY_ROUTING_HASH_FUNCTION, null);
         if (hashFunctionClass == null) {
             routingHashFunction = MURMUR3_HASH_FUNCTION;

--- a/src/test/java/org/elasticsearch/VersionTests.java
+++ b/src/test/java/org/elasticsearch/VersionTests.java
@@ -114,10 +114,10 @@ public class VersionTests extends ElasticsearchTestCase {
     public void testWrongVersionFromString() {
         Version.fromString("WRONG.VERSION");
     }
-
-    @Test(expected = ElasticsearchIllegalStateException.class)
+    
     public void testVersionNoPresentInSettings() {
-        Version.indexCreated(ImmutableSettings.builder().build());
+        assertEquals(Version.CURRENT, Version.indexCreated(ImmutableSettings.builder().build()));
+        assertEquals(null, Version.indexCreatedOrNull(ImmutableSettings.builder().build()));
     }
 
     public void testIndexCreatedVersion() {


### PR DESCRIPTION
When checking index settings within mappings code for indexVersionCreated, the setting does not exist for newly created indexes, because the mappings are processed before the index.version.created setting is added.  This change makes the helper function to find indexVersionCreated less strict, except in the place where we definitely better have the setting (on an already existing index).  I would rather solve this problem by moving up where the setting is added, but this looks hairy. For now, I think this change will do the job and it seems harmless IMO.
