### PR TITLE
Tests: Skip Version.CURRENT for static bwc indexes

### DIFF
--- a/src/test/java/org/elasticsearch/bwcompat/RestoreBackwardsCompatTests.java
+++ b/src/test/java/org/elasticsearch/bwcompat/RestoreBackwardsCompatTests.java
@@ -72,6 +72,7 @@ public class RestoreBackwardsCompatTests extends AbstractSnapshotTests {
                 Version v = (Version) field.get(Version.class);
                 if (v.snapshot()) continue;
                 if (v.onOrBefore(Version.V_1_0_0_Beta1)) continue;
+                if (v.equals(Version.CURRENT)) continue;
 
                 expectedVersions.add(v.toString());
             }


### PR DESCRIPTION
The current version is normally a snapshot while in development.
However, when the release process changes the snapshot flag to false,
this causes the static bwc tests to fail because they cannot
find an index for the current version.  Instead, this change
skips the current version, because there is no need to test
a verion's bwc against itself.

closes #10292
