### PR TITLE
Also throttle delete by query when merges fall behind

### DIFF
--- a/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -440,6 +440,7 @@ public class InternalEngine extends Engine {
     public void delete(Delete delete) throws EngineException {
         try (ReleasableLock _ = readLock.acquire()) {
             ensureOpen();
+            // NOTE: we don't throttle this when merges fall behind because delete-by-id does not create new segments:
             innerDelete(delete);
             flushNeeded = true;
         } catch (OutOfMemoryError | IllegalStateException | IOException t) {


### PR DESCRIPTION
Delete by query is extremely costly: it forces a refresh every time, which can create many segments if there is also concurrent indexing.  This changes throttles delete by query so only 1 thread can run at a time if merges are falling behind.
