### PR TITLE
Lock down `_size` field

### DIFF
--- a/docs/reference/migration/migrate_2_0.asciidoc
+++ b/docs/reference/migration/migrate_2_0.asciidoc
@@ -257,6 +257,7 @@ to provide special features.  They now have limited configuration options.
 * `_routing` configuration is limited to requiring the field.
 * `_boost` has been removed.
 * `_field_names` configuration is limited to disabling the field.
+* `_size` configuration is limited to enabling the field.
 
 === Codecs
 

--- a/src/test/java/org/elasticsearch/get/GetActionTests.java
+++ b/src/test/java/org/elasticsearch/get/GetActionTests.java
@@ -1067,8 +1067,8 @@ public class GetActionTests extends ElasticsearchIntegrationTest {
     @Test
     public void testUngeneratedFieldsNotPartOfSourceUnstored() throws IOException {
         indexSingleDocumentWithUngeneratedFieldsThatAreNeverPartOf_source(false, randomBoolean());
-        String[] fieldsList = {"_timestamp", "_size"};
-        String[] alwaysStoredFieldsList = {"_routing"};
+        String[] fieldsList = {"_timestamp"};
+        String[] alwaysStoredFieldsList = {"_routing", "_size"};
         // before refresh - document is only in translog
         assertGetFieldsAlwaysNull(indexOrAlias(), "doc", "1", fieldsList, "1");
         assertGetFieldsAlwaysWorks(indexOrAlias(), "doc", "1", alwaysStoredFieldsList, "1");
@@ -1111,7 +1111,6 @@ public class GetActionTests extends ElasticsearchIntegrationTest {
                 "        \"enabled\": true\n" +
                 "      },\n" +
                 "      \"_size\": {\n" +
-                "        \"store\": \"" + storedString + "\",\n" +
                 "        \"enabled\": true\n" +
                 "      }\n" +
                 "    }\n" +

--- a/src/test/java/org/elasticsearch/index/mapper/size/SizeMappingTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/size/SizeMappingTests.java
@@ -19,7 +19,11 @@
 
 package org.elasticsearch.index.mapper.size;
 
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.DocumentMapperParser;
@@ -31,8 +35,7 @@ import org.junit.Test;
 import static org.hamcrest.Matchers.*;
 
 public class SizeMappingTests extends ElasticsearchSingleNodeTest {
-
-    @Test
+    
     public void testSizeEnabled() throws Exception {
         String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
                 .startObject("_size").field("enabled", true).endObject()
@@ -46,16 +49,16 @@ public class SizeMappingTests extends ElasticsearchSingleNodeTest {
                 .bytes();
         ParsedDocument doc = docMapper.parse(SourceToParse.source(source).type("type").id("1"));
 
-        assertThat(doc.rootDoc().getField("_size").fieldType().stored(), equalTo(false));
+        assertThat(doc.rootDoc().getField("_size").fieldType().stored(), equalTo(true));
         assertThat(doc.rootDoc().getField("_size").tokenStream(docMapper.mappers().indexAnalyzer(), null), notNullValue());
     }
-
-    @Test
-    public void testSizeEnabledAndStored() throws Exception {
+    
+    public void testSizeEnabledAndStoredBackcompat() throws Exception {
         String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
                 .startObject("_size").field("enabled", true).field("store", "yes").endObject()
                 .endObject().endObject().string();
-        DocumentMapper docMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
+        Settings indexSettings = ImmutableSettings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.V_1_4_2.id).build();
+        DocumentMapper docMapper = createIndex("test", indexSettings).mapperService().documentMapperParser().parse(mapping);
 
         BytesReference source = XContentFactory.jsonBuilder()
                 .startObject()
@@ -67,8 +70,7 @@ public class SizeMappingTests extends ElasticsearchSingleNodeTest {
         assertThat(doc.rootDoc().getField("_size").fieldType().stored(), equalTo(true));
         assertThat(doc.rootDoc().getField("_size").tokenStream(docMapper.mappers().indexAnalyzer(), null), notNullValue());
     }
-
-    @Test
+    
     public void testSizeDisabled() throws Exception {
         String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
                 .startObject("_size").field("enabled", false).endObject()
@@ -84,8 +86,7 @@ public class SizeMappingTests extends ElasticsearchSingleNodeTest {
 
         assertThat(doc.rootDoc().getField("_size"), nullValue());
     }
-
-    @Test
+    
     public void testSizeNotSet() throws Exception {
         String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
                 .endObject().endObject().string();
@@ -100,8 +101,7 @@ public class SizeMappingTests extends ElasticsearchSingleNodeTest {
 
         assertThat(doc.rootDoc().getField("_size"), nullValue());
     }
-
-    @Test
+    
     public void testThatDisablingWorksWhenMerging() throws Exception {
         String enabledMapping = XContentFactory.jsonBuilder().startObject().startObject("type")
                 .startObject("_size").field("enabled", true).endObject()

--- a/src/test/java/org/elasticsearch/index/mapper/update/UpdateMappingTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/update/UpdateMappingTests.java
@@ -166,7 +166,6 @@ public class UpdateMappingTests extends ElasticsearchSingleNodeTest {
                 .startObject("type")
                 .startObject("_size")
                 .field("enabled", enabled)
-                .field("store", true)
                 .endObject()
                 .endObject()
                 .endObject();

--- a/src/test/java/org/elasticsearch/percolator/PercolatorTests.java
+++ b/src/test/java/org/elasticsearch/percolator/PercolatorTests.java
@@ -560,7 +560,7 @@ public class PercolatorTests extends ElasticsearchIntegrationTest {
     @Test
     public void percolateWithSizeField() throws Exception {
         String mapping = XContentFactory.jsonBuilder().startObject().startObject("type1")
-                .startObject("_size").field("enabled", true).field("store", "yes").endObject()
+                .startObject("_size").field("enabled", true).endObject()
                 .startObject("properties").startObject("field1").field("type", "string").endObject().endObject()
                 .endObject().endObject().string();
 

--- a/src/test/java/org/elasticsearch/search/fields/SearchFieldsTests.java
+++ b/src/test/java/org/elasticsearch/search/fields/SearchFieldsTests.java
@@ -72,8 +72,9 @@ public class SearchFieldsTests extends ElasticsearchIntegrationTest {
         client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForYellowStatus().execute().actionGet();
 
         String mapping = XContentFactory.jsonBuilder().startObject().startObject("type1")
-                // _timestamp is randomly enabled via templates but we don't want it here to test stored fields behaviour
+                // _timestamp and _size are randomly enabled via templates but we don't want it here to test stored fields behaviour
                 .startObject("_timestamp").field("enabled", false).endObject()
+                .startObject("_size").field("enabled", false).endObject()
                 .startObject("properties")
                 .startObject("field1").field("type", "string").field("store", "yes").endObject()
                 .startObject("field2").field("type", "string").field("store", "no").endObject()


### PR DESCRIPTION
This also changes the stored setting for _size to true (for
indexes created in 2.x).

see #8143
