### PR TITLE
Add filename to corruption message

### DIFF
--- a/src/main/java/org/elasticsearch/index/store/LegacyVerification.java
+++ b/src/main/java/org/elasticsearch/index/store/LegacyVerification.java
@@ -56,8 +56,8 @@ class LegacyVerification {
         final Checksum checksum = new BufferedChecksum(new Adler32());
         long written;
         
-        public Adler32VerifyingIndexOutput(IndexOutput out, String adler32, long length) {
-            super(out);
+        public Adler32VerifyingIndexOutput(IndexOutput out, String name, String adler32, long length) {
+            super(out, name);
             this.adler32 = adler32;
             this.length = length;
         }
@@ -65,13 +65,13 @@ class LegacyVerification {
         @Override
         public void verify() throws IOException {
             if (written != length) {
-                throw new CorruptIndexException("expected length=" + length + " != actual length: " + written + " : file truncated?" + 
-                                                " (resource=" + out + ")");
+                throw new CorruptIndexException("expected length=" + length + " != actual length: " + written + " : file truncated? " +
+                                                super.toString());
             }
             final String actualChecksum = Store.digestToString(checksum.getValue());
             if (!adler32.equals(actualChecksum)) {
                 throw new CorruptIndexException("checksum failed (hardware problem?) : expected=" + adler32 +
-                                                " actual=" + actualChecksum + " resource=(" + out + ")");
+                                                " actual=" + actualChecksum +" " + super.toString());
             }
         }
 
@@ -97,16 +97,16 @@ class LegacyVerification {
         final long length;
         long written;
         
-        public LengthVerifyingIndexOutput(IndexOutput out, long length) {
-            super(out);
+        public LengthVerifyingIndexOutput(IndexOutput out, String name, long length) {
+            super(out, name);
             this.length = length;
         }
 
         @Override
         public void verify() throws IOException {
             if (written != length) {
-                throw new CorruptIndexException("expected length=" + length + " != actual length: " + written + " : file truncated?" + 
-                                                " (resource=" + out + ")");
+                throw new CorruptIndexException("expected length=" + length + " != actual length: " + written + " : file truncated? " +
+                        super.toString());
             }
         }
 

--- a/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/src/main/java/org/elasticsearch/index/store/Store.java
@@ -430,16 +430,16 @@ public class Store extends AbstractIndexShardComponent implements CloseableIndex
             if (metadata.hasLegacyChecksum()) {
                 if (isUnreliableLegacyChecksum(metadata)) {
                     logger.debug("create legacy length-only output for non-write-once file {}", fileName);
-                    output = new LegacyVerification.LengthVerifyingIndexOutput(output, metadata.length());
+                    output = new LegacyVerification.LengthVerifyingIndexOutput(output, metadata.name(), metadata.length());
                 } else {
                     logger.debug("create legacy adler32 output for {}", fileName);
-                    output = new LegacyVerification.Adler32VerifyingIndexOutput(output, metadata.checksum(), metadata.length());
+                    output = new LegacyVerification.Adler32VerifyingIndexOutput(output, metadata.name(), metadata.checksum(), metadata.length());
                 }
             } else if (metadata.checksum() == null) {
                 // TODO: when the file is a segments_N, we can still CRC-32 + length for more safety
                 // its had that checksum forever.
                 logger.debug("create legacy length-only output for {}", fileName);
-                output = new LegacyVerification.LengthVerifyingIndexOutput(output, metadata.length());
+                output = new LegacyVerification.LengthVerifyingIndexOutput(output, metadata.name(), metadata.length());
             } else {
                 assert metadata.writtenBy() != null;
                 assert metadata.writtenBy().onOrAfter(Version.LUCENE_48);
@@ -1214,7 +1214,7 @@ public class Store extends AbstractIndexShardComponent implements CloseableIndex
         private String actualChecksum;
 
         LuceneVerifyingIndexOutput(StoreFileMetaData metadata, IndexOutput out) {
-            super(out);
+            super(out, metadata.name());
             this.metadata = metadata;
             checksumPosition = metadata.length() - 8; // the last 8 bytes are the checksum
         }

--- a/src/main/java/org/elasticsearch/index/store/VerifyingIndexOutput.java
+++ b/src/main/java/org/elasticsearch/index/store/VerifyingIndexOutput.java
@@ -31,9 +31,12 @@ import org.elasticsearch.common.lucene.store.FilterIndexOutput;
 // do NOT optimize this class for performance
 public abstract class VerifyingIndexOutput extends FilterIndexOutput {
 
+    private final String name;
+
     /** Sole constructor */
-    VerifyingIndexOutput(IndexOutput out) {
+    VerifyingIndexOutput(IndexOutput out, String name) {
         super(out);
+        this.name = name;
     }
     
     /**
@@ -41,5 +44,16 @@ public abstract class VerifyingIndexOutput extends FilterIndexOutput {
      * called after all data has been written to this output.
      */
     public abstract void verify() throws IOException;
+
+    /**
+     * Returns the name of the resource to verfiy
+     */
+    public String getName() {
+        return name;
+    }
+
+    public String toString() {
+        return "(resource=" + out + ")(name=" + name + ")"; // out.toString is buggy in 4.10.x so we also append the name here to see which file we verify
+    }
 
 }

--- a/src/test/java/org/elasticsearch/index/store/LegacyVerificationTests.java
+++ b/src/test/java/org/elasticsearch/index/store/LegacyVerificationTests.java
@@ -48,7 +48,7 @@ public class LegacyVerificationTests extends ElasticsearchLuceneTestCase {
         Directory dir = newDirectory();
         
         IndexOutput o = dir.createOutput("legacy", IOContext.DEFAULT);
-        VerifyingIndexOutput out = new LegacyVerification.Adler32VerifyingIndexOutput(o, expectedString, 8);
+        VerifyingIndexOutput out = new LegacyVerification.Adler32VerifyingIndexOutput(o, "legacy", expectedString, 8);
         out.writeBytes(bytes, 0, bytes.length);
         out.verify();
         out.close();
@@ -67,7 +67,7 @@ public class LegacyVerificationTests extends ElasticsearchLuceneTestCase {
         Directory dir = newDirectory();
         
         IndexOutput o = dir.createOutput("legacy", IOContext.DEFAULT);
-        VerifyingIndexOutput out = new LegacyVerification.Adler32VerifyingIndexOutput(o, expectedString, 8);
+        VerifyingIndexOutput out = new LegacyVerification.Adler32VerifyingIndexOutput(o, "legacy", expectedString, 8);
         out.writeBytes(corruptBytes, 0, bytes.length);
         try {
             out.verify();
@@ -91,7 +91,7 @@ public class LegacyVerificationTests extends ElasticsearchLuceneTestCase {
         Directory dir = newDirectory();
         
         IndexOutput o = dir.createOutput("oneByte", IOContext.DEFAULT);
-        VerifyingIndexOutput out = new LegacyVerification.LengthVerifyingIndexOutput(o, 1);
+        VerifyingIndexOutput out = new LegacyVerification.LengthVerifyingIndexOutput(o, "oneByte", 1);
         out.writeByte((byte) 3);
         out.verify();
         out.close();
@@ -104,7 +104,7 @@ public class LegacyVerificationTests extends ElasticsearchLuceneTestCase {
         Directory dir = newDirectory();
         
         IndexOutput o = dir.createOutput("oneByte", IOContext.DEFAULT);
-        VerifyingIndexOutput out = new LegacyVerification.LengthVerifyingIndexOutput(o, 2);
+        VerifyingIndexOutput out = new LegacyVerification.LengthVerifyingIndexOutput(o, "oneByte", 2);
         out.writeByte((byte) 3);
         try {
             out.verify();


### PR DESCRIPTION
Today we rely on the IndexOutput#toString method to print the actual
resource name we are verifying. This has a but in the 4.10.x series
that leaves us with the default toString. This commit adds the filename
to each corruption message for easier debugging.

Relates to #10062
