### PR TITLE
Remove component settings from AbstractComponent

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/restart/TransportNodesRestartAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/restart/TransportNodesRestartAction.java
@@ -61,7 +61,7 @@ public class TransportNodesRestartAction extends TransportNodesOperationAction<N
                                        Node node, ActionFilters actionFilters) {
         super(settings, NodesRestartAction.NAME, clusterName, threadPool, clusterService, transportService, actionFilters);
         this.node = node;
-        disabled = componentSettings.getAsBoolean("disabled", false);
+        disabled = this.settings.getAsBoolean("admin.cluster.node.restart.disabled", false);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/shutdown/TransportNodesShutdownAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/shutdown/TransportNodesShutdownAction.java
@@ -62,8 +62,8 @@ public class TransportNodesShutdownAction extends TransportMasterNodeOperationAc
         super(settings, NodesShutdownAction.NAME, transportService, clusterService, threadPool, actionFilters);
         this.node = node;
         this.clusterName = clusterName;
-        this.disabled = settings.getAsBoolean("action.disable_shutdown", componentSettings.getAsBoolean("disabled", false));
-        this.delay = componentSettings.getAsTime("delay", TimeValue.timeValueMillis(200));
+        this.disabled = settings.getAsBoolean("action.disable_shutdown", this.settings.getAsBoolean("action.admin.cluster.node.shutdown.disabled", false));
+        this.delay = this.settings.getAsTime("action.admin.cluster.node.shutdown.delay", TimeValue.timeValueMillis(200));
 
         this.transportService.registerHandler(SHUTDOWN_NODE_ACTION_NAME, new NodeShutdownRequestHandler());
     }

--- a/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
+++ b/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
@@ -86,7 +86,7 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
         this.createIndexAction = createIndexAction;
 
         this.autoCreateIndex = new AutoCreateIndex(settings);
-        this.allowIdGeneration = componentSettings.getAsBoolean("action.allow_id_generation", true);
+        this.allowIdGeneration = this.settings.getAsBoolean("action.bulk.action.allow_id_generation", true);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -69,7 +69,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
         this.scanAction = scanAction;
         this.countAction = countAction;
 
-        this.optimizeSingleShard = componentSettings.getAsBoolean("optimize_single_shard", true);
+        this.optimizeSingleShard = this.settings.getAsBoolean("action.search.optimize_single_shard", true);
 
 
     }

