### PR TITLE
Mark shadow replicas with 's' in _cat/shards output

### DIFF
--- a/rest-api-spec/test/cat.shards/10_basic.yaml
+++ b/rest-api-spec/test/cat.shards/10_basic.yaml
@@ -53,3 +53,26 @@
   - match:
       $body: |
                /^(index2 \s+ \d \s+ (p|r) \s+ ((STARTED|INITIALIZING) \s+ (\d \s+ (\d+|\d+[.]\d+)(kb|b) \s+)? \d{1,3}.\d{1,3}.\d{1,3}.\d{1,3} \s+ .+|UNASSIGNED \s+) \n?){5}$/
+
+  - do:
+      indices.create:
+        index: index3
+        body:
+          settings:
+            number_of_shards: "1"
+            number_of_replicas: "1"
+            shadow_replicas: true
+            shared_filesystem: false
+  - do:
+       cluster.health:
+         wait_for_status: yellow
+         wait_for_relocating_shards: 0
+
+  - do:
+      cat.shards:
+        index: index3
+        v: false
+  - match:
+      $body: |
+               /^(index3 \s+ \d \s+ (p|s) \s+ ((STARTED|INITIALIZING) \s+ (\d \s+ (\d+|\d+[.]\d+)(kb|b) \s+)? \d{1,3}.\d{1,3}.\d{1,3}.\d{1,3} \s+ .+|UNASSIGNED \s+) \n?){2}$/
+               


### PR DESCRIPTION
Fixes #9772
