### PR TITLE
[TEST] Work around URI encode limitations in RestClient

### DIFF
--- a/rest-api-spec/test/script/30_expressions.yaml
+++ b/rest-api-spec/test/script/30_expressions.yaml
@@ -22,6 +22,6 @@ setup:
 ---
 "Expressions scripting test":
 
-  - do: { search: { body: { script_fields : { my_field : { lang: expression, script: 'doc["age"].value' } } } } }
-  - match:  { hits.hits.0.fields.my_field.0: 23.0 }
+  - do: { search: { body: { script_fields : { my_field : { lang: expression, script: 'doc["age"].value + 19' } } } } }
+  - match:  { hits.hits.0.fields.my_field.0: 42.0 }
 


### PR DESCRIPTION
We've been relying on URI for url encoding, but it turns out it has some problems. For instance '+' stays as is while it should be encoded to `%2B`. If we go and manually encode query params we have to be careful though not to run into double encoding ('+'=>'%2B'=>'%252B'). The applied solution relies on URI encoding for the url path, but manual url encoding for the query parameters. We prevent URI from double encoding query params by using its single argument constructor that leaves everything as is.

We can also revert back the expression script REST test that revealed this to its original content (which contains an addition).

Closes #9769
