### PR TITLE
Remove redundant fs metadata ops.

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
@@ -527,7 +527,7 @@ public class MetaDataCreateIndexService extends AbstractComponent {
 
         // see if we have templates defined under config
         final Path templatesDir = environment.configFile().resolve("templates");
-        if (Files.exists(templatesDir) && Files.isDirectory(templatesDir)) {
+        if (Files.isDirectory(templatesDir)) {
             try (DirectoryStream<Path> stream = Files.newDirectoryStream(templatesDir)) {
                 for (Path templatesFile : stream) {
                     if (Files.isRegularFile(templatesFile)) {

--- a/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobContainer.java
+++ b/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobContainer.java
@@ -66,9 +66,7 @@ public class FsBlobContainer extends AbstractBlobContainer {
     @Override
     public void deleteBlob(String blobName) throws IOException {
         Path blobPath = path.resolve(blobName);
-        if (Files.exists(blobPath)) {
-            Files.delete(blobPath);
-        }
+        Files.deleteIfExists(blobPath);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/common/io/FileSystemUtils.java
+++ b/src/main/java/org/elasticsearch/common/io/FileSystemUtils.java
@@ -309,8 +309,8 @@ public final class FileSystemUtils {
             Path newFile = target.resolve(source.relativize(file));
             try {
                 Files.copy(file, newFile);
-                if ((delete) && (Files.exists(newFile))) {
-                    Files.delete(file);
+                if (delete) {
+                    Files.deleteIfExists(file);
                 }
             } catch (IOException x) {
                 // We ignore this

--- a/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -97,9 +97,7 @@ public class NodeEnvironment extends AbstractComponent implements Closeable{
         for (int possibleLockId = 0; possibleLockId < maxLocalStorageNodes; possibleLockId++) {
             for (int dirIndex = 0; dirIndex < environment.dataWithClusterFiles().length; dirIndex++) {
                 Path dir = environment.dataWithClusterFiles()[dirIndex].resolve(Paths.get(NODES_FOLDER, Integer.toString(possibleLockId)));
-                if (Files.exists(dir) == false) {
-                    Files.createDirectories(dir);
-                }
+                Files.createDirectories(dir);
                 
                 try (Directory luceneDir = FSDirectory.open(dir, NativeFSLockFactory.INSTANCE)) {
                     logger.trace("obtaining node lock on {} ...", dir.toAbsolutePath());
@@ -473,7 +471,7 @@ public class NodeEnvironment extends AbstractComponent implements Closeable{
         Set<String> indices = Sets.newHashSet();
         for (Path indicesLocation : nodeIndicesPaths) {
 
-            if (Files.exists(indicesLocation) && Files.isDirectory(indicesLocation)) {
+            if (Files.isDirectory(indicesLocation)) {
                 try (DirectoryStream<Path> stream = Files.newDirectoryStream(indicesLocation)) {
                     for (Path index : stream) {
                         if (Files.isDirectory(index)) {
@@ -505,7 +503,7 @@ public class NodeEnvironment extends AbstractComponent implements Closeable{
     private static Set<ShardId> findAllShardIds(@Nullable final String index, Path... locations) throws IOException {
         final Set<ShardId> shardIds = Sets.newHashSet();
         for (final Path location : locations) {
-            if (Files.exists(location) && Files.isDirectory(location)) {
+            if (Files.isDirectory(location)) {
                 try (DirectoryStream<Path> indexStream = Files.newDirectoryStream(location)) {
                     for (Path indexPath : indexStream) {
                         if (index == null || index.equals(indexPath.getFileName().toString())) {
@@ -520,11 +518,11 @@ public class NodeEnvironment extends AbstractComponent implements Closeable{
 
     private static Set<ShardId> findAllShardsForIndex(Path indexPath) throws IOException {
         Set<ShardId> shardIds = new HashSet<>();
-        if (Files.exists(indexPath) && Files.isDirectory(indexPath)) {
+        if (Files.isDirectory(indexPath)) {
             try (DirectoryStream<Path> stream = Files.newDirectoryStream(indexPath)) {
                 String currentIndex = indexPath.getFileName().toString();
                 for (Path shardPath : stream) {
-                    if (Files.exists(shardPath) && Files.isDirectory(shardPath)) {
+                    if (Files.isDirectory(shardPath)) {
                         Integer shardId = Ints.tryParse(shardPath.getFileName().toString());
                         if (shardId != null) {
                             ShardId id = new ShardId(currentIndex, shardId);

--- a/src/main/java/org/elasticsearch/gateway/MetaDataStateFormat.java
+++ b/src/main/java/org/elasticsearch/gateway/MetaDataStateFormat.java
@@ -232,7 +232,7 @@ public abstract class MetaDataStateFormat<T> {
         if (dataLocations != null) { // select all eligable files first
             for (Path dataLocation : dataLocations) {
                 final Path stateDir = dataLocation.resolve(STATE_DIR_NAME);
-                if (!Files.exists(stateDir) || !Files.isDirectory(stateDir)) {
+                if (!Files.isDirectory(stateDir)) {
                     continue;
                 }
                 // now, iterate over the current versions, and find latest one

--- a/src/main/java/org/elasticsearch/http/HttpServer.java
+++ b/src/main/java/org/elasticsearch/http/HttpServer.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.http;
 
 import com.google.common.collect.ImmutableMap;
+
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.inject.Inject;
@@ -33,6 +34,7 @@ import org.elasticsearch.rest.*;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -180,9 +182,11 @@ public class HttpServer extends AbstractLifecycleComponent<HttpServer> {
             channel.sendResponse(new BytesRestResponse(NOT_FOUND));
             return;
         }
-        if (!Files.isRegularFile(file)) {
+        
+        BasicFileAttributes attributes = Files.readAttributes(file, BasicFileAttributes.class);
+        if (!attributes.isRegularFile()) {
             // If it's not a dir, we send a 403
-            if (!Files.isDirectory(file)) {
+            if (!attributes.isDirectory()) {
                 channel.sendResponse(new BytesRestResponse(FORBIDDEN));
                 return;
             }

--- a/src/main/java/org/elasticsearch/plugins/PluginManager.java
+++ b/src/main/java/org/elasticsearch/plugins/PluginManager.java
@@ -237,7 +237,7 @@ public class PluginManager {
         // It could potentially be a non explicit _site plugin
         boolean potentialSitePlugin = true;
         Path binFile = extractLocation.resolve("bin");
-        if (Files.exists(binFile) && Files.isDirectory(binFile)) {
+        if (Files.isDirectory(binFile)) {
             Path toLocation = pluginHandle.binDir(environment);
             debug("Found bin, moving to " + toLocation.toAbsolutePath());
             if (Files.exists(toLocation)) {
@@ -270,7 +270,7 @@ public class PluginManager {
         }
 
         Path configFile = extractLocation.resolve("config");
-        if (Files.exists(configFile) && Files.isDirectory(configFile)) {
+        if (Files.isDirectory(configFile)) {
             Path configDestLocation = pluginHandle.configDir(environment);
             debug("Found config, moving to " + configDestLocation.toAbsolutePath());
             moveFilesWithoutOverwriting(configFile, configDestLocation, ".new");

--- a/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -387,7 +387,7 @@ public class PluginsService extends AbstractComponent {
                     List<Path> libFiles = Lists.newArrayList();
                     libFiles.addAll(Arrays.asList(files(plugin)));
                     Path libLocation = plugin.resolve("lib");
-                    if (Files.exists(libLocation) && Files.isDirectory(libLocation)) {
+                    if (Files.isDirectory(libLocation)) {
                         libFiles.addAll(Arrays.asList(files(libLocation)));
                     }
 
@@ -519,7 +519,7 @@ public class PluginsService extends AbstractComponent {
         // Let's try to find all _site plugins we did not already found
         Path pluginsFile = environment.pluginsFile();
 
-        if (!Files.exists(pluginsFile) || !Files.isDirectory(pluginsFile)) {
+        if (!Files.isDirectory(pluginsFile)) {
             return false;
         }
 

--- a/src/main/java/org/elasticsearch/watcher/FileWatcher.java
+++ b/src/main/java/org/elasticsearch/watcher/FileWatcher.java
@@ -25,6 +25,7 @@ import org.elasticsearch.common.logging.Loggers;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Arrays;
 
 /**
@@ -92,13 +93,14 @@ public class FileWatcher extends AbstractResourceWatcher<FileChangesListener> {
             exists = Files.exists(file);
             // TODO we might use the new NIO2 API to get real notification?
             if (exists) {
-                isDirectory = Files.isDirectory(file);
+                BasicFileAttributes attributes = Files.readAttributes(file, BasicFileAttributes.class);
+                isDirectory = attributes.isDirectory();
                 if (isDirectory) {
                     length = 0;
                     lastModified = 0;
                 } else {
-                    length = Files.size(file);
-                    lastModified = Files.getLastModifiedTime(file).toMillis();
+                    length = attributes.size();
+                    lastModified = attributes.lastModifiedTime().toMillis();
                 }
             } else {
                 isDirectory = false;
@@ -154,12 +156,13 @@ public class FileWatcher extends AbstractResourceWatcher<FileChangesListener> {
         private void init(boolean initial) throws IOException {
             exists = Files.exists(file);
             if (exists) {
-                isDirectory =Files.isDirectory(file);
+                BasicFileAttributes attributes = Files.readAttributes(file, BasicFileAttributes.class);
+                isDirectory = attributes.isDirectory();
                 if (isDirectory) {
                     onDirectoryCreated(initial);
                 } else {
-                    length = Files.size(file);
-                    lastModified = Files.getLastModifiedTime(file).toMillis();
+                    length = attributes.size();
+                    lastModified = attributes.lastModifiedTime().toMillis();
                     onFileCreated(initial);
                 }
             }


### PR DESCRIPTION
Some easy cleanups:
Files.exists(f) && Files.isDirectory(f) -> Files.isDirectory(f)
if (Files.exists(f)) Files.delete(f) -> Files.deleteIfExists(f)
if (!Files.exists(f)) Files.createDirectories(f) -> Files.createDirectories(f)

In a few places where successive i/o ops are done against the same file, convert
to Files.readAttributes().
