### PR TITLE
Transport: fix racing condition in timeout handling

### DIFF
--- a/src/main/java/org/elasticsearch/transport/TransportServiceAdapter.java
+++ b/src/main/java/org/elasticsearch/transport/TransportServiceAdapter.java
@@ -42,9 +42,10 @@ public interface TransportServiceAdapter {
 
     /**
      * called by the {@link Transport) implementation when a response or an exception has been recieved for a previously
-     * sent request (before any processing or deserialization was done
+     * sent request (before any processing or deserialization was done). Returns the appropriate response handler or null if not
+     * found.
      */
-    void onResponseReceived(long requestId);
+    TransportResponseHandler onResponseReceived(long requestId);
 
     /**
      * called by the {@link Transport) implementation when an incoming request arrives but before
@@ -53,8 +54,6 @@ public interface TransportServiceAdapter {
     void onRequestReceived(long requestId, String action);
 
     TransportRequestHandler handler(String action, Version version);
-
-    TransportResponseHandler remove(long requestId);
 
     void raiseNodeConnected(DiscoveryNode node);
 

--- a/src/main/java/org/elasticsearch/transport/local/LocalTransport.java
+++ b/src/main/java/org/elasticsearch/transport/local/LocalTransport.java
@@ -234,9 +234,7 @@ public class LocalTransport extends AbstractLifecycleComponent<Transport> implem
             if (isRequest) {
                 handleRequest(stream, requestId, sourceTransport, version);
             } else {
-                // notify with response before we process it and before we remove information about it.
-                transportServiceAdapter.onResponseReceived(requestId);
-                final TransportResponseHandler handler = transportServiceAdapter.remove(requestId);
+                final TransportResponseHandler handler = transportServiceAdapter.onResponseReceived(requestId);
                 // ignore if its null, the adapter logs it
                 if (handler != null) {
                     if (TransportStatus.isError(status)) {
@@ -248,7 +246,7 @@ public class LocalTransport extends AbstractLifecycleComponent<Transport> implem
             }
         } catch (Throwable e) {
             if (sendRequestId != null) {
-                TransportResponseHandler handler = transportServiceAdapter.remove(sendRequestId);
+                TransportResponseHandler handler = transportServiceAdapter.onResponseReceived(sendRequestId);
                 if (handler != null) {
                     handleException(handler, new RemoteTransportException(nodeName(), localAddress, action, e));
                 }

--- a/src/main/java/org/elasticsearch/transport/netty/MessageChannelHandler.java
+++ b/src/main/java/org/elasticsearch/transport/netty/MessageChannelHandler.java
@@ -121,9 +121,7 @@ public class MessageChannelHandler extends SimpleChannelUpstreamHandler {
                 buffer.readerIndex(expectedIndexReader);
             }
         } else {
-            // notify with response before we process it and before we remove information about it.
-            transportServiceAdapter.onResponseReceived(requestId);
-            TransportResponseHandler handler = transportServiceAdapter.remove(requestId);
+            TransportResponseHandler handler = transportServiceAdapter.onResponseReceived(requestId);
             // ignore if its null, the adapter logs it
             if (handler != null) {
                 if (TransportStatus.isError(status)) {

--- a/src/test/java/org/elasticsearch/client/transport/FailAndRetryMockTransport.java
+++ b/src/test/java/org/elasticsearch/client/transport/FailAndRetryMockTransport.java
@@ -64,7 +64,7 @@ abstract class FailAndRetryMockTransport<Response extends TransportResponse> imp
 
         //we make sure that nodes get added to the connected ones when calling addTransportAddress, by returning proper nodes info
         if (connectMode) {
-            TransportResponseHandler transportResponseHandler = transportServiceAdapter.remove(requestId);
+            TransportResponseHandler transportResponseHandler = transportServiceAdapter.onResponseReceived(requestId);
             NodeInfo nodeInfo = new NodeInfo(Version.CURRENT, Build.CURRENT, node, null, null, null, null, null, null, null, null, null, null);
             NodesInfoResponse nodesInfoResponse = new NodesInfoResponse(ClusterName.DEFAULT, new NodeInfo[]{nodeInfo});
             transportResponseHandler.handleResponse(nodesInfoResponse);
@@ -83,7 +83,7 @@ abstract class FailAndRetryMockTransport<Response extends TransportResponse> imp
                 //throw whatever exception that is not a subclass of ConnectTransportException
                 throw new IllegalStateException();
             } else {
-                TransportResponseHandler transportResponseHandler = transportServiceAdapter.remove(requestId);
+                TransportResponseHandler transportResponseHandler = transportServiceAdapter.onResponseReceived(requestId);
                 if (random.nextBoolean()) {
                     successes.incrementAndGet();
                     transportResponseHandler.handleResponse(newResponse());


### PR DESCRIPTION
If a request comes in at the same moment the timeout handler for it runs, we may leak a timeoutInfoHolder and erroneously log "Transport response handler not found of id" . The same issue could cause the request tracer to fire a traceUnresolvedResponse call instead of traceReceivedResponse , causing a failure of testTracerLog ( see #10187 ) .

This commit synchronizes the two execution paths and also unifies the TransportService.Adapter#remove(requestId) with TransportService.Adapter#onResponseReceived(requestId), as they are always called together to indicate a response was received.

Closes #10187
