### PR TITLE
Recovery: add total operations to the `_recovery` API

### DIFF
--- a/docs/reference/indices/recovery.asciidoc
+++ b/docs/reference/indices/recovery.asciidoc
@@ -65,6 +65,8 @@ coming[1.5.0, this syntax was change to fix inconsistencies with other API]
       },
       "translog" : {
         "recovered" : 0,
+        "total" : 0,
+        "percent" : "100.0%",
         "total_time" : "0s",
         "total_time_in_millis" : 0
       },

--- a/docs/reference/indices/recovery.asciidoc
+++ b/docs/reference/indices/recovery.asciidoc
@@ -67,6 +67,7 @@ coming[1.5.0, this syntax was change to fix inconsistencies with other API]
         "recovered" : 0,
         "total" : 0,
         "percent" : "100.0%",
+        "total_on_start" : 0,
         "total_time" : "0s",
         "total_time_in_millis" : 0
       },

--- a/rest-api-spec/test/cat.recovery/10_basic.yaml
+++ b/rest-api-spec/test/cat.recovery/10_basic.yaml
@@ -40,6 +40,9 @@
                 \d+\.\d+%   \s+                                 # bytes_percent
                 \d+         \s+                                 # total_files
                 \d+         \s+                                 # total_bytes
+                \d+         \s+                                 # translog
+                -?\d+\.\d+% \s+                                 # translog_percent
+                -?\d+       \s+                                 # total_translog
                 \n
               )+
               $/

--- a/rest-api-spec/test/indices.recovery/10_basic.yaml
+++ b/rest-api-spec/test/indices.recovery/10_basic.yaml
@@ -33,6 +33,8 @@
   - gte:   { test_1.shards.0.index.size.recovered_in_bytes:     0                       }
   - match: { test_1.shards.0.index.size.percent:                /^\d+\.\d\%$/           }
   - gte:   { test_1.shards.0.translog.recovered:                0                       }
+  - gte:   { test_1.shards.0.translog.total:                    -1                      }
+  - gte:   { test_1.shards.0.translog.total_on_start:           0                       }
   - gte:   { test_1.shards.0.translog.total_time_in_millis:     0                       }
   - gte:   { test_1.shards.0.start.check_index_time_in_millis:  0                       }
   - gte:   { test_1.shards.0.start.total_time_in_millis:        0                       }

--- a/src/main/java/org/elasticsearch/action/admin/indices/status/TransportIndicesStatusAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/status/TransportIndicesStatusAction.java
@@ -202,7 +202,7 @@ public class TransportIndicesStatusAction extends TransportBroadcastOperationAct
                             recoveryState.getTimer().time(),
                             index.totalBytes(),
                             index.reusedBytes(),
-                            index.recoveredBytes(), recoveryState.getTranslog().currentTranslogOperations());
+                            index.recoveredBytes(), recoveryState.getTranslog().recoveredOperations());
                 } else if (recoveryState.getType() == RecoveryState.Type.GATEWAY) {
                     GatewayRecoveryStatus.Stage stage;
                     switch (recoveryState.getStage()) {
@@ -222,7 +222,7 @@ public class TransportIndicesStatusAction extends TransportBroadcastOperationAct
                             stage = GatewayRecoveryStatus.Stage.INIT;
                     }
                     shardStatus.gatewayRecoveryStatus = new GatewayRecoveryStatus(stage, recoveryState.getTimer().startTime(), recoveryState.getTimer().time(),
-                            index.totalBytes(), index.reusedBytes(), index.recoveredBytes(), recoveryState.getTranslog().currentTranslogOperations());
+                            index.totalBytes(), index.reusedBytes(), index.recoveredBytes(), recoveryState.getTranslog().recoveredOperations());
                 }
             }
         }

--- a/src/main/java/org/elasticsearch/index/gateway/IndexShardGatewayService.java
+++ b/src/main/java/org/elasticsearch/index/gateway/IndexShardGatewayService.java
@@ -133,7 +133,7 @@ public class IndexShardGatewayService extends AbstractIndexShardComponent implem
                                 .append(new ByteSizeValue(index.reusedBytes())).append("]\n");
                         sb.append("    start    : took [").append(TimeValue.timeValueMillis(recoveryState.getStart().time())).append("], check_index [")
                                 .append(timeValueMillis(recoveryState.getStart().checkIndexTime())).append("]\n");
