### PR TITLE
Don't rethrow already handled merge exceptions

### DIFF
--- a/src/main/java/org/elasticsearch/index/merge/scheduler/ConcurrentMergeSchedulerProvider.java
+++ b/src/main/java/org/elasticsearch/index/merge/scheduler/ConcurrentMergeSchedulerProvider.java
@@ -141,7 +141,9 @@ public class ConcurrentMergeSchedulerProvider extends MergeSchedulerProvider {
         protected void handleMergeException(Directory dir, Throwable exc) {
             logger.warn("failed to merge", exc);
             provider.failedMerge(new MergePolicy.MergeException(exc, dir));
-            super.handleMergeException(dir, exc);
+            // NOTE: do not call super.handleMergeException here, which would just re-throw the exception
+            // and let Java's thread exc handler see it / log it to stderr, but we already 1) logged it
+            // and 2) handled the exception by failing the engine
         }
 
         @Override

--- a/src/main/java/org/elasticsearch/index/merge/scheduler/ConcurrentMergeSchedulerProvider.java
+++ b/src/main/java/org/elasticsearch/index/merge/scheduler/ConcurrentMergeSchedulerProvider.java
@@ -139,7 +139,7 @@ public class ConcurrentMergeSchedulerProvider extends MergeSchedulerProvider {
 
         @Override
         protected void handleMergeException(Directory dir, Throwable exc) {
-            logger.warn("failed to merge", exc);
+            logger.error("failed to merge", exc);
             provider.failedMerge(new MergePolicy.MergeException(exc, dir));
             // NOTE: do not call super.handleMergeException here, which would just re-throw the exception
             // and let Java's thread exc handler see it / log it to stderr, but we already 1) logged it


### PR DESCRIPTION
ES already has a custom merge exception handler that 1) logs the exception and 2) fails the engine ... and then it calls super, which throws an unhandled exception, which I think is redundant.  The JVM catches that and logs it again (to stderr), and this causes test failures like http://build-us-00.elastic.co/job/es_core_1x_centos/3701

I think we should remove the super call?
