### PR TITLE
Validate API: provide more verbose explanation

### DIFF
--- a/docs/reference/search/validate.asciidoc
+++ b/docs/reference/search/validate.asciidoc
@@ -75,3 +75,84 @@ curl -XGET 'http://localhost:9200/twitter/tweet/_validate/query?q=post_date:foo&
   } ]
 }
 --------------------------------------------------
+
+coming[1.6] When the query is valid, the explanation defaults to the string
+representation of that query. The explanation has been made more detailed to
+show the actual Lucene query that will be executed.
+
+For Fuzzy Queries:
+
+[source,js]
+--------------------------------------------------
+curl -XGET 'http://localhost:9200/imdb/movies/_validate/query?explain=true'
+{
+  "query": {
+    "fuzzy": {
+      "actors": "kyle"
+    }
+  }
+}
+--------------------------------------------------
+
+Response:
+
+[source,js]
+--------------------------------------------------
+{
+   "valid": true,
+   "_shards": {
+      "total": 1,
+      "successful": 1,
+      "failed": 0
+   },
+   "explanations": [
+      {
+         "index": "imdb",
+         "valid": true,
+         "explanation": "filtered(plot:kyle plot:kylie^0.75 plot:kyne^0.75 plot:lyle^0.75 plot:pyle^0.75)->cache(_type:movies)"
+      }
+   ]
+}
+--------------------------------------------------
+
+For More Like This:
+
+[source,js]
+--------------------------------------------------
+curl -XGET 'http://localhost:9200/imdb/movies/_validate/query?explain=true'
+{
+  "query": {
+    "more_like_this": {
+      "like": {
+        "_id": "88247"
+      },
+      "boost_terms": 1
+    }
+  }
+}
+--------------------------------------------------
+
+Response:
+
+[source,js]
+--------------------------------------------------
+{
+   "valid": true,
+   "_shards": {
+      "total": 1,
+      "successful": 1,
+      "failed": 0
+   },
+   "explanations": [
+      {
+         "index": "imdb",
+         "valid": true,
+         "explanation": "filtered(((title:terminator^3.71334 plot:future^2.763601 plot:human^2.8415773 plot:sarah^3.4193945 plot:kyle^3.8244398 plot:cyborg^3.9177752 plot:connor^4.040236 plot:reese^4.7133346 ... )~6) -ConstantScore(_uid:movies#88247))->cache(_type:movies)"
+      }
+   ]
+}
+--------------------------------------------------
+
+CAUTION: The request is executed on a single shard only, which is randomly
+selected. The detailed explanation of the query may depend on which shard is
+being hit, and therefore may vary from one request to another.

--- a/docs/reference/search/validate.asciidoc
+++ b/docs/reference/search/validate.asciidoc
@@ -77,14 +77,14 @@ curl -XGET 'http://localhost:9200/twitter/tweet/_validate/query?q=post_date:foo&
 --------------------------------------------------
 
 coming[1.6] When the query is valid, the explanation defaults to the string
-representation of that query. The explanation has been made more detailed to
-show the actual Lucene query that will be executed.
+representation of that query. With `rewrite` set to `true`, the explanation
+is more detailed showing the actual Lucene query that will be executed.
 
 For Fuzzy Queries:
 
 [source,js]
 --------------------------------------------------
