### PR TITLE
Add ability to launch bootstrapped ES using maven

### DIFF
--- a/TESTING.asciidoc
+++ b/TESTING.asciidoc
@@ -38,6 +38,15 @@ Alternatively, you can set the `ES_TEST_LOCAL` environment variable:
 export ES_TEST_LOCAL=true && mvn test
 -------------------------------------
 
+=== Running Elasticsearch from a checkout
+
+In order to run Elasticsearch from source without building a package, you can
+run it using Maven:
+
+-------------------------------------
+mvn compile exec:exec
+-------------------------------------
+
 === Test case filtering.
 
 - `tests.class` is a class-filtering shell-like glob pattern,

--- a/pom.xml
+++ b/pom.xml
@@ -409,7 +409,39 @@
         </testResources>
 
         <plugins>
-            <plugin>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <version>1.4.0</version>
+            <executions>
+              <execution>
+                <phase>exec</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <executable>java</executable>
+              <arguments>
+                <argument>-classpath</argument>
+                <classpath/>
+                <argument>org.elasticsearch.bootstrap.Bootstrap</argument>
+                <argument>-Xms256m</argument>
+                <argument>-Xmx1g</argument>
+                <argument>-Djava.awt.headless=true</argument>
+                <argument>-XX:+UseParNewGC</argument>
+                <argument>-XX:+UseConcMarkSweepGC</argument>
+                <argument>-XX:CMSInitiatingOccupancyFraction=75</argument>
+                <argument>-XX:+UseCMSInitiatingOccupancyOnly</argument>
+                <argument>-XX:+HeapDumpOnOutOfMemoryError</argument>
+                <argument>-XX:+DisableExplicitGC</argument>
+                <argument>-Dfile.encoding=UTF-8</argument>
+                <argument>-Delasticsearch</argument>
+              </arguments>
+            </configuration>
+          </plugin>
+          <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <version>1.3.1</version>


### PR DESCRIPTION
This adds the exec-maven-plugin that allows a developer to run:

```
mvn exec:exec
```

To launch the `Bootstrap` process similar to the way that a Java IDE
would. All the logs go to logs/elasticsearch.log (or wherever
configured)