-                        sb.append("    translog : number_of_operations [").append(recoveryState.getTranslog().currentTranslogOperations())
+                        sb.append("    translog : number_of_operations [").append(recoveryState.getTranslog().recoveredOperations())
                                 .append("], took [").append(TimeValue.timeValueMillis(recoveryState.getTranslog().time())).append("]");
                         logger.trace(sb.toString());
                     } else if (logger.isDebugEnabled()) {

--- a/src/main/java/org/elasticsearch/index/gateway/local/LocalIndexShardGateway.java
+++ b/src/main/java/org/elasticsearch/index/gateway/local/LocalIndexShardGateway.java
@@ -229,6 +229,7 @@ public class LocalIndexShardGateway extends AbstractIndexShardComponent implemen
                 // no translog to recovery from, start and bail
                 // no translog files, bail
                 recoveryState.getTranslog().totalOperations(0);
+                recoveryState.getTranslog().totalOperationsOnStart(0);
                 indexShard.finalizeRecovery();
                 indexShard.postRecovery("post recovery from gateway, no translog");
                 // no index, just start the shard and bail

--- a/src/main/java/org/elasticsearch/index/gateway/local/LocalIndexShardGateway.java
+++ b/src/main/java/org/elasticsearch/index/gateway/local/LocalIndexShardGateway.java
@@ -56,7 +56,6 @@ import java.io.EOFException;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.StandardCopyOption;
 import java.util.Arrays;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
@@ -229,6 +228,7 @@ public class LocalIndexShardGateway extends AbstractIndexShardComponent implemen
             if (recoveringTranslogFile == null || !recoveringTranslogFile.exists()) {
                 // no translog to recovery from, start and bail
                 // no translog files, bail
+                recoveryState.getTranslog().totalOperations(0);
                 indexShard.finalizeRecovery();
                 indexShard.postRecovery("post recovery from gateway, no translog");
                 // no index, just start the shard and bail
@@ -273,7 +273,7 @@ public class LocalIndexShardGateway extends AbstractIndexShardComponent implemen
                                 typesToUpdate.add(potentialIndexOperation.docMapper().type());
                             }
                         }
