### PR TITLE
Allow primary promotion on shadow replica without failing the shard

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/routing/MutableShardRouting.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/MutableShardRouting.java
@@ -101,16 +101,12 @@ public class MutableShardRouting extends ImmutableShardRouting {
     }
 
     /**
-     * Set the shards state to <code>UNASSIGNED</code>.
-     * //TODO document the state
+     * Moves the shard from started to initializing and bumps the version
      */
-    void deassignNode() {
+    void reinitializeShard() {
+        assert state == ShardRoutingState.STARTED;
         version++;
-        assert state != ShardRoutingState.UNASSIGNED;
-
-        state = ShardRoutingState.UNASSIGNED;
-        this.currentNodeId = null;
-        this.relocatingNodeId = null;
+        state = ShardRoutingState.INITIALIZING;
     }
 
     /**

--- a/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
@@ -520,6 +520,16 @@ public class RoutingNodes implements Iterable<RoutingNode> {
         return nodesToShards.values().toArray(new RoutingNode[nodesToShards.size()]);
     }
 
+    public void reinitShadowPrimary(MutableShardRouting candidate) {
+        if (candidate.relocating()) {
+            cancelRelocation(candidate);
+        }
+        candidate.reinitializeShard();
+        inactivePrimaryCount++;
+        inactiveShardCount++;
+
+    }
+
     public final static class UnassignedShards implements Iterable<MutableShardRouting>  {
 
         private final List<MutableShardRouting> unassigned;

--- a/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -1187,13 +1187,25 @@ public class IndexShard extends AbstractIndexShardComponent {
         }
     }
 
-    protected void createNewEngine() {
+    private void createNewEngine() {
         synchronized (mutex) {
             if (state == IndexShardState.CLOSED) {
                 throw new EngineClosedException(shardId);
             }
             assert this.currentEngineReference.get() == null;
-            this.currentEngineReference.set(engineFactory.newReadWriteEngine(config));
+            this.currentEngineReference.set(newEngine());
         }
+    }
+
+    protected Engine newEngine() {
+        return engineFactory.newReadWriteEngine(config);
+    }
+
+
+    /**
+     * Returns <code>true</code> iff this shard allows primary promotion, otherwise <code>false</code>
+     */
+    public boolean allowsPrimaryPromotion() {
+        return true;
     }
 }

--- a/src/main/java/org/elasticsearch/index/shard/ShadowIndexShard.java
+++ b/src/main/java/org/elasticsearch/index/shard/ShadowIndexShard.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.index.shard;
 
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchIllegalStateException;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.Nullable;
@@ -31,6 +32,7 @@ import org.elasticsearch.index.cache.filter.ShardFilterCache;
 import org.elasticsearch.index.cache.query.ShardQueryCache;
 import org.elasticsearch.index.codec.CodecService;
 import org.elasticsearch.index.deletionpolicy.SnapshotDeletionPolicy;
+import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.engine.EngineClosedException;
 import org.elasticsearch.index.engine.EngineFactory;
 import org.elasticsearch.index.fielddata.IndexFieldDataService;
@@ -62,7 +64,7 @@ import org.elasticsearch.threadpool.ThreadPool;
  * promoted to a primary causes the shard to fail, kicking off a re-allocation
  * of the primary shard.
  */
