### PR TITLE
Remove references to the thrift and memcached transport plugins

### DIFF
--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -3,11 +3,7 @@
 
 [partintro]
 --
-The *elasticsearch* REST APIs are exposed using:
-
-* <<modules-http,JSON over HTTP>>,
-* <<modules-thrift,thrift>>,
-* <<modules-memcached,memcached>>.
+The *elasticsearch* REST APIs are exposed using <<modules-http,JSON over HTTP>>.
 
 The conventions listed in this chapter can be applied throughout the REST
 API, unless otherwise specified.

--- a/docs/reference/migration/migrate_2_0.asciidoc
+++ b/docs/reference/migration/migrate_2_0.asciidoc
@@ -281,6 +281,12 @@ index.
 
 === Scripts
 
-Deprecated script parameters `id`, `file`, and `scriptField` have been removed 
-from all scriptable APIs. `script_id`, `script_file` and `script` should be used 
+Deprecated script parameters `id`, `file`, and `scriptField` have been removed
+from all scriptable APIs. `script_id`, `script_file` and `script` should be used
 in their place.
+
+=== Thrift and memcached transport
+
+The thrift and memcached transport plugins are no longer supported.  Instead, use
+either the HTTP transport (enabled by default) or the node or transport Java client.
+

--- a/docs/reference/modules.asciidoc
+++ b/docs/reference/modules.asciidoc
@@ -11,8 +11,6 @@ include::modules/http.asciidoc[]
 
 include::modules/indices.asciidoc[]
 
-include::modules/memcached.asciidoc[]
-
 include::modules/network.asciidoc[]
 
 include::modules/node.asciidoc[]
@@ -26,8 +24,6 @@ include::modules/scripting.asciidoc[]
 include::modules/advanced-scripting.asciidoc[]
 
 include::modules/threadpool.asciidoc[]
-
-include::modules/thrift.asciidoc[]
 
 include::modules/transport.asciidoc[]
 

--- a/docs/reference/modules/plugins.asciidoc
+++ b/docs/reference/modules/plugins.asciidoc
@@ -259,8 +259,6 @@ You can disable that check using `plugins.check_lucene: false`.
 ==== Transport Plugins
 
 .Supported by Elasticsearch
-* https://github.com/elasticsearch/elasticsearch-transport-memcached[Memcached transport plugin]
-* https://github.com/elasticsearch/elasticsearch-transport-thrift[Thrift Transport]
 * https://github.com/elasticsearch/elasticsearch-transport-wares[Servlet transport]
 
 .Supported by the community


### PR DESCRIPTION
Remove references to the thrift and memcached transport plugins as they are no longer supported

Closes #10166
