### PR TITLE
Always send current ES version when downloading plugins

### DIFF
--- a/src/main/java/org/elasticsearch/common/http/client/HttpDownloadHelper.java
+++ b/src/main/java/org/elasticsearch/common/http/client/HttpDownloadHelper.java
@@ -21,6 +21,7 @@ package org.elasticsearch.common.http.client;
 
 import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.ElasticsearchTimeoutException;
+import org.elasticsearch.Version;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.unit.TimeValue;
 
@@ -267,6 +268,9 @@ public class HttpDownloadHelper {
                 ((HttpURLConnection) connection).setUseCaches(true);
                 ((HttpURLConnection) connection).setConnectTimeout(5000);
             }
+            connection.setRequestProperty("ES-Version", Version.CURRENT.toString());
+            connection.setRequestProperty("User-Agent", "elasticsearch-plugin-manager");
+
             // connect to the remote site (may take some time)
             connection.connect();
 


### PR DESCRIPTION
to enable download servers to send the correct plugin version for the
node that is installing it this PR sends the current version as a header
to the server.
