### PR TITLE
Fix typo in reference

### DIFF
--- a/docs/reference/getting-started.asciidoc
+++ b/docs/reference/getting-started.asciidoc
@@ -456,7 +456,7 @@ Updates can also be performed by using simple scripts. This example uses a scrip
 --------------------------------------------------
 curl -XPOST 'localhost:9200/customer/external/1/_update?pretty' -d '
 {
-  "script" : "ctx._source.age += 5"
+  "script" : "ctx._source.doc.age += 5"
 }'
 --------------------------------------------------
 


### PR DESCRIPTION
I propose this change to avoid error bellow.

{
  "error" : "ElasticsearchIllegalArgumentException[failed to execute script]; nested: GroovyScriptEx
ecutionException[NullPointerException[Cannot execute null+null]]; ",
  "status" : 400
}
