### PR TITLE
Lock down `_uid` field

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/core/AbstractFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/AbstractFieldMapper.java
@@ -302,7 +302,7 @@ public abstract class AbstractFieldMapper<T> implements FieldMapper<T> {
     protected FieldDataType fieldDataType;
     protected final MultiFields multiFields;
     protected CopyTo copyTo;
-    protected final boolean writePre20Metadata;
+    protected final boolean writePre2xSettings;
 
     protected AbstractFieldMapper(Names names, float boost, FieldType fieldType, Boolean docValues, NamedAnalyzer indexAnalyzer,
                                   NamedAnalyzer searchAnalyzer, SimilarityProvider similarity,
@@ -348,7 +348,7 @@ public abstract class AbstractFieldMapper<T> implements FieldMapper<T> {
         }
         this.multiFields = multiFields;
         this.copyTo = copyTo;
-        this.writePre20Metadata = Version.indexCreated(indexSettings).before(Version.V_2_0_0);
+        this.writePre2xSettings = Version.indexCreated(indexSettings).before(Version.V_2_0_0);
     }
 
     @Nullable
@@ -683,7 +683,7 @@ public abstract class AbstractFieldMapper<T> implements FieldMapper<T> {
     protected void doXContentBody(XContentBuilder builder, boolean includeDefaults, Params params) throws IOException {
 
         builder.field("type", contentType());
-        if (writePre20Metadata && (includeDefaults || !names.name().equals(names.indexNameClean()))) {
+        if (writePre2xSettings && (includeDefaults || !names.name().equals(names.indexNameClean()))) {
             builder.field("index_name", names.indexNameClean());
         }
 

--- a/src/main/java/org/elasticsearch/index/mapper/internal/IdFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/IdFieldMapper.java
@@ -137,7 +137,6 @@ public class IdFieldMapper extends AbstractFieldMapper<String> implements Intern
     }
 
     private final String path;
-    private final boolean writePre20Settings;
 
     public IdFieldMapper(Settings indexSettings) {
         this(Defaults.NAME, Defaults.INDEX_NAME, Defaults.BOOST, idFieldType(indexSettings), null, Defaults.PATH, null, indexSettings);
@@ -148,7 +147,6 @@ public class IdFieldMapper extends AbstractFieldMapper<String> implements Intern
         super(new Names(name, indexName, indexName, name), boost, fieldType, docValues, Lucene.KEYWORD_ANALYZER,
                 Lucene.KEYWORD_ANALYZER, null, null, fieldDataSettings, indexSettings);
         this.path = path;
-        this.writePre20Settings = Version.indexCreated(indexSettings).before(Version.V_2_0_0);
     }
     
     private static FieldType idFieldType(Settings indexSettings) {
@@ -363,7 +361,7 @@ public class IdFieldMapper extends AbstractFieldMapper<String> implements Intern
         if (includeDefaults || fieldType.indexOptions() != Defaults.FIELD_TYPE.indexOptions()) {
             builder.field("index", indexTokenizeOptionToString(fieldType.indexOptions() != IndexOptions.NONE, fieldType.tokenized()));
         }
-        if (writePre20Settings && (includeDefaults || path != Defaults.PATH)) {
+        if (writePre2xSettings && (includeDefaults || path != Defaults.PATH)) {
             builder.field("path", path);
         }
 

--- a/src/main/java/org/elasticsearch/index/mapper/internal/RoutingFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/RoutingFieldMapper.java
@@ -123,7 +123,6 @@ public class RoutingFieldMapper extends AbstractFieldMapper<String> implements I
 
     private boolean required;
     private final String path;
-    private final boolean writePre20Settings;
 
     public RoutingFieldMapper(Settings indexSettings) {
         this(Defaults.FIELD_TYPE, Defaults.REQUIRED, Defaults.PATH, null, indexSettings);
@@ -134,7 +133,6 @@ public class RoutingFieldMapper extends AbstractFieldMapper<String> implements I
                 Lucene.KEYWORD_ANALYZER, null, null, fieldDataSettings, indexSettings);
         this.required = required;
         this.path = path;
-        this.writePre20Settings = Version.indexCreated(indexSettings).before(Version.V_2_0_0);
     }
 
     @Override
@@ -238,7 +236,7 @@ public class RoutingFieldMapper extends AbstractFieldMapper<String> implements I
         if (includeDefaults || required != Defaults.REQUIRED) {
             builder.field("required", required);
         }
-        if (writePre20Settings && (includeDefaults || path != Defaults.PATH)) {
+        if (writePre2xSettings && (includeDefaults || path != Defaults.PATH)) {
             builder.field("path", path);
         }
         builder.endObject();

--- a/src/test/java/org/elasticsearch/search/sort/SimpleSortTests.java
+++ b/src/test/java/org/elasticsearch/search/sort/SimpleSortTests.java
@@ -1561,8 +1561,7 @@ public class SimpleSortTests extends ElasticsearchIntegrationTest {
         final boolean idDocValues = maybeDocValues();
         final boolean timestampDocValues = maybeDocValues();
         assertAcked(prepareCreate("test")
-            .addMapping("typ", XContentFactory.jsonBuilder().startObject().startObject("typ")
-                        .startObject("_uid").startObject("fielddata").field("format", maybeDocValues() ? "doc_values" : null).endObject().endObject()
+            .addMapping("type", XContentFactory.jsonBuilder().startObject().startObject("type")
                         .startObject("_id").field("index", !idDocValues || randomBoolean() ? "not_analyzed" : "no").startObject("fielddata").field("format", idDocValues ? "doc_values" : null).endObject().endObject()
                         .startObject("_timestamp").field("enabled", true).field("store", true).field("index", !timestampDocValues || randomBoolean() ? "not_analyzed" : "no").startObject("fielddata").field("format", timestampDocValues ? "doc_values" : null).endObject().endObject()
                         .endObject().endObject()));
@@ -1570,7 +1569,7 @@ public class SimpleSortTests extends ElasticsearchIntegrationTest {
         final int numDocs = randomIntBetween(10, 20);
         IndexRequestBuilder[] indexReqs = new IndexRequestBuilder[numDocs];
         for (int i = 0; i < numDocs; ++i) {
-            indexReqs[i] = client().prepareIndex("test", "typ", Integer.toString(i)).setTimestamp(Integer.toString(randomInt(1000))).setSource();
+            indexReqs[i] = client().prepareIndex("test", "type", Integer.toString(i)).setTimestamp(Integer.toString(randomInt(1000))).setSource();
         }
         indexRandom(true, indexReqs);
 


### PR DESCRIPTION
Also, cleanup writePre20Settings so it is shared across all field mappers.

see #8143
