### PR TITLE
Add throttle stats to index stats and recovery stats

### DIFF
--- a/rest-api-spec/test/indices.recovery/10_basic.yaml
+++ b/rest-api-spec/test/indices.recovery/10_basic.yaml
@@ -14,27 +14,29 @@
 
   - do:
       cluster.health:
-        wait_for_status: yellow
+        wait_for_status: green
 
   - do:
       indices.recovery:
         index: [test_1]
 
-  - match: { test_1.shards.0.type:                              "GATEWAY"               }
-  - match: { test_1.shards.0.stage:                             "DONE"                  }
-  - match: { test_1.shards.0.primary:                           true                    }
-  - match: { test_1.shards.0.target.ip:                         /^\d+\.\d+\.\d+\.\d+$/  }
-  - gte:   { test_1.shards.0.index.files.total:                 0                       }
-  - gte:   { test_1.shards.0.index.files.reused:                0                       }
-  - gte:   { test_1.shards.0.index.files.recovered:             0                       }
-  - match: { test_1.shards.0.index.files.percent:               /^\d+\.\d\%$/           }
-  - gte:   { test_1.shards.0.index.size.total_in_bytes:         0                       }
-  - gte:   { test_1.shards.0.index.size.reused_in_bytes:        0                       }
-  - gte:   { test_1.shards.0.index.size.recovered_in_bytes:     0                       }
-  - match: { test_1.shards.0.index.size.percent:                /^\d+\.\d\%$/           }
-  - gte:   { test_1.shards.0.translog.recovered:                0                       }
-  - gte:   { test_1.shards.0.translog.total_time_in_millis:     0                       }
-  - gte:   { test_1.shards.0.start.check_index_time_in_millis:  0                       }
-  - gte:   { test_1.shards.0.start.total_time_in_millis:        0                       }
+  - match: { test_1.shards.0.type:                                 "GATEWAY"               }
+  - match: { test_1.shards.0.stage:                                "DONE"                  }
+  - match: { test_1.shards.0.primary:                              true                    }
+  - match: { test_1.shards.0.target.ip:                            /^\d+\.\d+\.\d+\.\d+$/  }
+  - gte:   { test_1.shards.0.index.files.total:                    0                       }
+  - gte:   { test_1.shards.0.index.files.reused:                   0                       }
+  - gte:   { test_1.shards.0.index.files.recovered:                0                       }
+  - match: { test_1.shards.0.index.files.percent:                  /^\d+\.\d\%$/           }
+  - gte:   { test_1.shards.0.index.size.total_in_bytes:            0                       }
+  - gte:   { test_1.shards.0.index.size.reused_in_bytes:           0                       }
+  - gte:   { test_1.shards.0.index.size.recovered_in_bytes:        0                       }
+  - match: { test_1.shards.0.index.size.percent:                   /^\d+\.\d\%$/           }
+  - gte:   { test_1.shards.0.index.source_throttle_time_in_millis: 0                       }
+  - gte:   { test_1.shards.0.index.target_throttle_time_in_millis: 0                       }
+  - gte:   { test_1.shards.0.translog.recovered:                   0                       }
+  - gte:   { test_1.shards.0.translog.total_time_in_millis:        0                       }
+  - gte:   { test_1.shards.0.start.check_index_time_in_millis:     0                       }
+  - gte:   { test_1.shards.0.start.total_time_in_millis:           0                       }
 
 

--- a/rest-api-spec/test/indices.stats/11_metric.yaml
+++ b/rest-api-spec/test/indices.stats/11_metric.yaml
@@ -37,6 +37,7 @@ setup:
   - is_true:  _all.total.segments
   - is_true:  _all.total.translog
   - is_true:  _all.total.suggest
+  - is_true:  _all.total.recovery
 
 ---
 "Metric - _all":
@@ -60,6 +61,7 @@ setup:
   - is_true:  _all.total.segments
   - is_true:  _all.total.translog
   - is_true:  _all.total.suggest
+  - is_true:  _all.total.recovery
 
 ---
 "Metric - one":
@@ -83,6 +85,7 @@ setup:
   - is_false:  _all.total.segments
   - is_false:  _all.total.translog
   - is_false:  _all.total.suggest
+  - is_false:  _all.total.recovery
 
 ---
 "Metric - multi":
@@ -106,5 +109,30 @@ setup:
   - is_false:  _all.total.segments
   - is_false:  _all.total.translog
   - is_false:  _all.total.suggest
+  - is_false:  _all.total.recovery
 
+
+---
+"Metric - recovery":
+  - do:
+      indices.stats: { metric: [ recovery ] }
+
+  - is_false:  _all.total.docs
+  - is_false:  _all.total.store
+  - is_false:  _all.total.indexing
+  - is_false:  _all.total.get
+  - is_false:  _all.total.search
+  - is_false:  _all.total.merges
+  - is_false:  _all.total.refresh
+  - is_false:  _all.total.flush
+  - is_false:  _all.total.warmer
+  - is_false:  _all.total.filter_cache
+  - is_false:  _all.total.id_cache
+  - is_false:  _all.total.fielddata
+  - is_false:  _all.total.percolate
+  - is_false:  _all.total.completion
+  - is_false:  _all.total.segments
+  - is_false:  _all.total.translog
+  - is_false:  _all.total.suggest
+  - is_true:   _all.total.recovery
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStats.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStats.java
@@ -37,6 +37,7 @@ import org.elasticsearch.index.get.GetStats;
 import org.elasticsearch.index.indexing.IndexingStats;
 import org.elasticsearch.index.merge.MergeStats;
 import org.elasticsearch.index.percolator.stats.PercolateStats;
