### PR TITLE
Aggregations: deprecate `pre_zone` and `post_zone` in `date_histogram`

### DIFF
--- a/docs/reference/migration/migrate_1_5.asciidoc
+++ b/docs/reference/migration/migrate_1_5.asciidoc
@@ -11,6 +11,6 @@ The `date_histogram` aggregation now support a simplified `offset` option that r
 `post_offset` which are deprecated in 1.5. Instead of having to specify two separate offset shifts of the underlying buckets, the `offset` option
 moves the bucket boundaries in positive or negative direction depending on its argument.
 
-Also for the `date_histogram`, options for `pre_zone` and `post_zone` options and the `pre_zone_adjust_large_interval` parameter
-are deprecated in 1.5 and replaced by the already existing `time_zone` option. The behavior of `time_zone` is currently equivalent to the former
+Also for `date_histogram`, options for `pre_zone` and `post_zone` options and the `pre_zone_adjust_large_interval` parameter
+are deprecated in 1.5 and replaced by the already existing `time_zone` option. The behavior of `time_zone` is equivalent to the former
 `pre_zone` option.

--- a/docs/reference/migration/migrate_1_5.asciidoc
+++ b/docs/reference/migration/migrate_1_5.asciidoc
@@ -10,3 +10,7 @@ your application from Elasticsearch 1.x to Elasticsearch 1.5.
 The `date_histogram` aggregation now support a simplified `offset` option that replaces the previous `pre_offset` and
 `post_offset` which are deprecated in 1.5. Instead of having to specify two separate offset shifts of the underlying buckets, the `offset` option
 moves the bucket boundaries in positive or negative direction depending on its argument.
+
+Also for the `date_histogram`, options for `pre_zone` and `post_zone` options and the `pre_zone_adjust_large_interval` parameter
+are deprecated in 1.5 and replaced by the already existing `time_zone` option. The behavior of `time_zone` is currently equivalent to the former
+`pre_zone` option.

--- a/docs/reference/search/aggregations/bucket/datehistogram-aggregation.asciidoc
+++ b/docs/reference/search/aggregations/bucket/datehistogram-aggregation.asciidoc
@@ -72,6 +72,11 @@ set `pre_zone_adjust_large_interval` to `true`, which will apply the same conver
 example, to day and above intervals (it can be set regardless of the interval, but only kick in when using day and
 higher intervals).
 
+deprecated[1.5.0, The `pre_zone` and `post_zone` options are deprecated. Instead of `pre_zone`, use the `time_zone` option.
+The use of `post_zone` is discouraged because bucket keys should be returned in UTC for better consistency. For the same reason
+the use of `pre_zone_adjust_large_interval` is deprecated. Setting `pre_zone_adjust_large_interval` to `true` is equivalent to the
+time zone behavior in future versions.]
+
 ==== Offset
 
 The `offset` option can be provided for shifting the date bucket intervals boundaries after any other shifts because of

--- a/docs/reference/search/aggregations/bucket/datehistogram-aggregation.asciidoc
+++ b/docs/reference/search/aggregations/bucket/datehistogram-aggregation.asciidoc
@@ -51,8 +51,7 @@ By default, times are stored as UTC milliseconds since the epoch. Thus, all comp
 done on UTC. It is possible to provide a time zone value, which will cause all computations to take the relevant zone
 into account. The time returned for each bucket/entry is milliseconds since the epoch of the provided time zone.
 
-deprecated[1.5.0, `pre_zone`, `post_zone` and `pre_zone_adjust_large_interval` are deprecated]
-deprecated[1.5.0, Using `time_zone` is the preferred way of specifying time zones now]
+deprecated[1.5.0, `pre_zone`, `post_zone` are replaced by `time_zone`]
 
 The parameters are `pre_zone` (pre rounding based on interval) and `post_zone` (post rounding based on interval). The
 `time_zone` parameter simply sets the `pre_zone` parameter. By default, those are set to `UTC`.
