### PR TITLE
Make assert less strict to ensure local node is not null

### DIFF
--- a/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -222,7 +222,7 @@ public class IndexShard extends AbstractIndexShardComponent {
         this.codecService = codecService;
         this.shardSuggestService = shardSuggestService;
         this.shardBitsetFilterCache = shardBitsetFilterCache;
-        assert clusterService.lifecycleState() == Lifecycle.State.STARTED : "expected lifecycle to be started but was: " + clusterService.lifecycleState() ; // otherwise localNode is still none;
+        assert clusterService.localNode() != null : "Local node is null lifecycle state is: " + clusterService.lifecycleState();
         this.localNode = clusterService.localNode();
         state = IndexShardState.CREATED;
         this.refreshInterval = indexSettings.getAsTime(INDEX_REFRESH_INTERVAL, EngineConfig.DEFAULT_REFRESH_INTERVAL);


### PR DESCRIPTION
we can trip this assert if we create a shard while we are shutting down the node 

see http://build-us-00.elasticsearch.org/job/es_core_master_window-2012/1081/consoleFull
