### PR TITLE
Hot threads should include timestamp and params

### DIFF
--- a/src/main/java/org/elasticsearch/monitor/jvm/HotThreads.java
+++ b/src/main/java/org/elasticsearch/monitor/jvm/HotThreads.java
@@ -21,6 +21,8 @@ package org.elasticsearch.monitor.jvm;
 
 import org.apache.lucene.util.CollectionUtil;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
+import org.elasticsearch.common.joda.FormatDateTimeFormatter;
+import org.elasticsearch.common.joda.Joda;
 import org.elasticsearch.common.unit.TimeValue;
 
 import java.lang.management.ManagementFactory;
@@ -34,6 +36,8 @@ import java.util.concurrent.TimeUnit;
 public class HotThreads {
 
     private static final Object mutex = new Object();
+
+    private static final FormatDateTimeFormatter DATE_TIME_FORMATTER = Joda.forPattern("dateOptionalTime");
 
     private int busiestThreads = 3;
     private TimeValue interval = new TimeValue(500, TimeUnit.MILLISECONDS);
@@ -122,6 +126,17 @@ public class HotThreads {
 
     private String innerDetect() throws Exception {
         StringBuilder sb = new StringBuilder();
+
+        sb.append("Hot threads at ");
+        sb.append(DATE_TIME_FORMATTER.printer().print(System.currentTimeMillis()));
+        sb.append(", interval=");
+        sb.append(interval);
+        sb.append(", busiestThreads=");
+        sb.append(busiestThreads);
+        sb.append(", ignoreIdleThreads=");
+        sb.append(ignoreIdleThreads);
+        sb.append(":\n");
+
         ThreadMXBean threadBean = ManagementFactory.getThreadMXBean();
         boolean enabledCpu = false;
         try {

--- a/src/test/java/org/elasticsearch/action/admin/HotThreadsTest.java
+++ b/src/test/java/org/elasticsearch/action/admin/HotThreadsTest.java
@@ -163,4 +163,17 @@ public class HotThreadsTest extends ElasticsearchIntegrationTest {
         // The filtered stacks should be smaller than unfiltered ones:
         assertThat(totSizeIgnoreIdle, lessThan(totSizeAll));
     }
+
+    public void testTimestampAndParams() throws ExecutionException, InterruptedException {
+
+        NodesHotThreadsResponse response = client().admin().cluster().prepareNodesHotThreads().execute().get();
+
+        for (NodeHotThreads node : response.getNodesMap().values()) {
+            String result = node.getHotThreads();
+            assertTrue(result.indexOf("Hot threads at") != -1);
+            assertTrue(result.indexOf("interval=500ms") != -1);
+            assertTrue(result.indexOf("busiestThreads=3") != -1);
+            assertTrue(result.indexOf("ignoreIdleThreads=true") != -1);
+        }
+    }
 }


### PR DESCRIPTION
When looking at a hot threads output, it's useful to know the exact time when the hot threads were taken, e.g. to correlate back to Marvel charts or other monitors.  If multiple hot threads were pulled at different times it's useful to know which one was when.

I think it's also useful to know the params that were passed (interval, busiestThreads count, whether idle threads were ignored).

This change just adds a line at the top of each node's hot threads, like this:

  Hot threads at 2015-02-19T10:33:52.333Z, interval=500ms, busiestThreads=2147483647, ignoreIdleThreads=false:
