### PR TITLE
Catch java.lang.Error when getting a mac address

### DIFF
--- a/src/main/java/org/elasticsearch/common/MacAddressProvider.java
+++ b/src/main/java/org/elasticsearch/common/MacAddressProvider.java
@@ -68,6 +68,9 @@ public class MacAddressProvider {
         } catch( SocketException se ) {
             logger.warn("Unable to get mac address, will use a dummy address", se);
             // address will be set below
+        } catch (Error e) {
+            //Apparently Azure WebJobs return java.lang.Error when trying to get the macaddress
+            logger.warn("unable to get mac address, will use a dummy address", e);
         }
 
         if (!isValidAddress(address)) {


### PR DESCRIPTION
Apparently Azure WebJobs throw a java.lang.Error when enumerating network interfaces.
Catch this error and just use the generated one in this case.

See #10099
