### PR TITLE
[maven] use elasticsearch-parent project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,6 +2,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>org.elasticsearch</groupId>
+        <artifactId>elasticsearch-parent</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+    </parent>
+
     <name>elasticsearch</name>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.elasticsearch</groupId>
@@ -24,66 +31,26 @@
         <url>http://github.com/elasticsearch/elasticsearch</url>
     </scm>
 
-    <parent>
-        <groupId>org.sonatype.oss</groupId>
-        <artifactId>oss-parent</artifactId>
-        <version>7</version>
-    </parent>
-
     <properties>
-        <lucene.version>5.1.0</lucene.version>
-        <lucene.maven.version>5.1.0-snapshot-1657571</lucene.maven.version>
-        <tests.jvms>auto</tests.jvms>
-        <tests.shuffle>true</tests.shuffle>
-        <tests.output>onerror</tests.output>
-        <tests.client.ratio></tests.client.ratio>
-        <tests.bwc.path>${project.basedir}/backwards</tests.bwc.path>
-        <tests.locale>random</tests.locale>
-        <tests.timezone>random</tests.timezone>
-        <es.logger.level>INFO</es.logger.level>
-        <tests.heap.size>512m</tests.heap.size>
-        <tests.heapdump.path>${basedir}/logs/</tests.heapdump.path>
-        <tests.topn>5</tests.topn>
-        <execution.hint.file>.local-${project.version}-execution-hints.log</execution.hint.file>
+        <!-- We inherit from common project properties but we can still force our settings -->
     </properties>
-
-    <repositories>
-        <repository>
-            <id>codehaus-snapshots</id>
-            <name>Codehaus Snapshots</name>
-            <url>http://repository.codehaus.org/</url>
-        </repository>
-        <repository>
-            <id>lucene-snapshots</id>
-            <name>Lucene Snapshots</name>
-            <url>https://download.elasticsearch.org/lucenesnapshots/1657571</url>
-        </repository>
-    </repositories>
 
     <dependencies>
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
-            <version>1.3</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.carrotsearch.randomizedtesting</groupId>
             <artifactId>randomizedtesting-runner</artifactId>
-            <version>2.1.11</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-test-framework</artifactId>
-            <version>${lucene.maven.version}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.3.5</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.google.jimfs</groupId>
@@ -95,109 +62,60 @@
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-core</artifactId>
-            <version>${lucene.maven.version}</version>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-backward-codecs</artifactId>
-            <version>${lucene.maven.version}</version>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-analyzers-common</artifactId>
-            <version>${lucene.maven.version}</version>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-queries</artifactId>
-            <version>${lucene.maven.version}</version>
-            <scope>compile</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>jakarta-regexp</groupId>
-                    <artifactId>jakarta-regexp</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-memory</artifactId>
-            <version>${lucene.maven.version}</version>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-highlighter</artifactId>
-            <version>${lucene.maven.version}</version>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-queryparser</artifactId>
-            <version>${lucene.maven.version}</version>
-            <scope>compile</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>jakarta-regexp</groupId>
-                    <artifactId>jakarta-regexp</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-suggest</artifactId>
-            <version>${lucene.maven.version}</version>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-join</artifactId>
-            <version>${lucene.maven.version}</version>
-            <scope>compile</scope>
         </dependency>
         <!-- Lucene spatial, make sure when upgrading to work with latest version of jts/spatial4j dependencies -->
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-spatial</artifactId>
-            <version>${lucene.maven.version}</version>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-expressions</artifactId>
-            <version>${lucene.maven.version}</version>
-            <scope>compile</scope>
-            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.spatial4j</groupId>
             <artifactId>spatial4j</artifactId>
-            <version>0.4.1</version>
-            <scope>compile</scope>
-            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.vividsolutions</groupId>
             <artifactId>jts</artifactId>
-            <version>1.13</version>
-            <scope>compile</scope>
-            <optional>true</optional>
-            <exclusions>
-                <exclusion>
-                    <groupId>xerces</groupId>
-                    <artifactId>xercesImpl</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <!-- needed for templating -->
         <dependency>
             <groupId>com.github.spullara.mustache.java</groupId>
             <artifactId>compiler</artifactId>
-            <version>0.8.13</version>
-            <optional>true</optional>
         </dependency>
         <!-- Lucene spatial -->
 
@@ -206,90 +124,65 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>18.0</version>
-            <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>com.carrotsearch</groupId>
             <artifactId>hppc</artifactId>
-            <version>0.6.0</version>
         </dependency>
 
         <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