@@ -68,6 +67,8 @@ results in `2012-03-31T20:00:00`, but, we want to return it in UTC (`post_zone` 
 UTC: `2012-04-01T04:00:00Z`. Note, we are consistent in the results, returning the rounded value in UTC.
 
 `post_zone` simply takes the result, and adds the relevant offset.
+
+deprecated[1.5.0, `pre_zone_adjust_large_interval` will be removed]
 
 Sometimes, we want to apply the same conversion to UTC we did above for hour also for day (and up) intervals. We can
 set `pre_zone_adjust_large_interval` to `true`, which will apply the same conversion done for hour interval in the

--- a/docs/reference/search/aggregations/bucket/datehistogram-aggregation.asciidoc
+++ b/docs/reference/search/aggregations/bucket/datehistogram-aggregation.asciidoc
@@ -48,9 +48,11 @@ See <<time-units>> for accepted abbreviations.
 ==== Time Zone
 
 By default, times are stored as UTC milliseconds since the epoch. Thus, all computation and "bucketing" / "rounding" is
-done on UTC. It is possible to provide a time zone (both pre rounding, and post rounding) value, which will cause all
-computations to take the relevant zone into account. The time returned for each bucket/entry is milliseconds since the
-epoch of the provided time zone.
+done on UTC. It is possible to provide a time zone value, which will cause all computations to take the relevant zone
+into account. The time returned for each bucket/entry is milliseconds since the epoch of the provided time zone.
+
+deprecated[1.5.0, `pre_zone`, `post_zone` and `pre_zone_adjust_large_interval` are deprecated]
+deprecated[1.5.0, Using `time_zone` is the preferred way of specifying time zones now]
 
 The parameters are `pre_zone` (pre rounding based on interval) and `post_zone` (post rounding based on interval). The
 `time_zone` parameter simply sets the `pre_zone` parameter. By default, those are set to `UTC`.
@@ -72,11 +74,6 @@ set `pre_zone_adjust_large_interval` to `true`, which will apply the same conver
 example, to day and above intervals (it can be set regardless of the interval, but only kick in when using day and
 higher intervals).
 
-deprecated[1.5.0, The `pre_zone` and `post_zone` options are deprecated. Instead of `pre_zone`, use the `time_zone` option.
-The use of `post_zone` is discouraged because bucket keys should be returned in UTC for better consistency. For the same reason
-the use of `pre_zone_adjust_large_interval` is deprecated. Setting `pre_zone_adjust_large_interval` to `true` is equivalent to the
-time zone behavior in future versions.]
-
 ==== Offset
 
 The `offset` option can be provided for shifting the date bucket intervals boundaries after any other shifts because of
@@ -85,6 +82,8 @@ or that monthly buckets go from the 10th of the month to the 10th of the next mo
 
 The `offset` option accepts positive or negative time durations like "1h" for an hour or "1M" for a Month. See <<time-units>> for more
 possible time duration options.
+
+deprecated[1.5.0, `pre_offset` and `post_offset` are deprecated and replaced by `offset`]
 
 ==== Keys
 

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramBuilder.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramBuilder.java
@@ -87,24 +87,39 @@ public class DateHistogramBuilder extends ValuesSourceAggregationBuilder<DateHis
     }
 
     /**
-     * Set the timezone in which to translate dates before computing buckets.
+     * Set the time zone in which to translate dates before computing buckets.
+     * @deprecated use timeZone() instead
      */
+    @Deprecated
     public DateHistogramBuilder preZone(String preZone) {
         this.preZone = preZone;
         return this;
     }
 
     /**
-     * Set the timezone in which to translate dates after having computed buckets.
+     * Set the time zone in which to translate dates after having computed buckets.
+     * @deprecated this option is going to be removed in 2.0 releases
      */
+    @Deprecated
     public DateHistogramBuilder postZone(String postZone) {
         this.postZone = postZone;
         return this;
     }
 
     /**
-     * Set whether to adjust large intervals, when using days or larger intervals.
+     * Set the time zone in which to translate dates before computing buckets.
      */
