### PR TITLE
Fix bulk item response types for update and delete in case of index errors.

### DIFF
--- a/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
+++ b/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
@@ -168,13 +168,13 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
         } else if (request instanceof DeleteRequest) {
             DeleteRequest deleteRequest = (DeleteRequest) request;
             if (index.equals(deleteRequest.index())) {
-                responses.set(idx, new BulkItemResponse(idx, "index", new BulkItemResponse.Failure(deleteRequest.index(), deleteRequest.type(), deleteRequest.id(), e)));
+                responses.set(idx, new BulkItemResponse(idx, "delete", new BulkItemResponse.Failure(deleteRequest.index(), deleteRequest.type(), deleteRequest.id(), e)));
                 return true;
             }
         } else if (request instanceof UpdateRequest) {
             UpdateRequest updateRequest = (UpdateRequest) request;
             if (index.equals(updateRequest.index())) {
-                responses.set(idx, new BulkItemResponse(idx, "index", new BulkItemResponse.Failure(updateRequest.index(), updateRequest.type(), updateRequest.id(), e)));
+                responses.set(idx, new BulkItemResponse(idx, "update", new BulkItemResponse.Failure(updateRequest.index(), updateRequest.type(), updateRequest.id(), e)));
                 return true;
             }
         } else {


### PR DESCRIPTION
This fixes issue #9821.

Writing a test for this turned out to be too tricky for me at this stage of familiarity with the code base. I get some test failures running `mvn test -Dtests.filter="not @slow"`, but these seem to be the same I get on master and not clearly related to the bulk API.
