### PR TITLE
Unify RecoveryState management to IndexShard and clean up semantics

### DIFF
--- a/src/main/java/org/elasticsearch/index/gateway/IndexShardGatewayService.java
+++ b/src/main/java/org/elasticsearch/index/gateway/IndexShardGatewayService.java
@@ -98,15 +98,12 @@ public class IndexShardGatewayService extends AbstractIndexShardComponent implem
             return;
         }
 
-        final RecoveryState recoveryState = indexShard.recoveryState();
-
         threadPool.generic().execute(new Runnable() {
             @Override
             public void run() {
-                recoveryState.getTimer().startTime(System.currentTimeMillis());
-                recoveryState.setStage(RecoveryState.Stage.INIT);
 
                 try {
+                    final RecoveryState recoveryState = indexShard.recoveryState();
                     if (indexShard.routingEntry().restoreSource() != null) {
                         logger.debug("restoring from {} ...", indexShard.routingEntry().restoreSource());
                         snapshotService.restore(recoveryState);
@@ -122,8 +119,6 @@ public class IndexShardGatewayService extends AbstractIndexShardComponent implem
                     // 3) Master will mark shard as started and this will be processed locally.
                     IndexShardState shardState = indexShard.state();
                     assert shardState == IndexShardState.POST_RECOVERY || shardState == IndexShardState.STARTED : "recovery process didn't call post_recovery. shardState [" + shardState + "]";
-
-                    recoveryState.setStage(RecoveryState.Stage.DONE);
 
                     if (logger.isTraceEnabled()) {
                         StringBuilder sb = new StringBuilder();

--- a/src/main/java/org/elasticsearch/index/gateway/IndexShardGatewayService.java
+++ b/src/main/java/org/elasticsearch/index/gateway/IndexShardGatewayService.java
@@ -115,17 +115,13 @@ public class IndexShardGatewayService extends AbstractIndexShardComponent implem
                         shardGateway.recover(indexShouldExists, recoveryState);
                     }
 
-                    // start the shard if the gateway has not started it already. Note that if the gateway
-                    // moved shard to POST_RECOVERY, it may have been started as well if:
+                    // Check that the gateway have set the shard to POST_RECOVERY. Note that if a shard
+                    // is in POST_RECOVERY, it may have been started as well if:
                     // 1) master sent a new cluster state indicating shard is initializing
                     // 2) IndicesClusterStateService#applyInitializingShard will send a shard started event
                     // 3) Master will mark shard as started and this will be processed locally.
                     IndexShardState shardState = indexShard.state();
-                    if (shardState != IndexShardState.POST_RECOVERY && shardState != IndexShardState.STARTED) {
-                        indexShard.postRecovery("post recovery from gateway");
-                    }
-                    // refresh the shard
-                    indexShard.refresh("post_gateway");
+                    assert shardState == IndexShardState.POST_RECOVERY || shardState == IndexShardState.STARTED : "recovery process didn't call post_recovery. shardState [" + shardState + "]";
 
                     recoveryState.setStage(RecoveryState.Stage.DONE);
 

--- a/src/main/java/org/elasticsearch/index/gateway/none/NoneIndexShardGateway.java
+++ b/src/main/java/org/elasticsearch/index/gateway/none/NoneIndexShardGateway.java
@@ -53,7 +53,7 @@ public class NoneIndexShardGateway extends AbstractIndexShardComponent implement
 
     @Override
     public void recover(boolean indexShouldExists, RecoveryState recoveryState) throws IndexShardGatewayRecoveryException {
-        recoveryState.getIndex().startTime(System.currentTimeMillis());
+        indexShard.prepareForStoreRecovery();
         // in the none case, we simply start the shard
         // clean the store, there should be nothing there...
         indexShard.store().incRef();
@@ -65,12 +65,8 @@ public class NoneIndexShardGateway extends AbstractIndexShardComponent implement
         } finally {
             indexShard.store().decRef();
         }
-        // TODO: fold all stages and timing to index shard.
-        recoveryState.getIndex().stopTime(System.currentTimeMillis());
-        indexShard.performRecoveryPrepareForTranslog();
-        recoveryState.getTranslog().startTime(System.currentTimeMillis());
-        indexShard.performRecoveryFinalization(false);
-        recoveryState.getTranslog().time(System.currentTimeMillis() - recoveryState.getTranslog().startTime());
+        indexShard.prepareForTranslogRecovery();
+        indexShard.finalizeRecovery(false);
         indexShard.postRecovery("post recovery from gateway");
     }
 

--- a/src/main/java/org/elasticsearch/index/gateway/none/NoneIndexShardGateway.java
+++ b/src/main/java/org/elasticsearch/index/gateway/none/NoneIndexShardGateway.java
@@ -65,11 +65,13 @@ public class NoneIndexShardGateway extends AbstractIndexShardComponent implement
         } finally {
             indexShard.store().decRef();
         }
+        // TODO: fold all stages and timing to index shard.
+        recoveryState.getIndex().stopTime(System.currentTimeMillis());
+        indexShard.performRecoveryPrepareForTranslog();
+        recoveryState.getTranslog().startTime(System.currentTimeMillis());
+        indexShard.performRecoveryFinalization(false);
+        recoveryState.getTranslog().time(System.currentTimeMillis() - recoveryState.getTranslog().startTime());
         indexShard.postRecovery("post recovery from gateway");
-        long time = System.currentTimeMillis();
-        recoveryState.getIndex().stopTime(time);
-        recoveryState.getTranslog().startTime(time);
-        recoveryState.getTranslog().time(0);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/gateway/none/NoneIndexShardGateway.java
+++ b/src/main/java/org/elasticsearch/index/gateway/none/NoneIndexShardGateway.java
@@ -53,7 +53,7 @@ public class NoneIndexShardGateway extends AbstractIndexShardComponent implement
 
     @Override
     public void recover(boolean indexShouldExists, RecoveryState recoveryState) throws IndexShardGatewayRecoveryException {
-        indexShard.prepareForStoreRecovery();
+        indexShard.prepareForIndexRecovery();
         // in the none case, we simply start the shard
         // clean the store, there should be nothing there...
         indexShard.store().incRef();
@@ -66,7 +66,7 @@ public class NoneIndexShardGateway extends AbstractIndexShardComponent implement
             indexShard.store().decRef();
         }
         indexShard.prepareForTranslogRecovery();
-        indexShard.finalizeRecovery(false);
+        indexShard.finalizeRecovery();
         indexShard.postRecovery("post recovery from gateway");
     }
 

--- a/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -738,8 +738,8 @@ public class IndexShard extends AbstractIndexShardComponent {
         return this;
     }
 
-    /** called before starting to copy files over for store recovery */
-    public void prepareForStoreRecovery() throws ElasticsearchException {
+    /** called before starting to copy index files over */
+    public void prepareForIndexRecovery() throws ElasticsearchException {
         if (state != IndexShardState.RECOVERING) {
             throw new IndexShardNotRecoveringException(shardId, state);
         }
@@ -786,11 +786,12 @@ public class IndexShard extends AbstractIndexShardComponent {
         return this.recoveryState;
     }
 
-    public void finalizeRecovery(boolean withFlush) throws ElasticsearchException {
+    /**
+     * perform the last stages of recovery once all translog operations are done.
+     * note that you should still call {@link #postRecovery(String)}.
+     */
+    public void finalizeRecovery() {
         recoveryState().setStage(RecoveryState.Stage.FINALIZE);
-        if (withFlush) {
-            engine().flush();
-        }
         // clear unreferenced files
         translog.clearUnreferenced();
         engine().refresh("recovery_finalization");

--- a/src/main/java/org/elasticsearch/index/snapshots/IndexShardSnapshotAndRestoreService.java
+++ b/src/main/java/org/elasticsearch/index/snapshots/IndexShardSnapshotAndRestoreService.java
@@ -28,12 +28,12 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.deletionpolicy.SnapshotIndexCommit;
 import org.elasticsearch.index.engine.SnapshotFailedEngineException;
-import org.elasticsearch.indices.recovery.RecoveryState;
 import org.elasticsearch.index.settings.IndexSettings;
 import org.elasticsearch.index.shard.AbstractIndexShardComponent;
+import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.IndexShardState;
 import org.elasticsearch.index.shard.ShardId;
-import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.indices.recovery.RecoveryState;
 import org.elasticsearch.repositories.RepositoriesService;
 import org.elasticsearch.snapshots.RestoreService;
 
@@ -121,6 +121,9 @@ public class IndexShardSnapshotAndRestoreService extends AbstractIndexShardCompo
                 snapshotShardId = new ShardId(restoreSource.index(), shardId.id());
             }
             indexShardRepository.restore(restoreSource.snapshotId(), shardId, snapshotShardId, recoveryState);
+            indexShard.performRecoveryPrepareForTranslog();
+            indexShard.performRecoveryFinalization(false);
+            indexShard.postRecovery("restore done");
             restoreService.indexShardRestoreCompleted(restoreSource.snapshotId(), shardId);
         } catch (Throwable t) {
             if (Lucene.isCorruptionException(t)) {

--- a/src/main/java/org/elasticsearch/index/snapshots/IndexShardSnapshotAndRestoreService.java
+++ b/src/main/java/org/elasticsearch/index/snapshots/IndexShardSnapshotAndRestoreService.java
@@ -115,14 +115,15 @@ public class IndexShardSnapshotAndRestoreService extends AbstractIndexShardCompo
             logger.trace("[{}] restoring shard  [{}]", restoreSource.snapshotId(), shardId);
         }
         try {
+            indexShard.prepareForStoreRecovery();
             IndexShardRepository indexShardRepository = repositoriesService.indexShardRepository(restoreSource.snapshotId().getRepository());
             ShardId snapshotShardId = shardId;
             if (!shardId.getIndex().equals(restoreSource.index())) {
                 snapshotShardId = new ShardId(restoreSource.index(), shardId.id());
             }
             indexShardRepository.restore(restoreSource.snapshotId(), shardId, snapshotShardId, recoveryState);
-            indexShard.performRecoveryPrepareForTranslog();
-            indexShard.performRecoveryFinalization(false);
+            indexShard.prepareForTranslogRecovery();
+            indexShard.finalizeRecovery(false);
             indexShard.postRecovery("restore done");
             restoreService.indexShardRestoreCompleted(restoreSource.snapshotId(), shardId);
         } catch (Throwable t) {

--- a/src/main/java/org/elasticsearch/index/snapshots/IndexShardSnapshotAndRestoreService.java
+++ b/src/main/java/org/elasticsearch/index/snapshots/IndexShardSnapshotAndRestoreService.java
@@ -115,7 +115,7 @@ public class IndexShardSnapshotAndRestoreService extends AbstractIndexShardCompo
             logger.trace("[{}] restoring shard  [{}]", restoreSource.snapshotId(), shardId);
         }
         try {
-            indexShard.prepareForStoreRecovery();
+            indexShard.prepareForIndexRecovery();
             IndexShardRepository indexShardRepository = repositoriesService.indexShardRepository(restoreSource.snapshotId().getRepository());
             ShardId snapshotShardId = shardId;
             if (!shardId.getIndex().equals(restoreSource.index())) {
@@ -123,7 +123,7 @@ public class IndexShardSnapshotAndRestoreService extends AbstractIndexShardCompo
             }
             indexShardRepository.restore(restoreSource.snapshotId(), shardId, snapshotShardId, recoveryState);
             indexShard.prepareForTranslogRecovery();
-            indexShard.finalizeRecovery(false);
+            indexShard.finalizeRecovery();
             indexShard.postRecovery("restore done");
             restoreService.indexShardRestoreCompleted(restoreSource.snapshotId(), shardId);
         } catch (Throwable t) {

--- a/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardRepository.java
+++ b/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardRepository.java
@@ -159,9 +159,7 @@ public class BlobStoreIndexShardRepository extends AbstractComponent implements 
     public void restore(SnapshotId snapshotId, ShardId shardId, ShardId snapshotShardId, RecoveryState recoveryState) {
         final RestoreContext snapshotContext = new RestoreContext(snapshotId, shardId, snapshotShardId, recoveryState);
         try {
-            recoveryState.getIndex().startTime(System.currentTimeMillis());
             snapshotContext.restore();
-            recoveryState.getIndex().stopTime(System.currentTimeMillis());
         } catch (Throwable e) {
             throw new IndexShardRestoreFailedException(shardId, "failed to restore snapshot [" + snapshotId.getSnapshot() + "]", e);
         }
@@ -710,8 +708,6 @@ public class BlobStoreIndexShardRepository extends AbstractComponent implements 
             try {
                 logger.debug("[{}] [{}] restoring to [{}] ...", snapshotId, repositoryName, shardId);
                 BlobStoreIndexShardSnapshot snapshot = loadSnapshot();
-
-                recoveryState.setStage(RecoveryState.Stage.INDEX);
                 final Store.MetadataSnapshot recoveryTargetMetadata;
                 try {
                     recoveryTargetMetadata = store.getMetadataOrEmpty();

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoverySource.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoverySource.java
@@ -114,11 +114,11 @@ public class RecoverySource extends AbstractComponent {
         }
 
         logger.trace("[{}][{}] starting recovery to {}, mark_as_relocated {}", request.shardId().index().name(), request.shardId().id(), request.targetNode(), request.markAsRelocated());
-        final ShardRecoveryHandler handler;
+        final RecoverySourceHandler handler;
         if (IndexMetaData.isOnSharedFilesystem(shard.indexSettings())) {
-            handler = new SharedFSRecoveryHandler(shard, request, recoverySettings, transportService, clusterService, indicesService, mappingUpdatedAction, logger);
+            handler = new SharedFSRecoverySourceHandler(shard, request, recoverySettings, transportService, clusterService, indicesService, mappingUpdatedAction, logger);
         } else {
-            handler = new ShardRecoveryHandler(shard, request, recoverySettings, transportService, clusterService, indicesService, mappingUpdatedAction, logger);
+            handler = new RecoverySourceHandler(shard, request, recoverySettings, transportService, clusterService, indicesService, mappingUpdatedAction, logger);
         }
         ongoingRecoveries.add(shard, handler);
         try {
@@ -150,10 +150,10 @@ public class RecoverySource extends AbstractComponent {
 
 
     private static final class OngoingRecoveres {
-        private final Map<IndexShard, Set<ShardRecoveryHandler>> ongoingRecoveries = new HashMap<>();
+        private final Map<IndexShard, Set<RecoverySourceHandler>> ongoingRecoveries = new HashMap<>();
 
-        synchronized void add(IndexShard shard, ShardRecoveryHandler handler) {
-            Set<ShardRecoveryHandler> shardRecoveryHandlers = ongoingRecoveries.get(shard);
+        synchronized void add(IndexShard shard, RecoverySourceHandler handler) {
+            Set<RecoverySourceHandler> shardRecoveryHandlers = ongoingRecoveries.get(shard);
             if (shardRecoveryHandlers == null) {
                 shardRecoveryHandlers = new HashSet<>();
                 ongoingRecoveries.put(shard, shardRecoveryHandlers);
@@ -162,8 +162,8 @@ public class RecoverySource extends AbstractComponent {
             shardRecoveryHandlers.add(handler);
         }
 
-        synchronized void remove(IndexShard shard, ShardRecoveryHandler handler) {
-            final Set<ShardRecoveryHandler> shardRecoveryHandlers = ongoingRecoveries.get(shard);
+        synchronized void remove(IndexShard shard, RecoverySourceHandler handler) {
+            final Set<RecoverySourceHandler> shardRecoveryHandlers = ongoingRecoveries.get(shard);
             assert shardRecoveryHandlers != null : "Shard was not registered [" + shard + "]";
             boolean remove = shardRecoveryHandlers.remove(handler);
             assert remove : "Handler was not registered [" + handler + "]";
@@ -173,10 +173,10 @@ public class RecoverySource extends AbstractComponent {
         }
 
         synchronized void cancel(IndexShard shard, String reason) {
-            final Set<ShardRecoveryHandler> shardRecoveryHandlers = ongoingRecoveries.get(shard);
+            final Set<RecoverySourceHandler> shardRecoveryHandlers = ongoingRecoveries.get(shard);
             if (shardRecoveryHandlers != null) {
                 final List<Exception> failures = new ArrayList<>();
-                for (ShardRecoveryHandler handlers : shardRecoveryHandlers) {
+                for (RecoverySourceHandler handlers : shardRecoveryHandlers) {
                     try {
                         handlers.cancel(reason);
                     } catch (Exception ex) {

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -42,7 +42,6 @@ import org.elasticsearch.common.compress.CompressorFactory;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.common.util.ArrayUtils;
 import org.elasticsearch.common.util.CancellableThreads;
 import org.elasticsearch.common.util.CancellableThreads.Interruptable;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
@@ -65,18 +64,17 @@ import org.elasticsearch.transport.TransportRequestOptions;
 import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
- * ShardRecoveryHandler handles the three phases of shard recovery, which is
+ * RecoverySourceHandler handles the three phases of shard recovery, which is
  * everything relating to copying the segment files as well as sending translog
  * operations across the wire once the segments have been copied.
  */
-public class ShardRecoveryHandler implements Engine.RecoveryHandler {
+public class RecoverySourceHandler implements Engine.RecoveryHandler {
 
     protected final ESLogger logger;
     // Shard that is going to be recovered (the "source")
@@ -109,9 +107,9 @@ public class ShardRecoveryHandler implements Engine.RecoveryHandler {
     };
 
 
-    public ShardRecoveryHandler(final IndexShard shard, final StartRecoveryRequest request, final RecoverySettings recoverySettings,
-                                final TransportService transportService, final ClusterService clusterService,
-                                final IndicesService indicesService, final MappingUpdatedAction mappingUpdatedAction, final ESLogger logger) {
+    public RecoverySourceHandler(final IndexShard shard, final StartRecoveryRequest request, final RecoverySettings recoverySettings,
+                                 final TransportService transportService, final ClusterService clusterService,
+                                 final IndicesService indicesService, final MappingUpdatedAction mappingUpdatedAction, final ESLogger logger) {
         this.shard = shard;
         this.request = request;
         this.recoverySettings = recoverySettings;

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoveryStatus.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoveryStatus.java
@@ -81,9 +81,7 @@ public class RecoveryStatus extends AbstractRefCounted {
         this.indexShard = indexShard;
         this.sourceNode = sourceNode;
         this.shardId = indexShard.shardId();
-        final RecoveryState.Timer timer = this.indexShard.recoveryState().getTimer();
-        timer.startTime(System.currentTimeMillis());
-        this.tempFilePrefix = RECOVERY_PREFIX + timer.startTime() + ".";
+        this.tempFilePrefix = RECOVERY_PREFIX + indexShard.recoveryState().getTimer().startTime() + ".";
         this.store = indexShard.store();
         // make sure the store is not released until we are done.
         store.incRef();
@@ -129,10 +127,6 @@ public class RecoveryStatus extends AbstractRefCounted {
     public Store store() {
         ensureRefCount();
         return store;
-    }
-
-    public void stage(RecoveryState.Stage stage) {
-        state().setStage(stage);
     }
 
     public RecoveryState.Stage stage() {
@@ -194,8 +188,6 @@ public class RecoveryStatus extends AbstractRefCounted {
         if (finished.compareAndSet(false, true)) {
             assert tempFileNames.isEmpty() : "not all temporary files are renamed";
             indexShard.postRecovery("peer recovery done");
-            state.getTimer().time(System.currentTimeMillis() - state.getTimer().startTime());
-            stage(RecoveryState.Stage.DONE);
             // release the initial reference. recovery files will be cleaned as soon as ref count goes to zero, potentially now
             decRef();
             listener.onRecoveryDone(state());

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoveryStatus.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoveryStatus.java
@@ -193,6 +193,9 @@ public class RecoveryStatus extends AbstractRefCounted {
     public void markAsDone() {
         if (finished.compareAndSet(false, true)) {
             assert tempFileNames.isEmpty() : "not all temporary files are renamed";
+            indexShard.postRecovery("peer recovery done");
+            state.getTimer().time(System.currentTimeMillis() - state.getTimer().startTime());
+            stage(RecoveryState.Stage.DONE);
             // release the initial reference. recovery files will be cleaned as soon as ref count goes to zero, potentially now
             decRef();
             listener.onRecoveryDone(state());

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
@@ -168,7 +168,7 @@ public class RecoveryTarget extends AbstractComponent {
         final AtomicReference<RecoveryResponse> responseHolder = new AtomicReference<>();
         try {
             logger.trace("[{}][{}] starting recovery from {}", request.shardId().index().name(), request.shardId().id(), request.sourceNode());
-
+            recoveryStatus.indexShard().prepareForStoreRecovery();
             recoveryStatus.CancellableThreads().execute(new CancellableThreads.Interruptable() {
                 @Override
                 public void run() throws InterruptedException {
@@ -349,7 +349,6 @@ public class RecoveryTarget extends AbstractComponent {
         public void messageReceived(RecoveryFilesInfoRequest request, TransportChannel channel) throws Exception {
             try (RecoveriesCollection.StatusRef statusRef = onGoingRecoveries.getStatusSafe(request.recoveryId(), request.shardId())) {
                 final RecoveryStatus recoveryStatus = statusRef.status();
-                recoveryStatus.indexShard().prepareForStoreRecovery();
                 final RecoveryState.Index index = recoveryStatus.state().getIndex();
                 for (int i = 0; i < request.phase1ExistingFileNames.size(); i++) {
                     index.addFileDetail(request.phase1ExistingFileNames.get(i), request.phase1ExistingFileSizes.get(i), true);

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
@@ -168,7 +168,7 @@ public class RecoveryTarget extends AbstractComponent {
         final AtomicReference<RecoveryResponse> responseHolder = new AtomicReference<>();
         try {
             logger.trace("[{}][{}] starting recovery from {}", request.shardId().index().name(), request.shardId().id(), request.sourceNode());
-            recoveryStatus.indexShard().prepareForStoreRecovery();
+            recoveryStatus.indexShard().prepareForIndexRecovery();
             recoveryStatus.CancellableThreads().execute(new CancellableThreads.Interruptable() {
                 @Override
                 public void run() throws InterruptedException {
@@ -202,7 +202,6 @@ public class RecoveryTarget extends AbstractComponent {
                 logger.trace(sb.toString());
             } else {
                 logger.debug("{} recovery done from [{}], took [{}]", request.shardId(), recoveryStatus.sourceNode(), recoveryTime);
-
             }
         } catch (CancellableThreads.ExecutionCancelledException e) {
             logger.trace("recovery cancelled", e);
@@ -300,7 +299,7 @@ public class RecoveryTarget extends AbstractComponent {
         public void messageReceived(RecoveryFinalizeRecoveryRequest request, TransportChannel channel) throws Exception {
             try (RecoveriesCollection.StatusRef statusRef = onGoingRecoveries.getStatusSafe(request.recoveryId(), request.shardId())) {
                 final RecoveryStatus recoveryStatus = statusRef.status();
-                recoveryStatus.indexShard().finalizeRecovery(false);
+                recoveryStatus.indexShard().finalizeRecovery();
             }
             channel.sendResponse(TransportResponse.Empty.INSTANCE);
         }

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
@@ -20,8 +20,6 @@
 package org.elasticsearch.indices.recovery;
 
 import org.apache.lucene.index.CorruptIndexException;
-import org.apache.lucene.index.IndexFormatTooNewException;
-import org.apache.lucene.index.IndexFormatTooOldException;
 import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.store.IndexOutput;
 import org.elasticsearch.ElasticsearchException;
@@ -31,7 +29,6 @@ import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.Nullable;
-import org.elasticsearch.common.StopWatch;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.inject.Inject;
@@ -172,7 +169,6 @@ public class RecoveryTarget extends AbstractComponent {
         try {
             logger.trace("[{}][{}] starting recovery from {}", request.shardId().index().name(), request.shardId().id(), request.sourceNode());
 
-            StopWatch stopWatch = new StopWatch().start();
             recoveryStatus.CancellableThreads().execute(new CancellableThreads.Interruptable() {
                 @Override
                 public void run() throws InterruptedException {
@@ -186,11 +182,13 @@ public class RecoveryTarget extends AbstractComponent {
             });
             final RecoveryResponse recoveryResponse = responseHolder.get();
             assert responseHolder != null;
-            stopWatch.stop();
+            final TimeValue recoveryTime = new TimeValue(recoveryStatus.state().getTimer().time());
+            // do this through ongoing recoveries to remove it from the collection
+            onGoingRecoveries.markRecoveryAsDone(recoveryStatus.recoveryId());
             if (logger.isTraceEnabled()) {
                 StringBuilder sb = new StringBuilder();
                 sb.append('[').append(request.shardId().index().name()).append(']').append('[').append(request.shardId().id()).append("] ");
-                sb.append("recovery completed from ").append(request.sourceNode()).append(", took[").append(stopWatch.totalTime()).append("]\n");
+                sb.append("recovery completed from ").append(request.sourceNode()).append(", took[").append(recoveryTime).append("]\n");
                 sb.append("   phase1: recovered_files [").append(recoveryResponse.phase1FileNames.size()).append("]").append(" with total_size of [").append(new ByteSizeValue(recoveryResponse.phase1TotalSize)).append("]")
                         .append(", took [").append(timeValueMillis(recoveryResponse.phase1Time)).append("], throttling_wait [").append(timeValueMillis(recoveryResponse.phase1ThrottlingWaitTime)).append(']')
                         .append("\n");
@@ -202,11 +200,10 @@ public class RecoveryTarget extends AbstractComponent {
                 sb.append("   phase3: recovered [").append(recoveryResponse.phase3Operations).append("]").append(" transaction log operations")
                         .append(", took [").append(timeValueMillis(recoveryResponse.phase3Time)).append("]");
                 logger.trace(sb.toString());
-            } else if (logger.isDebugEnabled()) {
-                logger.debug("{} recovery completed from [{}], took [{}]", request.shardId(), request.sourceNode(), stopWatch.totalTime());
+            } else {
+                logger.debug("{} recovery done from [{}], took [{}]", request.shardId(), recoveryStatus.sourceNode(), recoveryTime);
+
             }
-            // do this through ongoing recoveries to remove it from the collection
-            onGoingRecoveries.markRecoveryAsDone(recoveryStatus.recoveryId());
         } catch (CancellableThreads.ExecutionCancelledException e) {
             logger.trace("recovery cancelled", e);
         } catch (Throwable e) {
@@ -306,7 +303,6 @@ public class RecoveryTarget extends AbstractComponent {
             try (RecoveriesCollection.StatusRef statusRef = onGoingRecoveries.getStatusSafe(request.recoveryId(), request.shardId())) {
                 final RecoveryStatus recoveryStatus = statusRef.status();
                 recoveryStatus.indexShard().performRecoveryFinalization(false);
-                recoveryStatus.stage(RecoveryState.Stage.DONE);
             }
             channel.sendResponse(TransportResponse.Empty.INSTANCE);
         }

--- a/src/main/java/org/elasticsearch/indices/recovery/SharedFSRecoverySourceHandler.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/SharedFSRecoverySourceHandler.java
@@ -30,18 +30,16 @@ import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.transport.TransportService;
 
-import java.io.IOException;
-
 /**
  * A recovery handler that skips phase 1 as well as sending the snapshot. During phase 3 the shard is marked
  * as relocated an closed to ensure that the engine is closed and the target can acquire the IW write lock.
  */
-public class SharedFSRecoveryHandler extends ShardRecoveryHandler {
+public class SharedFSRecoverySourceHandler extends RecoverySourceHandler {
 
     private final IndexShard shard;
     private final StartRecoveryRequest request;
 
-    public SharedFSRecoveryHandler(IndexShard shard, StartRecoveryRequest request, RecoverySettings recoverySettings, TransportService transportService, ClusterService clusterService, IndicesService indicesService, MappingUpdatedAction mappingUpdatedAction, ESLogger logger) {
+    public SharedFSRecoverySourceHandler(IndexShard shard, StartRecoveryRequest request, RecoverySettings recoverySettings, TransportService transportService, ClusterService clusterService, IndicesService indicesService, MappingUpdatedAction mappingUpdatedAction, ESLogger logger) {
         super(shard, request, recoverySettings, transportService, clusterService, indicesService, mappingUpdatedAction, logger);
         this.shard = shard;
         this.request = request;

--- a/src/test/java/org/elasticsearch/indices/recovery/RecoveryStateTest.java
+++ b/src/test/java/org/elasticsearch/indices/recovery/RecoveryStateTest.java
@@ -18,11 +18,17 @@
  */
 package org.elasticsearch.indices.recovery;
 
+import org.elasticsearch.ElasticsearchIllegalStateException;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.BytesStreamInput;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.Streamable;
-import org.elasticsearch.indices.recovery.RecoveryState.File;
+import org.elasticsearch.common.transport.DummyTransportAddress;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.indices.recovery.RecoveryState.*;
 import org.elasticsearch.test.ElasticsearchTestCase;
 
 import java.io.IOException;
@@ -42,21 +48,43 @@ public class RecoveryStateTest extends ElasticsearchTestCase {
         final private AtomicBoolean shouldStop;
         final private T source;
         final AtomicReference<Throwable> error = new AtomicReference<>();
+        final Version streamVersion;
 
         Streamer(AtomicBoolean shouldStop, T source) {
-            this.shouldStop = shouldStop;
-            this.source = source;
+            this(shouldStop, source, randomVersion());
         }
 
-        void serializeDeserialize() throws IOException {
+        Streamer(AtomicBoolean shouldStop, T source, Version streamVersion) {
+            this.shouldStop = shouldStop;
+            this.source = source;
+            this.streamVersion = streamVersion;
+        }
+
+        public T lastRead() throws Throwable {
+            Throwable t = error.get();
+            if (t != null) {
+                throw t;
+            }
+            return lastRead;
+        }
+
+        public T serializeDeserialize() throws IOException {
             BytesStreamOutput out = new BytesStreamOutput();
             source.writeTo(out);
             out.close();
             StreamInput in = new BytesStreamInput(out.bytes());
-            lastRead = deserialize(in);
+            T obj = deserialize(in);
+            lastRead = obj;
+            return obj;
         }
 
-        abstract T deserialize(StreamInput in) throws IOException;
+        protected T deserialize(StreamInput in) throws IOException {
+            T obj = createObj();
+            obj.readFrom(in);
+            return obj;
+        }
+
+        abstract T createObj();
 
         @Override
         public void run() {
@@ -71,7 +99,80 @@ public class RecoveryStateTest extends ElasticsearchTestCase {
         }
     }
 
-    public void testIndex() throws Exception {
+    public void testTimers() throws Throwable {
+        final Timer timer;
+        Streamer<Timer> streamer;
+        AtomicBoolean stop = new AtomicBoolean();
+        if (randomBoolean()) {
+            timer = new Timer();
+            streamer = new Streamer<Timer>(stop, timer) {
+                @Override
+                Timer createObj() {
+                    return new Timer();
+                }
+            };
+        } else if (randomBoolean()) {
+            timer = new Index();
+            streamer = new Streamer<Timer>(stop, timer) {
+                @Override
+                Timer createObj() {
+                    return new Index();
+                }
+            };
+        } else if (randomBoolean()) {
+            timer = new Start();
+            streamer = new Streamer<Timer>(stop, timer) {
+                @Override
+                Timer createObj() {
+                    return new Start();
+                }
+            };
+        } else {
+            timer = new Translog();
+            streamer = new Streamer<Timer>(stop, timer) {
+                @Override
+                Timer createObj() {
+                    return new Translog();
+                }
+            };
+        }
+
+        timer.start();
+        assertThat(timer.startTime(), greaterThan(0l));
+        assertThat(timer.stopTime(), equalTo(0l));
+        Timer lastRead = streamer.serializeDeserialize();
+        final long time = lastRead.time();
+        assertThat(time, lessThanOrEqualTo(timer.time()));
+        assertBusy(new Runnable() {
+            @Override
+            public void run() {
+                assertThat("timer timer should progress compared to captured one ", time, lessThan(timer.time()));
+            }
+        });
+        assertThat("captured time shouldn't change", lastRead.time(), equalTo(time));
+
+        if (randomBoolean()) {
+            timer.stop();
+            assertThat(timer.stopTime(), greaterThanOrEqualTo(timer.startTime()));
+            assertThat(timer.time(), equalTo(timer.stopTime() - timer.startTime()));
+            lastRead = streamer.serializeDeserialize();
+            assertThat(lastRead.startTime(), equalTo(timer.startTime()));
+            assertThat(lastRead.time(), equalTo(timer.time()));
+            assertThat(lastRead.stopTime(), equalTo(timer.stopTime()));
+        }
+
+        timer.reset();
+        assertThat(timer.startTime(), equalTo(0l));
+        assertThat(timer.time(), equalTo(0l));
+        assertThat(timer.stopTime(), equalTo(0l));
+        lastRead = streamer.serializeDeserialize();
+        assertThat(lastRead.startTime(), equalTo(0l));
+        assertThat(lastRead.time(), equalTo(0l));
+        assertThat(lastRead.stopTime(), equalTo(0l));
+
+    }
+
+    public void testIndex() throws Throwable {
         File[] files = new File[randomIntBetween(1, 20)];
         ArrayList<File> filesToRecover = new ArrayList<>();
         long totalFileBytes = 0;
@@ -91,14 +192,26 @@ public class RecoveryStateTest extends ElasticsearchTestCase {
         }
 
         Collections.shuffle(Arrays.asList(files));
-
         final RecoveryState.Index index = new RecoveryState.Index();
-        final long startTime = System.currentTimeMillis();
+
+        if (randomBoolean()) {
+            // initialize with some data and then reset
+            index.start();
+            for (int i = randomIntBetween(0, 10); i > 0; i--) {
+                index.addFileDetail("t_" + i, randomIntBetween(1, 100), randomBoolean());
+            }
+            if (randomBoolean()) {
+                index.stop();
+            }
+            index.reset();
+        }
+
+
         // before we start we must report 0
         assertThat(index.recoveredFilesPercent(), equalTo((float) 0.0));
         assertThat(index.recoveredBytesPercent(), equalTo((float) 0.0));
 
-        index.startTime(startTime);
+        index.start();
         for (File file : files) {
             index.addFileDetail(file.name(), file.length(), file.reused());
         }
@@ -114,7 +227,6 @@ public class RecoveryStateTest extends ElasticsearchTestCase {
         assertThat(index.recoveredBytes(), equalTo(0l));
         assertThat(index.recoveredFilesPercent(), equalTo(filesToRecover.size() == 0 ? 100.0f : 0.0f));
         assertThat(index.recoveredBytesPercent(), equalTo(filesToRecover.size() == 0 ? 100.0f : 0.0f));
-        assertThat(index.startTime(), equalTo(startTime));
 
 
         long bytesToRecover = totalFileBytes - totalReusedBytes;
@@ -125,12 +237,10 @@ public class RecoveryStateTest extends ElasticsearchTestCase {
         }
         AtomicBoolean streamShouldStop = new AtomicBoolean();
 
-        Streamer<RecoveryState.Index> backgroundReader = new Streamer<RecoveryState.Index>(streamShouldStop, index) {
+        Streamer<Index> backgroundReader = new Streamer<RecoveryState.Index>(streamShouldStop, index) {
             @Override
-            RecoveryState.Index deserialize(StreamInput in) throws IOException {
-                RecoveryState.Index index = new RecoveryState.Index();
-                index.readFrom(in);
-                return index;
+            Index createObj() {
+                return new Index();
             }
         };
 
@@ -151,17 +261,23 @@ public class RecoveryStateTest extends ElasticsearchTestCase {
 
         if (completeRecovery) {
             assertThat(filesToRecover.size(), equalTo(0));
-            long time = System.currentTimeMillis();
-            index.stopTime(time);
-            assertThat(index.time(), equalTo(Math.max(0, time - startTime)));
+            index.stop();
+            assertThat(index.time(), equalTo(index.stopTime() - index.startTime()));
+            assertThat(index.time(), equalTo(index.stopTime() - index.startTime()));
         }
 
         logger.info("testing serialized information");
         streamShouldStop.set(true);
         backgroundReader.join();
-        assertThat(backgroundReader.lastRead.fileDetails().toArray(), arrayContainingInAnyOrder(index.fileDetails().toArray()));
-        assertThat(backgroundReader.lastRead.startTime(), equalTo(index.startTime()));
-        assertThat(backgroundReader.lastRead.time(), equalTo(index.time()));
+        final Index lastRead = backgroundReader.lastRead();
+        assertThat(lastRead.fileDetails().toArray(), arrayContainingInAnyOrder(index.fileDetails().toArray()));
+        assertThat(lastRead.startTime(), equalTo(index.startTime()));
+        if (completeRecovery) {
+            assertThat(lastRead.time(), equalTo(index.time()));
+        } else {
+            assertThat(lastRead.time(), lessThanOrEqualTo(index.time()));
+        }
+        assertThat(lastRead.stopTime(), equalTo(index.stopTime()));
 
         logger.info("testing post recovery");
         assertThat(index.totalBytes(), equalTo(totalFileBytes));
@@ -179,7 +295,142 @@ public class RecoveryStateTest extends ElasticsearchTestCase {
             assertThat((double) index.recoveredFilesPercent(), closeTo(100.0 * index.recoveredFileCount() / index.totalRecoverFiles(), 0.1));
             assertThat((double) index.recoveredBytesPercent(), closeTo(100.0 * index.recoveredBytes() / index.totalRecoverBytes(), 0.1));
         }
-        assertThat(index.startTime(), equalTo(startTime));
     }
 
+    public void testStageSequenceEnforcement() {
+        final DiscoveryNode discoveryNode = new DiscoveryNode("1", DummyTransportAddress.INSTANCE, Version.CURRENT);
+        Stage[] stages = Stage.values();
+        int i = randomIntBetween(0, stages.length - 1);
+        int j;
+        do {
+            j = randomIntBetween(0, stages.length - 1);
+        } while (j == i);
+        Stage t = stages[i];
+        stages[i] = stages[j];
+        stages[j] = t;
+        try {
+            RecoveryState state = new RecoveryState(new ShardId("bla", 0), randomBoolean(), randomFrom(Type.values()), discoveryNode, discoveryNode);
+            for (Stage stage : stages) {
+                state.setStage(stage);
+            }
+            fail("succeeded in performing the illegal sequence [" + Strings.arrayToCommaDelimitedString(stages) + "]");
+        } catch (ElasticsearchIllegalStateException e) {
+            // cool
+        }
+
+        // but reset should be always possible.
+        stages = Stage.values();
+        i = randomIntBetween(1, stages.length - 1);
+        ArrayList<Stage> list = new ArrayList<>(Arrays.asList(Arrays.copyOfRange(stages, 0, i)));
+        list.addAll(Arrays.asList(stages));
+        RecoveryState state = new RecoveryState(new ShardId("bla", 0), randomBoolean(), randomFrom(Type.values()), discoveryNode, discoveryNode);
+        for (Stage stage : list) {
+            state.setStage(stage);
+        }
+
+        assertThat(state.getStage(), equalTo(Stage.DONE));
+    }
+
+    public void testTranslog() throws Throwable {
+        final Translog translog = new Translog();
+        AtomicBoolean stop = new AtomicBoolean();
+        Streamer<Translog> streamer = new Streamer<Translog>(stop, translog) {
+            @Override
+            Translog createObj() {
+                return new Translog();
+            }
+        };
+
+        // we don't need to test the time aspect, it's done in the timer test
+        translog.start();
+        assertThat(translog.currentTranslogOperations(), equalTo(0));
+        streamer.start();
+        // force one
+        streamer.serializeDeserialize();
+        int ops = 0;
+        for (int i = scaledRandomIntBetween(10, 200); i > 0; i--) {
+            for (int j = randomIntBetween(1, 10); j > 0; j--) {
+                ops++;
+                translog.incrementTranslogOperations();
+            }
+            assertThat(translog.currentTranslogOperations(), equalTo(ops));
+            assertThat(streamer.lastRead().currentTranslogOperations(), greaterThanOrEqualTo(0));
+            assertThat(streamer.lastRead().currentTranslogOperations(), lessThanOrEqualTo(ops));
+        }
+
+        boolean stopped = false;
+        if (randomBoolean()) {
+            translog.stop();
+            stopped = true;
+        }
+
+        if (randomBoolean()) {
+            translog.reset();
+            ops = 0;
+            assertThat(translog.currentTranslogOperations(), equalTo(0));
+        }
+
+        stop.set(true);
+        streamer.join();
+        final Translog lastRead = streamer.lastRead();
+        assertThat(lastRead.currentTranslogOperations(), equalTo(ops));
+        assertThat(lastRead.startTime(), equalTo(translog.startTime()));
+        assertThat(lastRead.stopTime(), equalTo(translog.stopTime()));
+
+        if (stopped) {
+            assertThat(lastRead.time(), equalTo(translog.time()));
+        } else {
+            assertThat(lastRead.time(), lessThanOrEqualTo(translog.time()));
+        }
+    }
+
+    public void testStart() throws IOException {
+        final Start start = new Start();
+        AtomicBoolean stop = new AtomicBoolean();
+        Streamer<Start> streamer = new Streamer<Start>(stop, start) {
+            @Override
+            Start createObj() {
+                return new Start();
+            }
+        };
+
+        // we don't need to test the time aspect, it's done in the timer test
+        start.start();
+        assertThat(start.checkIndexTime(), equalTo(0l));
+        // force one
+        Start lastRead = streamer.serializeDeserialize();
+        assertThat(lastRead.checkIndexTime(), equalTo(0l));
+
+        long took = randomLong();
+        if (took < 0) {
+            took = -took;
+            took = Math.max(0l, took);
+
+        }
+        start.checkIndexTime(took);
+        assertThat(start.checkIndexTime(), equalTo(took));
+
+        boolean stopped = false;
+        if (randomBoolean()) {
+            start.stop();
+            stopped = true;
+        }
+
+        if (randomBoolean()) {
+            start.reset();
+            took = 0;
+            assertThat(start.checkIndexTime(), equalTo(took));
+        }
+
+        lastRead = streamer.serializeDeserialize();
+        assertThat(lastRead.checkIndexTime(), equalTo(took));
+        assertThat(lastRead.startTime(), equalTo(start.startTime()));
+        assertThat(lastRead.stopTime(), equalTo(start.stopTime()));
+
+        if (stopped) {
+            assertThat(lastRead.time(), equalTo(start.time()));
+        } else {
+            assertThat(lastRead.time(), lessThanOrEqualTo(start.time()));
+        }
+    }
 }

--- a/src/test/java/org/elasticsearch/indices/recovery/RecoveryStatusTests.java
+++ b/src/test/java/org/elasticsearch/indices/recovery/RecoveryStatusTests.java
@@ -71,6 +71,7 @@ public class RecoveryStatusTests extends ElasticsearchSingleNodeTest {
         strings = Sets.newHashSet(status.store().directory().listAll());
         assertTrue(strings.toString(), strings.contains("foo.bar"));
         assertFalse(strings.toString(), strings.contains(expectedFile));
-        status.markAsDone();
+        // we must fail the recovery because marking it as done will try to move the shard to POST_RECOVERY, which will fail because it's started
+        status.fail(new RecoveryFailedException(status.state(), "end of test. OK.", null), false);
     }
 }

--- a/src/test/java/org/elasticsearch/recovery/FullRollingRestartTests.java
+++ b/src/test/java/org/elasticsearch/recovery/FullRollingRestartTests.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.recovery;
 
-import org.apache.lucene.util.LuceneTestCase;
 import org.apache.lucene.util.LuceneTestCase.Slow;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequestBuilder;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
@@ -57,7 +56,6 @@ public class FullRollingRestartTests extends ElasticsearchIntegrationTest {
 
     @Test
     @Slow
-    @LuceneTestCase.AwaitsFix(bugUrl = "see https://github.com/elasticsearch/elasticsearch/issues/9503")
     public void testFullRollingRestart() throws Exception {
         Settings settings = ImmutableSettings.builder().put(ZenDiscovery.SETTING_JOIN_TIMEOUT, "30s").build();
         internalCluster().startNode(settings);

--- a/src/test/java/org/elasticsearch/recovery/RelocationTests.java
+++ b/src/test/java/org/elasticsearch/recovery/RelocationTests.java
@@ -34,12 +34,10 @@ import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.client.Client;
-import org.elasticsearch.cluster.ClusterChangedEvent;
-import org.elasticsearch.cluster.ClusterService;
-import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateListener;
+import org.elasticsearch.cluster.*;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.allocation.command.MoveAllocationCommand;
 import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider;
@@ -536,6 +534,126 @@ public class RelocationTests extends ElasticsearchIntegrationTest {
         // force a move.
         client().admin().cluster().prepareReroute().get();
         ensureGreen();
+    }
+
+
+    @Test
+    @TestLogging("cluster.service:TRACE,indices.recovery:TRACE")
+    public void testPrimaryRelocationWithBusyClusterUpdateThreadOnTargetNode() throws Exception {
+        // no commit - this was already reproduces by our CI . This is a crazy test which I'm not sure adds value except for reproducing a specific issue
+        final String indexName = "test";
+        final Settings settings = ImmutableSettings.builder()
+//  the local gateway will allocate the shard back
+//                .put("gateway.type", "local")
+                .put(DiscoverySettings.PUBLISH_TIMEOUT, "1s").build();
+        String master = internalCluster().startNode(settings);
+        ensureGreen();
+        List<String> nodes = internalCluster().startNodesAsync(2, settings).get();
+        final String node1 = nodes.get(0);
+        final String node2 = nodes.get(1);
+        ClusterHealthResponse response = client().admin().cluster().prepareHealth().setWaitForNodes("3").get();
+        assertThat(response.isTimedOut(), is(false));
+
+
+        client().admin().indices().prepareCreate(indexName)
+                .setSettings(
+                        ImmutableSettings.builder()
+                                .put(FilterAllocationDecider.INDEX_ROUTING_INCLUDE_GROUP + "_name", node1)
+                                .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
+                                .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
+                ).get();
+
+
+        List<IndexRequestBuilder> requests = new ArrayList<>();
+        int numDocs = scaledRandomIntBetween(25, 250);
+        for (int i = 0; i < numDocs; i++) {
+            requests.add(client().prepareIndex(indexName, "type").setCreate(true).setSource("{}"));
+        }
+        indexRandom(true, requests);
+        ensureSearchable(indexName);
+
+        // capture the incoming state indicate that the replicas have upgraded and assigned
+
+        final CountDownLatch relocationStartedOnTarget = new CountDownLatch(1);
+        final CountDownLatch shardActiveSent = new CountDownLatch(1);
+        final CountDownLatch releaseClusterState = new CountDownLatch(1);
+        final CountDownLatch postRecoverOnTarget = new CountDownLatch(1);
+        final CountDownLatch releaseRecovery = new CountDownLatch(1);
+        try {
+            internalCluster().getInstance(ClusterService.class, node2).addLast(new ClusterStateListener() {
+                @Override
+                public void clusterChanged(ClusterChangedEvent event) {
+                    ClusterState state = event.state();
+                    RoutingNode routingNode = state.routingNodes().node(state.nodes().localNodeId());
+                    if (routingNode.isEmpty()) {
+                        // no nodes assigned here.
+                        return;
+                    }
+
+                    relocationStartedOnTarget.countDown();
+                    if (event.source().equals("force_publish")) {
+                        // recovery completed
+                        shardActiveSent.countDown();
+                        try {
+                            releaseClusterState.await();
+                        } catch (InterruptedException e) {
+                            //
+                        }
+                    }
+                }
+
+            });
+
+
+            internalCluster().getInstance(IndicesLifecycle.class, node2).addListener(new IndicesLifecycle.Listener() {
+                @Override
+                public void afterIndexShardPostRecovery(IndexShard indexShard) {
+                    postRecoverOnTarget.countDown();
+                    try {
+                        releaseRecovery.await();
+                    } catch (InterruptedException e) {
+
+                    }
+                }
+            });
+
+            logger.info("--> starting relocating primary");
+            // we don't expect this to be acknowledge by node1 where we block the cluster state thread
+            assertAcked(client().admin().indices().prepareUpdateSettings(indexName)
+                    .setSettings(ImmutableSettings.builder()
+                                    .put(FilterAllocationDecider.INDEX_ROUTING_INCLUDE_GROUP + "_name", node2)
+
+                    ));
+
+            logger.info("--> waiting for node2 to process relocation");
+            relocationStartedOnTarget.await();
+            logger.info("--> waiting for recovery to get to post recovery");
+            postRecoverOnTarget.await();
+            logger.info("--> publishing a cluster state");
+            internalCluster().clusterService(node2).submitStateUpdateTask("force_publish", new ClusterStateNonMasterUpdateTask() {
+                @Override
+                public ClusterState execute(ClusterState currentState) throws Exception {
+                    return ClusterState.builder(currentState).build();
+                }
+
+                @Override
+                public void onFailure(String source, Throwable t) {
+                    logger.error("unexpected failure", t);
+                }
+            });
+
+            logger.info("--> waiting for shard started to be sent from node2");
+            shardActiveSent.await();
+            logger.info("--> waiting for shard started to be processed on node1");
+            client(node1).admin().cluster().prepareHealth().setWaitForRelocatingShards(0).setLocal(true).get();
+        } finally {
+            logger.info("--> releasing cluster state update thread and recovery");
+            releaseRecovery.countDown();
+            releaseClusterState.countDown();
+        }
+        logger.info("--> waiting for recovery to complete");
+        ensureGreen();
+        assertHitCount(client().prepareSearch().get(), numDocs);
     }
 
     @Test

--- a/src/test/java/org/elasticsearch/recovery/RelocationTests.java
+++ b/src/test/java/org/elasticsearch/recovery/RelocationTests.java
@@ -34,10 +34,12 @@ import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.client.Client;
-import org.elasticsearch.cluster.*;
+import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateListener;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
-import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.allocation.command.MoveAllocationCommand;
 import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider;
@@ -446,7 +448,7 @@ public class RelocationTests extends ElasticsearchIntegrationTest {
 
     @Test
     @TestLogging("cluster.service:TRACE,indices.recovery:TRACE")
-    public void testRecoveryWithBusyClusterUpdateThreadOnSourceNode() throws Exception {
+    public void testRelocationWithBusyClusterUpdateThread() throws Exception {
         final String indexName = "test";
         final Settings settings = ImmutableSettings.builder()
                 .put("gateway.type", "local")
@@ -534,125 +536,6 @@ public class RelocationTests extends ElasticsearchIntegrationTest {
         // force a move.
         client().admin().cluster().prepareReroute().get();
         ensureGreen();
-    }
-
-
-    @Test
-    @TestLogging("cluster.service:TRACE,indices.recovery:TRACE")
-    public void testPrimaryRelocationWithBusyClusterUpdateThreadOnTargetNode() throws Exception {
-        final String indexName = "test";
-        final Settings settings = ImmutableSettings.builder()
-//  the local gateway will allocate the shard back
-//                .put("gateway.type", "local")
-                .put(DiscoverySettings.PUBLISH_TIMEOUT, "1s").build();
-        String master = internalCluster().startNode(settings);
-        ensureGreen();
-        List<String> nodes = internalCluster().startNodesAsync(2, settings).get();
-        final String node1 = nodes.get(0);
-        final String node2 = nodes.get(1);
-        ClusterHealthResponse response = client().admin().cluster().prepareHealth().setWaitForNodes("3").get();
-        assertThat(response.isTimedOut(), is(false));
-
-
-        client().admin().indices().prepareCreate(indexName)
-                .setSettings(
-                        ImmutableSettings.builder()
-                                .put(FilterAllocationDecider.INDEX_ROUTING_INCLUDE_GROUP + "_name", node1)
-                                .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
-                                .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
-                ).get();
-
-
-        List<IndexRequestBuilder> requests = new ArrayList<>();
-        int numDocs = scaledRandomIntBetween(25, 250);
-        for (int i = 0; i < numDocs; i++) {
-            requests.add(client().prepareIndex(indexName, "type").setCreate(true).setSource("{}"));
-        }
-        indexRandom(true, requests);
-        ensureSearchable(indexName);
-
-        // capture the incoming state indicate that the replicas have upgraded and assigned
-
-        final CountDownLatch relocationStartedOnTarget = new CountDownLatch(1);
-        final CountDownLatch shardActiveSent = new CountDownLatch(1);
-        final CountDownLatch releaseClusterState = new CountDownLatch(1);
-        final CountDownLatch postRecoverOnTarget = new CountDownLatch(1);
-        final CountDownLatch releaseRecovery = new CountDownLatch(1);
-        try {
-            internalCluster().getInstance(ClusterService.class, node2).addLast(new ClusterStateListener() {
-                @Override
-                public void clusterChanged(ClusterChangedEvent event) {
-                    ClusterState state = event.state();
-                    RoutingNode routingNode = state.routingNodes().node(state.nodes().localNodeId());
-                    if (routingNode.isEmpty()) {
-                        // no nodes assigned here.
-                        return;
-                    }
-
-                    relocationStartedOnTarget.countDown();
-                    if (event.source().equals("force_publish")) {
-                        // recovery completed
-                        shardActiveSent.countDown();
-                        try {
-                            releaseClusterState.await();
-                        } catch (InterruptedException e) {
-                            //
-                        }
-                    }
-                }
-
-            });
-
-
-            internalCluster().getInstance(IndicesLifecycle.class, node2).addListener(new IndicesLifecycle.Listener() {
-                @Override
-                public void afterIndexShardPostRecovery(IndexShard indexShard) {
-                    postRecoverOnTarget.countDown();
-                    try {
-                        releaseRecovery.await();
-                    } catch (InterruptedException e) {
-
-                    }
-                }
-            });
-
-            logger.info("--> starting relocating primary");
-            // we don't expect this to be acknowledge by node1 where we block the cluster state thread
-            assertAcked(client().admin().indices().prepareUpdateSettings(indexName)
-                    .setSettings(ImmutableSettings.builder()
-                                    .put(FilterAllocationDecider.INDEX_ROUTING_INCLUDE_GROUP + "_name", node2)
-
-                    ));
-
-            logger.info("--> waiting for node2 to process relocation");
-            relocationStartedOnTarget.await();
-            logger.info("--> waiting for recovery to get to post recovery");
-            postRecoverOnTarget.await();
-            logger.info("--> publishing a cluster state");
-            internalCluster().clusterService(node2).submitStateUpdateTask("force_publish", new ClusterStateNonMasterUpdateTask() {
-                @Override
-                public ClusterState execute(ClusterState currentState) throws Exception {
-                    return ClusterState.builder(currentState).build();
-                }
-
-                @Override
-                public void onFailure(String source, Throwable t) {
-                    logger.error("unexpected failure", t);
-                }
-            });
-
-            logger.info("--> waiting for shard started to be sent from node2");
-            shardActiveSent.await();
-            logger.info("--> waiting for shard started to be processed on node1");
-            client(node1).admin().cluster().prepareHealth().setWaitForRelocatingShards(0).setLocal(true).get();
-        } finally {
-            logger.info("--> releasing cluster state update thread and recovery");
-            releaseRecovery.countDown();
-            releaseClusterState.countDown();
-        }
-        logger.info("--> waiting for recovery to complete");
-        ensureGreen();
-        assertHitCount(client().prepareSearch().get(), numDocs);
     }
 
     @Test

--- a/src/test/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/src/test/java/org/elasticsearch/test/InternalTestCluster.java
@@ -998,10 +998,17 @@ public final class InternalTestCluster extends TestCluster {
     }
 
     /**
-     * Returns a reference to a random nodes {@link ClusterService}
+     * Returns a reference to a random node's {@link ClusterService}
      */
-    public synchronized ClusterService clusterService() {
-        return getInstance(ClusterService.class);
+    public ClusterService clusterService() {
+        return clusterService(null);
+    }
+
+    /**
+     * Returns a reference to a node's {@link ClusterService}. If the given node is null, a random node will be selected.
+     */
+    public synchronized ClusterService clusterService(@Nullable String node) {
+        return getInstance(ClusterService.class, node);
     }
 
     /**


### PR DESCRIPTION
We keep track of the current stage of recovery using an instance of RecoveryState which is stored on the relevant IndexShard. At the moment changes to this object are made in many places of the code, which are charged of doing it in the right order, keeping track of timers and many more. Also the changes to shard state are decoupled from the recovery stages which caused #9503.

This PR refactors this and brings all of the changes into IndexShard. It also makes all recovery follow the exact same stages and shortcut some. This is in order to keep things simple and always the same (those shortcuts didn't add anything, we ended doing it all anyway). 

Also, all timer management is now folded into RecoveryState and unit tests are added.

This closes #9503 by moving the shard to post recovery only once the recovery is done (before they were decoupled), meaning that master promotion of the target shard to started can not cancel the recovery.

PS. This is a very tricky test to just simulate the issue in #9503 reliably. I plan to remove the test before committing as the scenario was already discovered by the CI.
