### PR TITLE
Core: deprecate index.fail_on_merge_failure

### DIFF
--- a/docs/reference/indices/update-settings.asciidoc
+++ b/docs/reference/indices/update-settings.asciidoc
@@ -65,7 +65,7 @@ settings API:
     experimental[] Defaults to `8`.
 
 `index.fail_on_merge_failure`::
-    experimental[] Default to `true`.
+    experimental[] Default to `true`.  deprecated[1.5.0,As of 2.0 the engine will always fail on an unexpected merge exception.]
 
 `index.translog.flush_threshold_ops`::
     When to flush based on operations.


### PR DESCRIPTION
When a merge exception happens I think we should always fail the engine, so I'd like to deprecate this setting in 1.5.0 and remove in 2.0.
