### PR TITLE
Deprecate `validate_*` and `normalize_*`

### DIFF
--- a/docs/reference/mapping/types/geo-point-type.asciidoc
+++ b/docs/reference/mapping/types/geo-point-type.asciidoc
@@ -143,20 +143,8 @@ longitude (default is `true`). *Note*: Validation only works when
 normalization has been disabled. This option will be deprecated and removed
 in upcoming releases.
 
-|`validate_lat` |Set to `false` to accept geo points with an invalid
-latitude (default is `true`). This option will be deprecated and removed
-in upcoming releases.
-
-|`validate_lon` |Set to `false` to accept geo points with an invalid
-longitude (default is `true`). This option will be deprecated and removed
-in upcoming releases.
-
 |`normalize` |Set to `true` to normalize latitude and longitude (default
 is `true`).
-
-|`normalize_lat` |Set to `true` to normalize latitude.
-
-|`normalize_lon` |Set to `true` to normalize longitude.
 
 |`precision_step` |The precision step (influences the number of terms 
 generated for each number value) for `.lat` and `.lon` fields 

--- a/docs/reference/query-dsl/filters/geo-bounding-box-filter.asciidoc
+++ b/docs/reference/query-dsl/filters/geo-bounding-box-filter.asciidoc
@@ -45,6 +45,33 @@ Then the following simple query can be executed with a
 --------------------------------------------------
 
 [float]
+==== Filter Options
+
+[cols="<,<",options="header",]
+|=======================================================================
+|Option |Description
+|`_name` |Optional name field to identify the filter
+
+|`_cache` |Set to `true` to cache the *result* of the filter.
+Defaults to `false`. See <<Caching,Caching>> below for further details.
+
+|`_cache_key` |Associate a unique custom cache key to use instead of
+the actual filter.
+
+|`validate` |Set to `false` to accept geo points with invalid latitude or
+longitude (default is `true`). *Note*: Validation only works when
+normalization has been disabled. This option will be deprecated and removed
+in upcoming releases.
+
+|`normalize` |Set to `true` to normalize latitude and longitude (default
+is `true`).
+
+|`type` |Set to one of `indexed` or `memory` to defines whether this filter will
+be executed in memory or indexed. See <<Type,Type>> below for further details
+Default is `memory`.
+|=======================================================================
+
+[float]
 ==== Accepted Formats
 
 In much the same way the geo_point type can accept different

--- a/docs/reference/query-dsl/filters/geo-distance-filter.asciidoc
+++ b/docs/reference/query-dsl/filters/geo-distance-filter.asciidoc
@@ -158,6 +158,29 @@ The following are options allowed on the filter:
     sure the `geo_point` type index lat lon in this case), or `none` which
     disables bounding box optimization.
 
+`_name`::
+
+    Optional name field to identify the filter
+
+`_cache`::
+
+    Set to `true` to cache the *result* of the filter.
+    Defaults to `false`. See <<Caching,Caching>> below for further details.
+
+`_cache_key`::
+
+    Associate a unique custom cache key to use instead of the actual filter.
+
+`validate`::
+
+    Set to `false` to accept geo points with invalid latitude or
+    longitude (default is `true`). *Note*: Validation only works when
+    normalization has been disabled. This option will be deprecated and removed
+    in upcoming releases.
+
+`normalize`::
+
+    Set to `true` to normalize latitude and longitude. Defaults to `true`.
 
 [float]
 ==== geo_point Type

--- a/docs/reference/query-dsl/filters/geo-distance-range-filter.asciidoc
+++ b/docs/reference/query-dsl/filters/geo-distance-range-filter.asciidoc
@@ -24,7 +24,7 @@ Filters documents that exists within a range from a specific point:
 }
 --------------------------------------------------
 
-Supports the same point location parameter as the
+Supports the same point location parameter and filter options as the
 <<query-dsl-geo-distance-filter,geo_distance>>
 filter. And also support the common parameters for range (lt, lte, gt,
 gte, from, to, include_upper and include_lower).

--- a/docs/reference/query-dsl/filters/geo-polygon-filter.asciidoc
+++ b/docs/reference/query-dsl/filters/geo-polygon-filter.asciidoc
@@ -27,6 +27,29 @@ points. Here is an example:
 --------------------------------------------------
 
 [float]