-            <!-- joda 2.0 moved to using volatile fields for datetime -->
-            <!-- When updating to a new version, make sure to update our copy of BaseDateTime -->
-            <version>2.7</version>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.joda</groupId>
             <artifactId>joda-convert</artifactId>
-            <version>1.2</version>
-            <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.4.2</version>
-            <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-smile</artifactId>
-            <version>2.4.2</version>
-            <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
-            <version>2.4.2</version>
-            <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-cbor</artifactId>
-            <version>2.4.2</version>
-            <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty</artifactId>
-            <version>3.10.0.Final</version>
-            <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>com.ning</groupId>
             <artifactId>compress-lzf</artifactId>
-            <version>1.0.2</version>
-            <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>com.tdunning</groupId>
             <artifactId>t-digest</artifactId>
-            <version>3.0</version>
-            <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.3.2</version>
         </dependency>
 
         <dependency>
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
-            <version>1.2</version>
         </dependency>
 
         <!-- END: dependencies that are shaded -->
@@ -297,50 +190,32 @@
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
-            <version>2.4.0</version>
             <classifier>indy</classifier>
-            <scope>compile</scope>
-            <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
-            <scope>compile</scope>
-            <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>apache-log4j-extras</artifactId>
-            <version>1.2.17</version>
-            <scope>compile</scope>
-            <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.6.2</version>
-            <scope>compile</scope>
-            <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>net.java.dev.jna</groupId>
             <artifactId>jna</artifactId>
-            <version>4.1.0</version>
-            <scope>compile</scope>
-            <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>org.fusesource</groupId>
             <artifactId>sigar</artifactId>
-            <version>1.6.4</version>
-            <scope>compile</scope>
-            <optional>true</optional>
         </dependency>
 
         <!-- We don't use this since the publish pom is then messed up -->
@@ -412,163 +287,18 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>1.3.1</version>
-                <executions>
-                    <execution>
-                        <id>enforce-versions</id>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
-                        <configuration>
-                            <rules>
-                                <requireJavaVersion>
-                                    <version>[1.7,)</version>
-                                </requireJavaVersion>
-                            </rules>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                    <fork>true</fork>
-                    <maxmem>512m</maxmem>
-                    <!-- REMOVE WHEN UPGRADE:
-                         see https://jira.codehaus.org/browse/MCOMPILER-209 it's a bug where
-                         incremental compilation doesn't work unless it's set to false causeing
-                         recompilation of the entire codebase each time without any changes. Should
-                         be fixed in version > 3.1
-                     -->
-                    <useIncrementalCompilation>false</useIncrementalCompilation>
-                    <compilerArgs>
-                        <arg>-XDignore.symbol.file</arg>
-                    </compilerArgs>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>com.carrotsearch.randomizedtesting</groupId>
                 <artifactId>junit4-maven-plugin</artifactId>
