### PR TITLE
Remove duplicated consistency level and replication type setters

### DIFF
--- a/src/main/java/org/elasticsearch/action/delete/DeleteRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/delete/DeleteRequestBuilder.java
@@ -20,8 +20,6 @@
 package org.elasticsearch.action.delete;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.WriteConsistencyLevel;
-import org.elasticsearch.action.support.replication.ReplicationType;
 import org.elasticsearch.action.support.replication.ShardReplicationOperationRequestBuilder;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Nullable;
@@ -98,22 +96,6 @@ public class DeleteRequestBuilder extends ShardReplicationOperationRequestBuilde
      */
     public DeleteRequestBuilder setVersionType(VersionType versionType) {
         request.versionType(versionType);
-        return this;
-    }
-
-    /**
-     * Set the replication type for this operation.
-     */
-    public DeleteRequestBuilder setReplicationType(ReplicationType replicationType) {
-        request.replicationType(replicationType);
-        return this;
-    }
-
-    /**
-     * Sets the consistency level. Defaults to {@link org.elasticsearch.action.WriteConsistencyLevel#DEFAULT}.
-     */
-    public DeleteRequestBuilder setConsistencyLevel(WriteConsistencyLevel consistencyLevel) {
-        request.consistencyLevel(consistencyLevel);
         return this;
     }
 

--- a/src/main/java/org/elasticsearch/action/index/IndexRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/index/IndexRequestBuilder.java
@@ -20,8 +20,6 @@
 package org.elasticsearch.action.index;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.WriteConsistencyLevel;
-import org.elasticsearch.action.support.replication.ReplicationType;
 import org.elasticsearch.action.support.replication.ShardReplicationOperationRequestBuilder;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Nullable;
@@ -250,30 +248,6 @@ public class IndexRequestBuilder extends ShardReplicationOperationRequestBuilder
      */
     public IndexRequestBuilder setRefresh(boolean refresh) {
         request.refresh(refresh);
-        return this;
-    }
-
-    /**
-     * Set the replication type for this operation.
-     */
-    public IndexRequestBuilder setReplicationType(ReplicationType replicationType) {
-        request.replicationType(replicationType);
-        return this;
-    }
-
-    /**
-     * Sets the consistency level. Defaults to {@link org.elasticsearch.action.WriteConsistencyLevel#DEFAULT}.
-     */
-    public IndexRequestBuilder setConsistencyLevel(WriteConsistencyLevel consistencyLevel) {
-        request.consistencyLevel(consistencyLevel);
-        return this;
-    }
-
-    /**
-     * Set the replication type for this operation.
-     */
-    public IndexRequestBuilder setReplicationType(String replicationType) {
-        request.replicationType(replicationType);
         return this;
     }
 


### PR DESCRIPTION
`setConsistencyLevel` and `setReplicationType` are already present in the base class `ShardReplicationOperationRequestBuilder`. They are not needed in `DeleteRequestBuilder` and `IndexRequestBuilder`.
