### PR TITLE
Expand wildcards in snapshot

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotRequest.java
@@ -385,10 +385,6 @@ public class CreateSnapshotRequest extends MasterNodeOperationRequest<CreateSnap
                 } else {
                     throw new ElasticsearchIllegalArgumentException("malformed indices section, should be an array of strings");
                 }
-            } else if (name.equals("ignore_unavailable") || name.equals("ignoreUnavailable")) {
-                ignoreUnavailable = nodeBooleanValue(entry.getValue());
-            } else if (name.equals("allow_no_indices") || name.equals("allowNoIndices")) {
-                allowNoIndices = nodeBooleanValue(entry.getValue());
             } else if (name.equals("expand_wildcards_open") || name.equals("expandWildcardsOpen")) {
                 expandWildcardsOpen = nodeBooleanValue(entry.getValue());
             } else if (name.equals("expand_wildcards_closed") || name.equals("expandWildcardsClosed")) {
@@ -404,7 +400,7 @@ public class CreateSnapshotRequest extends MasterNodeOperationRequest<CreateSnap
                 includeGlobalState = nodeBooleanValue(entry.getValue());
             }
         }
-        indicesOptions(IndicesOptions.fromOptions(ignoreUnavailable, allowNoIndices, expandWildcardsOpen, expandWildcardsClosed));
+        indicesOptions(IndicesOptions.fromMap((Map<String, Object>) source, IndicesOptions.fromOptions(ignoreUnavailable, allowNoIndices, expandWildcardsOpen, expandWildcardsClosed)));
         return this;
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
@@ -519,10 +519,6 @@ public class RestoreSnapshotRequest extends MasterNodeOperationRequest<RestoreSn
                 } else {
                     throw new ElasticsearchIllegalArgumentException("malformed indices section, should be an array of strings");
                 }
-            } else if (name.equals("ignore_unavailable") || name.equals("ignoreUnavailable")) {
-                ignoreUnavailable = nodeBooleanValue(entry.getValue());
-            } else if (name.equals("allow_no_indices") || name.equals("allowNoIndices")) {
-                allowNoIndices = nodeBooleanValue(entry.getValue());
             } else if (name.equals("expand_wildcards_open") || name.equals("expandWildcardsOpen")) {
                 expandWildcardsOpen = nodeBooleanValue(entry.getValue());
             } else if (name.equals("expand_wildcards_closed") || name.equals("expandWildcardsClosed")) {
@@ -567,7 +563,7 @@ public class RestoreSnapshotRequest extends MasterNodeOperationRequest<RestoreSn
                 throw new ElasticsearchIllegalArgumentException("Unknown parameter " + name);
             }
         }
-        indicesOptions(IndicesOptions.fromOptions(ignoreUnavailable, allowNoIndices, expandWildcardsOpen, expandWildcardsClosed));
+        indicesOptions(IndicesOptions.fromMap((Map<String, Object>) source, IndicesOptions.fromOptions(ignoreUnavailable, allowNoIndices, expandWildcardsOpen, expandWildcardsClosed)));
         return this;
     }
 

--- a/src/main/java/org/elasticsearch/common/xcontent/support/XContentMapValues.java
+++ b/src/main/java/org/elasticsearch/common/xcontent/support/XContentMapValues.java
@@ -387,4 +387,23 @@ public class XContentMapValues {
             throw new ElasticsearchParseException(desc + " should be a hash but was of type: " + node.getClass());
         }
     }
+
+    /**
+     * Returns an array of string value from a node value.
+     *
+     * If the node represents an array the corresponding array of strings is returned.
+     * Otherwise the node is treated as a comma-separated string.
+     */
+    public static String[] nodeStringArrayValue(Object node) {
+        if (isArray(node)) {
+            List list = (List) node;
+            String[] arr = new String[list.size()];
+            for (int i = 0; i < arr.length; i++) {
+                arr[i] = nodeStringValue(list.get(i), null);
+            }
+            return arr;
+        } else {
+            return Strings.splitStringByCommaToArray(node.toString());
+        }
+    }
 }

