### PR TITLE
Tests: Remove global shared cluster

### DIFF
--- a/docs/reference/testing/testing-framework.asciidoc
+++ b/docs/reference/testing/testing-framework.asciidoc
@@ -129,19 +129,19 @@ In order to execute any actions, you have to use a client. You can use the `Elas
 [[scoping]]
 ==== Scoping
 
-By default the tests are run without restarting the cluster between tests or test classes in order to be as fast as possible. Of course all indices and templates are deleted between each test. However, sometimes you need to start a new cluster for each test or for a whole test suite - for example, if you load a certain plugin, but you do not want to load it for every test.
+By default the tests are run with unique cluster per test suite. Of course all indices and templates are deleted between each test. However, sometimes you need to start a new cluster for each test - for example, if you load a certain plugin, but you do not want to load it for every test.
 
 You can use the `@ClusterScope` annotation at class level to configure this behaviour
 
 [source,java]
 -----------------------------------------
-@ClusterScope(scope=SUITE, numNodes=1)
+@ClusterScope(scope=TEST, numNodes=1)
 public class CustomSuggesterSearchTests extends ElasticsearchIntegrationTest {
   // ... tests go here
 }
 -----------------------------------------
 
-The above sample configures an own cluster for this test suite, which is the class. Other values could be `GLOBAL` (the default) or `TEST` in order to spawn a new cluster for each test. The `numNodes` settings allows you to only start a certain number of nodes, which can speed up test execution, as starting a new node is a costly and time consuming operation and might not be needed for this test.
+The above sample configures the test to use a new cluster for each test method. The default scope is `SUITE` (one cluster for all test methods in the test). The `numNodes` settings allows you to only start a certain number of nodes, which can speed up test execution, as starting a new node is a costly and time consuming operation and might not be needed for this test.
 
 
 [[changing-node-configuration]]

--- a/src/test/java/org/elasticsearch/network/DirectBufferNetworkTests.java
+++ b/src/test/java/org/elasticsearch/network/DirectBufferNetworkTests.java
@@ -23,11 +23,14 @@ import org.apache.http.impl.client.HttpClients;
 import org.apache.lucene.util.TestUtil;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.http.HttpServerTransport;
+import org.elasticsearch.node.internal.InternalNode;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.elasticsearch.test.rest.client.http.HttpRequestBuilder;
 import org.hamcrest.Matchers;
@@ -43,6 +46,13 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitC
 /**
  */
 public class DirectBufferNetworkTests extends ElasticsearchIntegrationTest {
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return ImmutableSettings.builder()
+            .put(InternalNode.HTTP_ENABLED, true)
+            .put(super.nodeSettings(nodeOrdinal)).build();
+    }
 
     /**
      * This test validates that using large data sets (large docs + large API requests) don't

--- a/src/test/java/org/elasticsearch/rest/CorsRegexDefaultTests.java
+++ b/src/test/java/org/elasticsearch/rest/CorsRegexDefaultTests.java
@@ -18,6 +18,9 @@
  */
 package org.elasticsearch.rest;
 
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.node.internal.InternalNode;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.elasticsearch.test.rest.client.http.HttpResponse;
 import org.junit.Test;
@@ -29,6 +32,13 @@ import static org.hamcrest.Matchers.*;
  *
  */
 public class CorsRegexDefaultTests extends ElasticsearchIntegrationTest {
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return ImmutableSettings.builder()
+            .put(InternalNode.HTTP_ENABLED, true)
+            .put(super.nodeSettings(nodeOrdinal)).build();
+    }
 
     @Test
     public void testCorsSettingDefaultBehaviourDoesNotReturnAnything() throws Exception {

--- a/src/test/java/org/elasticsearch/test/discovery/ClusterDiscoveryConfiguration.java
+++ b/src/test/java/org/elasticsearch/test/discovery/ClusterDiscoveryConfiguration.java
@@ -114,17 +114,10 @@ public class ClusterDiscoveryConfiguration extends SettingsSource {
         }
 
         private static int scopeId(ElasticsearchIntegrationTest.Scope scope) {
-            switch(scope) {
-                case GLOBAL:
-                    //we reserve a special base port for global clusters, as they stick around
-                    //the assumption is that no counter is needed as there's only one global cluster per jvm
-                    return 0;
-                default:
-                    //ports can be reused as suite or test clusters are never run concurrently
-                    //we don't reuse the same port immediately though but leave some time to make sure ports are freed
-                    //reserve 0 to global cluster, prevent conflicts between jvms by never going above 9
-                    return 1 + portCounter.incrementAndGet() % 9;
-            }
+            //ports can be reused as suite or test clusters are never run concurrently
+            //we don't reuse the same port immediately though but leave some time to make sure ports are freed
+            //prevent conflicts between jvms by never going above 9
+            return portCounter.incrementAndGet() % 9;
         }
 
         @Override

--- a/src/test/java/org/elasticsearch/test/rest/ElasticsearchRestTests.java
+++ b/src/test/java/org/elasticsearch/test/rest/ElasticsearchRestTests.java
@@ -30,6 +30,7 @@ import org.apache.lucene.util.TimeUnits;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.node.internal.InternalNode;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
 import org.elasticsearch.test.rest.client.RestException;
@@ -106,6 +107,13 @@ public class ElasticsearchRestTests extends ElasticsearchIntegrationTest {
         } else {
             blacklistPathMatchers = new PathMatcher[0];
         }
+    }
+    
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return ImmutableSettings.builder()
+            .put(InternalNode.HTTP_ENABLED, true)
+            .put(super.nodeSettings(nodeOrdinal)).build();
     }
 
     @ParametersFactory


### PR DESCRIPTION
This was previously attempted in #8854. I revived that branch and did
some performance testing as was suggested in the comments there.

I fixed all the errors, mostly just the rest tests, which
needed to have http enabled on the node settings (the global cluster previously had this always enabled). I also addressed the comments from that issue.

My performance tests involved running the entire test suite on my
desktop which has 6 cores, 16GB of ram, and nothing else was being
run on the box at the time. I ran each set of settings 3 times and
took the average time.

| mode | master | patch | diff |
| --- | --- | --- | --- |
| local | 409s | 417s | +2% |
| network | 368s | 380s | +3% |

This increase in average time is clearly worthwhile to pay to achieve
isolation of tests. One caveat is the way I fixed the rest tests
is still to have one cluster for the entire suite, so all the rest
tests can still potentially affect each other, but this is an
issue for another day.

There were some oddities that I noticed while running these tests
that I would like to point out, as they probably deserve some
investigation (but orthogonal to this PR):
- The total test run times are highly variable (more than a minute between the min and max)
- Running in network mode is on average actually _faster_ than local mode. How is this possible!?
