### PR TITLE
Fix Java 8 _ variable warning

### DIFF
--- a/src/main/java/org/elasticsearch/common/lucene/Lucene.java
+++ b/src/main/java/org/elasticsearch/common/lucene/Lucene.java
@@ -177,7 +177,7 @@ public class Lucene {
             }
         }
         final CommitPoint cp = new CommitPoint(si, directory);
-        try (IndexWriter _ = new IndexWriter(directory, new IndexWriterConfig(Lucene.STANDARD_ANALYZER)
+        try (IndexWriter writer = new IndexWriter(directory, new IndexWriterConfig(Lucene.STANDARD_ANALYZER)
                 .setIndexCommit(cp)
                 .setCommitOnClose(false)
                 .setMergePolicy(NoMergePolicy.INSTANCE)
@@ -203,7 +203,7 @@ public class Lucene {
                 }
             }
         }
-        try (IndexWriter _ = new IndexWriter(directory, new IndexWriterConfig(Lucene.STANDARD_ANALYZER)
+        try (IndexWriter writer = new IndexWriter(directory, new IndexWriterConfig(Lucene.STANDARD_ANALYZER)
                 .setMergePolicy(NoMergePolicy.INSTANCE) // no merges
                 .setCommitOnClose(false) // no commits
                 .setOpenMode(IndexWriterConfig.OpenMode.CREATE))) // force creation - don't append...

--- a/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -203,7 +203,7 @@ public class InternalEngine extends Engine {
 
     @Override
     public GetResult get(Get get) throws EngineException {
-        try (ReleasableLock _ = readLock.acquire()) {
+        try (ReleasableLock lock = readLock.acquire()) {
             ensureOpen();
             if (get.realtime()) {
                 VersionValue versionValue = versionMap.getUnderLock(get.uid().bytes());
@@ -232,7 +232,7 @@ public class InternalEngine extends Engine {
 
     @Override
     public void create(Create create) throws EngineException {
-        try (ReleasableLock _ = readLock.acquire()) {
+        try (ReleasableLock lock = readLock.acquire()) {
             ensureOpen();
             if (create.origin() == Operation.Origin.RECOVERY) {
                 // Don't throttle recovery operations
@@ -338,7 +338,7 @@ public class InternalEngine extends Engine {
 
     @Override
     public void index(Index index) throws EngineException {
-        try (ReleasableLock _ = readLock.acquire()) {
+        try (ReleasableLock lock = readLock.acquire()) {
             ensureOpen();
             if (index.origin() == Operation.Origin.RECOVERY) {
                 // Don't throttle recovery operations
@@ -438,7 +438,7 @@ public class InternalEngine extends Engine {
 
     @Override
     public void delete(Delete delete) throws EngineException {
-        try (ReleasableLock _ = readLock.acquire()) {
+        try (ReleasableLock lock = readLock.acquire()) {
             ensureOpen();
             // NOTE: we don't throttle this when merges fall behind because delete-by-id does not create new segments:
             innerDelete(delete);
@@ -506,7 +506,7 @@ public class InternalEngine extends Engine {
 
     @Override
     public void delete(DeleteByQuery delete) throws EngineException {
-        try (ReleasableLock _ = readLock.acquire()) {
+        try (ReleasableLock lock = readLock.acquire()) {
             ensureOpen();
             if (delete.origin() == Operation.Origin.RECOVERY) {
                 // Don't throttle recovery operations
@@ -549,7 +549,7 @@ public class InternalEngine extends Engine {
     public void refresh(String source) throws EngineException {
         // we obtain a read lock here, since we don't want a flush to happen while we are refreshing
         // since it flushes the index as well (though, in terms of concurrency, we are allowed to do it)
-        try (ReleasableLock _ = readLock.acquire()) {
+        try (ReleasableLock lock = readLock.acquire()) {
             ensureOpen();
             updateIndexWriterSettings();
             searcherManager.maybeRefreshBlocking();
@@ -594,7 +594,7 @@ public class InternalEngine extends Engine {
          *  Thread 1: flushes via API and gets the flush lock but blocks on the readlock since Thread 2 has the writeLock
          *  Thread 2: flushes at the end of the recovery holding the writeLock and blocks on the flushLock owned by Thread 1
          */
-        try (ReleasableLock _ = readLock.acquire()) {
+        try (ReleasableLock lock = readLock.acquire()) {
             ensureOpen();
             updateIndexWriterSettings();
             if (flushLock.tryLock() == false) {
@@ -731,7 +731,7 @@ public class InternalEngine extends Engine {
     @Override
     public void forceMerge(final boolean flush, int maxNumSegments, boolean onlyExpungeDeletes, final boolean upgrade) throws EngineException {
         if (optimizeMutex.compareAndSet(false, true)) {
-            try (ReleasableLock _ = readLock.acquire()) {
+            try (ReleasableLock lock = readLock.acquire()) {
                 ensureOpen();
                 /*
                  * The way we implement upgrades is a bit hackish in the sense that we set an instance
@@ -770,7 +770,7 @@ public class InternalEngine extends Engine {
         // we have to flush outside of the readlock otherwise we might have a problem upgrading
         // the to a write lock when we fail the engine in this operation
         flush(false, false, true);
-        try (ReleasableLock _ = readLock.acquire()) {
+        try (ReleasableLock lock = readLock.acquire()) {
             ensureOpen();
             return deletionPolicy.snapshot();
         } catch (IOException e) {
@@ -782,7 +782,7 @@ public class InternalEngine extends Engine {
     public void recover(RecoveryHandler recoveryHandler) throws EngineException {
         // take a write lock here so it won't happen while a flush is in progress
         // this means that next commits will not be allowed once the lock is released
-        try (ReleasableLock _ = writeLock.acquire()) {
+        try (ReleasableLock lock = writeLock.acquire()) {
             ensureOpen();
             onGoingRecoveries.startRecovery();
         }
@@ -871,7 +871,7 @@ public class InternalEngine extends Engine {
 
     @Override
     public List<Segment> segments(boolean verbose) {
-        try (ReleasableLock _ = readLock.acquire()) {
+        try (ReleasableLock lock = readLock.acquire()) {
             Segment[] segmentsArr = getSegmentInfo(lastCommittedSegmentInfos, verbose);
 
             // fill in the merges flag

--- a/src/main/java/org/elasticsearch/index/engine/ShadowEngine.java
+++ b/src/main/java/org/elasticsearch/index/engine/ShadowEngine.java
@@ -130,7 +130,7 @@ public class ShadowEngine extends Engine {
          * we can't use it.
          */
         store.incRef();
-        try (ReleasableLock _ = readLock.acquire()) {
+        try (ReleasableLock lock = readLock.acquire()) {
             // reread the last committed segment infos
             lastCommittedSegmentInfos = store.readLastCommittedSegmentsInfo();
         } catch (Throwable e) {
@@ -159,7 +159,7 @@ public class ShadowEngine extends Engine {
 
     @Override
     public List<Segment> segments(boolean verbose) {
-        try (ReleasableLock _ = readLock.acquire()) {
+        try (ReleasableLock lock = readLock.acquire()) {
             Segment[] segmentsArr = getSegmentInfo(lastCommittedSegmentInfos, verbose);
             for (int i = 0; i < segmentsArr.length; i++) {
                 // hard code all segments as committed, because they are in
@@ -174,7 +174,7 @@ public class ShadowEngine extends Engine {
     public void refresh(String source) throws EngineException {
         // we obtain a read lock here, since we don't want a flush to happen while we are refreshing
         // since it flushes the index as well (though, in terms of concurrency, we are allowed to do it)
-        try (ReleasableLock _ = readLock.acquire()) {
+        try (ReleasableLock lock = readLock.acquire()) {
             ensureOpen();
             searcherManager.maybeRefreshBlocking();
         } catch (AlreadyClosedException e) {


### PR DESCRIPTION
The _ variable causes a warning when compiling with Java 8, noting that it might be removed in a future version
