### PR TITLE
Upgrade to Jackson 2.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -234,28 +234,28 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.4.4</version>
+            <version>2.5.1</version>
             <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-smile</artifactId>
-            <version>2.4.4</version>
+            <version>2.5.1</version>
             <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
-            <version>2.4.4</version>
+            <version>2.5.1</version>
             <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-cbor</artifactId>
-            <version>2.4.4</version>
+            <version>2.5.1</version>
             <scope>compile</scope>
         </dependency>
 

--- a/src/main/java/org/elasticsearch/index/mapper/internal/AllFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/AllFieldMapper.java
@@ -269,6 +269,7 @@ public class AllFieldMapper extends AbstractFieldMapper<String> implements Inter
             // if all are defaults, no need to write it at all - generating is twice is ok though
             BytesStreamOutput bytesStreamOutput = new BytesStreamOutput(0);
             XContentBuilder b =  new XContentBuilder(builder.contentType().xContent(), bytesStreamOutput);
+            b.startObject().flush();
             long pos = bytesStreamOutput.position();
             innerToXContent(b, false);
             b.flush();

--- a/src/test/java/org/elasticsearch/action/termvectors/GetTermVectorsTests.java
+++ b/src/test/java/org/elasticsearch/action/termvectors/GetTermVectorsTests.java
@@ -73,7 +73,7 @@ public class GetTermVectorsTests extends AbstractTermVectorsTests {
             assertThat(actionGet.getIndex(), equalTo("test"));
             assertThat(actionGet.isExists(), equalTo(false));
             // check response is nevertheless serializable to json
-            actionGet.toXContent(jsonBuilder(), ToXContent.EMPTY_PARAMS);
+            actionGet.toXContent(jsonBuilder().startObject(), ToXContent.EMPTY_PARAMS);
         }
     }
 

--- a/src/test/java/org/elasticsearch/index/mapper/object/SimpleObjectMappingTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/object/SimpleObjectMappingTests.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.mapper.object;
 
 import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
@@ -93,8 +94,8 @@ public class SimpleObjectMappingTests extends ElasticsearchSingleNodeTest {
                                 .field("type", "string")
                                 .field("index", "analyzed")
                                 .startArray("fields")
-                                    .field("test", "string")
-                                    .field("test2", "string")
+                                    .startObject().field("test", "string").endObject()
+                                    .startObject().field("test2", "string").endObject()
                                 .endArray()
                             .endObject()
                         .endObject()
@@ -126,8 +127,8 @@ public class SimpleObjectMappingTests extends ElasticsearchSingleNodeTest {
                     .startObject("tweet")
                         .startObject("properties")
                             .startArray("fields")
-                                .field("test", "string")
-                                .field("test2", "string")
+                                .startObject().field("test", "string").endObject()
+                                .startObject().field("test2", "string").endObject()
                             .endArray()
                         .endObject()
                     .endObject()

--- a/src/test/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.util.BigArray;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHitField;
@@ -163,7 +164,9 @@ public class GeoBoundsTests extends ElasticsearchIntegrationTest {
         SearchResponse response = client().prepareSearch("high_card_idx").addField(NUMBER_FIELD_NAME).addSort(SortBuilders.fieldSort(NUMBER_FIELD_NAME).order(SortOrder.ASC)).setSize(5000).get();
         assertSearchResponse(response);
         long totalHits = response.getHits().totalHits();
-        XContentBuilder builder = response.toXContent(XContentBuilder.builder(JsonXContent.jsonXContent), ToXContent.EMPTY_PARAMS);
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
+        response.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        builder.endObject();
         logger.info("Full high_card_idx Response Content:\n{ {} }", builder.string());
         for (int i = 0; i < totalHits; i++) {
             SearchHit searchHit = response.getHits().getAt(i);


### PR DESCRIPTION
Note, Jackson 2.5 is less lenient when it comes to not starting an object before starting to add fields on a fresh builder, fixed where applicable.
