### PR TITLE
Node receiving a cluster state with a wrong master node should reject and throw an error

### DIFF
--- a/src/main/java/org/elasticsearch/discovery/zen/publish/PublishClusterStateAction.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/publish/PublishClusterStateAction.java
@@ -21,14 +21,15 @@ package org.elasticsearch.discovery.zen.publish;
 
 import com.google.common.collect.Maps;
 import org.elasticsearch.Version;
-import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.compress.Compressor;
 import org.elasticsearch.common.compress.CompressorFactory;
-import org.elasticsearch.common.io.stream.*;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.discovery.AckClusterStatePublishResponseHandler;
@@ -190,25 +191,34 @@ public class PublishClusterStateAction extends AbstractComponent {
             ClusterState clusterState = ClusterState.Builder.readFrom(in, nodesProvider.nodes().localNode());
             clusterState.status(ClusterState.ClusterStateStatus.RECEIVED);
             logger.debug("received cluster state version {}", clusterState.version());
-            listener.onNewClusterState(clusterState, new NewClusterStateListener.NewStateProcessed() {
-                @Override
-                public void onNewClusterStateProcessed() {
-                    try {
-                        channel.sendResponse(TransportResponse.Empty.INSTANCE);
-                    } catch (Throwable e) {
-                        logger.debug("failed to send response on cluster state processed", e);
+            try {
+                listener.onNewClusterState(clusterState, new NewClusterStateListener.NewStateProcessed() {
+                    @Override
+                    public void onNewClusterStateProcessed() {
+                        try {
+                            channel.sendResponse(TransportResponse.Empty.INSTANCE);
+                        } catch (Throwable e) {
+                            logger.debug("failed to send response on cluster state processed", e);
+                        }
                     }
-                }
 
-                @Override
-                public void onNewClusterStateFailed(Throwable t) {
-                    try {
-                        channel.sendResponse(t);
-                    } catch (Throwable e) {
-                        logger.debug("failed to send response on cluster state processed", e);
+                    @Override
+                    public void onNewClusterStateFailed(Throwable t) {
+                        try {
+                            channel.sendResponse(t);
+                        } catch (Throwable e) {
+                            logger.debug("failed to send response on cluster state processed", e);
+                        }
                     }
+                });
+            } catch (Exception e) {
+                logger.warn("unexpected error while processing cluster state version [{}]", e, clusterState.version());
+                try {
+                    channel.sendResponse(e);
+                } catch (Throwable e1) {
+                    logger.debug("failed to send response on cluster state processed", e1);
                 }
-            });
+            }
         }
 
         @Override

--- a/src/test/java/org/elasticsearch/discovery/DiscoveryWithServiceDisruptionsTests.java
+++ b/src/test/java/org/elasticsearch/discovery/DiscoveryWithServiceDisruptionsTests.java
@@ -594,7 +594,6 @@ public class DiscoveryWithServiceDisruptionsTests extends ElasticsearchIntegrati
      * them from following the stale master.
      */
     @Test
-    @LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elasticsearch/elasticsearch/pull/9963")
     public void testStaleMasterNotHijackingMajority() throws Exception {
         // TODO: on mac OS multicast threads are shared between nodes and we therefore we can't simulate GC and stop pinging for just one node
         // find a way to block thread creation in the generic thread pool to avoid this.
@@ -648,8 +647,8 @@ public class DiscoveryWithServiceDisruptionsTests extends ElasticsearchIntegrati
         masterNodeDisruption.startDisrupting();
 
         // Wait for the majority side to get stable
-        ensureStableCluster(2, majoritySide.get(0));
-        ensureStableCluster(2, majoritySide.get(1));
+        assertDifferentMaster(majoritySide.get(0), oldMasterNode);
+        assertDifferentMaster(majoritySide.get(1), oldMasterNode);
 
         // The old master node is frozen, but here we submit a cluster state update task that doesn't get executed,
         // but will be queued and once the old master node un-freezes it gets executed.


### PR DESCRIPTION
Previously it was ignored and the publish cluster state timeout would kick in. In that case a stale master node would just wait for the inevitable and waste valuable time.

This issue was discovered by the DiscoveryWithServiceDisruptionsTests#testStaleMasterNotHijackingMajority test.

Note this issue doesn't occur in any released version. (just on 1.x and master branches)
