### PR TITLE
[TEST] enable inline scripts on demand in bw comp tests

### DIFF
--- a/src/test/java/org/elasticsearch/search/functionscore/FunctionScoreBackwardCompatibilityTests.java
+++ b/src/test/java/org/elasticsearch/search/functionscore/FunctionScoreBackwardCompatibilityTests.java
@@ -18,11 +18,14 @@
  */
 package org.elasticsearch.search.functionscore;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.test.ElasticsearchBackwardsCompatIntegrationTest;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.junit.Test;
@@ -101,6 +104,24 @@ public class FunctionScoreBackwardCompatibilityTests extends ElasticsearchBackwa
         } while (upgraded);
         client().admin().indices().prepareUpdateSettings("test").setSettings(ImmutableSettings.builder().put(EnableAllocationDecider.INDEX_ROUTING_ALLOCATION_ENABLE, "all")).get();
         logger.debug("done function_score while upgrading");
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        //enable scripting on the internal nodes
+        return ImmutableSettings.builder().put(super.nodeSettings(nodeOrdinal)).put("script.inline", "on").build();
+    }
+
+    @Override
+    protected Settings externalNodeSettings(int nodeOrdinal) {
+        //enable scripting on the external nodes using the proper setting depending on the bwc version
+        ImmutableSettings.Builder builder = ImmutableSettings.builder().put(super.externalNodeSettings(nodeOrdinal));
+        if (compatibilityVersion().before(Version.V_1_6_0)) {
+            builder.put(ScriptService.DISABLE_DYNAMIC_SCRIPTING_SETTING, false);
+        } else {
+            builder.put("script.inline", "on");
+        }
+        return builder.build();
     }
 
     private void checkFunctionScoreStillWorks(String... ids) throws ExecutionException, InterruptedException, IOException {

--- a/src/test/java/org/elasticsearch/test/ElasticsearchBackwardsCompatIntegrationTest.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchBackwardsCompatIntegrationTest.java
@@ -169,17 +169,9 @@ public abstract class ElasticsearchBackwardsCompatIntegrationTest extends Elasti
         return ExternalNode.REQUIRED_SETTINGS;
     }
 
+    @Override
     protected Settings nodeSettings(int nodeOrdinal) {
-        ImmutableSettings.Builder builder = ImmutableSettings.builder().put(requiredSettings())
-                .put(TransportModule.TRANSPORT_TYPE_KEY, NettyTransport.class.getName()) // run same transport  / disco as external
-                .put(TransportModule.TRANSPORT_SERVICE_TYPE_KEY, TransportService.class.getName());
-        if (compatibilityVersion().before(Version.V_1_3_2)) {
-            // if we test against nodes before 1.3.2 we disable all the compression due to a known bug
-            // see #7210
-            builder.put(Transport.TransportSettings.TRANSPORT_TCP_COMPRESS, false)
-                   .put(RecoverySettings.INDICES_RECOVERY_COMPRESS, false);
-        }
-        return builder.build();
+        return commonNodeSettings(nodeOrdinal);
     }
 
     public void assertAllShardsOnNodes(String index, String pattern) {
@@ -196,7 +188,20 @@ public abstract class ElasticsearchBackwardsCompatIntegrationTest extends Elasti
         }
     }
 
+    protected Settings commonNodeSettings(int nodeOrdinal) {
+        ImmutableSettings.Builder builder = ImmutableSettings.builder().put(requiredSettings())
+                .put(TransportModule.TRANSPORT_TYPE_KEY, NettyTransport.class.getName()) // run same transport  / disco as external
+                .put(TransportModule.TRANSPORT_SERVICE_TYPE_KEY, TransportService.class.getName());
+        if (compatibilityVersion().before(Version.V_1_3_2)) {
+            // if we test against nodes before 1.3.2 we disable all the compression due to a known bug
+            // see #7210
+            builder.put(Transport.TransportSettings.TRANSPORT_TCP_COMPRESS, false)
+                    .put(RecoverySettings.INDICES_RECOVERY_COMPRESS, false);
+        }
+        return builder.build();
+    }
+
     protected Settings externalNodeSettings(int nodeOrdinal) {
-        return addLoggerSettings(nodeSettings(nodeOrdinal));
+        return addLoggerSettings(commonNodeSettings(nodeOrdinal));
     }
 }

--- a/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
@@ -1633,6 +1633,8 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
                 // from failing on nodes without enough disk space
                 .put(DiskThresholdDecider.CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK, "1b")
                 .put(DiskThresholdDecider.CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK, "1b")
+                .put("script.indexed", "on")
+                .put("script.inline", "on")
                 .build();
     }
 

--- a/src/test/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/src/test/java/org/elasticsearch/test/InternalTestCluster.java
@@ -268,8 +268,6 @@ public final class InternalTestCluster extends TestCluster {
         builder.put("http.port", basePort+101 + "-" + (basePort+200));
         builder.put("config.ignore_system_properties", true);
         builder.put("node.mode", NODE_MODE);
-        builder.put("script.indexed", "on");
-        builder.put("script.inline", "on");
         builder.put("http.pipelining", enableHttpPipelining);
         builder.put("plugins." + PluginsService.LOAD_PLUGIN_FROM_CLASSPATH, false);
         builder.put(NodeEnvironment.SETTING_CUSTOM_DATA_PATH_ENABLED, true);


### PR DESCRIPTION
We currently have a single bw comp test (FunctionScoreBackwardCompatibilityTests) that requires inline scripts on.
After introducing fine-grained script settings, we moved the internal cluster to use the newer settings, but they are not supported by older nodes started as part of the bw comp tests. Moved script settings out of the default settings, so they won't be part of the ordinary settings when running bw comp tests.
Added logic in FunctionScoreBackwardCompatibilityTests to enable dynamic scripts using the proper setting, depending on the version of the node.
