### PR TITLE
Move InternalEngine.segmentStats() into abstract Engine

### DIFF
--- a/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -283,7 +283,30 @@ public abstract class Engine implements Closeable {
     /**
      * Global stats on segments.
      */
-    public abstract SegmentsStats segmentsStats();
+    public final SegmentsStats segmentsStats() {
+        ensureOpen();
+        try (final Searcher searcher = acquireSearcher("segments_stats")) {
+            SegmentsStats stats = new SegmentsStats();
+            for (LeafReaderContext reader : searcher.reader().leaves()) {
+                final SegmentReader segmentReader = segmentReader(reader.reader());
+                stats.add(1, segmentReader.ramBytesUsed());
+                stats.addTermsMemoryInBytes(guardedRamBytesUsed(segmentReader.getPostingsReader()));
+                stats.addStoredFieldsMemoryInBytes(guardedRamBytesUsed(segmentReader.getFieldsReader()));
+                stats.addTermVectorsMemoryInBytes(guardedRamBytesUsed(segmentReader.getTermVectorsReader()));
+                stats.addNormsMemoryInBytes(guardedRamBytesUsed(segmentReader.getNormsReader()));
+                stats.addDocValuesMemoryInBytes(guardedRamBytesUsed(segmentReader.getDocValuesReader()));
+            }
+            writerSegmentStats(stats);
+            return stats;
+        }
+    }
+
+    protected void writerSegmentStats(SegmentsStats stats) {
+        // by default we don't have a writer here... subclasses can override this
+        stats.addVersionMapMemoryInBytes(0);
+        stats.addIndexWriterMemoryInBytes(0);
+        stats.addIndexWriterMaxMemoryInBytes(0);
+    }
 
     protected Segment[] getSegmentInfo(SegmentInfos lastCommittedSegmentInfos, boolean verbose) {
         ensureOpen();
@@ -405,7 +428,9 @@ public abstract class Engine implements Closeable {
     /**
      * Optimizes to 1 segment
      */
-    abstract void forceMerge(boolean flush);
+    public void forceMerge(boolean flush) {
+        forceMerge(flush, 1, false, false);
+    }
 
     /**
      * Triggers a forced merge on this engine

--- a/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -707,11 +707,6 @@ public class InternalEngine extends Engine {
     }
 
     @Override
-    public void forceMerge(boolean flush) {
-        forceMerge(flush, 1, false, false);
-    }
-
-    @Override
     public void forceMerge(final boolean flush, int maxNumSegments, boolean onlyExpungeDeletes, final boolean upgrade) throws EngineException {
         if (optimizeMutex.compareAndSet(false, true)) {
             try (ReleasableLock _ = readLock.acquire()) {
@@ -846,24 +841,10 @@ public class InternalEngine extends Engine {
     }
 
     @Override
-    public SegmentsStats segmentsStats() {
-        ensureOpen();
-        try (final Searcher searcher = acquireSearcher("segments_stats")) {
-                SegmentsStats stats = new SegmentsStats();
-                for (LeafReaderContext reader : searcher.reader().leaves()) {
-                    final SegmentReader segmentReader = segmentReader(reader.reader());
-                    stats.add(1, segmentReader.ramBytesUsed());
-                    stats.addTermsMemoryInBytes(guardedRamBytesUsed(segmentReader.getPostingsReader()));
-                    stats.addStoredFieldsMemoryInBytes(guardedRamBytesUsed(segmentReader.getFieldsReader()));
-                    stats.addTermVectorsMemoryInBytes(guardedRamBytesUsed(segmentReader.getTermVectorsReader()));
-                    stats.addNormsMemoryInBytes(guardedRamBytesUsed(segmentReader.getNormsReader()));
-                    stats.addDocValuesMemoryInBytes(guardedRamBytesUsed(segmentReader.getDocValuesReader()));
-                }
-                stats.addVersionMapMemoryInBytes(versionMap.ramBytesUsed());
-                stats.addIndexWriterMemoryInBytes(indexWriter.ramBytesUsed());
-                stats.addIndexWriterMaxMemoryInBytes((long) (indexWriter.getConfig().getRAMBufferSizeMB() * 1024 * 1024));
-                return stats;
-        }
+    protected final void writerSegmentStats(SegmentsStats stats) {
+        stats.addVersionMapMemoryInBytes(versionMap.ramBytesUsed());
+        stats.addIndexWriterMemoryInBytes(indexWriter.ramBytesUsed());
+        stats.addIndexWriterMaxMemoryInBytes((long) (indexWriter.getConfig().getRAMBufferSizeMB() * 1024 * 1024));
     }
 
     @Override


### PR DESCRIPTION
This is more refactoring that is a part of #9727 to make diffs easier to read and backport.