-public class ShadowIndexShard extends IndexShard {
+public final class ShadowIndexShard extends IndexShard {
 
     private final Object mutex = new Object();
 
@@ -98,28 +100,19 @@ public class ShadowIndexShard extends IndexShard {
      */
     @Override
     public IndexShard routingEntry(ShardRouting newRouting) {
-        ShardRouting shardRouting = this.routingEntry();
-        super.routingEntry(newRouting);
-        // check for a shadow replica that now needs to be transformed into
-        // a normal primary today we simply fail it to force reallocation
-        if (shardRouting != null && shardRouting.primary() == false && // currently a replica
-                newRouting.primary() == true) {// becoming a primary
-            failShard("can't promote shadow replica to primary",
-                    new ElasticsearchIllegalStateException("can't promote shadow replica to primary"));
+        if (newRouting.primary() == true) {// becoming a primary
+            throw new ElasticsearchIllegalStateException("can't promote shard to primary");
         }
-        return this;
+        return super.routingEntry(newRouting);
     }
 
     @Override
-    protected void createNewEngine() {
-        synchronized (mutex) {
-            if (state == IndexShardState.CLOSED) {
-                throw new EngineClosedException(shardId);
-            }
-            assert this.currentEngineReference.get() == null;
-            assert this.shardRouting.primary() == false;
-            // Use the read-only engine for shadow replicas
-            this.currentEngineReference.set(engineFactory.newReadOnlyEngine(config));
-        }
+    protected Engine newEngine() {
+        assert this.shardRouting.primary() == false;
+        return engineFactory.newReadOnlyEngine(config);
+    }
+
+    public boolean allowsPrimaryPromotion() {
+        return false;
     }
 }

--- a/src/test/java/org/elasticsearch/index/IndexWithShadowReplicasTests.java
+++ b/src/test/java/org/elasticsearch/index/IndexWithShadowReplicasTests.java
@@ -32,6 +32,8 @@ import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.elasticsearch.test.InternalTestCluster;
+import org.elasticsearch.test.junit.annotations.TestLogging;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.nio.file.Path;
@@ -165,6 +167,15 @@ public class IndexWithShadowReplicasTests extends ElasticsearchIntegrationTest {
         assertTrue(gResp2.toString(), gResp2.isExists());
         assertThat(gResp1.getField("foo").getValue().toString(), equalTo("bar"));
         assertThat(gResp2.getField("foo").getValue().toString(), equalTo("bar"));
+
+        client().prepareIndex(IDX, "doc", "1").setSource("foo", "foobar").get();
+        client().prepareIndex(IDX, "doc", "2").setSource("foo", "foobar").get();
+        gResp1 = client().prepareGet(IDX, "doc", "1").setFields("foo").get();
+        gResp2 = client().prepareGet(IDX, "doc", "2").setFields("foo").get();
+        assertTrue(gResp1.isExists());
+        assertTrue(gResp2.toString(), gResp2.isExists());
+        assertThat(gResp1.getField("foo").getValue().toString(), equalTo("foobar"));
+        assertThat(gResp2.getField("foo").getValue().toString(), equalTo("foobar"));
     }
 
     @Test

--- a/src/test/java/org/elasticsearch/test/store/MockFSDirectoryService.java
+++ b/src/test/java/org/elasticsearch/test/store/MockFSDirectoryService.java
@@ -27,6 +27,7 @@ import org.apache.lucene.store.LockFactory;
 import org.apache.lucene.store.StoreRateLimiting;
 import org.apache.lucene.util.AbstractRandomizedTest;
 import org.apache.lucene.util.IOUtils;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
@@ -86,7 +87,7 @@ public class MockFSDirectoryService extends FsDirectoryService {
                                                    @IndexSettings Settings indexSettings) {
                     if (indexShard != null && shardId.equals(sid)) {
                         logger.info("Shard state before potentially flushing is {}", indexShard.state());
-                        if (validCheckIndexStates.contains(indexShard.state()) && indexShard.engine() instanceof InternalEngine) {
+                        if (validCheckIndexStates.contains(indexShard.state()) && IndexMetaData.isOnSharedFilesystem(indexSettings) == false) {
                             // When the the internal engine closes we do a rollback, which removes uncommitted segments
                             // By doing a commit flush we perform a Lucene commit, but don't clear the translog,
                             // so that even in tests where don't flush we can check the integrity of the Lucene index


### PR DESCRIPTION
Today we fail the shard if we need to upgrade a replica to a primary on shadow replicas
on shared filesystem. Yet, this commit allows promotion by re-initializing on the master preventing
reallocation of all replicas.
