### PR TITLE
Engine: update index buffer size during recovery and allow configuring version map size

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/settings/Validator.java
+++ b/src/main/java/org/elasticsearch/cluster/settings/Validator.java
@@ -205,6 +205,44 @@ public interface Validator {
         }
     };
 
+    public static final Validator PERCENTAGE = new Validator() {
+        @Override
+        public String validate(String setting, String value) {
+            try {
+                if (value == null) {
+                    return "the value of " + setting + " can not be null";
+                }
+                if (!value.endsWith("%")) {
+                    return "the value of " + setting + " must end with %";
+                }
+                final double asDouble = Double.parseDouble(value.substring(0, value.length() - 1));
+                if (asDouble < 0.0 || asDouble > 100.0) {
+                    return "the value of the setting " + setting + " must be a percentage between 0% and 100%";
+                }
+            } catch (NumberFormatException ex) {
+                return ex.getMessage();
+            }
+            return null;
+        }
+    };
+
+
+    public static final Validator BYTES_SIZE_OR_PERCENTAGE = new Validator() {
+        @Override
+        public String validate(String setting, String value) {
+            String byteSize = BYTES_SIZE.validate(setting, value);
+            if (byteSize != null) {
+                String percentage = PERCENTAGE.validate(setting, value);
+                if (percentage == null) {
+                    return null;
+                }
+                return percentage + " or be a valid bytes size value, like [16mb]";
+            }
+            return null;
+        }
+    };
+
+
     public static final Validator MEMORY_SIZE = new Validator() {
         @Override
         public String validate(String setting, String value) {

--- a/src/main/java/org/elasticsearch/cluster/settings/Validator.java
+++ b/src/main/java/org/elasticsearch/cluster/settings/Validator.java
@@ -213,11 +213,11 @@ public interface Validator {
                     return "the value of " + setting + " can not be null";
                 }
                 if (!value.endsWith("%")) {
-                    return "the value of " + setting + " must end with %";
+                    return "the value [" + value + "] for " + setting + " must end with %";
                 }
                 final double asDouble = Double.parseDouble(value.substring(0, value.length() - 1));
                 if (asDouble < 0.0 || asDouble > 100.0) {
-                    return "the value of the setting " + setting + " must be a percentage between 0% and 100%";
+                    return "the value [" + value + "] for " + setting + " must be a percentage between 0% and 100%";
                 }
             } catch (NumberFormatException ex) {
                 return ex.getMessage();

--- a/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -26,7 +26,8 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.SearcherFactory;
 import org.apache.lucene.search.SearcherManager;
-import org.apache.lucene.store.*;
+import org.apache.lucene.store.AlreadyClosedException;
+import org.apache.lucene.store.LockObtainFailedException;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.ElasticsearchException;
@@ -370,11 +371,10 @@ public class InternalEngine extends Engine {
     }
 
     /**
-     * Forces a refresh if the versionMap is using too much RAM (currently > 25% of IndexWriter's RAM buffer).
+     * Forces a refresh if the versionMap is using too much RAM
      */
     private void checkVersionMapRefresh() {
-        // TODO: we force refresh when versionMap is using > 25% of IW's RAM buffer; should we make this separately configurable?
-        if (versionMap.ramBytesUsedForRefresh() > 0.25 * engineConfig.getIndexingBufferSize().bytes() && versionMapRefreshPending.getAndSet(true) == false) {
+        if (versionMap.ramBytesUsedForRefresh() > config().getVersionMapSize().bytes() && versionMapRefreshPending.getAndSet(true) == false) {
             try {
                 if (isClosed.get()) {
                     // no point...

--- a/src/main/java/org/elasticsearch/index/settings/IndexDynamicSettingsModule.java
+++ b/src/main/java/org/elasticsearch/index/settings/IndexDynamicSettingsModule.java
@@ -39,9 +39,9 @@ import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.store.support.AbstractIndexStore;
 import org.elasticsearch.index.translog.TranslogService;
 import org.elasticsearch.index.translog.fs.FsTranslog;
+import org.elasticsearch.indices.IndicesWarmer;
 import org.elasticsearch.indices.cache.query.IndicesQueryCache;
 import org.elasticsearch.indices.ttl.IndicesTTLService;
-import org.elasticsearch.indices.IndicesWarmer;
 
 /**
  */
@@ -87,6 +87,7 @@ public class IndexDynamicSettingsModule extends AbstractModule {
         indexDynamicSettings.addDynamicSetting(EngineConfig.INDEX_FAIL_ON_CORRUPTION_SETTING, Validator.BOOLEAN);
         indexDynamicSettings.addDynamicSetting(EngineConfig.INDEX_CHECKSUM_ON_MERGE, Validator.BOOLEAN);
         indexDynamicSettings.addDynamicSetting(IndexShard.INDEX_FLUSH_ON_CLOSE, Validator.BOOLEAN);
+        indexDynamicSettings.addDynamicSetting(EngineConfig.INDEX_VERSION_MAP_SIZE, Validator.BYTES_SIZE_OR_PERCENTAGE);
         indexDynamicSettings.addDynamicSetting(ShardSlowLogIndexingService.INDEX_INDEXING_SLOWLOG_THRESHOLD_INDEX_WARN, Validator.TIME);
         indexDynamicSettings.addDynamicSetting(ShardSlowLogIndexingService.INDEX_INDEXING_SLOWLOG_THRESHOLD_INDEX_INFO, Validator.TIME);
         indexDynamicSettings.addDynamicSetting(ShardSlowLogIndexingService.INDEX_INDEXING_SLOWLOG_THRESHOLD_INDEX_DEBUG, Validator.TIME);

--- a/src/main/java/org/elasticsearch/indices/memory/IndexingMemoryController.java
+++ b/src/main/java/org/elasticsearch/indices/memory/IndexingMemoryController.java
@@ -28,14 +28,13 @@ import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.FutureUtils;
-import org.elasticsearch.index.engine.Engine;
+import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.engine.EngineClosedException;
 import org.elasticsearch.index.engine.EngineConfig;
 import org.elasticsearch.index.engine.FlushNotAllowedEngineException;
-import org.elasticsearch.index.IndexService;
+import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.IndexShardState;
 import org.elasticsearch.index.shard.ShardId;
-import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.monitor.jvm.JvmInfo;
@@ -65,7 +64,8 @@ public class IndexingMemoryController extends AbstractLifecycleComponent<Indexin
 
     private volatile ScheduledFuture scheduler;
 
-    private static final EnumSet<IndexShardState> CAN_UPDATE_INDEX_BUFFER_STATES = EnumSet.of(IndexShardState.POST_RECOVERY, IndexShardState.STARTED, IndexShardState.RELOCATED);
+    private static final EnumSet<IndexShardState> CAN_UPDATE_INDEX_BUFFER_STATES = EnumSet.of(
+            IndexShardState.RECOVERING, IndexShardState.POST_RECOVERY, IndexShardState.STARTED, IndexShardState.RELOCATED);
 
     @Inject
     public IndexingMemoryController(Settings settings, ThreadPool threadPool, IndicesService indicesService) {

--- a/src/test/java/org/elasticsearch/cluster/settings/SettingsValidatorTests.java
+++ b/src/test/java/org/elasticsearch/cluster/settings/SettingsValidatorTests.java
@@ -22,9 +22,7 @@ package org.elasticsearch.cluster.settings;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.junit.Test;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.*;
 
 /**
  *
@@ -83,6 +81,24 @@ public class SettingsValidatorTests extends ElasticsearchTestCase {
         assertThat(Validator.POSITIVE_INTEGER.validate("", "0"), notNullValue());
         assertThat(Validator.POSITIVE_INTEGER.validate("", "-1"), notNullValue());
         assertThat(Validator.POSITIVE_INTEGER.validate("", "10.2"), notNullValue());
+
+        assertThat(Validator.PERCENTAGE.validate("", "asdasd"), notNullValue());
+        assertThat(Validator.PERCENTAGE.validate("", "-1"), notNullValue());
+        assertThat(Validator.PERCENTAGE.validate("", "20"), notNullValue()); // we expect 20%
+        assertThat(Validator.PERCENTAGE.validate("", "-1%"), notNullValue());
+        assertThat(Validator.PERCENTAGE.validate("", "101%"), notNullValue());
+        assertThat(Validator.PERCENTAGE.validate("", "100%"), nullValue());
+        assertThat(Validator.PERCENTAGE.validate("", "99%"), nullValue());
+        assertThat(Validator.PERCENTAGE.validate("", "0%"), nullValue());
+
+        assertThat(Validator.BYTES_SIZE_OR_PERCENTAGE.validate("", "asdasd"), notNullValue());
+        assertThat(Validator.BYTES_SIZE_OR_PERCENTAGE.validate("", "20"), nullValue());
+        assertThat(Validator.BYTES_SIZE_OR_PERCENTAGE.validate("", "20mb"), nullValue());
+        assertThat(Validator.BYTES_SIZE_OR_PERCENTAGE.validate("", "-1%"), notNullValue());
+        assertThat(Validator.BYTES_SIZE_OR_PERCENTAGE.validate("", "101%"), notNullValue());
+        assertThat(Validator.BYTES_SIZE_OR_PERCENTAGE.validate("", "100%"), nullValue());
+        assertThat(Validator.BYTES_SIZE_OR_PERCENTAGE.validate("", "99%"), nullValue());
+        assertThat(Validator.BYTES_SIZE_OR_PERCENTAGE.validate("", "0%"), nullValue());
     }
 
     @Test


### PR DESCRIPTION
To support real time gets, the engine keeps an in-memory map of recently index docs and their location in the translog. This is needed until documents become visible in Lucene. With 1.3.0, we have improved this map and made tightly integrated with refresh cycles in Lucene in order to keep the memory signature to a bare minimum. On top of that, if the version map grows above a 25% of the index buffer size, we proactively refresh in order to be able to trim the version map back to 0 (see #6363) . In the same release, we have fixed an issue where an update to the indexing buffer could result in an unwanted exception during recovery (#6667) . We solved this by waiting with updating the size of the index buffer until the shard was fully recovered. Sadly this two together can have a negative impact on the speed of translog recovery.

During the second phase of recovery we replay all operations that happened on the shard during the first phase of copying files. In parallel we start indexing new documents into the new created shard. At some point (phase 3 in the recovery), the translog replay starts to send operation which have already been indexed into the shard. The version map is crucial in being able to quickly detect this and skip the replayed operations, without hitting lucene. Sadly #6667 (only updating the index memory buffer once shard is started) means that a shard is using the default 64MB for it's index buffer, and thus only 16MB (25%) for the version map. This much less then the default index buffer size 10% of machine memory (shared between shards).

Since we don't flush anymore when updating the memory buffer, we can remove #6667 and update recovering shards as well. Also, we make the version map max size configurable, with the same default of 25% of the current index buffer.
