### PR TITLE
Schedule transport ping interval

### DIFF
--- a/src/main/java/org/elasticsearch/client/transport/TransportClient.java
+++ b/src/main/java/org/elasticsearch/client/transport/TransportClient.java
@@ -80,6 +80,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.threadpool.ThreadPoolModule;
 import org.elasticsearch.transport.TransportModule;
 import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.transport.netty.NettyTransport;
 
 import java.util.concurrent.TimeUnit;
 
@@ -152,7 +153,9 @@ public class TransportClient extends AbstractClient {
      */
     public TransportClient(Settings pSettings, boolean loadConfigSettings) throws ElasticsearchException {
         Tuple<Settings, Environment> tuple = InternalSettingsPreparer.prepareSettings(pSettings, loadConfigSettings);
-        Settings settings = settingsBuilder().put(tuple.v1())
+        Settings settings = settingsBuilder()
+                .put(NettyTransport.PING_SCHEDULE, "5s") // enable by default the transport schedule ping interval
+                .put(tuple.v1())
                 .put("network.server", false)
                 .put("node.client", true)
                 .put(CLIENT_TYPE_SETTING, CLIENT_TYPE)

--- a/src/main/java/org/elasticsearch/transport/netty/NettyHeader.java
+++ b/src/main/java/org/elasticsearch/transport/netty/NettyHeader.java
@@ -21,12 +21,33 @@ package org.elasticsearch.transport.netty;
 
 import org.elasticsearch.Version;
 import org.jboss.netty.buffer.ChannelBuffer;
+import org.jboss.netty.buffer.ChannelBuffers;
 
 /**
  */
 public class NettyHeader {
 
     public static final int HEADER_SIZE = 2 + 4 + 8 + 1 + 4;
+
+    /**
+     * The magic number (must be lower than 0) for a ping message. This is handled
+     * specifically in {@link org.elasticsearch.transport.netty.SizeHeaderFrameDecoder}.
+     */
+    public static final int PING_DATA_SIZE = -1;
+    private final static ChannelBuffer pingHeader;
+    static {
+        pingHeader = ChannelBuffers.buffer(6);
+        pingHeader.writeByte('E');
+        pingHeader.writeByte('S');
+        pingHeader.writeInt(PING_DATA_SIZE);
+    }
+
+    /**
+     * A ping header is same as regular header, just with -1 for the size of the message.
+     */
+    public static ChannelBuffer pingHeader() {
+        return pingHeader.duplicate();
+    }
 
     public static void writeHeader(ChannelBuffer buffer, long requestId, byte status, Version version) {
         int index = buffer.readerIndex();

--- a/src/main/java/org/elasticsearch/transport/netty/SizeHeaderFrameDecoder.java
+++ b/src/main/java/org/elasticsearch/transport/netty/SizeHeaderFrameDecoder.java
@@ -68,6 +68,12 @@ public class SizeHeaderFrameDecoder extends FrameDecoder {
         }
 
         int dataLen = buffer.getInt(buffer.readerIndex() + 2);
+        if (dataLen == NettyHeader.PING_DATA_SIZE) {
+            // discard the messages we read and continue, this is achieved by skipping the bytes
+            // and returning null
+            buffer.skipBytes(6);
+            return null;
+        }
         if (dataLen <= 0) {
             throw new StreamCorruptedException("invalid data length: " + dataLen);
         }

--- a/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
@@ -114,6 +114,7 @@ import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.SearchService;
 import org.elasticsearch.test.client.RandomizingClient;
 import org.elasticsearch.test.disruption.ServiceDisruptionScheme;
+import org.elasticsearch.transport.netty.NettyTransport;
 import org.hamcrest.Matchers;
 import org.joda.time.DateTimeZone;
 import org.junit.*;
@@ -464,6 +465,9 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
             // if we test against nodes before 1.3.2 we disable all the compression due to a known bug
             // see #7210
             builder.put(RecoverySettings.INDICES_RECOVERY_COMPRESS, false);
+        }
+        if (random.nextBoolean()) {
+            builder.put(NettyTransport.PING_SCHEDULE, RandomInts.randomIntBetween(random, 100, 2000) + "ms");
         }
         return builder;
     }

--- a/src/test/java/org/elasticsearch/transport/netty/NettyScheduledPingTests.java
+++ b/src/test/java/org/elasticsearch/transport/netty/NettyScheduledPingTests.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.transport.netty;
+
+import com.google.common.collect.ImmutableMap;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.lease.Releasables;
+import org.elasticsearch.common.network.NetworkService;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.test.transport.MockTransportService;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.*;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+
+/**
+ */
+public class NettyScheduledPingTests extends ElasticsearchTestCase {
+
+    @Test
+    public void testScheduledPing() throws Exception {
+        ThreadPool threadPool = new ThreadPool(getClass().getName());
+
+        int startPort = 11000 + randomIntBetween(0, 255);
+        int endPort = startPort + 10;
+        Settings settings = ImmutableSettings.builder().put(NettyTransport.PING_SCHEDULE, "5ms").put("transport.tcp.port", startPort + "-" + endPort).build();
+
+        final NettyTransport nettyA = new NettyTransport(settings, threadPool, new NetworkService(settings), BigArrays.NON_RECYCLING_INSTANCE, Version.CURRENT);
+        MockTransportService serviceA = new MockTransportService(settings, nettyA, threadPool);
+        serviceA.start();
+
+        final NettyTransport nettyB = new NettyTransport(settings, threadPool, new NetworkService(settings), BigArrays.NON_RECYCLING_INSTANCE, Version.CURRENT);
+        MockTransportService serviceB = new MockTransportService(settings, nettyB, threadPool);
+        serviceB.start();
+
+        DiscoveryNode nodeA = new DiscoveryNode("TS_A", "TS_A", serviceA.boundAddress().publishAddress(), ImmutableMap.<String, String>of(), Version.CURRENT);
+        DiscoveryNode nodeB = new DiscoveryNode("TS_B", "TS_B", serviceB.boundAddress().publishAddress(), ImmutableMap.<String, String>of(), Version.CURRENT);
+
+        serviceA.connectToNode(nodeB);
+        serviceB.connectToNode(nodeA);
+
+        assertBusy(new Runnable() {
+            @Override
+            public void run() {
+                assertThat(nettyA.scheduledPing.successfulPings.count(), greaterThan(100l));
+                assertThat(nettyB.scheduledPing.successfulPings.count(), greaterThan(100l));
+            }
+        });
+        assertThat(nettyA.scheduledPing.failedPings.count(), equalTo(0l));
+        assertThat(nettyB.scheduledPing.failedPings.count(), equalTo(0l));
+
+        serviceA.registerHandler("sayHello", new BaseTransportRequestHandler<TransportRequest.Empty>() {
+            @Override
+            public TransportRequest.Empty newInstance() {
+                return TransportRequest.Empty.INSTANCE;
+            }
+
+            @Override
+            public String executor() {
+                return ThreadPool.Names.GENERIC;
+            }
+
+            @Override
+            public void messageReceived(TransportRequest.Empty request, TransportChannel channel) {
+                try {
+                    channel.sendResponse(TransportResponse.Empty.INSTANCE, TransportResponseOptions.options());
+                } catch (IOException e) {
+                    e.printStackTrace();
+                    assertThat(e.getMessage(), false, equalTo(true));
+                }
+            }
+        });
+
+        // send some messages while ping requests are going around
+        int rounds = scaledRandomIntBetween(100, 5000);
+        for (int i = 0; i < rounds; i++) {
+            serviceB.submitRequest(nodeA, "sayHello",
+                    TransportRequest.Empty.INSTANCE, TransportRequestOptions.options().withCompress(randomBoolean()), new BaseTransportResponseHandler<TransportResponse.Empty>() {
+                        @Override
+                        public TransportResponse.Empty newInstance() {
+                            return TransportResponse.Empty.INSTANCE;
+                        }
+
+                        @Override
+                        public String executor() {
+                            return ThreadPool.Names.GENERIC;
+                        }
+
+                        @Override
+                        public void handleResponse(TransportResponse.Empty response) {
+                        }
+
+                        @Override
+                        public void handleException(TransportException exp) {
+                            exp.printStackTrace();
+                            assertThat("got exception instead of a response: " + exp.getMessage(), false, equalTo(true));
+                        }
+                    }).txGet();
+        }
+
+        assertBusy(new Runnable() {
+            @Override
+            public void run() {
+                assertThat(nettyA.scheduledPing.successfulPings.count(), greaterThan(200l));
+                assertThat(nettyB.scheduledPing.successfulPings.count(), greaterThan(200l));
+            }
+        });
+        assertThat(nettyA.scheduledPing.failedPings.count(), equalTo(0l));
+        assertThat(nettyB.scheduledPing.failedPings.count(), equalTo(0l));
+
+        Releasables.close(serviceA, serviceB);
+        terminate(threadPool);
+    }
+}


### PR DESCRIPTION
Sometimes, when using transport client for example, through a load balancer, there is a need to send a scheduled ping message to keep each channel alive.

Add support for `transport.ping_schedule`, which controls the schedule (-1 for disabled) at which a ping message will be sent. For transport client case, it gets enabled automatically since almost always this is the desired behavior.

We use the same 6 bytes header format for the ping message, with ES header and -1 for data length for ping message, and simply continue to process the next messages once this is encountered.
