### PR TITLE
Store: renaming temp files should log errors of delete in trace

### DIFF
--- a/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/src/main/java/org/elasticsearch/index/store/Store.java
@@ -233,7 +233,7 @@ public class Store extends AbstractIndexShardComponent implements CloseableIndex
      * Renames all the given files form the key of the map to the
      * value of the map. All successfully renamed files are removed from the map in-place.
      */
-    public void renameFilesSafe(Map<String, String> tempFileMap) throws IOException {
+    public void renameTempFilesSafe(Map<String, String> tempFileMap) throws IOException {
         // this works just like a lucene commit - we rename all temp files and once we successfully
         // renamed all the segments we rename the commit to ensure we don't leave half baked commits behind.
         final Map.Entry<String, String>[] entries = tempFileMap.entrySet().toArray(new Map.Entry[tempFileMap.size()]);
@@ -267,7 +267,7 @@ public class Store extends AbstractIndexShardComponent implements CloseableIndex
                     directory.deleteFile(origFile);
                 } catch (FileNotFoundException | NoSuchFileException e) {
                 } catch (Throwable ex) {
-                    logger.debug("failed to delete file [{}]", ex, origFile);
+                    logger.trace("failed to delete file [{}] (it may be missing, which is OK)", ex, origFile);
                 }
                 // now, rename the files... and fail it it won't work
                 this.renameFile(tempFile, origFile);

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoveryStatus.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoveryStatus.java
@@ -140,7 +140,7 @@ public class RecoveryStatus extends AbstractRefCounted {
     /** renames all temporary files to their true name, potentially overriding existing files */
     public void renameAllTempFiles() throws IOException {
         ensureRefCount();
-        store.renameFilesSafe(tempFileNames);
+        store.renameTempFilesSafe(tempFileNames);
     }
 
     /**


### PR DESCRIPTION
The method follows a delete then rename pattern. It currently logs errors in the delete under DEBUG and barfs if the rename fails. It also correctly ignores FileNotFoundException in the first delete round. This protection fails however since lucene uses File.delete() (which is changed in 5.0) so we get a generic IOException in this case. This can result in worrisome  log messages like:

```
[2015-02-28 16:11:42,720][DEBUG][index.store              ] [node_s2] [test][0] failed to delete file [segments_1]
java.io.IOException: Cannot delete .../nodes/2/indices/test/0/index/segments_1
    at org.apache.lucene.store.FSDirectory.deleteFile(FSDirectory.java:272)
```

I also gave the method a better name.
