### PR TITLE
Remove support for `script.disable_dynamic` setting

### DIFF
--- a/docs/reference/migration/migrate_2_0.asciidoc
+++ b/docs/reference/migration/migrate_2_0.asciidoc
@@ -288,6 +288,9 @@ index.
 
 === Scripts
 
+Removed support for `script.disable_dynamic` node setting, replaced by
+fine-grained script settings described in the <<enable-dynamic-scripting,scripting docs>>.
+
 Deprecated script parameters `id`, `file`, and `scriptField` have been removed
 from all scriptable APIs. `script_id`, `script_file` and `script` should be used
 in their place.

--- a/docs/reference/migration/migrate_2_0.asciidoc
+++ b/docs/reference/migration/migrate_2_0.asciidoc
@@ -286,10 +286,27 @@ setting. Please however note that using a non-default codec is discouraged as
 it could prevent future versions of Elasticsearch from being able to read the
 index.
 
-=== Scripts
+=== Scripting settings
 
 Removed support for `script.disable_dynamic` node setting, replaced by
 fine-grained script settings described in the <<enable-dynamic-scripting,scripting docs>>.
+The following setting previously used to enable dynamic scripts:
+
+[source,yaml]
+---------------
+script.disable_dynamic: false
+---------------
+
+can be replaced with the following two settings in `elasticsearch.yml` that
+achieve the same result:
+
+[source,yaml]
+---------------
+script.inline: on
+script.indexed: on
+---------------
+
+=== Script parameters
 
 Deprecated script parameters `id`, `file`, and `scriptField` have been removed
 from all scriptable APIs. `script_id`, `script_file` and `script` should be used

--- a/docs/reference/modules/scripting.asciidoc
+++ b/docs/reference/modules/scripting.asciidoc
@@ -246,8 +246,6 @@ application inbetween. If you *do* intend to expose Elasticsearch directly to
 your users, then you have to decide whether you trust them enough to run scripts
 on your box or not.
 
-deprecated[1.6.0, the `script.disable_dynamic` setting is deprecated in favour of fine-grained settings described as follows]
-
 It is possible to enable scripts based on their source, for
 every script engine, through the following settings that need to be added to the
 `config/elasticsearch.yml` file on every node.