+import org.elasticsearch.index.recovery.RecoveryStats;
 import org.elasticsearch.index.refresh.RefreshStats;
 import org.elasticsearch.index.search.stats.SearchStats;
 import org.elasticsearch.index.shard.DocsStats;
@@ -116,6 +117,9 @@ public class CommonStats implements Streamable, ToXContent {
                 case QueryCache:
                     queryCache = new QueryCacheStats();
                     break;
+                case Recovery:
+                    recoveryStats = new RecoveryStats();
+                    break;
                 default:
                     throw new IllegalStateException("Unknown Flag: " + flag);
             }
@@ -182,6 +186,9 @@ public class CommonStats implements Streamable, ToXContent {
                 case QueryCache:
                     queryCache = indexShard.queryCache().stats();
                     break;
+                case Recovery:
+                    recoveryStats = indexShard.recoveryStats();
+                    break;
                 default:
                     throw new IllegalStateException("Unknown Flag: " + flag);
             }
@@ -241,6 +248,9 @@ public class CommonStats implements Streamable, ToXContent {
 
     @Nullable
     public QueryCacheStats queryCache;
+
+    @Nullable
+    public RecoveryStats recoveryStats;
 
     public void add(CommonStats stats) {
         if (docs == null) {
@@ -389,6 +399,14 @@ public class CommonStats implements Streamable, ToXContent {
         } else {
             queryCache.add(stats.getQueryCache());
         }
+        if (recoveryStats == null) {
+            if (stats.getRecoveryStats() != null) {
+                recoveryStats = new RecoveryStats();
+                recoveryStats.add(stats.getRecoveryStats());
+            }
+        } else {
+            recoveryStats.add(stats.getRecoveryStats());
+        }
     }
 
     @Nullable
@@ -481,6 +499,11 @@ public class CommonStats implements Streamable, ToXContent {
         return queryCache;
     }
 
+    @Nullable
+    public RecoveryStats getRecoveryStats() {
+        return recoveryStats;
+    }
+
     public static CommonStats readCommonStats(StreamInput in) throws IOException {
         CommonStats stats = new CommonStats();
         stats.readFrom(in);
@@ -567,6 +590,11 @@ public class CommonStats implements Streamable, ToXContent {
         }
         if (in.getVersion().onOrAfter(Version.V_1_4_0_Beta1)) {
             queryCache = in.readOptionalStreamable(new QueryCacheStats());
+        }
+        if (in.getVersion().onOrAfter(Version.V_1_5_0)) {
+            if (in.readBoolean()) {
+                recoveryStats = RecoveryStats.readRecoveryStats(in);
+            }
         }
     }
 
@@ -669,6 +697,9 @@ public class CommonStats implements Streamable, ToXContent {
         if (out.getVersion().onOrAfter(Version.V_1_4_0_Beta1)) {
             out.writeOptionalStreamable(queryCache);
         }
+        if (out.getVersion().onOrAfter(Version.V_1_5_0)) {
+            out.writeOptionalStreamable(recoveryStats);
+        }
     }
 
     // note, requires a wrapping object
@@ -727,6 +758,9 @@ public class CommonStats implements Streamable, ToXContent {
         }
         if (queryCache != null) {
             queryCache.toXContent(builder, params);
+        }
+        if (recoveryStats != null) {
+            recoveryStats.toXContent(builder, params);
         }
         return builder;
     }

--- a/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStatsFlags.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStatsFlags.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.action.admin.indices.stats;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
@@ -169,6 +170,9 @@ public class CommonStatsFlags implements Streamable, Cloneable {
     public void writeTo(StreamOutput out) throws IOException {
         long longFlags = 0;
         for (Flag flag : flags) {
+            if (out.getVersion().before(Version.V_1_5_0) && flag == Flag.Recovery) {
+                continue;
+            }
             longFlags |= (1 << flag.ordinal());
         }
         out.writeLong(longFlags);
@@ -225,7 +229,9 @@ public class CommonStatsFlags implements Streamable, Cloneable {
         Segments("segments"),
         Translog("translog"),
         Suggest("suggest"),
-        QueryCache("query_cache");
+        QueryCache("query_cache"),
+        Recovery("recovery");
+
 
         private final String restName;
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsRequest.java
@@ -265,6 +265,15 @@ public class IndicesStatsRequest extends BroadcastOperationRequest<IndicesStatsR
         return flags.isSet(Flag.QueryCache);
     }
 
+    public IndicesStatsRequest recovery(boolean recovery) {
+        flags.set(Flag.Recovery, recovery);
+        return this;
+    }
+
+    public boolean recovery() {
+        return flags.isSet(Flag.Recovery);
+    }
+
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);

--- a/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsRequestBuilder.java
@@ -168,6 +168,11 @@ public class IndicesStatsRequestBuilder extends BroadcastOperationRequestBuilder
         return this;
     }
 
+    public IndicesStatsRequestBuilder setRecovery(boolean recovery) {
+        request.recovery(recovery);
+        return this;
+    }
+
     @Override
     protected void doExecute(ActionListener<IndicesStatsResponse> listener) {
         client.stats(request, listener);

--- a/src/main/java/org/elasticsearch/action/admin/indices/stats/TransportIndicesStatsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/stats/TransportIndicesStatsAction.java
@@ -37,10 +37,10 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.index.IndexShardMissingException;
 import org.elasticsearch.index.IndexService;
-import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.IndexShardMissingException;
 import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -200,6 +200,9 @@ public class TransportIndicesStatsAction extends TransportBroadcastOperationActi
         }
         if (request.request.queryCache()) {
             flags.set(CommonStatsFlags.Flag.QueryCache);
+        }
+        if (request.request.recovery()) {
+            flags.set(CommonStatsFlags.Flag.Recovery);
         }
 
         return new ShardStats(indexShard, indexShard.routingEntry(), flags);

--- a/src/main/java/org/elasticsearch/index/recovery/RecoveryStats.java
+++ b/src/main/java/org/elasticsearch/index/recovery/RecoveryStats.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.index.recovery;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentBuilderString;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ *
+ */
+public class RecoveryStats implements ToXContent, Streamable {
+
+    private final AtomicInteger currentAsSource = new AtomicInteger();
+    private final AtomicInteger currentAsTarget = new AtomicInteger();
+    private final AtomicLong throttleTimeInNanos = new AtomicLong();
+
+    public RecoveryStats() {
+    }
+
+    public void add(RecoveryStats recoveryStats) {
+        if (recoveryStats == null) {
+            return;
+        }
+        this.currentAsSource.addAndGet(recoveryStats.currentAsSource());
+        this.currentAsTarget.addAndGet(recoveryStats.currentAsTarget());
+        this.throttleTimeInNanos.addAndGet(recoveryStats.throttleTime().nanos());
+    }
+
+    /**
+     * Number of ongoing recoveries for which a shard serves as a source
+     */
+    public int currentAsSource() {
+        return currentAsSource.get();
+    }
+
+    /**
+     * Number of ongoing recoveries for which a shard serves as a source
+     */
+    public int currentAsTarget() {
+        return currentAsTarget.get();
+    }
+
+    /**
+     * Total time recoveries waited due to throttling
+     */
+    public TimeValue throttleTime() {
+        return TimeValue.timeValueNanos(throttleTimeInNanos.get());
+    }
+
+    public void incrementRecoveriesAsTarget() {
+        currentAsTarget.incrementAndGet();
+    }
+
+    public void decrementRecoveriesAsTarget() {
+        currentAsTarget.decrementAndGet();
+    }
+
+    public void incrementRecoveriesAsSource() {
+        currentAsSource.incrementAndGet();
+    }
+
+    public void decrementRecoveriesAsSource() {
+        currentAsTarget.decrementAndGet();
+    }
+
+    public void addThrottleTime(long nanos) {
+        throttleTimeInNanos.addAndGet(nanos);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(Fields.RECOVERY);
+        builder.field(Fields.CURRENT_AS_SOURCE, currentAsSource());
+        builder.field(Fields.CURRENT_AS_TARGET, currentAsTarget());
+        builder.timeValueField(Fields.THROTTLE_TIME_IN_MILLIS, Fields.THROTTLE_TIME, throttleTime());
+        builder.endObject();
+        return builder;
+    }
+
+    public static RecoveryStats readRecoveryStats(StreamInput in) throws IOException {
+        RecoveryStats stats = new RecoveryStats();
+        stats.readFrom(in);
+        return stats;
+    }
+
+    static final class Fields {
+        static final XContentBuilderString RECOVERY = new XContentBuilderString("recovery");
+        static final XContentBuilderString CURRENT_AS_SOURCE = new XContentBuilderString("current_as_source");
+        static final XContentBuilderString CURRENT_AS_TARGET = new XContentBuilderString("current_as_target");
+        static final XContentBuilderString THROTTLE_TIME = new XContentBuilderString("throttle_time");
+        static final XContentBuilderString THROTTLE_TIME_IN_MILLIS = new XContentBuilderString("throttle_time_in_millis");
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        currentAsSource.set(in.readVInt());
+        currentAsTarget.set(in.readVInt());
+        throttleTimeInNanos.set(in.readLong());
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVInt(currentAsSource.get());
+        out.writeVInt(currentAsTarget.get());
+        out.writeLong(throttleTimeInNanos.get());
+    }
+
+    @Override
+    public String toString() {
+        return "recoveryStats, currentAsSource [" + currentAsSource() + "],currentAsTarget ["
+                + currentAsTarget() + "], throttle [" + throttleTime() + "]";
+    }
+}

--- a/src/main/java/org/elasticsearch/index/recovery/RecoveryStats.java
+++ b/src/main/java/org/elasticsearch/index/recovery/RecoveryStats.java
@@ -31,7 +31,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
- *
+ * Recovery related statistics, starting at the shard level and allowing aggregation to
+ * indices and node level
  */
 public class RecoveryStats implements ToXContent, Streamable {
 
@@ -48,6 +49,17 @@ public class RecoveryStats implements ToXContent, Streamable {
         }
         this.currentAsSource.addAndGet(recoveryStats.currentAsSource());
         this.currentAsTarget.addAndGet(recoveryStats.currentAsTarget());
+        this.throttleTimeInNanos.addAndGet(recoveryStats.throttleTime().nanos());
+    }
+
+    /**
+     * add statistics that should be accumulated about old shards after they have been
+     * deleted or relocated
+     */
+    public void addAsOld(RecoveryStats recoveryStats) {
+        if (recoveryStats == null) {
+            return;
+        }
         this.throttleTimeInNanos.addAndGet(recoveryStats.throttleTime().nanos());
     }
 
@@ -72,20 +84,20 @@ public class RecoveryStats implements ToXContent, Streamable {
         return TimeValue.timeValueNanos(throttleTimeInNanos.get());
     }
 
-    public void incrementRecoveriesAsTarget() {
+    public void incCurrentAsTarget() {
         currentAsTarget.incrementAndGet();
     }
 
-    public void decrementRecoveriesAsTarget() {
+    public void decCurrentAsTarget() {
         currentAsTarget.decrementAndGet();
     }
 
-    public void incrementRecoveriesAsSource() {
+    public void incCurrentAsSource() {
         currentAsSource.incrementAndGet();
     }
 
-    public void decrementRecoveriesAsSource() {
-        currentAsTarget.decrementAndGet();
+    public void decCurrentAsSource() {
+        currentAsSource.decrementAndGet();
     }
 
     public void addThrottleTime(long nanos) {

--- a/src/main/java/org/elasticsearch/index/recovery/RecoveryStats.java
+++ b/src/main/java/org/elasticsearch/index/recovery/RecoveryStats.java
@@ -44,12 +44,11 @@ public class RecoveryStats implements ToXContent, Streamable {
     }
 
     public void add(RecoveryStats recoveryStats) {
-        if (recoveryStats == null) {
-            return;
+        if (recoveryStats != null) {
+            this.currentAsSource.addAndGet(recoveryStats.currentAsSource());
+            this.currentAsTarget.addAndGet(recoveryStats.currentAsTarget());
+            this.throttleTimeInNanos.addAndGet(recoveryStats.throttleTime().nanos());
         }
-        this.currentAsSource.addAndGet(recoveryStats.currentAsSource());
-        this.currentAsTarget.addAndGet(recoveryStats.currentAsTarget());
-        this.throttleTimeInNanos.addAndGet(recoveryStats.throttleTime().nanos());
     }
 
     /**
@@ -57,10 +56,9 @@ public class RecoveryStats implements ToXContent, Streamable {
      * deleted or relocated
      */
     public void addAsOld(RecoveryStats recoveryStats) {
-        if (recoveryStats == null) {
-            return;
+        if (recoveryStats != null) {
+            this.throttleTimeInNanos.addAndGet(recoveryStats.throttleTime().nanos());
         }
-        this.throttleTimeInNanos.addAndGet(recoveryStats.throttleTime().nanos());
     }
 
     /**

--- a/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -44,7 +44,6 @@ import org.elasticsearch.common.Preconditions;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.collect.Tuple;
-import org.elasticsearch.common.component.Lifecycle;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.lucene.Lucene;
@@ -85,6 +84,7 @@ import org.elasticsearch.index.merge.scheduler.MergeSchedulerProvider;
 import org.elasticsearch.index.percolator.PercolatorQueriesRegistry;
 import org.elasticsearch.index.percolator.stats.ShardPercolateService;
 import org.elasticsearch.index.query.IndexQueryParserService;
+import org.elasticsearch.index.recovery.RecoveryStats;
 import org.elasticsearch.index.refresh.RefreshStats;
 import org.elasticsearch.index.search.nested.NonNestedDocsFilter;
 import org.elasticsearch.index.search.stats.SearchStats;
@@ -167,6 +167,8 @@ public class IndexShard extends AbstractIndexShardComponent {
 
     @Nullable
     private RecoveryState recoveryState;
+
+    private final RecoveryStats recoveryStats = new RecoveryStats();
 
     private ApplyRefreshSettings applyRefreshSettings = new ApplyRefreshSettings();
 
@@ -776,6 +778,11 @@ public class IndexShard extends AbstractIndexShardComponent {
             IOUtils.close(engine);
             recoveryState().setStage(RecoveryState.Stage.INIT);
         }
+    }
+
+    /** returns stats about ongoing recoveries, both source and target */
+    public RecoveryStats recoveryStats() {
+        return recoveryStats;
     }
 
     /**

--- a/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -32,8 +32,6 @@ import org.elasticsearch.action.admin.indices.stats.CommonStatsFlags;
 import org.elasticsearch.action.admin.indices.stats.CommonStatsFlags.Flag;
 import org.elasticsearch.action.admin.indices.stats.IndexShardStats;
 import org.elasticsearch.action.admin.indices.stats.ShardStats;
-import org.elasticsearch.bootstrap.Elasticsearch;
-import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.Nullable;
@@ -89,7 +87,10 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.*;
-import java.util.concurrent.*;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import static com.google.common.collect.Maps.newHashMap;
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_REPLICAS;
@@ -227,6 +228,7 @@ public class IndicesService extends AbstractLifecycleComponent<IndicesService> i
                     }
                 } catch (IllegalIndexShardStateException e) {
                     // we can safely ignore illegal state on ones that are closing for example
+                    logger.trace("{} ignoring shard stats", e, indexShard.shardId());
                 }
             }
         }

--- a/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -68,6 +68,7 @@ import org.elasticsearch.index.mapper.MapperServiceModule;
 import org.elasticsearch.index.merge.MergeStats;
 import org.elasticsearch.index.query.IndexQueryParserModule;
 import org.elasticsearch.index.query.IndexQueryParserService;
+import org.elasticsearch.index.recovery.RecoveryStats;
 import org.elasticsearch.index.refresh.RefreshStats;
 import org.elasticsearch.index.search.stats.SearchStats;
 import org.elasticsearch.index.settings.IndexSettings;
@@ -204,6 +205,9 @@ public class IndicesService extends AbstractLifecycleComponent<IndicesService> i
                         break;
                     case Refresh:
                         oldStats.refresh.add(oldShardsStats.refreshStats);
+                        break;
+                    case Recovery:
+                        oldStats.recoveryStats.add(oldShardsStats.recoveryStats);
                         break;
                     case Flush:
                         oldStats.flush.add(oldShardsStats.flushStats);
@@ -418,6 +422,7 @@ public class IndicesService extends AbstractLifecycleComponent<IndicesService> i
         final MergeStats mergeStats = new MergeStats();
         final RefreshStats refreshStats = new RefreshStats();
         final FlushStats flushStats = new FlushStats();
+        final RecoveryStats recoveryStats = new RecoveryStats();
 
         @Override
         public synchronized void beforeIndexShardClosed(ShardId shardId, @Nullable IndexShard indexShard,
@@ -429,6 +434,7 @@ public class IndicesService extends AbstractLifecycleComponent<IndicesService> i
                 mergeStats.add(indexShard.mergeStats());
                 refreshStats.add(indexShard.refreshStats());
                 flushStats.add(indexShard.flushStats());
+                recoveryStats.addAsOld(indexShard.recoveryStats());
             }
         }
     }

--- a/src/main/java/org/elasticsearch/indices/NodeIndicesStats.java
+++ b/src/main/java/org/elasticsearch/indices/NodeIndicesStats.java
@@ -42,6 +42,7 @@ import org.elasticsearch.index.get.GetStats;
 import org.elasticsearch.index.indexing.IndexingStats;
 import org.elasticsearch.index.merge.MergeStats;
 import org.elasticsearch.index.percolator.stats.PercolateStats;
+import org.elasticsearch.index.recovery.RecoveryStats;
 import org.elasticsearch.index.refresh.RefreshStats;
 import org.elasticsearch.index.search.stats.SearchStats;
 import org.elasticsearch.index.shard.DocsStats;
@@ -158,6 +159,11 @@ public class NodeIndicesStats implements Streamable, Serializable, ToXContent {
     @Nullable
     public SuggestStats getSuggest() {
         return stats.getSuggest();
+    }
+
+    @Nullable
+    public RecoveryStats getRecoveryStats() {
+        return stats.getRecoveryStats();
     }
 
     public static NodeIndicesStats readIndicesStats(StreamInput in) throws IOException {

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoveryFileChunkRequest.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoveryFileChunkRequest.java
@@ -41,17 +41,20 @@ public final class RecoveryFileChunkRequest extends TransportRequest {  // publi
     private long position;
     private BytesReference content;
     private StoreFileMetaData metaData;
+    private long sourceThrottleTimeInNanos;
 
     RecoveryFileChunkRequest() {
     }
 
-    public RecoveryFileChunkRequest(long recoveryId, ShardId shardId, StoreFileMetaData metaData, long position, BytesReference content, boolean lastChunk) {
+    public RecoveryFileChunkRequest(long recoveryId, ShardId shardId, StoreFileMetaData metaData, long position, BytesReference content,
+                                    boolean lastChunk, long sourceThrottleTimeInNanos) {
         this.recoveryId = recoveryId;
         this.shardId = shardId;
         this.metaData = metaData;
         this.position = position;
         this.content = content;
         this.lastChunk = lastChunk;
+        this.sourceThrottleTimeInNanos = sourceThrottleTimeInNanos;
     }
 
     public long recoveryId() {
@@ -83,6 +86,10 @@ public final class RecoveryFileChunkRequest extends TransportRequest {  // publi
         return content;
     }
 
+    public long sourceThrottleTimeInNanos() {
+        return sourceThrottleTimeInNanos;
+    }
+
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
@@ -104,6 +111,11 @@ public final class RecoveryFileChunkRequest extends TransportRequest {  // publi
         } else {
             lastChunk = false;
         }
+        if (in.getVersion().onOrAfter(org.elasticsearch.Version.V_1_5_0)) {
+            sourceThrottleTimeInNanos = in.readLong();
+        } else {
+            sourceThrottleTimeInNanos = -1;
+        }
     }
 
     @Override
@@ -121,6 +133,9 @@ public final class RecoveryFileChunkRequest extends TransportRequest {  // publi
         }
         if (out.getVersion().onOrAfter(org.elasticsearch.Version.V_1_4_0_Beta1)) {
             out.writeBoolean(lastChunk);
+        }
+        if (out.getVersion().onOrAfter(org.elasticsearch.Version.V_1_5_0)) {
+            out.writeLong(sourceThrottleTimeInNanos);
         }
     }
 

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoverySource.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoverySource.java
@@ -160,6 +160,7 @@ public class RecoverySource extends AbstractComponent {
             }
             assert shardRecoveryHandlers.contains(handler) == false : "Handler was already registered [" + handler + "]";
             shardRecoveryHandlers.add(handler);
+            shard.recoveryStats().incrementRecoveriesAsSource();
         }
 
         synchronized void remove(IndexShard shard, RecoverySourceHandler handler) {
@@ -167,6 +168,9 @@ public class RecoverySource extends AbstractComponent {
             assert shardRecoveryHandlers != null : "Shard was not registered [" + shard + "]";
             boolean remove = shardRecoveryHandlers.remove(handler);
             assert remove : "Handler was not registered [" + handler + "]";
+            if (remove) {
+                shard.recoveryStats().decrementRecoveriesAsSource();
+            }
             if (shardRecoveryHandlers.isEmpty()) {
                 ongoingRecoveries.remove(shard);
             }
@@ -181,6 +185,8 @@ public class RecoverySource extends AbstractComponent {
                         handlers.cancel(reason);
                     } catch (Exception ex) {
                         failures.add(ex);
+                    } finally {
+                        shard.recoveryStats().decrementRecoveriesAsSource();
                     }
                 }
                 ExceptionsHelper.maybeThrowRuntimeAndSuppress(failures);

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoverySource.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoverySource.java
@@ -160,7 +160,7 @@ public class RecoverySource extends AbstractComponent {
             }
             assert shardRecoveryHandlers.contains(handler) == false : "Handler was already registered [" + handler + "]";
             shardRecoveryHandlers.add(handler);
-            shard.recoveryStats().incrementRecoveriesAsSource();
+            shard.recoveryStats().incCurrentAsSource();
         }
 
         synchronized void remove(IndexShard shard, RecoverySourceHandler handler) {
@@ -169,7 +169,7 @@ public class RecoverySource extends AbstractComponent {
             boolean remove = shardRecoveryHandlers.remove(handler);
             assert remove : "Handler was not registered [" + handler + "]";
             if (remove) {
-                shard.recoveryStats().decrementRecoveriesAsSource();
+                shard.recoveryStats().decCurrentAsSource();
             }
             if (shardRecoveryHandlers.isEmpty()) {
                 ongoingRecoveries.remove(shard);
@@ -186,7 +186,7 @@ public class RecoverySource extends AbstractComponent {
                     } catch (Exception ex) {
                         failures.add(ex);
                     } finally {
-                        shard.recoveryStats().decrementRecoveriesAsSource();
+                        shard.recoveryStats().decCurrentAsSource();
                     }
                 }
                 ExceptionsHelper.maybeThrowRuntimeAndSuppress(failures);

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoveryStatus.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoveryStatus.java
@@ -85,7 +85,7 @@ public class RecoveryStatus extends AbstractRefCounted {
         this.store = indexShard.store();
         // make sure the store is not released until we are done.
         store.incRef();
-        indexShard.recoveryStats().incrementRecoveriesAsTarget();
+        indexShard.recoveryStats().incCurrentAsTarget();
         logger.info("--> incremented recoveries {}", indexShard.recoveryStats());
     }
 
@@ -241,7 +241,7 @@ public class RecoveryStatus extends AbstractRefCounted {
         } finally {
             // free store. increment happens in constructor
             store.decRef();
-            indexShard.recoveryStats().decrementRecoveriesAsTarget();
+            indexShard.recoveryStats().decCurrentAsTarget();
         }
     }
 

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoveryStatus.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoveryStatus.java
@@ -85,6 +85,8 @@ public class RecoveryStatus extends AbstractRefCounted {
         this.store = indexShard.store();
         // make sure the store is not released until we are done.
         store.incRef();
+        indexShard.recoveryStats().incrementRecoveriesAsTarget();
+        logger.info("--> incremented recoveries {}", indexShard.recoveryStats());
     }
 
     private final Map<String, String> tempFileNames = ConcurrentCollections.newConcurrentMap();
@@ -239,6 +241,7 @@ public class RecoveryStatus extends AbstractRefCounted {
         } finally {
             // free store. increment happens in constructor
             store.decRef();
+            indexShard.recoveryStats().decrementRecoveriesAsTarget();
         }
     }
 

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
@@ -26,7 +26,6 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchIllegalStateException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.Version;
-import org.elasticsearch.bootstrap.Elasticsearch;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.Nullable;
@@ -458,6 +457,10 @@ public class RecoveryTarget extends AbstractComponent {
             try (RecoveriesCollection.StatusRef statusRef = onGoingRecoveries.getStatusSafe(request.recoveryId(), request.shardId())) {
                 final RecoveryStatus recoveryStatus = statusRef.status();
                 final Store store = recoveryStatus.store();
+                final RecoveryState.Index indexState = recoveryStatus.state().getIndex();
+                if (request.sourceThrottleTimeInNanos() != RecoveryState.Index.UNKNOWN) {
+                    indexState.addSourceThrottling(request.sourceThrottleTimeInNanos());
+                }
                 IndexOutput indexOutput;
                 if (request.position() == 0) {
                     indexOutput = recoveryStatus.openAndPutIndexOutput(request.name(), request.metadata(), store);
@@ -465,14 +468,16 @@ public class RecoveryTarget extends AbstractComponent {
                     indexOutput = recoveryStatus.getOpenIndexOutput(request.name());
                 }
                 if (recoverySettings.rateLimiter() != null) {
-                    recoverySettings.rateLimiter().pause(request.content().length());
+                    long targetThrottling = recoverySettings.rateLimiter().pause(request.content().length());
+                    indexState.addTargetThrottling(targetThrottling);
+                    recoveryStatus.indexShard().recoveryStats().addThrottleTime(targetThrottling);
                 }
                 BytesReference content = request.content();
                 if (!content.hasArray()) {
                     content = content.toBytesArray();
                 }
                 indexOutput.writeBytes(content.array(), content.arrayOffset(), content.length());
-                recoveryStatus.state().getIndex().addRecoveredBytesToFile(request.name(), content.length());
+                indexState.addRecoveredBytesToFile(request.name(), content.length());
                 if (indexOutput.getFilePointer() >= request.length() || request.lastChunk()) {
                     try {
                         Store.verify(indexOutput);

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/stats/RestIndicesStatsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/stats/RestIndicesStatsAction.java
@@ -81,6 +81,7 @@ public class RestIndicesStatsAction extends BaseRestHandler {
             indicesStatsRequest.completion(metrics.contains("completion"));
             indicesStatsRequest.suggest(metrics.contains("suggest"));
             indicesStatsRequest.queryCache(metrics.contains("query_cache"));
+            indicesStatsRequest.recovery(metrics.contains("recovery"));
         }
 
         if (request.hasParam("groups")) {

--- a/src/test/java/org/elasticsearch/index/store/CorruptedFileTest.java
+++ b/src/test/java/org/elasticsearch/index/store/CorruptedFileTest.java
@@ -404,7 +404,7 @@ public class CorruptedFileTest extends ElasticsearchIntegrationTest {
                         RecoveryFileChunkRequest req = (RecoveryFileChunkRequest) request;
                         if (truncate && req.length() > 1) {
                             BytesArray array = new BytesArray(req.content().array(), req.content().arrayOffset(), (int) req.length() - 1);
-                            request = new RecoveryFileChunkRequest(req.recoveryId(), req.shardId(), req.metadata(), req.position(), array, req.lastChunk());
+                            request = new RecoveryFileChunkRequest(req.recoveryId(), req.shardId(), req.metadata(), req.position(), array, req.lastChunk(), req.sourceThrottleTimeInNanos());
                         } else {
                             byte[] array = req.content().array();
                             int i = randomIntBetween(0, req.content().length() - 1);

--- a/src/test/java/org/elasticsearch/indices/stats/IndexStatsTests.java
+++ b/src/test/java/org/elasticsearch/indices/stats/IndexStatsTests.java
@@ -19,9 +19,7 @@
 
 package org.elasticsearch.indices.stats;
 
-import org.apache.lucene.util.LuceneTestCase;
 import org.apache.lucene.util.Version;
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsResponse;
 import org.elasticsearch.action.admin.indices.stats.*;
 import org.elasticsearch.action.admin.indices.stats.CommonStatsFlags.Flag;
@@ -650,7 +648,8 @@ public class IndexStatsTests extends ElasticsearchIntegrationTest {
     @Test
     public void testFlagOrdinalOrder() {
         Flag[] flags = new Flag[]{Flag.Store, Flag.Indexing, Flag.Get, Flag.Search, Flag.Merge, Flag.Flush, Flag.Refresh,
-                Flag.FilterCache, Flag.IdCache, Flag.FieldData, Flag.Docs, Flag.Warmer, Flag.Percolate, Flag.Completion, Flag.Segments, Flag.Translog, Flag.Suggest, Flag.QueryCache};
+                Flag.FilterCache, Flag.IdCache, Flag.FieldData, Flag.Docs, Flag.Warmer, Flag.Percolate, Flag.Completion, Flag.Segments,
+                Flag.Translog, Flag.Suggest, Flag.QueryCache, Flag.Recovery};
 
         assertThat(flags.length, equalTo(Flag.values().length));
         for (int i = 0; i < flags.length; i++) {
@@ -921,6 +920,9 @@ public class IndexStatsTests extends ElasticsearchIntegrationTest {
             case QueryCache:
                 builder.setQueryCache(set);
                 break;
+            case Recovery:
+                builder.setRecovery(set);
+                break;
             default:
                 fail("new flag? " + flag);
                 break;
@@ -965,6 +967,8 @@ public class IndexStatsTests extends ElasticsearchIntegrationTest {
                 return response.getSuggest() != null;
             case QueryCache:
                 return response.getQueryCache() != null;
+            case Recovery:
+                return response.getRecoveryStats() != null;
             default:
                 fail("new flag? " + flag);
                 return false;

--- a/src/test/java/org/elasticsearch/test/rest/section/Assertion.java
+++ b/src/test/java/org/elasticsearch/test/rest/section/Assertion.java
@@ -73,4 +73,11 @@ public abstract class Assertion implements ExecutableSection {
      * Executes the assertion comparing the actual value (parsed from the response) with the expected one
      */
     protected abstract void doAssert(Object actualValue, Object expectedValue);
+
+    /**
+     * a utility to get the class of an object, protecting for null (i.e., returning null if the input is null)
+     */
+    protected Class<?> safeClass(Object o) {
+        return o == null ? null : o.getClass();
+    }
 }

--- a/src/test/java/org/elasticsearch/test/rest/section/GreaterThanAssertion.java
+++ b/src/test/java/org/elasticsearch/test/rest/section/GreaterThanAssertion.java
@@ -43,7 +43,7 @@ public class GreaterThanAssertion extends Assertion {
     @SuppressWarnings("unchecked")
     protected void doAssert(Object actualValue, Object expectedValue) {
         logger.trace("assert that [{}] is greater than [{}] (field: [{}])", actualValue, expectedValue, getField());
-        assertThat("value of [" + getField() + "] is not comparable (got [" + actualValue.getClass() + "])", actualValue, instanceOf(Comparable.class));
+        assertThat("value of [" + getField() + "] is not comparable (got [" + safeClass(actualValue) + "])", actualValue, instanceOf(Comparable.class));
         assertThat("expected value of [" + getField() + "] is not comparable (got [" + expectedValue.getClass() + "])", expectedValue, instanceOf(Comparable.class));
         try {
             assertThat(errorMessage(), (Comparable) actualValue, greaterThan((Comparable) expectedValue));

--- a/src/test/java/org/elasticsearch/test/rest/section/GreaterThanEqualToAssertion.java
+++ b/src/test/java/org/elasticsearch/test/rest/section/GreaterThanEqualToAssertion.java
@@ -43,7 +43,7 @@ public class GreaterThanEqualToAssertion extends Assertion {
     @Override
     protected void doAssert(Object actualValue, Object expectedValue) {
         logger.trace("assert that [{}] is greater than or equal to [{}] (field: [{}])", actualValue, expectedValue, getField());
-        assertThat("value of [" + getField() + "] is not comparable (got [" + actualValue.getClass() + "])", actualValue, instanceOf(Comparable.class));
+        assertThat("value of [" + getField() + "] is not comparable (got [" + safeClass(actualValue) + "])", actualValue, instanceOf(Comparable.class));
         assertThat("expected value of [" + getField() + "] is not comparable (got [" + expectedValue.getClass() + "])", expectedValue, instanceOf(Comparable.class));
         try {
             assertThat(errorMessage(), (Comparable) actualValue, greaterThanOrEqualTo((Comparable) expectedValue));

--- a/src/test/java/org/elasticsearch/test/rest/section/LengthAssertion.java
+++ b/src/test/java/org/elasticsearch/test/rest/section/LengthAssertion.java
@@ -53,7 +53,7 @@ public class LengthAssertion extends Assertion {
         } else if (actualValue instanceof Map) {
             assertThat(errorMessage(), ((Map) actualValue).keySet().size(), equalTo(length));
         } else {
-            throw new UnsupportedOperationException("value is of unsupported type [" + actualValue.getClass().getSimpleName() + "]");
+            throw new UnsupportedOperationException("value is of unsupported type [" + safeClass(actualValue) + "]");
         }
     }
 

--- a/src/test/java/org/elasticsearch/test/rest/section/LessThanAssertion.java
+++ b/src/test/java/org/elasticsearch/test/rest/section/LessThanAssertion.java
@@ -44,7 +44,7 @@ public class LessThanAssertion extends Assertion {
     @SuppressWarnings("unchecked")
     protected void doAssert(Object actualValue, Object expectedValue) {
         logger.trace("assert that [{}] is less than [{}] (field: [{}])", actualValue, expectedValue, getField());
-        assertThat("value of [" + getField() + "] is not comparable (got [" + actualValue.getClass() + "])", actualValue, instanceOf(Comparable.class));
+        assertThat("value of [" + getField() + "] is not comparable (got [" + safeClass(actualValue) + "])", actualValue, instanceOf(Comparable.class));
         assertThat("expected value of [" + getField() + "] is not comparable (got [" + expectedValue.getClass() + "])", expectedValue, instanceOf(Comparable.class));
         try {
             assertThat(errorMessage(), (Comparable) actualValue, lessThan((Comparable) expectedValue));

--- a/src/test/java/org/elasticsearch/test/rest/section/LessThanOrEqualToAssertion.java
+++ b/src/test/java/org/elasticsearch/test/rest/section/LessThanOrEqualToAssertion.java
@@ -43,7 +43,7 @@ public class LessThanOrEqualToAssertion  extends Assertion {
     @Override
     protected void doAssert(Object actualValue, Object expectedValue) {
         logger.trace("assert that [{}] is less than or equal to [{}] (field: [{}])", actualValue, expectedValue, getField());
-        assertThat("value of [" + getField() + "] is not comparable (got [" + actualValue.getClass() + "])", actualValue, instanceOf(Comparable.class));
+        assertThat("value of [" + getField() + "] is not comparable (got [" + safeClass(actualValue) + "])", actualValue, instanceOf(Comparable.class));
         assertThat("expected value of [" + getField() + "] is not comparable (got [" + expectedValue.getClass() + "])", expectedValue, instanceOf(Comparable.class));
         try {
             assertThat(errorMessage(), (Comparable) actualValue, lessThanOrEqualTo((Comparable) expectedValue));

--- a/src/test/java/org/elasticsearch/test/rest/section/MatchAssertion.java
+++ b/src/test/java/org/elasticsearch/test/rest/section/MatchAssertion.java
@@ -48,7 +48,7 @@ public class MatchAssertion extends Assertion {
         if (expectedValue instanceof String) {
             String expValue = ((String) expectedValue).trim();
             if (expValue.length() > 2 && expValue.startsWith("/") && expValue.endsWith("/")) {
-                assertThat("field [" + getField() + "] was expected to be of type String but is an instanceof [" + actualValue.getClass() + "]", actualValue, instanceOf(String.class));
+                assertThat("field [" + getField() + "] was expected to be of type String but is an instanceof [" + safeClass(actualValue) + "]", actualValue, instanceOf(String.class));
                 String stringValue = (String) actualValue;
                 String regex = expValue.substring(1, expValue.length() - 1);
                 logger.trace("assert that [{}] matches [{}]", stringValue, regex);
@@ -60,7 +60,7 @@ public class MatchAssertion extends Assertion {
 
         assertThat(errorMessage(), actualValue, notNullValue());
         logger.trace("assert that [{}] matches [{}] (field [{}])", actualValue, expectedValue, getField());
-        if (!actualValue.getClass().equals(expectedValue.getClass())) {
+        if (!actualValue.getClass().equals(safeClass(expectedValue))) {
             if (actualValue instanceof Number && expectedValue instanceof Number) {
                 //Double 1.0 is equal to Integer 1
                 assertThat(errorMessage(), ((Number) actualValue).doubleValue(), equalTo(((Number) expectedValue).doubleValue()));


### PR DESCRIPTION
This commit adds throttling statistics to the index stats API and to the recovery state.
