### PR TITLE
Remove dangling indices settings, always import it

### DIFF
--- a/src/main/java/org/elasticsearch/gateway/DanglingIndicesState.java
+++ b/src/main/java/org/elasticsearch/gateway/DanglingIndicesState.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.gateway;
+
+import com.google.common.collect.*;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.common.component.AbstractComponent;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
+import org.elasticsearch.env.NodeEnvironment;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * The dangling indices state is responsible for finding new dangling indices (indices that have
+ * their state written on disk, but don't exists in the metadata of the cluster), and importing
+ * them into the cluster.
+ */
+public class DanglingIndicesState extends AbstractComponent {
+
+    private final NodeEnvironment nodeEnv;
+    private final MetaStateService metaStateService;
+    private final LocalAllocateDangledIndices allocateDangledIndices;
+
+    private final Map<String, IndexMetaData> danglingIndices = ConcurrentCollections.newConcurrentMap();
+
+    @Inject
+    public DanglingIndicesState(Settings settings, NodeEnvironment nodeEnv, MetaStateService metaStateService,
+                                LocalAllocateDangledIndices allocateDangledIndices) {
+        super(settings);
+        this.nodeEnv = nodeEnv;
+        this.metaStateService = metaStateService;
+        this.allocateDangledIndices = allocateDangledIndices;
+    }
+
+    /**
+     * Process dangling indices based on the provided meta data, handling cleanup, finding
+     * new dangling indices, and allocating outstanding ones.
+     */
+    public void processDanglingIndices(MetaData metaData) {
+        if (nodeEnv.hasNodeFile() == false) {
+            return;
+        }
+        cleanupAllocatedDangledIndices(metaData);
+        findNewAndAddDanglingIndices(metaData);
+        allocateDanglingIndices();
+    }
+
+    /**
+     * The current set of dangling indices.
+     */
+    Map<String, IndexMetaData> getDanglingIndices() {
+        return ImmutableMap.copyOf(danglingIndices);
+    }
+
+    /**
+     * Cleans dangling indices if they are already allocated on the provided meta data.
+     */
+    void cleanupAllocatedDangledIndices(MetaData metaData) {
+        for (String danglingIndex : danglingIndices.keySet()) {
+            if (metaData.hasIndex(danglingIndex)) {
+                logger.debug("[{}] no longer dangling (created), removing from dangling list", danglingIndex);
+                danglingIndices.remove(danglingIndex);
+            }
+        }
+    }
+
+    /**
+     * Finds (@{link #findNewAndAddDanglingIndices}) and adds the new dangling indices
+     * to the currently tracked dangling indices.
+     */
+    void findNewAndAddDanglingIndices(MetaData metaData) {
+        danglingIndices.putAll(findNewDanglingIndices(metaData));
+    }
+
+    /**
+     * Finds new dangling indices by iterating over the indices and trying to find indices
+     * that have state on disk, but are not part of the provided meta data, or not detected
+     * as dangled already.
+     */
+    Map<String, IndexMetaData> findNewDanglingIndices(MetaData metaData) {
+        final Set<String> indices;
+        try {
+            indices = nodeEnv.findAllIndices();
+        } catch (Throwable e) {
+            logger.warn("failed to list dangling indices", e);
+            return ImmutableMap.of();
+        }
+
+        Map<String, IndexMetaData>  newIndices = Maps.newHashMap();
+        for (String indexName : indices) {
+            if (metaData.hasIndex(indexName) == false && danglingIndices.containsKey(indexName) == false) {
+                try {
+                    IndexMetaData indexMetaData = metaStateService.loadIndexState(indexName);
+                    if (indexMetaData != null) {
+                        logger.info("[{}] dangling index, exists on local file system, but not in cluster metadata, auto import to cluster state", indexName);
+                        if (!indexMetaData.index().equals(indexName)) {
+                            logger.info("dangled index directory name is [{}], state name is [{}], renaming to directory name", indexName, indexMetaData.index());
+                            indexMetaData = IndexMetaData.builder(indexMetaData).index(indexName).build();
+                        }
+                        newIndices.put(indexName, indexMetaData);
+                    } else {
+                        logger.debug("[{}] dangling index directory detected, but no state found", indexName);
+                    }
+                } catch (Throwable t) {
+                    logger.warn("[{}] failed to load index state for detected dangled index", t, indexName);
+                }
+            }
+        }
+        return newIndices;
+    }
+
+    /**
+     * Allocates the provided list of the dangled indices by sending them to the master node
+     * for allocation.
+     */
+    private void allocateDanglingIndices() {
+        if (danglingIndices.isEmpty() == true) {
+            return;
+        }
+        try {
+            allocateDangledIndices.allocateDangled(ImmutableList.copyOf(danglingIndices.values()), new LocalAllocateDangledIndices.Listener() {
+                @Override
+                public void onResponse(LocalAllocateDangledIndices.AllocateDangledResponse response) {
+                    logger.trace("allocated dangled");
+                }
+
+                @Override
+                public void onFailure(Throwable e) {
+                    logger.info("failed to send allocated dangled", e);
+                }
+            });
+        } catch (Throwable e) {
+            logger.warn("failed to send allocate dangled", e);
+        }
+    }
+}

--- a/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
+++ b/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
@@ -19,15 +19,10 @@
 
 package org.elasticsearch.gateway;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.ElasticsearchIllegalStateException;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterChangedEvent;
-import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateListener;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
@@ -42,137 +37,38 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
-import org.elasticsearch.common.util.concurrent.FutureUtils;
-import org.elasticsearch.common.xcontent.ToXContent;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.env.NodeEnvironment;
-import org.elasticsearch.env.ShardLock;
-import org.elasticsearch.index.Index;
-import org.elasticsearch.indices.IndicesService;
-import org.elasticsearch.threadpool.ThreadPool;
 
 import java.io.IOException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ScheduledFuture;
-import java.util.regex.Pattern;
 
 /**
  *
  */
 public class GatewayMetaState extends AbstractComponent implements ClusterStateListener {
 
-    static final String GLOBAL_STATE_FILE_PREFIX = "global-";
-    private static final String INDEX_STATE_FILE_PREFIX = "state-";
-    static final Pattern GLOBAL_STATE_FILE_PATTERN = Pattern.compile(GLOBAL_STATE_FILE_PREFIX + "(\\d+)(" + MetaDataStateFormat.STATE_FILE_EXTENSION + ")?");
-    static final Pattern INDEX_STATE_FILE_PATTERN = Pattern.compile(INDEX_STATE_FILE_PREFIX + "(\\d+)(" + MetaDataStateFormat.STATE_FILE_EXTENSION + ")?");
-    private static final String GLOBAL_STATE_LOG_TYPE = "[_global]";
     private static final String DEPRECATED_SETTING_ROUTING_HASH_FUNCTION = "cluster.routing.operation.hash.type";
     private static final String DEPRECATED_SETTING_ROUTING_USE_TYPE = "cluster.routing.operation.use_type";
-    public static final String GATEWAY_DANGLING_TIMEOUT = "gateway.dangling_timeout";
-    public static final String GATEWAY_DELETE_TIMEOUT = "gateway.delete_timeout";
-    public static final String GATEWAY_AUTO_IMPORT_DANGLED = "gateway.auto_import_dangled";
-    // legacy - this used to be in a different package
-    private static final String GATEWAY_LOCAL_DANGLING_TIMEOUT = "gateway.local.dangling_timeout";
-    private static final String GATEWAY_LOCAL_AUTO_IMPORT_DANGLED = "gateway.local.auto_import_dangled";
-
-    static enum AutoImportDangledState {
-        NO() {
-            @Override
-            public boolean shouldImport() {
-                return false;
-            }
-        },
-        YES() {
-            @Override
-            public boolean shouldImport() {
-                return true;
-            }
-        },
-        CLOSED() {
-            @Override
-            public boolean shouldImport() {
-                return true;
-            }
-        };
-
-        public abstract boolean shouldImport();
-
-        public static AutoImportDangledState fromString(String value) {
-            if ("no".equalsIgnoreCase(value)) {
-                return NO;
-            } else if ("yes".equalsIgnoreCase(value)) {
-                return YES;
-            } else if ("closed".equalsIgnoreCase(value)) {
-                return CLOSED;
-            } else {
-                throw new ElasticsearchIllegalArgumentException("failed to parse [" + value + "], not a valid auto dangling import type");
-            }
-        }
-    }
 
     private final NodeEnvironment nodeEnv;
-    private final ThreadPool threadPool;
-
-    private final LocalAllocateDangledIndices allocateDangledIndices;
+    private final MetaStateService metaStateService;
+    private final DanglingIndicesState danglingIndicesState;
 
     @Nullable
     private volatile MetaData currentMetaData;
 
-    private final XContentType format;
-    private final ToXContent.Params formatParams;
-    private final ToXContent.Params gatewayModeFormatParams;
-
-
-    private final AutoImportDangledState autoImportDangled;
-    private final TimeValue danglingTimeout;
-    private final TimeValue deleteTimeout;
-    private final Map<String, DanglingIndex> danglingIndices = ConcurrentCollections.newConcurrentMap();
-    private final Object danglingMutex = new Object();
-    private final IndicesService indicesService;
-    private final ClusterService clusterService;
-
     @Inject
-    public GatewayMetaState(Settings settings, ThreadPool threadPool, NodeEnvironment nodeEnv,
-                            TransportNodesListGatewayMetaState nodesListGatewayMetaState, LocalAllocateDangledIndices allocateDangledIndices,
-                            IndicesService indicesService, ClusterService clusterService) throws Exception {
+    public GatewayMetaState(Settings settings, NodeEnvironment nodeEnv, MetaStateService metaStateService,
+                            DanglingIndicesState danglingIndicesState, TransportNodesListGatewayMetaState nodesListGatewayMetaState) throws Exception {
         super(settings);
         this.nodeEnv = nodeEnv;
-        this.threadPool = threadPool;
-        this.format = XContentType.fromRestContentType(settings.get("format", "smile"));
-        this.allocateDangledIndices = allocateDangledIndices;
+        this.metaStateService = metaStateService;
+        this.danglingIndicesState = danglingIndicesState;
         nodesListGatewayMetaState.init(this);
 
-        if (this.format == XContentType.SMILE) {
-            Map<String, String> params = Maps.newHashMap();
-            params.put("binary", "true");
-            formatParams = new ToXContent.MapParams(params);
-            Map<String, String> gatewayModeParams = Maps.newHashMap();
-            gatewayModeParams.put("binary", "true");
-            gatewayModeParams.put(MetaData.CONTEXT_MODE_PARAM, MetaData.CONTEXT_MODE_GATEWAY);
-            gatewayModeFormatParams = new ToXContent.MapParams(gatewayModeParams);
-        } else {
-            formatParams = ToXContent.EMPTY_PARAMS;
-            Map<String, String> gatewayModeParams = Maps.newHashMap();
-            gatewayModeParams.put(MetaData.CONTEXT_MODE_PARAM, MetaData.CONTEXT_MODE_GATEWAY);
-            gatewayModeFormatParams = new ToXContent.MapParams(gatewayModeParams);
-        }
 
-        this.autoImportDangled = AutoImportDangledState.fromString(settings.get(GATEWAY_AUTO_IMPORT_DANGLED, settings.get(GATEWAY_LOCAL_AUTO_IMPORT_DANGLED, AutoImportDangledState.YES.toString())));
-        this.danglingTimeout = settings.getAsTime(GATEWAY_DANGLING_TIMEOUT, settings.getAsTime(GATEWAY_LOCAL_DANGLING_TIMEOUT, TimeValue.timeValueHours(2)));
-        this.deleteTimeout = settings.getAsTime(GATEWAY_DELETE_TIMEOUT, TimeValue.timeValueSeconds(30));
-
-        logger.debug("using {} [{}],  {} [{}], with {} [{}]",
-                GATEWAY_AUTO_IMPORT_DANGLED, this.autoImportDangled,
-                GATEWAY_DELETE_TIMEOUT, this.deleteTimeout,
-                GATEWAY_DANGLING_TIMEOUT, this.danglingTimeout);
         if (DiscoveryNode.masterNode(settings) || DiscoveryNode.dataNode(settings)) {
             nodeEnv.ensureAtomicMoveSupported();
         }
@@ -181,19 +77,17 @@ public class GatewayMetaState extends AbstractComponent implements ClusterStateL
                 ensureNoPre019State();
                 pre20Upgrade();
                 long start = System.currentTimeMillis();
-                loadState();
+                metaStateService.loadFullState();
                 logger.debug("took {} to load state", TimeValue.timeValueMillis(System.currentTimeMillis() - start));
             } catch (Exception e) {
                 logger.error("failed to read local state, exiting...", e);
                 throw e;
             }
         }
-        this.indicesService = indicesService;
-        this.clusterService = clusterService;
     }
 
     public MetaData loadMetaState() throws Exception {
-        return loadState();
+        return metaStateService.loadFullState();
     }
 
     @Override
@@ -214,7 +108,7 @@ public class GatewayMetaState extends AbstractComponent implements ClusterStateL
             // check if the global state changed?
             if (currentMetaData == null || !MetaData.isGlobalStateEquals(currentMetaData, newMetaData)) {
                 try {
-                    writeGlobalState("changed", newMetaData);
+                    metaStateService.writeGlobalState("changed", newMetaData);
                 } catch (Throwable e) {
                     success = false;
                 }
@@ -227,7 +121,7 @@ public class GatewayMetaState extends AbstractComponent implements ClusterStateL
                 if (currentMetaData == null) {
                     // a new event..., check from the state stored
                     try {
-                        currentIndexMetaData = loadIndexState(indexMetaData.index());
+                        currentIndexMetaData = metaStateService.loadIndexState(indexMetaData.index());
                     } catch (IOException ex) {
                         throw new ElasticsearchException("failed to load index state", ex);
                     }
@@ -246,197 +140,19 @@ public class GatewayMetaState extends AbstractComponent implements ClusterStateL
                 }
 
                 try {
-                    writeIndex(writeReason, indexMetaData, currentIndexMetaData);
+                    metaStateService.writeIndex(writeReason, indexMetaData, currentIndexMetaData);
                 } catch (Throwable e) {
                     success = false;
                 }
             }
         }
 
