### PR TITLE
Fix 2 bugs in `children` agg

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/support/BaseInnerHitBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/support/BaseInnerHitBuilder.java
@@ -83,6 +83,14 @@ public abstract class BaseInnerHitBuilder<T extends BaseInnerHitBuilder> impleme
     }
 
     /**
+     * Add a stored field to be loaded and returned with the inner hit.
+     */
+    public T field(String name) {
+        sourceBuilder().field(name);
+        return (T) this;
+    }
+
+    /**
      * Sets no fields to be loaded, resulting in only id and type to be returned per field.
      */
     public T setNoFields() {

--- a/src/main/java/org/elasticsearch/index/query/support/InnerHitsQueryParserHelper.java
+++ b/src/main/java/org/elasticsearch/index/query/support/InnerHitsQueryParserHelper.java
@@ -103,6 +103,17 @@ public class InnerHitsQueryParserHelper {
                 case "fielddata_fields":
                     fieldDataFieldsParseElement.parse(parser, subSearchContext);
                     break;
+                case "fields":
+                    boolean added = false;
+                    while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
+                        String name = parser.text();
+                        added = true;
+                        subSearchContext.fieldNames().add(name);
+                    }
+                    if (!added) {
+                        subSearchContext.emptyFieldNames();
+                    }
+                    break;
                 default:
                     throw new ElasticsearchIllegalArgumentException("Unknown key for a " + token + " for nested query: [" + fieldName + "].");
             }
