### PR TITLE
Update API: Add noop field to response

### DIFF
--- a/docs/reference/docs/update.asciidoc
+++ b/docs/reference/docs/update.asciidoc
@@ -124,7 +124,19 @@ curl -XPOST 'localhost:9200/test/type1/1/_update' -d '{
 --------------------------------------------------
 
 If `name` was `new_name` before the request was sent then the entire update
-request is ignored.
+request is ignored. The `noop` element in the response indicates if the
+request was ignored.
+
+[source,js]
+--------------------------------------------------
+{
+   "_index": "test",
+   "_type": "type1",
+   "_id": "1",
+   "_version": 1,
+   "_noop": true
+}
+--------------------------------------------------
 
 [[upserts]]
 [float]

--- a/rest-api-spec/test/update/27_noop.yaml
+++ b/rest-api-spec/test/update/27_noop.yaml
@@ -1,0 +1,53 @@
+---
+"Noop":
+
+  - do:
+      update:
+          index:            test_1
+          type:             test
+          id:               1
+          body:
+            doc:            { foo: bar }
+            doc_as_upsert:  1
+
+  - match: { _version: 1  }
+  - match: { _noop: false }
+
+  - do:
+      update:
+          index:            test_1
+          type:             test
+          id:               1
+          body:
+            doc:            { foo: bar }
+            doc_as_upsert:  1
+            detect_noop:    true
+
+  - match: { _version: 1    }
+  - match: { _noop:    true }
+
+  - do:
+      update:
+          index:            test_1
+          type:             test
+          id:               1
+          body:
+            doc:            { foo: bar }
+            doc_as_upsert:  1
+            detect_noop:    false
+
+  - match: { _version: 2     }
+  - match: { _noop:    false }
+
+  - do:
+      update:
+          index:            test_1
+          type:             test
+          id:               1
+          body:
+            doc:            { foo: baz }
+            doc_as_upsert:  1
+            detect_noop:    true
+
+  - match: { _version: 3     }
+  - match: { _noop:    false }

--- a/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
+++ b/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
@@ -240,7 +240,7 @@ public class UpdateHelper extends AbstractComponent {
             deleteRequest.operationThreaded(false);
             return new Result(deleteRequest, Operation.DELETE, updatedSourceAsMap, updateSourceContentType);
         } else if ("none".equals(operation)) {
-            UpdateResponse update = new UpdateResponse(getResult.getIndex(), getResult.getType(), getResult.getId(), getResult.getVersion(), false);
+            UpdateResponse update = new UpdateResponse(getResult.getIndex(), getResult.getType(), getResult.getId(), getResult.getVersion(), false, true);
             update.setGetResult(extractGetResult(request, indexShard.indexService().index().name(), getResult.getVersion(), updatedSourceAsMap, updateSourceContentType, getResult.internalSourceRef()));
             return new Result(update, Operation.NONE, updatedSourceAsMap, updateSourceContentType);
         } else {

--- a/src/main/java/org/elasticsearch/action/update/UpdateResponse.java
+++ b/src/main/java/org/elasticsearch/action/update/UpdateResponse.java
@@ -35,6 +35,7 @@ public class UpdateResponse extends ActionWriteResponse {
     private String type;
     private long version;
     private boolean created;
+    private boolean noop;
     private GetResult getResult;
 
     public UpdateResponse() {
@@ -55,6 +56,11 @@ public class UpdateResponse extends ActionWriteResponse {
         this.type = type;
         this.version = version;
         this.created = created;
+    }
+
+    public UpdateResponse(String index, String type, String id, long version, boolean created, boolean noop) {
+        this(index, type, id, version, created);
+        this.noop = noop;
     }
 
     /**
@@ -98,6 +104,14 @@ public class UpdateResponse extends ActionWriteResponse {
      */
     public boolean isCreated() {
         return this.created;
+
+    }
+
+    /**
+     * Returns true if document was not updated due to a noop operation
+     */
+    public boolean isNoOp() {
+        return this.noop;
 
     }
 

--- a/src/main/java/org/elasticsearch/action/update/UpdateResponse.java
+++ b/src/main/java/org/elasticsearch/action/update/UpdateResponse.java
@@ -123,6 +123,7 @@ public class UpdateResponse extends ActionWriteResponse {
         id = in.readString();
         version = in.readLong();
         created = in.readBoolean();
+        noop = in.readBoolean();
         if (in.readBoolean()) {
             getResult = GetResult.readGetResult(in);
         }
@@ -136,6 +137,7 @@ public class UpdateResponse extends ActionWriteResponse {
         out.writeString(id);
         out.writeLong(version);
         out.writeBoolean(created);
+        out.writeBoolean(noop);
         if (getResult == null) {
             out.writeBoolean(false);
         } else {

--- a/src/main/java/org/elasticsearch/rest/action/update/RestUpdateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/update/RestUpdateAction.java
@@ -131,7 +131,8 @@ public class RestUpdateAction extends BaseRestHandler {
                 builder.field(Fields._INDEX, response.getIndex())
                         .field(Fields._TYPE, response.getType())
                         .field(Fields._ID, response.getId())
-                        .field(Fields._VERSION, response.getVersion());
+                        .field(Fields._VERSION, response.getVersion())
+                        .field(Fields._NOOP, response.isNoOp());
 
                 shardInfo.toXContent(builder, request);
                 if (response.getGetResult() != null) {
@@ -155,6 +156,7 @@ public class RestUpdateAction extends BaseRestHandler {
         static final XContentBuilderString _TYPE = new XContentBuilderString("_type");
         static final XContentBuilderString _ID = new XContentBuilderString("_id");
         static final XContentBuilderString _VERSION = new XContentBuilderString("_version");
+        static final XContentBuilderString _NOOP = new XContentBuilderString("_noop");
         static final XContentBuilderString GET = new XContentBuilderString("get");
     }
 }


### PR DESCRIPTION
Adds a boolean field `_noop` to Update API responses that indicates whether the update was a no-op or not. 

Closes #9642
