### PR TITLE
Fix handling of IndicesOptions in update settings REST API

### DIFF
--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/settings/RestUpdateSettingsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/settings/RestUpdateSettingsAction.java
@@ -33,11 +33,17 @@ import org.elasticsearch.rest.action.support.AcknowledgedRestListener;
 import java.util.Map;
 
 import static org.elasticsearch.client.Requests.updateSettingsRequest;
+import com.google.common.collect.ImmutableSet;
 
 /**
  *
  */
 public class RestUpdateSettingsAction extends BaseRestHandler {
+
+    private static final ImmutableSet<String> VALUES_TO_EXCLUDE = ImmutableSet.<String>builder()
+            .add("pretty").add("timeout").add("master_timeout").add("index")
+            .add("expand_wildcards").add("ignore_unavailable").add("allow_no_indices")
+            .build();
 
     @Inject
     public RestUpdateSettingsAction(Settings settings, RestController controller, Client client) {
@@ -69,7 +75,7 @@ public class RestUpdateSettingsAction extends BaseRestHandler {
             }
         }
         for (Map.Entry<String, String> entry : request.params().entrySet()) {
-            if (entry.getKey().equals("pretty") || entry.getKey().equals("timeout") || entry.getKey().equals("master_timeout") || entry.getKey().equals("index")) {
+            if (VALUES_TO_EXCLUDE.contains(entry.getKey())) {
                 continue;
             }
             updateSettings.put(entry.getKey(), entry.getValue());


### PR DESCRIPTION
The Update Settings API tries to merge the query params with the settings sent as body and excluding some "well known params"  such as pretty, timeouts ...
Those well known params does not include the params used by IndicesOptions, so ES merges those params with the settings but the resulting settings are invalid.
e.g. 

```
curl -XPUT 'localhost:9200/twitter/_settings?expand_wildcards&pretty' -d '
{
    "index" : {
        "number_of_replicas" : 2
    }
}'
```

returns 

```
{
  "error" : "ElasticsearchIllegalArgumentException[Can't update non dynamic settings[[index.expand_wildcards]] for open indices[[twitter]]]",
  "status" : 400
}
```

but works correctly without params relate to IndicesOptions.

I did not look at other APIs but some may suffer from the same issue.