--- a/src/test/java/org/elasticsearch/action/percolate/MultiPercolatorRequestTests.java
+++ b/src/test/java/org/elasticsearch/action/percolate/MultiPercolatorRequestTests.java
@@ -38,7 +38,7 @@ public class MultiPercolatorRequestTests extends ElasticsearchTestCase {
         byte[] data = Streams.copyToBytesFromClasspath("/org/elasticsearch/action/percolate/mpercolate1.json");
         MultiPercolateRequest request = new MultiPercolateRequest().add(data, 0, data.length);
 
-        assertThat(request.requests().size(), equalTo(6));
+        assertThat(request.requests().size(), equalTo(8));
         PercolateRequest percolateRequest = request.requests().get(0);
         assertThat(percolateRequest.indices()[0], equalTo("my-index1"));
         assertThat(percolateRequest.documentType(), equalTo("my-type1"));
@@ -61,8 +61,8 @@ public class MultiPercolatorRequestTests extends ElasticsearchTestCase {
         assertThat(percolateRequest.onlyCount(), equalTo(false));
         assertThat(percolateRequest.getRequest(), nullValue());
         assertThat(percolateRequest.source(), notNullValue());
-        sourceMap =  XContentFactory.xContent(percolateRequest.source()).createParser(percolateRequest.source()).map();
-        assertThat(sourceMap.get("doc"), equalTo((Object)MapBuilder.newMapBuilder().put("field1", "value2").map()));
+        sourceMap = XContentFactory.xContent(percolateRequest.source()).createParser(percolateRequest.source()).map();
+        assertThat(sourceMap.get("doc"), equalTo((Object) MapBuilder.newMapBuilder().put("field1", "value2").map()));
 
         percolateRequest = request.requests().get(2);
         assertThat(percolateRequest.indices()[0], equalTo("my-index4"));
@@ -74,8 +74,8 @@ public class MultiPercolatorRequestTests extends ElasticsearchTestCase {
         assertThat(percolateRequest.onlyCount(), equalTo(true));
         assertThat(percolateRequest.getRequest(), nullValue());
         assertThat(percolateRequest.source(), notNullValue());
-        sourceMap =  XContentFactory.xContent(percolateRequest.source()).createParser(percolateRequest.source()).map();
-        assertThat(sourceMap.get("doc"), equalTo((Object)MapBuilder.newMapBuilder().put("field1", "value3").map()));
+        sourceMap = XContentFactory.xContent(percolateRequest.source()).createParser(percolateRequest.source()).map();
+        assertThat(sourceMap.get("doc"), equalTo((Object) MapBuilder.newMapBuilder().put("field1", "value3").map()));
 
         percolateRequest = request.requests().get(3);
         assertThat(percolateRequest.indices()[0], equalTo("my-index6"));
@@ -114,8 +114,40 @@ public class MultiPercolatorRequestTests extends ElasticsearchTestCase {
         assertThat(percolateRequest.onlyCount(), equalTo(false));
         assertThat(percolateRequest.getRequest(), nullValue());
         assertThat(percolateRequest.source(), notNullValue());
-        sourceMap =  XContentFactory.xContent(percolateRequest.source()).createParser(percolateRequest.source()).map();
-        assertThat(sourceMap.get("doc"), equalTo((Object)MapBuilder.newMapBuilder().put("field1", "value4").map()));
+        sourceMap = XContentFactory.xContent(percolateRequest.source()).createParser(percolateRequest.source()).map();
+        assertThat(sourceMap.get("doc"), equalTo((Object) MapBuilder.newMapBuilder().put("field1", "value4").map()));
+
+        percolateRequest = request.requests().get(6);
+        assertThat(percolateRequest.indices()[0], equalTo("percolate-index1"));
+        assertThat(percolateRequest.documentType(), equalTo("other-type"));
+        assertThat(percolateRequest.routing(), equalTo("percolate-routing-1"));
+        assertThat(percolateRequest.preference(), equalTo("_local"));
+        assertThat(percolateRequest.getRequest(), notNullValue());
+        assertThat(percolateRequest.getRequest().indices()[0], equalTo("my-index9"));
+        assertThat(percolateRequest.getRequest().type(), equalTo("my-type1"));
+        assertThat(percolateRequest.getRequest().routing(), nullValue());
+        assertThat(percolateRequest.getRequest().preference(), nullValue());
+        assertThat(percolateRequest.indicesOptions(), equalTo(IndicesOptions.strictExpandOpenAndForbidClosed()));
+        assertThat(percolateRequest.onlyCount(), equalTo(false));
+        assertThat(percolateRequest.source(), notNullValue());
+        sourceMap = XContentFactory.xContent(percolateRequest.source()).createParser(percolateRequest.source()).map();
+        assertThat(sourceMap.get("doc"), nullValue());
+
+        percolateRequest = request.requests().get(7);
+        assertThat(percolateRequest.indices()[0], equalTo("my-index10"));
+        assertThat(percolateRequest.documentType(), equalTo("my-type1"));
+        assertThat(percolateRequest.routing(), nullValue());
+        assertThat(percolateRequest.preference(), nullValue());
+        assertThat(percolateRequest.getRequest(), notNullValue());
+        assertThat(percolateRequest.getRequest().indices()[0], equalTo("my-index10"));
+        assertThat(percolateRequest.getRequest().type(), equalTo("my-type1"));
+        assertThat(percolateRequest.getRequest().routing(), nullValue());
+        assertThat(percolateRequest.getRequest().preference(), nullValue());
+        assertThat(percolateRequest.indicesOptions(), equalTo(IndicesOptions.fromOptions(false, false, true, false, IndicesOptions.strictExpandOpenAndForbidClosed())));
+        assertThat(percolateRequest.onlyCount(), equalTo(false));
+        assertThat(percolateRequest.source(), notNullValue());
+        sourceMap = XContentFactory.xContent(percolateRequest.source()).createParser(percolateRequest.source()).map();
+        assertThat(sourceMap.get("doc"), nullValue());
     }
 
     @Test
@@ -147,8 +179,8 @@ public class MultiPercolatorRequestTests extends ElasticsearchTestCase {
         assertThat(percolateRequest.onlyCount(), equalTo(false));
         assertThat(percolateRequest.getRequest(), nullValue());
         assertThat(percolateRequest.source(), notNullValue());
-        sourceMap =  XContentFactory.xContent(percolateRequest.source()).createParser(percolateRequest.source()).map();
-        assertThat(sourceMap.get("doc"), equalTo((Object)MapBuilder.newMapBuilder().put("field1", "value2").map()));
+        sourceMap = XContentFactory.xContent(percolateRequest.source()).createParser(percolateRequest.source()).map();
+        assertThat(sourceMap.get("doc"), equalTo((Object) MapBuilder.newMapBuilder().put("field1", "value2").map()));
 
         percolateRequest = request.requests().get(2);
         assertThat(percolateRequest.indices()[0], equalTo("my-index1"));
@@ -157,8 +189,8 @@ public class MultiPercolatorRequestTests extends ElasticsearchTestCase {
         assertThat(percolateRequest.onlyCount(), equalTo(false));
         assertThat(percolateRequest.getRequest(), nullValue());
         assertThat(percolateRequest.source(), notNullValue());
-        sourceMap =  XContentFactory.xContent(percolateRequest.source()).createParser(percolateRequest.source()).map();
-        assertThat(sourceMap.get("doc"), equalTo((Object)MapBuilder.newMapBuilder().put("field1", "value3").map()));
+        sourceMap = XContentFactory.xContent(percolateRequest.source()).createParser(percolateRequest.source()).map();
+        assertThat(sourceMap.get("doc"), equalTo((Object) MapBuilder.newMapBuilder().put("field1", "value3").map()));
     }
 
 }

--- a/src/test/java/org/elasticsearch/action/percolate/mpercolate1.json
+++ b/src/test/java/org/elasticsearch/action/percolate/mpercolate1.json
@@ -10,3 +10,7 @@
 {}
 {"percolate" : {"index" : "my-index8", "type" : "my-type1", "routing" : "my-routing-1", "preference" : "primary"}}
 {"doc" : {"field1" : "value4"}}
+{"percolate" : {"id" : "3", "index" : "my-index9", "type" : "my-type1", "percolate_index": "percolate-index1", "percolate_type": "other-type", "percolate_preference": "_local", "percolate_routing": "percolate-routing-1"}}
+{}
+{"percolate" : {"id" : "4", "index" : "my-index10", "type" : "my-type1", "allow_no_indices": false, "expand_wildcards" : ["open"]}}
+{}

--- a/src/test/java/org/elasticsearch/action/search/MultiSearchRequestTests.java
+++ b/src/test/java/org/elasticsearch/action/search/MultiSearchRequestTests.java
@@ -35,20 +35,26 @@ public class MultiSearchRequestTests extends ElasticsearchTestCase {
     public void simpleAdd() throws Exception {
         byte[] data = Streams.copyToBytesFromClasspath("/org/elasticsearch/action/search/simple-msearch1.json");
         MultiSearchRequest request = new MultiSearchRequest().add(data, 0, data.length, null, null, null);
-        assertThat(request.requests().size(), equalTo(5));
+        assertThat(request.requests().size(), equalTo(8));
         assertThat(request.requests().get(0).indices()[0], equalTo("test"));
         assertThat(request.requests().get(0).indicesOptions(), equalTo(IndicesOptions.fromOptions(true, true, true, true, IndicesOptions.strictExpandOpenAndForbidClosed())));
         assertThat(request.requests().get(0).types().length, equalTo(0));
         assertThat(request.requests().get(1).indices()[0], equalTo("test"));
         assertThat(request.requests().get(1).indicesOptions(), equalTo(IndicesOptions.fromOptions(false, true, true, true, IndicesOptions.strictExpandOpenAndForbidClosed())));
         assertThat(request.requests().get(1).types()[0], equalTo("type1"));
-        assertThat(request.requests().get(2).indices(), nullValue());
-        assertThat(request.requests().get(2).types().length, equalTo(0));
-        assertThat(request.requests().get(3).indices(), nullValue());
-        assertThat(request.requests().get(3).types().length, equalTo(0));
-        assertThat(request.requests().get(3).searchType(), equalTo(SearchType.DFS_QUERY_THEN_FETCH));
-        assertThat(request.requests().get(4).indices(), nullValue());
-        assertThat(request.requests().get(4).types().length, equalTo(0));
+        assertThat(request.requests().get(2).indices()[0], equalTo("test"));
+        assertThat(request.requests().get(2).indicesOptions(), equalTo(IndicesOptions.fromOptions(false, true, true, false, IndicesOptions.strictExpandOpenAndForbidClosed())));
+        assertThat(request.requests().get(3).indices()[0], equalTo("test"));
+        assertThat(request.requests().get(3).indicesOptions(), equalTo(IndicesOptions.fromOptions(true, true, true, true, IndicesOptions.strictExpandOpenAndForbidClosed())));
+        assertThat(request.requests().get(4).indices()[0], equalTo("test"));
+        assertThat(request.requests().get(4).indicesOptions(), equalTo(IndicesOptions.fromOptions(true, false, false, true, IndicesOptions.strictExpandOpenAndForbidClosed())));
+        assertThat(request.requests().get(5).indices(), nullValue());
+        assertThat(request.requests().get(5).types().length, equalTo(0));
+        assertThat(request.requests().get(6).indices(), nullValue());
+        assertThat(request.requests().get(6).types().length, equalTo(0));
+        assertThat(request.requests().get(6).searchType(), equalTo(SearchType.DFS_QUERY_THEN_FETCH));
+        assertThat(request.requests().get(7).indices(), nullValue());
+        assertThat(request.requests().get(7).types().length, equalTo(0));
     }
 
     @Test
@@ -86,5 +92,26 @@ public class MultiSearchRequestTests extends ElasticsearchTestCase {
         assertThat(request.requests().get(3).indices(), nullValue());
         assertThat(request.requests().get(3).types().length, equalTo(0));
         assertThat(request.requests().get(3).searchType(), equalTo(SearchType.DFS_QUERY_THEN_FETCH));
+    }
+
+    @Test
+    public void simpleAdd4() throws Exception {
+        byte[] data = Streams.copyToBytesFromClasspath("/org/elasticsearch/action/search/simple-msearch4.json");
+        MultiSearchRequest request = new MultiSearchRequest().add(data, 0, data.length, null, null, null);
+        assertThat(request.requests().size(), equalTo(3));
+        assertThat(request.requests().get(0).indices()[0], equalTo("test0"));
+        assertThat(request.requests().get(0).indices()[1], equalTo("test1"));
+        assertThat(request.requests().get(0).queryCache(), equalTo(true));
+        assertThat(request.requests().get(0).preference(), nullValue());
+        assertThat(request.requests().get(1).indices()[0], equalTo("test2"));
+        assertThat(request.requests().get(1).indices()[1], equalTo("test3"));
+        assertThat(request.requests().get(1).types()[0], equalTo("type1"));
+        assertThat(request.requests().get(1).queryCache(), nullValue());
+        assertThat(request.requests().get(1).preference(), equalTo("_local"));
+        assertThat(request.requests().get(2).indices()[0], equalTo("test4"));
+        assertThat(request.requests().get(2).indices()[1], equalTo("test1"));
+        assertThat(request.requests().get(2).types()[0], equalTo("type2"));
+        assertThat(request.requests().get(2).types()[1], equalTo("type1"));
+        assertThat(request.requests().get(2).routing(), equalTo("123"));
     }
 }

--- a/src/test/java/org/elasticsearch/action/search/simple-msearch1.json
+++ b/src/test/java/org/elasticsearch/action/search/simple-msearch1.json
@@ -2,6 +2,12 @@
 {"query" : {"match_all" {}}}
 {"index" : "test", "type" : "type1", "expand_wildcards" : ["open", "closed"]}
 {"query" : {"match_all" {}}}
+{"index":"test", "ignore_unavailable" : false, "expand_wildcards" : ["open"]}}
+{"query" : {"match_all" {}}}
+{"index":"test", "ignore_unavailable" : true, "allow_no_indices": true, "expand_wildcards" : ["open", "closed"]}}
+{"query" : {"match_all" {}}}
+{"index":"test", "ignore_unavailable" : true, "allow_no_indices": false, "expand_wildcards" : ["closed"]}}
+{"query" : {"match_all" {}}}
 {}
 {"query" : {"match_all" {}}}
 {"search_type" : "dfs_query_then_fetch"}

--- a/src/test/java/org/elasticsearch/action/search/simple-msearch4.json
+++ b/src/test/java/org/elasticsearch/action/search/simple-msearch4.json
@@ -1,0 +1,6 @@
+{"index":["test0", "test1"], "query_cache": true}
+{"query" : {"match_all" {}}}
+{"index" : "test2,test3", "type" : "type1", "preference": "_local"}
+{"query" : {"match_all" {}}}
+{"index" : ["test4", "test1"], "type" :  [ "type2", "type1" ], "routing": "123"}
+{"query" : {"match_all" {}}}


### PR DESCRIPTION
This PR makes handling of expand_wildcards parameters consistent. The first commit f5d8ca8 will go to both 1.x and master and the second commit 7abe1ed will go into master only. Closes #6097.
