### PR TITLE
Fix PageCacheRecycler's max page size computation.

### DIFF
--- a/src/main/java/org/elasticsearch/cache/recycler/PageCacheRecycler.java
+++ b/src/main/java/org/elasticsearch/cache/recycler/PageCacheRecycler.java
@@ -66,15 +66,6 @@ public class PageCacheRecycler extends AbstractComponent {
         }
     }
 
-    // return the maximum number of pages that may be cached depending on
-    //  - limit: the total amount of memory available
-    //  - pageSize: the size of a single page
-    //  - weight: the weight for this data type
-    //  - totalWeight: the sum of all weights
-    private static int maxCount(long limit, long pageSize, double weight, double totalWeight) {
-        return (int) (weight / totalWeight * limit / pageSize);
-    }
-
     @Inject
     public PageCacheRecycler(Settings settings, ThreadPool threadPool) {
         super(settings);
@@ -103,8 +94,10 @@ public class PageCacheRecycler extends AbstractComponent {
         final double objectsWeight = settings.getAsDouble(WEIGHT + ".objects", 0.1d);
 
         final double totalWeight = bytesWeight + intsWeight + longsWeight + objectsWeight;
+        final int maxPageCount = (int) Math.min(Integer.MAX_VALUE, limit / BigArrays.PAGE_SIZE_IN_BYTES);
 
-        bytePage = build(type, maxCount(limit, BigArrays.BYTE_PAGE_SIZE, bytesWeight, totalWeight), searchThreadPoolSize, availableProcessors, new AbstractRecyclerC<byte[]>() {
+        final int maxBytePageCount = (int) (bytesWeight * maxPageCount / totalWeight);
+        bytePage = build(type, maxBytePageCount, searchThreadPoolSize, availableProcessors, new AbstractRecyclerC<byte[]>() {
             @Override
             public byte[] newInstance(int sizing) {
                 return new byte[BigArrays.BYTE_PAGE_SIZE];
@@ -114,7 +107,9 @@ public class PageCacheRecycler extends AbstractComponent {
                 // nothing to do
             }
         });
-        intPage = build(type, maxCount(limit, BigArrays.INT_PAGE_SIZE, intsWeight, totalWeight), searchThreadPoolSize, availableProcessors, new AbstractRecyclerC<int[]>() {
+
+        final int maxIntPageCount = (int) (intsWeight * maxPageCount / totalWeight);
+        intPage = build(type, maxIntPageCount, searchThreadPoolSize, availableProcessors, new AbstractRecyclerC<int[]>() {
             @Override
             public int[] newInstance(int sizing) {
                 return new int[BigArrays.INT_PAGE_SIZE];
@@ -124,17 +119,21 @@ public class PageCacheRecycler extends AbstractComponent {
                 // nothing to do
             }
         });
-        longPage = build(type, maxCount(limit, BigArrays.LONG_PAGE_SIZE, longsWeight, totalWeight), searchThreadPoolSize, availableProcessors, new AbstractRecyclerC<long[]>() {
+
+        final int maxLongPageCount = (int) (longsWeight * maxPageCount / totalWeight);
+        longPage = build(type, maxLongPageCount, searchThreadPoolSize, availableProcessors, new AbstractRecyclerC<long[]>() {
             @Override
             public long[] newInstance(int sizing) {
                 return new long[BigArrays.LONG_PAGE_SIZE];
             }
             @Override
             public void recycle(long[] value) {
-                // nothing to do               
+                // nothing to do
             }
         });
-        objectPage = build(type, maxCount(limit, BigArrays.OBJECT_PAGE_SIZE, objectsWeight, totalWeight), searchThreadPoolSize, availableProcessors, new AbstractRecyclerC<Object[]>() {
+
+        final int maxObjectPageCount = (int) (objectsWeight * maxPageCount / totalWeight);
+        objectPage = build(type, maxObjectPageCount, searchThreadPoolSize, availableProcessors, new AbstractRecyclerC<Object[]>() {
             @Override
             public Object[] newInstance(int sizing) {
                 return new Object[BigArrays.OBJECT_PAGE_SIZE];
@@ -144,6 +143,8 @@ public class PageCacheRecycler extends AbstractComponent {
                 Arrays.fill(value, null); // we need to remove the strong refs on the objects stored in the array
             }
         });
+
+        assert BigArrays.PAGE_SIZE_IN_BYTES * (maxBytePageCount + maxIntPageCount + maxLongPageCount + maxObjectPageCount) <= limit;
     }
 
     public Recycler.V<byte[]> bytePage(boolean clear) {


### PR DESCRIPTION
PageCacheRecycler was mistakenly using the maximum number of items per page
instead of the byte size of a page. This could result in higher memory usage
than configured.

Close #10077
