### PR TITLE
Remove async replication from the docs and REST spec

### DIFF
--- a/docs/reference/docs/delete-by-query.asciidoc
+++ b/docs/reference/docs/delete-by-query.asciidoc
@@ -30,7 +30,7 @@ commands is:
 --------------------------------------------------
 {
     "_indices" : {
-        "twitter" : { 
+        "twitter" : {
             "_shards" : {
                 "total" : 10,
                 "failed" : 0,
@@ -123,15 +123,6 @@ there, replicated across all shards replicas.
 The routing value (a comma separated list of the routing values) can be
 specified to control which shards the delete by query request will be
 executed on.
-
-[float]
-[[replication-type]]
-=== Replication Type
-
-The replication of the operation can be done in an asynchronous manner
-to the replicas (the operation will return once it has be executed on
-the primary shard). The `replication` parameter can be set to `async`
-(defaults to `sync`) in order to enable it.
 
 [float]
 [[delete-by-query-consistency]]

--- a/docs/reference/docs/delete.asciidoc
+++ b/docs/reference/docs/delete.asciidoc
@@ -94,15 +94,6 @@ redirected into the primary shard within that id group, and replicated
 (if needed) to shard replicas within that id group.
 
 [float]
-[[delete-replication]]
-=== Replication Type
-
-The replication of the operation can be done in an asynchronous manner
-to the replicas (the operation will return once it has be executed on
-the primary shard). The `replication` parameter can be set to `async`
-(defaults to `sync`) in order to enable it.
-
-[float]
 [[delete-consistency]]
 === Write Consistency
 

--- a/docs/reference/docs/index_.asciidoc
+++ b/docs/reference/docs/index_.asciidoc
@@ -343,21 +343,8 @@ Note, for the case where the number of replicas is 1 (total of 2 copies
 of the data), then the default behavior is to succeed if 1 copy (the primary)
 can perform the write.
 
-[float]
-[[index-replication]]
-=== Asynchronous Replication
-
-By default, the index operation only returns after all shards within the
-replication group have indexed the document (sync replication). To
-enable asynchronous replication, causing the replication process to take
-place in the background, set the `replication` parameter to `async`.
-When asynchronous replication is used, the index operation will return
-as soon as the operation succeeds on the primary shard.
-
-The default value for the `replication` setting is `sync` and this default can 
-be overridden on a node-by-node basis using the `action.replication_type`
-setting. Valid values for replication type are `sync` and `async`. To alter this
-behavior per-operation, the `replication` request parameter can be used.
+The index operation only returns after all *active* shards within the
+replication group have indexed the document (sync replication).
 
 [float]
 [[index-refresh]]

--- a/docs/reference/docs/update.asciidoc
+++ b/docs/reference/docs/update.asciidoc
@@ -202,9 +202,6 @@ including:
 
 `timeout`::     Timeout waiting for a shard to become available.
 
-`replication`:: The replication type for the delete/index operation
-                (sync or async).
-
 `consistency`:: The write consistency of the index/delete operation.
 
 `refresh`::     Refresh the relevant primary and replica shards (not the whole

--- a/docs/reference/migration/migrate_2_0.asciidoc
+++ b/docs/reference/migration/migrate_2_0.asciidoc
@@ -51,6 +51,13 @@ In addition, the following node settings related to routing have been deprecated
   document into account when computing its shard (default: `false`). `false` is
   now enforced on new indices.
 
+=== Async replication
+
+The `replication` parameter has been removed from all CRUD operations (index,
+update, delete, bulk, delete-by-query).  These operations are now synchronous
+only, and a request will only return once the changes have been replicated to
+all active shards in the shard group.
+
 === Store
 
 The `memory` / `ram` store (`index.store.type`) option was removed in Elasticsearch 2.0.

--- a/rest-api-spec/api/bulk.json
+++ b/rest-api-spec/api/bulk.json
@@ -25,12 +25,6 @@
           "type" : "boolean",
           "description" : "Refresh the index after performing the operation"
         },
-        "replication": {
-          "type" : "enum",
-          "options" : ["sync","async"],
-          "default" : "sync",
-          "description" : "Explicitly set the replication type"
-        },
         "routing": {
           "type" : "string",
           "description" : "Specific routing value"

--- a/rest-api-spec/api/delete.json
+++ b/rest-api-spec/api/delete.json
@@ -36,12 +36,6 @@
           "type" : "boolean",
           "description" : "Refresh the index after performing the operation"
         },
-        "replication": {
-          "type" : "enum",
-          "options" : ["sync","async"],
-          "default" : "sync",
-          "description" : "Specific replication type"
-        },
         "routing": {
           "type" : "string",
           "description" : "Specific routing value"

--- a/rest-api-spec/api/delete_by_query.json
+++ b/rest-api-spec/api/delete_by_query.json
@@ -50,12 +50,6 @@
             "default" : "open",
             "description" : "Whether to expand wildcard expression to concrete indices that are open, closed or both."
         },
-        "replication": {
-          "type" : "enum",
-          "options" : ["sync","async"],
-          "default" : "sync",
-          "description" : "Specific replication type"
-        },
         "q": {
           "type" : "string",
           "description" : "Query in the Lucene query string syntax"

--- a/rest-api-spec/api/index.json
+++ b/rest-api-spec/api/index.json
@@ -41,12 +41,6 @@
           "type" : "boolean",
           "description" : "Refresh the index after performing the operation"
         },
-        "replication": {
-          "type" : "enum",
-          "options" : ["sync","async"],
-          "default" : "sync",
-          "description" : "Specific replication type"
-        },
         "routing": {
           "type" : "string",
           "description" : "Specific routing value"

--- a/rest-api-spec/api/update.json
+++ b/rest-api-spec/api/update.json
@@ -40,12 +40,6 @@
           "type": "boolean",
           "description": "Refresh the index after performing the operation"
         },
-        "replication": {
-          "type": "enum",
-          "options": ["sync", "async"],
-          "default": "sync",
-          "description": "Specific replication type"
-        },
         "retry_on_conflict": {
           "type": "number",
           "description": "Specify how many times should the operation be retried when a conflict occurs (default: 0)"
@@ -61,7 +55,7 @@
           "description": "The id of a stored script"
         },
         "scripted_upsert": {
-          "type": "boolean",        
+          "type": "boolean",
           "description": "True if the script referenced in script or script_id should be called to perform inserts - defaults to false"
         },
         "timeout": {

--- a/rest-api-spec/test/create/TODO.txt
+++ b/rest-api-spec/test/create/TODO.txt
@@ -1,5 +1,3 @@
 Tests missing for:
 
 # consistency
-# percolate
-# replication

--- a/rest-api-spec/test/delete/TODO.txt
+++ b/rest-api-spec/test/delete/TODO.txt
@@ -1,6 +1,5 @@
 Tests missing for:
 
 # consistency
-# replication
 # timeout
 

--- a/rest-api-spec/test/index/12_shard_header_pending.yaml
+++ b/rest-api-spec/test/index/12_shard_header_pending.yaml
@@ -21,7 +21,6 @@
           index:  foobar
           type:   baz
           id:     1
-          replication:  async
           body:   { foo: bar }
 
  - match:   { _index:   foobar }

--- a/rest-api-spec/test/index/TODO.txt
+++ b/rest-api-spec/test/index/TODO.txt
@@ -1,5 +1,3 @@
 Tests missing for:
 
 # consistency
-# percolate
-# replication

--- a/rest-api-spec/test/update/TODO.txt
+++ b/rest-api-spec/test/update/TODO.txt
@@ -1,7 +1,5 @@
 Tests missing for:
 
 # consistency
-# percolate
-# replication
 # retry_on_conflict
 # timeout


### PR DESCRIPTION
Async replication was deprecated in 1.5, and removed in 2.0.

Relates to #10114
