### PR TITLE
[GEO] Fix geo_shape orientation parameter persistence

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/geo/GeoShapeFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/geo/GeoShapeFieldMapper.java
@@ -292,6 +292,10 @@ public class GeoShapeFieldMapper extends AbstractFieldMapper<String> {
         if (includeDefaults || defaultStrategy.getDistErrPct() != Defaults.DISTANCE_ERROR_PCT) {
             builder.field(Names.DISTANCE_ERROR_PCT, defaultStrategy.getDistErrPct());
         }
+
+        if (includeDefaults || orientation() != Defaults.ORIENTATION) {
+            builder.field(Names.ORIENTATION, orientation());
+        }
     }
 
     @Override

--- a/src/test/java/org/elasticsearch/search/geo/GeoShapeIntegrationTests.java
+++ b/src/test/java/org/elasticsearch/search/geo/GeoShapeIntegrationTests.java
@@ -22,6 +22,10 @@ package org.elasticsearch.search.geo;
 import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.index.IndexService;
+import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.geo.GeoShapeFieldMapper;
+import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.test.geo.RandomShapeGenerator;
 import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.common.geo.builders.GeometryCollectionBuilder;
@@ -455,5 +459,60 @@ public class GeoShapeIntegrationTests extends ElasticsearchIntegrationTest {
                 .setPostFilter(filter).get();
         assertSearchResponse(result);
         assertHitCount(result, 1);
+    }
+
+    /**
+     * Test that orientation parameter correctly persists across cluster restart
+     * @throws IOException
+     */
+    public void testOrientationPersistence() throws Exception {
+        String idxName = "orientation";
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("shape")
+                .startObject("properties").startObject("location")
+                .field("type", "geo_shape")
+                .field("orientation", "left")
+                .endObject().endObject()
+                .endObject().endObject().string();
+
+        // create index
+        assertAcked(prepareCreate(idxName).addMapping("shape", mapping));
+
+        mapping = XContentFactory.jsonBuilder().startObject().startObject("shape")
+                .startObject("properties").startObject("location")
+                .field("type", "geo_shape")
+                .field("orientation", "right")
+                .endObject().endObject()
+                .endObject().endObject().string();
+
+        assertAcked(prepareCreate(idxName+"2").addMapping("shape", mapping));
+        ensureGreen();
+
+        // test mapper persistence through restart
+        internalCluster().fullRestart();
+        ensureGreen();
+
+        // left orientation test
+        IndicesService indicesService = internalCluster().getInstance(IndicesService.class);
+        IndexService indexService = indicesService.indexService(idxName);
+        FieldMapper fieldMapper = indexService.mapperService().smartNameFieldMapper("location");
+        assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
+
+        GeoShapeFieldMapper gsfm = (GeoShapeFieldMapper)fieldMapper;
+        ShapeBuilder.Orientation orientation = gsfm.orientation();
+        assertThat(orientation, equalTo(ShapeBuilder.Orientation.CLOCKWISE));
+        assertThat(orientation, equalTo(ShapeBuilder.Orientation.LEFT));
+        assertThat(orientation, equalTo(ShapeBuilder.Orientation.CW));
+
+        // right orientation test
+        indicesService = internalCluster().getInstance(IndicesService.class);
+        indexService = indicesService.indexService(idxName+"2");
+        fieldMapper = indexService.mapperService().smartNameFieldMapper("location");
+        assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
+
+        gsfm = (GeoShapeFieldMapper)fieldMapper;
+        orientation = gsfm.orientation();
+        assertThat(orientation, equalTo(ShapeBuilder.Orientation.COUNTER_CLOCKWISE));
+        assertThat(orientation, equalTo(ShapeBuilder.Orientation.RIGHT));
+        assertThat(orientation, equalTo(ShapeBuilder.Orientation.CCW));
     }
 }


### PR DESCRIPTION
Fixing geo_shape field mapper to persist the orientation parameter. Adding parsing and integration tests to ensure persistence across cluster restarts.