--- a/src/main/java/org/elasticsearch/cache/recycler/PageCacheRecycler.java
+++ b/src/main/java/org/elasticsearch/cache/recycler/PageCacheRecycler.java
@@ -38,10 +38,9 @@ import static org.elasticsearch.common.recycler.Recyclers.*;
 /** A recycler of fixed-size pages. */
 public class PageCacheRecycler extends AbstractComponent {
 
-    public static final String TYPE = "page.type";
-    public static final String LIMIT_HEAP = "page.limit.heap";
-    public static final String LIMIT_PER_THREAD = "page.limit.per_thread";
-    public static final String WEIGHT = "page.weight";
+    public static final String TYPE = "recycler.page.type";
+    public static final String LIMIT_HEAP = "recycler.page.limit.heap";
+    public static final String WEIGHT = "recycler.page.weight";
 
     private final Recycler<byte[]> bytePage;
     private final Recycler<int[]> intPage;
@@ -79,8 +78,8 @@ public class PageCacheRecycler extends AbstractComponent {
     @Inject
     public PageCacheRecycler(Settings settings, ThreadPool threadPool) {
         super(settings);
-        final Type type = Type.parse(componentSettings.get(TYPE));
-        final long limit = componentSettings.getAsMemory(LIMIT_HEAP, "10%").bytes();
+        final Type type = Type.parse(settings.get(TYPE));
+        final long limit = settings.getAsMemory(LIMIT_HEAP, "10%").bytes();
         final int availableProcessors = EsExecutors.boundedNumberOfProcessors(settings);
         final int searchThreadPoolSize = maximumSearchThreadPoolSize(threadPool, settings);
 
@@ -97,11 +96,11 @@ public class PageCacheRecycler extends AbstractComponent {
         // to direct ByteBuffers or sun.misc.Unsafe on a byte[] but this would have other issues
         // that would need to be addressed such as garbage collection of native memory or safety
         // of Unsafe writes.
-        final double bytesWeight = componentSettings.getAsDouble(WEIGHT + ".bytes", 1d);
-        final double intsWeight = componentSettings.getAsDouble(WEIGHT + ".ints", 1d);
-        final double longsWeight = componentSettings.getAsDouble(WEIGHT + ".longs", 1d);
+        final double bytesWeight = settings.getAsDouble(WEIGHT + ".bytes", 1d);
+        final double intsWeight = settings.getAsDouble(WEIGHT + ".ints", 1d);
+        final double longsWeight = settings.getAsDouble(WEIGHT + ".longs", 1d);
         // object pages are less useful to us so we give them a lower weight by default
-        final double objectsWeight = componentSettings.getAsDouble(WEIGHT + ".objects", 0.1d);
+        final double objectsWeight = settings.getAsDouble(WEIGHT + ".objects", 0.1d);
 
         final double totalWeight = bytesWeight + intsWeight + longsWeight + objectsWeight;
 

--- a/src/main/java/org/elasticsearch/client/transport/TransportClientNodesService.java
+++ b/src/main/java/org/elasticsearch/client/transport/TransportClientNodesService.java
@@ -104,15 +104,15 @@ public class TransportClientNodesService extends AbstractComponent {
         this.minCompatibilityVersion = version.minimumCompatibilityVersion();
         this.headers = headers;
 
-        this.nodesSamplerInterval = componentSettings.getAsTime("nodes_sampler_interval", timeValueSeconds(5));
-        this.pingTimeout = componentSettings.getAsTime("ping_timeout", timeValueSeconds(5)).millis();
-        this.ignoreClusterName = componentSettings.getAsBoolean("ignore_cluster_name", false);
+        this.nodesSamplerInterval = this.settings.getAsTime("client.transport.nodes_sampler_interval", timeValueSeconds(5));
+        this.pingTimeout = this.settings.getAsTime("client.transport.ping_timeout", timeValueSeconds(5)).millis();
+        this.ignoreClusterName = this.settings.getAsBoolean("client.transport.ignore_cluster_name", false);
 
         if (logger.isDebugEnabled()) {
             logger.debug("node_sampler_interval[" + nodesSamplerInterval + "]");
         }
 
-        if (componentSettings.getAsBoolean("sniff", false)) {
+        if (this.settings.getAsBoolean("client.transport.sniff", false)) {
             this.nodesSampler = new SniffNodesSampler();
         } else {
             this.nodesSampler = new SimpleNodeSampler();

--- a/src/main/java/org/elasticsearch/cluster/routing/RoutingService.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/RoutingService.java
@@ -70,7 +70,7 @@ public class RoutingService extends AbstractLifecycleComponent<RoutingService> i
         this.threadPool = threadPool;
         this.clusterService = clusterService;
         this.allocationService = allocationService;
-        this.schedule = componentSettings.getAsTime("schedule", timeValueSeconds(10));
+        this.schedule = settings.getAsTime("cluster.routing.schedule", timeValueSeconds(10));
         clusterService.addFirst(this);
     }
 

--- a/src/main/java/org/elasticsearch/cluster/service/InternalClusterService.java
+++ b/src/main/java/org/elasticsearch/cluster/service/InternalClusterService.java
@@ -117,7 +117,7 @@ public class InternalClusterService extends AbstractLifecycleComponent<ClusterSe
 
         this.nodeSettingsService.setClusterService(this);
 
-        this.reconnectInterval = componentSettings.getAsTime("reconnect_interval", TimeValue.timeValueSeconds(10));
+        this.reconnectInterval = this.settings.getAsTime("cluster.service.reconnect_interval", TimeValue.timeValueSeconds(10));
 
         localNodeMasterListeners = new LocalNodeMasterListeners(threadPool);
 

--- a/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobStore.java
+++ b/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobStore.java
@@ -49,7 +49,7 @@ public class FsBlobStore extends AbstractComponent implements BlobStore {
         super(settings);
         this.path = path;
         Files.createDirectories(path);
-        this.bufferSizeInBytes = (int) settings.getAsBytesSize("buffer_size", new ByteSizeValue(100, ByteSizeUnit.KB)).bytes();
+        this.bufferSizeInBytes = (int) settings.getAsBytesSize("repositories.fs.buffer_size", new ByteSizeValue(100, ByteSizeUnit.KB)).bytes();
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/common/blobstore/url/URLBlobStore.java
+++ b/src/main/java/org/elasticsearch/common/blobstore/url/URLBlobStore.java
@@ -57,7 +57,7 @@ public class URLBlobStore extends AbstractComponent implements BlobStore {
     public URLBlobStore(Settings settings, URL path) {
         super(settings);
         this.path = path;
-        this.bufferSizeInBytes = (int) settings.getAsBytesSize("buffer_size", new ByteSizeValue(100, ByteSizeUnit.KB)).bytes();
+        this.bufferSizeInBytes = (int) settings.getAsBytesSize("repositories.uri.buffer_size", new ByteSizeValue(100, ByteSizeUnit.KB)).bytes();
     }
 
     /**

--- a/src/main/java/org/elasticsearch/common/component/AbstractComponent.java
+++ b/src/main/java/org/elasticsearch/common/component/AbstractComponent.java
@@ -26,51 +26,26 @@ import org.elasticsearch.common.settings.Settings;
 /**
  *
  */
-public class AbstractComponent {
+public abstract class AbstractComponent {
 
     protected final ESLogger logger;
 
     protected final Settings settings;
 
-    protected final Settings componentSettings;
-
     public AbstractComponent(Settings settings) {
         this.logger = Loggers.getLogger(getClass(), settings);
         this.settings = settings;
-        this.componentSettings = settings.getComponentSettings(getClass());
-    }
-
-    public AbstractComponent(Settings settings, String prefixSettings) {
-        this.logger = Loggers.getLogger(getClass(), settings);
-        this.settings = settings;
-        this.componentSettings = settings.getComponentSettings(prefixSettings, getClass());
     }
 
     public AbstractComponent(Settings settings, Class customClass) {
         this.logger = Loggers.getLogger(customClass, settings);
         this.settings = settings;
-        this.componentSettings = settings.getComponentSettings(customClass);
     }
 
-    public AbstractComponent(Settings settings, String prefixSettings, Class customClass) {
-        this.logger = Loggers.getLogger(customClass, settings);
-        this.settings = settings;
-        this.componentSettings = settings.getComponentSettings(prefixSettings, customClass);
-    }
-
-    public AbstractComponent(Settings settings, Class loggerClass, Class componentClass) {
-        this.logger = Loggers.getLogger(loggerClass, settings);
-        this.settings = settings;
-        this.componentSettings = settings.getComponentSettings(componentClass);
-    }
-
-    public AbstractComponent(Settings settings, String prefixSettings, Class loggerClass, Class componentClass) {
-        this.logger = Loggers.getLogger(loggerClass, settings);
-        this.settings = settings;
-        this.componentSettings = settings.getComponentSettings(prefixSettings, componentClass);
-    }
-
-    public String nodeName() {
+    /**
+     * Returns the nodes name from the settings or the empty string if not set.
+     */
+    public final String nodeName() {
         return settings.get("name", "");
     }
 }

--- a/src/main/java/org/elasticsearch/common/component/AbstractLifecycleComponent.java
+++ b/src/main/java/org/elasticsearch/common/component/AbstractLifecycleComponent.java
@@ -42,22 +42,6 @@ public abstract class AbstractLifecycleComponent<T> extends AbstractComponent im
         super(settings, customClass);
     }
 
-    protected AbstractLifecycleComponent(Settings settings, Class loggerClass, Class componentClass) {
-        super(settings, loggerClass, componentClass);
-    }
-
-    protected AbstractLifecycleComponent(Settings settings, String prefixSettings) {
-        super(settings, prefixSettings);
-    }
-
-    protected AbstractLifecycleComponent(Settings settings, String prefixSettings, Class customClass) {
-        super(settings, prefixSettings, customClass);
-    }
-
-    protected AbstractLifecycleComponent(Settings settings, String prefixSettings, Class loggerClass, Class componentClass) {
-        super(settings, prefixSettings, loggerClass, componentClass);
-    }
-
     @Override
     public Lifecycle.State lifecycleState() {
         return this.lifecycle.state();

--- a/src/main/java/org/elasticsearch/common/settings/ImmutableSettings.java
+++ b/src/main/java/org/elasticsearch/common/settings/ImmutableSettings.java
@@ -188,27 +188,6 @@ public class ImmutableSettings implements Settings {
         return map;
     }
 
-
-    @Override
-    public Settings getComponentSettings(Class component) {
-        if (component.getName().startsWith("org.elasticsearch")) {
-            return getComponentSettings("org.elasticsearch", component);
-        }
-        // not starting with org.elasticsearch, just remove the first package part (probably org/net/com)
-        return getComponentSettings(component.getName().substring(0, component.getName().indexOf('.')), component);
-    }
-
-    @Override
-    public Settings getComponentSettings(String prefix, Class component) {
-        String type = component.getName();
-        if (!type.startsWith(prefix)) {
-            throw new SettingsException("Component [" + type + "] does not start with prefix [" + prefix + "]");
-        }
-        String settingPrefix = type.substring(prefix.length() + 1); // 1 for the '.'
-        settingPrefix = settingPrefix.substring(0, settingPrefix.length() - component.getSimpleName().length()); // remove the simple class name (keep the dot)
-        return getByPrefix(settingPrefix);
-    }
-
     @Override
     public Settings getByPrefix(String prefix) {
         Builder builder = new Builder();

--- a/src/main/java/org/elasticsearch/common/settings/Settings.java
+++ b/src/main/java/org/elasticsearch/common/settings/Settings.java
@@ -42,19 +42,6 @@ import java.util.Set;
 public interface Settings extends ToXContent {
 
     /**
-     * Component settings for a specific component. Returns all the settings for the given class, where the
-     * FQN of the class is used, without the <tt>org.elasticsearch<tt> prefix. If there is no <tt>org.elasticsearch</tt>
-     * prefix, then the prefix used is the first part of the package name (<tt>org</tt> / <tt>com</tt> / ...)
-     */
-    Settings getComponentSettings(Class component);
-
-    /**
-     * Component settings for a specific component. Returns all the settings for the given class, where the
-     * FQN of the class is used, without provided prefix.
-     */
-    Settings getComponentSettings(String prefix, Class component);
-
-    /**
      * A settings that are filtered (and key is removed) with the specified prefix.
      */
     Settings getByPrefix(String prefix);

--- a/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -31,7 +31,6 @@ import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
-import org.elasticsearch.cluster.node.DiscoveryNodeService;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
@@ -103,7 +102,6 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
     private final ClusterService clusterService;
     private AllocationService allocationService;
     private final ClusterName clusterName;
-    private final DiscoveryNodeService discoveryNodeService;
     private final DiscoverySettings discoverySettings;
     private final ZenPingService pingService;
     private final MasterFaultDetection masterFD;
@@ -150,20 +148,17 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
     @Inject
     public ZenDiscovery(Settings settings, ClusterName clusterName, ThreadPool threadPool,
                         TransportService transportService, final ClusterService clusterService, NodeSettingsService nodeSettingsService,
-                        DiscoveryNodeService discoveryNodeService, ZenPingService pingService, ElectMasterService electMasterService,
+                        ZenPingService pingService, ElectMasterService electMasterService,
                         DiscoverySettings discoverySettings, @ClusterDynamicSettings DynamicSettings dynamicSettings) {
         super(settings);
         this.clusterName = clusterName;
         this.clusterService = clusterService;
         this.transportService = transportService;
-        this.discoveryNodeService = discoveryNodeService;
         this.discoverySettings = discoverySettings;
         this.pingService = pingService;
         this.electMaster = electMasterService;
-
-        // keep using componentSettings for BWC, in case this class gets extended.
-        TimeValue pingTimeout = componentSettings.getAsTime("initial_ping_timeout", timeValueSeconds(3));
-        pingTimeout = componentSettings.getAsTime("ping_timeout", pingTimeout);
+        TimeValue pingTimeout = this.settings.getAsTime("discovery.zen.initial_ping_timeout", timeValueSeconds(3));
+        pingTimeout = this.settings.getAsTime("discovery.zen.ping_timeout", pingTimeout);
         pingTimeout = settings.getAsTime("discovery.zen.ping_timeout", pingTimeout);
         this.pingTimeout = settings.getAsTime(SETTING_PING_TIMEOUT, pingTimeout);
 

--- a/src/main/java/org/elasticsearch/discovery/zen/ping/ZenPingService.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ping/ZenPingService.java
@@ -55,7 +55,7 @@ public class ZenPingService extends AbstractLifecycleComponent<ZenPing> implemen
                           Version version, ElectMasterService electMasterService, @Nullable Set<UnicastHostsProvider> unicastHostsProviders) {
         super(settings);
         ImmutableList.Builder<ZenPing> zenPingsBuilder = ImmutableList.builder();
-        if (componentSettings.getAsBoolean("multicast.enabled", true)) {
+        if (this.settings.getAsBoolean("discovery.zen.ping.multicast.enabled", true)) {
             zenPingsBuilder.add(new MulticastZenPing(settings, threadPool, transportService, clusterName, networkService, version));
         }
         // always add the unicast hosts, so it will be able to receive unicast requests even when working in multicast

--- a/src/main/java/org/elasticsearch/discovery/zen/ping/multicast/MulticastZenPing.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ping/multicast/MulticastZenPing.java
@@ -97,13 +97,13 @@ public class MulticastZenPing extends AbstractLifecycleComponent<ZenPing> implem
         this.networkService = networkService;
         this.version = version;
 
-        this.address = componentSettings.get("address");
-        this.port = componentSettings.getAsInt("port", 54328);
-        this.group = componentSettings.get("group", "224.2.2.4");
-        this.bufferSize = componentSettings.getAsInt("buffer_size", 2048);
-        this.ttl = componentSettings.getAsInt("ttl", 3);
+        this.address = this.settings.get("discovery.zen.ping.multicast.address");
+        this.port = this.settings.getAsInt("discovery.zen.ping.multicast.port", 54328);
+        this.group = this.settings.get("discovery.zen.ping.multicast.group", "224.2.2.4");
+        this.bufferSize = this.settings.getAsInt("discovery.zen.ping.multicast.buffer_size", 2048);
+        this.ttl = this.settings.getAsInt("discovery.zen.ping.multicast.ttl", 3);
 
-        this.pingEnabled = componentSettings.getAsBoolean("ping.enabled", true);
+        this.pingEnabled = this.settings.getAsBoolean("discovery.zen.ping.multicast.ping.enabled", true);
 
         logger.debug("using group [{}], with port [{}], ttl [{}], and address [{}]", group, port, ttl, address);
 
@@ -123,7 +123,7 @@ public class MulticastZenPing extends AbstractLifecycleComponent<ZenPing> implem
         try {
             // we know OSX has bugs in the JVM when creating multiple instances of multicast sockets
             // causing for "socket close" exceptions when receive and/or crashes
-            boolean shared = componentSettings.getAsBoolean("shared", Constants.MAC_OS_X);
+            boolean shared = settings.getAsBoolean("discovery.zen.ping.multicast.shared", Constants.MAC_OS_X);
             multicastChannel = MulticastChannel.getChannel(nodeName(), shared,
                     new MulticastChannel.Config(port, group, bufferSize, ttl, networkService.resolvePublishHostAddress(address)),
                     new Receiver());

--- a/src/main/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPing.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPing.java
@@ -112,8 +112,8 @@ public class UnicastZenPing extends AbstractLifecycleComponent<ZenPing> implemen
             }
         }
 
-        this.concurrentConnects = componentSettings.getAsInt("concurrent_connects", 10);
-        String[] hostArr = componentSettings.getAsArray("hosts");
+        this.concurrentConnects = this.settings.getAsInt("discovery.zen.ping.unicast.concurrent_connects", 10);
+        String[] hostArr = this.settings.getAsArray("discovery.zen.ping.unicast.hosts");
         // trim the hosts
         for (int i = 0; i < hostArr.length; i++) {
             hostArr[i] = hostArr[i].trim();

--- a/src/main/java/org/elasticsearch/gateway/GatewayAllocator.java
+++ b/src/main/java/org/elasticsearch/gateway/GatewayAllocator.java
@@ -80,8 +80,8 @@ public class GatewayAllocator extends AbstractComponent {
         this.listGatewayStartedShards = listGatewayStartedShards;
         this.listShardStoreMetaData = listShardStoreMetaData;
 
-        this.listTimeout = componentSettings.getAsTime("list_timeout", settings.getAsTime("gateway.local.list_timeout", TimeValue.timeValueSeconds(30)));
-        this.initialShards = componentSettings.get("initial_shards", settings.get("gateway.local.initial_shards", "quorum"));
+        this.listTimeout = settings.getAsTime("gateway.list_timeout", settings.getAsTime("gateway.local.list_timeout", TimeValue.timeValueSeconds(30)));
+        this.initialShards = settings.get("gateway.initial_shards", settings.get("gateway.local.initial_shards", "quorum"));
 
         logger.debug("using initial_shards [{}], list_timeout [{}]", initialShards, listTimeout);
     }

--- a/src/main/java/org/elasticsearch/gateway/GatewayService.java
+++ b/src/main/java/org/elasticsearch/gateway/GatewayService.java
@@ -82,20 +82,20 @@ public class GatewayService extends AbstractLifecycleComponent<GatewayService> i
         this.discoveryService = discoveryService;
         this.threadPool = threadPool;
         // allow to control a delay of when indices will get created
-        this.expectedNodes = componentSettings.getAsInt("expected_nodes", -1);
-        this.expectedDataNodes = componentSettings.getAsInt("expected_data_nodes", -1);
-        this.expectedMasterNodes = componentSettings.getAsInt("expected_master_nodes", -1);
+        this.expectedNodes = this.settings.getAsInt("gateway.expected_nodes", -1);
+        this.expectedDataNodes = this.settings.getAsInt("gateway.expected_data_nodes", -1);
+        this.expectedMasterNodes = this.settings.getAsInt("gateway.expected_master_nodes", -1);
 
         TimeValue defaultRecoverAfterTime = null;
         if (expectedNodes >= 0 || expectedDataNodes >= 0 || expectedMasterNodes >= 0) {
             defaultRecoverAfterTime = DEFAULT_RECOVER_AFTER_TIME_IF_EXPECTED_NODES_IS_SET;
         }
 
-        this.recoverAfterTime = componentSettings.getAsTime("recover_after_time", defaultRecoverAfterTime);
-        this.recoverAfterNodes = componentSettings.getAsInt("recover_after_nodes", -1);
-        this.recoverAfterDataNodes = componentSettings.getAsInt("recover_after_data_nodes", -1);
+        this.recoverAfterTime = this.settings.getAsTime("gateway.recover_after_time", defaultRecoverAfterTime);
+        this.recoverAfterNodes = this.settings.getAsInt("gateway.recover_after_nodes", -1);
+        this.recoverAfterDataNodes = this.settings.getAsInt("gateway.recover_after_data_nodes", -1);
         // default the recover after master nodes to the minimum master nodes in the discovery
-        this.recoverAfterMasterNodes = componentSettings.getAsInt("recover_after_master_nodes", settings.getAsInt("discovery.zen.minimum_master_nodes", -1));
+        this.recoverAfterMasterNodes = this.settings.getAsInt("gateway.recover_after_master_nodes", settings.getAsInt("discovery.zen.minimum_master_nodes", -1));
 
         // Add the not recovered as initial state block, we don't allow anything until
         this.clusterService.addInitialStateBlock(STATE_NOT_RECOVERED_BLOCK);

--- a/src/main/java/org/elasticsearch/http/HttpServer.java
+++ b/src/main/java/org/elasticsearch/http/HttpServer.java
@@ -25,13 +25,11 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.FileSystemUtils;
-import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.node.service.NodeService;
 import org.elasticsearch.rest.*;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
@@ -69,7 +67,7 @@ public class HttpServer extends AbstractLifecycleComponent<HttpServer> {
         this.nodeService = nodeService;
         nodeService.setHttpServer(this);
 
-        this.disableSites = componentSettings.getAsBoolean("disable_sites", false);
+        this.disableSites = this.settings.getAsBoolean("http.disable_sites", false);
 
         transport.httpServerAdapter(new Dispatcher(this));
     }

--- a/src/main/java/org/elasticsearch/http/netty/NettyHttpServerTransport.java
+++ b/src/main/java/org/elasticsearch/http/netty/NettyHttpServerTransport.java
@@ -142,26 +142,26 @@ public class NettyHttpServerTransport extends AbstractLifecycleComponent<HttpSer
             System.setProperty("org.jboss.netty.epollBugWorkaround", "true");
         }
 
-        ByteSizeValue maxContentLength = componentSettings.getAsBytesSize("max_content_length", settings.getAsBytesSize("http.max_content_length", new ByteSizeValue(100, ByteSizeUnit.MB)));
-        this.maxChunkSize = componentSettings.getAsBytesSize("max_chunk_size", settings.getAsBytesSize("http.max_chunk_size", new ByteSizeValue(8, ByteSizeUnit.KB)));
-        this.maxHeaderSize = componentSettings.getAsBytesSize("max_header_size", settings.getAsBytesSize("http.max_header_size", new ByteSizeValue(8, ByteSizeUnit.KB)));
-        this.maxInitialLineLength = componentSettings.getAsBytesSize("max_initial_line_length", settings.getAsBytesSize("http.max_initial_line_length", new ByteSizeValue(4, ByteSizeUnit.KB)));
+        ByteSizeValue maxContentLength = settings.getAsBytesSize("http.netty.max_content_length", settings.getAsBytesSize("http.max_content_length", new ByteSizeValue(100, ByteSizeUnit.MB)));
+        this.maxChunkSize = settings.getAsBytesSize("http.netty.max_chunk_size", settings.getAsBytesSize("http.max_chunk_size", new ByteSizeValue(8, ByteSizeUnit.KB)));
+        this.maxHeaderSize = settings.getAsBytesSize("http.netty.max_header_size", settings.getAsBytesSize("http.max_header_size", new ByteSizeValue(8, ByteSizeUnit.KB)));
+        this.maxInitialLineLength = settings.getAsBytesSize("http.netty.max_initial_line_length", settings.getAsBytesSize("http.max_initial_line_length", new ByteSizeValue(4, ByteSizeUnit.KB)));
         // don't reset cookies by default, since I don't think we really need to
         // note, parsing cookies was fixed in netty 3.5.1 regarding stack allocation, but still, currently, we don't need cookies
-        this.resetCookies = componentSettings.getAsBoolean("reset_cookies", settings.getAsBoolean("http.reset_cookies", false));
-        this.maxCumulationBufferCapacity = componentSettings.getAsBytesSize("max_cumulation_buffer_capacity", null);
-        this.maxCompositeBufferComponents = componentSettings.getAsInt("max_composite_buffer_components", -1);
-        this.workerCount = componentSettings.getAsInt("worker_count", EsExecutors.boundedNumberOfProcessors(settings) * 2);
-        this.blockingServer = settings.getAsBoolean("http.blocking_server", settings.getAsBoolean(TCP_BLOCKING_SERVER, settings.getAsBoolean(TCP_BLOCKING, false)));
-        this.port = componentSettings.get("port", settings.get("http.port", "9200-9300"));
-        this.bindHost = componentSettings.get("bind_host", settings.get("http.bind_host", settings.get("http.host")));
-        this.publishHost = componentSettings.get("publish_host", settings.get("http.publish_host", settings.get("http.host")));
-        this.publishPort = componentSettings.getAsInt("publish_port", settings.getAsInt("http.publish_port", 0));
-        this.tcpNoDelay = componentSettings.get("tcp_no_delay", settings.get(TCP_NO_DELAY, "true"));
-        this.tcpKeepAlive = componentSettings.get("tcp_keep_alive", settings.get(TCP_KEEP_ALIVE, "true"));
-        this.reuseAddress = componentSettings.getAsBoolean("reuse_address", settings.getAsBoolean(TCP_REUSE_ADDRESS, NetworkUtils.defaultReuseAddress()));
-        this.tcpSendBufferSize = componentSettings.getAsBytesSize("tcp_send_buffer_size", settings.getAsBytesSize(TCP_SEND_BUFFER_SIZE, TCP_DEFAULT_SEND_BUFFER_SIZE));
-        this.tcpReceiveBufferSize = componentSettings.getAsBytesSize("tcp_receive_buffer_size", settings.getAsBytesSize(TCP_RECEIVE_BUFFER_SIZE, TCP_DEFAULT_RECEIVE_BUFFER_SIZE));
+        this.resetCookies = settings.getAsBoolean("http.netty.reset_cookies", settings.getAsBoolean("http.reset_cookies", false));
+        this.maxCumulationBufferCapacity = settings.getAsBytesSize("http.netty.max_cumulation_buffer_capacity", null);
+        this.maxCompositeBufferComponents = settings.getAsInt("http.netty.max_composite_buffer_components", -1);
+        this.workerCount = settings.getAsInt("http.netty.worker_count", EsExecutors.boundedNumberOfProcessors(settings) * 2);
+        this.blockingServer = settings.getAsBoolean("http.netty.http.blocking_server", settings.getAsBoolean(TCP_BLOCKING_SERVER, settings.getAsBoolean(TCP_BLOCKING, false)));
+        this.port = settings.get("http.netty.port", settings.get("http.port", "9200-9300"));
+        this.bindHost = settings.get("http.netty.bind_host", settings.get("http.bind_host", settings.get("http.host")));
+        this.publishHost = settings.get("http.netty.publish_host", settings.get("http.publish_host", settings.get("http.host")));
+        this.publishPort = settings.getAsInt("http.netty.publish_port", settings.getAsInt("http.publish_port", 0));
+        this.tcpNoDelay = settings.get("http.netty.tcp_no_delay", settings.get(TCP_NO_DELAY, "true"));
+        this.tcpKeepAlive = settings.get("http.netty.tcp_keep_alive", settings.get(TCP_KEEP_ALIVE, "true"));
+        this.reuseAddress = settings.getAsBoolean("http.netty.reuse_address", settings.getAsBoolean(TCP_REUSE_ADDRESS, NetworkUtils.defaultReuseAddress()));
+        this.tcpSendBufferSize = settings.getAsBytesSize("http.netty.tcp_send_buffer_size", settings.getAsBytesSize(TCP_SEND_BUFFER_SIZE, TCP_DEFAULT_SEND_BUFFER_SIZE));
+        this.tcpReceiveBufferSize = settings.getAsBytesSize("http.netty.tcp_receive_buffer_size", settings.getAsBytesSize(TCP_RECEIVE_BUFFER_SIZE, TCP_DEFAULT_RECEIVE_BUFFER_SIZE));
 
         long defaultReceiverPredictor = 512 * 1024;
         if (JvmInfo.jvmInfo().mem().directMemoryMax().bytes() > 0) {
@@ -171,8 +171,8 @@ public class NettyHttpServerTransport extends AbstractLifecycleComponent<HttpSer
         }
 
         // See AdaptiveReceiveBufferSizePredictor#DEFAULT_XXX for default values in netty..., we can use higher ones for us, even fixed one
-        ByteSizeValue receivePredictorMin = componentSettings.getAsBytesSize("receive_predictor_min", componentSettings.getAsBytesSize("receive_predictor_size", new ByteSizeValue(defaultReceiverPredictor)));
-        ByteSizeValue receivePredictorMax = componentSettings.getAsBytesSize("receive_predictor_max", componentSettings.getAsBytesSize("receive_predictor_size", new ByteSizeValue(defaultReceiverPredictor)));
+        ByteSizeValue receivePredictorMin = settings.getAsBytesSize("http.netty.receive_predictor_min", settings.getAsBytesSize("http.netty.receive_predictor_size", new ByteSizeValue(defaultReceiverPredictor)));
+        ByteSizeValue receivePredictorMax = settings.getAsBytesSize("http.netty.receive_predictor_max", settings.getAsBytesSize("http.netty.receive_predictor_size", new ByteSizeValue(defaultReceiverPredictor)));
         if (receivePredictorMax.bytes() == receivePredictorMin.bytes()) {
             receiveBufferSizePredictorFactory = new FixedReceiveBufferSizePredictorFactory((int) receivePredictorMax.bytes());
         } else {

--- a/src/main/java/org/elasticsearch/index/AbstractIndexComponent.java
+++ b/src/main/java/org/elasticsearch/index/AbstractIndexComponent.java
@@ -35,8 +35,6 @@ public abstract class AbstractIndexComponent implements IndexComponent {
 
     protected final Settings indexSettings;
 
-    protected final Settings componentSettings;
-
     /**
      * Constructs a new index component, with the index name and its settings.
      *
@@ -46,23 +44,6 @@ public abstract class AbstractIndexComponent implements IndexComponent {
     protected AbstractIndexComponent(Index index, @IndexSettings Settings indexSettings) {
         this.index = index;
         this.indexSettings = indexSettings;
-        this.componentSettings = indexSettings.getComponentSettings(getClass());
-
-        this.logger = Loggers.getLogger(getClass(), indexSettings, index);
-    }
-
-    /**
-     * Constructs a new index component, with the index name and its settings, as well as settings prefix.
-     *
-     * @param index          The index name
-     * @param indexSettings  The index settings
-     * @param prefixSettings A settings prefix (like "com.mycompany") to simplify extracting the component settings
-     */
-    protected AbstractIndexComponent(Index index, @IndexSettings Settings indexSettings, String prefixSettings) {
-        this.index = index;
-        this.indexSettings = indexSettings;
-        this.componentSettings = indexSettings.getComponentSettings(prefixSettings, getClass());
-
         this.logger = Loggers.getLogger(getClass(), indexSettings, index);
     }
 

--- a/src/main/java/org/elasticsearch/index/analysis/AbstractIndexAnalyzerProvider.java
+++ b/src/main/java/org/elasticsearch/index/analysis/AbstractIndexAnalyzerProvider.java
@@ -49,20 +49,6 @@ public abstract class AbstractIndexAnalyzerProvider<T extends Analyzer> extends 
     }
 
     /**
-     * Constructs a new analyzer component, with the index name and its settings and the analyzer name.
-     *
-     * @param index          The index name
-     * @param indexSettings  The index settings
-     * @param prefixSettings A settings prefix (like "com.mycompany") to simplify extracting the component settings
-     * @param name           The analyzer name
-     */
-    public AbstractIndexAnalyzerProvider(Index index, @IndexSettings Settings indexSettings, String prefixSettings, String name, Settings settings) {
-        super(index, indexSettings, prefixSettings);
-        this.name = name;
-        this.version = Analysis.parseAnalysisVersion(indexSettings, settings, logger);
-    }
-
-    /**
      * Returns the injected name of the analyzer.
      */
     @Override

--- a/src/main/java/org/elasticsearch/index/cache/query/parser/resident/ResidentQueryParserCache.java
+++ b/src/main/java/org/elasticsearch/index/cache/query/parser/resident/ResidentQueryParserCache.java
@@ -49,8 +49,8 @@ public class ResidentQueryParserCache extends AbstractIndexComponent implements 
     public ResidentQueryParserCache(Index index, @IndexSettings Settings indexSettings) {
         super(index, indexSettings);
 
-        this.maxSize = componentSettings.getAsInt("max_size", 100);
-        this.expire = componentSettings.getAsTime("expire", null);
+        this.maxSize = indexSettings.getAsInt("index.cache.query.parser.resident.max_size", 100);
+        this.expire = indexSettings.getAsTime("index.cache.query.parser.resident.expire", null);
         logger.debug("using [resident] query cache with max_size [{}], expire [{}]", maxSize, expire);
 
         CacheBuilder cacheBuilder = CacheBuilder.newBuilder().maximumSize(maxSize);

--- a/src/main/java/org/elasticsearch/index/deletionpolicy/AbstractESDeletionPolicy.java
+++ b/src/main/java/org/elasticsearch/index/deletionpolicy/AbstractESDeletionPolicy.java
@@ -35,21 +35,9 @@ abstract class AbstractESDeletionPolicy extends IndexDeletionPolicy implements I
 
     protected final Settings indexSettings;
 
-    protected final Settings componentSettings;
-
     protected AbstractESDeletionPolicy(ShardId shardId, @IndexSettings Settings indexSettings) {
         this.shardId = shardId;
         this.indexSettings = indexSettings;
-        this.componentSettings = indexSettings.getComponentSettings(getClass());
-
-        this.logger = Loggers.getLogger(getClass(), indexSettings, shardId);
-    }
-
-    protected AbstractESDeletionPolicy(ShardId shardId, @IndexSettings Settings indexSettings, String prefixSettings) {
-        this.shardId = shardId;
-        this.indexSettings = indexSettings;
-        this.componentSettings = indexSettings.getComponentSettings(prefixSettings, getClass());
-
         this.logger = Loggers.getLogger(getClass(), indexSettings, shardId);
     }
 

--- a/src/main/java/org/elasticsearch/index/deletionpolicy/KeepLastNDeletionPolicy.java
+++ b/src/main/java/org/elasticsearch/index/deletionpolicy/KeepLastNDeletionPolicy.java
@@ -40,7 +40,7 @@ public class KeepLastNDeletionPolicy extends AbstractESDeletionPolicy {
     @Inject
     public KeepLastNDeletionPolicy(ShardId shardId, @IndexSettings Settings indexSettings) {
         super(shardId, indexSettings);
-        this.numToKeep = componentSettings.getAsInt("num_to_keep", 5);
+        this.numToKeep = indexSettings.getAsInt("index.deletionpolicy.num_to_keep", 5);
         logger.debug("Using [keep_last_n] deletion policy with num_to_keep[{}]", numToKeep);
     }
 

--- a/src/main/java/org/elasticsearch/index/gateway/IndexShardGateway.java
+++ b/src/main/java/org/elasticsearch/index/gateway/IndexShardGateway.java
@@ -84,8 +84,8 @@ public class IndexShardGateway extends AbstractIndexShardComponent implements Cl
         this.indexService = indexService;
         this.indexShard = indexShard;
 
-        this.waitForMappingUpdatePostRecovery = componentSettings.getAsTime("wait_for_mapping_update_post_recovery", TimeValue.timeValueSeconds(30));
-        syncInterval = componentSettings.getAsTime("sync", TimeValue.timeValueSeconds(5));
+        this.waitForMappingUpdatePostRecovery = indexSettings.getAsTime("index.gateway.wait_for_mapping_update_post_recovery", TimeValue.timeValueSeconds(30));
+        syncInterval = indexSettings.getAsTime("index.gateway.sync", TimeValue.timeValueSeconds(5));
         if (syncInterval.millis() > 0) {
             this.indexShard.translog().syncOnEachOperation(false);
             flushScheduler = threadPool.schedule(syncInterval, ThreadPool.Names.SAME, new Sync());

--- a/src/main/java/org/elasticsearch/index/indexing/slowlog/ShardSlowLogIndexingService.java
+++ b/src/main/java/org/elasticsearch/index/indexing/slowlog/ShardSlowLogIndexingService.java
@@ -97,14 +97,14 @@ public class ShardSlowLogIndexingService extends AbstractIndexShardComponent {
     public ShardSlowLogIndexingService(ShardId shardId, @IndexSettings Settings indexSettings, IndexSettingsService indexSettingsService) {
         super(shardId, indexSettings);
 
-        this.reformat = componentSettings.getAsBoolean("reformat", true);
+        this.reformat = indexSettings.getAsBoolean(INDEX_INDEXING_SLOWLOG_REFORMAT, true);
 
-        this.indexWarnThreshold = componentSettings.getAsTime("threshold.index.warn", TimeValue.timeValueNanos(-1)).nanos();
-        this.indexInfoThreshold = componentSettings.getAsTime("threshold.index.info", TimeValue.timeValueNanos(-1)).nanos();
-        this.indexDebugThreshold = componentSettings.getAsTime("threshold.index.debug", TimeValue.timeValueNanos(-1)).nanos();
-        this.indexTraceThreshold = componentSettings.getAsTime("threshold.index.trace", TimeValue.timeValueNanos(-1)).nanos();
+        this.indexWarnThreshold = indexSettings.getAsTime(INDEX_INDEXING_SLOWLOG_THRESHOLD_INDEX_WARN, TimeValue.timeValueNanos(-1)).nanos();
+        this.indexInfoThreshold = indexSettings.getAsTime(INDEX_INDEXING_SLOWLOG_THRESHOLD_INDEX_INFO, TimeValue.timeValueNanos(-1)).nanos();
+        this.indexDebugThreshold = indexSettings.getAsTime(INDEX_INDEXING_SLOWLOG_THRESHOLD_INDEX_DEBUG, TimeValue.timeValueNanos(-1)).nanos();
+        this.indexTraceThreshold = indexSettings.getAsTime(INDEX_INDEXING_SLOWLOG_THRESHOLD_INDEX_TRACE, TimeValue.timeValueNanos(-1)).nanos();
 
-        this.level = componentSettings.get("level", "TRACE").toUpperCase(Locale.ROOT);
+        this.level = indexSettings.get(INDEX_INDEXING_SLOWLOG_LEVEL, "TRACE").toUpperCase(Locale.ROOT);
 
         this.indexLogger = Loggers.getLogger(logger, ".index");
         this.deleteLogger = Loggers.getLogger(logger, ".delete");

--- a/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -138,8 +138,8 @@ public class MapperService extends AbstractIndexComponent  {
         this.searchAnalyzer = new SmartIndexNameSearchAnalyzer(analysisService.defaultSearchAnalyzer());
         this.searchQuoteAnalyzer = new SmartIndexNameSearchQuoteAnalyzer(analysisService.defaultSearchQuoteAnalyzer());
 
-        this.dynamic = componentSettings.getAsBoolean("dynamic", true);
-        String defaultMappingLocation = componentSettings.get("default_mapping_location");
+        this.dynamic = indexSettings.getAsBoolean("index.mapper.dynamic", true);
+        String defaultMappingLocation = indexSettings.get("index.mapper.default_mapping_location");
         final URL defaultMappingUrl;
         if (index.getName().equals(ScriptService.SCRIPT_INDEX)){
             defaultMappingUrl = getMappingUrl(indexSettings, environment, defaultMappingLocation, "script-mapping.json", "org/elasticsearch/index/mapper/script-mapping.json");
@@ -172,7 +172,7 @@ public class MapperService extends AbstractIndexComponent  {
             }
         }
 
-        String percolatorMappingLocation = componentSettings.get("default_percolator_mapping_location");
+        String percolatorMappingLocation = indexSettings.get("index.mapper.default_percolator_mapping_location");
         URL percolatorMappingUrl = null;
         if (percolatorMappingLocation != null) {
             try {

--- a/src/main/java/org/elasticsearch/index/merge/policy/LogByteSizeMergePolicyProvider.java
+++ b/src/main/java/org/elasticsearch/index/merge/policy/LogByteSizeMergePolicyProvider.java
@@ -29,9 +29,6 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.index.settings.IndexSettingsService;
 import org.elasticsearch.index.store.Store;
 
-import java.util.Set;
-import java.util.concurrent.CopyOnWriteArraySet;
-
 /**
  *
  */
@@ -50,11 +47,11 @@ public class LogByteSizeMergePolicyProvider extends AbstractMergePolicyProvider<
         Preconditions.checkNotNull(store, "Store must be provided to merge policy");
         this.indexSettingsService = indexSettingsService;
 
-        ByteSizeValue minMergeSize = componentSettings.getAsBytesSize("min_merge_size", DEFAULT_MIN_MERGE_SIZE);
-        ByteSizeValue maxMergeSize = componentSettings.getAsBytesSize("max_merge_size", DEFAULT_MAX_MERGE_SIZE);
-        int mergeFactor = componentSettings.getAsInt("merge_factor", LogByteSizeMergePolicy.DEFAULT_MERGE_FACTOR);
-        int maxMergeDocs = componentSettings.getAsInt("max_merge_docs", LogByteSizeMergePolicy.DEFAULT_MAX_MERGE_DOCS);
-        boolean calibrateSizeByDeletes = componentSettings.getAsBoolean("calibrate_size_by_deletes", true);
+        ByteSizeValue minMergeSize = indexSettings.getAsBytesSize("index.merge.policy.min_merge_size", DEFAULT_MIN_MERGE_SIZE);
+        ByteSizeValue maxMergeSize = indexSettings.getAsBytesSize("index.merge.policy.max_merge_size", DEFAULT_MAX_MERGE_SIZE);
+        int mergeFactor = indexSettings.getAsInt("index.merge.policy.merge_factor", LogByteSizeMergePolicy.DEFAULT_MERGE_FACTOR);
+        int maxMergeDocs = indexSettings.getAsInt("index.merge.policy.max_merge_docs", LogByteSizeMergePolicy.DEFAULT_MAX_MERGE_DOCS);
+        boolean calibrateSizeByDeletes = indexSettings.getAsBoolean("index.merge.policy.calibrate_size_by_deletes", true);
 
         mergePolicy.setMinMergeMB(minMergeSize.mbFrac());
         mergePolicy.setMaxMergeMB(maxMergeSize.mbFrac());

--- a/src/main/java/org/elasticsearch/index/merge/policy/LogDocMergePolicyProvider.java
+++ b/src/main/java/org/elasticsearch/index/merge/policy/LogDocMergePolicyProvider.java
@@ -27,9 +27,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.settings.IndexSettingsService;
 import org.elasticsearch.index.store.Store;
 
-import java.util.Set;
-import java.util.concurrent.CopyOnWriteArraySet;
-
 /**
  *
  */
@@ -50,10 +47,10 @@ public class LogDocMergePolicyProvider extends AbstractMergePolicyProvider<LogDo
         Preconditions.checkNotNull(store, "Store must be provided to merge policy");
         this.indexSettingsService = indexSettingsService;
 
-        int minMergeDocs = componentSettings.getAsInt("min_merge_docs", LogDocMergePolicy.DEFAULT_MIN_MERGE_DOCS);
-        int maxMergeDocs = componentSettings.getAsInt("max_merge_docs", LogDocMergePolicy.DEFAULT_MAX_MERGE_DOCS);
-        int mergeFactor = componentSettings.getAsInt("merge_factor", LogDocMergePolicy.DEFAULT_MERGE_FACTOR);
-        boolean calibrateSizeByDeletes = componentSettings.getAsBoolean("calibrate_size_by_deletes", true);
+        int minMergeDocs = indexSettings.getAsInt(MIN_MERGE_DOCS_KEY, LogDocMergePolicy.DEFAULT_MIN_MERGE_DOCS);
+        int maxMergeDocs = indexSettings.getAsInt(MAX_MERGE_DOCS_KEY, LogDocMergePolicy.DEFAULT_MAX_MERGE_DOCS);
+        int mergeFactor = indexSettings.getAsInt(MERGE_FACTORY_KEY, LogDocMergePolicy.DEFAULT_MERGE_FACTOR);
+        boolean calibrateSizeByDeletes = indexSettings.getAsBoolean("index.merge.policy.calibrate_size_by_deletes", true);
 
         mergePolicy.setMinMergeDocs(minMergeDocs);
         mergePolicy.setMaxMergeDocs(maxMergeDocs);

--- a/src/main/java/org/elasticsearch/index/merge/policy/TieredMergePolicyProvider.java
+++ b/src/main/java/org/elasticsearch/index/merge/policy/TieredMergePolicyProvider.java
@@ -47,14 +47,14 @@ public class TieredMergePolicyProvider extends AbstractMergePolicyProvider<Tiere
         super(store);
         this.indexSettingsService = indexSettingsService;
 
-        double forceMergeDeletesPctAllowed = componentSettings.getAsDouble("expunge_deletes_allowed", DEFAULT_EXPUNGE_DELETES_ALLOWED); // percentage
-        ByteSizeValue floorSegment = componentSettings.getAsBytesSize("floor_segment", DEFAULT_FLOOR_SEGMENT);
-        int maxMergeAtOnce = componentSettings.getAsInt("max_merge_at_once", DEFAULT_MAX_MERGE_AT_ONCE);
-        int maxMergeAtOnceExplicit = componentSettings.getAsInt("max_merge_at_once_explicit", DEFAULT_MAX_MERGE_AT_ONCE_EXPLICIT);
+        double forceMergeDeletesPctAllowed = indexSettings.getAsDouble("index.merge.policy.expunge_deletes_allowed", DEFAULT_EXPUNGE_DELETES_ALLOWED); // percentage
+        ByteSizeValue floorSegment = indexSettings.getAsBytesSize("index.merge.policy.floor_segment", DEFAULT_FLOOR_SEGMENT);
+        int maxMergeAtOnce = indexSettings.getAsInt("index.merge.policy.max_merge_at_once", DEFAULT_MAX_MERGE_AT_ONCE);
+        int maxMergeAtOnceExplicit = indexSettings.getAsInt("index.merge.policy.max_merge_at_once_explicit", DEFAULT_MAX_MERGE_AT_ONCE_EXPLICIT);
         // TODO is this really a good default number for max_merge_segment, what happens for large indices, won't they end up with many segments?
-        ByteSizeValue maxMergedSegment = componentSettings.getAsBytesSize("max_merged_segment", DEFAULT_MAX_MERGED_SEGMENT);
-        double segmentsPerTier = componentSettings.getAsDouble("segments_per_tier", DEFAULT_SEGMENTS_PER_TIER);
-        double reclaimDeletesWeight = componentSettings.getAsDouble("reclaim_deletes_weight", DEFAULT_RECLAIM_DELETES_WEIGHT);
+        ByteSizeValue maxMergedSegment = indexSettings.getAsBytesSize("index.merge.policy.max_merged_segment", DEFAULT_MAX_MERGED_SEGMENT);
+        double segmentsPerTier = indexSettings.getAsDouble("index.merge.policy.segments_per_tier", DEFAULT_SEGMENTS_PER_TIER);
+        double reclaimDeletesWeight = indexSettings.getAsDouble("index.merge.policy.reclaim_deletes_weight", DEFAULT_RECLAIM_DELETES_WEIGHT);
 
         maxMergeAtOnce = adjustMaxMergeAtOnceIfNeeded(maxMergeAtOnce, segmentsPerTier);
         mergePolicy.setNoCFSRatio(noCFSRatio);

--- a/src/main/java/org/elasticsearch/index/merge/scheduler/MergeSchedulerProvider.java
+++ b/src/main/java/org/elasticsearch/index/merge/scheduler/MergeSchedulerProvider.java
@@ -70,7 +70,7 @@ public abstract class MergeSchedulerProvider extends AbstractIndexShardComponent
     protected MergeSchedulerProvider(ShardId shardId, @IndexSettings Settings indexSettings, ThreadPool threadPool) {
         super(shardId, indexSettings);
         this.threadPool = threadPool;
-        this.notifyOnMergeFailure = componentSettings.getAsBoolean("notify_on_failure", true);
+        this.notifyOnMergeFailure = indexSettings.getAsBoolean("index.merge.scheduler.notify_on_failure", true);
     }
 
     public void addFailureListener(FailureListener listener) {

--- a/src/main/java/org/elasticsearch/index/search/slowlog/ShardSlowLogSearchService.java
+++ b/src/main/java/org/elasticsearch/index/search/slowlog/ShardSlowLogSearchService.java
@@ -123,19 +123,19 @@ public class ShardSlowLogSearchService extends AbstractIndexShardComponent {
     public ShardSlowLogSearchService(ShardId shardId, @IndexSettings Settings indexSettings, IndexSettingsService indexSettingsService) {
         super(shardId, indexSettings);
 
-        this.reformat = componentSettings.getAsBoolean("reformat", true);
+        this.reformat = indexSettings.getAsBoolean(INDEX_SEARCH_SLOWLOG_REFORMAT, true);
 
-        this.queryWarnThreshold = componentSettings.getAsTime("threshold.query.warn", TimeValue.timeValueNanos(-1)).nanos();
-        this.queryInfoThreshold = componentSettings.getAsTime("threshold.query.info", TimeValue.timeValueNanos(-1)).nanos();
-        this.queryDebugThreshold = componentSettings.getAsTime("threshold.query.debug", TimeValue.timeValueNanos(-1)).nanos();
-        this.queryTraceThreshold = componentSettings.getAsTime("threshold.query.trace", TimeValue.timeValueNanos(-1)).nanos();
+        this.queryWarnThreshold = indexSettings.getAsTime(INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_WARN, TimeValue.timeValueNanos(-1)).nanos();
+        this.queryInfoThreshold = indexSettings.getAsTime(INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_INFO, TimeValue.timeValueNanos(-1)).nanos();
+        this.queryDebugThreshold = indexSettings.getAsTime(INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_DEBUG, TimeValue.timeValueNanos(-1)).nanos();
+        this.queryTraceThreshold = indexSettings.getAsTime(INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_TRACE, TimeValue.timeValueNanos(-1)).nanos();
 
-        this.fetchWarnThreshold = componentSettings.getAsTime("threshold.fetch.warn", TimeValue.timeValueNanos(-1)).nanos();
-        this.fetchInfoThreshold = componentSettings.getAsTime("threshold.fetch.info", TimeValue.timeValueNanos(-1)).nanos();
-        this.fetchDebugThreshold = componentSettings.getAsTime("threshold.fetch.debug", TimeValue.timeValueNanos(-1)).nanos();
-        this.fetchTraceThreshold = componentSettings.getAsTime("threshold.fetch.trace", TimeValue.timeValueNanos(-1)).nanos();
+        this.fetchWarnThreshold = indexSettings.getAsTime(INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_WARN, TimeValue.timeValueNanos(-1)).nanos();
+        this.fetchInfoThreshold = indexSettings.getAsTime(INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_INFO, TimeValue.timeValueNanos(-1)).nanos();
+        this.fetchDebugThreshold = indexSettings.getAsTime(INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_DEBUG, TimeValue.timeValueNanos(-1)).nanos();
+        this.fetchTraceThreshold = indexSettings.getAsTime(INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_TRACE, TimeValue.timeValueNanos(-1)).nanos();
 
-        this.level = componentSettings.get("level", "TRACE").toUpperCase(Locale.ROOT);
+        this.level = indexSettings.get(INDEX_SEARCH_SLOWLOG_LEVEL, "TRACE").toUpperCase(Locale.ROOT);
 
         this.queryLogger = Loggers.getLogger(logger, ".query");
         this.fetchLogger = Loggers.getLogger(logger, ".fetch");

--- a/src/main/java/org/elasticsearch/index/shard/AbstractIndexShardComponent.java
+++ b/src/main/java/org/elasticsearch/index/shard/AbstractIndexShardComponent.java
@@ -35,21 +35,9 @@ public abstract class AbstractIndexShardComponent implements IndexShardComponent
 
     protected final Settings indexSettings;
 
-    protected final Settings componentSettings;
-
     protected AbstractIndexShardComponent(ShardId shardId, @IndexSettings Settings indexSettings) {
         this.shardId = shardId;
         this.indexSettings = indexSettings;
-        this.componentSettings = indexSettings.getComponentSettings(getClass());
-
-        this.logger = Loggers.getLogger(getClass(), indexSettings, shardId);
-    }
-
-    protected AbstractIndexShardComponent(ShardId shardId, @IndexSettings Settings indexSettings, String prefixSettings) {
-        this.shardId = shardId;
-        this.indexSettings = indexSettings;
-        this.componentSettings = indexSettings.getComponentSettings(prefixSettings, getClass());
-
         this.logger = Loggers.getLogger(getClass(), indexSettings, shardId);
     }
 

--- a/src/main/java/org/elasticsearch/index/store/fs/FsDirectoryService.java
+++ b/src/main/java/org/elasticsearch/index/store/fs/FsDirectoryService.java
@@ -19,13 +19,11 @@
 
 package org.elasticsearch.index.store.fs;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.apache.lucene.store.*;
-import org.elasticsearch.common.io.FileSystemUtils;
 import org.elasticsearch.common.metrics.CounterMetric;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.settings.IndexSettings;
@@ -58,7 +56,7 @@ public abstract class FsDirectoryService extends DirectoryService implements Sto
     }
 
     protected final LockFactory buildLockFactory() throws IOException {
-        String fsLock = componentSettings.get("lock", componentSettings.get("fs_lock", "native"));
+        String fsLock = indexSettings.get("index.store.fs.lock", indexSettings.get("index.store.fs.fs_lock", "native"));
         LockFactory lockFactory;
         if (fsLock.equals("native")) {
             lockFactory = NativeFSLockFactory.INSTANCE;

--- a/src/main/java/org/elasticsearch/index/translog/TranslogService.java
+++ b/src/main/java/org/elasticsearch/index/translog/TranslogService.java
@@ -47,17 +47,12 @@ import static org.elasticsearch.common.unit.TimeValue.timeValueMillis;
  */
 public class TranslogService extends AbstractIndexShardComponent implements Closeable {
 
-    private static final String FLUSH_THRESHOLD_OPS_KEY = "flush_threshold_ops";
-    private static final String FLUSH_THRESHOLD_SIZE_KEY = "flush_threshold_size";
-    private static final String FLUSH_THRESHOLD_PERIOD_KEY = "flush_threshold_period";
-    private static final String FLUSH_THRESHOLD_DISABLE_FLUSH_KEY = "disable_flush";
-    private static final String FLUSH_THRESHOLD_INTERVAL_KEY = "interval";
 
-    public static final String INDEX_TRANSLOG_FLUSH_INTERVAL = "index.translog." + FLUSH_THRESHOLD_INTERVAL_KEY;
-    public static final String INDEX_TRANSLOG_FLUSH_THRESHOLD_OPS = "index.translog." + FLUSH_THRESHOLD_OPS_KEY;
-    public static final String INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE = "index.translog." + FLUSH_THRESHOLD_SIZE_KEY;
-    public static final String INDEX_TRANSLOG_FLUSH_THRESHOLD_PERIOD =  "index.translog." + FLUSH_THRESHOLD_PERIOD_KEY;
-    public static final String INDEX_TRANSLOG_DISABLE_FLUSH = "index.translog." + FLUSH_THRESHOLD_DISABLE_FLUSH_KEY;
+    public static final String INDEX_TRANSLOG_FLUSH_INTERVAL = "index.translog.interval";
+    public static final String INDEX_TRANSLOG_FLUSH_THRESHOLD_OPS = "index.translog.flush_threshold_ops";
+    public static final String INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE = "index.translog.flush_threshold_size";
+    public static final String INDEX_TRANSLOG_FLUSH_THRESHOLD_PERIOD =  "index.translog.flush_threshold_period";
+    public static final String INDEX_TRANSLOG_DISABLE_FLUSH = "index.translog.disable_flush";
 
     private final ThreadPool threadPool;
     private final IndexSettingsService indexSettingsService;
@@ -80,11 +75,11 @@ public class TranslogService extends AbstractIndexShardComponent implements Clos
         this.indexSettingsService = indexSettingsService;
         this.indexShard = indexShard;
         this.translog = translog;
-        this.flushThresholdOperations = componentSettings.getAsInt(FLUSH_THRESHOLD_OPS_KEY, componentSettings.getAsInt("flush_threshold", Integer.MAX_VALUE));
-        this.flushThresholdSize = componentSettings.getAsBytesSize(FLUSH_THRESHOLD_SIZE_KEY, new ByteSizeValue(512, ByteSizeUnit.MB));
-        this.flushThresholdPeriod = componentSettings.getAsTime(FLUSH_THRESHOLD_PERIOD_KEY, TimeValue.timeValueMinutes(30));
-        this.interval = componentSettings.getAsTime(FLUSH_THRESHOLD_INTERVAL_KEY, timeValueMillis(5000));
-        this.disableFlush = componentSettings.getAsBoolean(FLUSH_THRESHOLD_DISABLE_FLUSH_KEY, false);
+        this.flushThresholdOperations = indexSettings.getAsInt(INDEX_TRANSLOG_FLUSH_THRESHOLD_OPS, indexSettings.getAsInt("index.translog.flush_threshold", Integer.MAX_VALUE));
+        this.flushThresholdSize = indexSettings.getAsBytesSize(INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE, new ByteSizeValue(512, ByteSizeUnit.MB));
+        this.flushThresholdPeriod = indexSettings.getAsTime(INDEX_TRANSLOG_FLUSH_THRESHOLD_PERIOD, TimeValue.timeValueMinutes(30));
+        this.interval = indexSettings.getAsTime(INDEX_TRANSLOG_FLUSH_INTERVAL, timeValueMillis(5000));
+        this.disableFlush = indexSettings.getAsBoolean(INDEX_TRANSLOG_DISABLE_FLUSH, false);
 
         logger.debug("interval [{}], flush_threshold_ops [{}], flush_threshold_size [{}], flush_threshold_period [{}]", interval, flushThresholdOperations, flushThresholdSize, flushThresholdPeriod);
 

--- a/src/main/java/org/elasticsearch/index/translog/fs/FsTranslog.java
+++ b/src/main/java/org/elasticsearch/index/translog/fs/FsTranslog.java
@@ -108,9 +108,9 @@ public class FsTranslog extends AbstractIndexShardComponent implements Translog 
             Files.createDirectories(location);
         }
 
-        this.type = FsTranslogFile.Type.fromString(componentSettings.get("type", FsTranslogFile.Type.BUFFERED.name()));
-        this.bufferSize = (int) componentSettings.getAsBytesSize("buffer_size", ByteSizeValue.parseBytesSizeValue("64k")).bytes(); // Not really interesting, updated by IndexingMemoryController...
-        this.transientBufferSize = (int) componentSettings.getAsBytesSize("transient_buffer_size", ByteSizeValue.parseBytesSizeValue("8k")).bytes();
+        this.type = FsTranslogFile.Type.fromString(indexSettings.get("index.translog.fs.type", FsTranslogFile.Type.BUFFERED.name()));
+        this.bufferSize = (int) indexSettings.getAsBytesSize("index.translog.fs.buffer_size", ByteSizeValue.parseBytesSizeValue("64k")).bytes(); // Not really interesting, updated by IndexingMemoryController...
+        this.transientBufferSize = (int) indexSettings.getAsBytesSize("index.translog.fs.transient_buffer_size", ByteSizeValue.parseBytesSizeValue("8k")).bytes();
 
         indexSettingsService.addListener(applySettings);
     }
@@ -122,8 +122,8 @@ public class FsTranslog extends AbstractIndexShardComponent implements Translog 
         Files.createDirectories(location);
         this.bigArrays = BigArrays.NON_RECYCLING_INSTANCE;
 
-        this.type = FsTranslogFile.Type.fromString(componentSettings.get("type", FsTranslogFile.Type.BUFFERED.name()));
-        this.bufferSize = (int) componentSettings.getAsBytesSize("buffer_size", ByteSizeValue.parseBytesSizeValue("64k")).bytes();
+        this.type = FsTranslogFile.Type.fromString(indexSettings.get("index.translog.fs.type", FsTranslogFile.Type.BUFFERED.name()));
+        this.bufferSize = (int) indexSettings.getAsBytesSize("index.translog.fs.buffer_size", ByteSizeValue.parseBytesSizeValue("64k")).bytes();
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -127,7 +127,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent<Indic
         this.nodeIndexDeletedAction = nodeIndexDeletedAction;
         this.nodeMappingRefreshAction = nodeMappingRefreshAction;
 
-        this.sendRefreshMapping = componentSettings.getAsBoolean("send_refresh_mapping", true);
+        this.sendRefreshMapping = this.settings.getAsBoolean("indices.cluster.send_refresh_mapping", true);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/indices/fielddata/cache/IndicesFieldDataCache.java
+++ b/src/main/java/org/elasticsearch/indices/fielddata/cache/IndicesFieldDataCache.java
@@ -54,6 +54,8 @@ public class IndicesFieldDataCache extends AbstractComponent implements RemovalL
 
     public static final String FIELDDATA_CLEAN_INTERVAL_SETTING = "indices.fielddata.cache.cleanup_interval";
     public static final String FIELDDATA_CACHE_CONCURRENCY_LEVEL = "indices.fielddata.cache.concurrency_level";
+    public static final String INDICES_FIELDDATA_CACHE_SIZE_KEY = "indices.fielddata.cache.size";
+    public static final String INDICES_FIELDDATA_CACHE_EXPIRE_KEY = "indices.fielddata.cache.expire";
 
 
     private final IndicesFieldDataCacheListener indicesFieldDataCacheListener;
@@ -67,9 +69,9 @@ public class IndicesFieldDataCache extends AbstractComponent implements RemovalL
         super(settings);
         this.threadPool = threadPool;
         this.indicesFieldDataCacheListener = indicesFieldDataCacheListener;
-        final String size = componentSettings.get("size", "-1");
-        final long sizeInBytes = componentSettings.getAsMemory("size", "-1").bytes();
-        final TimeValue expire = componentSettings.getAsTime("expire", null);
+        final String size = settings.get(INDICES_FIELDDATA_CACHE_SIZE_KEY, "-1");
+        final long sizeInBytes = settings.getAsMemory(INDICES_FIELDDATA_CACHE_SIZE_KEY, "-1").bytes();
+        final TimeValue expire = settings.getAsTime(INDICES_FIELDDATA_CACHE_EXPIRE_KEY, null);
         CacheBuilder<Key, Accountable> cacheBuilder = CacheBuilder.newBuilder()
                 .removalListener(this);
         if (sizeInBytes > 0) {

--- a/src/main/java/org/elasticsearch/indices/memory/IndexingMemoryController.java
+++ b/src/main/java/org/elasticsearch/indices/memory/IndexingMemoryController.java
@@ -28,7 +28,6 @@ import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.FutureUtils;
-import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.engine.EngineClosedException;
 import org.elasticsearch.index.engine.EngineConfig;
 import org.elasticsearch.index.engine.FlushNotAllowedEngineException;
@@ -74,12 +73,12 @@ public class IndexingMemoryController extends AbstractLifecycleComponent<Indexin
         this.indicesService = indicesService;
 
         ByteSizeValue indexingBuffer;
-        String indexingBufferSetting = componentSettings.get("index_buffer_size", "10%");
+        String indexingBufferSetting = this.settings.get("indices.memory.index_buffer_size", "10%");
         if (indexingBufferSetting.endsWith("%")) {
             double percent = Double.parseDouble(indexingBufferSetting.substring(0, indexingBufferSetting.length() - 1));
             indexingBuffer = new ByteSizeValue((long) (((double) JvmInfo.jvmInfo().mem().heapMax().bytes()) * (percent / 100)));
-            ByteSizeValue minIndexingBuffer = componentSettings.getAsBytesSize("min_index_buffer_size", new ByteSizeValue(48, ByteSizeUnit.MB));
-            ByteSizeValue maxIndexingBuffer = componentSettings.getAsBytesSize("max_index_buffer_size", null);
+            ByteSizeValue minIndexingBuffer = this.settings.getAsBytesSize("indices.memory.min_index_buffer_size", new ByteSizeValue(48, ByteSizeUnit.MB));
+            ByteSizeValue maxIndexingBuffer = this.settings.getAsBytesSize("indices.memory.max_index_buffer_size", null);
 
             if (indexingBuffer.bytes() < minIndexingBuffer.bytes()) {
                 indexingBuffer = minIndexingBuffer;
@@ -91,17 +90,17 @@ public class IndexingMemoryController extends AbstractLifecycleComponent<Indexin
             indexingBuffer = ByteSizeValue.parseBytesSizeValue(indexingBufferSetting, null);
         }
         this.indexingBuffer = indexingBuffer;
-        this.minShardIndexBufferSize = componentSettings.getAsBytesSize("min_shard_index_buffer_size", new ByteSizeValue(4, ByteSizeUnit.MB));
+        this.minShardIndexBufferSize = this.settings.getAsBytesSize("indices.memory.min_shard_index_buffer_size", new ByteSizeValue(4, ByteSizeUnit.MB));
         // LUCENE MONITOR: Based on this thread, currently (based on Mike), having a large buffer does not make a lot of sense: https://issues.apache.org/jira/browse/LUCENE-2324?focusedCommentId=13005155&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-13005155
-        this.maxShardIndexBufferSize = componentSettings.getAsBytesSize("max_shard_index_buffer_size", new ByteSizeValue(512, ByteSizeUnit.MB));
+        this.maxShardIndexBufferSize = this.settings.getAsBytesSize("indices.memory.max_shard_index_buffer_size", new ByteSizeValue(512, ByteSizeUnit.MB));
 
         ByteSizeValue translogBuffer;
-        String translogBufferSetting = componentSettings.get("translog_buffer_size", "1%");
+        String translogBufferSetting = this.settings.get("indices.memory.translog_buffer_size", "1%");
         if (translogBufferSetting.endsWith("%")) {
             double percent = Double.parseDouble(translogBufferSetting.substring(0, translogBufferSetting.length() - 1));
             translogBuffer = new ByteSizeValue((long) (((double) JvmInfo.jvmInfo().mem().heapMax().bytes()) * (percent / 100)));
-            ByteSizeValue minTranslogBuffer = componentSettings.getAsBytesSize("min_translog_buffer_size", new ByteSizeValue(256, ByteSizeUnit.KB));
-            ByteSizeValue maxTranslogBuffer = componentSettings.getAsBytesSize("max_translog_buffer_size", null);
+            ByteSizeValue minTranslogBuffer = this.settings.getAsBytesSize("indices.memory.min_translog_buffer_size", new ByteSizeValue(256, ByteSizeUnit.KB));
+            ByteSizeValue maxTranslogBuffer = this.settings.getAsBytesSize("indices.memory.max_translog_buffer_size", null);
 
             if (translogBuffer.bytes() < minTranslogBuffer.bytes()) {
                 translogBuffer = minTranslogBuffer;
@@ -113,12 +112,12 @@ public class IndexingMemoryController extends AbstractLifecycleComponent<Indexin
             translogBuffer = ByteSizeValue.parseBytesSizeValue(translogBufferSetting, null);
         }
         this.translogBuffer = translogBuffer;
-        this.minShardTranslogBufferSize = componentSettings.getAsBytesSize("min_shard_translog_buffer_size", new ByteSizeValue(2, ByteSizeUnit.KB));
-        this.maxShardTranslogBufferSize = componentSettings.getAsBytesSize("max_shard_translog_buffer_size", new ByteSizeValue(64, ByteSizeUnit.KB));
+        this.minShardTranslogBufferSize = this.settings.getAsBytesSize("indices.memory.min_shard_translog_buffer_size", new ByteSizeValue(2, ByteSizeUnit.KB));
+        this.maxShardTranslogBufferSize = this.settings.getAsBytesSize("indices.memory.max_shard_translog_buffer_size", new ByteSizeValue(64, ByteSizeUnit.KB));
 
-        this.inactiveTime = componentSettings.getAsTime("shard_inactive_time", TimeValue.timeValueMinutes(30));
+        this.inactiveTime = this.settings.getAsTime("indices.memory.shard_inactive_time", TimeValue.timeValueMinutes(30));
         // we need to have this relatively small to move a shard from inactive to active fast (enough)
-        this.interval = componentSettings.getAsTime("interval", TimeValue.timeValueSeconds(30));
+        this.interval = this.settings.getAsTime("indices.memory.interval", TimeValue.timeValueSeconds(30));
 
         logger.debug("using index_buffer_size [{}], with min_shard_index_buffer_size [{}], max_shard_index_buffer_size [{}], shard_inactive_time [{}]", this.indexingBuffer, this.minShardIndexBufferSize, this.maxShardIndexBufferSize, this.inactiveTime);
 

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoverySettings.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoverySettings.java
@@ -124,12 +124,12 @@ public class RecoverySettings extends AbstractComponent implements Closeable {
         );
 
 
-        this.concurrentStreams = componentSettings.getAsInt("concurrent_streams", settings.getAsInt("index.shard.recovery.concurrent_streams", 3));
+        this.concurrentStreams = settings.getAsInt("indices.recovery.concurrent_streams", settings.getAsInt("index.shard.recovery.concurrent_streams", 3));
         this.concurrentStreamPool = EsExecutors.newScaling(0, concurrentStreams, 60, TimeUnit.SECONDS, EsExecutors.daemonThreadFactory(settings, "[recovery_stream]"));
-        this.concurrentSmallFileStreams = componentSettings.getAsInt("concurrent_small_file_streams", settings.getAsInt("index.shard.recovery.concurrent_small_file_streams", 2));
+        this.concurrentSmallFileStreams = settings.getAsInt("indices.recovery.concurrent_small_file_streams", settings.getAsInt("index.shard.recovery.concurrent_small_file_streams", 2));
         this.concurrentSmallFileStreamPool = EsExecutors.newScaling(0, concurrentSmallFileStreams, 60, TimeUnit.SECONDS, EsExecutors.daemonThreadFactory(settings, "[small_file_recovery_stream]"));
 
-        this.maxBytesPerSec = componentSettings.getAsBytesSize("max_bytes_per_sec", componentSettings.getAsBytesSize("max_size_per_sec", new ByteSizeValue(20, ByteSizeUnit.MB)));
+        this.maxBytesPerSec = settings.getAsBytesSize("indices.recovery.max_bytes_per_sec", settings.getAsBytesSize("indices.recovery.max_size_per_sec", new ByteSizeValue(20, ByteSizeUnit.MB)));
         if (maxBytesPerSec.bytes() <= 0) {
             rateLimiter = null;
         } else {

--- a/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
+++ b/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
@@ -112,9 +112,9 @@ public class IndicesStore extends AbstractComponent implements ClusterStateListe
         transportService.registerHandler(ACTION_SHARD_EXISTS, new ShardActiveRequestHandler());
 
         // we don't limit by default (we default to CMS's auto throttle instead):
-        this.rateLimitingType = componentSettings.get("throttle.type", StoreRateLimiting.Type.NONE.name());
+        this.rateLimitingType = settings.get("indices.store.throttle.type", StoreRateLimiting.Type.NONE.name());
         rateLimiting.setType(rateLimitingType);
-        this.rateLimitingThrottle = componentSettings.getAsBytesSize("throttle.max_bytes_per_sec", new ByteSizeValue(10240, ByteSizeUnit.MB));
+        this.rateLimitingThrottle = settings.getAsBytesSize("indices.store.throttle.max_bytes_per_sec", new ByteSizeValue(10240, ByteSizeUnit.MB));
         rateLimiting.setMaxRate(rateLimitingThrottle);
 
         logger.debug("using indices.store.throttle.type [{}], with index.store.throttle.max_bytes_per_sec [{}]", rateLimitingType, rateLimitingThrottle);

--- a/src/main/java/org/elasticsearch/indices/ttl/IndicesTTLService.java
+++ b/src/main/java/org/elasticsearch/indices/ttl/IndicesTTLService.java
@@ -82,9 +82,9 @@ public class IndicesTTLService extends AbstractLifecycleComponent<IndicesTTLServ
         super(settings);
         this.clusterService = clusterService;
         this.indicesService = indicesService;
-        TimeValue interval = componentSettings.getAsTime("interval", TimeValue.timeValueSeconds(60));
+        TimeValue interval = this.settings.getAsTime("indices.ttl.interval", TimeValue.timeValueSeconds(60));
         this.bulkAction = bulkAction;
-        this.bulkSize = componentSettings.getAsInt("bulk_size", 10000);
+        this.bulkSize = this.settings.getAsInt("indices.ttl.bulk_size", 10000);
         this.purgerThread = new PurgerThread(EsExecutors.threadName(settings, "[ttl_expire]"), interval);
 
         nodeSettingsService.addListener(new ApplySettings());

--- a/src/main/java/org/elasticsearch/monitor/jvm/JvmMonitorService.java
+++ b/src/main/java/org/elasticsearch/monitor/jvm/JvmMonitorService.java
@@ -79,11 +79,11 @@ public class JvmMonitorService extends AbstractLifecycleComponent<JvmMonitorServ
         super(settings);
         this.threadPool = threadPool;
 
-        this.enabled = componentSettings.getAsBoolean("enabled", true);
-        this.interval = componentSettings.getAsTime("interval", timeValueSeconds(1));
+        this.enabled = this.settings.getAsBoolean("monitor.jvm.enabled", true);
+        this.interval = this.settings.getAsTime("monitor.jvm.interval", timeValueSeconds(1));
 
         MapBuilder<String, GcThreshold> gcThresholds = MapBuilder.newMapBuilder();
-        Map<String, Settings> gcThresholdGroups = componentSettings.getGroups("gc");
+        Map<String, Settings> gcThresholdGroups = this.settings.getGroups("monitor.jvm.gc");
         for (Map.Entry<String, Settings> entry : gcThresholdGroups.entrySet()) {
             String name = entry.getKey();
             TimeValue warn = entry.getValue().getAsTime("warn", null);

--- a/src/main/java/org/elasticsearch/monitor/jvm/JvmService.java
+++ b/src/main/java/org/elasticsearch/monitor/jvm/JvmService.java
@@ -41,7 +41,7 @@ public class JvmService extends AbstractComponent {
         this.jvmInfo = JvmInfo.jvmInfo();
         this.jvmStats = JvmStats.jvmStats();
 
-        this.refreshInterval = componentSettings.getAsTime("refresh_interval", TimeValue.timeValueSeconds(1));
+        this.refreshInterval = this.settings.getAsTime("refresh_interval", TimeValue.timeValueSeconds(1));
 
         logger.debug("Using refresh_interval [{}]", refreshInterval);
     }

--- a/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -57,11 +57,13 @@ import static org.elasticsearch.common.io.FileSystemUtils.isAccessibleDirectory;
  *
  */
 public class PluginsService extends AbstractComponent {
-    public static final String ES_PLUGIN_PROPERTIES_FILE_KEY = "properties_file";
+    public static final String ES_PLUGIN_PROPERTIES_FILE_KEY = "plugins.properties_file";
     public static final String ES_PLUGIN_PROPERTIES = "es-plugin.properties";
-    public static final String LOAD_PLUGIN_FROM_CLASSPATH = "load_classpath_plugins";
+    public static final String LOAD_PLUGIN_FROM_CLASSPATH = "plugins.load_classpath_plugins";
 
     private static final PathMatcher PLUGIN_LIB_MATCHER = FileSystems.getDefault().getPathMatcher("glob:**.{jar,zip}");
+    public static final String PLUGINS_CHECK_LUCENE_KEY = "plugins.check_lucene";
+    public static final String PLUGINS_INFO_REFRESH_INTERVAL_KEY = "plugins.info_refresh_interval";
 
 
     private final Environment environment;
@@ -98,9 +100,9 @@ public class PluginsService extends AbstractComponent {
     public PluginsService(Settings settings, Environment environment) {
         super(settings);
         this.environment = environment;
-        this.checkLucene = componentSettings.getAsBoolean("check_lucene", true);
-        this.esPluginPropertiesFile = componentSettings.get(ES_PLUGIN_PROPERTIES_FILE_KEY, ES_PLUGIN_PROPERTIES);
-        this.loadClasspathPlugins = componentSettings.getAsBoolean(LOAD_PLUGIN_FROM_CLASSPATH, true);
+        this.checkLucene = settings.getAsBoolean(PLUGINS_CHECK_LUCENE_KEY, true);
+        this.esPluginPropertiesFile = settings.get(ES_PLUGIN_PROPERTIES_FILE_KEY, ES_PLUGIN_PROPERTIES);
+        this.loadClasspathPlugins = settings.getAsBoolean(LOAD_PLUGIN_FROM_CLASSPATH, true);
 
         ImmutableList.Builder<Tuple<PluginInfo, Plugin>> tupleBuilder = ImmutableList.builder();
 
@@ -187,7 +189,7 @@ public class PluginsService extends AbstractComponent {
         }
         this.onModuleReferences = onModuleReferences.immutableMap();
 
-        this.refreshInterval = componentSettings.getAsTime("info_refresh_interval", TimeValue.timeValueSeconds(10));
+        this.refreshInterval = settings.getAsTime(PLUGINS_INFO_REFRESH_INTERVAL_KEY, TimeValue.timeValueSeconds(10));
     }
 
     public ImmutableList<Tuple<PluginInfo, Plugin>> plugins() {

--- a/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -444,7 +444,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent<Rep
      */
     private RateLimiter getRateLimiter(RepositorySettings repositorySettings, String setting, ByteSizeValue defaultRate) {
         ByteSizeValue maxSnapshotBytesPerSec = repositorySettings.settings().getAsBytesSize(setting,
-                componentSettings.getAsBytesSize(setting, defaultRate));
+                settings.getAsBytesSize(setting, defaultRate));
         if (maxSnapshotBytesPerSec.bytes() <= 0) {
             return null;
         } else {

--- a/src/main/java/org/elasticsearch/repositories/fs/FsRepository.java
+++ b/src/main/java/org/elasticsearch/repositories/fs/FsRepository.java
@@ -29,9 +29,7 @@ import org.elasticsearch.repositories.RepositoryException;
 import org.elasticsearch.repositories.RepositoryName;
 import org.elasticsearch.repositories.RepositorySettings;
 import org.elasticsearch.repositories.blobstore.BlobStoreRepository;
-import org.elasticsearch.threadpool.ThreadPool;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -71,16 +69,16 @@ public class FsRepository extends BlobStoreRepository {
     public FsRepository(RepositoryName name, RepositorySettings repositorySettings, IndexShardRepository indexShardRepository) throws IOException {
         super(name.getName(), repositorySettings, indexShardRepository);
         Path locationFile;
-        String location = repositorySettings.settings().get("location", componentSettings.get("location"));
+        String location = repositorySettings.settings().get("location", settings.get("repositories.fs.location"));
         if (location == null) {
             logger.warn("using local fs location for gateway, should be changed to be a shared location across nodes");
             throw new RepositoryException(name.name(), "missing location");
         } else {
             locationFile = Paths.get(location);
         }
-        blobStore = new FsBlobStore(componentSettings, locationFile);
-        this.chunkSize = repositorySettings.settings().getAsBytesSize("chunk_size", componentSettings.getAsBytesSize("chunk_size", null));
-        this.compress = repositorySettings.settings().getAsBoolean("compress", componentSettings.getAsBoolean("compress", false));
+        blobStore = new FsBlobStore(settings, locationFile);
+        this.chunkSize = repositorySettings.settings().getAsBytesSize("chunk_size", settings.getAsBytesSize("repositories.fs.chunk_size", null));
+        this.compress = repositorySettings.settings().getAsBoolean("compress", settings.getAsBoolean("repositories.fs.compress", false));
         this.basePath = BlobPath.cleanPath();
     }
 

--- a/src/main/java/org/elasticsearch/repositories/uri/URLRepository.java
+++ b/src/main/java/org/elasticsearch/repositories/uri/URLRepository.java
@@ -30,7 +30,6 @@ import org.elasticsearch.repositories.RepositoryException;
 import org.elasticsearch.repositories.RepositoryName;
 import org.elasticsearch.repositories.RepositorySettings;
 import org.elasticsearch.repositories.blobstore.BlobStoreRepository;
-import org.elasticsearch.threadpool.ThreadPool;
 
 import java.io.IOException;
 import java.net.URL;
@@ -66,14 +65,14 @@ public class URLRepository extends BlobStoreRepository {
     public URLRepository(RepositoryName name, RepositorySettings repositorySettings, IndexShardRepository indexShardRepository) throws IOException {
         super(name.getName(), repositorySettings, indexShardRepository);
         URL url;
-        String path = repositorySettings.settings().get("url", componentSettings.get("url"));
+        String path = repositorySettings.settings().get("url", settings.get("repositories.uri.url"));
         if (path == null) {
             throw new RepositoryException(name.name(), "missing url");
         } else {
             url = new URL(path);
         }
-        listDirectories = repositorySettings.settings().getAsBoolean("list_directories", componentSettings.getAsBoolean("list_directories", true));
-        blobStore = new URLBlobStore(componentSettings, url);
+        listDirectories = repositorySettings.settings().getAsBoolean("list_directories", settings.getAsBoolean("repositories.uri.list_directories", true));
+        blobStore = new URLBlobStore(settings, url);
         basePath = BlobPath.cleanPath();
     }
 

--- a/src/main/java/org/elasticsearch/script/ScriptService.java
+++ b/src/main/java/org/elasticsearch/script/ScriptService.java
@@ -87,6 +87,7 @@ public class ScriptService extends AbstractComponent {
     public static final String DISABLE_DYNAMIC_SCRIPTING_DEFAULT = "sandbox";
     public static final String SCRIPT_INDEX = ".scripts";
     public static final String DEFAULT_LANG = "groovy";
+    public static final String SCRIPT_AUTO_RELOAD_ENABLED_SETTING = "script.auto_reload_enabled";
 
     private final String defaultLang;
 
@@ -264,7 +265,7 @@ public class ScriptService extends AbstractComponent {
         this.fileWatcher = new FileWatcher(scriptsDirectory);
         fileWatcher.addListener(new ScriptChangesListener());
 
-        if (componentSettings.getAsBoolean("auto_reload_enabled", true)) {
+        if (settings.getAsBoolean(SCRIPT_AUTO_RELOAD_ENABLED_SETTING, true)) {
             // automatic reload is enabled - register scripts
             resourceWatcherService.add(fileWatcher);
         } else {

--- a/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/src/main/java/org/elasticsearch/search/SearchService.java
@@ -102,10 +102,8 @@ import static org.elasticsearch.common.unit.TimeValue.timeValueMinutes;
 public class SearchService extends AbstractLifecycleComponent<SearchService> {
 
     public static final String NORMS_LOADING_KEY = "index.norms.loading";
-    private static final String DEFAULT_KEEPALIVE_COMPONENENT_KEY = "default_keep_alive";
-    public static final String DEFAULT_KEEPALIVE_KEY = "search." + DEFAULT_KEEPALIVE_COMPONENENT_KEY;
-    private static final String KEEPALIVE_INTERVAL_COMPONENENT_KEY = "keep_alive_interval";
-    public static final String KEEPALIVE_INTERVAL_KEY = "search." + KEEPALIVE_INTERVAL_COMPONENENT_KEY;
+    public static final String DEFAULT_KEEPALIVE_KEY = "search.default_keep_alive";
+    public static final String KEEPALIVE_INTERVAL_KEY = "search.keep_alive_interval";
 
 
     private final ThreadPool threadPool;
@@ -166,9 +164,9 @@ public class SearchService extends AbstractLifecycleComponent<SearchService> {
         this.fetchPhase = fetchPhase;
         this.indicesQueryCache = indicesQueryCache;
 
-        TimeValue keepAliveInterval = componentSettings.getAsTime(KEEPALIVE_INTERVAL_COMPONENENT_KEY, timeValueMinutes(1));
+        TimeValue keepAliveInterval = settings.getAsTime(KEEPALIVE_INTERVAL_KEY, timeValueMinutes(1));
         // we can have 5 minutes here, since we make sure to clean with search requests and when shard/index closes
-        this.defaultKeepAlive = componentSettings.getAsTime(DEFAULT_KEEPALIVE_COMPONENENT_KEY, timeValueMinutes(5)).millis();
+        this.defaultKeepAlive = settings.getAsTime(DEFAULT_KEEPALIVE_KEY, timeValueMinutes(5)).millis();
 
         Map<String, SearchParseElement> elementParsers = new HashMap<>();
         elementParsers.putAll(dfsPhase.parseElements());

--- a/src/main/java/org/elasticsearch/search/controller/SearchPhaseController.java
+++ b/src/main/java/org/elasticsearch/search/controller/SearchPhaseController.java
@@ -66,6 +66,7 @@ public class SearchPhaseController extends AbstractComponent {
     };
 
     public static final ScoreDoc[] EMPTY_DOCS = new ScoreDoc[0];
+    public static final String SEARCH_CONTROLLER_OPTIMIZE_SINGLE_SHARD_KEY = "search.controller.optimize_single_shard";
 
     private final BigArrays bigArrays;
     private final boolean optimizeSingleShard;
@@ -77,7 +78,7 @@ public class SearchPhaseController extends AbstractComponent {
         super(settings);
         this.bigArrays = bigArrays;
         this.scriptService = scriptService;
-        this.optimizeSingleShard = componentSettings.getAsBoolean("optimize_single_shard", true);
+        this.optimizeSingleShard = settings.getAsBoolean(SEARCH_CONTROLLER_OPTIMIZE_SINGLE_SHARD_KEY, true);
     }
 
     public boolean optimizeSingleShard() {

--- a/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
+++ b/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
@@ -155,7 +155,7 @@ public class ThreadPool extends AbstractComponent {
             nodeSettingsService.addListener(new ApplySettings());
         }
 
-        TimeValue estimatedTimeInterval = componentSettings.getAsTime("estimated_time_interval", TimeValue.timeValueMillis(200));
+        TimeValue estimatedTimeInterval = settings.getAsTime("threadpool.estimated_time_interval", TimeValue.timeValueMillis(200));
         this.estimatedTimeThread = new EstimatedTimeThread(EsExecutors.threadName(settings, "[timer]"), estimatedTimeInterval.millis());
         this.estimatedTimeThread.start();
     }

--- a/src/main/java/org/elasticsearch/transport/netty/NettyTransport.java
+++ b/src/main/java/org/elasticsearch/transport/netty/NettyTransport.java
@@ -161,17 +161,17 @@ public class NettyTransport extends AbstractLifecycleComponent<Transport> implem
         }
 
         this.workerCount = settings.getAsInt(WORKER_COUNT, EsExecutors.boundedNumberOfProcessors(settings) * 2);
-        this.blockingClient = settings.getAsBoolean("transport.tcp.blocking_client", settings.getAsBoolean(TCP_BLOCKING_CLIENT, settings.getAsBoolean(TCP_BLOCKING, false)));
-        this.connectTimeout = componentSettings.getAsTime("connect_timeout", settings.getAsTime("transport.tcp.connect_timeout", settings.getAsTime(TCP_CONNECT_TIMEOUT, TCP_DEFAULT_CONNECT_TIMEOUT)));
-        this.maxCumulationBufferCapacity = componentSettings.getAsBytesSize("max_cumulation_buffer_capacity", null);
-        this.maxCompositeBufferComponents = componentSettings.getAsInt("max_composite_buffer_components", -1);
+        this.blockingClient = settings.getAsBoolean("transport.netty.transport.tcp.blocking_client", settings.getAsBoolean(TCP_BLOCKING_CLIENT, settings.getAsBoolean(TCP_BLOCKING, false)));
+        this.connectTimeout = this.settings.getAsTime("transport.netty.connect_timeout", settings.getAsTime("transport.tcp.connect_timeout", settings.getAsTime(TCP_CONNECT_TIMEOUT, TCP_DEFAULT_CONNECT_TIMEOUT)));
+        this.maxCumulationBufferCapacity = this.settings.getAsBytesSize("transport.netty.max_cumulation_buffer_capacity", null);
+        this.maxCompositeBufferComponents = this.settings.getAsInt("transport.netty.max_composite_buffer_components", -1);
         this.compress = settings.getAsBoolean(TransportSettings.TRANSPORT_TCP_COMPRESS, false);
 
-        this.connectionsPerNodeRecovery = componentSettings.getAsInt("connections_per_node.recovery", settings.getAsInt(CONNECTIONS_PER_NODE_RECOVERY, 2));
-        this.connectionsPerNodeBulk = componentSettings.getAsInt("connections_per_node.bulk", settings.getAsInt(CONNECTIONS_PER_NODE_BULK, 3));
-        this.connectionsPerNodeReg = componentSettings.getAsInt("connections_per_node.reg", settings.getAsInt(CONNECTIONS_PER_NODE_REG, 6));
-        this.connectionsPerNodeState = componentSettings.getAsInt("connections_per_node.high", settings.getAsInt(CONNECTIONS_PER_NODE_STATE, 1));
-        this.connectionsPerNodePing = componentSettings.getAsInt("connections_per_node.ping", settings.getAsInt(CONNECTIONS_PER_NODE_PING, 1));
+        this.connectionsPerNodeRecovery = this.settings.getAsInt("transport.netty.connections_per_node.recovery", settings.getAsInt(CONNECTIONS_PER_NODE_RECOVERY, 2));
+        this.connectionsPerNodeBulk = this.settings.getAsInt("transport.netty.connections_per_node.bulk", settings.getAsInt(CONNECTIONS_PER_NODE_BULK, 3));
+        this.connectionsPerNodeReg = this.settings.getAsInt("transport.netty.connections_per_node.reg", settings.getAsInt(CONNECTIONS_PER_NODE_REG, 6));
+        this.connectionsPerNodeState = this.settings.getAsInt("transport.netty.connections_per_node.high", settings.getAsInt(CONNECTIONS_PER_NODE_STATE, 1));
+        this.connectionsPerNodePing = this.settings.getAsInt("transport.netty.connections_per_node.ping", settings.getAsInt(CONNECTIONS_PER_NODE_PING, 1));
 
         // we want to have at least 1 for reg/state/ping
         if (this.connectionsPerNodeReg == 0) {
@@ -192,8 +192,8 @@ public class NettyTransport extends AbstractLifecycleComponent<Transport> implem
         }
 
         // See AdaptiveReceiveBufferSizePredictor#DEFAULT_XXX for default values in netty..., we can use higher ones for us, even fixed one
-        this.receivePredictorMin = componentSettings.getAsBytesSize("receive_predictor_min", componentSettings.getAsBytesSize("receive_predictor_size", new ByteSizeValue(defaultReceiverPredictor)));
-        this.receivePredictorMax = componentSettings.getAsBytesSize("receive_predictor_max", componentSettings.getAsBytesSize("receive_predictor_size", new ByteSizeValue(defaultReceiverPredictor)));
+        this.receivePredictorMin = this.settings.getAsBytesSize("transport.netty.receive_predictor_min", this.settings.getAsBytesSize("transport.netty.receive_predictor_size", new ByteSizeValue(defaultReceiverPredictor)));
+        this.receivePredictorMax = this.settings.getAsBytesSize("transport.netty.receive_predictor_max", this.settings.getAsBytesSize("transport.netty.receive_predictor_size", new ByteSizeValue(defaultReceiverPredictor)));
         if (receivePredictorMax.bytes() == receivePredictorMin.bytes()) {
             receiveBufferSizePredictorFactory = new FixedReceiveBufferSizePredictorFactory((int) receivePredictorMax.bytes());
         } else {
@@ -247,7 +247,7 @@ public class NettyTransport extends AbstractLifecycleComponent<Transport> implem
             if (DEFAULT_PROFILE.equals(name)) {
                 profileSettings = settingsBuilder()
                         .put(profileSettings)
-                        .put("port", profileSettings.get("port", componentSettings.get("port", this.settings.get("transport.tcp.port", DEFAULT_PORT_RANGE))))
+                        .put("port", profileSettings.get("port", settings.get("port", this.settings.get("transport.tcp.port", DEFAULT_PORT_RANGE))))
                         .build();
             } else {
                 // if profile does not have a port, skip it
@@ -269,8 +269,8 @@ public class NettyTransport extends AbstractLifecycleComponent<Transport> implem
         }
 
         InetSocketAddress boundAddress = (InetSocketAddress) serverChannels.get(DEFAULT_PROFILE).getLocalAddress();
-        int publishPort = componentSettings.getAsInt("publish_port", settings.getAsInt("transport.publish_port", boundAddress.getPort()));
-        String publishHost = componentSettings.get("publish_host", settings.get("transport.publish_host", settings.get("transport.host")));
+        int publishPort = settings.getAsInt("transport.netty.publish_port", settings.getAsInt("transport.publish_port", boundAddress.getPort()));
+        String publishHost = settings.get("transport.netty.publish_host", settings.get("transport.publish_host", settings.get("transport.host")));
         InetSocketAddress publishAddress = createPublishAddress(publishHost, publishPort);
         this.boundAddress = new BoundTransportAddress(new InetSocketTransportAddress(boundAddress), new InetSocketTransportAddress(publishAddress));
     }
@@ -293,7 +293,7 @@ public class NettyTransport extends AbstractLifecycleComponent<Transport> implem
         if (blockingClient) {
             clientBootstrap = new ClientBootstrap(new OioClientSocketChannelFactory(Executors.newCachedThreadPool(daemonThreadFactory(settings, TRANSPORT_CLIENT_WORKER_THREAD_NAME_PREFIX))));
         } else {
-            int bossCount = componentSettings.getAsInt("boss_count", 1);
+            int bossCount = settings.getAsInt("transport.netty.boss_count", 1);
             clientBootstrap = new ClientBootstrap(new NioClientSocketChannelFactory(
                     Executors.newCachedThreadPool(daemonThreadFactory(settings, TRANSPORT_CLIENT_BOSS_THREAD_NAME_PREFIX)),
                     bossCount,
@@ -303,29 +303,29 @@ public class NettyTransport extends AbstractLifecycleComponent<Transport> implem
         clientBootstrap.setPipelineFactory(configureClientChannelPipelineFactory());
         clientBootstrap.setOption("connectTimeoutMillis", connectTimeout.millis());
 
-        String tcpNoDelay = componentSettings.get("tcp_no_delay", settings.get(TCP_NO_DELAY, "true"));
+        String tcpNoDelay = settings.get("transport.netty.tcp_no_delay", settings.get(TCP_NO_DELAY, "true"));
         if (!"default".equals(tcpNoDelay)) {
             clientBootstrap.setOption("tcpNoDelay", Booleans.parseBoolean(tcpNoDelay, null));
         }
 
-        String tcpKeepAlive = componentSettings.get("tcp_keep_alive", settings.get(TCP_KEEP_ALIVE, "true"));
+        String tcpKeepAlive = settings.get("transport.netty.tcp_keep_alive", settings.get(TCP_KEEP_ALIVE, "true"));
         if (!"default".equals(tcpKeepAlive)) {
             clientBootstrap.setOption("keepAlive", Booleans.parseBoolean(tcpKeepAlive, null));
         }
 
-        ByteSizeValue tcpSendBufferSize = componentSettings.getAsBytesSize("tcp_send_buffer_size", settings.getAsBytesSize(TCP_SEND_BUFFER_SIZE, TCP_DEFAULT_SEND_BUFFER_SIZE));
+        ByteSizeValue tcpSendBufferSize = settings.getAsBytesSize("transport.netty.tcp_send_buffer_size", settings.getAsBytesSize(TCP_SEND_BUFFER_SIZE, TCP_DEFAULT_SEND_BUFFER_SIZE));
         if (tcpSendBufferSize != null && tcpSendBufferSize.bytes() > 0) {
             clientBootstrap.setOption("sendBufferSize", tcpSendBufferSize.bytes());
         }
 
-        ByteSizeValue tcpReceiveBufferSize = componentSettings.getAsBytesSize("tcp_receive_buffer_size", settings.getAsBytesSize(TCP_RECEIVE_BUFFER_SIZE, TCP_DEFAULT_RECEIVE_BUFFER_SIZE));
+        ByteSizeValue tcpReceiveBufferSize = settings.getAsBytesSize("transport.netty.tcp_receive_buffer_size", settings.getAsBytesSize(TCP_RECEIVE_BUFFER_SIZE, TCP_DEFAULT_RECEIVE_BUFFER_SIZE));
         if (tcpReceiveBufferSize != null && tcpReceiveBufferSize.bytes() > 0) {
             clientBootstrap.setOption("receiveBufferSize", tcpReceiveBufferSize.bytes());
         }
 
         clientBootstrap.setOption("receiveBufferSizePredictorFactory", receiveBufferSizePredictorFactory);
 
-        Boolean reuseAddress = componentSettings.getAsBoolean("reuse_address", settings.getAsBoolean(TCP_REUSE_ADDRESS, NetworkUtils.defaultReuseAddress()));
+        Boolean reuseAddress = settings.getAsBoolean("transport.netty.reuse_address", settings.getAsBoolean(TCP_REUSE_ADDRESS, NetworkUtils.defaultReuseAddress()));
         if (reuseAddress != null) {
             clientBootstrap.setOption("reuseAddress", reuseAddress);
         }
@@ -336,37 +336,37 @@ public class NettyTransport extends AbstractLifecycleComponent<Transport> implem
     private Settings createFallbackSettings() {
         ImmutableSettings.Builder fallbackSettingsBuilder = settingsBuilder();
 
-        String fallbackBindHost = componentSettings.get("bind_host", settings.get("transport.bind_host", settings.get("transport.host")));
+        String fallbackBindHost = settings.get("transport.netty.bind_host", settings.get("transport.bind_host", settings.get("transport.host")));
         if (fallbackBindHost != null) {
             fallbackSettingsBuilder.put("bind_host", fallbackBindHost);
         }
 
-        String fallbackPublishHost = componentSettings.get("publish_host", settings.get("transport.publish_host", settings.get("transport.host")));
+        String fallbackPublishHost = settings.get("transport.netty.publish_host", settings.get("transport.publish_host", settings.get("transport.host")));
         if (fallbackPublishHost != null) {
             fallbackSettingsBuilder.put("publish_host", fallbackPublishHost);
         }
 
-        String fallbackTcpNoDelay = componentSettings.get("tcp_no_delay", settings.get(TCP_NO_DELAY, "true"));
+        String fallbackTcpNoDelay = settings.get("transport.netty.tcp_no_delay", settings.get(TCP_NO_DELAY, "true"));
         if (fallbackTcpNoDelay != null) {
             fallbackSettingsBuilder.put("tcp_no_delay", fallbackTcpNoDelay);
         }
 
-        String fallbackTcpKeepAlive = componentSettings.get("tcp_keep_alive", settings.get(TCP_KEEP_ALIVE, "true"));
+        String fallbackTcpKeepAlive = settings.get("transport.netty.tcp_keep_alive", settings.get(TCP_KEEP_ALIVE, "true"));
         if (fallbackTcpKeepAlive != null) {
             fallbackSettingsBuilder.put("tcp_keep_alive", fallbackTcpKeepAlive);
         }
 
-        Boolean fallbackReuseAddress = componentSettings.getAsBoolean("reuse_address", settings.getAsBoolean(TCP_REUSE_ADDRESS, NetworkUtils.defaultReuseAddress()));
+        Boolean fallbackReuseAddress = settings.getAsBoolean("transport.netty.reuse_address", settings.getAsBoolean(TCP_REUSE_ADDRESS, NetworkUtils.defaultReuseAddress()));
         if (fallbackReuseAddress != null) {
             fallbackSettingsBuilder.put("reuse_address", fallbackReuseAddress);
         }
 
-        ByteSizeValue fallbackTcpSendBufferSize = componentSettings.getAsBytesSize("tcp_send_buffer_size", settings.getAsBytesSize(TCP_SEND_BUFFER_SIZE, TCP_DEFAULT_SEND_BUFFER_SIZE));
+        ByteSizeValue fallbackTcpSendBufferSize = settings.getAsBytesSize("transport.netty.tcp_send_buffer_size", settings.getAsBytesSize(TCP_SEND_BUFFER_SIZE, TCP_DEFAULT_SEND_BUFFER_SIZE));
         if (fallbackTcpSendBufferSize != null) {
             fallbackSettingsBuilder.put("tcp_send_buffer_size", fallbackTcpSendBufferSize);
         }
 
-        ByteSizeValue fallbackTcpBufferSize = componentSettings.getAsBytesSize("tcp_receive_buffer_size", settings.getAsBytesSize(TCP_RECEIVE_BUFFER_SIZE, TCP_DEFAULT_RECEIVE_BUFFER_SIZE));
+        ByteSizeValue fallbackTcpBufferSize = settings.getAsBytesSize("transport.netty.tcp_receive_buffer_size", settings.getAsBytesSize(TCP_RECEIVE_BUFFER_SIZE, TCP_DEFAULT_RECEIVE_BUFFER_SIZE));
         if (fallbackTcpBufferSize != null) {
             fallbackSettingsBuilder.put("tcp_receive_buffer_size", fallbackTcpBufferSize);
         }
@@ -560,7 +560,7 @@ public class NettyTransport extends AbstractLifecycleComponent<Transport> implem
             index = address.lastIndexOf(':');
             if (index == -1) {
                 List<TransportAddress> addresses = Lists.newArrayList();
-                String defaultPort = settings.get("transport.profiles.default.port", componentSettings.get("port", this.settings.get("transport.tcp.port", DEFAULT_PORT_RANGE)));
+                String defaultPort = settings.get("transport.profiles.default.port", settings.get("transport.netty.port", this.settings.get("transport.tcp.port", DEFAULT_PORT_RANGE)));
                 int[] iPorts = new PortsRange(defaultPort).ports();
                 for (int iPort : iPorts) {
                     addresses.add(new InetSocketTransportAddress(address, iPort));

--- a/src/main/java/org/elasticsearch/watcher/ResourceWatcherService.java
+++ b/src/main/java/org/elasticsearch/watcher/ResourceWatcherService.java
@@ -80,14 +80,14 @@ public class ResourceWatcherService extends AbstractLifecycleComponent<ResourceW
     @Inject
     public ResourceWatcherService(Settings settings, ThreadPool threadPool) {
         super(settings);
-        this.enabled = componentSettings.getAsBoolean("enabled", true);
+        this.enabled = settings.getAsBoolean("watcher.enabled", true);
         this.threadPool = threadPool;
 
-        TimeValue interval = componentSettings.getAsTime("interval.low", Frequency.LOW.interval);
+        TimeValue interval = settings.getAsTime("watcher.interval.low", Frequency.LOW.interval);
         lowMonitor = new ResourceMonitor(interval, Frequency.LOW);
-        interval = componentSettings.getAsTime("interval.medium", componentSettings.getAsTime("interval", Frequency.MEDIUM.interval));
+        interval = settings.getAsTime("watcher.interval.medium", settings.getAsTime("watcher.interval", Frequency.MEDIUM.interval));
         mediumMonitor = new ResourceMonitor(interval, Frequency.MEDIUM);
-        interval = componentSettings.getAsTime("interval.high", Frequency.HIGH.interval);
+        interval = settings.getAsTime("watcher.interval.high", Frequency.HIGH.interval);
         highMonitor = new ResourceMonitor(interval, Frequency.HIGH);
     }
 

--- a/src/test/java/org/elasticsearch/plugins/PluginLuceneCheckerTests.java
+++ b/src/test/java/org/elasticsearch/plugins/PluginLuceneCheckerTests.java
@@ -45,9 +45,9 @@ public class PluginLuceneCheckerTests extends ElasticsearchIntegrationTest {
     @Test
     public void testDisableLuceneVersionCheckingPlugin() throws URISyntaxException {
         String serverNodeId = SimpleNodesInfoTests.startNodeWithPlugins(
-                settingsBuilder().put("plugins.check_lucene", false)
-                        .put("plugins." + PluginsService.ES_PLUGIN_PROPERTIES_FILE_KEY, "es-plugin-test.properties")
-                        .put("plugins." + PluginsService.LOAD_PLUGIN_FROM_CLASSPATH, true).build(),
+                settingsBuilder().put(PluginsService.PLUGINS_CHECK_LUCENE_KEY, false)
+                        .put(PluginsService.ES_PLUGIN_PROPERTIES_FILE_KEY, "es-plugin-test.properties")
+                        .put(PluginsService.LOAD_PLUGIN_FROM_CLASSPATH, true).build(),
                 "/org/elasticsearch/plugins/lucene/");
         logger.info("--> server {} started" + serverNodeId);
 
@@ -70,9 +70,9 @@ public class PluginLuceneCheckerTests extends ElasticsearchIntegrationTest {
     @Test
     public void testEnableLuceneVersionCheckingPlugin() throws URISyntaxException {
         String serverNodeId = SimpleNodesInfoTests.startNodeWithPlugins(
-                settingsBuilder().put("plugins.check_lucene", true)
-                        .put("plugins." + PluginsService.ES_PLUGIN_PROPERTIES_FILE_KEY, "es-plugin-test.properties")
-                        .put("plugins." + PluginsService.LOAD_PLUGIN_FROM_CLASSPATH, true).build(),
+                settingsBuilder().put(PluginsService.PLUGINS_CHECK_LUCENE_KEY, true)
+                        .put(PluginsService.ES_PLUGIN_PROPERTIES_FILE_KEY, "es-plugin-test.properties")
+                        .put(PluginsService.LOAD_PLUGIN_FROM_CLASSPATH, true).build(),
                 "/org/elasticsearch/plugins/lucene/");
         logger.info("--> server {} started" + serverNodeId);
 

--- a/src/test/java/org/elasticsearch/plugins/PluginServiceTests.java
+++ b/src/test/java/org/elasticsearch/plugins/PluginServiceTests.java
@@ -44,8 +44,8 @@ public class PluginServiceTests extends ElasticsearchIntegrationTest {
     public void testPluginLoadingFromClassName() throws URISyntaxException {
         Settings settings = settingsBuilder()
                                 // Defines a plugin in classpath
-                                .put("plugins." + PluginsService.LOAD_PLUGIN_FROM_CLASSPATH, true)
-                                .put("plugins." + PluginsService.ES_PLUGIN_PROPERTIES_FILE_KEY, "es-plugin-test.properties")
+                                .put(PluginsService.LOAD_PLUGIN_FROM_CLASSPATH, true)
+                                .put(PluginsService.ES_PLUGIN_PROPERTIES_FILE_KEY, "es-plugin-test.properties")
                                 // Defines a plugin in settings
                                 .put("plugin.types", InSettingsPlugin.class.getName())
                             .build();


### PR DESCRIPTION
Today we have two ways of getting a setting, either with the full settings key or with only
the last part of the key where the prefix is implicit depending on the package the class is in via
component settings. this is trappy as well as confusing for users and can break easily if a class is moved
to a new package since the prefix then implicitly changes.
This commit removes the component settings from the codebase.