+    public DateHistogramBuilder timeZone(String timeZone) {
+        // currently this is still equivallent to using pre_zone, will change in future version
+        this.preZone = timeZone;
+        return this;
+    }
+
+    /**
+     * Set whether to adjust large intervals, when using days or larger intervals.
+     * @deprecated this option is going to be removed in 2.0 releases
+     */
+    @Deprecated
     public DateHistogramBuilder preZoneAdjustLargeInterval(boolean preZoneAdjustLargeInterval) {
         this.preZoneAdjustLargeInterval = preZoneAdjustLargeInterval;
         return this;
@@ -122,7 +137,7 @@ public class DateHistogramBuilder extends ValuesSourceAggregationBuilder<DateHis
 
     /**
      * Set the offset to apply after having computed buckets.
-     * @deprecated the preOffset option will be replaced by offset in future version.
+     * @deprecated the postOffset option will be replaced by offset in future version.
      */
     @Deprecated
     public DateHistogramBuilder postOffset(String postOffset) {

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramParser.java
@@ -44,13 +44,13 @@ public class DateHistogramParser implements Aggregator.Parser {
 
     static final ParseField EXTENDED_BOUNDS = new ParseField("extended_bounds");
     static final ParseField OFFSET = new ParseField("offset");
-    static final ParseField PRE_OFFSET = new ParseField("", "pre_offset");
-    static final ParseField POST_OFFSET = new ParseField("", "post_offset");
-    static final ParseField PRE_ZONE = new ParseField("", "pre_zone");
-    static final ParseField POST_ZONE = new ParseField("", "post_zone");
+    static final ParseField PRE_OFFSET = new ParseField("pre_offset").withAllDeprecated("offset");
+    static final ParseField POST_OFFSET = new ParseField("post_offset").withAllDeprecated("offset");
+    static final ParseField PRE_ZONE = new ParseField("pre_zone").withAllDeprecated("time_zone");
+    static final ParseField POST_ZONE = new ParseField("post_zone").withAllDeprecated("time_zone");
     static final ParseField TIME_ZONE = new ParseField("time_zone");
     static final ParseField INTERVAL = new ParseField("interval");
-    static final ParseField PRE_ZONE_ADJUST = new ParseField("", "pre_zone_adjust_large_interval");
+    static final ParseField PRE_ZONE_ADJUST = new ParseField("pre_zone_adjust_large_interval").withAllDeprecated("");
 
 
     private final ImmutableMap<String, DateTimeUnit> dateFieldUnits;

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramParser.java
@@ -46,6 +46,12 @@ public class DateHistogramParser implements Aggregator.Parser {
     static final ParseField OFFSET = new ParseField("offset");
     static final ParseField PRE_OFFSET = new ParseField("", "pre_offset");
     static final ParseField POST_OFFSET = new ParseField("", "post_offset");
+    static final ParseField PRE_ZONE = new ParseField("", "pre_zone");
+    static final ParseField POST_ZONE = new ParseField("", "post_zone");
+    static final ParseField TIME_ZONE = new ParseField("time_zone");
+    static final ParseField INTERVAL = new ParseField("interval");
+    static final ParseField PRE_ZONE_ADJUST = new ParseField("", "pre_zone_adjust_large_interval");
+
 
     private final ImmutableMap<String, DateTimeUnit> dateFieldUnits;
 
@@ -102,11 +108,11 @@ public class DateHistogramParser implements Aggregator.Parser {
             } else if (vsParser.token(currentFieldName, token, parser)) {
                 continue;
             } else if (token == XContentParser.Token.VALUE_STRING) {
-                if ("time_zone".equals(currentFieldName) || "timeZone".equals(currentFieldName)) {
+                if (TIME_ZONE.match(currentFieldName)) {
                     preZone = DateMathParser.parseZone(parser.text());
-                } else if ("pre_zone".equals(currentFieldName) || "preZone".equals(currentFieldName)) {
+                } else if (PRE_ZONE.match(currentFieldName)) {
                     preZone = DateMathParser.parseZone(parser.text());
-                } else if ("post_zone".equals(currentFieldName) || "postZone".equals(currentFieldName)) {
+                } else if (POST_ZONE.match(currentFieldName)) {
                     postZone = DateMathParser.parseZone(parser.text());
                 } else if (PRE_OFFSET.match(currentFieldName)) {
                     preOffset = parseOffset(parser.text());
@@ -115,7 +121,7 @@ public class DateHistogramParser implements Aggregator.Parser {
                 } else if (OFFSET.match(currentFieldName)) {
                     postOffset = parseOffset(parser.text());
                     preOffset = -postOffset;
-                } else if ("interval".equals(currentFieldName)) {
+                } else if (INTERVAL.match(currentFieldName)) {
                     interval = parser.text();
                 } else {
                     throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
@@ -131,11 +137,11 @@ public class DateHistogramParser implements Aggregator.Parser {
             } else if (token == XContentParser.Token.VALUE_NUMBER) {
                 if ("min_doc_count".equals(currentFieldName) || "minDocCount".equals(currentFieldName)) {
                     minDocCount = parser.longValue();
-                } else if ("time_zone".equals(currentFieldName) || "timeZone".equals(currentFieldName)) {
+                } else if (TIME_ZONE.match(currentFieldName)) {
                     preZone = DateTimeZone.forOffsetHours(parser.intValue());
-                } else if ("pre_zone".equals(currentFieldName) || "preZone".equals(currentFieldName)) {
+                } else if (PRE_ZONE.match(currentFieldName)) {
                     preZone = DateTimeZone.forOffsetHours(parser.intValue());
-                } else if ("post_zone".equals(currentFieldName) || "postZone".equals(currentFieldName)) {
+                } else if (POST_ZONE.match(currentFieldName)) {
                     postZone = DateTimeZone.forOffsetHours(parser.intValue());
                 } else {
                     throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/DateHistogramTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/DateHistogramTests.java
@@ -1018,7 +1018,7 @@ public class DateHistogramTests extends ElasticsearchIntegrationTest {
     }
 
     @Test
-    public void singleValue_WithPreZone() throws Exception {
+    public void singleValue_WithtimeZone() throws Exception {
         prepareCreate("idx2").addMapping("type", "date", "type=date").execute().actionGet();
         IndexRequestBuilder[] reqs = new IndexRequestBuilder[5];
         DateTime date = date("2014-03-11T00:00:00+00:00");
@@ -1032,7 +1032,7 @@ public class DateHistogramTests extends ElasticsearchIntegrationTest {
                 .setQuery(matchAllQuery())
                 .addAggregation(dateHistogram("date_histo")
                         .field("date")
-                        .preZone("-2:00")
+                        .timeZone("-2:00")
                         .interval(DateHistogram.Interval.DAY)
                         .format("yyyy-MM-dd"))
                 .execute().actionGet();
@@ -1067,7 +1067,7 @@ public class DateHistogramTests extends ElasticsearchIntegrationTest {
                 .setQuery(matchAllQuery())
                 .addAggregation(dateHistogram("date_histo")
                         .field("date")
-                        .preZone("-2:00")
+                        .timeZone("-2:00")
                         .interval(DateHistogram.Interval.DAY)
                         .preZoneAdjustLargeInterval(true)
                         .format("yyyy-MM-dd'T'HH:mm:ss"))
@@ -1233,7 +1233,7 @@ public class DateHistogramTests extends ElasticsearchIntegrationTest {
 
     public void testIssue6965() {
         SearchResponse response = client().prepareSearch("idx")
-                .addAggregation(dateHistogram("histo").field("date").preZone("+01:00").interval(DateHistogram.Interval.MONTH).minDocCount(0))
+                .addAggregation(dateHistogram("histo").field("date").timeZone("+01:00").interval(DateHistogram.Interval.MONTH).minDocCount(0))
                 .execute().actionGet();
 
         assertSearchResponse(response);


### PR DESCRIPTION
The options for `pre_zone` and `post_zone` in `date_histogram` are going to be removed in 2.0 (see #9062) in favor of the already existing `time_zone` option. This commit deprecates those fields using ParseFields and adds deprecation notice to the migration guide.
