### PR TITLE
toString for SearchRequestBuilder and CountRequestBuilder

### DIFF
--- a/src/main/java/org/elasticsearch/action/count/CountRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/count/CountRequestBuilder.java
@@ -19,12 +19,14 @@
 
 package org.elasticsearch.action.count;
 
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.QuerySourceBuilder;
 import org.elasticsearch.action.support.broadcast.BroadcastOperationRequestBuilder;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.index.query.QueryBuilder;
 
 /**
@@ -151,5 +153,20 @@ public class CountRequestBuilder extends BroadcastOperationRequestBuilder<CountR
             sourceBuilder = new QuerySourceBuilder();
         }
         return sourceBuilder;
+    }
+
+    @Override
+    public String toString() {
+        if (sourceBuilder != null) {
+            return sourceBuilder.toString();
+        }
+        if (request.source() != null) {
+            try {
+                return XContentHelper.convertToJson(request.source().toBytesArray(), false, true);
+            } catch(Exception e) {
+                return "{ \"error\" : \"" + ExceptionsHelper.detailedMessage(e) + "\"}";
+            }
+        }
+        return new QuerySourceBuilder().toString();
     }
 }

--- a/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.action.search;
 
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.support.IndicesOptions;
@@ -28,6 +29,7 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.index.query.FilterBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.script.ScriptService;
@@ -366,9 +368,6 @@ public class SearchRequestBuilder extends ActionRequestBuilder<SearchRequest, Se
 
     /**
      * Indicates whether the response should contain the stored _source for every hit
-     *
-     * @param fetch
-     * @return
      */
     public SearchRequestBuilder setFetchSource(boolean fetch) {
         sourceBuilder().fetchSource(fetch);
@@ -1008,7 +1007,17 @@ public class SearchRequestBuilder extends ActionRequestBuilder<SearchRequest, Se
 
     @Override
     public String toString() {
-        return internalBuilder().toString();
+        if (sourceBuilder != null) {
+            return sourceBuilder.toString();
+        }
+        if (request.source() != null) {
+            try {
+                return XContentHelper.convertToJson(request.source().toBytesArray(), false, true);
+            } catch(Exception e) {
+                return "{ \"error\" : \"" + ExceptionsHelper.detailedMessage(e) + "\"}";
+            }
+        }
+        return new SearchSourceBuilder().toString();
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/support/QuerySourceBuilder.java
+++ b/src/main/java/org/elasticsearch/action/support/QuerySourceBuilder.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.action.support;
 
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -72,6 +73,17 @@ public class QuerySourceBuilder implements ToXContent {
             return builder.bytes();
         } catch (Exception e) {
             throw new SearchSourceBuilderException("Failed to build search source", e);
+        }
+    }
+
+    @Override
+    public String toString() {
+        try {
+            XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON).prettyPrint();
+            toXContent(builder, ToXContent.EMPTY_PARAMS);
+            return builder.string();
+        } catch (Exception e) {
+            return "{ \"error\" : \"" + ExceptionsHelper.detailedMessage(e) + "\"}";
         }
     }
 }

--- a/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
+++ b/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import org.elasticsearch.ElasticsearchGenerationException;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.client.Requests;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
@@ -630,7 +631,7 @@ public class SearchSourceBuilder implements ToXContent {
             toXContent(builder, ToXContent.EMPTY_PARAMS);
             return builder.string();
         } catch (Exception e) {
-            return "{ \"error\" : \"" + e.getMessage() + "\"}";
+            return "{ \"error\" : \"" + ExceptionsHelper.detailedMessage(e) + "\"}";
         }
     }
 

