### PR TITLE
Cleanup ScriptService & friends in preparation for #6418

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/ScriptFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/ScriptFilterParser.java
@@ -69,7 +69,7 @@ public class ScriptFilterParser implements FilterParser {
         HashedBytesRef cacheKey = null;
         // also, when caching, since its isCacheable is false, will result in loading all bit set...
         String script = null;
-        String scriptLang = null;
+        String scriptLang;
         Map<String, Object> params = null;
 
         String filterName = null;
@@ -130,12 +130,9 @@ public class ScriptFilterParser implements FilterParser {
 
         private final SearchScript searchScript;
 
-        private final ScriptService.ScriptType scriptType;
-
         public ScriptFilter(String scriptLang, String script, ScriptService.ScriptType scriptType, Map<String, Object> params, ScriptService scriptService, SearchLookup searchLookup) {
             this.script = script;
             this.params = params;
-            this.scriptType = scriptType;
             this.searchScript = scriptService.search(searchLookup, scriptLang, script, scriptType, newHashMap(params));
         }
 

--- a/src/main/java/org/elasticsearch/index/query/TemplateQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/TemplateQueryBuilder.java
@@ -21,7 +21,6 @@ package org.elasticsearch.index.query;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.script.ScriptService;
-import org.elasticsearch.search.aggregations.support.ValuesSource;
 
 import java.io.IOException;
 import java.util.Map;

--- a/src/main/java/org/elasticsearch/index/query/TemplateQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TemplateQueryParser.java
@@ -19,17 +19,15 @@
 package org.elasticsearch.index.query;
 
 import org.apache.lucene.search.Query;
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.logging.ESLogger;
-import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.script.ExecutableScript;
 import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.script.mustache.MustacheScriptEngineService;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -52,9 +50,9 @@ public class TemplateQueryParser implements QueryParser {
 
     private final static Map<String,ScriptService.ScriptType> parametersToTypes = new HashMap<>();
     static {
-        parametersToTypes.put("query",ScriptService.ScriptType.INLINE);
-        parametersToTypes.put("file",ScriptService.ScriptType.FILE);
-        parametersToTypes.put("id",ScriptService.ScriptType.INDEXED);
+        parametersToTypes.put("query", ScriptService.ScriptType.INLINE);
+        parametersToTypes.put("file", ScriptService.ScriptType.FILE);
+        parametersToTypes.put("id", ScriptService.ScriptType.INDEXED);
     }
 
     @Inject
@@ -78,15 +76,14 @@ public class TemplateQueryParser implements QueryParser {
     public Query parse(QueryParseContext parseContext) throws IOException {
         XContentParser parser = parseContext.parser();
         TemplateContext templateContext = parse(parser, PARAMS, parametersToTypes);
-        ExecutableScript executable = this.scriptService.executable("mustache", templateContext.template(), templateContext.scriptType(), templateContext.params());
+        ExecutableScript executable = this.scriptService.executable(MustacheScriptEngineService.NAME, templateContext.template(), templateContext.scriptType(), templateContext.params());
 
         BytesReference querySource = (BytesReference) executable.run();
 
         try (XContentParser qSourceParser = XContentFactory.xContent(querySource).createParser(querySource)) {
             final QueryParseContext context = new QueryParseContext(parseContext.index(), parseContext.indexQueryParserService());
             context.reset(qSourceParser);
-            Query result = context.parseInnerQuery();
-            return result;
+            return context.parseInnerQuery();
         }
     }
 

--- a/src/main/java/org/elasticsearch/index/query/functionscore/script/ScriptScoreFunctionParser.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/script/ScriptScoreFunctionParser.java
@@ -56,7 +56,6 @@ public class ScriptScoreFunctionParser implements ScoreFunctionParser {
     public ScoreFunction parse(QueryParseContext parseContext, XContentParser parser) throws IOException, QueryParsingException {
         ScriptParameterParser scriptParameterParser = new ScriptParameterParser();
         String script = null;
-        String scriptLang = null;
         Map<String, Object> vars = null;
         ScriptService.ScriptType scriptType = null;
         String currentFieldName = null;
@@ -82,15 +81,13 @@ public class ScriptScoreFunctionParser implements ScoreFunctionParser {
             script = scriptValue.script();
             scriptType = scriptValue.scriptType();
         }
-        scriptLang = scriptParameterParser.lang();
-
         if (script == null) {
             throw new QueryParsingException(parseContext.index(), NAMES[0] + " requires 'script' field");
         }
 
         SearchScript searchScript;
         try {
-            searchScript = parseContext.scriptService().search(parseContext.lookup(), scriptLang, script, scriptType, vars);
+            searchScript = parseContext.scriptService().search(parseContext.lookup(), scriptParameterParser.lang(), script, scriptType, vars);
             return new ScriptScoreFunction(script, vars, searchScript);
         } catch (Exception e) {
             throw new QueryParsingException(parseContext.index(), NAMES[0] + " the script could not be loaded", e);

--- a/src/main/java/org/elasticsearch/rest/action/template/RestDeleteSearchTemplateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/template/RestDeleteSearchTemplateAction.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.script.RestDeleteIndexedScriptAction;
+import org.elasticsearch.script.mustache.MustacheScriptEngineService;
 
 import static org.elasticsearch.rest.RestRequest.Method.DELETE;
 
@@ -37,6 +38,6 @@ public class RestDeleteSearchTemplateAction extends RestDeleteIndexedScriptActio
 
     @Override
     protected String getScriptLang(RestRequest request) {
-        return "mustache";
+        return MustacheScriptEngineService.NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/rest/action/template/RestGetSearchTemplateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/template/RestGetSearchTemplateAction.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.script.RestGetIndexedScriptAction;
+import org.elasticsearch.script.mustache.MustacheScriptEngineService;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 
@@ -40,7 +41,7 @@ public class RestGetSearchTemplateAction extends RestGetIndexedScriptAction {
 
     @Override
     protected String getScriptLang(RestRequest request) {
-        return "mustache";
+        return MustacheScriptEngineService.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/rest/action/template/RestPutSearchTemplateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/template/RestPutSearchTemplateAction.java
@@ -23,6 +23,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.script.RestPutIndexedScriptAction;
+import org.elasticsearch.script.mustache.MustacheScriptEngineService;
 
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 import static org.elasticsearch.rest.RestRequest.Method.PUT;
@@ -58,6 +59,6 @@ public class RestPutSearchTemplateAction extends RestPutIndexedScriptAction {
 
     @Override
     protected String getScriptLang(RestRequest request) {
-        return "mustache";
+        return MustacheScriptEngineService.NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/script/NativeScriptEngineService.java
+++ b/src/main/java/org/elasticsearch/script/NativeScriptEngineService.java
@@ -34,6 +34,8 @@ import java.util.Map;
  */
 public class NativeScriptEngineService extends AbstractComponent implements ScriptEngineService {
 
+    public static final String NAME = "native";
+
     private final ImmutableMap<String, NativeScriptFactory> scripts;
 
     @Inject
@@ -44,7 +46,7 @@ public class NativeScriptEngineService extends AbstractComponent implements Scri
 
     @Override
     public String[] types() {
-        return new String[]{"native"};
+        return new String[]{NAME};
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/script/SearchScript.java
+++ b/src/main/java/org/elasticsearch/script/SearchScript.java
@@ -20,8 +20,6 @@ package org.elasticsearch.script;
 
 import org.elasticsearch.common.lucene.ReaderContextAware;
 import org.elasticsearch.common.lucene.ScorerAware;
-import org.elasticsearch.search.internal.SearchContext;
-import org.elasticsearch.search.lookup.SearchLookup;
 
 import java.util.Map;
 
@@ -39,36 +37,4 @@ public interface SearchScript extends ExecutableScript, ReaderContextAware, Scor
     long runAsLong();
 
     double runAsDouble();
-
-    public static class Builder {
-
-        private String script;
-        private ScriptService.ScriptType scriptType;
-        private String lang;
-        private Map<String, Object> params;
-
-        public Builder script(String script, ScriptService.ScriptType scriptType) {
-            this.script = script;
-            this.scriptType = scriptType;
-            return this;
-        }
-
-        public Builder lang(String lang) {
-            this.lang = lang;
-            return this;
-        }
-
-        public Builder params(Map<String, Object> params) {
-            this.params = params;
-            return this;
-        }
-
-        public SearchScript build(SearchContext context) {
-            return build(context.scriptService(), context.lookup());
-        }
-
-        public SearchScript build(ScriptService service, SearchLookup lookup) {
-            return service.search(lookup, lang, script, scriptType, params);
-        }
-    }
 }

--- a/src/main/java/org/elasticsearch/script/expression/ExpressionScriptEngineService.java
+++ b/src/main/java/org/elasticsearch/script/expression/ExpressionScriptEngineService.java
@@ -48,6 +48,8 @@ import java.util.Map;
  */
 public class ExpressionScriptEngineService extends AbstractComponent implements ScriptEngineService {
 
+    public static final String NAME = "expression";
+
     @Inject
     public ExpressionScriptEngineService(Settings settings) {
         super(settings);
@@ -55,12 +57,12 @@ public class ExpressionScriptEngineService extends AbstractComponent implements 
 
     @Override
     public String[] types() {
-        return new String[]{"expression"};
+        return new String[]{NAME};
     }
 
     @Override
     public String[] extensions() {
-        return new String[]{"expression"};
+        return new String[]{NAME};
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/script/mustache/MustacheScriptEngineService.java
+++ b/src/main/java/org/elasticsearch/script/mustache/MustacheScriptEngineService.java
@@ -47,6 +47,8 @@ import java.util.Map;
  */
 public class MustacheScriptEngineService extends AbstractComponent implements ScriptEngineService {
 
+    public static final String NAME = "mustache";
+
     /** Thread local UTF8StreamWriter to store template execution results in, thread local to save object creation.*/
     private static ThreadLocal<SoftReference<UTF8StreamWriter>> utf8StreamWriter = new ThreadLocal<>();
 
@@ -116,12 +118,12 @@ public class MustacheScriptEngineService extends AbstractComponent implements Sc
 
     @Override
     public String[] types() {
-        return new String[] {"mustache"};
+        return new String[] {NAME};
     }
 
     @Override
     public String[] extensions() {
-        return new String[] {"mustache"};
+        return new String[] {NAME};
     }
 
     @Override
@@ -172,7 +174,7 @@ public class MustacheScriptEngineService extends AbstractComponent implements Sc
         public MustacheExecutableScript(Mustache mustache,
                 Map<String, Object> vars) {
             this.mustache = mustache;
-            this.vars = vars == null ? Collections.EMPTY_MAP : vars;
+            this.vars = vars == null ? Collections.<String, Object>emptyMap() : vars;
         }
 
         @Override
@@ -184,7 +186,7 @@ public class MustacheScriptEngineService extends AbstractComponent implements Sc
         public Object run() {
             BytesStreamOutput result = new BytesStreamOutput();
             UTF8StreamWriter writer = utf8StreamWriter().setOutput(result);
-            ((Mustache) mustache).execute(writer, vars);
+            mustache.execute(writer, vars);
             try {
                 writer.flush();
             } catch (IOException e) {

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/scripted/InternalScriptedMetric.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/scripted/InternalScriptedMetric.java
@@ -92,9 +92,9 @@ public class InternalScriptedMetric extends InternalMetricsAggregation implement
         if (firstAggregation.reduceScript != null) {
             Map<String, Object> params;
             if (firstAggregation.reduceParams != null) {
-                params = new HashMap<String, Object>(firstAggregation.reduceParams);
+                params = new HashMap<>(firstAggregation.reduceParams);
             } else {
-                params = new HashMap<String, Object>();
+                params = new HashMap<>();
             }
             params.put("_aggs", aggregationObjects);
             ExecutableScript script = reduceContext.scriptService().executable(firstAggregation.scriptLang, firstAggregation.reduceScript,

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/scripted/ScriptedMetricAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/scripted/ScriptedMetricAggregator.java
@@ -52,14 +52,12 @@ public class ScriptedMetricAggregator extends MetricsAggregator {
     private final Map<String, Object> params;
     // initial parameters for {reduce}
     private final Map<String, Object> reduceParams;
-    private final ScriptService scriptService;
     private final ScriptType reduceScriptType;
 
     protected ScriptedMetricAggregator(String name, String scriptLang, ScriptType initScriptType, String initScript,
             ScriptType mapScriptType, String mapScript, ScriptType combineScriptType, String combineScript, ScriptType reduceScriptType,
             String reduceScript, Map<String, Object> params, Map<String, Object> reduceParams, AggregationContext context, Aggregator parent, Map<String, Object> metaData) throws IOException {
         super(name, context, parent, metaData);
-        this.scriptService = context.searchContext().scriptService();
         this.scriptLang = scriptLang;
         this.reduceScriptType = reduceScriptType;
         if (params == null) {
@@ -73,6 +71,7 @@ public class ScriptedMetricAggregator extends MetricsAggregator {
         } else {
             this.reduceParams = reduceParams;
         }
+        ScriptService scriptService = context.searchContext().scriptService();
         if (initScript != null) {
             scriptService.executable(scriptLang, initScript, initScriptType, this.params).run();
         }

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/scripted/ScriptedMetricParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/scripted/ScriptedMetricParser.java
@@ -51,7 +51,7 @@ public class ScriptedMetricParser implements Aggregator.Parser {
 
     @Override
     public AggregatorFactory parse(String aggregationName, XContentParser parser, SearchContext context) throws IOException {
-        String scriptLang = null;
+        String scriptLang;
         Map<String, Object> params = null;
         Map<String, Object> reduceParams = null;
         XContentParser.Token token;

--- a/src/main/java/org/elasticsearch/search/fetch/script/ScriptFieldsParseElement.java
+++ b/src/main/java/org/elasticsearch/search/fetch/script/ScriptFieldsParseElement.java
@@ -56,7 +56,6 @@ public class ScriptFieldsParseElement implements SearchParseElement {
                 String fieldName = currentFieldName;
                 ScriptParameterParser scriptParameterParser = new ScriptParameterParser();
                 String script = null;
-                String scriptLang = null;
                 ScriptService.ScriptType scriptType = null;
                 Map<String, Object> params = null;
                 boolean ignoreException = false;
@@ -79,9 +78,7 @@ public class ScriptFieldsParseElement implements SearchParseElement {
                     script = scriptValue.script();
                     scriptType = scriptValue.scriptType();
                 }
-                scriptLang = scriptParameterParser.lang();
-                
-                SearchScript searchScript = context.scriptService().search(context.lookup(), scriptLang, script, scriptType, params);
+                SearchScript searchScript = context.scriptService().search(context.lookup(), scriptParameterParser.lang(), script, scriptType, params);
                 context.scriptFields().add(new ScriptFieldsContext.ScriptField(fieldName, searchScript, ignoreException));
             }
         }

--- a/src/main/java/org/elasticsearch/search/sort/ScriptSortParser.java
+++ b/src/main/java/org/elasticsearch/search/sort/ScriptSortParser.java
@@ -32,7 +32,6 @@ import org.elasticsearch.index.fielddata.*;
 import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource.Nested;
 import org.elasticsearch.index.fielddata.fieldcomparator.BytesRefFieldComparatorSource;
 import org.elasticsearch.index.fielddata.fieldcomparator.DoubleValuesComparatorSource;
-import org.elasticsearch.index.mapper.object.ObjectMapper;
 import org.elasticsearch.index.query.support.NestedInnerQueryParseSupport;
 import org.elasticsearch.index.search.nested.NonNestedDocsFilter;
 import org.elasticsearch.script.ScriptService;
@@ -128,7 +127,6 @@ public class ScriptSortParser implements SortParser {
         }
 
         // If nested_path is specified, then wrap the `fieldComparatorSource` in a `NestedFieldComparatorSource`
-        ObjectMapper objectMapper;
         final Nested nested;
         if (nestedHelper != null && nestedHelper.getPath() != null) {
             BitDocIdSetFilter rootDocumentsFilter = context.bitsetFilterCache().getBitDocIdSetFilter(NonNestedDocsFilter.INSTANCE);

--- a/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestParser.java
+++ b/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestParser.java
@@ -30,6 +30,8 @@ import org.elasticsearch.index.analysis.ShingleTokenFilterFactory;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.script.CompiledScript;
+import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.script.mustache.MustacheScriptEngineService;
 import org.elasticsearch.search.suggest.SuggestContextParser;
 import org.elasticsearch.search.suggest.SuggestUtils;
 import org.elasticsearch.search.suggest.SuggestionSearchContext;
@@ -150,7 +152,7 @@ public final class PhraseSuggestParser implements SuggestContextParser {
                             if (suggestion.getCollateQueryScript() != null) {
                                 throw new ElasticsearchIllegalArgumentException("suggester[phrase][collate] query already set, doesn't support additional [" + fieldName + "]");
                             }
-                            CompiledScript compiledScript = suggester.scriptService().compile("mustache", templateNameOrTemplateContent);
+                            CompiledScript compiledScript = suggester.scriptService().compile(MustacheScriptEngineService.NAME, templateNameOrTemplateContent, ScriptService.ScriptType.INLINE);
                             if ("query".equals(fieldName)) {
                                 suggestion.setCollateQueryScript(compiledScript);
                             } else {

--- a/src/test/java/org/elasticsearch/cluster/NoMasterNodeTests.java
+++ b/src/test/java/org/elasticsearch/cluster/NoMasterNodeTests.java
@@ -38,7 +38,6 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
-import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.junit.Test;
 
 import java.util.HashMap;

--- a/src/test/java/org/elasticsearch/index/mapper/TransformOnIndexMapperIntegrationTest.java
+++ b/src/test/java/org/elasticsearch/index/mapper/TransformOnIndexMapperIntegrationTest.java
@@ -27,6 +27,7 @@ import org.elasticsearch.action.suggest.SuggestResponse;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.script.groovy.GroovyScriptEngineService;
 import org.elasticsearch.search.suggest.SuggestBuilders;
 import org.elasticsearch.search.suggest.completion.CompletionSuggestion;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
@@ -90,7 +91,7 @@ public class TransformOnIndexMapperIntegrationTest extends ElasticsearchIntegrat
         builder.endObject();
         builder.startObject("transform");
         builder.field("script", "ctx._source.suggest = ['input': ctx._source.text];ctx._source.suggest.payload = ['display': ctx._source.text, 'display_detail': 'on the fly']");
-        builder.field("lang", "groovy");
+        builder.field("lang", GroovyScriptEngineService.NAME);
         builder.endObject();
         assertAcked(client().admin().indices().prepareCreate("test").addMapping("test", builder));
         // Payload is stored using original source format (json, smile, yaml, whatever)
@@ -127,7 +128,7 @@ public class TransformOnIndexMapperIntegrationTest extends ElasticsearchIntegrat
             // Single transform
             builder.startObject();
             buildTransformScript(builder);
-            builder.field("lang", "groovy");
+            builder.field("lang", GroovyScriptEngineService.NAME);
             builder.endObject();
         } else {
             // Multiple transforms
@@ -141,7 +142,7 @@ public class TransformOnIndexMapperIntegrationTest extends ElasticsearchIntegrat
                 } else {
                     builder.field("script", "true");
                 }
-                builder.field("lang", "groovy");
+                builder.field("lang", GroovyScriptEngineService.NAME);
                 builder.endObject();
             }
             builder.endArray();

--- a/src/test/java/org/elasticsearch/index/query/TemplateQueryTest.java
+++ b/src/test/java/org/elasticsearch/index/query/TemplateQueryTest.java
@@ -19,7 +19,6 @@
 package org.elasticsearch.index.query;
 
 import com.google.common.collect.Maps;
-
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.indexedscripts.delete.DeleteIndexedScriptResponse;
 import org.elasticsearch.action.indexedscripts.get.GetIndexedScriptResponse;
@@ -31,6 +30,7 @@ import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.script.mustache.MustacheScriptEngineService;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.junit.Before;
 import org.junit.Test;
@@ -43,9 +43,7 @@ import java.util.Map;
 
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertFailures;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.*;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
@@ -230,7 +228,7 @@ public class TemplateQueryTest extends ElasticsearchIntegrationTest {
         createIndex(ScriptService.SCRIPT_INDEX);
         ensureGreen(ScriptService.SCRIPT_INDEX);
 
-        PutIndexedScriptResponse scriptResponse = client().preparePutIndexedScript("mustache", "testTemplate", "{" +
+        PutIndexedScriptResponse scriptResponse = client().preparePutIndexedScript(MustacheScriptEngineService.NAME, "testTemplate", "{" +
                 "\"template\":{" +
                 "                \"query\":{" +
                 "                   \"match\":{" +
@@ -241,7 +239,7 @@ public class TemplateQueryTest extends ElasticsearchIntegrationTest {
 
         assertTrue(scriptResponse.isCreated());
 
-        scriptResponse = client().preparePutIndexedScript("mustache", "testTemplate", "{" +
+        scriptResponse = client().preparePutIndexedScript(MustacheScriptEngineService.NAME, "testTemplate", "{" +
                 "\"template\":{" +
                 "                \"query\":{" +
                 "                   \"match\":{" +
@@ -252,7 +250,7 @@ public class TemplateQueryTest extends ElasticsearchIntegrationTest {
 
         assertEquals(scriptResponse.getVersion(), 2);
 
-        GetIndexedScriptResponse getResponse = client().prepareGetIndexedScript("mustache", "testTemplate").get();
+        GetIndexedScriptResponse getResponse = client().prepareGetIndexedScript(MustacheScriptEngineService.NAME, "testTemplate").get();
         assertTrue(getResponse.isExists());
 
         List<IndexRequestBuilder> builders = new ArrayList<>();
@@ -272,10 +270,10 @@ public class TemplateQueryTest extends ElasticsearchIntegrationTest {
                 setTemplateName("testTemplate").setTemplateType(ScriptService.ScriptType.INDEXED).setTemplateParams(templateParams).get();
         assertHitCount(searchResponse, 4);
 
-        DeleteIndexedScriptResponse deleteResponse = client().prepareDeleteIndexedScript("mustache","testTemplate").get();
+        DeleteIndexedScriptResponse deleteResponse = client().prepareDeleteIndexedScript(MustacheScriptEngineService.NAME,"testTemplate").get();
         assertTrue(deleteResponse.isFound());
 
-        getResponse = client().prepareGetIndexedScript("mustache", "testTemplate").get();
+        getResponse = client().prepareGetIndexedScript(MustacheScriptEngineService.NAME, "testTemplate").get();
         assertFalse(getResponse.isExists());
 
         client().prepareSearch("test").setTypes("type").
@@ -287,7 +285,7 @@ public class TemplateQueryTest extends ElasticsearchIntegrationTest {
         createIndex(ScriptService.SCRIPT_INDEX);
         ensureGreen(ScriptService.SCRIPT_INDEX);
         List<IndexRequestBuilder> builders = new ArrayList<>();
-        builders.add(client().prepareIndex(ScriptService.SCRIPT_INDEX, "mustache", "1a").setSource("{" +
+        builders.add(client().prepareIndex(ScriptService.SCRIPT_INDEX, MustacheScriptEngineService.NAME, "1a").setSource("{" +
                 "\"template\":{"+
                 "                \"query\":{" +
                 "                   \"match\":{" +
@@ -295,7 +293,7 @@ public class TemplateQueryTest extends ElasticsearchIntegrationTest {
                 "       }" +
                     "}" +
                 "}"));
-        builders.add(client().prepareIndex(ScriptService.SCRIPT_INDEX, "mustache", "2").setSource("{" +
+        builders.add(client().prepareIndex(ScriptService.SCRIPT_INDEX, MustacheScriptEngineService.NAME, "2").setSource("{" +
                 "\"template\":{"+
                 "                \"query\":{" +
                 "                   \"match\":{" +
@@ -304,7 +302,7 @@ public class TemplateQueryTest extends ElasticsearchIntegrationTest {
                     "}" +
                 "}"));
 
-        builders.add(client().prepareIndex(ScriptService.SCRIPT_INDEX, "mustache", "3").setSource("{" +
+        builders.add(client().prepareIndex(ScriptService.SCRIPT_INDEX, MustacheScriptEngineService.NAME, "3").setSource("{" +
                 "\"template\":{"+
                 "             \"match\":{" +
                 "                    \"theField\" : \"{{fieldParam}}\"}" +
@@ -381,7 +379,7 @@ public class TemplateQueryTest extends ElasticsearchIntegrationTest {
 
       String multiQuery = "{\"query\":{\"terms\":{\"theField\":[\"{{#fieldParam}}\",\"{{.}}\",\"{{/fieldParam}}\"]}}}";
 
-      builders.add(client().prepareIndex(ScriptService.SCRIPT_INDEX, "mustache", "4").setSource(jsonBuilder().startObject().field("template", multiQuery).endObject()));
+      builders.add(client().prepareIndex(ScriptService.SCRIPT_INDEX, MustacheScriptEngineService.NAME, "4").setSource(jsonBuilder().startObject().field("template", multiQuery).endObject()));
 
       indexRandom(true,builders);
 

--- a/src/test/java/org/elasticsearch/script/GroovyScriptTests.java
+++ b/src/test/java/org/elasticsearch/script/GroovyScriptTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.lucene.search.function.CombineFunction;
+import org.elasticsearch.script.groovy.GroovyScriptEngineService;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.junit.Test;
 
@@ -72,7 +73,7 @@ public class GroovyScriptTests extends ElasticsearchIntegrationTest {
         }
         indexRandom(true, false, reqs);
         try {
-            client().prepareSearch("test").setQuery(constantScoreQuery(scriptFilter("1 == not_found").lang("groovy"))).get();
+            client().prepareSearch("test").setQuery(constantScoreQuery(scriptFilter("1 == not_found").lang(GroovyScriptEngineService.NAME))).get();
             fail("should have thrown an exception");
         } catch (SearchPhaseExecutionException e) {
             assertThat(ExceptionsHelper.detailedMessage(e) + "should not contained NotSerializableTransportException",

--- a/src/test/java/org/elasticsearch/script/NativeScriptTests.java
+++ b/src/test/java/org/elasticsearch/script/NativeScriptTests.java
@@ -28,11 +28,9 @@ import org.elasticsearch.common.settings.SettingsModule;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.threadpool.ThreadPoolModule;
-import org.elasticsearch.watcher.ResourceWatcherService;
 import org.junit.Test;
 
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.Matchers.equalTo;
 
@@ -51,7 +49,7 @@ public class NativeScriptTests extends ElasticsearchTestCase {
 
         ScriptService scriptService = injector.getInstance(ScriptService.class);
 
-        ExecutableScript executable = scriptService.executable("native", "my", ScriptService.ScriptType.INLINE, null);
+        ExecutableScript executable = scriptService.executable(NativeScriptEngineService.NAME, "my", ScriptService.ScriptType.INLINE, null);
         assertThat(executable.run().toString(), equalTo("test"));
         terminate(injector.getInstance(ThreadPool.class));
     }

--- a/src/test/java/org/elasticsearch/script/ScriptServiceTests.java
+++ b/src/test/java/org/elasticsearch/script/ScriptServiceTests.java
@@ -83,7 +83,7 @@ public class ScriptServiceTests extends ElasticsearchTestCase {
         logger.info("--> verify that file with extension was correctly removed");
         try {
             scriptService.compile("test", "test_script", ScriptService.ScriptType.FILE);
-            fail("the script test_script should no longe exist");
+            fail("the script test_script should no longer exist");
         } catch (ElasticsearchIllegalArgumentException ex) {
             assertThat(ex.getMessage(), containsString("Unable to find on disk script test_script"));
         }

--- a/src/test/java/org/elasticsearch/script/expression/ExpressionScriptTests.java
+++ b/src/test/java/org/elasticsearch/script/expression/ExpressionScriptTests.java
@@ -20,24 +20,21 @@
 package org.elasticsearch.script.expression;
 
 import org.elasticsearch.ExceptionsHelper;
-import org.elasticsearch.action.get.GetRequestBuilder;
-import org.elasticsearch.action.search.*;
-import org.elasticsearch.common.xcontent.ToXContent;
-import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.action.search.SearchPhaseExecutionException;
+import org.elasticsearch.action.search.SearchRequestBuilder;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilder;
 import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilders;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.metrics.stats.Stats;
-import org.elasticsearch.search.sort.SortBuilder;
 import org.elasticsearch.search.sort.SortBuilders;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
-import java.io.IOException;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -225,8 +222,8 @@ public class ExpressionScriptTests extends ElasticsearchIntegrationTest {
 
         SearchRequestBuilder req = new SearchRequestBuilder(client()).setIndices("test");
         req.setQuery(QueryBuilders.matchAllQuery())
-           .addAggregation(AggregationBuilders.stats("int_agg").field("x").script("_value * 3").lang("expression"))
-           .addAggregation(AggregationBuilders.stats("double_agg").field("y").script("_value - 1.1").lang("expression"));
+           .addAggregation(AggregationBuilders.stats("int_agg").field("x").script("_value * 3").lang(ExpressionScriptEngineService.NAME))
+           .addAggregation(AggregationBuilders.stats("double_agg").field("y").script("_value - 1.1").lang(ExpressionScriptEngineService.NAME));
 
         SearchResponse rsp = req.get();
         assertEquals(3, rsp.getHits().getTotalHits());
@@ -251,7 +248,7 @@ public class ExpressionScriptTests extends ElasticsearchIntegrationTest {
 
         SearchRequestBuilder req = new SearchRequestBuilder(client()).setIndices("test");
         req.setQuery(QueryBuilders.matchAllQuery())
-           .addAggregation(AggregationBuilders.terms("term_agg").field("text").script("_value").lang("expression"));
+           .addAggregation(AggregationBuilders.terms("term_agg").field("text").script("_value").lang(ExpressionScriptEngineService.NAME));
 
         String message;
         try {

--- a/src/test/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.action.indexedscripts.put.PutIndexedScriptResponse;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.script.groovy.GroovyScriptEngineService;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.bucket.global.Global;
@@ -91,11 +92,11 @@ public class ScriptedMetricTests extends ElasticsearchIntegrationTest {
                     jsonBuilder().startObject().field("value", i * 2).endObject()));
         }
 
-        PutIndexedScriptResponse indexScriptResponse = client().preparePutIndexedScript("groovy", "initScript_indexed", "{\"script\":\"vars.multiplier = 3\"}").get();
+        PutIndexedScriptResponse indexScriptResponse = client().preparePutIndexedScript(GroovyScriptEngineService.NAME, "initScript_indexed", "{\"script\":\"vars.multiplier = 3\"}").get();
         assertThat(indexScriptResponse.isCreated(), equalTo(true));
-        indexScriptResponse = client().preparePutIndexedScript("groovy", "mapScript_indexed", "{\"script\":\"_agg.add(vars.multiplier)\"}").get();
+        indexScriptResponse = client().preparePutIndexedScript(GroovyScriptEngineService.NAME, "mapScript_indexed", "{\"script\":\"_agg.add(vars.multiplier)\"}").get();
         assertThat(indexScriptResponse.isCreated(), equalTo(true));
-        indexScriptResponse = client().preparePutIndexedScript("groovy", "combineScript_indexed",
+        indexScriptResponse = client().preparePutIndexedScript(GroovyScriptEngineService.NAME, "combineScript_indexed",
                 "{\"script\":\"newaggregation = []; sum = 0;for (a in _agg) { sum += a}; newaggregation.add(sum); return newaggregation\"}")
                 .get();
         assertThat(indexScriptResponse.isCreated(), equalTo(true));

--- a/src/test/java/org/elasticsearch/update/UpdateByNativeScriptTests.java
+++ b/src/test/java/org/elasticsearch/update/UpdateByNativeScriptTests.java
@@ -22,10 +22,7 @@ import com.google.common.collect.Maps;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.script.AbstractExecutableScript;
-import org.elasticsearch.script.ExecutableScript;
-import org.elasticsearch.script.NativeScriptFactory;
-import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.script.*;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
 import org.junit.Test;
@@ -61,7 +58,7 @@ public class UpdateByNativeScriptTests extends ElasticsearchIntegrationTest {
         params.put("foo", "SETVALUE");
         client().prepareUpdate("test", "type", "1")
                 .setScript("custom", ScriptService.ScriptType.INLINE)
-                .setScriptLang("native").setScriptParams(params).get();
+                .setScriptLang(NativeScriptEngineService.NAME).setScriptParams(params).get();
 
         Map<String, Object> data = client().prepareGet("test", "type", "1").get().getSource();
         assertThat(data, hasKey("foo"));

--- a/src/test/java/org/elasticsearch/update/UpdateTests.java
+++ b/src/test/java/org/elasticsearch/update/UpdateTests.java
@@ -19,10 +19,7 @@
 
 package org.elasticsearch.update;
 
-import org.apache.lucene.index.MergePolicy;
-import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.util.LuceneTestCase.Slow;
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequestValidationException;
@@ -34,16 +31,13 @@ import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.action.update.UpdateRequestBuilder;
 import org.elasticsearch.action.update.UpdateResponse;
 import org.elasticsearch.client.transport.NoNodeAvailableException;
-import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.index.engine.DocumentMissingException;
 import org.elasticsearch.index.engine.VersionConflictEngineException;
-import org.elasticsearch.index.merge.policy.AbstractMergePolicyProvider;
 import org.elasticsearch.index.merge.policy.MergePolicyModule;
-import org.elasticsearch.index.store.Store;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.elasticsearch.test.index.merge.NoMergePolicyProvider;


### PR DESCRIPTION
While working on #6418, I found myself cleaning some things up around scripting code, which I figured would be better to isolate on a different PR, to make the fine grained settings change easier to review.
- Added NAME constants for each script language, avoiding to repeat the same strings all over the place.
- Simplified `compile` method signatures by removing a couple of variants. Note that all of these signatures are going to change again with #6418 as in order to compile/execute a script the caller will need to specify which operation is attempting to execute the script, info that will be provided as an additional mandatory argument.
- Removed double call to ScriptService#verifyDynamicScripting for every indexed or dynamic script.
- Decreased ScriptService inner classes visibility to private (CacheKey, IndexedScript, ApplySettings)
- Moved ScriptService inner classes to the bottom of the class, I think it makes it more readable.
- Resolved some compiler warnings
