### PR TITLE
Aggs: Fix rounding issue using `date_histogram` with `pre_zone_adjust_large_interval`

### DIFF
--- a/src/main/java/org/elasticsearch/common/rounding/TimeZoneRounding.java
+++ b/src/main/java/org/elasticsearch/common/rounding/TimeZoneRounding.java
@@ -169,8 +169,10 @@ public abstract class TimeZoneRounding extends Rounding {
         @Override
         public long nextRoundingValue(long time) {
             long currentWithoutPostZone = postTz.convertLocalToUTC(time, true);
-            long nextWithoutPostZone = durationField.add(currentWithoutPostZone, 1);
-            return postTz.convertUTCToLocal(nextWithoutPostZone);
+            // we also need to correct for preTz because rounding takes place in local time zone
+            long local = preTz.convertUTCToLocal(currentWithoutPostZone);
+            long nextLocal = durationField.add(local, 1);
+            return postTz.convertUTCToLocal(preTz.convertLocalToUTC((nextLocal), true));
         }
 
         @Override


### PR DESCRIPTION
Fixes an issue with using `date_histogram` aggregation for month intervals
in combination with `pre_zone_adjust_large_interval` reported in #8209.

Closes #8209
