### PR TITLE
ban Throwable.toString() and Throwable.getMessage()

### DIFF
--- a/dev-tools/forbidden/core-signatures.txt
+++ b/dev-tools/forbidden/core-signatures.txt
@@ -114,3 +114,7 @@ org.apache.lucene.search.TimeLimitingCollector#getGlobalCounter()
 
 @defaultMessage Don't interrupt threads use FutureUtils#cancel(Future<T>) instead
 java.util.concurrent.Future#cancel(boolean)
+
+@defaultMessage Use ExceptionsHelper.stackTrace(Throwable) instead
+java.lang.Throwable#getMessage()
+java.lang.Throwable#toString()


### PR DESCRIPTION
This way, we never have "partial exceptions" with incomplete information anywhere.

I havent yet fixed any of the 97 violations in question.

 Errors in the branch look like this:
[ERROR] Forbidden method invocation: java.lang.Throwable#getMessage() [Use ExceptionsHelper.stackTrace(Throwable) instead]
[ERROR]   in org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardRepository (BlobStoreIndexShardRepository.java:152)