-curl -XGET 'http://localhost:9200/imdb/movies/_validate/query?explain=true'
+curl -XGET 'http://localhost:9200/imdb/movies/_validate/query?rewrite=true'
 {
   "query": {
     "fuzzy": {
@@ -119,7 +119,7 @@ For More Like This:
 
 [source,js]
 --------------------------------------------------
-curl -XGET 'http://localhost:9200/imdb/movies/_validate/query?explain=true'
+curl -XGET 'http://localhost:9200/imdb/movies/_validate/query?rewrite=true'
 {
   "query": {
     "more_like_this": {

--- a/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ShardValidateQueryRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ShardValidateQueryRequest.java
@@ -37,6 +37,7 @@ class ShardValidateQueryRequest extends BroadcastShardOperationRequest {
     private BytesReference source;
     private String[] types = Strings.EMPTY_ARRAY;
     private boolean explain;
+    private boolean rewrite;
     private long nowInMillis;
 
     @Nullable
@@ -51,6 +52,7 @@ class ShardValidateQueryRequest extends BroadcastShardOperationRequest {
         this.source = request.source();
         this.types = request.types();
         this.explain = request.explain();
+        this.rewrite = request.rewrite();
         this.filteringAliases = filteringAliases;
         this.nowInMillis = request.nowInMillis;
     }
@@ -65,6 +67,10 @@ class ShardValidateQueryRequest extends BroadcastShardOperationRequest {
 
     public boolean explain() {
         return this.explain;
+    }
+
+    public boolean rewrite() { 
+        return this.rewrite; 
     }
 
     public String[] filteringAliases() {
@@ -96,6 +102,7 @@ class ShardValidateQueryRequest extends BroadcastShardOperationRequest {
         }
 
         explain = in.readBoolean();
+        rewrite = in.readBoolean();
         nowInMillis = in.readVLong();
     }
 
@@ -118,6 +125,7 @@ class ShardValidateQueryRequest extends BroadcastShardOperationRequest {
         }
 
         out.writeBoolean(explain);
+        out.writeBoolean(rewrite);
         out.writeVLong(nowInMillis);
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryRequest.java
@@ -50,6 +50,7 @@ public class ValidateQueryRequest extends BroadcastOperationRequest<ValidateQuer
     private boolean sourceUnsafe;
 
     private boolean explain;
+    private boolean rewrite;
 
     private String[] types = Strings.EMPTY_ARRAY;
 
@@ -176,6 +177,20 @@ public class ValidateQueryRequest extends BroadcastOperationRequest<ValidateQuer
         return explain;
     }
 
+    /**
+     * Indicates whether the query should be rewritten into primitive queries
+     */
+    public void rewrite(boolean rewrite) {
+        this.rewrite = rewrite;
+    }
+
+    /**
+     * Indicates whether the query should be rewritten into primitive queries
+     */
+    public boolean rewrite() {
+        return rewrite;
+    }
+
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
@@ -192,7 +207,7 @@ public class ValidateQueryRequest extends BroadcastOperationRequest<ValidateQuer
         }
 
         explain = in.readBoolean();
-
+        rewrite = in.readBoolean();
     }
 
     @Override
@@ -207,6 +222,7 @@ public class ValidateQueryRequest extends BroadcastOperationRequest<ValidateQuer
         }
 
         out.writeBoolean(explain);
+        out.writeBoolean(rewrite);
     }
 
     @Override
@@ -217,6 +233,7 @@ public class ValidateQueryRequest extends BroadcastOperationRequest<ValidateQuer
         } catch (Exception e) {
             // ignore
         }
-        return "[" + Arrays.toString(indices) + "]" + Arrays.toString(types) + ", source[" + sSource + "], explain:" + explain;
+        return "[" + Arrays.toString(indices) + "]" + Arrays.toString(types) + ", source[" + sSource + "], explain:" + explain + 
+                ", rewrite:" + rewrite;
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryRequestBuilder.java
@@ -95,6 +95,14 @@ public class ValidateQueryRequestBuilder extends BroadcastOperationRequestBuilde
         return this;
     }
 
+    /**
+     * Indicates whether the query should be rewritten into primitive queries
+     */
+    public ValidateQueryRequestBuilder setRewrite(boolean rewrite) {
+        request.rewrite(rewrite);
+        return this;
+    }
+
     @Override
     protected void doExecute(ActionListener<ValidateQueryResponse> listener) {
         if (sourceBuilder != null) {

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/validate/query/RestValidateQueryAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/validate/query/RestValidateQueryAction.java
@@ -78,6 +78,11 @@ public class RestValidateQueryAction extends BaseRestHandler {
         } else {
             validateQueryRequest.explain(false);
         }
+        if (request.paramAsBoolean("rewrite", false)) {
+            validateQueryRequest.rewrite(true);
+        } else {
+            validateQueryRequest.rewrite(false);
+        }
 
         client.admin().indices().validateQuery(validateQueryRequest, new RestBuilderListener<ValidateQueryResponse>(channel) {
             @Override


### PR DESCRIPTION
For Fuzzy Queries:

```
GET /imdb/movies/_validate/query?explain=true
{
  "query": {
    "fuzzy": {
      "actors": "kyle"
    }
  }
}

Response:

{
   ...
   "explanations": [
      {
         "index": "imdb",
         "valid": true,
         "explanation": "filtered(actors:eyle^0.75 actors:kale^0.75 actors:kayle^0.75 ... )->cache(_type:movies)"
      }
   ]
}
```

For More Like This:

```
GET /imdb/movies/_validate/query?explain=true
{
  "query": {
    "more_like_this": {
      "like": {
        "_id": "88247"
      }
    }
  }
}

Response:

{
   ...
   "explanations": [
      {
         "index": "imdb",
         "valid": true,
         "explanation": "filtered((((title:terminator^3.71334 plot:kyle^1.0604408 plot:cyborg^1.0863208 ... )~2)) -ConstantScore(_uid:movies#88247))->cache(_type:movies)"
      }
   ]
}
```

Relates to #1412
