### PR TITLE
[ENGINE] Upgrade 3.x segments on engine startup

### DIFF
--- a/src/test/java/org/elasticsearch/common/lucene/LuceneTest.java
+++ b/src/test/java/org/elasticsearch/common/lucene/LuceneTest.java
@@ -24,12 +24,18 @@ import org.apache.lucene.document.TextField;
 import org.apache.lucene.index.*;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.MockDirectoryWrapper;
+import org.apache.lucene.util.TestUtil;
 import org.apache.lucene.util.Version;
+import org.elasticsearch.index.engine.InternalEngine;
+import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.test.ElasticsearchLuceneTestCase;
 import org.junit.Test;
 
+import java.io.File;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -203,5 +209,40 @@ public class LuceneTest extends ElasticsearchLuceneTestCase {
         writer.close();
         dir.close();
 
+    }
+
+    public void testNeedsUpgrading() throws URISyntaxException, IOException {
+        OLD_FORMAT_IMPERSONATION_IS_ACTIVE = false;
+        File indexDir = createTempDir();
+        File backwardsIndex = new File(getClass().getResource("/org/elasticsearch/bwcompat/index-0.20.6.zip").toURI());
+        TestUtil.unzip(backwardsIndex, indexDir);
+        File luceneIndex = new File(indexDir, "data/bwc_index_0.20.6/nodes/0/indices/test/0/index");
+        try (Directory dir = newFSDirectory(luceneIndex)) {
+            SegmentInfos before = Lucene.readSegmentInfos(dir);
+            assertTrue(before.getUserData().containsKey(Translog.TRANSLOG_ID_KEY));
+            String key = before.getUserData().get(Translog.TRANSLOG_ID_KEY);
+            assertNotNull(key);
+
+            for (int i = 0; i < 2; i++) {
+                assertTrue(Lucene.indexNeeds3xUpgrading(dir));
+            }
+
+            for (int i = 0; i < 2; i++) {
+                boolean upgraded = Lucene.upgradeLucene3xSegmentsMetadata(dir);
+                if (i == 0) {
+                    assertTrue(upgraded);
+                } else {
+                    assertFalse(upgraded);
+                }
+            }
+
+            for (int i = 0; i < 2; i++) {
+                assertFalse(Lucene.indexNeeds3xUpgrading(dir));
+            }
+
+            SegmentInfos after = Lucene.readSegmentInfos(dir);
+            assertEquals(after.getUserData(), before.getUserData());
+            assertEquals(key, after.getUserData().get(Translog.TRANSLOG_ID_KEY));
+        }
     }
 }


### PR DESCRIPTION
Upgrading 3.x segments have been proven to be error prone especially when it get's to
concurrency. Bugs like LUCENE-6287 cause index corrupting when segmetns are upgraded
concurrently to a merge. To play safe this commit upgrades pending segments without
merging etc. before the engine gets started up.
