### PR TITLE
Update templates.asciidoc

### DIFF
--- a/docs/reference/indices/templates.asciidoc
+++ b/docs/reference/indices/templates.asciidoc
@@ -191,3 +191,5 @@ added if it matches an index. Here is a sample of the mentioned file:
     }
 }
 --------------------------------------------------
+
+*Please note that templates added this way will not appear in the `/_template/*` API request.*


### PR DESCRIPTION
I've been attempting to programatically verify that adding index templates via the `{path.conf}/templates/` directory works fine although I was never able to validate this via an API call to the `/_template/`.  It seems that these templates do not appear in that API call, which I discovered in the following mail thread:

http://elasticsearch-users.115913.n3.nabble.com/Loading-of-index-settings-template-from-file-in-config-templates-td4024923.html#d1366317284000-912

My question is why wouldn't the `/_template/*` method return these templates?  This tends to complicate things for those that want to perform automated tests to verify that they are in fact being recognized and used by Elasticsearch.
