### PR TITLE
Fix thread leak in Hunspell service tests

### DIFF
--- a/src/test/java/org/elasticsearch/indices/analyze/HunspellServiceTests.java
+++ b/src/test/java/org/elasticsearch/indices/analyze/HunspellServiceTests.java
@@ -91,7 +91,6 @@ public class HunspellServiceTests extends ElasticsearchIntegrationTest {
     }
 
     @Test
-    @LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elasticsearch/elasticsearch/issues/9849")
     public void testDicWithNoAff() throws Exception {
         Settings settings = ImmutableSettings.settingsBuilder()
                 .put("path.conf", getResourcePath("/indices/analyze/no_aff_conf_dir"))
@@ -111,7 +110,6 @@ public class HunspellServiceTests extends ElasticsearchIntegrationTest {
     }
 
     @Test
-    @LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elasticsearch/elasticsearch/issues/9849")
     public void testDicWithTwoAffs() throws Exception {
         Settings settings = ImmutableSettings.settingsBuilder()
                 .put("path.conf", getResourcePath("/indices/analyze/two_aff_conf_dir"))


### PR DESCRIPTION
An unchecked exception might be thrown when instantiating the HunspellService, leading to thread leaks in tests.

Closes #9849
