### PR TITLE
Only cancel recovery when primary completed relocation

### DIFF
--- a/src/main/java/org/elasticsearch/action/support/broadcast/TransportBroadcastOperationAction.java
+++ b/src/main/java/org/elasticsearch/action/support/broadcast/TransportBroadcastOperationAction.java
@@ -128,7 +128,7 @@ public abstract class TransportBroadcastOperationAction<Request extends Broadcas
             shardsIts = shards(clusterState, request, concreteIndices);
             expectedOps = shardsIts.size();
 
-            shardsResponses = new AtomicReferenceArray<Object>(expectedOps);
+            shardsResponses = new AtomicReferenceArray<>(expectedOps);
         }
 
         public void start() {

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoveriesCollection.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoveriesCollection.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.indices.recovery;
 
+import com.google.common.base.Predicate;
 import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.Nullable;
@@ -95,13 +96,15 @@ public class RecoveriesCollection {
     }
 
     /** cancel the recovery with the given id (if found) and remove it from the recovery collection */
-    public void cancelRecovery(long id, String reason) {
+    public boolean cancelRecovery(long id, String reason) {
         RecoveryStatus removed = onGoingRecoveries.remove(id);
-        if (removed != null) {
-            logger.trace("{} canceled recovery from {}, id [{}] (reason [{}])",
-                    removed.shardId(), removed.sourceNode(), removed.recoveryId(), reason);
-            removed.cancel(reason);
+        if (removed == null) {
+            return false;
         }
+        logger.trace("{} canceled recovery from {}, id [{}] (reason [{}])",
+                removed.shardId(), removed.sourceNode(), removed.recoveryId(), reason);
+        removed.cancel(reason);
+        return true;
     }
 
     /**
@@ -128,41 +131,48 @@ public class RecoveriesCollection {
         }
     }
 
-    /**
-     * Try to find an ongoing recovery for a given shard. returns null if not found.
-     */
-    @Nullable
-    public StatusRef findRecoveryByShard(IndexShard indexShard) {
-        for (RecoveryStatus recoveryStatus : onGoingRecoveries.values()) {
-            // check if the recovery has already finished and if not protect
-            // against it being closed on us while we check
-            if (recoveryStatus.tryIncRef()) {
-                try {
-                    if (recoveryStatus.indexShard() == indexShard) {
-                        recoveryStatus.incRef();
-                        return new StatusRef(recoveryStatus);
-                    }
-                } finally {
-                    recoveryStatus.decRef();
-                }
-            }
-        }
-        return null;
-    }
-
     /** the number of ongoing recoveries */
     public int size() {
         return onGoingRecoveries.size();
     }
 
     /** cancel all ongoing recoveries for the given shard. typically because the shards is closed */
-    public void cancelRecoveriesForShard(ShardId shardId, String reason) {
+    public boolean cancelRecoveriesForShard(ShardId shardId, String reason) {
+        return cancelRecoveriesForShard(shardId, reason, null);
+    }
+
+    /**
+     * cancel all ongoing recoveries for the given shard, if their status match a predicate
+     *
+     * @param reason       reason for cancellation
+     * @param shardId      shardId for which to cancel recoveries
+     * @param shouldCancel a predicate to check if a recovery should be cancelled or not. Null means cancel without an extra check.
+     *                     note that the recovery state can change after this check, but before it is being cancelled via other
+     *                     already issued outstanding references.
+     * @return true if a recovery was cancelled
+     */
+    public boolean cancelRecoveriesForShard(ShardId shardId, String reason, @Nullable Predicate<RecoveryStatus> shouldCancel) {
+        boolean cancelled = false;
         for (RecoveryStatus status : onGoingRecoveries.values()) {
             if (status.shardId().equals(shardId)) {
-                cancelRecovery(status.recoveryId(), reason);
+                boolean cancel = true;
+                if (shouldCancel != null) {
+                    if (status.tryIncRef()) {
+                        try {
+                            cancel = shouldCancel.apply(status);
+                        } finally {
+                            status.decRef();
+                        }
+                    }
+                }
+                if (cancel && cancelRecovery(status.recoveryId(), reason)) {
+                    cancelled = true;
+                }
             }
         }
+        return cancelled;
     }
+
 
     /**
      * a reference to {@link RecoveryStatus}, which implements {@link AutoCloseable}. closing the reference

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoveriesCollection.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoveriesCollection.java
@@ -20,9 +20,9 @@
 package org.elasticsearch.indices.recovery;
 
 import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
 import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.cluster.node.DiscoveryNode;
-import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
@@ -137,16 +137,9 @@ public class RecoveriesCollection {
         return onGoingRecoveries.size();
     }
 
-    public static final Predicate<RecoveryStatus> ALLWAYS_MATCH_STATUS = new Predicate<RecoveryStatus>() {
-        @Override
-        public boolean apply(@Nullable RecoveryStatus input) {
-            return true;
-        }
-    };
-
     /** cancel all ongoing recoveries for the given shard. typically because the shards is closed */
     public boolean cancelRecoveriesForShard(ShardId shardId, String reason) {
-        return cancelRecoveriesForShard(shardId, reason, ALLWAYS_MATCH_STATUS);
+        return cancelRecoveriesForShard(shardId, reason, Predicates.<RecoveryStatus>alwaysTrue());
     }
 
     /**


### PR DESCRIPTION
When a primary moves to another node, we cancel ongoing recoveries and retry from the primary's new home. At the moment this happens when the primary relocation _starts_. It's a shame as we cancel recoveries that may be close to completion and will finish before the primary has been fully relocated. This commit only triggers the cancelation once the primary relocation is completed.

Next to this, it fixes a race condition between recovery cancellation and the recovery completion. At the moment we may trigger remove a recovered shard just after it was completed. Instead, we should use the recovery cancellation logic to make sure only one code path is followed.

All of the above caused the recoverWhileUnderLoadWithNodeShutdown test to fail (see http://build-us-00.elastic.co/job/es_core_15_debian/32/ ). The test creates an index and then increasingly disallows nodes for it, until only 1 node is left in the allocation filtering rules. Normally, this means we stay in green, but the premature recovery cancellation plus the race condition mentioned above caused a shard to be failed and stay unassigned and the test asserts to fail. This happens due to the following sequence:
- The shard has finished recovering and sent the master a shard started command.
- The recovery is cancelled locally, removing the index shard.
- Master starts shard (deleting it's other copy).
- Local node gets a cluster state with the shard started in it, which cause it to send a shard failed (to make the master aware).
- Shard is failed and can't be re-assigned due to the allocation filter.

The  recoverWhileUnderLoadWithNodeShutdown is also adapted a bit to fit the current behavior of allocation filtering (in the past it used to really shut down nodes). Last, all tests in that class are given better names to fit the current terminology.
