### PR TITLE
Add before/afterIndexShardDelete callbacks to index lifecycle

### DIFF
--- a/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/src/main/java/org/elasticsearch/index/IndexService.java
@@ -441,7 +441,12 @@ public class IndexService extends AbstractIndexComponent implements IndexCompone
         if (deleted.get()) { // we remove that shards content if this index has been deleted
             try {
                 if (ownsShard) {
-                    indicesServices.deleteShardStore("delete index", lock, indexSettings);
+                    try {
+                        indicesLifecycle.beforeIndexShardDeleted(lock.getShardId(), indexSettings);
+                    } finally {
+                        indicesServices.deleteShardStore("delete index", lock, indexSettings);
+                        indicesLifecycle.afterIndexShardDeleted(lock.getShardId(), indexSettings);
+                    }
                 }
             } catch (IOException e) {
                 indicesServices.addPendingDelete(lock.getShardId(), indexSettings);

--- a/src/main/java/org/elasticsearch/indices/IndicesLifecycle.java
+++ b/src/main/java/org/elasticsearch/indices/IndicesLifecycle.java
@@ -153,7 +153,7 @@ public interface IndicesLifecycle {
          * @param shardId The shard id
          * @param indexSettings the shards index settings
          */
-        public void beforeIndexShardDeleted(ShardId shardId, Settings indexSettings) {
+        public void beforeIndexShardDeleted(ShardId shardId, @IndexSettings Settings indexSettings) {
         }
 
         /**
@@ -164,7 +164,7 @@ public interface IndicesLifecycle {
          * @param shardId The shard id
          * @param indexSettings the shards index settings
          */
-        public void afterIndexShardDeleted(ShardId shardId, Settings indexSettings) {
+        public void afterIndexShardDeleted(ShardId shardId, @IndexSettings Settings indexSettings) {
         }
 
         /**

--- a/src/main/java/org/elasticsearch/indices/IndicesLifecycle.java
+++ b/src/main/java/org/elasticsearch/indices/IndicesLifecycle.java
@@ -147,6 +147,27 @@ public interface IndicesLifecycle {
         }
 
         /**
+         * Called before the index shard gets deleted from disk
+         * Note: this method is only executed on the first attempt of deleting the shard. Retries are will not invoke
+         * this method.
+         * @param shardId The shard id
+         * @param indexSettings the shards index settings
+         */
+        public void beforeIndexShardDeleted(ShardId shardId, Settings indexSettings) {
+        }
+
+        /**
+         * Called after the index shard has been deleted from disk.
+         *
+         * Note: this method is only called if the deletion of the shard did finish without an exception
+         *
+         * @param shardId The shard id
+         * @param indexSettings the shards index settings
+         */
+        public void afterIndexShardDeleted(ShardId shardId, Settings indexSettings) {
+        }
+
+        /**
          * Called after a shard's {@link org.elasticsearch.index.shard.IndexShardState} changes.
          * The order of concurrent events is preserved. The execution must be lightweight.
          *

--- a/src/main/java/org/elasticsearch/indices/InternalIndicesLifecycle.java
+++ b/src/main/java/org/elasticsearch/indices/InternalIndicesLifecycle.java
@@ -212,6 +212,30 @@ public class InternalIndicesLifecycle extends AbstractComponent implements Indic
         }
     }
 
+    public void beforeIndexShardDeleted(ShardId shardId,
+                                       @IndexSettings Settings indexSettings) {
+        for (Listener listener : listeners) {
+            try {
+                listener.beforeIndexShardDeleted(shardId, indexSettings);
+            } catch (Throwable t) {
+                logger.warn("{} failed to invoke before shard deleted callback", t, shardId);
+                throw t;
+            }
+        }
+    }
+
+    public void afterIndexShardDeleted(ShardId shardId,
+                                      @IndexSettings Settings indexSettings) {
+        for (Listener listener : listeners) {
+            try {
+                listener.afterIndexShardDeleted(shardId, indexSettings);
+            } catch (Throwable t) {
+                logger.warn("{} failed to invoke after shard deleted callback", t, shardId);
+                throw t;
+            }
+        }
+    }
+
     public void indexShardStateChanged(IndexShard indexShard, @Nullable IndexShardState previousState, @Nullable String reason) {
         for (Listener listener : listeners) {
             try {

--- a/src/test/java/org/elasticsearch/indices/IndicesLifecycleListenerSingleNodeTests.java
+++ b/src/test/java/org/elasticsearch/indices/IndicesLifecycleListenerSingleNodeTests.java
@@ -22,6 +22,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.settings.IndexSettings;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.test.ElasticsearchSingleNodeTest;
 import org.junit.Test;
 
@@ -48,7 +49,7 @@ public class IndicesLifecycleListenerSingleNodeTests extends ElasticsearchSingle
         getInstanceFromNode(IndicesLifecycle.class).addListener(new IndicesLifecycle.Listener() {
             @Override
             public void afterIndexClosed(Index index, @IndexSettings Settings indexSettings) {
-                assertEquals(counter.get(), 3);
+                assertEquals(counter.get(), 5);
                 counter.incrementAndGet();
             }
 
@@ -60,18 +61,30 @@ public class IndicesLifecycleListenerSingleNodeTests extends ElasticsearchSingle
 
             @Override
             public void afterIndexDeleted(Index index, @IndexSettings Settings indexSettings) {
-                assertEquals(counter.get(), 4);
+                assertEquals(counter.get(), 6);
                 counter.incrementAndGet();
             }
 
             @Override
-            public void beforeIndexDeleted(IndexService indexService) {
+              public void beforeIndexDeleted(IndexService indexService) {
                 assertEquals(counter.get(), 2);
+                counter.incrementAndGet();
+            }
+
+            @Override
+            public void beforeIndexShardDeleted(ShardId shardId, Settings indexSettings) {
+                assertEquals(counter.get(), 3);
+                counter.incrementAndGet();
+            }
+
+            @Override
+            public void afterIndexShardDeleted(ShardId shardId, Settings indexSettings) {
+                assertEquals(counter.get(), 4);
                 counter.incrementAndGet();
             }
         });
         assertAcked(client().admin().indices().prepareDelete("test").get());
-        assertEquals(5, counter.get());
+        assertEquals(7, counter.get());
     }
 
 }


### PR DESCRIPTION
This commit allows code to be executed before or after a shards contentvis deleted from disk. This is only executed if the shard owns the content ie. on a shard file system only a primary shard will execute these operations.
