### PR TITLE
Better detection of CBOR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -234,28 +234,28 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.4.2</version>
+            <version>2.4.4</version>
             <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-smile</artifactId>
-            <version>2.4.2</version>
+            <version>2.4.4</version>
             <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
-            <version>2.4.2</version>
+            <version>2.4.4</version>
             <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-cbor</artifactId>
-            <version>2.4.2</version>
+            <version>2.4.4</version>
             <scope>compile</scope>
         </dependency>
 

--- a/src/main/java/org/elasticsearch/common/xcontent/XContentFactory.java
+++ b/src/main/java/org/elasticsearch/common/xcontent/XContentFactory.java
@@ -208,16 +208,14 @@ public class XContentFactory {
      * Guesses the content type based on the provided input stream.
      */
     public static XContentType xContentType(InputStream si) throws IOException {
-        int iFirst = si.read();
-        if (iFirst == -1) {
+        byte first = (byte) si.read();
+        if (first == -1) {
             return null;
         }
-        byte first = (byte) iFirst;
-        int iSecond = si.read();
-        if (iSecond == -1) {
+        byte second = (byte) si.read();
+        if (second == -1) {
             return null;
         }
-        byte second = (byte) iSecond;
         if (first == SmileConstants.HEADER_BYTE_1 && second == SmileConstants.HEADER_BYTE_2) {
             int third = si.read();
             if (third == SmileConstants.HEADER_BYTE_3) {
@@ -239,11 +237,10 @@ public class XContentFactory {
         }
         if (CBORConstants.hasMajorType(CBORConstants.MAJOR_TYPE_TAG, first)) {
             // Actually, specific "self-describe tag" is a very good indicator
-            int iThird = si.read();
-            if (iThird == -1) {
+            int third = si.read();
+            if (third == -1) {
                 return null;
             }
-            byte third = (byte) iThird;
             if (first == (byte) 0xD9 && second == (byte) 0xD9 && third == (byte) 0xF7) {
                 return XContentType.CBOR;
             }

--- a/src/main/java/org/elasticsearch/common/xcontent/XContentFactory.java
+++ b/src/main/java/org/elasticsearch/common/xcontent/XContentFactory.java
@@ -208,14 +208,16 @@ public class XContentFactory {
      * Guesses the content type based on the provided input stream.
      */
     public static XContentType xContentType(InputStream si) throws IOException {
-        int first = si.read();
-        if (first == -1) {
+        int iFirst = si.read();
+        if (iFirst == -1) {
             return null;
         }
-        int second = si.read();
-        if (second == -1) {
+        byte first = (byte) iFirst;
+        int iSecond = si.read();
+        if (iSecond == -1) {
             return null;
         }
+        byte second = (byte) iSecond;
         if (first == SmileConstants.HEADER_BYTE_1 && second == SmileConstants.HEADER_BYTE_2) {
             int third = si.read();
             if (third == SmileConstants.HEADER_BYTE_3) {
@@ -231,9 +233,27 @@ public class XContentFactory {
                 return XContentType.YAML;
             }
         }
-        if (first == (CBORConstants.BYTE_OBJECT_INDEFINITE & 0xff)){
+        // CBOR logic similar to CBORFactory#hasCBORFormat
+        if (first == CBORConstants.BYTE_OBJECT_INDEFINITE){
             return XContentType.CBOR;
         }
+        if (CBORConstants.hasMajorType(CBORConstants.MAJOR_TYPE_TAG, first)) {
+            // Actually, specific "self-describe tag" is a very good indicator
+            int iThird = si.read();
+            if (iThird == -1) {
+                return null;
+            }
+            byte third = (byte) iThird;
+            if (first == (byte) 0xD9 && second == (byte) 0xD9 && third == (byte) 0xF7) {
+                return XContentType.CBOR;
+            }
+        }
+        // for small objects, some encoders just encode as major type object, we can safely
+        // say its CBOR since it doesn't contradict SMILE or JSON, and its a last resort
+        if (CBORConstants.hasMajorType(CBORConstants.MAJOR_TYPE_OBJECT, first)) {
+            return XContentType.CBOR;
+        }
+
         for (int i = 2; i < GUESS_HEADER_LENGTH; i++) {
             int val = si.read();
             if (val == -1) {
@@ -279,9 +299,23 @@ public class XContentFactory {
         if (length > 2 && first == '-' && bytes.get(1) == '-' && bytes.get(2) == '-') {
             return XContentType.YAML;
         }
-        if (first == CBORConstants.BYTE_OBJECT_INDEFINITE){
+        // CBOR logic similar to CBORFactory#hasCBORFormat
+        if (first == CBORConstants.BYTE_OBJECT_INDEFINITE && length > 1){
             return XContentType.CBOR;
         }
+        if (CBORConstants.hasMajorType(CBORConstants.MAJOR_TYPE_TAG, first) && length > 2) {
+            // Actually, specific "self-describe tag" is a very good indicator
+            if (first == (byte) 0xD9 && bytes.get(1) == (byte) 0xD9 && bytes.get(2) == (byte) 0xF7) {
+                return XContentType.CBOR;
+            }
+        }
+        // for small objects, some encoders just encode as major type object, we can safely
+        // say its CBOR since it doesn't contradict SMILE or JSON, and its a last resort
+        if (CBORConstants.hasMajorType(CBORConstants.MAJOR_TYPE_OBJECT, first)) {
+            return XContentType.CBOR;
+        }
+
+        // a last chance for JSON
         for (int i = 0; i < length; i++) {
             if (bytes.get(i) == '{') {
                 return XContentType.JSON;

--- a/src/test/java/org/elasticsearch/common/xcontent/XContentFactoryTests.java
+++ b/src/test/java/org/elasticsearch/common/xcontent/XContentFactoryTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.io.stream.BytesStreamInput;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.junit.Test;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -87,5 +88,13 @@ public class XContentFactoryTests extends ElasticsearchTestCase {
     public void testCBORBasedOnMagicHeaderDetection() {
         byte[] bytes = new byte[] {(byte) 0xd9, (byte) 0xd9, (byte) 0xf7};
         assertThat(XContentFactory.xContentType(bytes), equalTo(XContentType.CBOR));
+    }
+
+    public void testEmptyStream() throws Exception {
+        ByteArrayInputStream is = new ByteArrayInputStream(new byte[0]);
+        assertNull(XContentFactory.xContentType(is));
+
+        is = new ByteArrayInputStream(new byte[] {(byte) 1});
+        assertNull(XContentFactory.xContentType(is));
     }
 }

--- a/src/test/java/org/elasticsearch/common/xcontent/XContentFactoryTests.java
+++ b/src/test/java/org/elasticsearch/common/xcontent/XContentFactoryTests.java
@@ -74,9 +74,15 @@ public class XContentFactoryTests extends ElasticsearchTestCase {
     }
 
     public void testCBORBasedOnMajorObjectDetection() {
-        // for this {"foo"=> 5} perl encoder for example generates:
-        byte[] bytes = new byte[] {(byte) 0xA1, (byte) 0x43, (byte) 0x66, (byte) 6f, (byte) 6f, (byte) 5};
+        // for this {"f "=> 5} perl encoder for example generates:
+        byte[] bytes = new byte[] {(byte) 0xA1, (byte) 0x43, (byte) 0x66, (byte) 6f, (byte) 6f, (byte) 0x5};
         assertThat(XContentFactory.xContentType(bytes), equalTo(XContentType.CBOR));
+        //assertThat(((Number) XContentHelper.convertToMap(bytes, true).v2().get("foo")).intValue(), equalTo(5));
+
+        // this if for {"foo" : 5} in python CBOR
+        bytes = new byte[] {(byte) 0xA1, (byte) 0x63, (byte) 0x66, (byte) 0x6f, (byte) 0x6f, (byte) 0x5};
+        assertThat(XContentFactory.xContentType(bytes), equalTo(XContentType.CBOR));
+        assertThat(((Number) XContentHelper.convertToMap(bytes, true).v2().get("foo")).intValue(), equalTo(5));
 
         // also make sure major type check doesn't collide with SMILE and JSON, just in case
         assertThat(CBORConstants.hasMajorType(CBORConstants.MAJOR_TYPE_OBJECT, SmileConstants.HEADER_BYTE_1), equalTo(false));


### PR DESCRIPTION
CBOR has a special header that is optional, if exists, allows for exact detection. Also, since we know which formats we support in ES, we can support the object major type case.
closes #7640