--- a/src/test/java/org/elasticsearch/action/count/CountRequestBuilderTests.java
+++ b/src/test/java/org/elasticsearch/action/count/CountRequestBuilderTests.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.count;
+
+import org.elasticsearch.action.support.QuerySourceBuilder;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.client.transport.TransportClient;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+
+public class CountRequestBuilderTests extends ElasticsearchTestCase {
+
+    private static Client client;
+
+    @BeforeClass
+    public static void initClient() {
+        //this client will not be hit by any request, but it needs to be a non null proper client
+        //that is why we create it but we don't add any transport address to it
+        client = new TransportClient();
+    }
+
+    @AfterClass
+    public static void closeClient() {
+        client.close();
+        client = null;
+    }
+
+    @Test
+    public void testEmptySourceToString() {
+        CountRequestBuilder countRequestBuilder = new CountRequestBuilder(client);
+        assertThat(countRequestBuilder.toString(), equalTo(new QuerySourceBuilder().toString()));
+    }
+
+    @Test
+    public void testQueryBuilderQueryToString() {
+        CountRequestBuilder countRequestBuilder = new CountRequestBuilder(client);
+        countRequestBuilder.setQuery(QueryBuilders.matchAllQuery());
+        assertThat(countRequestBuilder.toString(), equalTo(new QuerySourceBuilder().setQuery(QueryBuilders.matchAllQuery()).toString()));
+    }
+
+    @Test
+    public void testStringQueryToString() {
+        CountRequestBuilder countRequestBuilder = new CountRequestBuilder(client);
+        String query = "{ \"match_all\" : {} }";
+        countRequestBuilder.setQuery(new BytesArray(query));
+        assertThat(countRequestBuilder.toString(), equalTo("{\n  \"query\":{ \"match_all\" : {} }\n}"));
+    }
+
+    @Test
+    public void testXContentBuilderQueryToString() throws IOException {
+        CountRequestBuilder countRequestBuilder = new CountRequestBuilder(client);
+        XContentBuilder xContentBuilder = XContentFactory.contentBuilder(randomFrom(XContentType.values()));
+        xContentBuilder.startObject();
+        xContentBuilder.startObject("match_all");
+        xContentBuilder.endObject();
+        xContentBuilder.endObject();
+        countRequestBuilder.setQuery(xContentBuilder);
+        assertThat(countRequestBuilder.toString(), equalTo(new QuerySourceBuilder().setQuery(xContentBuilder.bytes()).toString()));
+    }
+
+    @Test
+    public void testStringSourceToString() {
+        CountRequestBuilder countRequestBuilder = new CountRequestBuilder(client);
+        String query = "{ \"query\": { \"match_all\" : {} } }";
+        countRequestBuilder.setSource(new BytesArray(query));
+        assertThat(countRequestBuilder.toString(), equalTo("{ \"query\": { \"match_all\" : {} } }"));
+    }
+
+    @Test
+    public void testXContentBuilderSourceToString() throws IOException {
+        CountRequestBuilder countRequestBuilder = new CountRequestBuilder(client);
+        XContentBuilder xContentBuilder = XContentFactory.contentBuilder(randomFrom(XContentType.values()));
+        xContentBuilder.startObject();
+        xContentBuilder.startObject("match_all");
+        xContentBuilder.endObject();
+        xContentBuilder.endObject();
+        countRequestBuilder.setSource(xContentBuilder.bytes());
+        assertThat(countRequestBuilder.toString(), equalTo(XContentHelper.convertToJson(xContentBuilder.bytes(), false, true)));
+    }
+
+    @Test
+    public void testThatToStringDoesntWipeSource() {
+        String source = "{\n" +
+                "            \"query\" : {\n" +
+                "            \"match\" : {\n" +
+                "                \"field\" : {\n" +
+                "                    \"query\" : \"value\"" +
+                "                }\n" +
+                "            }\n" +
+                "        }\n" +
+                "        }";
+        CountRequestBuilder countRequestBuilder = new CountRequestBuilder(client).setSource(new BytesArray(source));
+        String preToString = countRequestBuilder.request().source().toUtf8();
+        assertThat(countRequestBuilder.toString(), equalTo(source));
+        String postToString = countRequestBuilder.request().source().toUtf8();
+        assertThat(preToString, equalTo(postToString));
+    }
+}

