### PR TITLE
Rename Maven repository id

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,11 +49,13 @@
 
     <repositories>
         <repository>
-            <id>Codehaus Snapshots</id>
+            <id>codehaus-snapshots</id>
+            <name>Codehaus Snapshots</name>
             <url>http://repository.codehaus.org/</url>
         </repository>
         <repository>
-            <id>Lucene snapshots</id>
+            <id>lucene-snapshots</id>
+            <name>Lucene Snapshots</name>
             <url>https://download.elasticsearch.org/lucenesnapshots/1657571</url>
         </repository>
     </repositories>


### PR DESCRIPTION
We are using repository ids with spaces in our `pom.xml`. Although it's not forbidden, a common practice is to avoid space in id.

This commit changes codehaus snapshots and lucene snapshots to a consistent naming (using a dash, all lowercase).
We also add a name which is used by Maven when displaying some information about the repository.

This naming is also consistent with [elasticsearch-parent project](https://github.com/elasticsearch/elasticsearch-parent) which will be used in the next future in 1.x and master branch.

**Important note**: If you have trouble to compile elasticsearch or a plugin using `mvn compile` and hit a `Access denied to: [URL_HERE], ReasonPhrase: Forbidden. -> [Help 1]`, you can remove related maven files:

``` sh
find ~/.m2/repository -name _remote.repositories -exec rm -v {} \;
find ~/.m2/repository -name _maven.repositories -exec rm -v {} \;
```

Another option is to tell Maven not using those files with `--llr`:

``` sh
mvn compile --llr
```
