### PR TITLE
Add support for `minimum_should_match` to `simple_query_string`

### DIFF
--- a/docs/reference/query-dsl/queries/simple-query-string-query.asciidoc
+++ b/docs/reference/query-dsl/queries/simple-query-string-query.asciidoc
@@ -49,6 +49,11 @@ Defaults to `ROOT`.
 
 |`lenient` | If set to `true` will cause format based failures
 (like providing text to a numeric field) to be ignored.
+
+|`minimum_should_match` | The minimum number of clauses that must match for a
+ document to be returned. See the
+ <<query-dsl-minimum-should-match,`minimum_should_match`>> documentation for the
+ full list of options.
 |=======================================================================
 
 [float]

--- a/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
@@ -36,6 +36,7 @@ public class SimpleQueryStringBuilder extends BaseQueryBuilder {
     private Operator operator;
     private final String queryText;
     private String queryName;
+    private String minimumShouldMatch;
     private int flags = -1;
     private Boolean lowercaseExpandedTerms;
     private Boolean lenient;
@@ -134,6 +135,11 @@ public class SimpleQueryStringBuilder extends BaseQueryBuilder {
         return this;
     }
 
+    public SimpleQueryStringBuilder minimumShouldMatch(String minimumShouldMatch) {
+        this.minimumShouldMatch = minimumShouldMatch;
+        return this;
+    }
+
     @Override
     public void doXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(SimpleQueryStringParser.NAME);
@@ -184,6 +190,10 @@ public class SimpleQueryStringBuilder extends BaseQueryBuilder {
 
         if (queryName != null) {
             builder.field("_name", queryName);
+        }
+
+        if (minimumShouldMatch != null) {
+            builder.field("minimum_should_match", minimumShouldMatch);
         }
 
         builder.endObject();

--- a/src/main/java/org/elasticsearch/index/query/SimpleQueryStringParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SimpleQueryStringParser.java
@@ -21,9 +21,11 @@ package org.elasticsearch.index.query;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.LocaleUtils;
@@ -89,6 +91,7 @@ public class SimpleQueryStringParser implements QueryParser {
         String queryBody = null;
         String queryName = null;
         String field = null;
+        String minimumShouldMatch = null;
         Map<String, Float> fieldsAndWeights = null;
         BooleanClause.Occur defaultOperator = null;
         Analyzer analyzer = null;
@@ -182,6 +185,8 @@ public class SimpleQueryStringParser implements QueryParser {
                     sqsSettings.analyzeWildcard(parser.booleanValue());
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
+                } else if ("minimum_should_match".equals(currentFieldName)) {
+                    minimumShouldMatch = parser.textOrNull();
                 } else {
                     throw new QueryParsingException(parseContext.index(), "[" + NAME + "] unsupported field [" + parser.currentName() + "]");
                 }
@@ -220,6 +225,10 @@ public class SimpleQueryStringParser implements QueryParser {
         Query query = sqp.parse(queryBody);
         if (queryName != null) {
             parseContext.addNamedQuery(queryName, query);
+        }
+
+        if (minimumShouldMatch != null && query instanceof BooleanQuery) {
+            Queries.applyMinimumShouldMatch((BooleanQuery) query, minimumShouldMatch);
         }
         return query;
     }


### PR DESCRIPTION
This behaves similar to the way that `minimum_should_match` works for
the `match` query (in fact it is implemented in the exact same way)

Fixes #6449
