### PR TITLE
Don't use the fixed bitset filter cache for child nested level filters, but the regular filter cache instead

### DIFF
--- a/src/main/java/org/elasticsearch/index/fielddata/IndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/IndexFieldData.java
@@ -129,9 +129,11 @@ public interface IndexFieldData<FD extends AtomicFieldData> extends IndexCompone
          * parent + 1, or 0 if there is no previous parent, and R (excluded).
          */
         public static class Nested {
-            private final BitDocIdSetFilter rootFilter, innerFilter;
 
-            public Nested(BitDocIdSetFilter rootFilter, BitDocIdSetFilter innerFilter) {
+            private final BitDocIdSetFilter rootFilter;
+            private final Filter innerFilter;
+
+            public Nested(BitDocIdSetFilter rootFilter, Filter innerFilter) {
                 this.rootFilter = rootFilter;
                 this.innerFilter = innerFilter;
             }
@@ -144,10 +146,10 @@ public interface IndexFieldData<FD extends AtomicFieldData> extends IndexCompone
             }
 
             /**
-             * Get a {@link BitDocIdSet} that matches the inner documents.
+             * Get a {@link DocIdSet} that matches the inner documents.
              */
-            public BitDocIdSet innerDocs(LeafReaderContext ctx) throws IOException {
-                return innerFilter.getDocIdSet(ctx);
+            public DocIdSet innerDocs(LeafReaderContext ctx) throws IOException {
+                return innerFilter.getDocIdSet(ctx, null);
             }
         }
 

--- a/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/BytesRefFieldComparatorSource.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/BytesRefFieldComparatorSource.java
@@ -23,6 +23,7 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.RandomAccessOrds;
 import org.apache.lucene.index.SortedDocValues;
+import org.apache.lucene.search.DocIdSet;
 import org.apache.lucene.search.FieldComparator;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.SortField;
@@ -81,7 +82,7 @@ public class BytesRefFieldComparatorSource extends IndexFieldData.XFieldComparat
                         selectedValues = sortMode.select(values);
                     } else {
                         final BitSet rootDocs = nested.rootDocs(context).bits();
-                        final BitSet innerDocs = nested.innerDocs(context).bits();
+                        final DocIdSet innerDocs = nested.innerDocs(context);
                         selectedValues = sortMode.select(values, rootDocs, innerDocs);
                     }
                     if (sortMissingFirst(missingValue) || sortMissingLast(missingValue)) {
@@ -132,7 +133,7 @@ public class BytesRefFieldComparatorSource extends IndexFieldData.XFieldComparat
                     selectedValues = sortMode.select(values, nonNullMissingBytes);
                 } else {
                     final BitSet rootDocs = nested.rootDocs(context).bits();
-                    final BitSet innerDocs = nested.innerDocs(context).bits();
+                    final DocIdSet innerDocs = nested.innerDocs(context);
                     selectedValues = sortMode.select(values, nonNullMissingBytes, rootDocs, innerDocs, context.reader().maxDoc());
                 }
                 return selectedValues;

--- a/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/DoubleValuesComparatorSource.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/DoubleValuesComparatorSource.java
@@ -21,6 +21,7 @@ package org.elasticsearch.index.fielddata.fieldcomparator;
 
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.search.DocIdSet;
 import org.apache.lucene.search.FieldComparator;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.SortField;
@@ -78,7 +79,7 @@ public class DoubleValuesComparatorSource extends IndexFieldData.XFieldComparato
                     selectedValues = sortMode.select(values, dMissingValue);
                 } else {
                     final BitSet rootDocs = nested.rootDocs(context).bits();
-                    final BitSet innerDocs = nested.innerDocs(context).bits();
+                    final DocIdSet innerDocs = nested.innerDocs(context);
                     selectedValues = sortMode.select(values, dMissingValue, rootDocs, innerDocs, context.reader().maxDoc());
                 }
                 return selectedValues.getRawDoubleValues();

--- a/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/FloatValuesComparatorSource.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/FloatValuesComparatorSource.java
@@ -20,6 +20,7 @@ package org.elasticsearch.index.fielddata.fieldcomparator;
 
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.search.DocIdSet;
 import org.apache.lucene.search.FieldComparator;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.util.BitSet;
