### PR TITLE
Return an HTTP error code when a suggest request failed instead of 200

### DIFF
--- a/src/main/java/org/elasticsearch/action/count/CountResponse.java
+++ b/src/main/java/org/elasticsearch/action/count/CountResponse.java
@@ -19,15 +19,13 @@
 
 package org.elasticsearch.action.count;
 
-import org.elasticsearch.Version;
+import java.io.IOException;
+import java.util.List;
 import org.elasticsearch.action.ShardOperationFailedException;
 import org.elasticsearch.action.support.broadcast.BroadcastOperationResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.rest.RestStatus;
-
-import java.io.IOException;
-import java.util.List;
 
 /**
  * The response of the count action.
@@ -62,24 +60,7 @@ public class CountResponse extends BroadcastOperationResponse {
     }
 
     public RestStatus status() {
-        if (getFailedShards() == 0) {
-            if (getSuccessfulShards() == 0 && getTotalShards() > 0) {
-                return RestStatus.SERVICE_UNAVAILABLE;
-            }
-            return RestStatus.OK;
-        }
-        // if total failure, bubble up the status code to the response level
-        if (getSuccessfulShards() == 0 && getTotalShards() > 0) {
-            RestStatus status = RestStatus.OK;
-            for (ShardOperationFailedException shardFailure : getShardFailures()) {
-                RestStatus shardStatus = shardFailure.status();
-                if (shardStatus.getStatus() >= status.getStatus()) {
-                    status = shardStatus;
-                }
-            }
-            return status;
-        }
-        return RestStatus.OK;
+        return RestStatus.status(getSuccessfulShards(), getTotalShards(), getShardFailures());
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/search/SearchResponse.java
+++ b/src/main/java/org/elasticsearch/action/search/SearchResponse.java
@@ -69,24 +69,7 @@ public class SearchResponse extends ActionResponse implements StatusToXContent {
 
     @Override
     public RestStatus status() {
-        if (shardFailures.length == 0) {
-            if (successfulShards == 0 && totalShards > 0) {
-                return RestStatus.SERVICE_UNAVAILABLE;
-            }
-            return RestStatus.OK;
-        }
-        // if total failure, bubble up the status code to the response level
-        if (successfulShards == 0 && totalShards > 0) {
-            RestStatus status = RestStatus.OK;
-            for (int i = 0; i < shardFailures.length; i++) {
-                RestStatus shardStatus = shardFailures[i].status();
-                if (shardStatus.getStatus() >= status.getStatus()) {
-                    status = shardFailures[i].status();
-                }
-            }
-            return status;
-        }
-        return RestStatus.OK;
+        return RestStatus.status(successfulShards, totalShards, shardFailures);
     }
 
     /**

--- a/src/main/java/org/elasticsearch/rest/action/suggest/RestSuggestAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/suggest/RestSuggestAction.java
@@ -19,6 +19,9 @@
 
 package org.elasticsearch.rest.action.suggest;
 
+import static org.elasticsearch.rest.RestRequest.Method.GET;
+import static org.elasticsearch.rest.RestRequest.Method.POST;
+import static org.elasticsearch.rest.action.support.RestActions.buildBroadcastShardsHeader;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.action.suggest.SuggestRequest;
 import org.elasticsearch.action.suggest.SuggestResponse;
@@ -28,14 +31,15 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.rest.*;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.BytesRestResponse;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.RestResponse;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.rest.action.support.RestBuilderListener;
 import org.elasticsearch.search.suggest.Suggest;
-
-import static org.elasticsearch.rest.RestRequest.Method.GET;
-import static org.elasticsearch.rest.RestRequest.Method.POST;
-import static org.elasticsearch.rest.RestStatus.OK;
-import static org.elasticsearch.rest.action.support.RestActions.buildBroadcastShardsHeader;
 
 /**
  *
@@ -72,6 +76,7 @@ public class RestSuggestAction extends BaseRestHandler {
         client.suggest(suggestRequest, new RestBuilderListener<SuggestResponse>(channel) {
             @Override
             public RestResponse buildResponse(SuggestResponse response, XContentBuilder builder) throws Exception {
+                RestStatus restStatus = RestStatus.status(response.getSuccessfulShards(), response.getTotalShards(), response.getShardFailures());
                 builder.startObject();
                 buildBroadcastShardsHeader(builder, response);
                 Suggest suggest = response.getSuggest();
@@ -79,7 +84,7 @@ public class RestSuggestAction extends BaseRestHandler {
                     suggest.toXContent(builder, request);
                 }
                 builder.endObject();
-                return new BytesRestResponse(OK, builder);
+                return new BytesRestResponse(restStatus, builder);
             }
         });
     }

--- a/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
+++ b/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
@@ -18,7 +18,8 @@
  */
 package org.elasticsearch.snapshots;
 
-import com.google.common.collect.ImmutableList;
+import java.io.IOException;
+import org.elasticsearch.action.ShardOperationFailedException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
@@ -28,8 +29,7 @@ import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentBuilderString;
 import org.elasticsearch.rest.RestStatus;
-
-import java.io.IOException;
+import com.google.common.collect.ImmutableList;
 
 /**
  * Information about snapshot
@@ -179,15 +179,7 @@ public class SnapshotInfo implements ToXContent, Streamable {
         if (shardFailures.size() == 0) {
             return RestStatus.OK;
         }
-        RestStatus status = RestStatus.OK;
-        if (successfulShards == 0 && totalShards > 0) {
-            for (SnapshotShardFailure shardFailure : shardFailures)
-                if (shardFailure.status().getStatus() > status().getStatus()) {
-                    status = shardFailure.status();
-                }
-            return status;
-        }
-        return status;
+        return RestStatus.status(successfulShards, totalShards, shardFailures.toArray(new ShardOperationFailedException[shardFailures.size()]));
     }
 
     static final class Fields {


### PR DESCRIPTION
The `_suggest` API always returns 200 regardless of the call being successful or not.
This PR sets the http status in a way similar to the SearchResponse https://github.com/elastic/elasticsearch/blob/master/src/main/java/org/elasticsearch/action/search/SearchResponse.java#L71
