### PR TITLE
Add pending tasks count to cluster health

### DIFF
--- a/docs/reference/cat/health.asciidoc
+++ b/docs/reference/cat/health.asciidoc
@@ -10,8 +10,8 @@ timestamping.
 % curl 192.168.56.10:9200/_cat/health
 1384308967 18:16:07 foo green 3 3 3 3 0 0 0
 % curl '192.168.56.10:9200/_cat/health?v&ts=0'
-cluster status nodeTotal nodeData shards pri relo init unassign
-foo     green          3        3      3   3    0    0        0
+cluster status nodeTotal nodeData shards pri relo init unassign tasks
+foo     green          3        3      3   3    0    0        0     0
 --------------------------------------------------
 
 A common use of this command is to verify the health is consistent
@@ -21,11 +21,11 @@ across nodes:
 --------------------------------------------------
 % pssh -i -h list.of.cluster.hosts curl -s localhost:9200/_cat/health
 [1] 20:20:52 [SUCCESS] es3.vm
-1384309218 18:20:18 foo green 3 3 3 3 0 0 0
+1384309218 18:20:18 foo green 3 3 3 3 0 0 0 0
 [2] 20:20:52 [SUCCESS] es1.vm
-1384309218 18:20:18 foo green 3 3 3 3 0 0 0
+1384309218 18:20:18 foo green 3 3 3 3 0 0 0 0
 [3] 20:20:52 [SUCCESS] es2.vm
-1384309218 18:20:18 foo green 3 3 3 3 0 0 0
+1384309218 18:20:18 foo green 3 3 3 3 0 0 0 0
 --------------------------------------------------
 
 A less obvious use is to track recovery of a large cluster over
@@ -36,9 +36,9 @@ to track its progress is by using this command in a delayed loop:
 [source,shell]
 --------------------------------------------------
 % while true; do curl 192.168.56.10:9200/_cat/health; sleep 120; done
-1384309446 18:24:06 foo red 3 3 20 20 0 0 1812
-1384309566 18:26:06 foo yellow 3 3 950 916 0 12 870
-1384309686 18:28:06 foo yellow 3 3 1328 916 0 12 492
+1384309446 18:24:06 foo red 3 3 20 20 0 0 1812 0
+1384309566 18:26:06 foo yellow 3 3 950 916 0 12 870 0
+1384309686 18:28:06 foo yellow 3 3 1328 916 0 12 492 0
 1384309806 18:30:06 foo green 3 3 1832 916 4 0 0
 ^C
 --------------------------------------------------

--- a/docs/reference/cluster/health.asciidoc
+++ b/docs/reference/cluster/health.asciidoc
@@ -17,9 +17,12 @@ $ curl -XGET 'http://localhost:9200/_cluster/health?pretty=true'
   "active_shards" : 10,                                                                      
   "relocating_shards" : 0,                                                                   
   "initializing_shards" : 0,                                                                 
-  "unassigned_shards" : 0                                                                    
+  "unassigned_shards" : 0,
+  "number_of_pending_tasks" : 0
 }
 --------------------------------------------------
+
+coming[1.5.0, number of pending tasks was added in 1.5.0]
 
 The API can also be executed against one or more indices to get just the
 specified indices health:

--- a/rest-api-spec/test/cat.health/10_basic.yaml
+++ b/rest-api-spec/test/cat.health/10_basic.yaml
@@ -1,0 +1,48 @@
+---
+"Help":
+  - do:
+      cat.health:
+        help: true
+
+  - match:
+      $body: |
+               /^  epoch      .+ \n
+                   timestamp  .+ \n
+                   cluster    .+ \n
+                   status     .+ \n
+                   node.total .+ \n
+                   node.data  .+ \n
+                   shards     .+ \n
+                   pri        .+ \n
+                   relo       .+ \n
+                   init       .+ \n
+                   unassign   .+ \n
+                   tasks      .+ \n
+
+               $/
+
+
+---
+"Empty cluster":
+
+  - do:
+      cat.health: {}
+
+  - match:
+      $body: |
+            /^
+              ( \d+            \s+ # epoch
+                \d\d:\d\d:\d\d \s+ # timestamp
+                \S+            \s+ # cluster
+                \w+            \s+ # status
+                \d+            \s+ # node.total
+                \d+            \s+ # node.data
+                \d+            \s+ # shards
+                \d+            \s+ # pri
+                \d+            \s+ # relo
+                \d+            \s+ # init
+                \d+            \s+ # unassign
+                \d+            \s+ # tasks
+                \n
+              )+
+            $/

