### PR TITLE
Remove `index.fail_on_merge_failure`

### DIFF
--- a/docs/reference/indices/update-settings.asciidoc
+++ b/docs/reference/indices/update-settings.asciidoc
@@ -64,9 +64,6 @@ settings API:
 `index.index_concurrency`::
     experimental[] Defaults to `8`.
 
-`index.fail_on_merge_failure`::
-    experimental[] Default to `true`.
-
 `index.translog.flush_threshold_ops`::
     When to flush based on operations.
 

--- a/src/main/java/org/elasticsearch/index/engine/EngineConfig.java
+++ b/src/main/java/org/elasticsearch/index/engine/EngineConfig.java
@@ -50,7 +50,6 @@ import java.util.concurrent.TimeUnit;
  */
 public final class EngineConfig {
     private final ShardId shardId;
-    private volatile boolean failOnMergeFailure = true;
     private volatile boolean failEngineOnCorruption = true;
     private volatile ByteSizeValue indexingBufferSize;
     private final int indexConcurrency;
@@ -98,12 +97,6 @@ public final class EngineConfig {
      * This setting is realtime updateable
      */
     public static final String INDEX_GC_DELETES_SETTING = "index.gc_deletes";
-
-    /**
-     * Index setting to enable / disable engine failures on merge exceptions. Default is <code>true</code> / <tt>enabled</tt>.
-     * This setting is realtime updateable.
-     */
-    public static final String INDEX_FAIL_ON_MERGE_FAILURE_SETTING = "index.fail_on_merge_failure";
 
     /**
      * Index setting to enable / disable engine failures on detected index corruptions. Default is <code>true</code> / <tt>enabled</tt>.
@@ -156,7 +149,6 @@ public final class EngineConfig {
         codecName = indexSettings.get(EngineConfig.INDEX_CODEC_SETTING, EngineConfig.DEFAULT_CODEC_NAME);
         indexingBufferSize = indexSettings.getAsBytesSize(INDEX_BUFFER_SIZE_SETTING, DEFAUTL_INDEX_BUFFER_SIZE);
         failEngineOnCorruption = indexSettings.getAsBoolean(INDEX_FAIL_ON_CORRUPTION_SETTING, true);
-        failOnMergeFailure = indexSettings.getAsBoolean(INDEX_FAIL_ON_MERGE_FAILURE_SETTING, true);
         gcDeletesInMillis = indexSettings.getAsTime(INDEX_GC_DELETES_SETTING, EngineConfig.DEFAULT_GC_DELETES).millis();
     }
 
@@ -174,13 +166,6 @@ public final class EngineConfig {
      */
     public void setEnableGcDeletes(boolean enableGcDeletes) {
         this.enableGcDeletes = enableGcDeletes;
-    }
-
-    /**
-     * Returns <code>true</code> iff the engine should be failed if a merge error is hit. Defaults to <code>true</code>
-     */
-    public boolean isFailOnMergeFailure() {
-        return failOnMergeFailure;
     }
 
     /**
@@ -376,12 +361,5 @@ public final class EngineConfig {
      */
     public void setFailEngineOnCorruption(boolean failEngineOnCorruption) {
         this.failEngineOnCorruption = failEngineOnCorruption;
-    }
-
-    /**
-     * Sets if the engine should be failed if a merge error is hit. Defaults to <code>true</code>
-     */
-    public void setFailOnMergeFailure(boolean failOnMergeFailure) {
-        this.failOnMergeFailure = failOnMergeFailure;
     }
 }

--- a/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -1098,7 +1098,7 @@ public class InternalEngine extends Engine {
                 } else {
                     logger.warn("corrupt file detected source: [merge] but [{}] is set to [{}]", e, EngineConfig.INDEX_FAIL_ON_CORRUPTION_SETTING, engineConfig.isFailEngineOnCorruption());
                 }
-            } else if (engineConfig.isFailOnMergeFailure()) {
+            } else {
                 failEngine("merge exception", e);
             }
         }