@@ -123,6 +134,9 @@ public class InnerHitsQueryParserHelper {
                     break;
                 case "explain":
                     subSearchContext.explain(parser.booleanValue());
+                    break;
+                case "fields":
+                    subSearchContext.fieldNames().add(parser.text());
                     break;
                 default:
                     throw new ElasticsearchIllegalArgumentException("Unknown key for a " + token + " for nested query: [" + fieldName + "].");

--- a/src/main/java/org/elasticsearch/search/aggregations/Aggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/Aggregator.java
@@ -331,8 +331,8 @@ public abstract class Aggregator extends BucketCollector implements Releasable {
      * Called after collection of all document is done.
      */
     public final void postCollection() throws IOException {
-        collectableSubAggregators.postCollection();
         doPostCollection();
+        collectableSubAggregators.postCollection();
     }
 
     /** Called upon release of the aggregator. */

--- a/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
+++ b/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
@@ -294,7 +294,10 @@ public class FetchPhase implements SearchPhase {
             SearchHit.NestedIdentity nested = nestedIdentity;
             do {
                 Object extractedValue = XContentMapValues.extractValue(nested.getField().string(), sourceAsMap);
-                if (extractedValue instanceof List) {
+                if (extractedValue == null) {
+                    // The nested objects may not exist in the _source, because it was filtered because of _source filtering
+                    break;
+                } else if (extractedValue instanceof List) {
                     // nested field has an array value in the _source
                     nestedParsedSource = (List<Map<String, Object>>) extractedValue;
                 } else if (extractedValue instanceof Map) {

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/ChildrenTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/ChildrenTests.java
@@ -21,6 +21,8 @@ package org.elasticsearch.search.aggregations.bucket;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.update.UpdateResponse;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.aggregations.bucket.children.Children;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
@@ -327,6 +329,53 @@ public class ChildrenTests extends ElasticsearchIntegrationTest {
         assertThat(termsAgg.getBucketByKey("38").getDocCount(), equalTo(1l));
         assertThat(termsAgg.getBucketByKey("40").getDocCount(), equalTo(1l));
         assertThat(termsAgg.getBucketByKey("44").getDocCount(), equalTo(1l));
+    }
+
+    @Test
+    public void testHierarchicalChildrenAggs() {
+        String indexName = "geo";
+        String grandParentType = "continent";
+        String parentType = "country";
+        String childType = "city";
+        assertAcked(
+                prepareCreate(indexName)
+                        .setSettings(ImmutableSettings.builder()
+                                .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
+                                .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
+                        )
+                        .addMapping(grandParentType)
+                        .addMapping(parentType, "_parent", "type=" + grandParentType)
+                        .addMapping(childType, "_parent", "type=" + parentType)
+        );
+
+        client().prepareIndex(indexName, grandParentType, "1").setSource("name", "europe").get();
+        client().prepareIndex(indexName, parentType, "2").setParent("1").setSource("name", "belgium").get();
+        client().prepareIndex(indexName, childType, "3").setParent("2").setRouting("1").setSource("name", "brussels").get();
+        refresh();
+
+        SearchResponse response = client().prepareSearch(indexName)
+                .setQuery(matchQuery("name", "europe"))
+                .addAggregation(
+                        children(parentType).childType(parentType).subAggregation(
+                                children(childType).childType(childType).subAggregation(
+                                        terms("name").field("name")
+                                )
+                        )
+                )
+                .get();
+        assertNoFailures(response);
+        assertHitCount(response, 1);
+
+        Children children = response.getAggregations().get(parentType);
+        assertThat(children.getName(), equalTo(parentType));
+        assertThat(children.getDocCount(), equalTo(1l));
+        children = children.getAggregations().get(childType);
+        assertThat(children.getName(), equalTo(childType));
+        assertThat(children.getDocCount(), equalTo(1l));
+        Terms terms = children.getAggregations().get("name");
+        assertThat(terms.getBuckets().size(), equalTo(1));
+        assertThat(terms.getBuckets().get(0).getKey().toString(), equalTo("brussels"));
+        assertThat(terms.getBuckets().get(0).getDocCount(), equalTo(1l));
     }
 
     private static final class Control {

--- a/src/test/java/org/elasticsearch/search/innerhits/InnerHitsTests.java
+++ b/src/test/java/org/elasticsearch/search/innerhits/InnerHitsTests.java
@@ -687,4 +687,156 @@ public class InnerHitsTests extends ElasticsearchIntegrationTest {
         assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getAt(0).getNestedIdentity().getChild(), nullValue());
     }
 
+    @Test
+    public void testNestedInnerHitsWithStoredFieldsAndNoSource() throws Exception {
+        assertAcked(prepareCreate("articles")
+                .addMapping("article", jsonBuilder().startObject()
+                                .startObject("_source").field("enabled", false).endObject()
+                                .startObject("properties")
+                                    .startObject("comments")
+                                        .field("type", "nested")
+                                        .startObject("properties")
+                                            .startObject("message").field("type", "string").field("store", "yes").endObject()
+                                        .endObject()
+                                    .endObject()
+                                    .endObject()
+                                .endObject()
+                )
+        );
+
+        List<IndexRequestBuilder> requests = new ArrayList<>();
+        requests.add(client().prepareIndex("articles", "article", "1").setSource(jsonBuilder().startObject()
+                .field("title", "quick brown fox")
+                .startObject("comments").field("message", "fox eat quick").endObject()
+                .endObject()));
+        indexRandom(true, requests);
+
+        SearchResponse response = client().prepareSearch("articles")
+                .setQuery(nestedQuery("comments", matchQuery("comments.message", "fox")).innerHit(new QueryInnerHitBuilder().field("comments.message")))
+                .get();
+        assertNoFailures(response);
+        assertHitCount(response, 1);
+        assertThat(response.getHits().getAt(0).id(), equalTo("1"));
+        assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getTotalHits(), equalTo(1l));
+        assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getAt(0).id(), equalTo("1"));
+        assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getAt(0).getNestedIdentity().getField().string(), equalTo("comments"));
+        assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getAt(0).getNestedIdentity().getOffset(), equalTo(0));
+        assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getAt(0).getNestedIdentity().getChild(), nullValue());
+        assertThat(String.valueOf(response.getHits().getAt(0).getInnerHits().get("comments").getAt(0).fields().get("comments.message").getValue()), equalTo("fox eat quick"));
+    }
+
+    @Test
+    public void testNestedInnerHitsWithHighlightOnStoredField() throws Exception {
+        assertAcked(prepareCreate("articles")
+                        .addMapping("article", jsonBuilder().startObject()
+                                        .startObject("_source").field("enabled", false).endObject()
+                                            .startObject("properties")
+                                                .startObject("comments")
+                                                    .field("type", "nested")
+                                                    .startObject("properties")
+                                                        .startObject("message").field("type", "string").field("store", "yes").endObject()
+                                                    .endObject()
+                                                .endObject()
+                                            .endObject()
+                                        .endObject()
+                        )
+        );
+
+        List<IndexRequestBuilder> requests = new ArrayList<>();
+        requests.add(client().prepareIndex("articles", "article", "1").setSource(jsonBuilder().startObject()
+                .field("title", "quick brown fox")
+                .startObject("comments").field("message", "fox eat quick").endObject()
+                .endObject()));
+        indexRandom(true, requests);
+
+        SearchResponse response = client().prepareSearch("articles")
+                .setQuery(nestedQuery("comments", matchQuery("comments.message", "fox")).innerHit(new QueryInnerHitBuilder().addHighlightedField("comments.message")))
+                .get();
+        assertNoFailures(response);
+        assertHitCount(response, 1);
+        assertThat(response.getHits().getAt(0).id(), equalTo("1"));
+        assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getTotalHits(), equalTo(1l));
+        assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getAt(0).id(), equalTo("1"));
+        assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getAt(0).getNestedIdentity().getField().string(), equalTo("comments"));
+        assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getAt(0).getNestedIdentity().getOffset(), equalTo(0));
+        assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getAt(0).getNestedIdentity().getChild(), nullValue());
+        assertThat(String.valueOf(response.getHits().getAt(0).getInnerHits().get("comments").getAt(0).highlightFields().get("comments.message").getFragments()[0]), equalTo("<em>fox</em> eat quick"));
+    }
+
+    @Test
+    public void testNestedInnerHitsWithExcludeSource() throws Exception {
+        assertAcked(prepareCreate("articles")
+                        .addMapping("article", jsonBuilder().startObject()
+                                        .startObject("_source").field("excludes", new String[]{"comments"}).endObject()
+                                        .startObject("properties")
+                                            .startObject("comments")
+                                                .field("type", "nested")
+                                                .startObject("properties")
+                                                    .startObject("message").field("type", "string").field("store", "yes").endObject()
+                                                .endObject()
+                                                .endObject()
+                                            .endObject()
+                                        .endObject()
+                        )
+        );
+
+        List<IndexRequestBuilder> requests = new ArrayList<>();
+        requests.add(client().prepareIndex("articles", "article", "1").setSource(jsonBuilder().startObject()
+                .field("title", "quick brown fox")
+                .startObject("comments").field("message", "fox eat quick").endObject()
+                .endObject()));
+        indexRandom(true, requests);
+
+        SearchResponse response = client().prepareSearch("articles")
+                .setQuery(nestedQuery("comments", matchQuery("comments.message", "fox")).innerHit(new QueryInnerHitBuilder().field("comments.message").setFetchSource(true)))
+                .get();
+        assertNoFailures(response);
+        assertHitCount(response, 1);
+        assertThat(response.getHits().getAt(0).id(), equalTo("1"));
+        assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getTotalHits(), equalTo(1l));
+        assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getAt(0).id(), equalTo("1"));
+        assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getAt(0).getNestedIdentity().getField().string(), equalTo("comments"));
+        assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getAt(0).getNestedIdentity().getOffset(), equalTo(0));
+        assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getAt(0).getNestedIdentity().getChild(), nullValue());
+        assertThat(String.valueOf(response.getHits().getAt(0).getInnerHits().get("comments").getAt(0).fields().get("comments.message").getValue()), equalTo("fox eat quick"));
+    }
+
+    @Test
+    public void testNestedInnerHitsHiglightWithExcludeSource() throws Exception {
+        assertAcked(prepareCreate("articles")
+                        .addMapping("article", jsonBuilder().startObject()
+                                        .startObject("_source").field("excludes", new String[]{"comments"}).endObject()
+                                        .startObject("properties")
+                                        .startObject("comments")
+                                        .field("type", "nested")
+                                        .startObject("properties")
+                                        .startObject("message").field("type", "string").field("store", "yes").endObject()
+                                        .endObject()
+                                        .endObject()
+                                        .endObject()
+                                        .endObject()
+                        )
+        );
+
+        List<IndexRequestBuilder> requests = new ArrayList<>();
+        requests.add(client().prepareIndex("articles", "article", "1").setSource(jsonBuilder().startObject()
+                .field("title", "quick brown fox")
+                .startObject("comments").field("message", "fox eat quick").endObject()
+                .endObject()));
+        indexRandom(true, requests);
+
+        SearchResponse response = client().prepareSearch("articles")
+                .setQuery(nestedQuery("comments", matchQuery("comments.message", "fox")).innerHit(new QueryInnerHitBuilder().addHighlightedField("comments.message")))
+                .get();
+        assertNoFailures(response);
+        assertHitCount(response, 1);
+        assertThat(response.getHits().getAt(0).id(), equalTo("1"));
+        assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getTotalHits(), equalTo(1l));
+        assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getAt(0).id(), equalTo("1"));
+        assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getAt(0).getNestedIdentity().getField().string(), equalTo("comments"));
+        assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getAt(0).getNestedIdentity().getOffset(), equalTo(0));
+        assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getAt(0).getNestedIdentity().getChild(), nullValue());
+        assertThat(String.valueOf(response.getHits().getAt(0).getInnerHits().get("comments").getAt(0).highlightFields().get("comments.message").getFragments()[0]), equalTo("<em>fox</em> eat quick"));
+    }
+
 }


### PR DESCRIPTION
PR for #10158

1) Multiple nested children aggs result in a NPE. This only occurs in 1.x and not in master, since post collection works there in the correct order.
2) Fixed a counting bug where the same readers where post collected twice. Possible fixes #9958

Note this PR is against 1.x b/c bug 1 is fixed in master already. This bug fix was part of a refactoring that happened as part of #9544
