### PR TITLE
Removed deprecated script parameter names

### DIFF
--- a/docs/reference/migration/migrate_2_0.asciidoc
+++ b/docs/reference/migration/migrate_2_0.asciidoc
@@ -249,3 +249,9 @@ It is still possible to change the whole codec by using the `index.codec`
 setting. Please however note that using a non-default codec is discouraged as
 it could prevent future versions of Elasticsearch from being able to read the
 index.
+
+=== Scripts
+
+Deprecated script parameters `id`, `file`, and `scriptField` have been removed 
+from all scriptable APIs. `script_id`, `script_file` and `script` should be used 
+in their place.

--- a/src/main/java/org/elasticsearch/script/ScriptService.java
+++ b/src/main/java/org/elasticsearch/script/ScriptService.java
@@ -25,6 +25,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.RemovalListener;
 import com.google.common.cache.RemovalNotification;
 import com.google.common.collect.ImmutableMap;
+
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.ElasticsearchIllegalStateException;
 import org.elasticsearch.action.ActionListener;
@@ -133,9 +134,9 @@ public class ScriptService extends AbstractComponent {
     }
 
     public static final ParseField SCRIPT_LANG = new ParseField("lang","script_lang");
-    public static final ParseField SCRIPT_FILE = new ParseField("script_file","file");
-    public static final ParseField SCRIPT_ID = new ParseField("script_id", "id");
-    public static final ParseField SCRIPT_INLINE = new ParseField("script","scriptField");
+    public static final ParseField SCRIPT_FILE = new ParseField("script_file");
+    public static final ParseField SCRIPT_ID = new ParseField("script_id");
+    public static final ParseField SCRIPT_INLINE = new ParseField("script");
 
     public static enum ScriptType {
 
@@ -339,15 +340,6 @@ public class ScriptService extends AbstractComponent {
                 return compiled;
             } else {
                 throw new ElasticsearchIllegalArgumentException("Unable to find on disk script " + script);
-            }
-        }
-
-        if (scriptType != ScriptType.INDEXED) {
-            //For backwards compat attempt to load from disk
-            compiled = staticCache.get(script); //On disk scripts will be loaded into the staticCache by the listener
-
-            if (compiled != null) {
-                return compiled;
             }
         }
 

--- a/src/test/java/org/elasticsearch/index/query/TemplateQueryTest.java
+++ b/src/test/java/org/elasticsearch/index/query/TemplateQueryTest.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.index.query;
 
 import com.google.common.collect.Maps;
+
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.indexedscripts.delete.DeleteIndexedScriptResponse;
 import org.elasticsearch.action.indexedscripts.get.GetIndexedScriptResponse;
@@ -42,7 +43,9 @@ import java.util.Map;
 
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.*;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
@@ -210,13 +213,15 @@ public class TemplateQueryTest extends ElasticsearchIntegrationTest {
         templateParams.put("myField", "theField");
         templateParams.put("myValue", "foo");
 
-        SearchResponse searchResponse = client().prepareSearch("test").setTypes("type").setTemplateName("full-query-template").setTemplateParams(templateParams).get();
+        SearchResponse searchResponse = client().prepareSearch("test").setTypes("type").setTemplateName("full-query-template")
+                .setTemplateParams(templateParams).setTemplateType(ScriptService.ScriptType.FILE).get();
         assertHitCount(searchResponse, 4);
         // size kicks in here...
         assertThat(searchResponse.getHits().getHits().length, is(2));
 
         templateParams.put("myField", "otherField");
-        searchResponse = client().prepareSearch("test").setTypes("type").setTemplateName("full-query-template").setTemplateParams(templateParams).get();
+        searchResponse = client().prepareSearch("test").setTypes("type").setTemplateName("full-query-template")
+                .setTemplateParams(templateParams).setTemplateType(ScriptService.ScriptType.FILE).get();
         assertHitCount(searchResponse, 1);
     }
 

