### PR TITLE
Tests: Add random setup for DerivativeTests

### DIFF
--- a/src/test/java/org/elasticsearch/search/aggregations/reducers/DerivativeTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/reducers/DerivativeTests.java
@@ -110,7 +110,7 @@ public class DerivativeTests extends ElasticsearchIntegrationTest {
 
         // setup for index with empty buckets
         valueCounts_empty = new Long[] { 1l, 1l, 2l, 0l, 2l, 2l, 0l, 0l, 0l, 3l, 2l, 1l };
-        firstDerivValueCounts_empty = new Double[] { null, 0d, 1d, -2d, 2d, 0d, -2d, 0d, 0d, 3d, -1d, -1d};
+        firstDerivValueCounts_empty = new Double[] { null, 0d, 1d, -2d, 2d, 0d, -2d, 0d, 0d, 3d, -1d, -1d };
 
         assertAcked(prepareCreate("empty_bucket_idx").addMapping("type", SINGLE_VALUED_FIELD_NAME, "type=integer"));
         for (int i = 0; i < valueCounts_empty.length; i++) {
@@ -151,7 +151,7 @@ public class DerivativeTests extends ElasticsearchIntegrationTest {
 
         for (int i = 0; i < numValueBuckets; ++i) {
             Histogram.Bucket bucket = buckets.get(i);
-            checkBucketValues("Bucket "+i, bucket, i * interval, valueCounts[i]);
+            checkBucketKeyAndDocCount("Bucket " + i, bucket, i * interval, valueCounts[i]);
             SimpleValue docCountDeriv = bucket.getAggregations().get("deriv");
             if (i > 0) {
                 assertThat(docCountDeriv, notNullValue());
@@ -189,10 +189,11 @@ public class DerivativeTests extends ElasticsearchIntegrationTest {
         Object[] propertiesSumCounts = (Object[]) deriv.getProperty("sum.value");
 
         List<Bucket> buckets = new ArrayList<Bucket>(deriv.getBuckets());
-        Long expectedSumPreviousBucket = Long.MIN_VALUE; // start value, gets overwritten
+        Long expectedSumPreviousBucket = Long.MIN_VALUE; // start value, gets
+                                                         // overwritten
         for (int i = 0; i < numValueBuckets; ++i) {
             Histogram.Bucket bucket = buckets.get(i);
-            checkBucketValues("Bucket " + i, bucket, i * interval, valueCounts[i]);
+            checkBucketKeyAndDocCount("Bucket " + i, bucket, i * interval, valueCounts[i]);
             Sum sum = bucket.getAggregations().get("sum");
             assertThat(sum, notNullValue());
             long expectedSum = valueCounts[i] * (i * interval);
@@ -248,7 +249,7 @@ public class DerivativeTests extends ElasticsearchIntegrationTest {
 
         for (int i = 0; i < numValueBuckets; ++i) {
             Histogram.Bucket bucket = buckets.get(i);
-            checkBucketValues("Bucket "+i, bucket, i * interval, valueCounts[i]);
+            checkBucketKeyAndDocCount("Bucket " + i, bucket, i * interval, valueCounts[i]);
             SimpleValue docCountDeriv = bucket.getAggregations().get("deriv");
             if (i > 0) {
                 assertThat(docCountDeriv, notNullValue());
@@ -278,7 +279,7 @@ public class DerivativeTests extends ElasticsearchIntegrationTest {
 
         for (int i = 0; i < valueCounts_empty.length; i++) {
             Histogram.Bucket bucket = buckets.get(i);
-            checkBucketValues("Bucket "+i, bucket, i , valueCounts_empty[i]);
+            checkBucketKeyAndDocCount("Bucket " + i, bucket, i, valueCounts_empty[i]);
             SimpleValue docCountDeriv = bucket.getAggregations().get("deriv");
             if (firstDerivValueCounts_empty[i] == null) {
                 assertThat(docCountDeriv, nullValue());
@@ -308,7 +309,7 @@ public class DerivativeTests extends ElasticsearchIntegrationTest {
 
         for (int i = 0; i < valueCounts_empty.length; i++) {
             Histogram.Bucket bucket = buckets.get(i);
-            checkBucketValues("Bucket " + i + ": ", bucket, i, valueCounts_empty[i]);
+            checkBucketKeyAndDocCount("Bucket " + i + ": ", bucket, i, valueCounts_empty[i]);
             SimpleValue docCountDeriv = bucket.getAggregations().get("deriv");
             if (firstDerivValueCounts_empty[i] == null) {
                 assertThat(docCountDeriv, nullValue());
@@ -318,9 +319,10 @@ public class DerivativeTests extends ElasticsearchIntegrationTest {
         }
     }
 
-    private void checkBucketValues(final String msg, final Histogram.Bucket bucket, final long key, final long docCount) {
+    private void checkBucketKeyAndDocCount(final String msg, final Histogram.Bucket bucket, final long expectedKey,
+            final long expectedDocCount) {
         assertThat(msg, bucket, notNullValue());
-        assertThat(msg + " key", ((Number) bucket.getKey()).longValue(), equalTo(key));
-        assertThat(msg + " docCount", bucket.getDocCount(), equalTo(docCount));
+        assertThat(msg + " key", ((Number) bucket.getKey()).longValue(), equalTo(expectedKey));
+        assertThat(msg + " docCount", bucket.getDocCount(), equalTo(expectedDocCount));
     }
 }

--- a/src/test/java/org/elasticsearch/search/aggregations/reducers/DerivativeTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/reducers/DerivativeTests.java
@@ -21,9 +21,10 @@ package org.elasticsearch.search.aggregations.reducers;
 
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
-import org.elasticsearch.search.aggregations.bucket.histogram.Histogram.Bucket;
 import org.elasticsearch.search.aggregations.bucket.histogram.InternalHistogram;
+import org.elasticsearch.search.aggregations.bucket.histogram.InternalHistogram.Bucket;
 import org.elasticsearch.search.aggregations.metrics.sum.Sum;
 import org.elasticsearch.search.aggregations.reducers.derivative.DerivativeReducer.GapPolicy;
 import org.elasticsearch.search.aggregations.support.AggregationPath;
@@ -31,6 +32,7 @@ import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -42,7 +44,6 @@ import static org.elasticsearch.search.aggregations.reducers.ReducerBuilders.der
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
 
@@ -50,49 +51,38 @@ import static org.hamcrest.core.IsNull.nullValue;
 public class DerivativeTests extends ElasticsearchIntegrationTest {
 
     private static final String SINGLE_VALUED_FIELD_NAME = "l_value";
-    private static final String MULTI_VALUED_FIELD_NAME = "l_values";
 
-    static int numDocs;
     static int interval;
-    static int numValueBuckets, numValuesBuckets;
+    static int numValueBuckets;
     static int numFirstDerivValueBuckets, numFirstDerivValuesBuckets;
     static int numSecondDerivValueBuckets;
-    static long[] valueCounts, valuesCounts;
-    static long[] firstDerivValueCounts, firstDerivValuesCounts;
+    static long[] valueCounts;
+    static long[] firstDerivValueCounts;
     static long[] secondDerivValueCounts;
+
+    static Long[] valueCounts_empty;
+    static long numDocsEmptyIdx;
+    static Double[] firstDerivValueCounts_empty;
 
     @Override
     public void setupSuiteScopeCluster() throws Exception {
         createIndex("idx");
         createIndex("idx_unmapped");
 
-        numDocs = randomIntBetween(6, 20);
-        interval = randomIntBetween(2, 5);
+        interval = 5;
+        numValueBuckets = randomIntBetween(6, 80);
 
-        numValueBuckets = numDocs / interval + 1;
         valueCounts = new long[numValueBuckets];
-        for (int i = 0; i < numDocs; i++) {
-            final int bucket = (i + 1) / interval;
-            valueCounts[bucket]++;
-        }
-
-        numValuesBuckets = (numDocs + 1) / interval + 1;
-        valuesCounts = new long[numValuesBuckets];
-        for (int i = 0; i < numDocs; i++) {
-            final int bucket1 = (i + 1) / interval;
-            final int bucket2 = (i + 2) / interval;
-            valuesCounts[bucket1]++;
-            if (bucket1 != bucket2) {
-                valuesCounts[bucket2]++;
-            }
+        for (int i = 0; i < numValueBuckets; i++) {
+            valueCounts[i] = randomIntBetween(1, 20);
         }
 
         numFirstDerivValueBuckets = numValueBuckets - 1;
         firstDerivValueCounts = new long[numFirstDerivValueBuckets];
-        long lastValueCount = -1;
+        Long lastValueCount = null;
         for (int i = 0; i < numValueBuckets; i++) {
             long thisValue = valueCounts[i];
-            if (lastValueCount != -1) {
+            if (lastValueCount != null) {
                 long diff = thisValue - lastValueCount;
                 firstDerivValueCounts[i - 1] = diff;
             }
@@ -101,112 +91,48 @@ public class DerivativeTests extends ElasticsearchIntegrationTest {
 
         numSecondDerivValueBuckets = numFirstDerivValueBuckets - 1;
         secondDerivValueCounts = new long[numSecondDerivValueBuckets];
-        long lastFirstDerivativeValueCount = -1;
+        Long lastFirstDerivativeValueCount = null;
         for (int i = 0; i < numFirstDerivValueBuckets; i++) {
             long thisFirstDerivativeValue = firstDerivValueCounts[i];
-            if (lastFirstDerivativeValueCount != -1) {
+            if (lastFirstDerivativeValueCount != null) {
                 long diff = thisFirstDerivativeValue - lastFirstDerivativeValueCount;
                 secondDerivValueCounts[i - 1] = diff;
             }
             lastFirstDerivativeValueCount = thisFirstDerivativeValue;
         }
 
-        numFirstDerivValuesBuckets = numValuesBuckets - 1;
-        firstDerivValuesCounts = new long[numFirstDerivValuesBuckets];
-        long lastValuesCount = -1;
-        for (int i = 0; i < numValuesBuckets; i++) {
-            long thisValue = valuesCounts[i];
-            if (lastValuesCount != -1) {
-                long diff = thisValue - lastValuesCount;
-                firstDerivValuesCounts[i - 1] = diff;
-            }
-            lastValuesCount = thisValue;
-        }
-
         List<IndexRequestBuilder> builders = new ArrayList<>();
-
-        for (int i = 0; i < numDocs; i++) {
-            builders.add(client().prepareIndex("idx", "type").setSource(
-                    jsonBuilder().startObject().field(SINGLE_VALUED_FIELD_NAME, i + 1).startArray(MULTI_VALUED_FIELD_NAME).value(i + 1)
-                            .value(i + 2).endArray().field("tag", "tag" + i).endObject()));
+        for (int i = 0; i < numValueBuckets; i++) {
+            for (int docs = 0; docs < valueCounts[i]; docs++) {
+                builders.add(client().prepareIndex("idx", "type").setSource(newDocBuilder(i * interval)));
+            }
         }
+
+        // setup for index with empty buckets
+        valueCounts_empty = new Long[] { 1l, 1l, 2l, 0l, 2l, 2l, 0l, 0l, 0l, 3l, 2l, 1l };
+        firstDerivValueCounts_empty = new Double[] { null, 0d, 1d, -2d, 2d, 0d, -2d, 0d, 0d, 3d, -1d, -1d};
 
         assertAcked(prepareCreate("empty_bucket_idx").addMapping("type", SINGLE_VALUED_FIELD_NAME, "type=integer"));
-        builders.add(client().prepareIndex("empty_bucket_idx", "type", "" + 0).setSource(
-                jsonBuilder().startObject().field(SINGLE_VALUED_FIELD_NAME, 0).endObject()));
-
-        builders.add(client().prepareIndex("empty_bucket_idx", "type", "" + 1).setSource(
-                jsonBuilder().startObject().field(SINGLE_VALUED_FIELD_NAME, 1).endObject()));
-
-        builders.add(client().prepareIndex("empty_bucket_idx", "type", "" + 2).setSource(
-                jsonBuilder().startObject().field(SINGLE_VALUED_FIELD_NAME, 2).endObject()));
-        builders.add(client().prepareIndex("empty_bucket_idx", "type", "" + 3).setSource(
-                jsonBuilder().startObject().field(SINGLE_VALUED_FIELD_NAME, 2).endObject()));
-
-        builders.add(client().prepareIndex("empty_bucket_idx", "type", "" + 4).setSource(
-                jsonBuilder().startObject().field(SINGLE_VALUED_FIELD_NAME, 4).endObject()));
-        builders.add(client().prepareIndex("empty_bucket_idx", "type", "" + 5).setSource(
-                jsonBuilder().startObject().field(SINGLE_VALUED_FIELD_NAME, 4).endObject()));
-
-        builders.add(client().prepareIndex("empty_bucket_idx", "type", "" + 6).setSource(
-                jsonBuilder().startObject().field(SINGLE_VALUED_FIELD_NAME, 5).endObject()));
-        builders.add(client().prepareIndex("empty_bucket_idx", "type", "" + 7).setSource(
-                jsonBuilder().startObject().field(SINGLE_VALUED_FIELD_NAME, 5).endObject()));
-
-        builders.add(client().prepareIndex("empty_bucket_idx", "type", "" + 8).setSource(
-                jsonBuilder().startObject().field(SINGLE_VALUED_FIELD_NAME, 9).endObject()));
-        builders.add(client().prepareIndex("empty_bucket_idx", "type", "" + 9).setSource(
-                jsonBuilder().startObject().field(SINGLE_VALUED_FIELD_NAME, 9).endObject()));
-        builders.add(client().prepareIndex("empty_bucket_idx", "type", "" + 10).setSource(
-                jsonBuilder().startObject().field(SINGLE_VALUED_FIELD_NAME, 9).endObject()));
-
-        builders.add(client().prepareIndex("empty_bucket_idx", "type", "" + 11).setSource(
-                jsonBuilder().startObject().field(SINGLE_VALUED_FIELD_NAME, 10).endObject()));
-        builders.add(client().prepareIndex("empty_bucket_idx", "type", "" + 12).setSource(
-                jsonBuilder().startObject().field(SINGLE_VALUED_FIELD_NAME, 10).endObject()));
-
-        builders.add(client().prepareIndex("empty_bucket_idx", "type", "" + 13).setSource(
-                jsonBuilder().startObject().field(SINGLE_VALUED_FIELD_NAME, 11).endObject()));
+        for (int i = 0; i < valueCounts_empty.length; i++) {
+            for (int docs = 0; docs < valueCounts_empty[i]; docs++) {
+                builders.add(client().prepareIndex("empty_bucket_idx", "type").setSource(newDocBuilder(i)));
+                numDocsEmptyIdx++;
+            }
+        }
 
         indexRandom(true, builders);
         ensureSearchable();
     }
 
-    @Test
-    public void singleValuedField() {
-
-        SearchResponse response = client().prepareSearch("idx")
-                .addAggregation(
-                        histogram("histo").field(SINGLE_VALUED_FIELD_NAME).interval(interval)
-                                .subAggregation(derivative("deriv").setBucketsPaths("_count")))
-                .execute().actionGet();
-
-        assertSearchResponse(response);
-
-        InternalHistogram deriv = response.getAggregations().get("histo");
-        assertThat(deriv, notNullValue());
-        assertThat(deriv.getName(), equalTo("histo"));
-        List<? extends Bucket> buckets = deriv.getBuckets();
-        assertThat(buckets.size(), equalTo(numValueBuckets));
-
-        for (int i = 0; i < numValueBuckets; ++i) {
-            Histogram.Bucket bucket = buckets.get(i);
-            assertThat(bucket, notNullValue());
-            assertThat(bucket.getKeyAsString(), equalTo(String.valueOf(i * interval)));
-            assertThat(((Number) bucket.getKey()).longValue(), equalTo((long) i * interval));
-            assertThat(bucket.getDocCount(), equalTo(valueCounts[i]));
-            SimpleValue docCountDeriv = bucket.getAggregations().get("deriv");
-            if (i > 0) {
-                assertThat(docCountDeriv, notNullValue());
-                assertThat(docCountDeriv.value(), equalTo((double) firstDerivValueCounts[i - 1]));
-            } else {
-                assertThat(docCountDeriv, nullValue());
-            }
-        }
+    private XContentBuilder newDocBuilder(int singleValueFieldValue) throws IOException {
+        return jsonBuilder().startObject().field(SINGLE_VALUED_FIELD_NAME, singleValueFieldValue).endObject();
     }
 
+    /**
+     * test first and second derivative on the sing
+     */
     @Test
-    public void singleValuedField_secondDerivative() {
+    public void singleValuedField() {
 
         SearchResponse response = client()
                 .prepareSearch("idx")
@@ -217,7 +143,7 @@ public class DerivativeTests extends ElasticsearchIntegrationTest {
 
         assertSearchResponse(response);
 
-        InternalHistogram deriv = response.getAggregations().get("histo");
+        InternalHistogram<Bucket> deriv = response.getAggregations().get("histo");
         assertThat(deriv, notNullValue());
         assertThat(deriv.getName(), equalTo("histo"));
         List<? extends Bucket> buckets = deriv.getBuckets();
@@ -225,10 +151,7 @@ public class DerivativeTests extends ElasticsearchIntegrationTest {
 
         for (int i = 0; i < numValueBuckets; ++i) {
             Histogram.Bucket bucket = buckets.get(i);
-            assertThat(bucket, notNullValue());
-            assertThat(bucket.getKeyAsString(), equalTo(String.valueOf(i * interval)));
-            assertThat(((Number) bucket.getKey()).longValue(), equalTo((long) i * interval));
-            assertThat(bucket.getDocCount(), equalTo(valueCounts[i]));
+            checkBucketValues("Bucket "+i, bucket, i * interval, valueCounts[i]);
             SimpleValue docCountDeriv = bucket.getAggregations().get("deriv");
             if (i > 0) {
                 assertThat(docCountDeriv, notNullValue());
@@ -257,7 +180,7 @@ public class DerivativeTests extends ElasticsearchIntegrationTest {
 
         assertSearchResponse(response);
 
-        InternalHistogram deriv = response.getAggregations().get("histo");
+        InternalHistogram<Bucket> deriv = response.getAggregations().get("histo");
         assertThat(deriv, notNullValue());
         assertThat(deriv.getName(), equalTo("histo"));
         assertThat(deriv.getBuckets().size(), equalTo(numValueBuckets));
@@ -265,92 +188,43 @@ public class DerivativeTests extends ElasticsearchIntegrationTest {
         Object[] propertiesDocCounts = (Object[]) deriv.getProperty("_count");
         Object[] propertiesSumCounts = (Object[]) deriv.getProperty("sum.value");
 
-        List<Histogram.Bucket> buckets = new ArrayList<>(deriv.getBuckets());
+        List<Bucket> buckets = new ArrayList<Bucket>(deriv.getBuckets());
+        Long expectedSumPreviousBucket = Long.MIN_VALUE; // start value, gets overwritten
         for (int i = 0; i < numValueBuckets; ++i) {
             Histogram.Bucket bucket = buckets.get(i);
-            assertThat(bucket, notNullValue());
-            assertThat(bucket.getKeyAsString(), equalTo(String.valueOf(i * interval)));
-            assertThat(((Number) bucket.getKey()).longValue(), equalTo((long) i * interval));
-            assertThat(bucket.getDocCount(), equalTo(valueCounts[i]));
-            assertThat(bucket.getAggregations().asList().isEmpty(), is(false));
+            checkBucketValues("Bucket " + i, bucket, i * interval, valueCounts[i]);
             Sum sum = bucket.getAggregations().get("sum");
             assertThat(sum, notNullValue());
-            long s = 0;
-            for (int j = 0; j < numDocs; ++j) {
-                if ((j + 1) / interval == i) {
-                    s += j + 1;
-                }
-            }
+            long expectedSum = valueCounts[i] * (i * interval);
+            assertThat(sum.getValue(), equalTo((double) expectedSum));
             SimpleValue sumDeriv = bucket.getAggregations().get("deriv");
-            assertThat(sum.getValue(), equalTo((double) s));
             if (i > 0) {
                 assertThat(sumDeriv, notNullValue());
-                long s1 = 0;
-                long s2 = 0;
-                for (int j = 0; j < numDocs; ++j) {
-                    if ((j + 1) / interval == i - 1) {
-                        s1 += j + 1;
-                    }
-                    if ((j + 1) / interval == i) {
-                        s2 += j + 1;
-                    }
-                }
-                long sumDerivValue = s2 - s1;
+                long sumDerivValue = expectedSum - expectedSumPreviousBucket;
                 assertThat(sumDeriv.value(), equalTo((double) sumDerivValue));
                 assertThat((double) bucket.getProperty("histo", AggregationPath.parse("deriv.value").getPathElementsAsStringList()),
                         equalTo((double) sumDerivValue));
             } else {
                 assertThat(sumDeriv, nullValue());
             }
+            expectedSumPreviousBucket = expectedSum;
             assertThat((long) propertiesKeys[i], equalTo((long) i * interval));
             assertThat((long) propertiesDocCounts[i], equalTo(valueCounts[i]));
-            assertThat((double) propertiesSumCounts[i], equalTo((double) s));
-        }
-    }
-
-    @Test
-    public void multiValuedField() throws Exception {
-        SearchResponse response = client().prepareSearch("idx")
-                .addAggregation(
-                        histogram("histo").field(MULTI_VALUED_FIELD_NAME).interval(interval)
-                        .subAggregation(derivative("deriv").setBucketsPaths("_count")))
-                .execute().actionGet();
-
-        assertSearchResponse(response);
-
-        InternalHistogram deriv = response.getAggregations().get("histo");
-        assertThat(deriv, notNullValue());
-        assertThat(deriv.getName(), equalTo("histo"));
-        List<? extends Bucket> buckets = deriv.getBuckets();
-        assertThat(deriv.getBuckets().size(), equalTo(numValuesBuckets));
-
-        for (int i = 0; i < numValuesBuckets; ++i) {
-            Histogram.Bucket bucket = buckets.get(i);
-            assertThat(bucket, notNullValue());
-            assertThat(bucket.getKeyAsString(), equalTo(String.valueOf(i * interval)));
-            assertThat(((Number) bucket.getKey()).longValue(), equalTo((long) i * interval));
-            assertThat(bucket.getDocCount(), equalTo(valuesCounts[i]));
-            SimpleValue docCountDeriv = bucket.getAggregations().get("deriv");
-            if (i > 0) {
-                assertThat(docCountDeriv, notNullValue());
-                assertThat(docCountDeriv.value(), equalTo((double) firstDerivValuesCounts[i - 1]));
-            } else {
-                assertThat(docCountDeriv, nullValue());
-            }
+            assertThat((double) propertiesSumCounts[i], equalTo((double) expectedSum));
         }
     }
 
     @Test
     public void unmapped() throws Exception {
-        SearchResponse response = client().prepareSearch("idx_unmapped")
+        SearchResponse response = client()
+                .prepareSearch("idx_unmapped")
                 .addAggregation(
                         histogram("histo").field(SINGLE_VALUED_FIELD_NAME).interval(interval)
-                        .subAggregation(derivative("deriv").setBucketsPaths("_count")))
-                .execute().actionGet();
+                                .subAggregation(derivative("deriv").setBucketsPaths("_count"))).execute().actionGet();
 
         assertSearchResponse(response);
 
-        InternalHistogram deriv = response.getAggregations().get("histo");
+        InternalHistogram<Bucket> deriv = response.getAggregations().get("histo");
         assertThat(deriv, notNullValue());
         assertThat(deriv.getName(), equalTo("histo"));
         assertThat(deriv.getBuckets().size(), equalTo(0));
@@ -358,15 +232,15 @@ public class DerivativeTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void partiallyUnmapped() throws Exception {
-        SearchResponse response = client().prepareSearch("idx", "idx_unmapped")
+        SearchResponse response = client()
+                .prepareSearch("idx", "idx_unmapped")
                 .addAggregation(
                         histogram("histo").field(SINGLE_VALUED_FIELD_NAME).interval(interval)
-                        .subAggregation(derivative("deriv").setBucketsPaths("_count")))
-                .execute().actionGet();
+                                .subAggregation(derivative("deriv").setBucketsPaths("_count"))).execute().actionGet();
 
         assertSearchResponse(response);
 
-        InternalHistogram deriv = response.getAggregations().get("histo");
+        InternalHistogram<Bucket> deriv = response.getAggregations().get("histo");
         assertThat(deriv, notNullValue());
         assertThat(deriv.getName(), equalTo("histo"));
         List<? extends Bucket> buckets = deriv.getBuckets();
@@ -374,10 +248,7 @@ public class DerivativeTests extends ElasticsearchIntegrationTest {
 
         for (int i = 0; i < numValueBuckets; ++i) {
             Histogram.Bucket bucket = buckets.get(i);
-            assertThat(bucket, notNullValue());
-            assertThat(bucket.getKeyAsString(), equalTo(String.valueOf(i * interval)));
-            assertThat(((Number) bucket.getKey()).longValue(), equalTo((long) i * interval));
-            assertThat(bucket.getDocCount(), equalTo(valueCounts[i]));
+            checkBucketValues("Bucket "+i, bucket, i * interval, valueCounts[i]);
             SimpleValue docCountDeriv = bucket.getAggregations().get("deriv");
             if (i > 0) {
                 assertThat(docCountDeriv, notNullValue());
@@ -395,111 +266,26 @@ public class DerivativeTests extends ElasticsearchIntegrationTest {
                 .setQuery(matchAllQuery())
                 .addAggregation(
                         histogram("histo").field(SINGLE_VALUED_FIELD_NAME).interval(1).minDocCount(0)
-                                .subAggregation(derivative("deriv").setBucketsPaths("_count")))
-                .execute().actionGet();
+                                .subAggregation(derivative("deriv").setBucketsPaths("_count"))).execute().actionGet();
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(14l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(numDocsEmptyIdx));
 
-        InternalHistogram deriv = searchResponse.getAggregations().get("histo");
+        InternalHistogram<Bucket> deriv = searchResponse.getAggregations().get("histo");
         assertThat(deriv, Matchers.notNullValue());
         assertThat(deriv.getName(), equalTo("histo"));
-        List<Histogram.Bucket> buckets = (List<Bucket>) deriv.getBuckets();
-        assertThat(buckets.size(), equalTo(12));
+        List<Bucket> buckets = deriv.getBuckets();
+        assertThat(buckets.size(), equalTo(valueCounts_empty.length));
 
-        Histogram.Bucket bucket = buckets.get(0);
-        assertThat(bucket, notNullValue());
-        assertThat(((Number) bucket.getKey()).longValue(), equalTo(0l));
-        assertThat(bucket.getDocCount(), equalTo(1l));
-        SimpleValue docCountDeriv = bucket.getAggregations().get("deriv");
-        assertThat(docCountDeriv, nullValue());
-
-        bucket = buckets.get(1);
-        assertThat(bucket, notNullValue());
-        assertThat(((Number) bucket.getKey()).longValue(), equalTo(1l));
-        assertThat(bucket.getDocCount(), equalTo(1l));
-        docCountDeriv = bucket.getAggregations().get("deriv");
-        assertThat(docCountDeriv, notNullValue());
-        assertThat(docCountDeriv.value(), equalTo(0d));
-
-        bucket = buckets.get(2);
-        assertThat(bucket, notNullValue());
-        assertThat(((Number) bucket.getKey()).longValue(), equalTo(2l));
-        assertThat(bucket.getDocCount(), equalTo(2l));
-        docCountDeriv = bucket.getAggregations().get("deriv");
-        assertThat(docCountDeriv, notNullValue());
-        assertThat(docCountDeriv.value(), equalTo(1d));
-
-        bucket = buckets.get(3);
-        assertThat(bucket, notNullValue());
-        assertThat(((Number) bucket.getKey()).longValue(), equalTo(3l));
-        assertThat(bucket.getDocCount(), equalTo(0l));
-        docCountDeriv = bucket.getAggregations().get("deriv");
-        assertThat(docCountDeriv, notNullValue());
-        assertThat(docCountDeriv.value(), equalTo(-2d));
-
-        bucket = buckets.get(4);
-        assertThat(bucket, notNullValue());
-        assertThat(((Number) bucket.getKey()).longValue(), equalTo(4l));
-        assertThat(bucket.getDocCount(), equalTo(2l));
-        docCountDeriv = bucket.getAggregations().get("deriv");
-        assertThat(docCountDeriv, notNullValue());
-        assertThat(docCountDeriv.value(), equalTo(2d));
-
-        bucket = buckets.get(5);
-        assertThat(bucket, notNullValue());
-        assertThat(((Number) bucket.getKey()).longValue(), equalTo(5l));
-        assertThat(bucket.getDocCount(), equalTo(2l));
-        docCountDeriv = bucket.getAggregations().get("deriv");
-        assertThat(docCountDeriv, notNullValue());
-        assertThat(docCountDeriv.value(), equalTo(0d));
-
-        bucket = buckets.get(6);
-        assertThat(bucket, notNullValue());
-        assertThat(((Number) bucket.getKey()).longValue(), equalTo(6l));
-        assertThat(bucket.getDocCount(), equalTo(0l));
-        docCountDeriv = bucket.getAggregations().get("deriv");
-        assertThat(docCountDeriv, notNullValue());
-        assertThat(docCountDeriv.value(), equalTo(-2d));
-
-        bucket = buckets.get(7);
-        assertThat(bucket, notNullValue());
-        assertThat(((Number) bucket.getKey()).longValue(), equalTo(7l));
-        assertThat(bucket.getDocCount(), equalTo(0l));
-        docCountDeriv = bucket.getAggregations().get("deriv");
-        assertThat(docCountDeriv, notNullValue());
-        assertThat(docCountDeriv.value(), equalTo(0d));
-
-        bucket = buckets.get(8);
-        assertThat(bucket, notNullValue());
-        assertThat(((Number) bucket.getKey()).longValue(), equalTo(8l));
-        assertThat(bucket.getDocCount(), equalTo(0l));
-        docCountDeriv = bucket.getAggregations().get("deriv");
-        assertThat(docCountDeriv, notNullValue());
-        assertThat(docCountDeriv.value(), equalTo(0d));
-
-        bucket = buckets.get(9);
-        assertThat(bucket, notNullValue());
-        assertThat(((Number) bucket.getKey()).longValue(), equalTo(9l));
-        assertThat(bucket.getDocCount(), equalTo(3l));
-        docCountDeriv = bucket.getAggregations().get("deriv");
-        assertThat(docCountDeriv, notNullValue());
-        assertThat(docCountDeriv.value(), equalTo(3d));
-
-        bucket = buckets.get(10);
-        assertThat(bucket, notNullValue());
-        assertThat(((Number) bucket.getKey()).longValue(), equalTo(10l));
-        assertThat(bucket.getDocCount(), equalTo(2l));
-        docCountDeriv = bucket.getAggregations().get("deriv");
-        assertThat(docCountDeriv, notNullValue());
-        assertThat(docCountDeriv.value(), equalTo(-1d));
-
-        bucket = buckets.get(11);
-        assertThat(bucket, notNullValue());
-        assertThat(((Number) bucket.getKey()).longValue(), equalTo(11l));
-        assertThat(bucket.getDocCount(), equalTo(1l));
-        docCountDeriv = bucket.getAggregations().get("deriv");
-        assertThat(docCountDeriv, notNullValue());
-        assertThat(docCountDeriv.value(), equalTo(-1d));
+        for (int i = 0; i < valueCounts_empty.length; i++) {
+            Histogram.Bucket bucket = buckets.get(i);
+            checkBucketValues("Bucket "+i, bucket, i , valueCounts_empty[i]);
+            SimpleValue docCountDeriv = bucket.getAggregations().get("deriv");
+            if (firstDerivValueCounts_empty[i] == null) {
+                assertThat(docCountDeriv, nullValue());
+            } else {
+                assertThat(docCountDeriv.value(), equalTo(firstDerivValueCounts_empty[i]));
+            }
+        }
     }
 
     @Test
@@ -509,111 +295,32 @@ public class DerivativeTests extends ElasticsearchIntegrationTest {
                 .setQuery(matchAllQuery())
                 .addAggregation(
                         histogram("histo").field(SINGLE_VALUED_FIELD_NAME).interval(1).minDocCount(0)
-                                .subAggregation(derivative("deriv").setBucketsPaths("_count").gapPolicy(GapPolicy.INSERT_ZEROS)))
-                .execute().actionGet();
+                                .subAggregation(derivative("deriv").setBucketsPaths("_count").gapPolicy(GapPolicy.INSERT_ZEROS))).execute()
+                .actionGet();
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(14l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(numDocsEmptyIdx));
 
-        InternalHistogram deriv = searchResponse.getAggregations().get("histo");
+        InternalHistogram<Bucket> deriv = searchResponse.getAggregations().get("histo");
         assertThat(deriv, Matchers.notNullValue());
         assertThat(deriv.getName(), equalTo("histo"));
-        List<Histogram.Bucket> buckets = (List<Bucket>) deriv.getBuckets();
-        assertThat(buckets.size(), equalTo(12));
+        List<Bucket> buckets = deriv.getBuckets();
+        assertThat(buckets.size(), equalTo(valueCounts_empty.length));
 
-        Histogram.Bucket bucket = buckets.get(0);
-        assertThat(bucket, notNullValue());
-        assertThat(((Number) bucket.getKey()).longValue(), equalTo(0l));
-        assertThat(bucket.getDocCount(), equalTo(1l));
-        SimpleValue docCountDeriv = bucket.getAggregations().get("deriv");
-        assertThat(docCountDeriv, nullValue());
-
-        bucket = buckets.get(1);
-        assertThat(bucket, notNullValue());
-        assertThat(((Number) bucket.getKey()).longValue(), equalTo(1l));
-        assertThat(bucket.getDocCount(), equalTo(1l));
-        docCountDeriv = bucket.getAggregations().get("deriv");
-        assertThat(docCountDeriv, notNullValue());
-        assertThat(docCountDeriv.value(), equalTo(0d));
-
-        bucket = buckets.get(2);
-        assertThat(bucket, notNullValue());
-        assertThat(((Number) bucket.getKey()).longValue(), equalTo(2l));
-        assertThat(bucket.getDocCount(), equalTo(2l));
-        docCountDeriv = bucket.getAggregations().get("deriv");
-        assertThat(docCountDeriv, notNullValue());
-        assertThat(docCountDeriv.value(), equalTo(1d));
-
-        bucket = buckets.get(3);
-        assertThat(bucket, notNullValue());
-        assertThat(((Number) bucket.getKey()).longValue(), equalTo(3l));
-        assertThat(bucket.getDocCount(), equalTo(0l));
-        docCountDeriv = bucket.getAggregations().get("deriv");
-        assertThat(docCountDeriv, notNullValue());
-        assertThat(docCountDeriv.value(), equalTo(-2d));
-
-        bucket = buckets.get(4);
-        assertThat(bucket, notNullValue());
-        assertThat(((Number) bucket.getKey()).longValue(), equalTo(4l));
-        assertThat(bucket.getDocCount(), equalTo(2l));
-        docCountDeriv = bucket.getAggregations().get("deriv");
-        assertThat(docCountDeriv, notNullValue());
-        assertThat(docCountDeriv.value(), equalTo(2d));
-
-        bucket = buckets.get(5);
-        assertThat(bucket, notNullValue());
-        assertThat(((Number) bucket.getKey()).longValue(), equalTo(5l));
-        assertThat(bucket.getDocCount(), equalTo(2l));
-        docCountDeriv = bucket.getAggregations().get("deriv");
-        assertThat(docCountDeriv, notNullValue());
-        assertThat(docCountDeriv.value(), equalTo(0d));
-
-        bucket = buckets.get(6);
-        assertThat(bucket, notNullValue());
-        assertThat(((Number) bucket.getKey()).longValue(), equalTo(6l));
-        assertThat(bucket.getDocCount(), equalTo(0l));
-        docCountDeriv = bucket.getAggregations().get("deriv");
-        assertThat(docCountDeriv, notNullValue());
-        assertThat(docCountDeriv.value(), equalTo(-2d));
-
-        bucket = buckets.get(7);
-        assertThat(bucket, notNullValue());
-        assertThat(((Number) bucket.getKey()).longValue(), equalTo(7l));
-        assertThat(bucket.getDocCount(), equalTo(0l));
-        docCountDeriv = bucket.getAggregations().get("deriv");
-        assertThat(docCountDeriv, notNullValue());
-        assertThat(docCountDeriv.value(), equalTo(0d));
-
-        bucket = buckets.get(8);
-        assertThat(bucket, notNullValue());
-        assertThat(((Number) bucket.getKey()).longValue(), equalTo(8l));
-        assertThat(bucket.getDocCount(), equalTo(0l));
-        docCountDeriv = bucket.getAggregations().get("deriv");
-        assertThat(docCountDeriv, notNullValue());
-        assertThat(docCountDeriv.value(), equalTo(0d));
-
-        bucket = buckets.get(9);
-        assertThat(bucket, notNullValue());
-        assertThat(((Number) bucket.getKey()).longValue(), equalTo(9l));
-        assertThat(bucket.getDocCount(), equalTo(3l));
-        docCountDeriv = bucket.getAggregations().get("deriv");
-        assertThat(docCountDeriv, notNullValue());
-        assertThat(docCountDeriv.value(), equalTo(3d));
-
-        bucket = buckets.get(10);
-        assertThat(bucket, notNullValue());
-        assertThat(((Number) bucket.getKey()).longValue(), equalTo(10l));
-        assertThat(bucket.getDocCount(), equalTo(2l));
-        docCountDeriv = bucket.getAggregations().get("deriv");
-        assertThat(docCountDeriv, notNullValue());
-        assertThat(docCountDeriv.value(), equalTo(-1d));
-
-        bucket = buckets.get(11);
-        assertThat(bucket, notNullValue());
-        assertThat(((Number) bucket.getKey()).longValue(), equalTo(11l));
-        assertThat(bucket.getDocCount(), equalTo(1l));
-        docCountDeriv = bucket.getAggregations().get("deriv");
-        assertThat(docCountDeriv, notNullValue());
-        assertThat(docCountDeriv.value(), equalTo(-1d));
+        for (int i = 0; i < valueCounts_empty.length; i++) {
+            Histogram.Bucket bucket = buckets.get(i);
+            checkBucketValues("Bucket " + i + ": ", bucket, i, valueCounts_empty[i]);
+            SimpleValue docCountDeriv = bucket.getAggregations().get("deriv");
+            if (firstDerivValueCounts_empty[i] == null) {
+                assertThat(docCountDeriv, nullValue());
+            } else {
+                assertThat(docCountDeriv.value(), equalTo(firstDerivValueCounts_empty[i]));
+            }
+        }
     }
 
+    private void checkBucketValues(final String msg, final Histogram.Bucket bucket, final long key, final long docCount) {
+        assertThat(msg, bucket, notNullValue());
+        assertThat(msg + " key", ((Number) bucket.getKey()).longValue(), equalTo(key));
+        assertThat(msg + " docCount", bucket.getDocCount(), equalTo(docCount));
+    }
 }


### PR DESCRIPTION
Changed the exiting tests to have a  more randomized setup, keeping interval constant and instead insert random number of docs per bucket in test setup. Also added common helper methods to check bucket contents, removed the test for multi-valued fields (no benefit in testing this for the derivative) and do the first and second derivative testing in one method.
