### PR TITLE
XGET should've been XPOST

### DIFF
--- a/docs/reference/search/request-body.asciidoc
+++ b/docs/reference/search/request-body.asciidoc
@@ -7,7 +7,7 @@ example:
 
 [source,js]
 --------------------------------------------------
-$ curl -XGET 'http://localhost:9200/twitter/tweet/_search' -d '{
+$ curl -XPOST 'http://localhost:9200/twitter/tweet/_search' -d '{
     "query" : {
         "term" : { "user" : "kimchy" }
     }


### PR DESCRIPTION
Title says it all. I've seen this error in the 0.90 and 1.4 reference, I guess the other versions have it as well.
