### PR TITLE
Be lenient when converting local to utc time in time zone roundings

### DIFF
--- a/src/main/java/org/elasticsearch/common/rounding/TimeZoneRounding.java
+++ b/src/main/java/org/elasticsearch/common/rounding/TimeZoneRounding.java
@@ -125,7 +125,7 @@ public abstract class TimeZoneRounding extends Rounding {
             long timeLocal = utcMillis;
             timeLocal = timeZone.convertUTCToLocal(utcMillis);
             long rounded = field.roundFloor(timeLocal);
-            return timeZone.convertLocalToUTC(rounded, true, utcMillis);
+            return timeZone.convertLocalToUTC(rounded, false, utcMillis);
         }
 
         @Override
@@ -139,7 +139,7 @@ public abstract class TimeZoneRounding extends Rounding {
             long timeLocal = time;
             timeLocal = timeZone.convertUTCToLocal(time);
             long nextInLocalTime = durationField.add(timeLocal, 1);
-            return timeZone.convertLocalToUTC(nextInLocalTime, true);
+            return timeZone.convertLocalToUTC(nextInLocalTime, false);
         }
 
         @Override
@@ -184,7 +184,7 @@ public abstract class TimeZoneRounding extends Rounding {
             long timeLocal = utcMillis;
             timeLocal = timeZone.convertUTCToLocal(utcMillis);
             long rounded = Rounding.Interval.roundValue(Rounding.Interval.roundKey(timeLocal, interval), interval);
-            return timeZone.convertLocalToUTC(rounded, true);
+            return timeZone.convertLocalToUTC(rounded, false);
         }
 
         @Override
@@ -198,7 +198,7 @@ public abstract class TimeZoneRounding extends Rounding {
             long timeLocal = time;
             timeLocal = timeZone.convertUTCToLocal(time);
             long next = timeLocal + interval;
-            return timeZone.convertLocalToUTC(next, true);
+            return timeZone.convertLocalToUTC(next, false);
         }
 
         @Override

--- a/src/test/java/org/elasticsearch/common/rounding/TimeZoneRoundingTests.java
+++ b/src/test/java/org/elasticsearch/common/rounding/TimeZoneRoundingTests.java
@@ -21,7 +21,6 @@ package org.elasticsearch.common.rounding;
 
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.test.ElasticsearchTestCase;
-import org.hamcrest.collection.IsMapContaining;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.format.ISODateTimeFormat;


### PR DESCRIPTION
This solves a problem in the time zone rounding classes where time dates that
fall into a DST gap will cause joda time library to throw an exception.
Changing the conversion methods 'strict' option to false prevents this.

Closes #10025
