### PR TITLE
Fail shard when index service/mappings fails to instantiate

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
+++ b/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
@@ -79,14 +79,9 @@ public class ShardStateAction extends AbstractComponent {
     public void shardFailed(final ShardRouting shardRouting, final String indexUUID, final String reason) throws ElasticsearchException {
         DiscoveryNode masterNode = clusterService.state().nodes().masterNode();
         if (masterNode == null) {
-            logger.warn("can't send shard failed for {}. no master known.", shardRouting);
+            logger.warn("can't send shard failed for {}, no master known.", shardRouting);
             return;
         }
-        shardFailed(shardRouting, indexUUID, reason, masterNode);
-    }
-
-    public void shardFailed(final ShardRouting shardRouting, final String indexUUID, final String reason, final DiscoveryNode masterNode) throws ElasticsearchException {
-        logger.warn("{} sending failed shard for {}, indexUUID [{}], reason [{}]", shardRouting.shardId(), shardRouting, indexUUID, reason);
         innerShardFailed(shardRouting, indexUUID, reason, masterNode);
     }
 

--- a/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -404,7 +404,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent<Indic
                 // so this failure typically means wrong node level configuration or something similar
                 for (IndexShard indexShard : indexService) {
                     ShardRouting shardRouting = indexShard.routingEntry();
-                    logger.warn("[{}][{}] failed to create shard", t, shardRouting.index(), shardRouting.id());
+                    logger.warn("[{}][{}] failed to updated mappings", t, shardRouting.index(), shardRouting.id());
                     try {
                         indexService.removeShard(indexShard.shardId().id(), "failed to update mappings [" + ExceptionsHelper.detailedMessage(t) + "]");
                     } catch (IndexShardMissingException e1) {

--- a/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -315,7 +315,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent<Indic
                     logger.warn("[{}] failed to create index for shard {}", e, indexMetaData.index(), shard.shardId());
                     failedShards.put(shard.shardId(), new FailedShard(shard.version()));
                     shardStateAction.shardFailed(shard, indexMetaData.getUUID(),
-                            "failed to create index to allocated shard " + shard.shardId() + ", failure " + ExceptionsHelper.detailedMessage(e),
+                            "failed to create index for newly allocated shard " + shard.shardId() + ", failure " + ExceptionsHelper.detailedMessage(e),
                             event.state().nodes().masterNode());
                 }
             }


### PR DESCRIPTION
When the index service (which holds shards) fails to be created as a result of a shard being allocated on a node, we should fail the relevant shard, otherwise, it will remain stuck.
Same goes when there is a failure to process updated mappings form the master.

Note, both failures typically happen when the node is misconfigured (i.e. missing plugins, ...), since they get created and processed on the master node before being published.
