### PR TITLE
boost_factor deprecated

### DIFF
--- a/docs/reference/query-dsl/queries/function-score-query.asciidoc
+++ b/docs/reference/query-dsl/queries/function-score-query.asciidoc
@@ -149,7 +149,7 @@ not.
 
 ===== Boost factor
 
-deprecated[1.4.0.Beta1]
+`boost_factor` deprecated[1.4.0.Beta1]
 
 Same as `weight`. Use `weight` instead.
 


### PR DESCRIPTION
this word is not present as it is in source code from last ES versions
