### PR TITLE
Retry if shard deletes fail due to IOExceptions

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/action/index/NodeIndexDeletedAction.java
+++ b/src/main/java/org/elasticsearch/cluster/action/index/NodeIndexDeletedAction.java
@@ -29,10 +29,12 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.env.ShardLock;
 import org.elasticsearch.index.Index;
+import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.*;
 
@@ -52,16 +54,16 @@ public class NodeIndexDeletedAction extends AbstractComponent {
     private final ThreadPool threadPool;
     private final TransportService transportService;
     private final List<Listener> listeners = new CopyOnWriteArrayList<>();
-    private final NodeEnvironment nodeEnv;
+    private final IndicesService indicesService;
 
     @Inject
-    public NodeIndexDeletedAction(Settings settings, ThreadPool threadPool, TransportService transportService, NodeEnvironment nodeEnv) {
+    public NodeIndexDeletedAction(Settings settings, ThreadPool threadPool, TransportService transportService, NodeEnvironment nodeEnv, IndicesService indicesService) {
         super(settings);
         this.threadPool = threadPool;
         this.transportService = transportService;
         transportService.registerHandler(INDEX_DELETED_ACTION_NAME, new NodeIndexDeletedTransportHandler());
         transportService.registerHandler(INDEX_STORE_DELETED_ACTION_NAME, new NodeIndexStoreDeletedTransportHandler());
-        this.nodeEnv = nodeEnv;
+        this.indicesService = indicesService;
     }
 
     public void add(Listener listener) {
@@ -120,16 +122,12 @@ public class NodeIndexDeletedAction extends AbstractComponent {
             // master. If we can't acquire the locks here immediately there might be a shard of this index still holding on to the lock
             // due to a "currently canceled recovery" or so. The shard will delete itself BEFORE the lock is released so it's guaranteed to be
             // deleted by the time we get the lock
-            final List<ShardLock> locks = nodeEnv.lockAllForIndex(new Index(index), TimeUnit.MINUTES.toMillis(30));
-            try {
-                if (nodes.localNodeMaster()) {
-                    innerNodeIndexStoreDeleted(index, nodeId);
-                } else {
-                    transportService.sendRequest(clusterState.nodes().masterNode(),
-                            INDEX_STORE_DELETED_ACTION_NAME, new NodeIndexStoreDeletedMessage(index, nodeId), EmptyTransportResponseHandler.INSTANCE_SAME);
-                }
-            } finally {
-                IOUtils.close(locks); // release them again
+            indicesService.processPendingDeletes(new Index(index), new TimeValue(30, TimeUnit.MINUTES));
+            if (nodes.localNodeMaster()) {
+                innerNodeIndexStoreDeleted(index, nodeId);
+            } else {
+                transportService.sendRequest(clusterState.nodes().masterNode(),
+                        INDEX_STORE_DELETED_ACTION_NAME, new NodeIndexStoreDeletedMessage(index, nodeId), EmptyTransportResponseHandler.INSTANCE_SAME);
             }
         } catch (LockObtainFailedException exc) {
             logger.warn("[{}] failed to lock all shards for index - timed out after 30 seconds", index);

--- a/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/src/main/java/org/elasticsearch/index/IndexService.java
@@ -440,7 +440,8 @@ public class IndexService extends AbstractIndexComponent implements IndexCompone
                     indicesServices.deleteShardStore("delete index", lock, indexSettings);
                 }
             } catch (IOException e) {
-                logger.warn("{} failed to delete shard content", e, lock.getShardId());
+                indicesServices.addPendingDelete(index(), lock.getShardId(), indexSettings);
+                logger.debug("{} failed to delete shard content - scheduled a retry", e, lock.getShardId());
             }
         }
     }

--- a/src/test/java/org/elasticsearch/indices/IndicesServiceTest.java
+++ b/src/test/java/org/elasticsearch/indices/IndicesServiceTest.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.indices;
 
+import org.apache.lucene.store.LockObtainFailedException;
 import org.elasticsearch.ElasticsearchIllegalStateException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
@@ -28,14 +29,18 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.Priority;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.gateway.GatewayMetaState;
+import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.test.ElasticsearchSingleNodeTest;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
@@ -119,5 +124,47 @@ public class IndicesServiceTest extends ElasticsearchSingleNodeTest {
         }
         assertAcked(client().admin().indices().prepareOpen("test"));
         ensureGreen("test");
+    }
+
+    public void testPendingTasks() throws IOException {
+        IndicesService indicesService = getIndicesService();
+        IndexService test = createIndex("test");
+        NodeEnvironment nodeEnc = getInstanceFromNode(NodeEnvironment.class);
+
+        assertTrue(test.hasShard(0));
+        Path[] paths = nodeEnc.shardDataPaths(new ShardId(test.index(), 0), test.getIndexSettings());
+        try {
+            indicesService.processPendingDeletes(test.index(), new TimeValue(0, TimeUnit.MILLISECONDS));
+            fail("can't get lock");
+        } catch (LockObtainFailedException ex) {
+
+        }
+        for (Path p : paths) {
+            assertTrue(Files.exists(p));
+        }
+        indicesService.addPendingDelete(test.index(), new ShardId(test.index(), 0), test.getIndexSettings());
+        assertAcked(client().admin().indices().prepareClose("test"));
+        for (Path p : paths) {
+            assertTrue(Files.exists(p));
+        }
+        assertEquals(indicesService.numPendingDeletes(test.index()), 1);
+        // shard lock released... we can now delete
+        indicesService.processPendingDeletes(test.index(), new TimeValue(0, TimeUnit.MILLISECONDS));
+        assertEquals(indicesService.numPendingDeletes(test.index()), 0);
+        for (Path p : paths) {
+            assertFalse(Files.exists(p));
+        }
+
+        if (randomBoolean()) {
+            indicesService.addPendingDelete(test.index(), new ShardId(test.index(), 0), test.getIndexSettings());
+            indicesService.addPendingDelete(test.index(), new ShardId(test.index(), 1), test.getIndexSettings());
+            indicesService.addPendingDelete(new Index("bogus"), new ShardId("bogus", 1), test.getIndexSettings());
+            assertEquals(indicesService.numPendingDeletes(test.index()), 2);
+            // shard lock released... we can now delete
+            indicesService.processPendingDeletes(test.index(), new TimeValue(0, TimeUnit.MILLISECONDS));
+            assertEquals(indicesService.numPendingDeletes(test.index()), 0);
+        }
+        assertAcked(client().admin().indices().prepareOpen("test"));
+
     }
 }

