### PR TITLE
Engine: close snapshots before recovery counter

### DIFF
--- a/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -802,6 +802,7 @@ public class InternalEngine extends Engine {
             recoveryHandler.phase1(phase1Snapshot);
         } catch (Throwable e) {
             maybeFailEngine("recovery phase 1", e);
+            // close the snapshot first to release the reference to the translog file, so a flush post recovery can delete it
             Releasables.closeWhileHandlingException(phase1Snapshot, onGoingRecoveries);
             throw new RecoveryEngineException(shardId, 1, "Execution failed", wrapIfClosed(e));
         }
@@ -818,6 +819,7 @@ public class InternalEngine extends Engine {
             recoveryHandler.phase2(phase2Snapshot);
         } catch (Throwable e) {
             maybeFailEngine("recovery phase 2", e);
+            // close the snapshots first to release the reference to the translog file, so a flush post recovery can delete it
             Releasables.closeWhileHandlingException(phase1Snapshot, phase2Snapshot, onGoingRecoveries);
             throw new RecoveryEngineException(shardId, 2, "Execution failed", wrapIfClosed(e));
         }
@@ -834,6 +836,7 @@ public class InternalEngine extends Engine {
             maybeFailEngine("recovery phase 3", e);
             throw new RecoveryEngineException(shardId, 3, "Execution failed", wrapIfClosed(e));
         } finally {
+            // close the snapshots first to release the reference to the translog file, so a flush post recovery can delete it
             Releasables.close(success, phase1Snapshot, phase2Snapshot, phase3Snapshot,
                     onGoingRecoveries, writeLock); // hmm why can't we use try-with here?
         }

--- a/src/main/java/org/elasticsearch/index/translog/Translog.java
+++ b/src/main/java/org/elasticsearch/index/translog/Translog.java
@@ -118,9 +118,11 @@ public interface Translog extends IndexShardComponent, CloseableIndexComponent, 
     Snapshot snapshot(Snapshot snapshot);
 
     /**
-     * Clears unreferenced transaclogs.
+     * Clears unreferenced transaction logs.
+     *
+     * @return the number of clean up files
      */
-    void clearUnreferenced();
+    int clearUnreferenced();
 
     /**
      * Sync's the translog.

--- a/src/main/java/org/elasticsearch/index/translog/fs/FsTranslog.java
+++ b/src/main/java/org/elasticsearch/index/translog/fs/FsTranslog.java
@@ -200,8 +200,9 @@ public class FsTranslog extends AbstractIndexShardComponent implements Translog 
     }
 
     @Override
-    public void clearUnreferenced() {
+    public int clearUnreferenced() {
         rwl.writeLock().lock();
+        int deleted = 0;
         try {
             for (File location : locations) {
                 File[] files = location.listFiles();
@@ -216,6 +217,7 @@ public class FsTranslog extends AbstractIndexShardComponent implements Translog 
                         try {
                             logger.trace("clearing unreferenced translog {}", file);
                             file.delete();
+                            deleted++;
                         } catch (Exception e) {
                             // ignore
                         }
@@ -225,6 +227,7 @@ public class FsTranslog extends AbstractIndexShardComponent implements Translog 
         } finally {
             rwl.writeLock().unlock();
         }
+        return deleted;
     }
 
     @Override


### PR DESCRIPTION
When we clean up after recoveries, we currently close the recovery counter first, followed up by the different snapshots. Since the recovery counter may issue a flush (introduced in #9439) , the snapshot references prevent the flush from deleting the current translog file once it's no longer needed. 

Note: this is not a problem on master, as we moved the translog delete logic, making it kick in if needed 
when the ref counter goes to 0.

relates to https://github.com/elasticsearch/elasticsearch/issues/9226#issuecomment-74873737