--- a/src/main/java/org/elasticsearch/script/ScriptService.java
+++ b/src/main/java/org/elasticsearch/script/ScriptService.java
@@ -82,7 +82,6 @@ import java.util.concurrent.TimeUnit;
 public class ScriptService extends AbstractComponent implements Closeable {
 
     public static final String DEFAULT_SCRIPTING_LANGUAGE_SETTING = "script.default_lang";
-    public static final String DISABLE_DYNAMIC_SCRIPTING_SETTING = "script.disable_dynamic";
     public static final String SCRIPT_CACHE_SIZE_SETTING = "script.cache.max_size";
     public static final String SCRIPT_CACHE_EXPIRE_SETTING = "script.cache.expire";
     public static final String SCRIPT_INDEX = ".scripts";
@@ -104,37 +103,6 @@ public class ScriptService extends AbstractComponent implements Closeable {
     private final ScriptModes scriptModes;
 
     private Client client = null;
-
-    /**
-     * Enum defining the different dynamic settings for scripting, either
-     * ONLY_DISK_ALLOWED (scripts must be placed on disk), EVERYTHING_ALLOWED
-     * (all dynamic scripting is enabled), or SANDBOXED_ONLY (only sandboxed
-     * scripting languages are allowed)
-     */
-    enum DynamicScriptDisabling {
-        EVERYTHING_ALLOWED,
-        ONLY_DISK_ALLOWED,
-        SANDBOXED_ONLY;
-
-        static DynamicScriptDisabling parse(String s) {
-            switch (s.toLowerCase(Locale.ROOT)) {
-                // true for "disable_dynamic" means only on-disk scripts are enabled
-                case "true":
-                case "all":
-                    return ONLY_DISK_ALLOWED;
-                // false for "disable_dynamic" means all scripts are enabled
-                case "false":
-                case "none":
-                    return EVERYTHING_ALLOWED;
-                // only sandboxed scripting is enabled
-                case "sandbox":
-                case "sandboxed":
-                    return SANDBOXED_ONLY;
-                default:
-                    throw new ElasticsearchIllegalArgumentException("Unrecognized script allowance setting: [" + s + "]");
-            }
-        }
-    }
 
     public static final ParseField SCRIPT_LANG = new ParseField("lang","script_lang");
     public static final ParseField SCRIPT_FILE = new ParseField("script_file");
@@ -175,7 +143,7 @@ public class ScriptService extends AbstractComponent implements Closeable {
         this.scriptEnginesByLang = enginesByLangBuilder.build();
         this.scriptEnginesByExt = enginesByExtBuilder.build();
 
-        this.scriptModes = new ScriptModes(this.scriptEnginesByLang, settings, logger);
+        this.scriptModes = new ScriptModes(this.scriptEnginesByLang, settings);
 
         // add file watcher for static scripts
         scriptsDirectory = env.configFile().resolve("scripts");

--- a/src/main/java/org/elasticsearch/script/ScriptService.java
+++ b/src/main/java/org/elasticsearch/script/ScriptService.java
@@ -81,6 +81,8 @@ import java.util.concurrent.TimeUnit;
  */
 public class ScriptService extends AbstractComponent implements Closeable {
 
+    static final String DISABLE_DYNAMIC_SCRIPTING_SETTING = "script.disable_dynamic";
+
     public static final String DEFAULT_SCRIPTING_LANGUAGE_SETTING = "script.default_lang";
     public static final String SCRIPT_CACHE_SIZE_SETTING = "script.cache.max_size";
     public static final String SCRIPT_CACHE_EXPIRE_SETTING = "script.cache.expire";
@@ -113,6 +115,11 @@ public class ScriptService extends AbstractComponent implements Closeable {
     public ScriptService(Settings settings, Environment env, Set<ScriptEngineService> scriptEngines,
                          ResourceWatcherService resourceWatcherService, NodeSettingsService nodeSettingsService) throws IOException {
         super(settings);
+
+        if (Strings.hasLength(settings.get(DISABLE_DYNAMIC_SCRIPTING_SETTING))) {
+            throw new ElasticsearchIllegalArgumentException(DISABLE_DYNAMIC_SCRIPTING_SETTING + " is not a supported setting, replace with fine-grained script settings. \n" +
+                    "Dynamic scripts can be enabled for all languages and all operations by replacing `script.disable_dynamic: false` with `script.inline: on` and `script.indexed: on` in elasticsearch.yml");
+        }
 
         this.scriptEngines = scriptEngines;
         int cacheMaxSize = settings.getAsInt(SCRIPT_CACHE_SIZE_SETTING, 100);

--- a/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
+++ b/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
@@ -27,7 +27,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.ShardId;
-import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.junit.Test;
 
@@ -399,7 +398,6 @@ public class NodeEnvironmentTests extends ElasticsearchTestCase {
                 .put(settings)
                 .put("path.home", newTempDirPath().toAbsolutePath().toString())
                 .put(NodeEnvironment.SETTING_CUSTOM_DATA_PATH_ENABLED, true)
-                .put(ScriptService.DISABLE_DYNAMIC_SCRIPTING_SETTING, false)
                 .putArray("path.data", tmpPaths()).build();
         return new NodeEnvironment(build, new Environment(build));
     }
@@ -409,7 +407,6 @@ public class NodeEnvironmentTests extends ElasticsearchTestCase {
                 .put(settings)
                 .put("path.home", newTempDirPath().toAbsolutePath().toString())
                 .put(NodeEnvironment.SETTING_CUSTOM_DATA_PATH_ENABLED, true)
-                .put(ScriptService.DISABLE_DYNAMIC_SCRIPTING_SETTING, false)
                 .putArray("path.data", dataPaths).build();
         return new NodeEnvironment(build, new Environment(build));
     }

--- a/src/test/java/org/elasticsearch/script/NativeScriptTests.java
+++ b/src/test/java/org/elasticsearch/script/NativeScriptTests.java
@@ -86,21 +86,6 @@ public class NativeScriptTests extends ElasticsearchTestCase {
         }
     }
 
-    @Test
-    public void testDisableDynamicDoesntAffectNativeScripts() throws IOException {
-        Settings settings = ImmutableSettings.settingsBuilder().put(ScriptService.DISABLE_DYNAMIC_SCRIPTING_SETTING, randomFrom("true", "false", "sandbox")).build();
-        Environment environment = new Environment(settings);
-        ResourceWatcherService resourceWatcherService = new ResourceWatcherService(settings, null);
-        Map<String, NativeScriptFactory> nativeScriptFactoryMap = new HashMap<>();
-        nativeScriptFactoryMap.put("my", new MyNativeScriptFactory());
-        Set<ScriptEngineService> scriptEngineServices = ImmutableSet.<ScriptEngineService>of(new NativeScriptEngineService(settings, nativeScriptFactoryMap));
-        ScriptService scriptService = new ScriptService(settings, environment, scriptEngineServices, resourceWatcherService, new NodeSettingsService(settings));
-
-        for (ScriptContext scriptContext : ScriptContext.values()) {
-            assertThat(scriptService.compile(NativeScriptEngineService.NAME, "my", ScriptType.INLINE, scriptContext), notNullValue());
-        }
-    }
-
     static class MyNativeScriptFactory implements NativeScriptFactory {
         @Override
         public ExecutableScript newScript(@Nullable Map<String, Object> params) {

--- a/src/test/java/org/elasticsearch/script/ScriptServiceTests.java
+++ b/src/test/java/org/elasticsearch/script/ScriptServiceTests.java
@@ -94,6 +94,16 @@ public class ScriptServiceTests extends ElasticsearchTestCase {
     }
 
     @Test
+    public void testNotSupportedDisableDynamicSetting() throws IOException {
+        try {
+            buildScriptService(ImmutableSettings.builder().put(ScriptService.DISABLE_DYNAMIC_SCRIPTING_SETTING, randomUnicodeOfLength(randomIntBetween(1, 10))).build());
+            fail("script service should have thrown exception due to non supported script.disable_dynamic setting");
+        } catch(ElasticsearchIllegalArgumentException e) {
+            assertThat(e.getMessage(), containsString(ScriptService.DISABLE_DYNAMIC_SCRIPTING_SETTING + " is not a supported setting, replace with fine-grained script settings"));
+        }
+    }
+
+    @Test
     public void testScriptsWithoutExtensions() throws IOException {
         buildScriptService(ImmutableSettings.EMPTY);
         logger.info("--> setup two test files one with extension and another without");

--- a/src/test/java/org/elasticsearch/search/functionscore/FunctionScoreBackwardCompatibilityTests.java
+++ b/src/test/java/org/elasticsearch/search/functionscore/FunctionScoreBackwardCompatibilityTests.java
@@ -18,14 +18,12 @@
  */
 package org.elasticsearch.search.functionscore;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.test.ElasticsearchBackwardsCompatIntegrationTest;
 import org.junit.Test;
 
@@ -104,21 +102,9 @@ public class FunctionScoreBackwardCompatibilityTests extends ElasticsearchBackwa
     }
 
     @Override
-    protected Settings nodeSettings(int nodeOrdinal) {
-        //enable scripting on the internal nodes
-        return ImmutableSettings.builder().put(super.nodeSettings(nodeOrdinal)).put("script.inline", "on").build();
-    }
-
-    @Override
-    protected Settings externalNodeSettings(int nodeOrdinal) {
-        //enable scripting on the external nodes using the proper setting depending on the bwc version
-        ImmutableSettings.Builder builder = ImmutableSettings.builder().put(super.externalNodeSettings(nodeOrdinal));
-        if (compatibilityVersion().before(Version.V_1_6_0)) {
-            builder.put(ScriptService.DISABLE_DYNAMIC_SCRIPTING_SETTING, false);
-        } else {
-            builder.put("script.inline", "on");
-        }
-        return builder.build();
+    protected Settings commonNodeSettings(int nodeOrdinal) {
+        return ImmutableSettings.builder().put(super.commonNodeSettings(nodeOrdinal))
+                .put("script.inline", "on").build();
     }
 
     private void checkFunctionScoreStillWorks(String... ids) throws ExecutionException, InterruptedException, IOException {


### PR DESCRIPTION
Now that fine-grained script settings are supported (#10116) we can remove support for the `script.disable_dynamic` setting, which is deprecated in our docs as of `1.6.0`. Also, from `1.6.0` a deprecation warning will be printed out at startup in the logs whenever using the `'script.disable_dynamic` param in `elasticsearch.yml`.

Note that the same result as `script.disable_dynamic: false` can be obtained as follows:

```
script.inline: on
script.indexed: on
```
