### PR TITLE
get tests working on java 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -502,7 +502,6 @@
                             <jvmArgs>
                                 <param>-Xmx${tests.heap.size}</param>
                                 <param>-Xms${tests.heap.size}</param>
-                                <param>-XX:MaxPermSize=128m</param>
                                 <param>-XX:MaxDirectMemorySize=512m</param>
                                 <param>-Des.logger.prefix=</param>
                                 <param>-XX:+HeapDumpOnOutOfMemoryError</param>

--- a/src/main/java/org/elasticsearch/common/collect/Iterators2.java
+++ b/src/main/java/org/elasticsearch/common/collect/Iterators2.java
@@ -31,7 +31,8 @@ public enum Iterators2 {
 
     /** Remove duplicated elements from an iterator over sorted content. */
     public static <T> Iterator<T> deduplicateSorted(Iterator<? extends T> iterator, final Comparator<? super T> comparator) {
-        final PeekingIterator<T> it = Iterators.peekingIterator(iterator);
+        // TODO: infer type once JI-9019884 is fixed
+        final PeekingIterator<T> it = Iterators.<T>peekingIterator(iterator);
         return new UnmodifiableIterator<T>() {
 
             @Override

--- a/src/main/java/org/elasticsearch/common/inject/Scopes.java
+++ b/src/main/java/org/elasticsearch/common/inject/Scopes.java
@@ -112,8 +112,9 @@ public class Scopes {
 
         Scope scope = scoping.getScopeInstance();
 
+        // TODO: use diamond operator once JI-9019884 is fixed
         Provider<T> scoped
-                = scope.scope(key, new ProviderToInternalFactoryAdapter<>(injector, creator));
+                = scope.scope(key, new ProviderToInternalFactoryAdapter<T>(injector, creator));
         return new InternalFactoryToProviderAdapter<>(
                 Initializables.<Provider<? extends T>>of(scoped));
     }

--- a/src/main/java/org/elasticsearch/common/inject/util/Modules.java
+++ b/src/main/java/org/elasticsearch/common/inject/util/Modules.java
@@ -90,7 +90,8 @@ public final class Modules {
      * Returns a new module that installs all of {@code modules}.
      */
     public static Module combine(Iterable<? extends Module> modules) {
-        final Set<Module> modulesSet = ImmutableSet.copyOf(modules);
+        // TODO: infer type once JI-9019884 is fixed
+        final Set<Module> modulesSet = ImmutableSet.<Module>copyOf(modules);
         return new Module() {
             @Override
             public void configure(Binder binder) {
@@ -122,7 +123,8 @@ public final class Modules {
         private final ImmutableSet<Module> baseModules;
 
         private RealOverriddenModuleBuilder(Iterable<? extends Module> baseModules) {
-            this.baseModules = ImmutableSet.copyOf(baseModules);
+            // TODO: infer type once JI-9019884 is fixed
+            this.baseModules = ImmutableSet.<Module>copyOf(baseModules);
         }
 
         @Override

--- a/src/main/java/org/elasticsearch/search/fetch/script/ScriptFieldsFetchSubPhase.java
+++ b/src/main/java/org/elasticsearch/search/fetch/script/ScriptFieldsFetchSubPhase.java
@@ -100,7 +100,8 @@ public class ScriptFieldsFetchSubPhase implements FetchSubPhase {
                 if (value == null) {
                     values = Collections.emptyList();
                 } else if (value instanceof Collection) {
-                    values = new ArrayList<>((Collection<?>) value);
+                    // TODO: use diamond operator once JI-9019884 is fixed
+                    values = new ArrayList<Object>((Collection<?>) value);
                 } else {
                     values = Collections.singletonList(value);
                 }

--- a/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
+++ b/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
@@ -342,8 +342,14 @@ public class ThreadPool extends AbstractComponent {
                         int updatedSize = settings.getAsInt("size", previousInfo.getMax());
                         if (previousInfo.getMax() != updatedSize) {
                             logger.debug("updating thread_pool [{}], type [{}], size [{}], queue_size [{}]", name, type, updatedSize, updatedQueueSize);
-                            ((EsThreadPoolExecutor) previousExecutorHolder.executor()).setCorePoolSize(updatedSize);
-                            ((EsThreadPoolExecutor) previousExecutorHolder.executor()).setMaximumPoolSize(updatedSize);
+                            // if you think this code is crazy: that's because it is!
+                            if (updatedSize > previousInfo.getMax()) {
+                                ((EsThreadPoolExecutor) previousExecutorHolder.executor()).setMaximumPoolSize(updatedSize);
+                                ((EsThreadPoolExecutor) previousExecutorHolder.executor()).setCorePoolSize(updatedSize);
+                            } else {
+                                ((EsThreadPoolExecutor) previousExecutorHolder.executor()).setCorePoolSize(updatedSize);
+                                ((EsThreadPoolExecutor) previousExecutorHolder.executor()).setMaximumPoolSize(updatedSize);
+                            }
                             return new ExecutorHolder(previousExecutorHolder.executor(), new Info(name, type, updatedSize, updatedSize, null, updatedQueueSize));
                         }
                         return previousExecutorHolder;

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/DateHistogramTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/DateHistogramTests.java
@@ -625,7 +625,8 @@ public class DateHistogramTests extends ElasticsearchIntegrationTest {
         assertThat(histo.getName(), equalTo("histo"));
         assertThat(histo.getBuckets().size(), equalTo(4));
 
-        List<Histogram.Bucket> buckets = new ArrayList<>(histo.getBuckets());
+        // TODO: use diamond once JI-9019884 is fixed
+        List<Histogram.Bucket> buckets = new ArrayList<Histogram.Bucket>(histo.getBuckets());
 
         Histogram.Bucket bucket = buckets.get(0);
         assertThat(bucket, notNullValue());

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/DateRangeTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/DateRangeTests.java
@@ -124,7 +124,8 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(range.getName(), equalTo("range"));
         assertThat(range.getBuckets().size(), equalTo(3));
 
-        List<Range.Bucket> buckets = new ArrayList<>(range.getBuckets());
+        // TODO: use diamond once JI-9019884 is fixed
+        List<Range.Bucket> buckets = new ArrayList<Range.Bucket>(range.getBuckets());
 
         Range.Bucket bucket = buckets.get(0);
         assertThat((String) bucket.getKey(), equalTo("a long time ago"));
@@ -1064,7 +1065,8 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket, Matchers.notNullValue());
 
         Range dateRange = bucket.getAggregations().get("date_range");
-        List<Range.Bucket> buckets = new ArrayList<>(dateRange.getBuckets());
+        // TODO: use diamond once JI-9019884 is fixed
+        List<Range.Bucket> buckets = new ArrayList<Range.Bucket>(dateRange.getBuckets());
         assertThat(dateRange, Matchers.notNullValue());
         assertThat(dateRange.getName(), equalTo("date_range"));
         assertThat(buckets.size(), is(1));

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoDistanceTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoDistanceTests.java
@@ -425,7 +425,8 @@ public class GeoDistanceTests extends ElasticsearchIntegrationTest {
         assertThat(bucket, Matchers.notNullValue());
 
         Range geoDistance = bucket.getAggregations().get("geo_dist");
-        List<Range.Bucket> buckets = new ArrayList<>(geoDistance.getBuckets());
+        // TODO: use diamond once JI-9019884 is fixed
+        List<Range.Bucket> buckets = new ArrayList<Range.Bucket>(geoDistance.getBuckets());
         assertThat(geoDistance, Matchers.notNullValue());
         assertThat(geoDistance.getName(), equalTo("geo_dist"));
         assertThat(buckets.size(), is(1));

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/HistogramTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/HistogramTests.java
@@ -224,7 +224,8 @@ public class HistogramTests extends ElasticsearchIntegrationTest {
         assertThat(histo.getName(), equalTo("histo"));
         assertThat(histo.getBuckets().size(), equalTo(numValueBuckets));
 
-        List<Histogram.Bucket> buckets = new ArrayList<>(histo.getBuckets());
+        // TODO: use diamond once JI-9019884 is fixed
+        List<Histogram.Bucket> buckets = new ArrayList<Histogram.Bucket>(histo.getBuckets());
         for (int i = 0; i < numValueBuckets; ++i) {
             Histogram.Bucket bucket = buckets.get(i);
             assertThat(bucket, notNullValue());
@@ -247,7 +248,8 @@ public class HistogramTests extends ElasticsearchIntegrationTest {
         assertThat(histo.getName(), equalTo("histo"));
         assertThat(histo.getBuckets().size(), equalTo(numValueBuckets));
 
-        List<Histogram.Bucket> buckets = new ArrayList<>(histo.getBuckets());
+        // TODO: use diamond once JI-9019884 is fixed
+        List<Histogram.Bucket> buckets = new ArrayList<Histogram.Bucket>(histo.getBuckets());
         for (int i = 0; i < numValueBuckets; ++i) {
             Histogram.Bucket bucket = buckets.get(numValueBuckets - i - 1);
             assertThat(bucket, notNullValue());
@@ -271,7 +273,8 @@ public class HistogramTests extends ElasticsearchIntegrationTest {
         assertThat(histo.getBuckets().size(), equalTo(numValueBuckets));
 
         LongOpenHashSet buckets = new LongOpenHashSet();
-        List<Histogram.Bucket> histoBuckets = new ArrayList<>(histo.getBuckets());
+        // TODO: use diamond once JI-9019884 is fixed
+        List<Histogram.Bucket> histoBuckets = new ArrayList<Histogram.Bucket>(histo.getBuckets());
         long previousCount = Long.MIN_VALUE;
         for (int i = 0; i < numValueBuckets; ++i) {
             Histogram.Bucket bucket = histoBuckets.get(i);
@@ -300,7 +303,8 @@ public class HistogramTests extends ElasticsearchIntegrationTest {
         assertThat(histo.getBuckets().size(), equalTo(numValueBuckets));
 
         LongOpenHashSet buckets = new LongOpenHashSet();
-        List<Histogram.Bucket> histoBuckets = new ArrayList<>(histo.getBuckets());
+        // TODO: use diamond once JI-9019884 is fixed
+        List<Histogram.Bucket> histoBuckets = new ArrayList<Histogram.Bucket>(histo.getBuckets());
         long previousCount = Long.MAX_VALUE;
         for (int i = 0; i < numValueBuckets; ++i) {
             Histogram.Bucket bucket = histoBuckets.get(i);
@@ -332,7 +336,8 @@ public class HistogramTests extends ElasticsearchIntegrationTest {
         Object[] propertiesDocCounts = (Object[]) histo.getProperty("_count");
         Object[] propertiesCounts = (Object[]) histo.getProperty("sum.value");
 
-        List<Histogram.Bucket> buckets = new ArrayList<>(histo.getBuckets());
+        // TODO: use diamond once JI-9019884 is fixed
+        List<Histogram.Bucket> buckets = new ArrayList<Histogram.Bucket>(histo.getBuckets());
         for (int i = 0; i < numValueBuckets; ++i) {
             Histogram.Bucket bucket = buckets.get(i);
             assertThat(bucket, notNullValue());
@@ -369,7 +374,8 @@ public class HistogramTests extends ElasticsearchIntegrationTest {
         assertThat(histo.getName(), equalTo("histo"));
         assertThat(histo.getBuckets().size(), equalTo(numValueBuckets));
 
-        List<Histogram.Bucket> buckets = new ArrayList<>(histo.getBuckets());
+        // TODO: use diamond once JI-9019884 is fixed
+        List<Histogram.Bucket> buckets = new ArrayList<Histogram.Bucket>(histo.getBuckets());
         for (int i = 0; i < numValueBuckets; ++i) {
             Histogram.Bucket bucket = buckets.get(i);
             assertThat(bucket, notNullValue());
@@ -405,7 +411,8 @@ public class HistogramTests extends ElasticsearchIntegrationTest {
 
         LongOpenHashSet visited = new LongOpenHashSet();
         double previousSum = Double.NEGATIVE_INFINITY;
-        List<Histogram.Bucket> buckets = new ArrayList<>(histo.getBuckets());
+        // TODO: use diamond once JI-9019884 is fixed
+        List<Histogram.Bucket> buckets = new ArrayList<Histogram.Bucket>(histo.getBuckets());
         for (int i = 0; i < numValueBuckets; ++i) {
             Histogram.Bucket bucket = buckets.get(i);
             assertThat(bucket, notNullValue());
@@ -445,7 +452,8 @@ public class HistogramTests extends ElasticsearchIntegrationTest {
 
         LongOpenHashSet visited = new LongOpenHashSet();
         double previousSum = Double.POSITIVE_INFINITY;
-        List<Histogram.Bucket> buckets = new ArrayList<>(histo.getBuckets());
+        // TODO: use diamond once JI-9019884 is fixed
+        List<Histogram.Bucket> buckets = new ArrayList<Histogram.Bucket>(histo.getBuckets());
         for (int i = 0; i < numValueBuckets; ++i) {
             Histogram.Bucket bucket = buckets.get(i);
             assertThat(bucket, notNullValue());
@@ -485,7 +493,8 @@ public class HistogramTests extends ElasticsearchIntegrationTest {
 
         LongOpenHashSet visited = new LongOpenHashSet();
         double previousSum = Double.NEGATIVE_INFINITY;
-        List<Histogram.Bucket> buckets = new ArrayList<>(histo.getBuckets());
+        // TODO: use diamond once JI-9019884 is fixed
+        List<Histogram.Bucket> buckets = new ArrayList<Histogram.Bucket>(histo.getBuckets());
         for (int i = 0; i < numValueBuckets; ++i) {
             Histogram.Bucket bucket = buckets.get(i);
             assertThat(bucket, notNullValue());
@@ -525,7 +534,8 @@ public class HistogramTests extends ElasticsearchIntegrationTest {
 
         LongOpenHashSet visited = new LongOpenHashSet();
         double previousSum = Double.POSITIVE_INFINITY;
-        List<Histogram.Bucket> buckets = new ArrayList<>(histo.getBuckets());
+        // TODO: use diamond once JI-9019884 is fixed
+        List<Histogram.Bucket> buckets = new ArrayList<Histogram.Bucket>(histo.getBuckets());
         for (int i = 0; i < numValueBuckets; ++i) {
             Histogram.Bucket bucket = buckets.get(i);
             assertThat(bucket, notNullValue());
@@ -567,7 +577,8 @@ public class HistogramTests extends ElasticsearchIntegrationTest {
 
         LongOpenHashSet visited = new LongOpenHashSet();
         double prevMax = asc ? Double.NEGATIVE_INFINITY : Double.POSITIVE_INFINITY;
-        List<Histogram.Bucket> buckets = new ArrayList<>(histo.getBuckets());
+        // TODO: use diamond once JI-9019884 is fixed
+        List<Histogram.Bucket> buckets = new ArrayList<Histogram.Bucket>(histo.getBuckets());
         for (int i = 0; i < numValueBuckets; ++i) {
             Histogram.Bucket bucket = buckets.get(i);
             assertThat(bucket, notNullValue());
@@ -653,7 +664,8 @@ public class HistogramTests extends ElasticsearchIntegrationTest {
         assertThat(histo.getName(), equalTo("histo"));
         assertThat(histo.getBuckets().size(), equalTo(numValuesBuckets));
 
-        List<Histogram.Bucket> buckets = new ArrayList<>(histo.getBuckets());
+        // TODO: use diamond once JI-9019884 is fixed
+        List<Histogram.Bucket> buckets = new ArrayList<Histogram.Bucket>(histo.getBuckets());
         for (int i = 0; i < numValuesBuckets; ++i) {
             Histogram.Bucket bucket = buckets.get(numValuesBuckets - i - 1);
             assertThat(bucket, notNullValue());
@@ -782,7 +794,8 @@ public class HistogramTests extends ElasticsearchIntegrationTest {
         assertThat(histo.getName(), equalTo("histo"));
         assertThat(histo.getBuckets().size(), equalTo(numValueBuckets));
 
-        List<Histogram.Bucket> buckets = new ArrayList<>(histo.getBuckets());
+        // TODO: use diamond once JI-9019884 is fixed
+        List<Histogram.Bucket> buckets = new ArrayList<Histogram.Bucket>(histo.getBuckets());
         for (int i = 0; i < numValueBuckets; ++i) {
             Histogram.Bucket bucket = buckets.get(i);
             assertThat(bucket, notNullValue());

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/IPv4RangeTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/IPv4RangeTests.java
@@ -877,7 +877,8 @@ public class IPv4RangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket, Matchers.notNullValue());
 
         Range range = bucket.getAggregations().get("ip_range");
-        List<Range.Bucket> buckets = new ArrayList<>(range.getBuckets());
+        // TODO: use diamond once JI-9019884 is fixed
+        List<Range.Bucket> buckets = new ArrayList<Range.Bucket>(range.getBuckets());
         assertThat(range, Matchers.notNullValue());
         assertThat(range.getName(), equalTo("ip_range"));
         assertThat(buckets.size(), is(1));

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/RangeTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/RangeTests.java
@@ -1116,7 +1116,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
         assertThat(bucket, Matchers.notNullValue());
 
         Range range = bucket.getAggregations().get("range");
-        List<Range.Bucket> buckets = new ArrayList<>(range.getBuckets());
+        // TODO: use diamond once JI-9019884 is fixed
+        List<Range.Bucket> buckets = new ArrayList<Range.Bucket>(range.getBuckets());
         assertThat(range, Matchers.notNullValue());
         assertThat(range.getName(), equalTo("range"));
         assertThat(buckets.size(), is(1));

--- a/src/test/java/org/elasticsearch/search/suggest/CustomSuggesterSearchTests.java
+++ b/src/test/java/org/elasticsearch/search/suggest/CustomSuggesterSearchTests.java
@@ -76,7 +76,8 @@ public class CustomSuggesterSearchTests extends ElasticsearchIntegrationTest {
 
         SearchResponse searchResponse = searchRequestBuilder.execute().actionGet();
 
-        List<Suggest.Suggestion.Entry<? extends Suggest.Suggestion.Entry.Option>> suggestions = Lists.newArrayList(searchResponse.getSuggest().getSuggestion("someName").iterator());
+        // TODO: infer type once JI-9019884 is fixed
+        List<Suggest.Suggestion.Entry<? extends Suggest.Suggestion.Entry.Option>> suggestions = Lists.<Suggest.Suggestion.Entry<? extends Suggest.Suggestion.Entry.Option>>newArrayList(searchResponse.getSuggest().getSuggestion("someName").iterator());
         assertThat(suggestions, hasSize(2));
         assertThat(suggestions.get(0).getText().string(), is(String.format(Locale.ROOT, "%s-%s-%s-12", randomText, randomField, randomSuffix)));
         assertThat(suggestions.get(1).getText().string(), is(String.format(Locale.ROOT, "%s-%s-%s-123", randomText, randomField, randomSuffix)));


### PR DESCRIPTION
Fix build for java9.
- add compiler workarounds for java 9 (compiler bug, JI-9019884 filed for this)
- remove permgen specification during tests (this results in an error)

Fixes #10145