@@ -70,7 +71,7 @@ public class FloatValuesComparatorSource extends IndexFieldData.XFieldComparator
                     selectedValues = sortMode.select(values, dMissingValue);
                 } else {
                     final BitSet rootDocs = nested.rootDocs(context).bits();
-                    final BitSet innerDocs = nested.innerDocs(context).bits();
+                    final DocIdSet  innerDocs = nested.innerDocs(context);
                     selectedValues = sortMode.select(values, dMissingValue, rootDocs, innerDocs, context.reader().maxDoc());
                 }
                 return selectedValues.getRawFloatValues();

--- a/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/LongValuesComparatorSource.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/LongValuesComparatorSource.java
@@ -21,6 +21,7 @@ package org.elasticsearch.index.fielddata.fieldcomparator;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.search.DocIdSet;
 import org.apache.lucene.search.FieldComparator;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.util.BitSet;
@@ -69,7 +70,7 @@ public class LongValuesComparatorSource extends IndexFieldData.XFieldComparatorS
                     selectedValues = sortMode.select(values, dMissingValue);
                 } else {
                     final BitSet rootDocs = nested.rootDocs(context).bits();
-                    final BitSet innerDocs = nested.innerDocs(context).bits();
+                    final DocIdSet innerDocs = nested.innerDocs(context);
                     selectedValues = sortMode.select(values, dMissingValue, rootDocs, innerDocs, context.reader().maxDoc());
                 }
                 return selectedValues;

--- a/src/main/java/org/elasticsearch/search/sort/ScriptSortParser.java
+++ b/src/main/java/org/elasticsearch/search/sort/ScriptSortParser.java
@@ -21,6 +21,7 @@ package org.elasticsearch.search.sort;
 
 import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.Filter;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.join.BitDocIdSetFilter;
@@ -131,11 +132,11 @@ public class ScriptSortParser implements SortParser {
         final Nested nested;
         if (nestedHelper != null && nestedHelper.getPath() != null) {
             BitDocIdSetFilter rootDocumentsFilter = context.bitsetFilterCache().getBitDocIdSetFilter(NonNestedDocsFilter.INSTANCE);
-            BitDocIdSetFilter innerDocumentsFilter;
+            Filter innerDocumentsFilter;
             if (nestedHelper.filterFound()) {
-                innerDocumentsFilter = context.bitsetFilterCache().getBitDocIdSetFilter(nestedHelper.getInnerFilter());
+                innerDocumentsFilter = context.filterCache().cache(nestedHelper.getInnerFilter(), null, context.queryParserService().autoFilterCachePolicy());
             } else {
-                innerDocumentsFilter = context.bitsetFilterCache().getBitDocIdSetFilter(nestedHelper.getNestedObjectMapper().nestedTypeFilter());
+                innerDocumentsFilter = context.filterCache().cache(nestedHelper.getNestedObjectMapper().nestedTypeFilter(), null, context.queryParserService().autoFilterCachePolicy());
             }
             nested = new Nested(rootDocumentsFilter, innerDocumentsFilter);
         } else {

--- a/src/main/java/org/elasticsearch/search/sort/SortParseElement.java
+++ b/src/main/java/org/elasticsearch/search/sort/SortParseElement.java
@@ -21,6 +21,7 @@ package org.elasticsearch.search.sort;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import org.apache.lucene.search.Filter;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.join.BitDocIdSetFilter;
@@ -252,11 +253,11 @@ public class SortParseElement implements SearchParseElement {
             final Nested nested;
             if (nestedHelper != null && nestedHelper.getPath() != null) {
                 BitDocIdSetFilter rootDocumentsFilter = context.bitsetFilterCache().getBitDocIdSetFilter(NonNestedDocsFilter.INSTANCE);
-                BitDocIdSetFilter innerDocumentsFilter;
+                Filter innerDocumentsFilter;
                 if (nestedHelper.filterFound()) {
-                    innerDocumentsFilter = context.bitsetFilterCache().getBitDocIdSetFilter(nestedHelper.getInnerFilter());
+                    innerDocumentsFilter = context.filterCache().cache(nestedHelper.getInnerFilter(), null, context.queryParserService().autoFilterCachePolicy());
                 } else {
-                    innerDocumentsFilter = context.bitsetFilterCache().getBitDocIdSetFilter(nestedHelper.getNestedObjectMapper().nestedTypeFilter());
+                    innerDocumentsFilter = context.filterCache().cache(nestedHelper.getNestedObjectMapper().nestedTypeFilter(), null, context.queryParserService().autoFilterCachePolicy());
                 }
                 nested = new Nested(rootDocumentsFilter, innerDocumentsFilter);
             } else {


### PR DESCRIPTION
Random access based bitsets are not required for the child level nested level filters.

Closes #8810