-                        recoveryState.getTranslog().addTranslogOperations(1);
+                        recoveryState.getTranslog().incrementRecoveredOperations();
                     } catch (ElasticsearchException e) {
                         if (e.status() == RestStatus.BAD_REQUEST) {
                             // mainly for MapperParsingException and Failure to detect xcontent

--- a/src/main/java/org/elasticsearch/index/gateway/none/NoneIndexShardGateway.java
+++ b/src/main/java/org/elasticsearch/index/gateway/none/NoneIndexShardGateway.java
@@ -65,6 +65,8 @@ public class NoneIndexShardGateway extends AbstractIndexShardComponent implement
         } finally {
             indexShard.store().decRef();
         }
+        recoveryState.getTranslog().totalOperations(0);
+        recoveryState.getTranslog().totalOperationsOnStart(0);
         indexShard.prepareForTranslogRecovery();
         indexShard.finalizeRecovery();
         indexShard.postRecovery("post recovery from gateway");

--- a/src/main/java/org/elasticsearch/index/snapshots/IndexShardSnapshotAndRestoreService.java
+++ b/src/main/java/org/elasticsearch/index/snapshots/IndexShardSnapshotAndRestoreService.java
@@ -116,6 +116,7 @@ public class IndexShardSnapshotAndRestoreService extends AbstractIndexShardCompo
         }
         try {
             recoveryState.getTranslog().totalOperations(0);
+            recoveryState.getTranslog().totalOperationsOnStart(0);
             indexShard.prepareForIndexRecovery();
             IndexShardRepository indexShardRepository = repositoriesService.indexShardRepository(restoreSource.snapshotId().getRepository());
             ShardId snapshotShardId = shardId;

--- a/src/main/java/org/elasticsearch/index/snapshots/IndexShardSnapshotAndRestoreService.java
+++ b/src/main/java/org/elasticsearch/index/snapshots/IndexShardSnapshotAndRestoreService.java
@@ -115,6 +115,7 @@ public class IndexShardSnapshotAndRestoreService extends AbstractIndexShardCompo
             logger.trace("[{}] restoring shard  [{}]", restoreSource.snapshotId(), shardId);
         }
         try {
+            recoveryState.getTranslog().totalOperations(0);
             indexShard.prepareForIndexRecovery();
             IndexShardRepository indexShardRepository = repositoriesService.indexShardRepository(restoreSource.snapshotId().getRepository());
             ShardId snapshotShardId = shardId;

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoveryFilesInfoRequest.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoveryFilesInfoRequest.java
@@ -42,6 +42,8 @@ class RecoveryFilesInfoRequest extends TransportRequest {
     List<String> phase1ExistingFileNames;
     List<Long> phase1ExistingFileSizes;
 
+    int totalTranslogOps;
+
     @Deprecated
     long phase1TotalSize;
 
@@ -52,7 +54,7 @@ class RecoveryFilesInfoRequest extends TransportRequest {
     }
 
     RecoveryFilesInfoRequest(long recoveryId, ShardId shardId, List<String> phase1FileNames, List<Long> phase1FileSizes,
-                             List<String> phase1ExistingFileNames, List<Long> phase1ExistingFileSizes,
+                             List<String> phase1ExistingFileNames, List<Long> phase1ExistingFileSizes, int totalTranslogOps,
                              // needed for BWC only
                              @Deprecated long phase1TotalSize, @Deprecated long phase1ExistingTotalSize) {
         this.recoveryId = recoveryId;
@@ -61,6 +63,7 @@ class RecoveryFilesInfoRequest extends TransportRequest {
         this.phase1FileSizes = phase1FileSizes;
         this.phase1ExistingFileNames = phase1ExistingFileNames;
         this.phase1ExistingFileSizes = phase1ExistingFileSizes;
+        this.totalTranslogOps = totalTranslogOps;
         this.phase1TotalSize = phase1TotalSize;
         this.phase1ExistingTotalSize = phase1ExistingTotalSize;
     }
@@ -107,6 +110,9 @@ class RecoveryFilesInfoRequest extends TransportRequest {
             in.readVLong();
             //phase1ExistingTotalSize
             in.readVLong();
+            totalTranslogOps = RecoveryState.Translog.UNKNOWN;
+        } else {
+            totalTranslogOps = in.readVInt();
         }
     }
 
@@ -139,6 +145,8 @@ class RecoveryFilesInfoRequest extends TransportRequest {
         if (out.getVersion().before(Version.V_1_5_0)) {
             out.writeVLong(phase1TotalSize);
             out.writeVLong(phase1ExistingTotalSize);
+        } else {
+            out.writeVInt(totalTranslogOps);
         }
     }
 }

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java
@@ -493,7 +493,7 @@ public class RecoveryState implements ToXContent, Streamable {
     }
 
     public static class Translog extends Timer implements ToXContent, Streamable {
-        public static int UNKNOWN = -1;
+        public static final int UNKNOWN = -1;
 
         private int recovered;
         private int total = UNKNOWN;
@@ -507,13 +507,13 @@ public class RecoveryState implements ToXContent, Streamable {
         }
 
         public synchronized void incrementRecoveredOperations() {
-            this.recovered++;
+            recovered++;
             assert total == UNKNOWN || total >= recovered : "total, if known, should be > recovered. total [" + total + "], recovered [" + recovered + "]";
         }
 
         /** returns the total number of translog operations recovered so far */
         public synchronized int recoveredOperations() {
-            return this.recovered;
+            return recovered;
         }
 
         /**
@@ -523,7 +523,7 @@ public class RecoveryState implements ToXContent, Streamable {
          * A value of -1 ({@link RecoveryState.Translog#UNKNOWN} is return if this is unknown (typically a gateway recovery)
          */
         public synchronized int totalOperations() {
-            return this.total;
+            return total;
         }
 
         public synchronized void totalOperations(int total) {

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
@@ -377,6 +377,7 @@ public class RecoveryTarget extends AbstractComponent {
                     index.addFileDetail(request.phase1FileNames.get(i), request.phase1FileSizes.get(i), false);
                 }
                 recoveryStatus.state().getTranslog().totalOperations(request.totalTranslogOps);
+                recoveryStatus.state().getTranslog().totalOperationsOnStart(request.totalTranslogOps);
                 // recoveryBytesCount / recoveryFileCount will be set as we go...
                 channel.sendResponse(TransportResponse.Empty.INSTANCE);
             }

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
@@ -26,7 +26,6 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchIllegalStateException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.Version;
-import org.elasticsearch.bootstrap.Elasticsearch;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.Nullable;
@@ -296,6 +295,7 @@ public class RecoveryTarget extends AbstractComponent {
         public void messageReceived(RecoveryPrepareForTranslogOperationsRequest request, TransportChannel channel) throws Exception {
             try (RecoveriesCollection.StatusRef statusRef = onGoingRecoveries.getStatusSafe(request.recoveryId(), request.shardId())) {
                 final RecoveryStatus recoveryStatus = statusRef.status();
+                recoveryStatus.state().getTranslog().totalOperations(request.totalTranslogOps());
                 recoveryStatus.indexShard().prepareForTranslogRecovery();
             }
             channel.sendResponse(TransportResponse.Empty.INSTANCE);
@@ -341,9 +341,11 @@ public class RecoveryTarget extends AbstractComponent {
         public void messageReceived(RecoveryTranslogOperationsRequest request, TransportChannel channel) throws Exception {
             try (RecoveriesCollection.StatusRef statusRef = onGoingRecoveries.getStatusSafe(request.recoveryId(), request.shardId())) {
                 final RecoveryStatus recoveryStatus = statusRef.status();
+                final RecoveryState.Translog translog = recoveryStatus.state().getTranslog();
+                translog.totalOperations(request.totalTranslogOps());
                 for (Translog.Operation operation : request.operations()) {
                     recoveryStatus.indexShard().performRecoveryOperation(operation);
-                    recoveryStatus.state().getTranslog().incrementTranslogOperations();
+                    translog.incrementRecoveredOperations();
                 }
             }
             channel.sendResponse(TransportResponse.Empty.INSTANCE);
@@ -374,6 +376,7 @@ public class RecoveryTarget extends AbstractComponent {
                 for (int i = 0; i < request.phase1FileNames.size(); i++) {
                     index.addFileDetail(request.phase1FileNames.get(i), request.phase1FileSizes.get(i), false);
                 }
+                recoveryStatus.state().getTranslog().totalOperations(request.totalTranslogOps);
                 // recoveryBytesCount / recoveryFileCount will be set as we go...
                 channel.sendResponse(TransportResponse.Empty.INSTANCE);
             }
@@ -396,6 +399,7 @@ public class RecoveryTarget extends AbstractComponent {
         public void messageReceived(RecoveryCleanFilesRequest request, TransportChannel channel) throws Exception {
             try (RecoveriesCollection.StatusRef statusRef = onGoingRecoveries.getStatusSafe(request.recoveryId(), request.shardId())) {
                 final RecoveryStatus recoveryStatus = statusRef.status();
+                recoveryStatus.state().getTranslog().totalOperations(request.totalTranslogOps());
                 // first, we go and move files that were created with the recovery id suffix to
                 // the actual names, its ok if we have a corrupted index here, since we have replicas
                 // to recover from in case of a full cluster shutdown just when this code executes...
@@ -458,6 +462,7 @@ public class RecoveryTarget extends AbstractComponent {
             try (RecoveriesCollection.StatusRef statusRef = onGoingRecoveries.getStatusSafe(request.recoveryId(), request.shardId())) {
                 final RecoveryStatus recoveryStatus = statusRef.status();
                 final Store store = recoveryStatus.store();
+                recoveryStatus.state().getTranslog().totalOperations(request.totalTranslogOps());
                 IndexOutput indexOutput;
                 if (request.position() == 0) {
                     indexOutput = recoveryStatus.openAndPutIndexOutput(request.name(), request.metadata(), store);

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestRecoveryAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestRecoveryAction.java
@@ -98,6 +98,9 @@ public class RestRecoveryAction extends AbstractCatAction {
                 .addCell("bytes_percent", "alias:bp;desc:percent of bytes recovered")
                 .addCell("total_files", "alias:tf;desc:total number of files")
                 .addCell("total_bytes", "alias:tb;desc:total number of bytes")
+                .addCell("translog", "alias:tr;desc:translog operations recovered")
+                .addCell("translog_percent", "alias:trp;desc:percent of translog recovery")
+                .addCell("total_translog", "alias:trt;desc:current total translog operations")
                 .endHeaders();
         return t;
     }
@@ -156,6 +159,9 @@ public class RestRecoveryAction extends AbstractCatAction {
                 t.addCell(String.format(Locale.ROOT, "%1.1f%%", state.getIndex().recoveredBytesPercent()));
                 t.addCell(state.getIndex().totalFileCount());
                 t.addCell(state.getIndex().totalBytes());
+                t.addCell(state.getTranslog().recoveredOperations());
+                t.addCell(String.format(Locale.ROOT, "%1.1f%%", state.getTranslog().recoveredPercent()));
+                t.addCell(state.getTranslog().totalOperations());
                 t.endRow();
             }
         }

--- a/src/test/java/org/elasticsearch/benchmark/recovery/ReplicaRecoveryBenchmark.java
+++ b/src/test/java/org/elasticsearch/benchmark/recovery/ReplicaRecoveryBenchmark.java
@@ -132,7 +132,7 @@ public class ReplicaRecoveryBenchmark {
                     long translogOps;
                     long bytes;
                     if (indexRecoveries.size() > 0) {
-                        translogOps = indexRecoveries.get(0).recoveryState().getTranslog().currentTranslogOperations();
+                        translogOps = indexRecoveries.get(0).recoveryState().getTranslog().recoveredOperations();
                         bytes = recoveryResponse.shardResponses().get(INDEX_NAME).get(0).recoveryState().getIndex().recoveredBytes();
                     } else {
                         bytes = lastBytes = 0;

--- a/src/test/java/org/elasticsearch/index/store/CorruptedFileTest.java
+++ b/src/test/java/org/elasticsearch/index/store/CorruptedFileTest.java
@@ -404,7 +404,7 @@ public class CorruptedFileTest extends ElasticsearchIntegrationTest {
                         RecoveryFileChunkRequest req = (RecoveryFileChunkRequest) request;
                         if (truncate && req.length() > 1) {
                             BytesArray array = new BytesArray(req.content().array(), req.content().arrayOffset(), (int) req.length() - 1);
-                            request = new RecoveryFileChunkRequest(req.recoveryId(), req.shardId(), req.metadata(), req.position(), array, req.lastChunk());
+                            request = new RecoveryFileChunkRequest(req.recoveryId(), req.shardId(), req.metadata(), req.position(), array, req.lastChunk(), req.totalTranslogOps());
                         } else {
                             byte[] array = req.content().array();
                             int i = randomIntBetween(0, req.content().length() - 1);

--- a/src/test/java/org/elasticsearch/indices/recovery/RecoveryStateTest.java
+++ b/src/test/java/org/elasticsearch/indices/recovery/RecoveryStateTest.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.indices.recovery;
 
-import com.carrotsearch.randomizedtesting.annotations.Repeat;
 import org.elasticsearch.ElasticsearchIllegalStateException;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -332,7 +331,6 @@ public class RecoveryStateTest extends ElasticsearchTestCase {
         assertThat(state.getStage(), equalTo(Stage.DONE));
     }
 
-    @Repeat(iterations = 300)
     public void testTranslog() throws Throwable {
         final Translog translog = new Translog();
         AtomicBoolean stop = new AtomicBoolean();


### PR DESCRIPTION
This commit adds the current total number of translog operations to the recovery reporting API.  We also expose the recovered / total percentage:

```
"translog": {
     "recovered": 536,
     "total": 986,
     "percent": "54.3%",
     "total_time": "2ms",
     "total_time_in_millis": 2
},
```

Closes #9368