-        // handle dangling indices, we handle those for all nodes that have a node file (data or master)
-        if (nodeEnv.hasNodeFile()) {
-            if (danglingTimeout.millis() >= 0) {
-                synchronized (danglingMutex) {
-                    for (String danglingIndex : danglingIndices.keySet()) {
-                        if (newMetaData.hasIndex(danglingIndex)) {
-                            logger.debug("[{}] no longer dangling (created), removing", danglingIndex);
-                            DanglingIndex removed = danglingIndices.remove(danglingIndex);
-                            FutureUtils.cancel(removed.future);
-                        }
-                    }
-                    // delete indices that are no longer part of the metadata
-                    try {
-                        for (String indexName : nodeEnv.findAllIndices()) {
-                            // if we have the index on the metadata, don't delete it
-                            if (newMetaData.hasIndex(indexName)) {
-                                continue;
-                            }
-                            if (danglingIndices.containsKey(indexName)) {
-                                // already dangling, continue
-                                continue;
-                            }
-                            final IndexMetaData indexMetaData = loadIndexState(indexName);
-                            if (indexMetaData != null) {
-                                if(autoImportDangled.shouldImport()){
-                                    logger.info("[{}] dangling index, exists on local file system, but not in cluster metadata, auto import to cluster state [{}]", indexName, autoImportDangled);
-                                    danglingIndices.put(indexName, new DanglingIndex(indexName, null));
-                                } else if (danglingTimeout.millis() == 0) {
-                                    logger.info("[{}] dangling index, exists on local file system, but not in cluster metadata, timeout set to 0, deleting now", indexName);
-                                    indicesService.deleteIndexStore("dangling index with timeout set to 0", indexMetaData, state);
-                                } else {
-                                    logger.info("[{}] dangling index, exists on local file system, but not in cluster metadata, scheduling to delete in [{}], auto import to cluster state [{}]", indexName, danglingTimeout, autoImportDangled);
-                                    danglingIndices.put(indexName,
-                                            new DanglingIndex(indexName,
-                                                    threadPool.schedule(danglingTimeout,
-                                                            ThreadPool.Names.SAME,
-                                                            new RemoveDanglingIndex(indexMetaData))));
-                                }
-                            }
-                        }
-                    } catch (Throwable e) {
-                        logger.warn("failed to find dangling indices", e);
-                    }
-                }
-            }
-            if (autoImportDangled.shouldImport() && !danglingIndices.isEmpty()) {
-                final List<IndexMetaData> dangled = Lists.newArrayList();
-                for (String indexName : danglingIndices.keySet()) {
-                    IndexMetaData indexMetaData;
-                    try {
-                        indexMetaData = loadIndexState(indexName);
-                    } catch (IOException ex) {
-                        throw new ElasticsearchException("failed to load index state", ex);
-                    }
-                    if (indexMetaData == null) {
-                        logger.debug("failed to find state for dangling index [{}]", indexName);
-                        continue;
-                    }
-                    // we might have someone copying over an index, renaming the directory, handle that
-                    if (!indexMetaData.index().equals(indexName)) {
-                        logger.info("dangled index directory name is [{}], state name is [{}], renaming to directory name", indexName, indexMetaData.index());
-                        indexMetaData = IndexMetaData.builder(indexMetaData).index(indexName).build();
-                    }
-                    if (autoImportDangled == AutoImportDangledState.CLOSED) {
-                        indexMetaData = IndexMetaData.builder(indexMetaData).state(IndexMetaData.State.CLOSE).build();
-                    }
-                    if (indexMetaData != null) {
-                        dangled.add(indexMetaData);
-                    }
-                }
-                IndexMetaData[] dangledIndices = dangled.toArray(new IndexMetaData[dangled.size()]);
-                try {
-                    allocateDangledIndices.allocateDangled(dangledIndices, new LocalAllocateDangledIndices.Listener() {
-                        @Override
-                        public void onResponse(LocalAllocateDangledIndices.AllocateDangledResponse response) {
-                            logger.trace("allocated dangled");
-                        }
-
-                        @Override
-                        public void onFailure(Throwable e) {
-                            logger.info("failed to send allocated dangled", e);
-                        }
-                    });
-                } catch (Throwable e) {
-                    logger.warn("failed to send allocate dangled", e);
-                }
-            }
-        }
+        danglingIndicesState.processDanglingIndices(newMetaData);
 
         if (success) {
             currentMetaData = newMetaData;
         }
     }
