### PR TITLE
Deprecated the thrift and memcached transports

### DIFF
--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -3,11 +3,7 @@
 
 [partintro]
 --
-The *elasticsearch* REST APIs are exposed using:
-
-* <<modules-http,JSON over HTTP>>,
-* <<modules-thrift,thrift>>,
-* <<modules-memcached,memcached>>.
+The *elasticsearch* REST APIs are exposed using <<modules-http,JSON over HTTP>>.
 
 The conventions listed in this chapter can be applied throughout the REST
 API, unless otherwise specified.

--- a/docs/reference/modules/memcached.asciidoc
+++ b/docs/reference/modules/memcached.asciidoc
@@ -1,6 +1,8 @@
 [[modules-memcached]]
 == memcached
 
+deprecated[1.5.0,The memcached transport is deprecated and will be removed in 2.0.0]
+
 The memcached module allows to expose *elasticsearch*
 APIs over the memcached protocol (as closely
 as possible).

--- a/docs/reference/modules/plugins.asciidoc
+++ b/docs/reference/modules/plugins.asciidoc
@@ -259,8 +259,6 @@ You can disable that check using `plugins.check_lucene: false`.
 ==== Transport Plugins
 
 .Supported by Elasticsearch
-* https://github.com/elasticsearch/elasticsearch-transport-memcached[Memcached transport plugin]
-* https://github.com/elasticsearch/elasticsearch-transport-thrift[Thrift Transport]
 * https://github.com/elasticsearch/elasticsearch-transport-wares[Servlet transport]
 
 .Supported by the community


### PR DESCRIPTION
The thrift and memcached transport layers were experimental, but in
the end didn't buy us much. Memcached is very limited in scope,
supporting only a portion of the REST API, and thrift has much
the same throughput as HTTP.

They are deprecated as of 1.5.0, and will be removed in 2.0.

Document changes for #10166