--- a/src/test/java/org/elasticsearch/script/OnDiskScriptTests.java
+++ b/src/test/java/org/elasticsearch/script/OnDiskScriptTests.java
@@ -57,37 +57,13 @@ public class OnDiskScriptTests extends ElasticsearchIntegrationTest {
 
         indexRandom(true,builders);
 
-        String query = "{ \"query\" : { \"match_all\": {}} , \"script_fields\" : { \"test1\" : { \"file\" : \"script1\" }, \"test2\" : { \"file\" : \"script2\", \"params\":{\"factor\":3}  }}, size:1}";
+        String query = "{ \"query\" : { \"match_all\": {}} , \"script_fields\" : { \"test1\" : { \"script_file\" : \"script1\" }, \"test2\" : { \"script_file\" : \"script2\", \"params\":{\"factor\":3}  }}, size:1}";
         SearchResponse searchResponse = client().prepareSearch().setSource(query).setIndices("test").setTypes("scriptTest").get();
         assertHitCount(searchResponse,5);
         assertTrue(searchResponse.getHits().hits().length == 1);
         SearchHit sh = searchResponse.getHits().getAt(0);
         assertThat((Integer)sh.field("test1").getValue(), equalTo(2));
         assertThat((Integer)sh.field("test2").getValue(), equalTo(6));
-
-
-    }
-
-    @Test
-    public void testFieldOnDiskBackwardCompatScript()  throws ExecutionException, InterruptedException {
-
-        List<IndexRequestBuilder> builders = new ArrayList();
-        builders.add(client().prepareIndex("test", "scriptTest", "1").setSource("{\"theField\":\"foo\"}"));
-        builders.add(client().prepareIndex("test", "scriptTest", "2").setSource("{\"theField\":\"foo 2\"}"));
-        builders.add(client().prepareIndex("test", "scriptTest", "3").setSource("{\"theField\":\"foo 3\"}"));
-        builders.add(client().prepareIndex("test", "scriptTest", "4").setSource("{\"theField\":\"foo 4\"}"));
-        builders.add(client().prepareIndex("test", "scriptTest", "5").setSource("{\"theField\":\"bar\"}"));
-
-        indexRandom(true,builders);
-
-        String query = "{ \"query\" : { \"match_all\": {}} , \"script_fields\" : { \"test1\" : { \"script\" : \"script1\" }, \"test2\" : { \"script\" : \"script2\", \"params\":{\"factor\":3}  }}, size:1}";
-        SearchResponse searchResponse = client().prepareSearch().setSource(query).setIndices("test").setTypes("scriptTest").get();
-        assertHitCount(searchResponse,5);
-        assertTrue(searchResponse.getHits().hits().length == 1);
-        SearchHit sh = searchResponse.getHits().getAt(0);
-        assertThat((Integer)sh.field("test1").getValue(), equalTo(2));
-        assertThat((Integer)sh.field("test2").getValue(), equalTo(6));
-
     }
 
 

--- a/src/test/java/org/elasticsearch/script/ScriptParameterParserTest.java
+++ b/src/test/java/org/elasticsearch/script/ScriptParameterParserTest.java
@@ -32,7 +32,12 @@ import org.elasticsearch.test.ElasticsearchTestCase;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
@@ -73,16 +78,6 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
         assertThat(paramParser.lang(), nullValue());
 
         parser = XContentHelper.createParser(new BytesArray("{ \"scriptFile\" : \"scriptValue\" }"));
-        token = parser.nextToken();
-        while (token != Token.VALUE_STRING) {
-            token = parser.nextToken();
-        }
-        paramParser = new ScriptParameterParser();
-        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser), equalTo(true));
-        assertDefaultParameterValue(paramParser, "scriptValue", ScriptType.FILE);
-        assertThat(paramParser.lang(), nullValue());
-
-        parser = XContentHelper.createParser(new BytesArray("{ \"file\" : \"scriptValue\" }"));
         token = parser.nextToken();
         while (token != Token.VALUE_STRING) {
             token = parser.nextToken();
@@ -555,14 +550,6 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
 
         config = new HashMap<>();
         config.put("scriptFile", "scriptValue");
-        paramParser = new ScriptParameterParser();
-        paramParser.parseConfig(config, true);
-        assertDefaultParameterValue(paramParser, "scriptValue", ScriptType.FILE);
-        assertThat(paramParser.lang(), nullValue());
-        assertThat(config.isEmpty(), equalTo(true));
-
-        config = new HashMap<>();
-        config.put("file", "scriptValue");
         paramParser = new ScriptParameterParser();
         paramParser.parseConfig(config, true);
         assertDefaultParameterValue(paramParser, "scriptValue", ScriptType.FILE);


### PR DESCRIPTION
This change removes the deprecated script parameter names ('file', 'id', and 'scriptField').
It also removes the ability to load file scripts using the 'script' parameter. File scripts should be loaded using the 'script_file' parameter only.