-
-    /**
-     * Returns a StateFormat that can read and write {@link MetaData}
-     */
-    static MetaDataStateFormat<MetaData> globalStateFormat(XContentType format, final ToXContent.Params formatParams, final boolean deleteOldFiles) {
-        return new MetaDataStateFormat<MetaData>(format, deleteOldFiles) {
-
-            @Override
-            public void toXContent(XContentBuilder builder, MetaData state) throws IOException {
-                MetaData.Builder.toXContent(state, builder, formatParams);
-            }
-
-            @Override
-            public MetaData fromXContent(XContentParser parser) throws IOException {
-                return MetaData.Builder.fromXContent(parser);
-            }
-        };
-    }
-
-    /**
-     * Returns a StateFormat that can read and write {@link IndexMetaData}
-     */
-    static MetaDataStateFormat<IndexMetaData> indexStateFormat(XContentType format, final ToXContent.Params formatParams, boolean deleteOldFiles) {
-        return new MetaDataStateFormat<IndexMetaData>(format, deleteOldFiles) {
-
-            @Override
-            public void toXContent(XContentBuilder builder, IndexMetaData state) throws IOException {
-                IndexMetaData.Builder.toXContent(state, builder, formatParams);            }
-
-            @Override
-            public IndexMetaData fromXContent(XContentParser parser) throws IOException {
-                return IndexMetaData.Builder.fromXContent(parser);
-            }
-        };
-    }
-
-    private void writeIndex(String reason, IndexMetaData indexMetaData, @Nullable IndexMetaData previousIndexMetaData) throws Exception {
-        logger.trace("[{}] writing state, reason [{}]", indexMetaData.index(), reason);
-        final boolean deleteOldFiles = previousIndexMetaData != null && previousIndexMetaData.version() != indexMetaData.version();
-        final MetaDataStateFormat<IndexMetaData> writer = indexStateFormat(format, formatParams, deleteOldFiles);
-        try {
-            writer.write(indexMetaData, INDEX_STATE_FILE_PREFIX, indexMetaData.version(),
-                    nodeEnv.indexPaths(new Index(indexMetaData.index())));
-        } catch (Throwable ex) {
-            logger.warn("[{}]: failed to write index state", ex, indexMetaData.index());
-            throw new IOException("failed to write state for [" + indexMetaData.index() + "]", ex);
-        }
-    }
-
-    private void writeGlobalState(String reason, MetaData metaData) throws Exception {
-        logger.trace("{} writing state, reason [{}]", GLOBAL_STATE_LOG_TYPE, reason);
-        final MetaDataStateFormat<MetaData> writer = globalStateFormat(format, gatewayModeFormatParams, true);
-        try {
-            writer.write(metaData, GLOBAL_STATE_FILE_PREFIX, metaData.version(), nodeEnv.nodeDataPaths());
-        } catch (Throwable ex) {
-            logger.warn("{}: failed to write global state", ex, GLOBAL_STATE_LOG_TYPE);
-            throw new IOException("failed to write global state", ex);
-        }
-    }
-
-    private MetaData loadState() throws Exception {
-        MetaData globalMetaData = loadGlobalState();
-        MetaData.Builder metaDataBuilder;
-        if (globalMetaData != null) {
-            metaDataBuilder = MetaData.builder(globalMetaData);
-        } else {
-            metaDataBuilder = MetaData.builder();
-        }
-
-        final Set<String> indices = nodeEnv.findAllIndices();
-        for (String index : indices) {
-            IndexMetaData indexMetaData = loadIndexState(index);
-            if (indexMetaData == null) {
-                logger.debug("[{}] failed to find metadata for existing index location", index);
-            } else {
-                metaDataBuilder.put(indexMetaData, false);
-            }
-        }
-        return metaDataBuilder.build();
-    }
-
-    @Nullable
-    private IndexMetaData loadIndexState(String index) throws IOException {
-        return MetaDataStateFormat.loadLatestState(logger, indexStateFormat(format, formatParams, true),
-                INDEX_STATE_FILE_PATTERN, "[" + index + "]", nodeEnv.indexPaths(new Index(index)));
-    }
-
-    private MetaData loadGlobalState() throws IOException {
-        return MetaDataStateFormat.loadLatestState(logger, globalStateFormat(format, gatewayModeFormatParams, true), GLOBAL_STATE_FILE_PATTERN, GLOBAL_STATE_LOG_TYPE, nodeEnv.nodeDataPaths());
-    }
-
 
     /**
      * Throws an IAE if a pre 0.19 state is detected
@@ -500,7 +216,7 @@ public class GatewayMetaState extends AbstractComponent implements ClusterStateL
                         .version(indexMetaData.version())
                         .settings(indexSettings)
                         .build();
-                writeIndex("upgrade", newMetaData, null);
+                metaStateService.writeIndex("upgrade", newMetaData, null);
             } else if (indexMetaData.getCreationVersion().onOrAfter(Version.V_2_0_0)) {
                 if (indexMetaData.getSettings().get(IndexMetaData.SETTING_LEGACY_ROUTING_HASH_FUNCTION) != null
                         || indexMetaData.getSettings().get(IndexMetaData.SETTING_LEGACY_ROUTING_USE_TYPE) != null) {
@@ -514,41 +230,4 @@ public class GatewayMetaState extends AbstractComponent implements ClusterStateL
                     + "used some custom routing logic, you can now remove these settings from your `elasticsearch.yml` file", DEPRECATED_SETTING_ROUTING_HASH_FUNCTION, DEPRECATED_SETTING_ROUTING_USE_TYPE);
         }
     }
-
-    class RemoveDanglingIndex implements Runnable {
-
-        private final IndexMetaData metaData;
-
-        RemoveDanglingIndex(IndexMetaData metaData) {
-            this.metaData = metaData;
-        }
-
-        @Override
-        public void run() {
-            synchronized (danglingMutex) {
-                DanglingIndex remove = danglingIndices.remove(metaData.index());
-                // no longer there...
-                if (remove == null) {
-                    return;
-                }
-                logger.warn("[{}] deleting dangling index", metaData.index());
-                try {
-                    indicesService.deleteIndexStore("deleting dangling index", metaData, clusterService.state());
-                } catch (Exception ex) {
-                    logger.debug("failed to delete dangling index", ex);
-                }
-            }
-        }
-    }
-
-    static class DanglingIndex {
-        public final String index;
-        public final ScheduledFuture future;
-
-        DanglingIndex(String index, ScheduledFuture future) {
-            this.index = index;
-            this.future = future;
-        }
-    }
-
 }

--- a/src/main/java/org/elasticsearch/gateway/GatewayModule.java
+++ b/src/main/java/org/elasticsearch/gateway/GatewayModule.java
@@ -28,6 +28,8 @@ public class GatewayModule extends AbstractModule {
 
     @Override
     protected void configure() {
+        bind(MetaStateService.class).asEagerSingleton();
+        bind(DanglingIndicesState.class).asEagerSingleton();
         bind(GatewayService.class).asEagerSingleton();
         bind(Gateway.class).asEagerSingleton();
         bind(GatewayShardsState.class).asEagerSingleton();

--- a/src/main/java/org/elasticsearch/gateway/LocalAllocateDangledIndices.java
+++ b/src/main/java/org/elasticsearch/gateway/LocalAllocateDangledIndices.java
@@ -40,6 +40,7 @@ import org.elasticsearch.transport.*;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collection;
 
 /**
  */
