### PR TITLE
Tests: improve logging of external node version and build

### DIFF
--- a/src/main/java/org/elasticsearch/Build.java
+++ b/src/main/java/org/elasticsearch/Build.java
@@ -93,4 +93,9 @@ public class Build {
         out.writeString(build.hashShort());
         out.writeString(build.timestamp());
     }
+
+    @Override
+    public String toString() {
+        return "[" + hash + "][" + timestamp + "]";
+    }
 }

--- a/src/test/java/org/elasticsearch/test/ExternalNode.java
+++ b/src/test/java/org/elasticsearch/test/ExternalNode.java
@@ -43,7 +43,6 @@ import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
-import static junit.framework.Assert.assertFalse;
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 
 /**
@@ -141,6 +140,7 @@ final class ExternalNode implements Closeable {
             if (waitForNode(client, nodeName)) {
                 nodeInfo = nodeInfo(client, nodeName);
                 assert nodeInfo != null;
+                logger.debug("external node {} found, version [{}], build {}", nodeInfo.getNode(), nodeInfo.getVersion(), nodeInfo.getBuild());
             } else {
                 throw new IllegalStateException("Node [" + nodeName + "] didn't join the cluster");
             }


### PR DESCRIPTION
The BWC tests also run against a snapshot build of previous release branches. Upon a failure it's important to know what commit exactly was used.
