### PR TITLE
Fix logging a RoutingNode object, log an object with a good .toString instead

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/routing/RoutingNode.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/RoutingNode.java
@@ -175,6 +175,22 @@ public class RoutingNode implements Iterable<MutableShardRouting> {
         return sb.toString();
     }
 
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("routingNode ([");
+        sb.append(node.getName());
+        sb.append("][");
+        sb.append(node.getId());
+        sb.append("][");
+        sb.append(node.getHostName());
+        sb.append("][");
+        sb.append(node.getHostAddress());
+        sb.append("], [");
+        sb.append(shards.size());
+        sb.append(" assigned shards])");
+        return sb.toString();
+    }
+
     public MutableShardRouting get(int i) {
         return shards.get(i) ;
     }


### PR DESCRIPTION
Previously this would log:

```
[2015-02-24 11:13:45,105][TRACE][cluster.routing.allocation.allocator] [Poltergeist] Try moving shard [[test][2], node[HFn4dJ7fQAyfSAB8BquaSQ], [R], s[STARTED]] from [org.elasticsearch.cluster.routing.RoutingNode@6df2c498]
```

DiscoveryNode has an actual `toString()` implementation, so log it instead