@@ -62,14 +63,14 @@ public class LocalAllocateDangledIndices extends AbstractComponent {
         transportService.registerHandler(ACTION_NAME, new AllocateDangledRequestHandler());
     }
 
-    public void allocateDangled(IndexMetaData[] indices, final Listener listener) {
+    public void allocateDangled(Collection<IndexMetaData> indices, final Listener listener) {
         ClusterState clusterState = clusterService.state();
         DiscoveryNode masterNode = clusterState.nodes().masterNode();
         if (masterNode == null) {
             listener.onFailure(new MasterNotDiscoveredException("no master to send allocate dangled request"));
             return;
         }
-        AllocateDangledRequest request = new AllocateDangledRequest(clusterService.localNode(), indices);
+        AllocateDangledRequest request = new AllocateDangledRequest(clusterService.localNode(), indices.toArray(new IndexMetaData[indices.size()]));
         transportService.sendRequest(masterNode, ACTION_NAME, request, new TransportResponseHandler<AllocateDangledResponse>() {
             @Override
             public AllocateDangledResponse newInstance() {

--- a/src/main/java/org/elasticsearch/gateway/MetaStateService.java
+++ b/src/main/java/org/elasticsearch/gateway/MetaStateService.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.gateway;
+
+import com.google.common.collect.Maps;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.component.AbstractComponent;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.env.NodeEnvironment;
+import org.elasticsearch.index.Index;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * Handles writing and loading both {@link MetaData} and {@link IndexMetaData}
+ */
+public class MetaStateService extends AbstractComponent {
+
+    static final String FORMAT_SETTING = "gateway.format";
+
+    static final String GLOBAL_STATE_FILE_PREFIX = "global-";
+    private static final String INDEX_STATE_FILE_PREFIX = "state-";
+    static final Pattern GLOBAL_STATE_FILE_PATTERN = Pattern.compile(GLOBAL_STATE_FILE_PREFIX + "(\\d+)(" + MetaDataStateFormat.STATE_FILE_EXTENSION + ")?");
+    static final Pattern INDEX_STATE_FILE_PATTERN = Pattern.compile(INDEX_STATE_FILE_PREFIX + "(\\d+)(" + MetaDataStateFormat.STATE_FILE_EXTENSION + ")?");
+    private static final String GLOBAL_STATE_LOG_TYPE = "[_global]";
+
+    private final NodeEnvironment nodeEnv;
+
+    private final XContentType format;
+    private final ToXContent.Params formatParams;
+    private final ToXContent.Params gatewayModeFormatParams;
+
+    @Inject
+    public MetaStateService(Settings settings, NodeEnvironment nodeEnv) {
+        super(settings);
+        this.nodeEnv = nodeEnv;
+        this.format = XContentType.fromRestContentType(settings.get(FORMAT_SETTING, "smile"));
+
+        if (this.format == XContentType.SMILE) {
+            Map<String, String> params = Maps.newHashMap();
+            params.put("binary", "true");
+            formatParams = new ToXContent.MapParams(params);
+            Map<String, String> gatewayModeParams = Maps.newHashMap();
+            gatewayModeParams.put("binary", "true");
+            gatewayModeParams.put(MetaData.CONTEXT_MODE_PARAM, MetaData.CONTEXT_MODE_GATEWAY);
+            gatewayModeFormatParams = new ToXContent.MapParams(gatewayModeParams);
+        } else {
+            formatParams = ToXContent.EMPTY_PARAMS;
+            Map<String, String> gatewayModeParams = Maps.newHashMap();
+            gatewayModeParams.put(MetaData.CONTEXT_MODE_PARAM, MetaData.CONTEXT_MODE_GATEWAY);
+            gatewayModeFormatParams = new ToXContent.MapParams(gatewayModeParams);
+        }
+    }
+
+    /**
+     * Loads the full state, which includes both the global state and all the indices
+     * meta state.
+     */
+    MetaData loadFullState() throws Exception {
+        MetaData globalMetaData = loadGlobalState();
+        MetaData.Builder metaDataBuilder;
+        if (globalMetaData != null) {
+            metaDataBuilder = MetaData.builder(globalMetaData);
+        } else {
+            metaDataBuilder = MetaData.builder();
+        }
+
+        final Set<String> indices = nodeEnv.findAllIndices();
+        for (String index : indices) {
+            IndexMetaData indexMetaData = loadIndexState(index);
+            if (indexMetaData == null) {
+                logger.debug("[{}] failed to find metadata for existing index location", index);
+            } else {
+                metaDataBuilder.put(indexMetaData, false);
+            }
+        }
+        return metaDataBuilder.build();
+    }
+
+    /**
+     * Loads the index state for the provided index name, returning null if doesn't exists.
+     */
+    @Nullable
+    IndexMetaData loadIndexState(String index) throws IOException {
+        return MetaDataStateFormat.loadLatestState(logger, indexStateFormat(format, formatParams, true),
+                INDEX_STATE_FILE_PATTERN, "[" + index + "]", nodeEnv.indexPaths(new Index(index)));
+    }
+
+    /**
+     * Loads the global state, *without* index state, see {@link #loadFullState()} for that.
+     */
+    MetaData loadGlobalState() throws IOException {
+        return MetaDataStateFormat.loadLatestState(logger, globalStateFormat(format, gatewayModeFormatParams, true), GLOBAL_STATE_FILE_PATTERN, GLOBAL_STATE_LOG_TYPE, nodeEnv.nodeDataPaths());
+    }
+
+    /**
+     * Writes the index state.
+     */
+    void writeIndex(String reason, IndexMetaData indexMetaData, @Nullable IndexMetaData previousIndexMetaData) throws Exception {
+        logger.trace("[{}] writing state, reason [{}]", indexMetaData.index(), reason);
+        final boolean deleteOldFiles = previousIndexMetaData != null && previousIndexMetaData.version() != indexMetaData.version();
+        final MetaDataStateFormat<IndexMetaData> writer = indexStateFormat(format, formatParams, deleteOldFiles);
+        try {
+            writer.write(indexMetaData, INDEX_STATE_FILE_PREFIX, indexMetaData.version(),
+                    nodeEnv.indexPaths(new Index(indexMetaData.index())));
+        } catch (Throwable ex) {
+            logger.warn("[{}]: failed to write index state", ex, indexMetaData.index());
+            throw new IOException("failed to write state for [" + indexMetaData.index() + "]", ex);
+        }
+    }
+
+    /**
+     * Writes the global state, *without* the indices states.
+     */
+    void writeGlobalState(String reason, MetaData metaData) throws Exception {
+        logger.trace("{} writing state, reason [{}]", GLOBAL_STATE_LOG_TYPE, reason);
+        final MetaDataStateFormat<MetaData> writer = globalStateFormat(format, gatewayModeFormatParams, true);
+        try {
+            writer.write(metaData, GLOBAL_STATE_FILE_PREFIX, metaData.version(), nodeEnv.nodeDataPaths());
+        } catch (Throwable ex) {
+            logger.warn("{}: failed to write global state", ex, GLOBAL_STATE_LOG_TYPE);
+            throw new IOException("failed to write global state", ex);
+        }
+    }
+
+    /**
+     * Returns a StateFormat that can read and write {@link MetaData}
+     */
+    static MetaDataStateFormat<MetaData> globalStateFormat(XContentType format, final ToXContent.Params formatParams, final boolean deleteOldFiles) {
+        return new MetaDataStateFormat<MetaData>(format, deleteOldFiles) {
+
+            @Override
+            public void toXContent(XContentBuilder builder, MetaData state) throws IOException {
+                MetaData.Builder.toXContent(state, builder, formatParams);
+            }
+
+            @Override
+            public MetaData fromXContent(XContentParser parser) throws IOException {
+                return MetaData.Builder.fromXContent(parser);
+            }
+        };
+    }
+
+    /**
+     * Returns a StateFormat that can read and write {@link IndexMetaData}
+     */
+    static MetaDataStateFormat<IndexMetaData> indexStateFormat(XContentType format, final ToXContent.Params formatParams, boolean deleteOldFiles) {
+        return new MetaDataStateFormat<IndexMetaData>(format, deleteOldFiles) {
+
+            @Override
+            public void toXContent(XContentBuilder builder, IndexMetaData state) throws IOException {
+                IndexMetaData.Builder.toXContent(state, builder, formatParams);            }
+
+            @Override
+            public IndexMetaData fromXContent(XContentParser parser) throws IOException {
+                return IndexMetaData.Builder.fromXContent(parser);
+            }
+        };
+    }
+}

--- a/src/test/java/org/elasticsearch/gateway/DanglingIndicesStateTests.java
+++ b/src/test/java/org/elasticsearch/gateway/DanglingIndicesStateTests.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.gateway;
+
+import com.google.common.collect.ImmutableList;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.env.NodeEnvironment;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+
+/**
+ */
+public class DanglingIndicesStateTests extends ElasticsearchTestCase {
+
+    private static Settings indexSettings = ImmutableSettings.builder()
+            .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
+            .build();
+
+    @Test
+    public void testCleanupWhenEmpty() throws Exception {
+        final NodeEnvironment env = newNodeEnvironment();
+        MetaStateService metaStateService = new MetaStateService(ImmutableSettings.EMPTY, env);
+        DanglingIndicesState danglingState = new DanglingIndicesState(ImmutableSettings.EMPTY, env, metaStateService, null);
+
+        assertTrue(danglingState.getDanglingIndices().isEmpty());
+        MetaData metaData = MetaData.builder().build();
+        danglingState.cleanupAllocatedDangledIndices(metaData);
+        assertTrue(danglingState.getDanglingIndices().isEmpty());
+    }
+
+    @Test
+    public void testDanglingProcessing() throws Exception {
+        final NodeEnvironment env = newNodeEnvironment();
+        MetaStateService metaStateService = new MetaStateService(ImmutableSettings.EMPTY, env);
+        DanglingIndicesState danglingState = new DanglingIndicesState(ImmutableSettings.EMPTY, env, metaStateService, null);
+
+        MetaData metaData = MetaData.builder().build();
+
+        IndexMetaData dangledIndex = IndexMetaData.builder("test1").settings(indexSettings).build();
+        metaStateService.writeIndex("test_write", dangledIndex, null);
+
+        // check that several runs when not in the metadata still keep the dangled index around
+        int numberOfChecks = randomIntBetween(1, 10);
+        for (int i = 0; i < numberOfChecks; i++) {
+            Map<String, IndexMetaData> newDanglingIndices = danglingState.findNewDanglingIndices(metaData);
+            assertThat(newDanglingIndices.size(), equalTo(1));
+            assertThat(newDanglingIndices.keySet(), Matchers.hasItems("test1"));
+            assertTrue(danglingState.getDanglingIndices().isEmpty());
+        }
+
+        for (int i = 0; i < numberOfChecks; i++) {
+            danglingState.findNewAndAddDanglingIndices(metaData);
+
+            assertThat(danglingState.getDanglingIndices().size(), equalTo(1));
+            assertThat(danglingState.getDanglingIndices().keySet(), Matchers.hasItems("test1"));
+        }
+
+        // simulate allocation to the metadata
+        metaData = MetaData.builder(metaData).put(dangledIndex, true).build();
+
+        // check that several runs when in the metadata, but not cleaned yet, still keeps dangled
+        for (int i = 0; i < numberOfChecks; i++) {
+            Map<String, IndexMetaData> newDanglingIndices = danglingState.findNewDanglingIndices(metaData);
+            assertTrue(newDanglingIndices.isEmpty());
+
+            assertThat(danglingState.getDanglingIndices().size(), equalTo(1));
+            assertThat(danglingState.getDanglingIndices().keySet(), Matchers.hasItems("test1"));
+        }
+
+        danglingState.cleanupAllocatedDangledIndices(metaData);
+        assertTrue(danglingState.getDanglingIndices().isEmpty());
+    }
+
+    @Test
+    public void testRenameOfIndexState() throws Exception {
+        final NodeEnvironment env = newNodeEnvironment();
+        MetaStateService metaStateService = new MetaStateService(ImmutableSettings.EMPTY, env);
+        DanglingIndicesState danglingState = new DanglingIndicesState(ImmutableSettings.EMPTY, env, metaStateService, null);
+
+        MetaData metaData = MetaData.builder().build();
+
+        IndexMetaData dangledIndex = IndexMetaData.builder("test1").settings(indexSettings).build();
+        metaStateService.writeIndex("test_write", dangledIndex, null);
+
+        for (Path path : env.indexPaths(new Index("test1"))) {
+            Files.move(path, path.getParent().resolve("test1_renamed"));
+        }
+
+        Map<String, IndexMetaData> newDanglingIndices = danglingState.findNewDanglingIndices(metaData);
+        assertThat(newDanglingIndices.size(), equalTo(1));
+        assertThat(newDanglingIndices.keySet(), Matchers.hasItems("test1_renamed"));
+    }
+}

--- a/src/test/java/org/elasticsearch/gateway/MetaDataStateFormatTest.java
+++ b/src/test/java/org/elasticsearch/gateway/MetaDataStateFormatTest.java
@@ -258,7 +258,7 @@ public class MetaDataStateFormatTest extends ElasticsearchTestCase {
     // If the latest version doesn't use the legacy format while previous versions do, then fail hard
     public void testLatestVersionDoesNotUseLegacy() throws IOException {
         final ToXContent.Params params = ToXContent.EMPTY_PARAMS;
-        MetaDataStateFormat<MetaData> format = GatewayMetaState.globalStateFormat(randomFrom(XContentType.values()), params, randomBoolean());
+        MetaDataStateFormat<MetaData> format = MetaStateService.globalStateFormat(randomFrom(XContentType.values()), params, randomBoolean());
         final Path[] dirs = new Path[2];
         dirs[0] = newTempDirPath(LifecycleScope.TEST);
         dirs[1] = newTempDirPath(LifecycleScope.TEST);
@@ -268,14 +268,14 @@ public class MetaDataStateFormatTest extends ElasticsearchTestCase {
         final Path dir1 = randomFrom(dirs);
         final int v1 = randomInt(10);
         // write a first state file in the new format
-        format.write(randomMeta(), GatewayMetaState.GLOBAL_STATE_FILE_PREFIX, v1, dir1);
+        format.write(randomMeta(), MetaStateService.GLOBAL_STATE_FILE_PREFIX, v1, dir1);
 
         // write older state files in the old format but with a newer version
         final int numLegacyFiles = randomIntBetween(1, 5);
         for (int i = 0; i < numLegacyFiles; ++i) {
             final Path dir2 = randomFrom(dirs);
             final int v2 = v1 + 1 + randomInt(10);
-            try (XContentBuilder xcontentBuilder = XContentFactory.contentBuilder(format.format(), Files.newOutputStream(dir2.resolve(MetaDataStateFormat.STATE_DIR_NAME).resolve(GatewayMetaState.GLOBAL_STATE_FILE_PREFIX + v2)))) {
+            try (XContentBuilder xcontentBuilder = XContentFactory.contentBuilder(format.format(), Files.newOutputStream(dir2.resolve(MetaDataStateFormat.STATE_DIR_NAME).resolve(MetaStateService.GLOBAL_STATE_FILE_PREFIX + v2)))) {
                 xcontentBuilder.startObject();
                 MetaData.Builder.toXContent(randomMeta(), xcontentBuilder, params);
                 xcontentBuilder.endObject();
@@ -283,7 +283,7 @@ public class MetaDataStateFormatTest extends ElasticsearchTestCase {
         }
 
         try {
-            MetaDataStateFormat.loadLatestState(logger, format, GatewayMetaState.GLOBAL_STATE_FILE_PATTERN, "foobar", dirs);
+            MetaDataStateFormat.loadLatestState(logger, format, MetaStateService.GLOBAL_STATE_FILE_PATTERN, "foobar", dirs);
             fail("latest version can not be read");
         } catch (ElasticsearchIllegalStateException ex) {
             assertThat(ex.getMessage(), startsWith("Could not find a state file to recover from among "));
@@ -293,7 +293,7 @@ public class MetaDataStateFormatTest extends ElasticsearchTestCase {
     // If both the legacy and the new format are available for the latest version, prefer the new format
     public void testPrefersNewerFormat() throws IOException {
         final ToXContent.Params params = ToXContent.EMPTY_PARAMS;
-        MetaDataStateFormat<MetaData> format = GatewayMetaState.globalStateFormat(randomFrom(XContentType.values()), params, randomBoolean());
+        MetaDataStateFormat<MetaData> format = MetaStateService.globalStateFormat(randomFrom(XContentType.values()), params, randomBoolean());
         final Path[] dirs = new Path[2];
         dirs[0] = newTempDirPath(LifecycleScope.TEST);
         dirs[1] = newTempDirPath(LifecycleScope.TEST);
@@ -310,16 +310,16 @@ public class MetaDataStateFormatTest extends ElasticsearchTestCase {
         final Path dir2 = randomFrom(dirs);
         MetaData meta2 = randomMeta();
         assertFalse(meta2.uuid().equals(uuid));
-        try (XContentBuilder xcontentBuilder = XContentFactory.contentBuilder(format.format(), Files.newOutputStream(dir2.resolve(MetaDataStateFormat.STATE_DIR_NAME).resolve(GatewayMetaState.GLOBAL_STATE_FILE_PREFIX + v)))) {
+        try (XContentBuilder xcontentBuilder = XContentFactory.contentBuilder(format.format(), Files.newOutputStream(dir2.resolve(MetaDataStateFormat.STATE_DIR_NAME).resolve(MetaStateService.GLOBAL_STATE_FILE_PREFIX + v)))) {
             xcontentBuilder.startObject();
             MetaData.Builder.toXContent(randomMeta(), xcontentBuilder, params);
             xcontentBuilder.endObject();
         }
 
         // write a second state file in the new format but with the same version
-        format.write(meta, GatewayMetaState.GLOBAL_STATE_FILE_PREFIX, v, dir1);
+        format.write(meta, MetaStateService.GLOBAL_STATE_FILE_PREFIX, v, dir1);
 
-        MetaData state = MetaDataStateFormat.loadLatestState(logger, format, GatewayMetaState.GLOBAL_STATE_FILE_PATTERN, "foobar", dirs);
+        MetaData state = MetaDataStateFormat.loadLatestState(logger, format, MetaStateService.GLOBAL_STATE_FILE_PATTERN, "foobar", dirs);
         assertThat(state.uuid(), equalTo(uuid));
     }
 
@@ -334,7 +334,7 @@ public class MetaDataStateFormatTest extends ElasticsearchTestCase {
             meta.add(randomMeta());
         }
         Set<Path> corruptedFiles = new HashSet<>();
-        MetaDataStateFormat<MetaData> format = GatewayMetaState.globalStateFormat(randomFrom(XContentType.values()), params, randomBoolean());
+        MetaDataStateFormat<MetaData> format = MetaStateService.globalStateFormat(randomFrom(XContentType.values()), params, randomBoolean());
         for (int i = 0; i < dirs.length; i++) {
             dirs[i] = newTempDirPath(LifecycleScope.TEST);
             Files.createDirectories(dirs[i].resolve(MetaDataStateFormat.STATE_DIR_NAME));
@@ -352,7 +352,7 @@ public class MetaDataStateFormatTest extends ElasticsearchTestCase {
                 }
             }
             for (int j = numLegacy; j < numStates; j++) {
-                format.write(meta.get(j), GatewayMetaState.GLOBAL_STATE_FILE_PREFIX, j, dirs[i]);
+                format.write(meta.get(j), MetaStateService.GLOBAL_STATE_FILE_PREFIX, j, dirs[i]);
                 if (randomBoolean() && (j < numStates - 1 || dirs.length > 0 && i != 0)) {  // corrupt a file that we do not necessarily need here....
                     Path file = dirs[i].resolve(MetaDataStateFormat.STATE_DIR_NAME).resolve("global-" + j + ".st");
                     corruptedFiles.add(file);
@@ -363,7 +363,7 @@ public class MetaDataStateFormatTest extends ElasticsearchTestCase {
         }
         List<Path> dirList = Arrays.asList(dirs);
         Collections.shuffle(dirList, getRandom());
-        MetaData loadedMetaData = MetaDataStateFormat.loadLatestState(logger, format, GatewayMetaState.GLOBAL_STATE_FILE_PATTERN, "foobar", dirList.toArray(new Path[0]));
+        MetaData loadedMetaData = MetaDataStateFormat.loadLatestState(logger, format, MetaStateService.GLOBAL_STATE_FILE_PATTERN, "foobar", dirList.toArray(new Path[0]));
         MetaData latestMetaData = meta.get(numStates-1);
         assertThat(loadedMetaData.uuid(), not(equalTo("_na_")));
         assertThat(loadedMetaData.uuid(), equalTo(latestMetaData.uuid()));
@@ -387,7 +387,7 @@ public class MetaDataStateFormatTest extends ElasticsearchTestCase {
                 MetaDataStateFormatTest.corruptFile(file, logger);
             }
             try {
-                MetaDataStateFormat.loadLatestState(logger, format, GatewayMetaState.GLOBAL_STATE_FILE_PATTERN, "foobar", dirList.toArray(new Path[0]));
+                MetaDataStateFormat.loadLatestState(logger, format, MetaStateService.GLOBAL_STATE_FILE_PATTERN, "foobar", dirList.toArray(new Path[0]));
                 fail("latest version can not be read");
             } catch (ElasticsearchException ex) {
                 assertThat(ex.getCause(), instanceOf(CorruptStateException.class));

--- a/src/test/java/org/elasticsearch/gateway/MetaStateServiceTests.java
+++ b/src/test/java/org/elasticsearch/gateway/MetaStateServiceTests.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.gateway;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.env.NodeEnvironment;
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+/**
+ */
+public class MetaStateServiceTests extends ElasticsearchTestCase {
+
+    private static Settings indexSettings = ImmutableSettings.builder()
+            .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
+            .build();
+
+    @Test
+    public void testWriteLoadIndex() throws Exception {
+        final NodeEnvironment env = newNodeEnvironment();
+        MetaStateService metaStateService = new MetaStateService(randomSettings(), env);
+
+        IndexMetaData index = IndexMetaData.builder("test1").settings(indexSettings).build();
+        metaStateService.writeIndex("test_write", index, null);
+        assertThat(metaStateService.loadIndexState("test1"), equalTo(index));
+    }
+
+    @Test
+    public void testLoadMissingIndex() throws Exception {
+        final NodeEnvironment env = newNodeEnvironment();
+        MetaStateService metaStateService = new MetaStateService(randomSettings(), env);
+        assertThat(metaStateService.loadIndexState("test1"), nullValue());
+    }
+
+    @Test
+    public void testWriteLoadGlobal() throws Exception {
+        final NodeEnvironment env = newNodeEnvironment();
+        MetaStateService metaStateService = new MetaStateService(randomSettings(), env);
+
+        MetaData metaData = MetaData.builder()
+                .persistentSettings(ImmutableSettings.builder().put("test1", "value1").build())
+                .build();
+        metaStateService.writeGlobalState("test_write", metaData);
+        assertThat(metaStateService.loadGlobalState().persistentSettings(), equalTo(metaData.persistentSettings()));
+    }
+
+    @Test
+    public void testWriteGlobalStateWithIndexAndNoIndexIsLoaded() throws Exception {
+        final NodeEnvironment env = newNodeEnvironment();
+        MetaStateService metaStateService = new MetaStateService(randomSettings(), env);
+
+        MetaData metaData = MetaData.builder()
+                .persistentSettings(ImmutableSettings.builder().put("test1", "value1").build())
+                .build();
+        IndexMetaData index = IndexMetaData.builder("test1").settings(indexSettings).build();
+        MetaData metaDataWithIndex = MetaData.builder(metaData).put(index, true).build();
+
+        metaStateService.writeGlobalState("test_write", metaDataWithIndex);
+        assertThat(metaStateService.loadGlobalState().persistentSettings(), equalTo(metaData.persistentSettings()));
+        assertThat(metaStateService.loadGlobalState().hasIndex("test1"), equalTo(false));
+    }
+
+    @Test
+    public void tesLoadGlobal() throws Exception {
+        final NodeEnvironment env = newNodeEnvironment();
+        MetaStateService metaStateService = new MetaStateService(randomSettings(), env);
+
+        IndexMetaData index = IndexMetaData.builder("test1").settings(indexSettings).build();
+        MetaData metaData = MetaData.builder()
+                .persistentSettings(ImmutableSettings.builder().put("test1", "value1").build())
+                .put(index, true)
+                .build();
+
+        metaStateService.writeGlobalState("test_write", metaData);
+        metaStateService.writeIndex("test_write", index, null);
+
+        MetaData loadedState = metaStateService.loadFullState();
+        assertThat(loadedState.persistentSettings(), equalTo(metaData.persistentSettings()));
+        assertThat(loadedState.hasIndex("test1"), equalTo(true));
+        assertThat(loadedState.index("test1"), equalTo(index));
+    }
+
+    private Settings randomSettings() {
+        ImmutableSettings.Builder builder = ImmutableSettings.builder();
+        if (randomBoolean()) {
+            builder.put(MetaStateService.FORMAT_SETTING, randomXContentType().shortName());
+        }
+        return builder.build();
+    }
+}

--- a/src/test/java/org/elasticsearch/test/ElasticsearchTestCase.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchTestCase.java
@@ -241,7 +241,7 @@ public abstract class ElasticsearchTestCase extends AbstractRandomizedTest {
         Requests.INDEX_CONTENT_TYPE = randomXContentType();
     }
 
-    private static XContentType randomXContentType() {
+    public static XContentType randomXContentType() {
         return randomFrom(XContentType.values());
     }
 


### PR DESCRIPTION
Remove the settings around dangling indices, such as no import and timeout for deletion, we always want to import dangling indices for safety, and we should not allow to change the behavior. This also cleans up the code quite a bit.
