### PR TITLE
Increase default rate limiting for snapshot, restore and recovery to 40 MB/sec

### DIFF
--- a/docs/reference/modules/indices.asciidoc
+++ b/docs/reference/modules/indices.asciidoc
@@ -59,5 +59,5 @@ The following settings can be set to manage the recovery policy:
     defaults to `true`.
 
 `indices.recovery.max_bytes_per_sec`::
-    defaults to `20mb`.
+    defaults to `40mb`.
 

--- a/docs/reference/modules/snapshots.asciidoc
+++ b/docs/reference/modules/snapshots.asciidoc
@@ -69,8 +69,8 @@ on all data and master nodes. The following settings are supported:
 `compress`:: Turns on compression of the snapshot files. Compression is applied only to metadata files (index mapping and settings). Data files are not compressed. Defaults to `true`.
 `chunk_size`:: Big files can be broken down into chunks during snapshotting if needed. The chunk size can be specified in bytes or by
  using size value notation, i.e. 1g, 10m, 5k. Defaults to `null` (unlimited chunk size).
-`max_restore_bytes_per_sec`:: Throttles per node restore rate. Defaults to `20mb` per second.
-`max_snapshot_bytes_per_sec`:: Throttles per node snapshot rate. Defaults to `20mb` per second.
+`max_restore_bytes_per_sec`:: Throttles per node restore rate. Defaults to `40mb` per second.
+`max_snapshot_bytes_per_sec`:: Throttles per node snapshot rate. Defaults to `40mb` per second.
 `verify`:: Verify repository upon creation. Defaults to `true`.
 
 [float]

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoverySettings.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoverySettings.java
@@ -129,7 +129,7 @@ public class RecoverySettings extends AbstractComponent implements Closeable {
         this.concurrentSmallFileStreams = settings.getAsInt("indices.recovery.concurrent_small_file_streams", settings.getAsInt("index.shard.recovery.concurrent_small_file_streams", 2));
         this.concurrentSmallFileStreamPool = EsExecutors.newScaling(0, concurrentSmallFileStreams, 60, TimeUnit.SECONDS, EsExecutors.daemonThreadFactory(settings, "[small_file_recovery_stream]"));
 
-        this.maxBytesPerSec = settings.getAsBytesSize("indices.recovery.max_bytes_per_sec", settings.getAsBytesSize("indices.recovery.max_size_per_sec", new ByteSizeValue(20, ByteSizeUnit.MB)));
+        this.maxBytesPerSec = settings.getAsBytesSize("indices.recovery.max_bytes_per_sec", settings.getAsBytesSize("indices.recovery.max_size_per_sec", new ByteSizeValue(40, ByteSizeUnit.MB)));
         if (maxBytesPerSec.bytes() <= 0) {
             rateLimiter = null;
         } else {

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -283,12 +283,13 @@ public class RecoverySourceHandler implements Engine.RecoveryHandler {
 
                                 // Pause using the rate limiter, if desired, to throttle the recovery
                                 RateLimiter rl = recoverySettings.rateLimiter();
+                                long throttleTimeInNanos = 0;
                                 if (rl != null) {
                                     long bytes = bytesSinceLastPause.addAndGet(toRead);
                                     if (bytes > rl.getMinPauseCheckBytes()) {
                                         // Time to pause
                                         bytesSinceLastPause.addAndGet(-bytes);
-                                        long throttleTimeInNanos = rl.pause(bytes);
+                                        throttleTimeInNanos = rl.pause(bytes);
                                         shard.recoveryStats().addThrottleTime(throttleTimeInNanos);
                                     }
                                 }

--- a/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -151,8 +151,8 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent<Rep
         Map<String, String> snpashotOnlyParams = Maps.newHashMap();
         snpashotOnlyParams.put(MetaData.CONTEXT_MODE_PARAM, MetaData.CONTEXT_MODE_SNAPSHOT);
         snapshotOnlyFormatParams = new ToXContent.MapParams(snpashotOnlyParams);
-        snapshotRateLimiter = getRateLimiter(repositorySettings, "max_snapshot_bytes_per_sec", new ByteSizeValue(20, ByteSizeUnit.MB));
-        restoreRateLimiter = getRateLimiter(repositorySettings, "max_restore_bytes_per_sec", new ByteSizeValue(20, ByteSizeUnit.MB));
+        snapshotRateLimiter = getRateLimiter(repositorySettings, "max_snapshot_bytes_per_sec", new ByteSizeValue(40, ByteSizeUnit.MB));
+        restoreRateLimiter = getRateLimiter(repositorySettings, "max_restore_bytes_per_sec", new ByteSizeValue(40, ByteSizeUnit.MB));
     }
 
     /**


### PR DESCRIPTION
Lucene's RateLimiter can do too much sleeping ("over rate limiting") if you call it on small values for bytes.

This fixes recovery source and target to only call every RateLimiter.minPauseCheckBytes.

I think at default settings this is not hurting recovery speed too much, because we rate limit at 20 MB/sec by default, and use a buffer size of 512 KB, but we do still call on small values, e.g. for small files or for the last small chunk of a large file.

This is similar to #6018, but for recovery instead of store throttling during merging.

This change does mean that files < minPauseCheckSize (100 KB @ 20 MB/sec) won't visit the rate limiter but I think that's OK.

However, @bleskes was worried this change might weaken tests?
