### PR TITLE
[API] changed all the links in json specs to the new site

### DIFF
--- a/rest-api-spec/README.markdown
+++ b/rest-api-spec/README.markdown
@@ -1,15 +1,15 @@
 # Elasticsearch REST API JSON specification
 
-This repository contains a collection of JSON files which describe the [Elasticsearch](http://elasticsearch.org) HTTP API.
+This repository contains a collection of JSON files which describe the [Elasticsearch](http://elastic.co) HTTP API.
 
 Their purpose is to formalize and standardize the API, to facilitate development of libraries and integrations.
 
-Example for the ["Create Index"](http://www.elasticsearch.org/guide/reference/api/admin-indices-create-index/) API:
+Example for the ["Create Index"](http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-create-index.html) API:
 
 ```json
 {
   "indices.create": {
-    "documentation": "http://www.elasticsearch.org/guide/reference/api/admin-indices-create-index/",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-create-index.html",
     "methods": ["PUT", "POST"],
     "url": {
       "path": "/{index}",
@@ -38,7 +38,7 @@ Example for the ["Create Index"](http://www.elasticsearch.org/guide/reference/ap
 The specification contains:
 
 * The _name_ of the API (`indices.create`), which usually corresponds to the client calls
-* Link to the documentation at <http://elasticsearch.org>
+* Link to the documentation at <http://elastic.co>
 * List of HTTP methods for the endpoint
 * URL specification: path, parts, parameters
 * Whether body is allowed for the endpoint or not and its description

--- a/rest-api-spec/api/bulk.json
+++ b/rest-api-spec/api/bulk.json
@@ -1,6 +1,6 @@
 {
   "bulk": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/docs-bulk.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html",
     "methods": ["POST", "PUT"],
     "url": {
       "path": "/_bulk",

--- a/rest-api-spec/api/cat.aliases.json
+++ b/rest-api-spec/api/cat.aliases.json
@@ -1,6 +1,6 @@
 {
   "cat.aliases": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-alias.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-alias.html",
     "methods": ["GET"],
     "url": {
       "path": "/_cat/aliases",

--- a/rest-api-spec/api/cat.allocation.json
+++ b/rest-api-spec/api/cat.allocation.json
@@ -1,6 +1,6 @@
 {
   "cat.allocation": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-allocation.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-allocation.html",
     "methods": ["GET"],
     "url": {
       "path": "/_cat/allocation",

--- a/rest-api-spec/api/cat.count.json
+++ b/rest-api-spec/api/cat.count.json
@@ -1,6 +1,6 @@
 {
   "cat.count": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-count.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-count.html",
     "methods": ["GET"],
     "url": {
       "path": "/_cat/count",

--- a/rest-api-spec/api/cat.fielddata.json
+++ b/rest-api-spec/api/cat.fielddata.json
@@ -1,6 +1,6 @@
 {
   "cat.fielddata": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-fielddata.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-fielddata.html",
     "methods": ["GET"],
     "url": {
       "path": "/_cat/fielddata",

--- a/rest-api-spec/api/cat.health.json
+++ b/rest-api-spec/api/cat.health.json
@@ -1,6 +1,6 @@
 {
   "cat.health": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-health.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-health.html",
     "methods": ["GET"],
     "url": {
       "path": "/_cat/health",

--- a/rest-api-spec/api/cat.help.json
+++ b/rest-api-spec/api/cat.help.json
@@ -1,6 +1,6 @@
 {
   "cat.help": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat.html",
     "methods": ["GET"],
     "url": {
       "path": "/_cat",

--- a/rest-api-spec/api/cat.indices.json
+++ b/rest-api-spec/api/cat.indices.json
@@ -1,6 +1,6 @@
 {
   "cat.indices": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-indices.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-indices.html",
     "methods": ["GET"],
     "url": {
       "path": "/_cat/indices",

--- a/rest-api-spec/api/cat.master.json
+++ b/rest-api-spec/api/cat.master.json
@@ -1,6 +1,6 @@
 {
   "cat.master": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-master.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-master.html",
     "methods": ["GET"],
     "url": {
       "path": "/_cat/master",

--- a/rest-api-spec/api/cat.nodes.json
+++ b/rest-api-spec/api/cat.nodes.json
@@ -1,6 +1,6 @@
 {
   "cat.nodes": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-nodes.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodes.html",
     "methods": ["GET"],
     "url": {
       "path": "/_cat/nodes",

--- a/rest-api-spec/api/cat.pending_tasks.json
+++ b/rest-api-spec/api/cat.pending_tasks.json
@@ -1,6 +1,6 @@
 {
   "cat.pending_tasks": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-pending-tasks.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-pending-tasks.html",
     "methods": ["GET"],
     "url": {
       "path": "/_cat/pending_tasks",

--- a/rest-api-spec/api/cat.plugins.json
+++ b/rest-api-spec/api/cat.plugins.json
@@ -1,6 +1,6 @@
 {
   "cat.plugins": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-plugins.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-plugins.html",
     "methods": ["GET"],
     "url": {
       "path": "/_cat/plugins",

--- a/rest-api-spec/api/cat.recovery.json
+++ b/rest-api-spec/api/cat.recovery.json
@@ -1,6 +1,6 @@
 {
   "cat.recovery": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-recovery.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-recovery.html",
     "methods": ["GET"],
     "url": {
       "path": "/_cat/recovery",

--- a/rest-api-spec/api/cat.segments.json
+++ b/rest-api-spec/api/cat.segments.json
@@ -1,6 +1,6 @@
 {
   "cat.segments": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-segments.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html",
     "methods": ["GET"],
     "url": {
       "path": "/_cat/segments",

--- a/rest-api-spec/api/cat.shards.json
+++ b/rest-api-spec/api/cat.shards.json
@@ -1,6 +1,6 @@
 {
   "cat.shards": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-shards.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-shards.html",
     "methods": ["GET"],
     "url": {
       "path": "/_cat/shards",

--- a/rest-api-spec/api/cat.thread_pool.json
+++ b/rest-api-spec/api/cat.thread_pool.json
@@ -1,6 +1,6 @@
 {
   "cat.thread_pool": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-thread-pool.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-thread-pool.html",
     "methods": ["GET"],
     "url": {
       "path": "/_cat/thread_pool",

--- a/rest-api-spec/api/clear_scroll.json
+++ b/rest-api-spec/api/clear_scroll.json
@@ -1,6 +1,6 @@
 {
   "clear_scroll": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-request-scroll.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html",
     "methods": ["DELETE"],
     "url": {
       "path": "/_search/scroll/{scroll_id}",

--- a/rest-api-spec/api/cluster.get_settings.json
+++ b/rest-api-spec/api/cluster.get_settings.json
@@ -1,6 +1,6 @@
 {
   "cluster.get_settings": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cluster-update-settings.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html",
     "methods": ["GET"],
     "url": {
       "path": "/_cluster/settings",

--- a/rest-api-spec/api/cluster.health.json
+++ b/rest-api-spec/api/cluster.health.json
@@ -1,6 +1,6 @@
 {
   "cluster.health": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cluster-health.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-health.html",
     "methods": ["GET"],
     "url": {
       "path": "/_cluster/health",

--- a/rest-api-spec/api/cluster.pending_tasks.json
+++ b/rest-api-spec/api/cluster.pending_tasks.json
@@ -1,6 +1,6 @@
 {
   "cluster.pending_tasks": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cluster-pending.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-pending.html",
     "methods": ["GET"],
     "url": {
       "path": "/_cluster/pending_tasks",

--- a/rest-api-spec/api/cluster.put_settings.json
+++ b/rest-api-spec/api/cluster.put_settings.json
@@ -1,6 +1,6 @@
 {
   "cluster.put_settings": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cluster-update-settings.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html",
     "methods": ["PUT"],
     "url": {
       "path": "/_cluster/settings",

--- a/rest-api-spec/api/cluster.reroute.json
+++ b/rest-api-spec/api/cluster.reroute.json
@@ -1,6 +1,6 @@
 {
   "cluster.reroute": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cluster-reroute.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-reroute.html",
     "methods": ["POST"],
     "url": {
       "path": "/_cluster/reroute",

--- a/rest-api-spec/api/cluster.state.json
+++ b/rest-api-spec/api/cluster.state.json
@@ -1,6 +1,6 @@
 {
   "cluster.state": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cluster-state.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-state.html",
     "methods": ["GET"],
     "url": {
       "path": "/_cluster/state",

--- a/rest-api-spec/api/cluster.stats.json
+++ b/rest-api-spec/api/cluster.stats.json
@@ -1,6 +1,6 @@
 {
   "cluster.stats": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cluster-stats.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-stats.html",
     "methods": ["GET"],
     "url": {
       "path": "/_cluster/stats",

--- a/rest-api-spec/api/count.json
+++ b/rest-api-spec/api/count.json
@@ -1,6 +1,6 @@
 {
   "count": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-count.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-count.html",
     "methods": ["POST", "GET"],
     "url": {
       "path": "/_count",

--- a/rest-api-spec/api/count_percolate.json
+++ b/rest-api-spec/api/count_percolate.json
@@ -1,6 +1,6 @@
 {
   "count_percolate": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-percolate.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-percolate.html",
     "methods": ["GET", "POST"],
     "url": {
       "path": "/{index}/{type}/_percolate/count",

--- a/rest-api-spec/api/delete.json
+++ b/rest-api-spec/api/delete.json
@@ -1,6 +1,6 @@
 {
   "delete": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/docs-delete.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete.html",
     "methods": ["DELETE"],
     "url": {
       "path": "/{index}/{type}/{id}",

--- a/rest-api-spec/api/delete_by_query.json
+++ b/rest-api-spec/api/delete_by_query.json
@@ -1,6 +1,6 @@
 {
   "delete_by_query": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/docs-delete-by-query.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete-by-query.html",
     "methods": ["DELETE"],
     "url": {
       "path": "/{index}/_query",

--- a/rest-api-spec/api/delete_script.json
+++ b/rest-api-spec/api/delete_script.json
@@ -1,6 +1,6 @@
 {
   "delete_script": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-scripting.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html",
     "methods": ["DELETE"],
     "url": {
       "path": "/_scripts/{lang}/{id}",

--- a/rest-api-spec/api/delete_template.json
+++ b/rest-api-spec/api/delete_template.json
@@ -1,6 +1,6 @@
 {
   "delete_template": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-template.html",
     "methods": ["DELETE"],
     "url": {
       "path": "/_search/template/{id}",

--- a/rest-api-spec/api/exists.json
+++ b/rest-api-spec/api/exists.json
@@ -1,6 +1,6 @@
 {
   "exists": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/docs-get.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html",
     "methods": ["HEAD"],
     "url": {
       "path": "/{index}/{type}/{id}",

--- a/rest-api-spec/api/explain.json
+++ b/rest-api-spec/api/explain.json
@@ -1,6 +1,6 @@
 {
   "explain": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-explain.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-explain.html",
     "methods": ["GET", "POST"],
     "url": {
       "path": "/{index}/{type}/{id}/_explain",

--- a/rest-api-spec/api/get.json
+++ b/rest-api-spec/api/get.json
@@ -1,6 +1,6 @@
 {
   "get": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/docs-get.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html",
     "methods": ["GET"],
     "url": {
       "path": "/{index}/{type}/{id}",

--- a/rest-api-spec/api/get_script.json
+++ b/rest-api-spec/api/get_script.json
@@ -1,6 +1,6 @@
 {
   "get_script": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-scripting.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html",
     "methods": ["GET"],
     "url": {
       "path": "/_scripts/{lang}/{id}",

--- a/rest-api-spec/api/get_source.json
+++ b/rest-api-spec/api/get_source.json
@@ -1,6 +1,6 @@
 {
   "get_source": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/docs-get.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html",
     "methods": ["GET"],
     "url": {
       "path": "/{index}/{type}/{id}/_source",

--- a/rest-api-spec/api/get_template.json
+++ b/rest-api-spec/api/get_template.json
@@ -1,6 +1,6 @@
 {
   "get_template": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-template.html",
     "methods": ["GET"],
     "url": {
       "path": "/_search/template/{id}",

--- a/rest-api-spec/api/index.json
+++ b/rest-api-spec/api/index.json
@@ -1,6 +1,6 @@
 {
   "index": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/docs-index_.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html",
     "methods": ["POST", "PUT"],
     "url": {
       "path": "/{index}/{type}",

--- a/rest-api-spec/api/indices.analyze.json
+++ b/rest-api-spec/api/indices.analyze.json
@@ -1,6 +1,6 @@
 {
   "indices.analyze": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-analyze.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-analyze.html",
     "methods": ["GET", "POST"],
     "url": {
       "path": "/_analyze",

--- a/rest-api-spec/api/indices.clear_cache.json
+++ b/rest-api-spec/api/indices.clear_cache.json
@@ -1,6 +1,6 @@
 {
   "indices.clear_cache": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-clearcache.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clearcache.html",
     "methods": ["POST", "GET"],
     "url": {
       "path": "/_cache/clear",

--- a/rest-api-spec/api/indices.close.json
+++ b/rest-api-spec/api/indices.close.json
@@ -1,6 +1,6 @@
 {
   "indices.close": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-open-close.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html",
     "methods": ["POST"],
     "url": {
       "path": "/{index}/_close",

--- a/rest-api-spec/api/indices.create.json
+++ b/rest-api-spec/api/indices.create.json
@@ -1,6 +1,6 @@
 {
   "indices.create": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-create-index.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-create-index.html",
     "methods": ["PUT", "POST"],
     "url": {
       "path": "/{index}",

--- a/rest-api-spec/api/indices.delete.json
+++ b/rest-api-spec/api/indices.delete.json
@@ -1,6 +1,6 @@
 {
   "indices.delete": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-delete-index.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-delete-index.html",
     "methods": ["DELETE"],
     "url": {
       "path": "/{index}",

--- a/rest-api-spec/api/indices.delete_alias.json
+++ b/rest-api-spec/api/indices.delete_alias.json
@@ -1,6 +1,6 @@
 {
   "indices.delete_alias": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-aliases.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html",
     "methods": ["DELETE"],
     "url": {
       "path": "/{index}/_alias/{name}",

--- a/rest-api-spec/api/indices.delete_mapping.json
+++ b/rest-api-spec/api/indices.delete_mapping.json
@@ -1,6 +1,6 @@
 {
   "indices.delete_mapping": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-delete-mapping.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-delete-mapping.html",
     "methods": ["DELETE"],
     "url": {
       "path": "/{index}/{type}/_mapping",

--- a/rest-api-spec/api/indices.delete_template.json
+++ b/rest-api-spec/api/indices.delete_template.json
@@ -1,6 +1,6 @@
 {
   "indices.delete_template": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-templates.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html",
     "methods": ["DELETE"],
     "url": {
       "path": "/_template/{name}",

--- a/rest-api-spec/api/indices.delete_warmer.json
+++ b/rest-api-spec/api/indices.delete_warmer.json
@@ -1,6 +1,6 @@
 {
   "indices.delete_warmer": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-warmers.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-warmers.html",
     "methods": ["DELETE"],
     "url": {
       "path": "/{index}/_warmer/{name}",

--- a/rest-api-spec/api/indices.exists.json
+++ b/rest-api-spec/api/indices.exists.json
@@ -1,6 +1,6 @@
 {
   "indices.exists": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-exists.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-exists.html",
     "methods": ["HEAD"],
     "url": {
       "path": "/{index}",

--- a/rest-api-spec/api/indices.exists_alias.json
+++ b/rest-api-spec/api/indices.exists_alias.json
@@ -1,6 +1,6 @@
 {
   "indices.exists_alias": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-aliases.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html",
     "methods": ["HEAD"],
     "url": {
       "path": "/_alias/{name}",

--- a/rest-api-spec/api/indices.exists_template.json
+++ b/rest-api-spec/api/indices.exists_template.json
@@ -1,6 +1,6 @@
 {
   "indices.exists_template": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-templates.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html",
     "methods": ["HEAD"],
     "url": {
       "path": "/_template/{name}",

--- a/rest-api-spec/api/indices.exists_type.json
+++ b/rest-api-spec/api/indices.exists_type.json
@@ -1,6 +1,6 @@
 {
   "indices.exists_type": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-types-exists.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-types-exists.html",
     "methods": ["HEAD"],
     "url": {
       "path": "/{index}/{type}",

--- a/rest-api-spec/api/indices.flush.json
+++ b/rest-api-spec/api/indices.flush.json
@@ -1,6 +1,6 @@
 {
   "indices.flush": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-flush.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html",
     "methods": ["POST", "GET"],
     "url": {
       "path": "/_flush",

--- a/rest-api-spec/api/indices.get.json
+++ b/rest-api-spec/api/indices.get.json
@@ -1,6 +1,6 @@
 {
   "indices.get":{
-    "documentation":"http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-get-index.html",
+    "documentation":"http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-index.html",
     "methods":[ "GET" ],
     "url":{
       "path":"/{index}",

--- a/rest-api-spec/api/indices.get_alias.json
+++ b/rest-api-spec/api/indices.get_alias.json
@@ -1,6 +1,6 @@
 {
   "indices.get_alias": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-aliases.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html",
     "methods": ["GET"],
     "url": {
       "path": "/_alias/",

--- a/rest-api-spec/api/indices.get_aliases.json
+++ b/rest-api-spec/api/indices.get_aliases.json
@@ -1,6 +1,6 @@
 {
   "indices.get_aliases": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-aliases.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html",
     "methods": ["GET"],
     "url": {
       "path": "/_aliases",

--- a/rest-api-spec/api/indices.get_field_mapping.json
+++ b/rest-api-spec/api/indices.get_field_mapping.json
@@ -1,6 +1,6 @@
 {
   "indices.get_field_mapping": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-get-field-mapping.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-field-mapping.html",
     "methods": ["GET"],
     "url": {
       "path": "/_mapping/field/{field}",

--- a/rest-api-spec/api/indices.get_mapping.json
+++ b/rest-api-spec/api/indices.get_mapping.json
@@ -1,6 +1,6 @@
 {
   "indices.get_mapping": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-get-mapping.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-mapping.html",
     "methods": ["GET"],
     "url": {
       "path": "/_mapping",

--- a/rest-api-spec/api/indices.get_settings.json
+++ b/rest-api-spec/api/indices.get_settings.json
@@ -1,6 +1,6 @@
 {
   "indices.get_settings": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-get-settings.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-settings.html",
     "methods": ["GET"],
     "url": {
       "path": "/_settings",

--- a/rest-api-spec/api/indices.get_template.json
+++ b/rest-api-spec/api/indices.get_template.json
@@ -1,6 +1,6 @@
 {
   "indices.get_template": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-templates.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html",
     "methods": ["GET"],
     "url": {
       "path": "/_template/{name}",

--- a/rest-api-spec/api/indices.get_upgrade.json
+++ b/rest-api-spec/api/indices.get_upgrade.json
@@ -1,6 +1,6 @@
 {
   "indices.get_upgrade": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-upgrade.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html",
     "methods": ["GET"],
     "url": {
       "path": "/_upgrade",

--- a/rest-api-spec/api/indices.get_warmer.json
+++ b/rest-api-spec/api/indices.get_warmer.json
@@ -1,6 +1,6 @@
 {
   "indices.get_warmer": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-warmers.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-warmers.html",
     "methods": ["GET"],
     "url": {
       "path": "/_warmer",

--- a/rest-api-spec/api/indices.open.json
+++ b/rest-api-spec/api/indices.open.json
@@ -1,6 +1,6 @@
 {
   "indices.open": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-open-close.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html",
     "methods": ["POST"],
     "url": {
       "path": "/{index}/_open",

--- a/rest-api-spec/api/indices.optimize.json
+++ b/rest-api-spec/api/indices.optimize.json
@@ -1,6 +1,6 @@
 {
   "indices.optimize": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-optimize.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-optimize.html",
     "methods": ["POST", "GET"],
     "url": {
       "path": "/_optimize",

--- a/rest-api-spec/api/indices.put_alias.json
+++ b/rest-api-spec/api/indices.put_alias.json
@@ -1,6 +1,6 @@
 {
   "indices.put_alias": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-aliases.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html",
     "methods": ["PUT", "POST"],
     "url": {
       "path": "/{index}/_alias/{name}",

--- a/rest-api-spec/api/indices.put_mapping.json
+++ b/rest-api-spec/api/indices.put_mapping.json
@@ -1,6 +1,6 @@
 {
   "indices.put_mapping": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-put-mapping.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-put-mapping.html",
     "methods": ["PUT", "POST"],
     "url": {
       "path": "/{index}/{type}/_mapping",

--- a/rest-api-spec/api/indices.put_settings.json
+++ b/rest-api-spec/api/indices.put_settings.json
@@ -1,6 +1,6 @@
 {
   "indices.put_settings": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-update-settings.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-update-settings.html",
     "methods": ["PUT"],
     "url": {
       "path": "/_settings",

--- a/rest-api-spec/api/indices.put_template.json
+++ b/rest-api-spec/api/indices.put_template.json
@@ -1,6 +1,6 @@
 {
   "indices.put_template": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-templates.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html",
     "methods": ["PUT", "POST"],
     "url": {
       "path": "/_template/{name}",

--- a/rest-api-spec/api/indices.put_warmer.json
+++ b/rest-api-spec/api/indices.put_warmer.json
@@ -1,6 +1,6 @@
 {
   "indices.put_warmer": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-warmers.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-warmers.html",
     "methods": ["PUT", "POST"],
     "url": {
       "path": "/{index}/_warmer/{name}",

--- a/rest-api-spec/api/indices.recovery.json
+++ b/rest-api-spec/api/indices.recovery.json
@@ -1,6 +1,6 @@
 {
     "indices.recovery" : {
-        "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-recovery.html",
+        "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html",
         "methods": ["GET"],
         "url": {
             "path": "/_recovery",

--- a/rest-api-spec/api/indices.refresh.json
+++ b/rest-api-spec/api/indices.refresh.json
@@ -1,6 +1,6 @@
 {
   "indices.refresh": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-refresh.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-refresh.html",
     "methods": ["POST", "GET"],
     "url": {
       "path": "/_refresh",

--- a/rest-api-spec/api/indices.segments.json
+++ b/rest-api-spec/api/indices.segments.json
@@ -1,6 +1,6 @@
 {
   "indices.segments": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-segments.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-segments.html",
     "methods": ["GET"],
     "url": {
       "path": "/_segments",

--- a/rest-api-spec/api/indices.stats.json
+++ b/rest-api-spec/api/indices.stats.json
@@ -1,6 +1,6 @@
 {
   "indices.stats": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-stats.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-stats.html",
     "methods": ["GET"],
     "url": {
       "path": "/_stats",

--- a/rest-api-spec/api/indices.update_aliases.json
+++ b/rest-api-spec/api/indices.update_aliases.json
@@ -1,6 +1,6 @@
 {
   "indices.update_aliases": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-aliases.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html",
     "methods": ["POST"],
     "url": {
       "path": "/_aliases",

--- a/rest-api-spec/api/indices.upgrade.json
+++ b/rest-api-spec/api/indices.upgrade.json
@@ -1,6 +1,6 @@
 {
   "indices.upgrade": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-upgrade.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html",
     "methods": ["POST"],
     "url": {
       "path": "/_upgrade",

--- a/rest-api-spec/api/indices.validate_query.json
+++ b/rest-api-spec/api/indices.validate_query.json
@@ -1,6 +1,6 @@
 {
   "indices.validate_query": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-validate.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-validate.html",
     "methods": ["GET", "POST"],
     "url": {
       "path": "/_validate/query",

--- a/rest-api-spec/api/info.json
+++ b/rest-api-spec/api/info.json
@@ -1,6 +1,6 @@
 {
   "info": {
-    "documentation": "http://www.elasticsearch.org/guide/",
+    "documentation": "http://www.elastic.co/guide/",
     "methods": ["GET"],
     "url": {
       "path": "/",

--- a/rest-api-spec/api/mget.json
+++ b/rest-api-spec/api/mget.json
@@ -1,6 +1,6 @@
 {
   "mget": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/docs-multi-get.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-get.html",
     "methods": ["GET", "POST"],
     "url": {
       "path": "/_mget",

--- a/rest-api-spec/api/mlt.json
+++ b/rest-api-spec/api/mlt.json
@@ -1,6 +1,6 @@
 {
   "mlt": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-more-like-this.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-more-like-this.html",
     "methods": ["GET", "POST"],
     "url": {
       "path": "/{index}/{type}/{id}/_mlt",

--- a/rest-api-spec/api/mpercolate.json
+++ b/rest-api-spec/api/mpercolate.json
@@ -1,6 +1,6 @@
 {
   "mpercolate": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-percolate.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-percolate.html",
     "methods": ["GET", "POST"],
     "url": {
       "path": "/_mpercolate",

--- a/rest-api-spec/api/msearch.json
+++ b/rest-api-spec/api/msearch.json
@@ -1,6 +1,6 @@
 {
   "msearch": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-multi-search.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-multi-search.html",
     "methods": ["GET", "POST"],
     "url": {
       "path": "/_msearch",

--- a/rest-api-spec/api/mtermvectors.json
+++ b/rest-api-spec/api/mtermvectors.json
@@ -1,6 +1,6 @@
 {
   "mtermvectors" : {
-    "documentation" : "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/docs-multi-termvectors.html",
+    "documentation" : "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-termvectors.html",
     "methods" : ["GET", "POST"],
     "url" : {
       "path" : "/_mtermvectors",

--- a/rest-api-spec/api/nodes.hot_threads.json
+++ b/rest-api-spec/api/nodes.hot_threads.json
@@ -1,6 +1,6 @@
 {
   "nodes.hot_threads": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cluster-nodes-hot-threads.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-hot-threads.html",
     "methods": ["GET"],
     "url": {
       "path": "/_nodes/hot_threads",

--- a/rest-api-spec/api/nodes.info.json
+++ b/rest-api-spec/api/nodes.info.json
@@ -1,6 +1,6 @@
 {
   "nodes.info": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cluster-nodes-info.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-info.html",
     "methods": ["GET"],
     "url": {
       "path": "/_nodes",

--- a/rest-api-spec/api/nodes.shutdown.json
+++ b/rest-api-spec/api/nodes.shutdown.json
@@ -1,6 +1,6 @@
 {
   "nodes.shutdown": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cluster-nodes-shutdown.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-shutdown.html",
     "methods": ["POST"],
     "url": {
       "path": "/_shutdown",

--- a/rest-api-spec/api/nodes.stats.json
+++ b/rest-api-spec/api/nodes.stats.json
@@ -1,6 +1,6 @@
 {
   "nodes.stats": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cluster-nodes-stats.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-stats.html",
     "methods": ["GET"],
     "url": {
       "path": "/_nodes/stats",

--- a/rest-api-spec/api/percolate.json
+++ b/rest-api-spec/api/percolate.json
@@ -1,6 +1,6 @@
 {
   "percolate": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-percolate.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-percolate.html",
     "methods": ["GET", "POST"],
     "url": {
       "path": "/{index}/{type}/_percolate",

--- a/rest-api-spec/api/ping.json
+++ b/rest-api-spec/api/ping.json
@@ -1,6 +1,6 @@
 {
   "ping": {
-    "documentation": "http://www.elasticsearch.org/guide/",
+    "documentation": "http://www.elastic.co/guide/",
     "methods": ["HEAD"],
     "url": {
       "path": "/",

--- a/rest-api-spec/api/put_script.json
+++ b/rest-api-spec/api/put_script.json
@@ -1,6 +1,6 @@
 {
   "put_script": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-scripting.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html",
     "methods": ["PUT", "POST"],
     "url": {
       "path": "/_scripts/{lang}/{id}",

--- a/rest-api-spec/api/put_template.json
+++ b/rest-api-spec/api/put_template.json
@@ -1,6 +1,6 @@
 {
   "put_template": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-template.html",
     "methods": ["PUT", "POST"],
     "url": {
       "path": "/_search/template/{id}",

--- a/rest-api-spec/api/scroll.json
+++ b/rest-api-spec/api/scroll.json
@@ -1,6 +1,6 @@
 {
   "scroll": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-request-scroll.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html",
     "methods": ["GET", "POST"],
     "url": {
       "path": "/_search/scroll",

--- a/rest-api-spec/api/search.json
+++ b/rest-api-spec/api/search.json
@@ -1,6 +1,6 @@
 {
   "search": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-search.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html",
     "methods": ["GET", "POST"],
     "url": {
       "path": "/_search",

--- a/rest-api-spec/api/search_exists.json
+++ b/rest-api-spec/api/search_exists.json
@@ -1,6 +1,6 @@
 {
   "search_exists": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html",
     "methods": ["POST", "GET"],
     "url": {
       "path": "/_search/exists",

--- a/rest-api-spec/api/search_shards.json
+++ b/rest-api-spec/api/search_shards.json
@@ -1,6 +1,6 @@
 {
   "search_shards": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html",
     "methods": ["GET", "POST"],
     "url": {
       "path": "/{index}/{type}/_search_shards",

--- a/rest-api-spec/api/search_template.json
+++ b/rest-api-spec/api/search_template.json
@@ -1,6 +1,6 @@
 {
   "search_template": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html",
     "methods": ["GET", "POST"],
     "url": {
       "path": "/_search/template",

--- a/rest-api-spec/api/snapshot.create.json
+++ b/rest-api-spec/api/snapshot.create.json
@@ -1,6 +1,6 @@
 {
   "snapshot.create": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html",
     "methods": ["PUT", "POST"],
     "url": {
       "path": "/_snapshot/{repository}/{snapshot}",

--- a/rest-api-spec/api/snapshot.create_repository.json
+++ b/rest-api-spec/api/snapshot.create_repository.json
@@ -1,6 +1,6 @@
 {
   "snapshot.create_repository": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html",
     "methods": ["PUT", "POST"],
     "url": {
       "path": "/_snapshot/{repository}",

--- a/rest-api-spec/api/snapshot.delete.json
+++ b/rest-api-spec/api/snapshot.delete.json
@@ -1,6 +1,6 @@
 {
   "snapshot.delete": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html",
     "methods": ["DELETE"],
     "url": {
       "path": "/_snapshot/{repository}/{snapshot}",

--- a/rest-api-spec/api/snapshot.delete_repository.json
+++ b/rest-api-spec/api/snapshot.delete_repository.json
@@ -1,6 +1,6 @@
 {
   "snapshot.delete_repository": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html",
     "methods": ["DELETE"],
     "url": {
       "path": "/_snapshot/{repository}",

--- a/rest-api-spec/api/snapshot.get.json
+++ b/rest-api-spec/api/snapshot.get.json
@@ -1,6 +1,6 @@
 {
   "snapshot.get": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html",
     "methods": ["GET"],
     "url": {
       "path": "/_snapshot/{repository}/{snapshot}",

--- a/rest-api-spec/api/snapshot.get_repository.json
+++ b/rest-api-spec/api/snapshot.get_repository.json
@@ -1,6 +1,6 @@
 {
   "snapshot.get_repository": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html",
     "methods": ["GET"],
     "url": {
       "path": "/_snapshot",

--- a/rest-api-spec/api/snapshot.restore.json
+++ b/rest-api-spec/api/snapshot.restore.json
@@ -1,6 +1,6 @@
 {
   "snapshot.restore": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html",
     "methods": ["POST"],
     "url": {
       "path": "/_snapshot/{repository}/{snapshot}/_restore",

--- a/rest-api-spec/api/snapshot.status.json
+++ b/rest-api-spec/api/snapshot.status.json
@@ -1,6 +1,6 @@
 {
   "snapshot.status": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html",
     "methods": ["GET"],
     "url": {
       "path": "/_snapshot/_status",

--- a/rest-api-spec/api/snapshot.verify_repository.json
+++ b/rest-api-spec/api/snapshot.verify_repository.json
@@ -1,6 +1,6 @@
 {
     "snapshot.verify_repository": {
-        "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html",
+        "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html",
         "methods": ["POST"],
         "url": {
             "path": "/_snapshot/{repository}/_verify",

--- a/rest-api-spec/api/suggest.json
+++ b/rest-api-spec/api/suggest.json
@@ -1,6 +1,6 @@
 {
   "suggest": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-suggesters.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-suggesters.html",
     "methods": ["POST", "GET"],
     "url": {
       "path": "/_suggest",

--- a/rest-api-spec/api/termvectors.json
+++ b/rest-api-spec/api/termvectors.json
@@ -1,6 +1,6 @@
 {
   "termvectors" : {
-    "documentation" : "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/docs-termvectors.html",
+    "documentation" : "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-termvectors.html",
     "methods" : ["GET", "POST"],
     "url" : {
       "path" : "/{index}/{type}/_termvectors",

--- a/rest-api-spec/api/update.json
+++ b/rest-api-spec/api/update.json
@@ -1,6 +1,6 @@
 {
   "update": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/docs-update.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update.html",
     "methods": ["POST"],
     "url": {
       "path": "/{index}/{type}/{id}/_update",


### PR DESCRIPTION
I am not sure if the link in README should point to just elastic.co or elastic.co/products/elasticsearch. Not 100% happy with either...
