### PR TITLE
Remove Triple Negative

### DIFF
--- a/docs/reference/query-dsl/filters/missing-filter.asciidoc
+++ b/docs/reference/query-dsl/filters/missing-filter.asciidoc
@@ -1,7 +1,7 @@
 [[query-dsl-missing-filter]]
 === Missing Filter
 
-Returns documents that have no non-`null` values in the original field:
+Returns documents that only have `null` values in the original field:
 
 [source,js]
 --------------------------------------------------
@@ -12,7 +12,7 @@ Returns documents that have no non-`null` values in the original field:
         }
     }
 }
---------------------------------------------------
+--------------------------------------------------n
 
 For instance, the following docs would match the above filter:
 


### PR DESCRIPTION
Double negatives are confusing, but a triple negative?!

> no non null

It takes five minutes to understand this little sentence.  Cleaned that up a bit.