--- a/src/test/java/org/elasticsearch/action/search/SearchRequestBuilderTests.java
+++ b/src/test/java/org/elasticsearch/action/search/SearchRequestBuilderTests.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.search;
+
+import org.elasticsearch.client.Client;
+import org.elasticsearch.client.transport.TransportClient;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+
+public class SearchRequestBuilderTests extends ElasticsearchTestCase {
+
+    private static Client client;
+
+    @BeforeClass
+    public static void initClient() {
+        //this client will not be hit by any request, but it needs to be a non null proper client
+        //that is why we create it but we don't add any transport address to it
+        client = new TransportClient();
+    }
+
+    @AfterClass
+    public static void closeClient() {
+        client.close();
+        client = null;
+    }
+
+    @Test
+    public void testEmptySourceToString() {
+        SearchRequestBuilder searchRequestBuilder = new SearchRequestBuilder(client);
+        assertThat(searchRequestBuilder.toString(), equalTo(new SearchSourceBuilder().toString()));
+    }
+
+    @Test
+    public void testQueryBuilderQueryToString() {
+        SearchRequestBuilder searchRequestBuilder = new SearchRequestBuilder(client);
+        searchRequestBuilder.setQuery(QueryBuilders.matchAllQuery());
+        assertThat(searchRequestBuilder.toString(), equalTo(new SearchSourceBuilder().query(QueryBuilders.matchAllQuery()).toString()));
+    }
+
+    @Test
+    public void testXContentBuilderQueryToString() throws IOException {
+        SearchRequestBuilder searchRequestBuilder = new SearchRequestBuilder(client);
+        XContentBuilder xContentBuilder = XContentFactory.contentBuilder(randomFrom(XContentType.values()));
+        xContentBuilder.startObject();
+        xContentBuilder.startObject("match_all");
+        xContentBuilder.endObject();
+        xContentBuilder.endObject();
+        searchRequestBuilder.setQuery(xContentBuilder);
+        assertThat(searchRequestBuilder.toString(), equalTo(new SearchSourceBuilder().query(xContentBuilder).toString()));
+    }
+
+    @Test
+    public void testStringQueryToString() {
+        SearchRequestBuilder searchRequestBuilder = new SearchRequestBuilder(client);
+        String query = "{ \"match_all\" : {} }";
+        searchRequestBuilder.setQuery(query);
+        assertThat(searchRequestBuilder.toString(), equalTo("{\n  \"query\":{ \"match_all\" : {} }\n}"));
+    }
+
+    @Test
+    public void testStringSourceToString() {
+        SearchRequestBuilder searchRequestBuilder = new SearchRequestBuilder(client);
+        String source = "{ \"query\" : { \"match_all\" : {} } }";
+        searchRequestBuilder.setSource(source);
+        assertThat(searchRequestBuilder.toString(), equalTo(source));
+    }
+
+    @Test
+    public void testXContentBuilderSourceToString() throws IOException {
+        SearchRequestBuilder searchRequestBuilder = new SearchRequestBuilder(client);
+        XContentBuilder xContentBuilder = XContentFactory.contentBuilder(randomFrom(XContentType.values()));
+        xContentBuilder.startObject();
+        xContentBuilder.startObject("query");
+        xContentBuilder.startObject("match_all");
+        xContentBuilder.endObject();
+        xContentBuilder.endObject();
+        xContentBuilder.endObject();
+        searchRequestBuilder.setSource(xContentBuilder);
+        assertThat(searchRequestBuilder.toString(), equalTo(XContentHelper.convertToJson(xContentBuilder.bytes(), false, true)));
+    }
+
+    @Test
+    public void testThatToStringDoesntWipeRequestSource() {
+        String source = "{\n" +
+                "            \"query\" : {\n" +
+                "            \"match\" : {\n" +
+                "                \"field\" : {\n" +
+                "                    \"query\" : \"value\"" +
+                "                }\n" +
+                "            }\n" +
+                "        }\n" +
+                "        }";
+        SearchRequestBuilder searchRequestBuilder = new SearchRequestBuilder(client).setSource(source);
+        String preToString = searchRequestBuilder.request().source().toUtf8();
+        assertThat(searchRequestBuilder.toString(), equalTo(source));
+        String postToString = searchRequestBuilder.request().source().toUtf8();
+        assertThat(preToString, equalTo(postToString));
+    }
+}


### PR DESCRIPTION
Fixed SearchRequestBuilder#toString to not wipe the request source when called.

Improved SearchRequestBuilder#toString to support the different ways a query can be set to it. Also printed out a merged version of source and extraSrouce in case there in case any extraSource is set, to reflect what will happen when executing the request builder.

Implemented toString in CountRequestBuilder

Closes #5576
Closes #5555