--- a/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
@@ -27,10 +27,8 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Lists;
 
-import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.store.StoreRateLimiting;
 import org.apache.lucene.util.AbstractRandomizedTest;
-import org.apache.lucene.util.Constants;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.TestUtil;
 import org.elasticsearch.ElasticsearchException;
@@ -1806,7 +1804,7 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
      */
     public void assertPathHasBeenCleared(Path path) throws Exception {
         logger.info("--> checking that [{}] has been cleared", path);
-        final List<Path> foundFiles = new ArrayList<>();
+        int count = 0;
         StringBuilder sb = new StringBuilder();
         sb.append("[");
         if (Files.exists(path)) {
@@ -1816,7 +1814,7 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
                     if (Files.isDirectory(file)) {
                         assertPathHasBeenCleared(file);
                     } else if (Files.isRegularFile(file)) {
-                        foundFiles.add(file);
+                        count++;
                         sb.append(file.toAbsolutePath().toString());
                         sb.append("\n");
                     }
@@ -1824,17 +1822,7 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
             }
         }
         sb.append("]");
-        if (Constants.WINDOWS) {
-            if (foundFiles.size() > 0) {
-                for (Path file : foundFiles) {
-                    // for now on windows we only ensure that there is at least no segments_N file left on the path
-                    // we don't have a retry mechanism in place yet.
-                    assertFalse(foundFiles.size() + " files exist that should have been cleaned:\n" + sb.toString(), file.getFileName().toString().startsWith(IndexFileNames.SEGMENTS));
-                }
-            }
-        } else {
-            assertThat(foundFiles.size() + " files exist that should have been cleaned:\n" + sb.toString(), foundFiles.size(), equalTo(0));
-        }
+        assertThat(count + " files exist that should have been cleaned:\n" + sb.toString(), count, equalTo(0));
     }
 
     protected static class NumShards {


### PR DESCRIPTION
Today if a shard deletion fails we simply ignore it and move on. On system like
windows where a virus scanner can hold on to files or any other process ie. the admins
explorer window we fail to delete shards leaving large amout of data behind. We should try
best effort to clean those shards up before we ack the delete.
