### PR TITLE
Delete index folder if all shards were allocated away from a data only node

### DIFF
--- a/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -470,15 +470,9 @@ public class IndicesService extends AbstractLifecycleComponent<IndicesService> i
     public void deleteIndexStore(String reason, IndexMetaData metaData) throws IOException {
         if (nodeEnv.hasNodeFile()) {
             synchronized (this) {
-                String indexName = metaData.index();
                 if (indices.containsKey(metaData.index())) {
                     String localUUid = indices.get(metaData.index()).v1().indexUUID();
                     throw new ElasticsearchIllegalStateException("Can't delete index store for [" + metaData.getIndex() + "] - it's still part of the indices service [" + localUUid+ "] [" + metaData.getUUID() + "]");
-                }
-                ClusterState clusterState = clusterService.state();
-                if (clusterState.metaData().hasIndex(indexName)) {
-                    final IndexMetaData index = clusterState.metaData().index(indexName);
-                    throw new ElasticsearchIllegalStateException("Can't delete closed index store for [" + indexName + "] - it's still part of the cluster state [" + index.getUUID() + "] [" + metaData.getUUID() + "]");
                 }
             }
             Index index = new Index(metaData.index());

--- a/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
+++ b/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
@@ -296,8 +296,17 @@ public class IndicesStore extends AbstractComponent implements ClusterStateListe
                     IndexMetaData indexMeta = clusterState.getMetaData().indices().get(shardId.getIndex());
                     try {
                         indicesService.deleteShardStore("no longer used", shardId, indexMeta);
-                    } catch (Exception ex) {
+                    } catch (Throwable ex) {
                         logger.debug("{} failed to delete unallocated shard, ignoring", ex, shardId);
+                    }
+                    // if the index doesn't exists anymore, delete its store as well, but only if its a non master node, since master
+                    // nodes keep the index metadata around 
+                    if (indicesService.hasIndex(shardId.getIndex()) == false && currentState.nodes().localNode().masterNode() == false) {
+                        try {
+                            indicesService.deleteIndexStore("no longer used", indexMeta);
+                        } catch (Throwable ex) {
+                            logger.debug("{} failed to delete unallocated index, ignoring", ex, shardId.getIndex());
+                        }
                     }
                     return currentState;
                 }

--- a/src/test/java/org/elasticsearch/indices/store/IndicesStoreIntegrationTests.java
+++ b/src/test/java/org/elasticsearch/indices/store/IndicesStoreIntegrationTests.java
@@ -27,11 +27,13 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.routing.*;
+import org.elasticsearch.cluster.routing.allocation.command.MoveAllocationCommand;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.discovery.DiscoveryService;
 import org.elasticsearch.env.NodeEnvironment;
+import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
@@ -52,6 +54,57 @@ import static org.hamcrest.Matchers.equalTo;
  */
 @ClusterScope(scope= Scope.TEST, numDataNodes = 0)
 public class IndicesStoreIntegrationTests extends ElasticsearchIntegrationTest {
+
+    @Test
+    public void indexCleanup() throws Exception {
+        final String masterNode = internalCluster().startNode(ImmutableSettings.builder().put("node.data", false));
+        final String node_1 = internalCluster().startNode(ImmutableSettings.builder().put("node.master", false));
+        final String node_2 = internalCluster().startNode(ImmutableSettings.builder().put("node.master", false));
+        logger.info("--> creating index [test] with one shard and on replica");
+        assertAcked(prepareCreate("test").setSettings(
+                        ImmutableSettings.builder().put(indexSettings())
+                                .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
+                                .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 1))
+        );
+        ensureGreen("test");
+
+        logger.info("--> making sure that shard and its replica are allocated on node_1 and node_2");
+        assertThat(Files.exists(shardDirectory(node_1, "test", 0)), equalTo(true));
+        assertThat(Files.exists(indexDirectory(node_1, "test")), equalTo(true));
+        assertThat(Files.exists(shardDirectory(node_2, "test", 0)), equalTo(true));
+        assertThat(Files.exists(indexDirectory(node_2, "test")), equalTo(true));
+
+        logger.info("--> starting node server3");
+        final String node_3 = internalCluster().startNode(ImmutableSettings.builder().put("node.master", false));
+        logger.info("--> running cluster_health");
+        ClusterHealthResponse clusterHealth = client().admin().cluster().prepareHealth()
+                .setWaitForNodes("4")
+                .setWaitForRelocatingShards(0)
+                .get();
+        assertThat(clusterHealth.isTimedOut(), equalTo(false));
+
+        assertThat(Files.exists(shardDirectory(node_1, "test", 0)), equalTo(true));
+        assertThat(Files.exists(indexDirectory(node_1, "test")), equalTo(true));
+        assertThat(Files.exists(shardDirectory(node_2, "test", 0)), equalTo(true));
+        assertThat(Files.exists(indexDirectory(node_2, "test")), equalTo(true));
+        assertThat(Files.exists(shardDirectory(node_3, "test", 0)), equalTo(false));
+        assertThat(Files.exists(indexDirectory(node_3, "test")), equalTo(false));
+
+        logger.info("--> move shard from node_1 to node_3, and wait for relocation to finish");
+        internalCluster().client().admin().cluster().prepareReroute().add(new MoveAllocationCommand(new ShardId("test", 0), node_1, node_3)).get();
+        clusterHealth = client().admin().cluster().prepareHealth()
+                .setWaitForNodes("4")
+                .setWaitForRelocatingShards(0)
+                .get();
+        assertThat(clusterHealth.isTimedOut(), equalTo(false));
+
+        assertThat(waitForShardDeletion(node_1, "test", 0), equalTo(false));
+        assertThat(waitForIndexDeletion(node_1, "test"), equalTo(false));
+        assertThat(Files.exists(shardDirectory(node_2, "test", 0)), equalTo(true));
+        assertThat(Files.exists(indexDirectory(node_2, "test")), equalTo(true));
+        assertThat(Files.exists(shardDirectory(node_3, "test", 0)), equalTo(true));
+        assertThat(Files.exists(indexDirectory(node_3, "test")), equalTo(true));
+    }
 
     @Test
     public void shardsCleanup() throws Exception {
@@ -166,6 +219,11 @@ public class IndicesStoreIntegrationTests extends ElasticsearchIntegrationTest {
         }
     }
 
+    private Path indexDirectory(String server, String index) {
+        NodeEnvironment env = internalCluster().getInstance(NodeEnvironment.class, server);
+        return env.indexPaths(new Index(index))[0];
+    }
+
     private Path shardDirectory(String server, String index, int shard) {
         NodeEnvironment env = internalCluster().getInstance(NodeEnvironment.class, server);
         return env.shardPaths(new ShardId(index, shard))[0];
@@ -181,5 +239,13 @@ public class IndicesStoreIntegrationTests extends ElasticsearchIntegrationTest {
         return Files.exists(shardDirectory(server, index, shard));
     }
 
-
+    private boolean waitForIndexDeletion(final String server, final  String index) throws InterruptedException {
+        awaitBusy(new Predicate<Object>() {
+            @Override
+            public boolean apply(Object o) {
+                return !Files.exists(indexDirectory(server, index));
+            }
+        });
+        return Files.exists(indexDirectory(server, index));
+    }
 }


### PR DESCRIPTION
If a folder for an index was created that folder is never deleted from that node unless the index is deleted.
Data only nodes therefore can have empty folders for indices that they do not even have shards for.
This commit makes sure empty folders are cleaned up after all shards have moved away from a data only 
node. The behavior is unchanged for master eligible nodes. 

I changed the `testShardActiveElseWhere` test to sometimes use data only nodes, not sure if this is useful. Also I added the check for `clusterState.metaData().hasIndex(indexName)` in  `IndicesService.deleteIndexStore` again. Did not come up with a better way to solve this. 
