### PR TITLE
Lock down `_routing` field

### DIFF
--- a/docs/reference/migration/migrate_2_0.asciidoc
+++ b/docs/reference/migration/migrate_2_0.asciidoc
@@ -254,6 +254,7 @@ to provide special features.  They now have limited configuration options.
 * `_id` configuration can no longer be changed.  If you need to sort, use `_uid` instead.
 * `_type` configuration can no longer be changed.
 * `_index` configuration is limited to enabling the field.
+* `_routing` configuration is limited to requiring the field.
 
 === Codecs
 

--- a/src/main/java/org/elasticsearch/index/mapper/internal/RoutingFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/RoutingFieldMapper.java
@@ -103,7 +103,9 @@ public class RoutingFieldMapper extends AbstractFieldMapper<String> implements I
         @Override
         public Mapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
             RoutingFieldMapper.Builder builder = routing();
-            parseField(builder, builder.name, node, parserContext);
+            if (parserContext.indexVersionCreated().before(Version.V_2_0_0)) {
+                parseField(builder, builder.name, node, parserContext);
+            }
             for (Iterator<Map.Entry<String, Object>> iterator = node.entrySet().iterator(); iterator.hasNext();) {
                 Map.Entry<String, Object> entry = iterator.next();
                 String fieldName = Strings.toUnderscoreCase(entry.getKey());
@@ -227,10 +229,10 @@ public class RoutingFieldMapper extends AbstractFieldMapper<String> implements I
             return builder;
         }
         builder.startObject(CONTENT_TYPE);
-        if (includeDefaults || indexed != indexedDefault) {
+        if (writePre2xSettings && (includeDefaults || indexed != indexedDefault)) {
             builder.field("index", indexTokenizeOptionToString(indexed, fieldType.tokenized()));
         }
-        if (includeDefaults || fieldType.stored() != Defaults.FIELD_TYPE.stored()) {
+        if (writePre2xSettings && (includeDefaults || fieldType.stored() != Defaults.FIELD_TYPE.stored())) {
             builder.field("store", fieldType.stored());
         }
         if (includeDefaults || required != Defaults.REQUIRED) {

--- a/src/test/java/org/elasticsearch/get/GetActionTests.java
+++ b/src/test/java/org/elasticsearch/get/GetActionTests.java
@@ -1072,15 +1072,19 @@ public class GetActionTests extends ElasticsearchIntegrationTest {
     @Test
     public void testUngeneratedFieldsNotPartOfSourceUnstored() throws IOException {
         indexSingleDocumentWithUngeneratedFieldsThatAreNeverPartOf_source(false, randomBoolean());
-        String[] fieldsList = {"_timestamp", "_size", "_routing"};
+        String[] fieldsList = {"_timestamp", "_size"};
+        String[] alwaysStoredFieldsList = {"_routing"};
         // before refresh - document is only in translog
         assertGetFieldsAlwaysNull(indexOrAlias(), "doc", "1", fieldsList, "1");
+        assertGetFieldsAlwaysWorks(indexOrAlias(), "doc", "1", alwaysStoredFieldsList, "1");
         refresh();
         //after refresh - document is in translog and also indexed
         assertGetFieldsAlwaysNull(indexOrAlias(), "doc", "1", fieldsList, "1");
+        assertGetFieldsAlwaysWorks(indexOrAlias(), "doc", "1", alwaysStoredFieldsList, "1");
         flush();
         //after flush - document is in not anymore translog - only indexed
         assertGetFieldsAlwaysNull(indexOrAlias(), "doc", "1", fieldsList, "1");
+        assertGetFieldsAlwaysWorks(indexOrAlias(), "doc", "1", alwaysStoredFieldsList, "1");
     }
 
     @Test
@@ -1110,9 +1114,6 @@ public class GetActionTests extends ElasticsearchIntegrationTest {
                 "      \"_timestamp\": {\n" +
                 "        \"store\": \"" + storedString + "\",\n" +
                 "        \"enabled\": true\n" +
-                "      },\n" +
-                "      \"_routing\": {\n" +
-                "        \"store\": \"" + storedString + "\"\n" +
                 "      },\n" +
                 "      \"_size\": {\n" +
                 "        \"store\": \"" + storedString + "\",\n" +

--- a/src/test/java/org/elasticsearch/index/mapper/routing/RoutingTypeMapperTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/routing/RoutingTypeMapperTests.java
@@ -20,6 +20,10 @@
 package org.elasticsearch.index.mapper.routing;
 
 import org.apache.lucene.index.IndexOptions;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
@@ -56,24 +60,26 @@ public class RoutingTypeMapperTests extends ElasticsearchSingleNodeTest {
     }
 
     @Test
-    public void testSetValues() throws Exception {
+    public void testFieldTypeSettingsBackcompat() throws Exception {
         String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
                 .startObject("_routing")
                 .field("store", "no")
                 .field("index", "no")
                 .endObject()
                 .endObject().endObject().string();
-        DocumentMapper docMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
+        Settings indexSettings = ImmutableSettings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.V_1_4_2.id).build();
+        DocumentMapper docMapper = createIndex("test", indexSettings).mapperService().documentMapperParser().parse(mapping);
         assertThat(docMapper.routingFieldMapper().fieldType().stored(), equalTo(false));
         assertEquals(IndexOptions.NONE, docMapper.routingFieldMapper().fieldType().indexOptions());
     }
 
     @Test
-    public void testThatSerializationWorksCorrectlyForIndexField() throws Exception {
+    public void testFieldTypeSettingsSerializationBackcompat() throws Exception {
         String enabledMapping = XContentFactory.jsonBuilder().startObject().startObject("type")
                 .startObject("_routing").field("store", "no").field("index", "no").endObject()
                 .endObject().endObject().string();
-        DocumentMapper enabledMapper = createIndex("test").mapperService().documentMapperParser().parse(enabledMapping);
+        Settings indexSettings = ImmutableSettings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.V_1_4_2.id).build();
+        DocumentMapper enabledMapper = createIndex("test", indexSettings).mapperService().documentMapperParser().parse(enabledMapping);
 
         XContentBuilder builder = JsonXContent.contentBuilder().startObject();
         enabledMapper.routingFieldMapper().toXContent(builder, ToXContent.EMPTY_PARAMS).endObject();


### PR DESCRIPTION
`required` is now the only changeable settings (on indexes created after 1.x).

see #8143