+==== Filter Options
+
+[cols="<,<",options="header",]
+|=======================================================================
+|Option |Description
+|`_name` |Optional name field to identify the filter
+
+|`_cache` |Set to `true` to cache the *result* of the filter.
+Defaults to `false`. See <<Caching,Caching>> below.
+
+|`_cache_key` |Associate a unique custom cache key to use instead of
+the actual filter.
+
+|`validate` |Set to `false` to accept geo points with invalid latitude or
+longitude (default is `true`). *Note*: Validation only works when
+normalization has been disabled. This option will be deprecated and removed
+in upcoming releases.
+
+|`normalize` |Set to `true` to normalize latitude and longitude (default
+is `true`).
+|=======================================================================
+
+[float]
 ==== Allowed Formats
 
 [float]

--- a/docs/reference/query-dsl/filters/geo-polygon-filter.asciidoc
+++ b/docs/reference/query-dsl/filters/geo-polygon-filter.asciidoc
@@ -45,8 +45,9 @@ longitude (default is `true`). *Note*: Validation only works when
 normalization has been disabled. This option will be deprecated and removed
 in upcoming releases.
 
-|`normalize` |Set to `true` to normalize latitude and longitude (default
-is `true`).
+|`normalize` |Set to `false` to prevent latitude and longitude from auto converting
+to proper lat/lon bounds.
+Default is `true'.
 |=======================================================================
 
 [float]

--- a/src/main/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapper.java
@@ -262,6 +262,10 @@ public class GeoPointFieldMapper extends AbstractFieldMapper<GeoPoint> implement
                     iterator.remove();
                 } else if (fieldName.equals("validate")) {
                     builder.validate = XContentMapValues.nodeBooleanValue(fieldNode);
+                    if (builder.backCompat) {
+                        builder.validateLat = builder.validate;
+                        builder.validateLon = builder.validate;
+                    }
                     iterator.remove();
                 } else if (builder.backCompat && fieldName.equals("validate_lon")) {
                     builder.validate = false;

--- a/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxFilterParser.java
@@ -84,6 +84,7 @@ public class GeoBoundingBoxFilterParser implements FilterParser {
         String filterName = null;
         String currentFieldName = null;
         XContentParser.Token token;
+        boolean validate = true;
         boolean normalize = true;
 
         GeoPoint sparse = new GeoPoint();
@@ -142,6 +143,8 @@ public class GeoBoundingBoxFilterParser implements FilterParser {
                     cache = parseContext.parseFilterCachePolicy();
                 } else if ("_cache_key".equals(currentFieldName) || "_cacheKey".equals(currentFieldName)) {
                     cacheKey = new HashedBytesRef(parser.text());
+                } else if ("validate".equals(currentFieldName)) {
+                    validate = parser.booleanValue();
                 } else if ("normalize".equals(currentFieldName)) {
                     normalize = parser.booleanValue();
                 } else if ("type".equals(currentFieldName)) {
@@ -156,14 +159,29 @@ public class GeoBoundingBoxFilterParser implements FilterParser {
         final GeoPoint bottomRight = new GeoPoint(bottom, right);
 
         if (normalize) {
-            // Special case: if the difference bettween the left and right is 360 and the right is greater than the left, we are asking for 
-            // the complete longitude range so need to set longitude to the complete longditude range
+            // Special case: if the difference between the left and right is 360 and the right is greater than the left, we are asking for
+            // the complete longitude range so need to set longitude to the complete longitude range
             boolean completeLonRange = ((right - left) % 360 == 0 && right > left);
             GeoUtils.normalizePoint(topLeft, true, !completeLonRange);
             GeoUtils.normalizePoint(bottomRight, true, !completeLonRange);
             if (completeLonRange) {
                 topLeft.resetLon(-180);
                 bottomRight.resetLon(180);
+            }
+        } else if (validate) {
+            if (topLeft.lat() > 90.0 || topLeft.lat() < -90.0) {
+                throw new QueryParsingException(parseContext.index(), "illegal latitude value [" + topLeft.lat() + "] for " + filterName);
+            }
+            if (topLeft.lon() > 180.0 || topLeft.lon() < -180) {
+                throw new QueryParsingException(parseContext.index(), "illegal longitude value [" + topLeft.lon() + "] for " + filterName);
+            }
+            if (bottomRight.lat() > 90.0 || bottomRight.lat() < -90.0) {
+                throw new QueryParsingException(parseContext.index(), "illegal latitude value [" + bottomRight.lat() + "] for " +
+                        filterName);
+            }
+            if (bottomRight.lon() > 180.0 || bottomRight.lon() < -180) {
+                throw new QueryParsingException(parseContext.index(), "illegal longitude value [" + bottomRight.lon() + "] for " +
+                        filterName);
             }
         }
 

--- a/src/main/java/org/elasticsearch/index/query/GeoDistanceFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoDistanceFilterParser.java
@@ -75,8 +75,8 @@ public class GeoDistanceFilterParser implements FilterParser {
         DistanceUnit unit = DistanceUnit.DEFAULT;
         GeoDistance geoDistance = GeoDistance.DEFAULT;
         String optimizeBbox = "memory";
-        boolean normalizeLon = true;
-        boolean normalizeLat = true;
+        boolean validate = true;
+        boolean normalize = true;
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
@@ -130,13 +130,25 @@ public class GeoDistanceFilterParser implements FilterParser {
                     cacheKey = new HashedBytesRef(parser.text());
                 } else if ("optimize_bbox".equals(currentFieldName) || "optimizeBbox".equals(currentFieldName)) {
                     optimizeBbox = parser.textOrNull();
+                } else if ("validate".equals(currentFieldName)) {
+                    validate = parser.booleanValue();
                 } else if ("normalize".equals(currentFieldName)) {
-                    normalizeLat = parser.booleanValue();
-                    normalizeLon = parser.booleanValue();
+                    normalize = parser.booleanValue();
                 } else {
                     point.resetFromString(parser.text());
                     fieldName = currentFieldName;
                 }
+            }
+        }
+
+        if (normalize) {
+            GeoUtils.normalizePoint(point, normalize, normalize);
+        } else if (validate) {
+            if (point.lat() > 90.0 || point.lat() < -90.0) {
+                throw new QueryParsingException(parseContext.index(), "illegal latitude value [" + point.lat() + "] for " + filterName);
+            }
+            if (point.lon() > 180.0 || point.lon() < -180) {
+                throw new QueryParsingException(parseContext.index(), "illegal longitude value [" + point.lon() + "] for " + filterName);
             }
         }
 
@@ -148,10 +160,6 @@ public class GeoDistanceFilterParser implements FilterParser {
             distance = DistanceUnit.parse((String) vDistance, unit, DistanceUnit.DEFAULT);
         }
         distance = geoDistance.normalize(distance, DistanceUnit.DEFAULT);
-
-        if (normalizeLat || normalizeLon) {
-            GeoUtils.normalizePoint(point, normalizeLat, normalizeLon);
-        }
 
         MapperService.SmartNameFieldMappers smartMappers = parseContext.smartFieldMappers(fieldName);
         if (smartMappers == null || !smartMappers.hasMapper()) {

--- a/src/main/java/org/elasticsearch/index/query/GeoPolygonFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoPolygonFilterParser.java
@@ -74,8 +74,8 @@ public class GeoPolygonFilterParser implements FilterParser {
 
         List<GeoPoint> shell = Lists.newArrayList();
 
-        boolean normalizeLon = true;
-        boolean normalizeLat = true;
+        boolean validate = true;
+        boolean normalize = true;
 
         String filterName = null;
         String currentFieldName = null;
@@ -109,9 +109,10 @@ public class GeoPolygonFilterParser implements FilterParser {
                     cache = parseContext.parseFilterCachePolicy();
                 } else if ("_cache_key".equals(currentFieldName) || "_cacheKey".equals(currentFieldName)) {
                     cacheKey = new HashedBytesRef(parser.text());
+                } else if ("validate".equals(currentFieldName)) {
+                    validate = parser.booleanValue();
                 } else if ("normalize".equals(currentFieldName)) {
-                    normalizeLat = parser.booleanValue();
-                    normalizeLon = parser.booleanValue();
+                    normalize = parser.booleanValue();
                 } else {
                     throw new QueryParsingException(parseContext.index(), "[geo_polygon] filter does not support [" + currentFieldName + "]");
                 }
@@ -135,9 +136,18 @@ public class GeoPolygonFilterParser implements FilterParser {
             }
         }
 
-        if (normalizeLat || normalizeLon) {
+        if (normalize) {
             for (GeoPoint point : shell) {
-                GeoUtils.normalizePoint(point, normalizeLat, normalizeLon);
+                GeoUtils.normalizePoint(point, normalize, normalize);
+            }
+        } else if (validate) {
+            for (GeoPoint point : shell) {
+                if (point.lat() > 90.0 || point.lat() < -90.0) {
+                    throw new QueryParsingException(parseContext.index(), "illegal latitude value [" + point.lat() + "] for " + filterName);
+                }
+                if (point.lon() > 180.0 || point.lon() < -180) {
+                    throw new QueryParsingException(parseContext.index(), "illegal longitude value [" + point.lon() + "] for " + filterName);
+                }
             }
         }
 

--- a/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortParser.java
+++ b/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortParser.java
@@ -65,8 +65,8 @@ public class GeoDistanceSortParser implements SortParser {
         MultiValueMode sortMode = null;
         NestedInnerQueryParseSupport nestedHelper = null;
 
-        boolean normalizeLon = true;
-        boolean normalizeLat = true;
+        boolean validate = true;
+        boolean normalize = true;
 
         XContentParser.Token token;
         String currentName = parser.currentName();
@@ -75,7 +75,6 @@ public class GeoDistanceSortParser implements SortParser {
                 currentName = parser.currentName();
             } else if (token == XContentParser.Token.START_ARRAY) {
                 parseGeoPoints(parser, geoPoints);
-
                 fieldName = currentName;
             } else if (token == XContentParser.Token.START_OBJECT) {
                 // the json in the format of -> field : { lat : 30, lon : 12 }
@@ -99,9 +98,10 @@ public class GeoDistanceSortParser implements SortParser {
                     unit = DistanceUnit.fromString(parser.text());
                 } else if (currentName.equals("distance_type") || currentName.equals("distanceType")) {
                     geoDistance = GeoDistance.fromString(parser.text());
+                } else if ("validate".equals(currentName)) {
+                    validate = parser.booleanValue();
                 } else if ("normalize".equals(currentName)) {
-                    normalizeLat = parser.booleanValue();
-                    normalizeLon = parser.booleanValue();
+                    normalize = parser.booleanValue();
                 } else if ("sort_mode".equals(currentName) || "sortMode".equals(currentName) || "mode".equals(currentName)) {
                     sortMode = MultiValueMode.fromString(parser.text());
                 } else if ("nested_path".equals(currentName) || "nestedPath".equals(currentName)) {
@@ -118,9 +118,18 @@ public class GeoDistanceSortParser implements SortParser {
             }
         }
 
-        if (normalizeLat || normalizeLon) {
+        if (normalize) {
             for (GeoPoint point : geoPoints) {
-                GeoUtils.normalizePoint(point, normalizeLat, normalizeLon);
+                GeoUtils.normalizePoint(point, normalize, normalize);
+            }
+        } else if (validate) {
+            for (GeoPoint point : geoPoints) {
+                if (point.lat() > 90.0 || point.lat() < -90.0) {
+                    throw new ElasticsearchIllegalArgumentException("illegal latitude value [" + point.lat() + "] for geo distance sort");
+                }
+                if (point.lon() > 180.0 || point.lon() < -180) {
+                    throw new ElasticsearchIllegalArgumentException("illegal longitude value [" + point.lon() + "] for geo distance sort");
+                }
             }
         }
 

--- a/src/test/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapperTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapperTests.java
@@ -488,9 +488,9 @@ public class GeoPointFieldMapperTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper.MergeResult mergeResult = stage1.merge(stage2.mapping(), mergeFlags().simulate(false));
         assertThat(mergeResult.hasConflicts(), equalTo(true));
-        assertThat(mergeResult.conflicts().length, equalTo(2));
+        assertThat(mergeResult.conflicts().length, equalTo(1));
         // todo better way of checking conflict?
-        assertThat("mapper [point] has different validate_lat", isIn(new ArrayList<>(Arrays.asList(mergeResult.conflicts()))));
+        assertThat("mapper [point] has different validate", isIn(new ArrayList<>(Arrays.asList(mergeResult.conflicts()))));
 
         // correct mapping and ensure no failures
         stage2Mapping = XContentFactory.jsonBuilder().startObject().startObject("type")

--- a/src/test/java/org/elasticsearch/index/search/geo/GeoUtilsTests.java
+++ b/src/test/java/org/elasticsearch/index/search/geo/GeoUtilsTests.java
@@ -339,8 +339,7 @@ public class GeoUtilsTests extends ElasticsearchTestCase {
     @Test
     public void testNormalizePoint_outsideNormalRange_withOptions() {
         for (int i = 0; i < 100; i++) {
-            boolean normLat = randomBoolean();
-            boolean normLon = randomBoolean();
+            boolean normalize = randomBoolean();
             double normalisedLat = (randomDouble() * 180.0) - 90.0;
             double normalisedLon = (randomDouble() * 360.0) - 180.0;
             int shiftLat = randomIntBetween(1, 10000);
@@ -350,23 +349,20 @@ public class GeoUtilsTests extends ElasticsearchTestCase {
 
             double expectedLat;
             double expectedLon;
-            if (normLat) {
+            if (normalize) {
                 expectedLat = normalisedLat * (shiftLat % 2 == 0 ? 1 : -1);
-            } else {
-                expectedLat = testLat;
-            }
-            if (normLon) {
-                expectedLon = normalisedLon + ((normLat && shiftLat % 2 == 1) ? 180 : 0);
+                expectedLon = normalisedLon + ((shiftLat % 2 == 1) ? 180 : 0);
                 if (expectedLon > 180.0) {
                     expectedLon -= 360;
                 }
             } else {
-                double shiftValue = normalisedLon > 0 ? -180 : 180;
-                expectedLon = testLon + ((normLat && shiftLat % 2 == 1) ? shiftValue : 0);
+                expectedLat = testLat;
+                expectedLon = testLon;
             }
+
             GeoPoint testPoint = new GeoPoint(testLat, testLon);
             GeoPoint expectedPoint = new GeoPoint(expectedLat, expectedLon);
-            GeoUtils.normalizePoint(testPoint, normLat, normLon);
+            GeoUtils.normalizePoint(testPoint, normalize, normalize);
             assertThat("Unexpected Latitude", testPoint.lat(), closeTo(expectedPoint.lat(), MAX_ACCEPTABLE_ERROR));
             assertThat("Unexpected Longitude", testPoint.lon(), closeTo(expectedPoint.lon(), MAX_ACCEPTABLE_ERROR));
         }

--- a/src/test/java/org/elasticsearch/search/geo/GeoPolygonTests.java
+++ b/src/test/java/org/elasticsearch/search/geo/GeoPolygonTests.java
@@ -86,7 +86,6 @@ public class GeoPolygonTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void simplePolygonTest() throws Exception {
-
         SearchResponse searchResponse = client().prepareSearch("test") // from NY
                 .setQuery(filteredQuery(matchAllQuery(), geoPolygonFilter("location")
                         .addPoint(40.7, -74.0)
@@ -95,6 +94,60 @@ public class GeoPolygonTests extends ElasticsearchIntegrationTest {
                         .addPoint(40.8, -74.0)
                         .addPoint(40.7, -74.0)))
                 .execute().actionGet();
+        assertHitCount(searchResponse, 4);
+        assertThat(searchResponse.getHits().hits().length, equalTo(4));
+        for (SearchHit hit : searchResponse.getHits()) {
+            assertThat(hit.id(), anyOf(equalTo("1"), equalTo("3"), equalTo("4"), equalTo("5")));
+        }
+    }
+
+    @Test
+    public void polygonNormalizationTest() throws Exception {
+        String invalidPolyFilter = "{\"geo_polygon\": { \"location\": { \"points\": [{\"lat\": 400.7, \"lon\": -74.0}, " +
+                "{\"lat\": 40.7, \"lon\": -74.1}, {\"lat\": 40.8, \"lon\": -74.1}, {\"lat\": 40.8, \"lon\": -74.0}, " +
+                "{\"lat\": 40.7, \"lon\": -74.0}]}, \"normalize\": false}}";
+
+        // test proper error handling for invalid poly (validation enabled, normalization disabled)
+        try {
+            client().prepareSearch("test") // from NY
+                    .setQuery(matchAllQuery()).setPostFilter(invalidPolyFilter).execute().actionGet();
+        } catch (Exception e) {
+            if (!e.getMessage().contains("illegal latitude value"))
+                throw new Exception("expected: 'QueryParsingException on latitude'\n got: " + e.getMessage());
+        }
+
+        // test correct filtering with valid poly (validation enabled, normalization disabled)
+        String validPolyFilter = "{\"geo_polygon\": { \"location\": { \"points\": [{\"lat\": 400.7, \"lon\": -74.0}, " +
+                "{\"lat\": 40.7, \"lon\": -74.1}, {\"lat\": 40.8, \"lon\": -74.1}, {\"lat\": 40.8, \"lon\": -74.0}, " +
+                "{\"lat\": 40.7, \"lon\": -74.0}]}, \"validate\": true, \"normalize\": true}}";
+        SearchResponse searchResponse = client().prepareSearch("test")
+                .setQuery(matchAllQuery()).setPostFilter(validPolyFilter).execute().actionGet();
+        assertHitCount(searchResponse, 4);
+        assertThat(searchResponse.getHits().hits().length, equalTo(4));
+        for (SearchHit hit : searchResponse.getHits()) {
+            assertThat(hit.id(), anyOf(equalTo("1"), equalTo("3"), equalTo("4"), equalTo("5")));
+        }
+
+        // test error handling for invalid poly
+        String invalidPoly = "{\"geo_polygon\": { \"location\": { \"points\": [{\"lat\": 400.7, \"lon\": -74.0}, " +
+                "{\"lat\": 40.7, \"lon\": -74.1}, {\"lat\": 40.8, \"lon\": -74.1}, {\"lat\": 40.8, \"lon\": -74.0}, " +
+                "{\"lat\": 40.7, \"lon\": -74.0}]}, \"validate\": false, \"normalize\": false}}";
+
+        // test proper error handling for invalid poly (validation enabled, normalization disabled)
+        try {
+            client().prepareSearch("test") // from NY
+                    .setQuery(matchAllQuery()).setPostFilter(invalidPoly).execute().actionGet();
+        } catch (Exception e) {
+            if (!e.getMessage().contains("illegal latitude value"))
+                throw new Exception("expected: 'QueryParsingException on latitude'\n got: " + e.getMessage());
+        }
+
+        // test correct filtering with valid poly (validation enabled, normalization disabled)
+        String validPoly = "{\"geo_polygon\": { \"location\": { \"points\": [{\"lat\": 40.7, \"lon\": -74.0}, " +
+                "{\"lat\": 40.7, \"lon\": -74.1}, {\"lat\": 40.8, \"lon\": -74.1}, {\"lat\": 40.8, \"lon\": -74.0}, " +
+                "{\"lat\": 40.7, \"lon\": -74.0}]}, \"validate\": false, \"normalize\": false}}";
+        searchResponse = client().prepareSearch("test")
+                .setQuery(matchAllQuery()).setPostFilter(validPoly).execute().actionGet();
         assertHitCount(searchResponse, 4);
         assertThat(searchResponse.getHits().hits().length, equalTo(4));
         for (SearchHit hit : searchResponse.getHits()) {


### PR DESCRIPTION
No need to carry 3 validate and 3 normalize options in GeoPointFieldMapping. This is just causing confusion. This change deprecates the validate_lat, validate_lon, normalize_lat, and normalize_lon options on the `geo_point` field mapping and simplifies the options by using just `validate` and `normalize`, respectively. Geo filters have been updated to include a `validate` and `normalize` option to provide consistency with the field mapping defaults. Unit tests and documentation have also been updated.

closes #10170
