### PR TITLE
Removed duplicate timeout param

### DIFF
--- a/rest-api-spec/api/bulk.json
+++ b/rest-api-spec/api/bulk.json
@@ -36,10 +36,6 @@
         "type": {
           "type" : "string",
           "description" : "Default document type for items which don't provide one"
-        },
-        "timeout": {
-          "type" : "time",
-          "description" : "Explicit operation timeout"
         }
       }
     },


### PR DESCRIPTION
Minor change; I removed the duplicate timeout param in the bulk.json rest-api-spec. It causes errors when deserialising the params to a map.
