### PR TITLE
Fix `_field_names` to be disabled on pre 1.3.0 indexes

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/internal/FieldNamesFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/FieldNamesFieldMapper.java
@@ -133,6 +133,7 @@ public class FieldNamesFieldMapper extends AbstractFieldMapper<String> implement
 
     private final FieldType defaultFieldType;
     private EnabledAttributeMapper enabledState;
+    private final boolean pre13Index; // if the index was created before 1.3, _field_names is always disabled
 
     public FieldNamesFieldMapper(Settings indexSettings) {
         this(Defaults.NAME, Defaults.NAME, Defaults.BOOST, new FieldType(Defaults.FIELD_TYPE), Defaults.ENABLED_STATE, null, indexSettings);
@@ -142,11 +143,12 @@ public class FieldNamesFieldMapper extends AbstractFieldMapper<String> implement
         super(new Names(name, indexName, indexName, name), boost, fieldType, null, Lucene.KEYWORD_ANALYZER,
                 Lucene.KEYWORD_ANALYZER, null, null, fieldDataSettings, indexSettings);
         this.defaultFieldType = Defaults.FIELD_TYPE;
+        this.pre13Index = Version.indexCreated(indexSettings).before(Version.V_1_3_0);
         this.enabledState = enabledState;
     }
 
     public boolean enabled() {
-        return enabledState.enabled;
+        return pre13Index == false && enabledState.enabled;
     }
 
     @Override
@@ -253,6 +255,9 @@ public class FieldNamesFieldMapper extends AbstractFieldMapper<String> implement
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        if (pre13Index) {
+            return builder;
+        }
         boolean includeDefaults = params.paramAsBoolean("include_defaults", false);
 
         if (includeDefaults == false && fieldType().equals(Defaults.FIELD_TYPE) && enabledState == Defaults.ENABLED_STATE) {

--- a/src/test/java/org/elasticsearch/bwcompat/OldIndexBackwardsCompatibilityTests.java
+++ b/src/test/java/org/elasticsearch/bwcompat/OldIndexBackwardsCompatibilityTests.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.merge.policy.MergePolicyModule;
+import org.elasticsearch.index.query.FilterBuilders;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.rest.action.admin.indices.upgrade.UpgradeTest;
@@ -49,6 +50,7 @@ import java.nio.file.Paths;
 import java.util.*;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.hamcrest.CoreMatchers.equalTo;
 
 @TimeoutSuite(millis = 40 * TimeUnits.MINUTE)
 public class OldIndexBackwardsCompatibilityTests extends StaticIndexBackwardCompatibilityTest {
@@ -137,6 +139,11 @@ public class OldIndexBackwardsCompatibilityTests extends StaticIndexBackwardComp
         
         searchReq.addSort("long_sort", SortOrder.ASC);
         ElasticsearchAssertions.assertNoFailures(searchReq.get());
+
+        searchReq = client().prepareSearch("test").setQuery(QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(), FilterBuilders.existsFilter("string")));
+        searchRsp = searchReq.get();
+        ElasticsearchAssertions.assertNoFailures(searchRsp);
+        assertThat(numDocs, equalTo(searchRsp.getHits().getTotalHits()));
     }
 
     void assertRealtimeGetWorks() {

--- a/src/test/java/org/elasticsearch/index/mapper/internal/FieldNamesFieldMapperTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/internal/FieldNamesFieldMapperTests.java
@@ -112,6 +112,14 @@ public class FieldNamesFieldMapperTests extends ElasticsearchSingleNodeTest {
         assertNull(doc.rootDoc().get("_field_names"));
     }
     
+    public void testPre13Disabled() throws Exception {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type").endObject().endObject().string();
+        Settings indexSettings = ImmutableSettings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.V_1_2_4.id).build();
+        DocumentMapper docMapper = createIndex("test", indexSettings).mapperService().documentMapperParser().parse(mapping);
+        FieldNamesFieldMapper fieldNamesMapper = docMapper.rootMapper(FieldNamesFieldMapper.class);
+        assertFalse(fieldNamesMapper.enabled());
+    }
+    
     public void testDisablingBackcompat() throws Exception {
         // before 1.5, disabling happened by setting index:no
         String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")


### PR DESCRIPTION
In #9893, an enabled flag was added for _field_names.  However,
backcompat for indexes created before 1.3.0 (when _field_names
was added) was lost. This change corrects the mapper
to always be disabled when used with older indexes that
cannot have _field_names.