-                <version>2.1.2</version>
-                <executions>
-                    <execution>
-                        <id>tests</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>junit4</goal>
-                        </goals>
-                        <configuration>
-                            <heartbeat>20</heartbeat>
-                            <jvmOutputAction>pipe,warn</jvmOutputAction>
-                            <leaveTemporary>true</leaveTemporary>
-                            <listeners>
-                                <report-ant-xml mavenExtensions="true"
-                                                dir="${project.build.directory}/surefire-reports"/>
-                                <report-text
-                                        showThrowable="true"
-                                        showStackTraces="true"
-                                        showOutput="${tests.output}"
-                                        showStatusOk="false"
-                                        showStatusError="true"
-                                        showStatusFailure="true"
-                                        showStatusIgnored="true"
-                                        showSuiteSummary="true"
-                                        timestamps="false"/>
-                                <report-execution-times historyLength="20" file="${basedir}/${execution.hint.file}"/>
-                            </listeners>
-                            <assertions>
-                                <enable/>
-                                <disable package="${tests.assertion.disabled}"/>
-                                <!-- pass org.elasticsearch to run without assertions -->
-                            </assertions>
-                            <parallelism>${tests.jvms}</parallelism>
-                            <balancers>
-                                <execution-times>
-                                    <fileset dir="${basedir}" includes="${execution.hint.file}"/>
-                                </execution-times>
-                            </balancers>
-                            <includes>
-                                <include>**/*Tests.class</include>
-                                <include>**/*Test.class</include>
-                            </includes>
-                            <excludes>
-                                <exclude>**/Abstract*.class</exclude>
-                                <exclude>**/*StressTest.class</exclude>
-                            </excludes>
-                            <jvmArgs>
-                                <param>-Xmx${tests.heap.size}</param>
-                                <param>-Xms${tests.heap.size}</param>
-                                <param>-XX:MaxPermSize=128m</param>
-                                <param>-XX:MaxDirectMemorySize=512m</param>
-                                <param>-Des.logger.prefix=</param>
-                                <param>-XX:+HeapDumpOnOutOfMemoryError</param>
-                                <param>-XX:HeapDumpPath=${tests.heapdump.path}</param>
-                            </jvmArgs>
-                            <shuffleOnSlave>${tests.shuffle}</shuffleOnSlave>
-                            <sysouts>${tests.verbose}</sysouts>
-                            <seed>${tests.seed}</seed>
-                            <haltOnFailure>${tests.failfast}</haltOnFailure>
-                            <uniqueSuiteNames>false</uniqueSuiteNames>
-                            <systemProperties>
-                                <java.io.tmpdir>.</java.io.tmpdir>
-                                <!-- we use '.' since this is different per JVM-->
-                                <!-- RandomizedTesting library system properties -->
-                                <tests.bwc>${tests.bwc}</tests.bwc>
-                                <tests.bwc.path>${tests.bwc.path}</tests.bwc.path>
-                                <tests.bwc.version>${tests.bwc.version}</tests.bwc.version>
-                                <tests.jvm.argline>${tests.jvm.argline}</tests.jvm.argline>
-                                <tests.processors>${tests.processors}</tests.processors>
-                                <tests.appendseed>${tests.appendseed}</tests.appendseed>
-                                <tests.iters>${tests.iters}</tests.iters>
-                                <tests.maxfailures>${tests.maxfailures}</tests.maxfailures>
-                                <tests.failfast>${tests.failfast}</tests.failfast>
-                                <tests.class>${tests.class}</tests.class>
-                                <tests.method>${tests.method}</tests.method>
-                                <tests.nightly>${tests.nightly}</tests.nightly>
-                                <tests.verbose>${tests.verbose}</tests.verbose>
-                                <tests.badapples>${tests.badapples}</tests.badapples>
-                                <tests.weekly>${tests.weekly}</tests.weekly>
-                                <tests.slow>${tests.slow}</tests.slow>
-                                <tests.awaitsfix>${tests.awaitsfix}</tests.awaitsfix>
-                                <tests.timeoutSuite>${tests.timeoutSuite}</tests.timeoutSuite>
-                                <tests.showSuccess>${tests.showSuccess}</tests.showSuccess>
-                                <tests.integration>${tests.integration}</tests.integration>
-                                <tests.client.ratio>${tests.client.ratio}</tests.client.ratio>
-                                <tests.enable_mock_modules>${tests.enable_mock_modules}</tests.enable_mock_modules>
-                                <tests.assertion.disabled>${tests.assertion.disabled}</tests.assertion.disabled>
-                                <tests.rest>${tests.rest}</tests.rest>
-                                <tests.rest.suite>${tests.rest.suite}</tests.rest.suite>
-                                <tests.rest.blacklist>${tests.rest.blacklist}</tests.rest.blacklist>
-                                <tests.rest.spec>${tests.rest.spec}</tests.rest.spec>
-                                <tests.network>${tests.network}</tests.network>
-                                <tests.cluster>${tests.cluster}</tests.cluster>
-                                <tests.heap.size>${tests.heap.size}</tests.heap.size>
-                                <tests.filter>${tests.filter}</tests.filter>
-                                <tests.version>${project.version}</tests.version>
-                                <tests.locale>${tests.locale}</tests.locale>
-                                <tests.timezone>${tests.timezone}</tests.timezone>
-                                <es.node.local>${env.ES_TEST_LOCAL}</es.node.local>
-                                <es.node.mode>${es.node.mode}</es.node.mode>
-                                <es.logger.level>${es.logger.level}</es.logger.level>
-                                <tests.security.manager>${tests.security.manager}</tests.security.manager>
-                                <tests.compatibility>${tests.compatibility}</tests.compatibility>
-                                <java.awt.headless>true</java.awt.headless>
-                                <!-- everything below is for security manager / test.policy -->
-                                <junit4.tempDir>${project.build.directory}</junit4.tempDir>
-                                <java.security.policy>${basedir}/dev-tools/tests.policy</java.security.policy>
-                            </systemProperties>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
-                <version>1.7</version>
                 <executions>
                     <execution>
                         <phase>validate</phase>
@@ -659,15 +389,10 @@
                 <!-- we skip surefire to work with randomized testing above -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.16</version>
-                <configuration>
-                    <skipTests>true</skipTests>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.2.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -700,7 +425,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.3</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -800,8 +524,8 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>2.6</version>
                 <executions>
                     <execution>
                         <id>copy-resources</id>
@@ -832,8 +556,8 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.4</version>
                 <configuration>
                     <appendAssemblyId>false</appendAssemblyId>
                     <outputDirectory>${project.build.directory}/releases/</outputDirectory>
@@ -854,23 +578,10 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>buildnumber-maven-plugin</artifactId>
-                <version>1.2</version>
-                <executions>
-                    <execution>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>create</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <doCheck>false</doCheck>
-                    <doUpdate>false</doUpdate>
-                </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>2.8</version>
                 <executions>
                     <execution>
                         <phase>prepare-package</phase>
@@ -885,13 +596,11 @@
                 </executions>
             </plugin>
             <plugin>
-                <!-- some infos https://github.com/tcurdt/jdeb/blob/master/docs/maven.md
-                -->
-                <artifactId>jdeb</artifactId>
+                <!-- some infos https://github.com/tcurdt/jdeb/blob/master/docs/maven.md -->
                 <groupId>org.vafer</groupId>
-                <version>1.0.1</version>
+                <artifactId>jdeb</artifactId>
                 <configuration>
-                    <deb>${project.build.directory}/releases/${project.artifactId}-${project.version}.deb</deb>
+                    <deb>${project.build.directory}/releases/${project.artifactId}-${elasticsearch.version}.deb</deb>
                 </configuration>
                 <executions>
                     <execution>
@@ -1023,7 +732,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>rpm-maven-plugin</artifactId>
-                <version>2.1-alpha-3</version>
                 <configuration>
                     <copyright>2013, Elasticsearch</copyright>
                     <distribution>Elasticsearch</distribution>
@@ -1215,8 +923,6 @@
             <plugin>
                 <groupId>de.thetaphi</groupId>
                 <artifactId>forbiddenapis</artifactId>
-                <version>1.7</version>
-
                 <executions>
                     <execution>
                         <id>check-forbidden-apis</id>
@@ -1311,7 +1017,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.4</version>
                 <executions>
                     <execution>
                         <phase>prepare-package</phase>
@@ -1338,88 +1043,17 @@
                 </executions>
             </plugin>
         </plugins>
-        <pluginManagement>
-            <plugins>
-                <!-- make m2e stfu -->
-                <plugin>
-                    <groupId>org.eclipse.m2e</groupId>
-                    <artifactId>lifecycle-mapping</artifactId>
-                    <version>1.0.0</version>
-                    <configuration>
-                        <lifecycleMappingMetadata>
-                            <pluginExecutions>
-                                <!-- copy-dependency plugin -->
-                                <pluginExecution>
-                                    <pluginExecutionFilter>
-                                        <groupId>org.apache.maven.plugins</groupId>
-                                        <artifactId>maven-dependency-plugin</artifactId>
-                                        <versionRange>[1.0.0,)</versionRange>
-                                        <goals>
-                                            <goal>copy-dependencies</goal>
-                                        </goals>
-                                    </pluginExecutionFilter>
-                                    <action>
-                                        <execute/>
-                                    </action>
-                                </pluginExecution>
-                                <!-- forbidden-apis plugin -->
-                                <pluginExecution>
-                                    <pluginExecutionFilter>
-                                        <groupId>de.thetaphi</groupId>
-                                        <artifactId>forbiddenapis</artifactId>
-                                        <versionRange>[1.0.0,)</versionRange>
-                                        <goals>
-                                            <goal>testCheck</goal>
-                                            <goal>check</goal>
-                                        </goals>
-                                    </pluginExecutionFilter>
-                                    <action>
-                                        <execute/>
-                                    </action>
-                                </pluginExecution>
-                                <!-- exec-maven plugin -->
-                                <pluginExecution>
-                                    <pluginExecutionFilter>
-                                        <artifactId>exec-maven-plugin</artifactId>
-                                        <groupId>org.codehaus.mojo</groupId>
-                                        <versionRange>[1.0.0,)</versionRange>
-                                        <goals>
-                                            <goal>exec</goal>
-                                        </goals>
-                                    </pluginExecutionFilter>
-                                    <action>
-                                        <execute/>
-                                    </action>
-                                </pluginExecution>
-                                <!-- copy-dependency plugin -->
-                                <pluginExecution>
-                                    <pluginExecutionFilter>
-                                        <groupId>org.apache.maven.plugins</groupId>
-                                        <artifactId>maven-enforcer-plugin</artifactId>
-                                        <versionRange>[1.0.0,)</versionRange>
-                                        <goals>
-                                            <goal>enforce</goal>
-                                        </goals>
-                                    </pluginExecutionFilter>
-                                    <action>
-                                        <execute/>
-                                    </action>
-                                </pluginExecution>
-                            </pluginExecutions>
-                        </lifecycleMappingMetadata>
-                    </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-eclipse-plugin</artifactId>
-                    <version>2.9</version>
-                    <configuration>
-                        <buildOutputDirectory>eclipse-build</buildOutputDirectory>
-                    </configuration>
-                </plugin>
-            </plugins>
-        </pluginManagement>
     </build>
+
+    <repositories>
+        <!-- Used for parent project when it's a SNAPSHOT version -->
+        <repository>
+            <id>oss-snapshots</id>
+            <name>Sonatype OSS Snapshots</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+        </repository>
+    </repositories>
+
     <profiles>
         <!-- default profile, with randomization setting kicks in -->
         <profile>
@@ -1439,7 +1073,6 @@
                     <plugin>
                         <groupId>com.mycila</groupId>
                         <artifactId>license-maven-plugin</artifactId>
-                        <version>2.5</version>
                         <configuration>
                             <header>dev-tools/elasticsearch_license_header.txt</header>
                             <headerDefinitions>
@@ -1487,7 +1120,6 @@
                     <plugin>
                         <groupId>de.thetaphi</groupId>
                         <artifactId>forbiddenapis</artifactId>
-                        <version>1.5.1</version>
                         <executions>
                             <execution>
                                 <id>check-forbidden-apis</id>
@@ -1511,7 +1143,7 @@
                     <value>true</value>
                 </property>
             </activation>
-            <!-- not including license-maven-plugin is sufficent to expose default license -->
+            <!-- not including license-maven-plugin is sufficient to expose default license -->
         </profile>
         <!-- jacoco coverage profile.  This will insert -jagent -->
         <profile>
@@ -1527,9 +1159,6 @@
                     <!--  must be on the classpath  -->
                     <groupId>org.jacoco</groupId>
                     <artifactId>org.jacoco.agent</artifactId>
-                    <classifier>runtime</classifier>
-                    <version>0.6.4.201312101107</version>
-                    <scope>test</scope>
                 </dependency>
             </dependencies>
             <build>
@@ -1537,34 +1166,6 @@
                     <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
-                        <version>0.6.4.201312101107</version>
-                        <executions>
-                            <execution>
-                                <id>default-prepare-agent</id>
-                                <goals>
-                                    <goal>prepare-agent</goal>
-                                </goals>
-                            </execution>
-                            <execution>
-                                <id>default-report</id>
-                                <phase>prepare-package</phase>
-                                <goals>
-                                    <goal>report</goal>
-                                </goals>
-                            </execution>
-                            <execution>
-                                <id>default-check</id>
-                                <goals>
-                                    <goal>check</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <excludes>
-                                <exclude>jsr166e/**</exclude>
-                                <exclude>org/apache/lucene/**</exclude>
-                            </excludes>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>
@@ -1582,7 +1183,6 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>findbugs-maven-plugin</artifactId>
-                        <version>2.5.3</version>
                     </plugin>
                 </plugins>
             </build>
@@ -1591,12 +1191,10 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-jxr-plugin</artifactId>
-                        <version>2.3</version>
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-pmd-plugin</artifactId>
-                        <version>3.0.1</version>
                         <configuration>
                             <rulesets>
                                 <ruleset>${basedir}/dev-tools/pmd/custom.xml</ruleset>
@@ -1612,7 +1210,6 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>findbugs-maven-plugin</artifactId>
-                        <version>2.5.3</version>
                         <configuration>
                             <xmlOutput>true</xmlOutput>
                             <xmlOutputDirectory>target/site</xmlOutputDirectory>
@@ -1625,7 +1222,6 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-project-info-reports-plugin</artifactId>
-                        <version>2.7</version>
                         <reportSets>
                             <reportSet>
                                 <reports>


### PR DESCRIPTION
We created another parent project [elasticsearch-parent](https://github.com/elasticsearch/elasticsearch-parent) which contains all dependencies that might be used in elasticsearch java projects including elasticsearch core itself.

This commit is the first step to this goal and could require some cleanup though `mvn clean install` is working fine.

Also, goal is to have in `elasticsearch-parent` one branch per major elasticsearch maintained version (master, 1.x) so this commit will be applied as well in 1.x branch but with a parent dependency on 1.5.0-SNAPSHOT.

The build release script must be also tested and modified if needed.

It might be interested to join the efforts done in plugins repos and in core repo to have at the end of the day one single release script available in `elasticsearch-common` project and that might be used as well by third-party plugins developers.

Note that releasing an elasticsearch version will require first to release the `elasticsearch-parent` related version, then update elasticsearch `pom.xml` to depend on the final version (remove `-SNAPSHOT` that is).
