### PR TITLE
Use direct mapping call in Kernel32Library

### DIFF
--- a/dev-tools/tests.policy
+++ b/dev-tools/tests.policy
@@ -70,7 +70,9 @@ grant {
   // needed by groovy scripting
   permission java.lang.RuntimePermission "getProtectionDomain";
 
+  // needed for natives calls
   permission java.lang.RuntimePermission "loadLibrary.*";
+  permission java.lang.RuntimePermission "createSecurityManager";
 
   // reflection hacks:
   // needed for Striped64 (what is this doing), also enables unmap hack


### PR DESCRIPTION
This commit modifies the Kernel32Library to use direct mapping instead of a proxy class when doing native calls on Windows platforms. It also adds the "createSecurityManager" permission to the tests.policy file, and adds unit tests that should have failed when the Java security manager is enabled.

Closes #9802