--- a/src/main/java/org/elasticsearch/index/settings/IndexDynamicSettingsModule.java
+++ b/src/main/java/org/elasticsearch/index/settings/IndexDynamicSettingsModule.java
@@ -85,7 +85,6 @@ public class IndexDynamicSettingsModule extends AbstractModule {
         indexDynamicSettings.addDynamicSetting(LogDocMergePolicyProvider.INDEX_COMPOUND_FORMAT);
         indexDynamicSettings.addDynamicSetting(EngineConfig.INDEX_COMPOUND_ON_FLUSH, Validator.BOOLEAN);
         indexDynamicSettings.addDynamicSetting(EngineConfig.INDEX_GC_DELETES_SETTING, Validator.TIME);
-        indexDynamicSettings.addDynamicSetting(EngineConfig.INDEX_FAIL_ON_MERGE_FAILURE_SETTING, Validator.BOOLEAN);
         indexDynamicSettings.addDynamicSetting(EngineConfig.INDEX_FAIL_ON_CORRUPTION_SETTING, Validator.BOOLEAN);
         indexDynamicSettings.addDynamicSetting(IndexShard.INDEX_FLUSH_ON_CLOSE, Validator.BOOLEAN);
         indexDynamicSettings.addDynamicSetting(ShardSlowLogIndexingService.INDEX_INDEXING_SLOWLOG_THRESHOLD_INDEX_WARN, Validator.TIME);

--- a/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -1036,12 +1036,6 @@ public class IndexShard extends AbstractIndexShardComponent {
                     config.setFailEngineOnCorruption(failEngineOnCorruption);
                     change = true;
                 }
-                final boolean failOnMergeFailure = settings.getAsBoolean(EngineConfig.INDEX_FAIL_ON_MERGE_FAILURE_SETTING, config.isFailOnMergeFailure());
-                if (failOnMergeFailure != config.isFailOnMergeFailure()) {
-                    logger.info("updating {} from [{}] to [{}]", EngineConfig.INDEX_FAIL_ON_MERGE_FAILURE_SETTING, config.isFailOnMergeFailure(), failOnMergeFailure);
-                    config.setFailOnMergeFailure(failOnMergeFailure);
-                    change = true;
-                }
             }
             if (change) {
                 refresh("apply settings");

--- a/src/test/java/org/elasticsearch/index/engine/InternalEngineSettingsTest.java
+++ b/src/test/java/org/elasticsearch/index/engine/InternalEngineSettingsTest.java
@@ -45,14 +45,12 @@ public class InternalEngineSettingsTest extends ElasticsearchSingleNodeTest {
         for (int i = 0; i < iters; i++) {
             boolean compoundOnFlush = randomBoolean();
             boolean failOnCorruption = randomBoolean();
-            boolean failOnMerge = randomBoolean();
             long gcDeletes = Math.max(0, randomLong());
 
             Settings build = ImmutableSettings.builder()
                     .put(EngineConfig.INDEX_FAIL_ON_CORRUPTION_SETTING, failOnCorruption)
                     .put(EngineConfig.INDEX_COMPOUND_ON_FLUSH, compoundOnFlush)
                     .put(EngineConfig.INDEX_GC_DELETES_SETTING, gcDeletes)
-                    .put(EngineConfig.INDEX_FAIL_ON_MERGE_FAILURE_SETTING, failOnMerge)
                     .build();
 
             client().admin().indices().prepareUpdateSettings("foo").setSettings(build).get();
@@ -64,8 +62,6 @@ public class InternalEngineSettingsTest extends ElasticsearchSingleNodeTest {
             assertEquals(engine.config().getGcDeletesInMillis(), gcDeletes);
             assertEquals(engine.getGcDeletesInMillis(), gcDeletes);
             assertEquals(engine.config().isFailEngineOnCorruption(), failOnCorruption);
-            assertEquals(engine.config().isFailOnMergeFailure(), failOnMerge); // only on the holder
-
         }
 
         Settings settings = ImmutableSettings.builder()

--- a/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -1505,7 +1505,6 @@ public class InternalEngineTests extends ElasticsearchLuceneTestCase {
         assertTrue(settings.containsSetting(EngineConfig.INDEX_FAIL_ON_CORRUPTION_SETTING));
         assertTrue(settings.containsSetting(EngineConfig.INDEX_COMPOUND_ON_FLUSH));
         assertTrue(settings.containsSetting(EngineConfig.INDEX_GC_DELETES_SETTING));
-        assertTrue(settings.containsSetting(EngineConfig.INDEX_FAIL_ON_MERGE_FAILURE_SETTING));
     }
 
     @Test


### PR DESCRIPTION
#10084 deprecates index.fail_on_merge_failure in 1.x and this PR removes it from master.