--- a/rest-api-spec/test/cat.health/10_basic.yaml
+++ b/rest-api-spec/test/cat.health/10_basic.yaml
@@ -6,18 +6,18 @@
 
   - match:
       $body: |
-               /^  epoch      .+ \n
-                   timestamp  .+ \n
-                   cluster    .+ \n
-                   status     .+ \n
-                   node.total .+ \n
-                   node.data  .+ \n
-                   shards     .+ \n
-                   pri        .+ \n
-                   relo       .+ \n
-                   init       .+ \n
-                   unassign   .+ \n
-                   tasks      .+ \n
+               /^  epoch         .+ \n
+                   timestamp     .+ \n
+                   cluster       .+ \n
+                   status        .+ \n
+                   node.total    .+ \n
+                   node.data     .+ \n
+                   shards        .+ \n
+                   pri           .+ \n
+                   relo          .+ \n
+                   init          .+ \n
+                   unassign      .+ \n
+                   pending_tasks .+ \n
 
                $/
 
@@ -42,7 +42,7 @@
                 \d+            \s+ # relo
                 \d+            \s+ # init
                 \d+            \s+ # unassign
-                \d+            \s+ # tasks
+                \d+            \s+ # pending_tasks
                 \n
               )+
             $/

--- a/rest-api-spec/test/cluster.health/10_basic.yaml
+++ b/rest-api-spec/test/cluster.health/10_basic.yaml
@@ -1,0 +1,57 @@
+---
+"cluster health basic test":
+  - do:
+      cluster.health: {}
+
+  - is_true:   cluster_name
+  - is_false:  timed_out
+  - gte:       { number_of_nodes:         1 }
+  - gte:       { number_of_data_nodes:    1 }
+  - match:     { active_primary_shards:   0 }
+  - match:     { active_shards:           0 }
+  - match:     { relocating_shards:       0 }
+  - match:     { initializing_shards:     0 }
+  - match:     { unassigned_shards:       0 }
+  - gte:       { number_of_pending_tasks: 0 }
+
+---
+"cluster health basic test, one index":
+  - do:
+      indices.create:
+        index: test_index
+  - do:
+      cluster.health:
+        wait_for_status: green
+
+  - is_true:   cluster_name
+  - is_false:  timed_out
+  - gte:       { number_of_nodes:         1 }
+  - gte:       { number_of_data_nodes:    1 }
+  - gt:        { active_primary_shards:   0 }
+  - gt:        { active_shards:           0 }
+  - gte:       { relocating_shards:       0 }
+  - match:     { initializing_shards:     0 }
+  - match:     { unassigned_shards:       0 }
+  - gte:       { number_of_pending_tasks: 0 }
+
+---
+"cluster health levels":
+  - do:
+      indices.create:
+        index: test_index
+  - do:
+      cluster.health:
+        wait_for_status: green
+        level: indices
+
+  - is_true: indices
+  - is_false: indices.test_index.shards
+
+  - do:
+        cluster.health:
+          level: shards
+
+  - is_true: indices
+  - is_true: indices.test_index.shards
+
+

--- a/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterIndexHealth.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterIndexHealth.java
@@ -204,14 +204,7 @@ public class ClusterIndexHealth implements Iterable<ClusterShardHealth>, Streama
             ClusterShardHealth shardHealth = readClusterShardHealth(in);
             shards.put(shardHealth.getId(), shardHealth);
         }
-        size = in.readVInt();
-        if (size == 0) {
-            validationFailures = ImmutableList.of();
-        } else {
-            for (int i = 0; i < size; i++) {
-                validationFailures.add(in.readString());
-            }
-        }
+        validationFailures = ImmutableList.copyOf(in.readStringArray());
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/cluster/ClusterService.java
+++ b/src/main/java/org/elasticsearch/cluster/ClusterService.java
@@ -113,4 +113,9 @@ public interface ClusterService extends LifecycleComponent<ClusterService> {
      */
     List<PendingClusterTask> pendingTasks();
 
+    /**
+     * Returns the number of currently pending tasks.
+     */
+    int numberOfPendingTasks();
+
 }

