### PR TITLE
Translog: make sure stats's op count and size are in sync

### DIFF
--- a/src/main/java/org/elasticsearch/index/translog/fs/FsTranslog.java
+++ b/src/main/java/org/elasticsearch/index/translog/fs/FsTranslog.java
@@ -466,6 +466,11 @@ public class FsTranslog extends AbstractIndexShardComponent implements Translog 
 
     @Override
     public TranslogStats stats() {
-        return new TranslogStats(estimatedNumberOfOperations(), translogSizeInBytes());
+        FsTranslogFile current1 = this.current;
+        if (current1 == null) {
+            return new TranslogStats(0, 0);
+        }
+
+        return new TranslogStats(current1.estimatedNumberOfOperations(), current1.translogSizeInBytes());
     }
 }

--- a/src/main/java/org/elasticsearch/index/translog/fs/FsTranslog.java
+++ b/src/main/java/org/elasticsearch/index/translog/fs/FsTranslog.java
@@ -466,11 +466,11 @@ public class FsTranslog extends AbstractIndexShardComponent implements Translog 
 
     @Override
     public TranslogStats stats() {
-        FsTranslogFile current1 = this.current;
-        if (current1 == null) {
+        FsTranslogFile current = this.current;
+        if (current == null) {
             return new TranslogStats(0, 0);
         }
 
-        return new TranslogStats(current1.estimatedNumberOfOperations(), current1.translogSizeInBytes());
+        return new TranslogStats(current.estimatedNumberOfOperations(), current.translogSizeInBytes());
     }
 }


### PR DESCRIPTION
During translog flush there is a very small window where translog stats reports can be inconsistent.

Example:

```
"translog" : {
   "operations" : 37415948,
   "size_in_bytes" : 0
},
```
