### PR TITLE
Handle RejectedExecutionException in ClusterStateObserver on timeout

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/service/InternalClusterService.java
+++ b/src/main/java/org/elasticsearch/cluster/service/InternalClusterService.java
@@ -522,7 +522,7 @@ public class InternalClusterService extends AbstractLifecycleComponent<ClusterSe
         }
     }
 
-    class NotifyTimeout implements Runnable {
+    class NotifyTimeout extends AbstractRunnable {
         final TimeoutClusterStateListener listener;
         final TimeValue timeout;
         ScheduledFuture future;
@@ -537,7 +537,17 @@ public class InternalClusterService extends AbstractLifecycleComponent<ClusterSe
         }
 
         @Override
-        public void run() {
+        public void onFailure(Throwable t) {
+          logger.warn("notifying cluster state listener on timeout failed ", t);
+        }
+
+        @Override
+        public void onRejection(Throwable t) {
+            // do nothing
+        }
+
+        @Override
+        protected void doRun() throws Exception {
             if (future.isCancelled()) {
                 return;
             }


### PR DESCRIPTION
When nodes shutdown then any ClusterStatObserver is notified (onClose() called).
If the cluster state observer executes code which throws RejectedExecutionException then this
is not caught automatically.
This is problematic for example when one wants to send something via a TransportChannel
on close but this operation is rejected because the node is shutting down.
Instead, rejections should be caught and ignored.

I have this problem in #10172 (https://github.com/elastic/elasticsearch/pull/10172/files#diff-60f857f2de28d320835e75281ae52146R371). It makes the tests fail occasionally.