--- a/src/main/java/org/elasticsearch/cluster/service/InternalClusterService.java
+++ b/src/main/java/org/elasticsearch/cluster/service/InternalClusterService.java
@@ -310,6 +310,12 @@ public class InternalClusterService extends AbstractLifecycleComponent<ClusterSe
         return pendingClusterTasks;
     }
 
+    @Override
+    public int numberOfPendingTasks() {
+        return updateTasksExecutor.getNumberOfPendingTasks();
+    }
+
+
     static abstract class TimedPrioritizedRunnable extends PrioritizedRunnable {
         private final long creationTime;
         protected final String source;

--- a/src/main/java/org/elasticsearch/common/util/concurrent/PrioritizedEsThreadPoolExecutor.java
+++ b/src/main/java/org/elasticsearch/common/util/concurrent/PrioritizedEsThreadPoolExecutor.java
@@ -50,6 +50,12 @@ public class PrioritizedEsThreadPoolExecutor extends EsThreadPoolExecutor {
         return pending.toArray(new Pending[pending.size()]);
     }
 
+    public int getNumberOfPendingTasks() {
+        int size = current.size();
+        size += getQueue().size();
+        return size;
+    }
+
     private void addPending(List<Runnable> runnables, List<Pending> pending, boolean executing) {
         for (Runnable runnable : runnables) {
             if (runnable instanceof TieBreakingPrioritizedRunnable) {

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestHealthAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestHealthAction.java
@@ -79,7 +79,7 @@ public class RestHealthAction extends AbstractCatAction {
         t.addCell("relo", "alias:r,shards.relocating,shardsRelocating;text-align:right;desc:number of relocating nodes");
         t.addCell("init", "alias:i,shards.initializing,shardsInitializing;text-align:right;desc:number of initializing nodes");
         t.addCell("unassign", "alias:u,shards.unassigned,shardsUnassigned;text-align:right;desc:number of unassigned shards");
-        t.addCell("tasks", "alias:tsk,tasks,pendingTasks;text-align:right;desc:number of pending tasks");
+        t.addCell("pending_tasks", "alias:pt,pendingTasks;text-align:right;desc:number of pending tasks");
         t.endHeaders();
 
         return t;

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestHealthAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestHealthAction.java
@@ -25,7 +25,10 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Table;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.rest.*;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.RestResponse;
 import org.elasticsearch.rest.action.support.RestResponseListener;
 import org.elasticsearch.rest.action.support.RestTable;
 import org.joda.time.format.DateTimeFormat;
@@ -76,6 +79,7 @@ public class RestHealthAction extends AbstractCatAction {
         t.addCell("relo", "alias:r,shards.relocating,shardsRelocating;text-align:right;desc:number of relocating nodes");
         t.addCell("init", "alias:i,shards.initializing,shardsInitializing;text-align:right;desc:number of initializing nodes");
         t.addCell("unassign", "alias:u,shards.unassigned,shardsUnassigned;text-align:right;desc:number of unassigned shards");
+        t.addCell("tasks", "alias:tsk,tasks,pendingTasks;text-align:right;desc:number of pending tasks");
         t.endHeaders();
 
         return t;
@@ -98,6 +102,7 @@ public class RestHealthAction extends AbstractCatAction {
         t.addCell(health.getRelocatingShards());
         t.addCell(health.getInitializingShards());
         t.addCell(health.getUnassignedShards());
+        t.addCell(health.getNumberOfPendingTasks());
         t.endRow();
         return t;
     }

--- a/src/test/java/org/elasticsearch/test/cluster/NoopClusterService.java
+++ b/src/test/java/org/elasticsearch/test/cluster/NoopClusterService.java
@@ -132,6 +132,11 @@ public class NoopClusterService implements ClusterService {
     }
 
     @Override
+    public int numberOfPendingTasks() {
+        return 0;
+    }
+
+    @Override
     public Lifecycle.State lifecycleState() {
         return null;
     }


### PR DESCRIPTION
The number of current pending tasks is useful to detect and overloaded master. This commit adds it to the cluster health API. The complete list can be retrieved from the dedicated pending tasks API.

It also adds rest tests for the cluster health variants.
