### PR TITLE
Deprecate delete-by-query in client/transport/action APIs too

### DIFF
--- a/src/main/java/org/elasticsearch/action/deletebyquery/DeleteByQueryAction.java
+++ b/src/main/java/org/elasticsearch/action/deletebyquery/DeleteByQueryAction.java
@@ -23,7 +23,10 @@ import org.elasticsearch.action.ClientAction;
 import org.elasticsearch.client.Client;
 
 /**
+ * @deprecated Delete by query will be removed in 2.0.  Instead, use the scroll/scan API to find all matching IDs and then issue a bulk
+ * request to delete them.
  */
+@Deprecated
 public class DeleteByQueryAction extends ClientAction<DeleteByQueryRequest, DeleteByQueryResponse, DeleteByQueryRequestBuilder> {
 
     public static final DeleteByQueryAction INSTANCE = new DeleteByQueryAction();

--- a/src/main/java/org/elasticsearch/action/deletebyquery/DeleteByQueryRequest.java
+++ b/src/main/java/org/elasticsearch/action/deletebyquery/DeleteByQueryRequest.java
@@ -52,7 +52,11 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
  * @see DeleteByQueryResponse
  * @see org.elasticsearch.client.Requests#deleteByQueryRequest(String...)
  * @see org.elasticsearch.client.Client#deleteByQuery(DeleteByQueryRequest)
+ *
+ * @deprecated Delete by query will be removed in 2.0.  Instead, use the scroll/scan API to find all matching IDs and then issue a bulk
+ * request to delete them.
  */
+@Deprecated
 public class DeleteByQueryRequest extends IndicesReplicationOperationRequest<DeleteByQueryRequest> {
 
     private BytesReference source;

--- a/src/main/java/org/elasticsearch/action/deletebyquery/DeleteByQueryRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/deletebyquery/DeleteByQueryRequestBuilder.java
@@ -32,8 +32,10 @@ import org.elasticsearch.index.query.QueryBuilder;
 import java.util.Map;
 
 /**
- *
+ * @deprecated Delete by query will be removed in 2.0.  Instead, use the scroll/scan API to find all matching IDs and then issue a bulk
+ * request to delete them.
  */
+@Deprecated
 public class DeleteByQueryRequestBuilder extends IndicesReplicationOperationRequestBuilder<DeleteByQueryRequest, DeleteByQueryResponse, DeleteByQueryRequestBuilder> {
 
     private QuerySourceBuilder sourceBuilder;

--- a/src/main/java/org/elasticsearch/action/deletebyquery/DeleteByQueryResponse.java
+++ b/src/main/java/org/elasticsearch/action/deletebyquery/DeleteByQueryResponse.java
@@ -33,7 +33,11 @@ import static com.google.common.collect.Maps.newHashMap;
 /**
  * The response of delete by query action. Holds the {@link IndexDeleteByQueryResponse}s from all the
  * different indices.
+ *
+ * @deprecated Delete by query will be removed in 2.0.  Instead, use the scroll/scan API to find all matching IDs and then issue a bulk
+ * request to delete them.
  */
+@Deprecated
 public class DeleteByQueryResponse extends ActionResponse implements Iterable<IndexDeleteByQueryResponse> {
 
     private Map<String, IndexDeleteByQueryResponse> indices = newHashMap();

--- a/src/main/java/org/elasticsearch/action/deletebyquery/IndexDeleteByQueryRequest.java
+++ b/src/main/java/org/elasticsearch/action/deletebyquery/IndexDeleteByQueryRequest.java
@@ -27,7 +27,11 @@ import java.util.Set;
 
 /**
  * Delete by query request to execute on a specific index.
+ *
+ * @deprecated Delete by query will be removed in 2.0.  Instead, use the scroll/scan API to find all matching IDs and then issue a bulk
+ * request to delete them.
  */
+@Deprecated
 class IndexDeleteByQueryRequest extends IndexReplicationOperationRequest<IndexDeleteByQueryRequest> {
 
     private final BytesReference source;

--- a/src/main/java/org/elasticsearch/action/deletebyquery/IndexDeleteByQueryResponse.java
+++ b/src/main/java/org/elasticsearch/action/deletebyquery/IndexDeleteByQueryResponse.java
@@ -30,7 +30,11 @@ import java.util.List;
 
 /**
  * Delete by query response executed on a specific index.
+ *
+ * @deprecated Delete by query will be removed in 2.0.  Instead, use the scroll/scan API to find all matching IDs and then issue a bulk
+ * request to delete them.
  */
+@Deprecated
 public class IndexDeleteByQueryResponse extends ActionResponse {
 
     private String index;

--- a/src/main/java/org/elasticsearch/action/deletebyquery/ShardDeleteByQueryRequest.java
+++ b/src/main/java/org/elasticsearch/action/deletebyquery/ShardDeleteByQueryRequest.java
@@ -40,7 +40,11 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 
 /**
  * Delete by query request to execute on a specific shard.
+ *
+ * @deprecated Delete by query will be removed in 2.0.  Instead, use the scroll/scan API to find all matching IDs and then issue a bulk
+ * request to delete them.
  */
+@Deprecated
 public class ShardDeleteByQueryRequest extends ShardReplicationOperationRequest<ShardDeleteByQueryRequest> {
 
     private int shardId;

--- a/src/main/java/org/elasticsearch/action/deletebyquery/ShardDeleteByQueryResponse.java
+++ b/src/main/java/org/elasticsearch/action/deletebyquery/ShardDeleteByQueryResponse.java
@@ -27,7 +27,11 @@ import java.io.IOException;
 
 /**
  * Delete by query response executed on a specific shard.
+ *
+ * @deprecated Delete by query will be removed in 2.0.  Instead, use the scroll/scan API to find all matching IDs and then issue a bulk
+ * request to delete them.
  */
+@Deprecated
 public class ShardDeleteByQueryResponse extends ActionResponse {
 
     @Override

--- a/src/main/java/org/elasticsearch/action/deletebyquery/TransportDeleteByQueryAction.java
+++ b/src/main/java/org/elasticsearch/action/deletebyquery/TransportDeleteByQueryAction.java
@@ -39,7 +39,10 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 
 /**
+ * @deprecated Delete by query will be removed in 2.0.  Instead, use the scroll/scan API to find all matching IDs and then issue a bulk
+ * request to delete them.
  */
+@Deprecated
 public class TransportDeleteByQueryAction extends TransportIndicesReplicationOperationAction<DeleteByQueryRequest, DeleteByQueryResponse, IndexDeleteByQueryRequest, IndexDeleteByQueryResponse, ShardDeleteByQueryRequest, ShardDeleteByQueryRequest, ShardDeleteByQueryResponse> {
 
     private final DestructiveOperations destructiveOperations;

--- a/src/main/java/org/elasticsearch/action/deletebyquery/TransportIndexDeleteByQueryAction.java
+++ b/src/main/java/org/elasticsearch/action/deletebyquery/TransportIndexDeleteByQueryAction.java
@@ -35,7 +35,11 @@ import java.util.List;
 
 /**
  * Internal transport action that broadcasts a delete by query request to all of the shards that belong to an index.
+ *
+ * @deprecated Delete by query will be removed in 2.0.  Instead, use the scroll/scan API to find all matching IDs and then issue a bulk
+ * request to delete them.
  */
+@Deprecated
 public class TransportIndexDeleteByQueryAction extends TransportIndexReplicationOperationAction<IndexDeleteByQueryRequest, IndexDeleteByQueryResponse, ShardDeleteByQueryRequest, ShardDeleteByQueryRequest, ShardDeleteByQueryResponse> {
 
     private static final String ACTION_NAME = DeleteByQueryAction.NAME + "[index]";

--- a/src/main/java/org/elasticsearch/action/deletebyquery/TransportShardDeleteByQueryAction.java
+++ b/src/main/java/org/elasticsearch/action/deletebyquery/TransportShardDeleteByQueryAction.java
@@ -45,8 +45,10 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
 /**
- *
+ * @deprecated Delete by query will be removed in 2.0.  Instead, use the scroll/scan API to find all matching IDs and then issue a bulk
+ * request to delete them.
  */
+@Deprecated
 public class TransportShardDeleteByQueryAction extends TransportShardReplicationOperationAction<ShardDeleteByQueryRequest, ShardDeleteByQueryRequest, ShardDeleteByQueryResponse> {
 
     public final static String DELETE_BY_QUERY_API = "delete_by_query";

--- a/src/main/java/org/elasticsearch/client/Client.java
+++ b/src/main/java/org/elasticsearch/client/Client.java
@@ -226,7 +226,11 @@ public interface Client extends ElasticsearchClient<Client>, Releasable {
      * @param request The delete by query request
      * @return The result future
      * @see Requests#deleteByQueryRequest(String...)
+     *
+     * @deprecated Delete by query will be removed in 2.0.  Instead, use the scroll/scan API to find all matching IDs and then issue a bulk
+     * request to delete them.
      */
+    @Deprecated
     ActionFuture<DeleteByQueryResponse> deleteByQuery(DeleteByQueryRequest request);
 
     /**
@@ -235,12 +239,20 @@ public interface Client extends ElasticsearchClient<Client>, Releasable {
      * @param request  The delete by query request
      * @param listener A listener to be notified with a result
      * @see Requests#deleteByQueryRequest(String...)
+     * 
+     * @deprecated Delete by query will be removed in 2.0.  Instead, use the scroll/scan API to find all matching IDs and then issue a bulk
+     * request to delete them.
      */
+    @Deprecated
     void deleteByQuery(DeleteByQueryRequest request, ActionListener<DeleteByQueryResponse> listener);
 
     /**
      * Deletes all documents from one or more indices based on a query.
+     * 
+     * @deprecated Delete by query will be removed in 2.0.  Instead, use the scroll/scan API to find all matching IDs and then issue a bulk
+     * request to delete them.
      */
+    @Deprecated
     DeleteByQueryRequestBuilder prepareDeleteByQuery(String... indices);
 
     /**

--- a/src/main/java/org/elasticsearch/index/engine/DeleteByQueryFailedEngineException.java
+++ b/src/main/java/org/elasticsearch/index/engine/DeleteByQueryFailedEngineException.java
@@ -22,8 +22,10 @@ package org.elasticsearch.index.engine;
 import org.elasticsearch.index.shard.ShardId;
 
 /**
- *
+ * @deprecated Delete by query will be removed in 2.0.  Instead, use the scroll/scan API to find all matching IDs and then issue a bulk
+ * request to delete them.
  */
+@Deprecated
 public class DeleteByQueryFailedEngineException extends EngineException {
 
     public DeleteByQueryFailedEngineException(ShardId shardId, Engine.DeleteByQuery deleteByQuery, Throwable cause) {

--- a/src/main/java/org/elasticsearch/rest/action/deletebyquery/RestDeleteByQueryAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/deletebyquery/RestDeleteByQueryAction.java
@@ -41,8 +41,10 @@ import org.elasticsearch.rest.action.support.RestBuilderListener;
 import static org.elasticsearch.rest.RestRequest.Method.DELETE;
 
 /**
- *
+ * @deprecated Delete by query will be removed in 2.0.  Instead, use the scroll/scan API to find all matching IDs and then issue a bulk
+ * request to delete them.
  */
+@Deprecated
 public class RestDeleteByQueryAction extends BaseRestHandler {
 
     @Inject


### PR DESCRIPTION
In #10082 we deprecated delete-by-query, only in the docs.  This PR also deprecates Java client APIs, and action/transport internal APIs too.
