### PR TITLE
Test: Remove use of globalTempDir() and forbid it from future use.

### DIFF
--- a/dev-tools/forbidden/test-signatures.txt
+++ b/dev-tools/forbidden/test-signatures.txt
@@ -1,0 +1,2 @@
+
+com.carrotsearch.randomizedtesting.RandomizedTest#globalTempDir() @ Use newTempDirPath() instead

--- a/src/test/java/org/elasticsearch/common/io/FileSystemUtilsTests.java
+++ b/src/test/java/org/elasticsearch/common/io/FileSystemUtilsTests.java
@@ -92,7 +92,7 @@ public class FileSystemUtilsTests extends ElasticsearchTestCase {
 
     @Test
     public void testMoveOverExistingFileAndIgnore() throws IOException {
-        Path dest = globalTempDirPath();
+        Path dest = newTempDirPath();
 
         FileSystemUtils.moveFilesWithoutOverwriting(src.resolve("v1"), dest, null);
         assertFileContent(dest, "file1.txt", "version1");

--- a/src/test/java/org/elasticsearch/test/ElasticsearchTestCase.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchTestCase.java
@@ -557,13 +557,6 @@ public abstract class ElasticsearchTestCase extends AbstractRandomizedTest {
     public static Path newTempDirPath(LifecycleScope scope) {
         return newTempDir(scope).toPath();
     }
-    
-    /**
-     * Returns 'global' temp dir (seems like a bad idea)
-     */
-    public static Path globalTempDirPath() {
-        return globalTempDir().toPath();
-    }
 
     /**
      * Returns a random number of temporary paths.


### PR DESCRIPTION
Using this temp dir circumvents test isolation and isn't necessary.
