### PR TITLE
Core: add deprecation messages for delete-by-query

### DIFF
--- a/docs/java-api/delete-by-query.asciidoc
+++ b/docs/java-api/delete-by-query.asciidoc
@@ -1,6 +1,8 @@
 [[delete-by-query]]
 == Delete By Query API
 
+deprecated[1.5.0, "Delete by Query will be removed in 2.0: it is problematic since it silently forces a refresh which can quickly cause OutOfMemoryError during concurrent indexing, and can also cause primary and replica to become inconsistent.  Instead, use the <<search-request-scroll,scroll/scan API>> to find all matching ids and then issue a bulk request to delete them.]
+
 The delete by query API allows one to delete documents from one or more
 indices and one or more types based on a <<query-dsl-queries,query>>. Here
 is an example:

--- a/docs/reference/docs/delete-by-query.asciidoc
+++ b/docs/reference/docs/delete-by-query.asciidoc
@@ -1,6 +1,8 @@
 [[docs-delete-by-query]]
 == Delete By Query API
 
+deprecated[1.5.0, "Delete by Query will be removed in 2.0: it is problematic since it silently forces a refresh which can quickly cause OutOfMemoryError during concurrent indexing, and can also cause primary and replica to become inconsistent.  Instead, use the <<search-request-scroll,scroll/scan API>> to find all matching ids and then issue a bulk request to delete them.]
+
 The delete by query API allows to delete documents from one or more
 indices and one or more types based on a query. The query can either be
 provided using a simple query string as a parameter, or using the


### PR DESCRIPTION
Patch is based on 1.x.

This commit just adds deprecation messages to delete-by-query docs ... but I'm not sure I got the deprecated markup correct.
