### PR TITLE
[TEST] enable scripts on demand via annotation and randomize default script settings

### DIFF
--- a/src/main/java/org/elasticsearch/script/ScriptModes.java
+++ b/src/main/java/org/elasticsearch/script/ScriptModes.java
@@ -36,8 +36,8 @@ import java.util.*;
  */
 public class ScriptModes {
 
-    static final String SCRIPT_SETTINGS_PREFIX = "script.";
-    static final String ENGINE_SETTINGS_PREFIX = "script.engine";
+    public static final String SCRIPT_SETTINGS_PREFIX = "script.";
+    public static final String ENGINE_SETTINGS_PREFIX = "script.engine";
 
     final ImmutableMap<String, ScriptMode> scriptModes;
 

--- a/src/test/java/org/elasticsearch/action/IndicesRequestTests.java
+++ b/src/test/java/org/elasticsearch/action/IndicesRequestTests.java
@@ -102,8 +102,10 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.node.settings.NodeSettingsService;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.action.SearchServiceTransportAction;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.RequiresScripts;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.*;
 import org.junit.After;
@@ -118,6 +120,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcke
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.*;
 
+@RequiresScripts(context = ScriptContext.UPDATE)
 @ClusterScope(scope = Scope.SUITE, numClientNodes = 1)
 public class IndicesRequestTests extends ElasticsearchIntegrationTest {
 

--- a/src/test/java/org/elasticsearch/document/BulkTests.java
+++ b/src/test/java/org/elasticsearch/document/BulkTests.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.document;
 
 import com.google.common.base.Charsets;
-
 import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.bulk.BulkRequest;
@@ -40,24 +39,20 @@ import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.RequiresScripts;
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.concurrent.CyclicBarrier;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertExists;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchHits;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.*;
+import static org.hamcrest.Matchers.*;
 
+@RequiresScripts(context = ScriptContext.UPDATE)
 public class BulkTests extends ElasticsearchIntegrationTest {
 
     @Test

--- a/src/test/java/org/elasticsearch/index/mapper/TransformOnIndexMapperIntegrationTest.java
+++ b/src/test/java/org/elasticsearch/index/mapper/TransformOnIndexMapperIntegrationTest.java
@@ -20,17 +20,18 @@
 package org.elasticsearch.index.mapper;
 
 import com.google.common.collect.ImmutableMap;
-
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.suggest.SuggestResponse;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.groovy.GroovyScriptEngineService;
 import org.elasticsearch.search.suggest.SuggestBuilders;
 import org.elasticsearch.search.suggest.completion.CompletionSuggestion;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.RequiresScripts;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -38,20 +39,15 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 import static org.elasticsearch.index.query.QueryBuilders.termQuery;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertExists;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchHits;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSuggestion;
-import static org.hamcrest.Matchers.both;
-import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.hasKey;
-import static org.hamcrest.Matchers.not;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.*;
+import static org.hamcrest.Matchers.*;
 
 /**
  * Tests for transforming the source document before indexing.
  */
+@RequiresScripts(context = ScriptContext.MAPPING)
 public class TransformOnIndexMapperIntegrationTest extends ElasticsearchIntegrationTest {
+
     @Test
     public void searchOnTransformed() throws Exception {
         setup(true);

--- a/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
+++ b/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
@@ -65,8 +65,10 @@ import org.elasticsearch.index.search.geo.GeoPolygonFilter;
 import org.elasticsearch.index.search.geo.InMemoryGeoBoundingBoxFilter;
 import org.elasticsearch.index.search.morelikethis.MoreLikeThisFetchService;
 import org.elasticsearch.index.IndexService;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.test.ElasticsearchSingleNodeTest;
+import org.elasticsearch.test.RequiresScripts;
 import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
@@ -87,9 +89,6 @@ import static org.elasticsearch.index.query.functionscore.ScoreFunctionBuilders.
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertBooleanSubQuery;
 import static org.hamcrest.Matchers.*;
 
-/**
- *
- */
 public class SimpleIndexQueryParserTests extends ElasticsearchSingleNodeTest {
 
     private IndexQueryParserService queryParser;

--- a/src/test/java/org/elasticsearch/index/query/TemplateQueryTest.java
+++ b/src/test/java/org/elasticsearch/index/query/TemplateQueryTest.java
@@ -29,9 +29,11 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.script.mustache.MustacheScriptEngineService;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.RequiresScripts;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -50,7 +52,7 @@ import static org.hamcrest.Matchers.is;
 /**
  * Full integration test of the template query plugin.
  */
-@ElasticsearchIntegrationTest.ClusterScope(scope = ElasticsearchIntegrationTest.Scope.SUITE)
+@RequiresScripts(lang = MustacheScriptEngineService.NAME, context = ScriptContext.SEARCH)
 public class TemplateQueryTest extends ElasticsearchIntegrationTest {
 
     @Before

--- a/src/test/java/org/elasticsearch/nested/SimpleNestedTests.java
+++ b/src/test/java/org/elasticsearch/nested/SimpleNestedTests.java
@@ -35,6 +35,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.query.FilterBuilders;
 import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.facet.FacetBuilders;
 import org.elasticsearch.search.facet.filter.FilterFacet;
 import org.elasticsearch.search.facet.statistical.StatisticalFacet;
@@ -42,6 +43,7 @@ import org.elasticsearch.search.facet.termsstats.TermsStatsFacet;
 import org.elasticsearch.search.sort.SortBuilders;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.RequiresScripts;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -55,6 +57,7 @@ import static org.elasticsearch.index.query.QueryBuilders.*;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.*;
 import static org.hamcrest.Matchers.*;
 
+@RequiresScripts(context = ScriptContext.SEARCH)
 public class SimpleNestedTests extends ElasticsearchIntegrationTest {
 
     @Test

--- a/src/test/java/org/elasticsearch/percolator/PercolatorTests.java
+++ b/src/test/java/org/elasticsearch/percolator/PercolatorTests.java
@@ -48,9 +48,11 @@ import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.QueryParsingException;
 import org.elasticsearch.index.query.functionscore.factor.FactorBuilder;
 import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.highlight.HighlightBuilder;
 import org.elasticsearch.search.sort.SortBuilders;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.RequiresScripts;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -67,9 +69,7 @@ import static org.elasticsearch.index.query.functionscore.ScoreFunctionBuilders.
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.*;
 import static org.hamcrest.Matchers.*;
 
-/**
- *
- */
+@RequiresScripts(context = ScriptContext.SEARCH)
 public class PercolatorTests extends ElasticsearchIntegrationTest {
 
     @Test

--- a/src/test/java/org/elasticsearch/routing/AliasRoutingTests.java
+++ b/src/test/java/org/elasticsearch/routing/AliasRoutingTests.java
@@ -26,19 +26,19 @@ import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.client.Requests;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.query.QueryBuilders;
-import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.RequiresScripts;
 import org.junit.Test;
 
 import static org.elasticsearch.cluster.metadata.AliasAction.newAddAliasAction;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
+import static org.elasticsearch.script.ScriptService.ScriptType;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 
-/**
- *
- */
+@RequiresScripts(context = ScriptContext.UPDATE)
 public class AliasRoutingTests extends ElasticsearchIntegrationTest {
 
     @Override
@@ -71,7 +71,7 @@ public class AliasRoutingTests extends ElasticsearchIntegrationTest {
         logger.info("--> updating with id [1] and routing through alias");
         client().prepareUpdate("alias0", "type1", "1")
                 .setUpsert(XContentFactory.jsonBuilder().startObject().field("field", 1).endObject())
-                .setScript("ctx._source.field = 'value2'", ScriptService.ScriptType.INLINE)
+                .setScript("ctx._source.field = 'value2'", ScriptType.INLINE)
                 .execute().actionGet();
         for (int i = 0; i < 5; i++) {
             assertThat(client().prepareGet("alias0", "type1", "1").execute().actionGet().isExists(), equalTo(true));

--- a/src/test/java/org/elasticsearch/script/GroovyScriptTests.java
+++ b/src/test/java/org/elasticsearch/script/GroovyScriptTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.lucene.search.function.CombineFunction;
 import org.elasticsearch.script.groovy.GroovyScriptEngineService;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.RequiresScripts;
 import org.junit.Test;
 
 import java.util.List;
@@ -41,6 +42,7 @@ import static org.hamcrest.Matchers.equalTo;
 /**
  * Various tests for Groovy scripting
  */
+@RequiresScripts(context = ScriptContext.SEARCH)
 public class GroovyScriptTests extends ElasticsearchIntegrationTest {
 
     @Test

--- a/src/test/java/org/elasticsearch/script/IndexLookupTests.java
+++ b/src/test/java/org/elasticsearch/script/IndexLookupTests.java
@@ -29,6 +29,7 @@ import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilders;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.RequiresScripts;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
@@ -43,6 +44,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcke
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.hamcrest.Matchers.equalTo;
 
+@RequiresScripts(context = ScriptContext.SEARCH)
 public class IndexLookupTests extends ElasticsearchIntegrationTest {
 
     String includeAllFlag = "_FREQUENCIES | _OFFSETS | _PAYLOADS | _POSITIONS | _CACHE";

--- a/src/test/java/org/elasticsearch/script/SandboxDisabledTests.java
+++ b/src/test/java/org/elasticsearch/script/SandboxDisabledTests.java
@@ -32,14 +32,14 @@ import static org.hamcrest.Matchers.containsString;
  * Test that a system where the sandbox is disabled while dynamic scripting is
  * also disabled does not allow a script to be sent
  */
-@ElasticsearchIntegrationTest.ClusterScope(scope=ElasticsearchIntegrationTest.Scope.SUITE)
 public class SandboxDisabledTests extends ElasticsearchIntegrationTest {
 
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {
         return ImmutableSettings.settingsBuilder().put(super.nodeSettings(nodeOrdinal))
-                .put(GroovyScriptEngineService.GROOVY_SCRIPT_SANDBOX_ENABLED, false)
-                .put("script.inline", false).build();
+            .put(GroovyScriptEngineService.GROOVY_SCRIPT_SANDBOX_ENABLED, false)
+            //override randomized script settings, we need groovy inline search off for this test
+            .put("script.engine.groovy.inline.search", false).build();
     }
 
     @Test

--- a/src/test/java/org/elasticsearch/script/expression/ExpressionScriptTests.java
+++ b/src/test/java/org/elasticsearch/script/expression/ExpressionScriptTests.java
@@ -27,12 +27,14 @@ import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilder;
 import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilders;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.metrics.stats.Stats;
 import org.elasticsearch.search.sort.SortBuilders;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.RequiresScripts;
 import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.util.HashMap;
@@ -41,6 +43,7 @@ import java.util.Map;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 
+@RequiresScripts(lang = ExpressionScriptEngineService.NAME, context = ScriptContext.SEARCH)
 public class ExpressionScriptTests extends ElasticsearchIntegrationTest {
 
     private SearchRequestBuilder buildRequest(String script, Object... params) {

--- a/src/test/java/org/elasticsearch/search/aggregations/RandomTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/RandomTests.java
@@ -29,6 +29,7 @@ import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.query.FilterBuilders;
 import org.elasticsearch.index.query.RangeFilterBuilder;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.aggregations.Aggregator.SubAggCollectionMode;
 import org.elasticsearch.search.aggregations.bucket.filter.Filter;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
@@ -38,6 +39,7 @@ import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregatorFactory;
 import org.elasticsearch.search.aggregations.metrics.sum.Sum;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.RequiresScripts;
 
 import java.util.List;
 
@@ -52,6 +54,7 @@ import static org.hamcrest.core.IsNull.notNullValue;
  * the growth of dynamic arrays is tested.
  */
 @Slow
+@RequiresScripts(context = ScriptContext.AGGS)
 public class RandomTests extends ElasticsearchIntegrationTest {
 
     // Make sure that unordered, reversed, disjoint and/or overlapping ranges are supported

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/DateHistogramTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/DateHistogramTests.java
@@ -25,12 +25,14 @@ import org.elasticsearch.common.joda.Joda;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.mapper.core.DateFieldMapper;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogram;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.metrics.max.Max;
 import org.elasticsearch.search.aggregations.metrics.sum.Sum;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.RequiresScripts;
 import org.hamcrest.Matchers;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -48,21 +50,13 @@ import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
-import static org.elasticsearch.search.aggregations.AggregationBuilders.dateHistogram;
-import static org.elasticsearch.search.aggregations.AggregationBuilders.histogram;
-import static org.elasticsearch.search.aggregations.AggregationBuilders.max;
-import static org.elasticsearch.search.aggregations.AggregationBuilders.stats;
-import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.*;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.IsNull.notNullValue;
 
-/**
- *
- */
+@RequiresScripts(context = ScriptContext.AGGS)
 @ElasticsearchIntegrationTest.SuiteScopeTest
 public class DateHistogramTests extends ElasticsearchIntegrationTest {
 

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/DateRangeTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/DateRangeTests.java
@@ -20,6 +20,7 @@ package org.elasticsearch.search.aggregations.bucket;
 
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.bucket.range.date.DateRange;
 import org.elasticsearch.search.aggregations.bucket.range.date.DateRangeBuilder;
@@ -27,6 +28,7 @@ import org.elasticsearch.search.aggregations.metrics.max.Max;
 import org.elasticsearch.search.aggregations.metrics.min.Min;
 import org.elasticsearch.search.aggregations.metrics.sum.Sum;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.RequiresScripts;
 import org.hamcrest.Matchers;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -46,10 +48,8 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
 
-/**
- *
- */
 @ElasticsearchIntegrationTest.SuiteScopeTest
+@RequiresScripts(context = ScriptContext.AGGS)
 public class DateRangeTests extends ElasticsearchIntegrationTest {
 
     private static IndexRequestBuilder indexDoc(int month, int day, int value) throws Exception {
@@ -66,6 +66,7 @@ public class DateRangeTests extends ElasticsearchIntegrationTest {
     }
 
     private static int numDocs;
+
     @Override
     public void setupSuiteScopeCluster() throws Exception {
         createIndex("idx");

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/DoubleTermsTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/DoubleTermsTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.index.query.FilterBuilders;
 import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilders;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.aggregations.Aggregator.SubAggCollectionMode;
 import org.elasticsearch.search.aggregations.bucket.filter.Filter;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
@@ -33,40 +34,27 @@ import org.elasticsearch.search.aggregations.metrics.stats.Stats;
 import org.elasticsearch.search.aggregations.metrics.stats.extended.ExtendedStats;
 import org.elasticsearch.search.aggregations.metrics.sum.Sum;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.RequiresScripts;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.functionScoreQuery;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
-import static org.elasticsearch.search.aggregations.AggregationBuilders.avg;
-import static org.elasticsearch.search.aggregations.AggregationBuilders.extendedStats;
-import static org.elasticsearch.search.aggregations.AggregationBuilders.filter;
-import static org.elasticsearch.search.aggregations.AggregationBuilders.histogram;
-import static org.elasticsearch.search.aggregations.AggregationBuilders.max;
-import static org.elasticsearch.search.aggregations.AggregationBuilders.stats;
-import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
-import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.*;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 
-/**
- *
- */
 @ElasticsearchIntegrationTest.SuiteScopeTest
 @TestLogging("org.elasticsearch.action.search:TRACE,org.elasticsearch.search:TRACE")
+@RequiresScripts(context = {ScriptContext.AGGS, ScriptContext.SEARCH})
 public class DoubleTermsTests extends AbstractTermsTests {
 
     private static final int NUM_DOCS = 5; // TODO: randomize the size?

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/HistogramTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/HistogramTests.java
@@ -22,6 +22,7 @@ import com.carrotsearch.hppc.LongOpenHashSet;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.aggregations.Aggregator.SubAggCollectionMode;
 import org.elasticsearch.search.aggregations.bucket.filter.Filter;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
@@ -30,6 +31,7 @@ import org.elasticsearch.search.aggregations.metrics.max.Max;
 import org.elasticsearch.search.aggregations.metrics.stats.Stats;
 import org.elasticsearch.search.aggregations.metrics.sum.Sum;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.RequiresScripts;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
@@ -46,10 +48,8 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSear
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.IsNull.notNullValue;
 
-/**
- *
- */
 @ElasticsearchIntegrationTest.SuiteScopeTest
+@RequiresScripts(context = ScriptContext.AGGS)
 public class HistogramTests extends ElasticsearchIntegrationTest {
 
     private static final String SINGLE_VALUED_FIELD_NAME = "l_value";

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/IPv4RangeTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/IPv4RangeTests.java
@@ -21,11 +21,13 @@ package org.elasticsearch.search.aggregations.bucket;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.index.mapper.ip.IpFieldMapper;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.bucket.range.ipv4.IPv4Range;
 import org.elasticsearch.search.aggregations.metrics.max.Max;
 import org.elasticsearch.search.aggregations.metrics.sum.Sum;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.RequiresScripts;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
@@ -42,10 +44,8 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
 
-/**
- *
- */
 @ElasticsearchIntegrationTest.SuiteScopeTest
+@RequiresScripts(context = ScriptContext.AGGS)
 public class IPv4RangeTests extends ElasticsearchIntegrationTest {
 
     @Override

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/LongTermsTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/LongTermsTests.java
@@ -22,6 +22,7 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.index.query.FilterBuilders;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.aggregations.Aggregator.SubAggCollectionMode;
 import org.elasticsearch.search.aggregations.bucket.filter.Filter;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
@@ -32,28 +33,17 @@ import org.elasticsearch.search.aggregations.metrics.stats.Stats;
 import org.elasticsearch.search.aggregations.metrics.stats.extended.ExtendedStats;
 import org.elasticsearch.search.aggregations.metrics.sum.Sum;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.RequiresScripts;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
-import static org.elasticsearch.search.aggregations.AggregationBuilders.avg;
-import static org.elasticsearch.search.aggregations.AggregationBuilders.extendedStats;
-import static org.elasticsearch.search.aggregations.AggregationBuilders.filter;
-import static org.elasticsearch.search.aggregations.AggregationBuilders.histogram;
-import static org.elasticsearch.search.aggregations.AggregationBuilders.max;
-import static org.elasticsearch.search.aggregations.AggregationBuilders.stats;
-import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
-import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.*;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.equalTo;
@@ -65,6 +55,7 @@ import static org.hamcrest.core.IsNull.notNullValue;
  */
 @ElasticsearchIntegrationTest.SuiteScopeTest
 @TestLogging("org.elasticsearch.action.search:TRACE,org.elasticsearch.search:TRACE")
+@RequiresScripts(context = ScriptContext.AGGS)
 public class LongTermsTests extends AbstractTermsTests {
 
     private static final int NUM_DOCS = 5; // TODO randomize the size?

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/MinDocCountTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/MinDocCountTests.java
@@ -28,13 +28,14 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.aggregations.Aggregator.SubAggCollectionMode;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogram;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsBuilder;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
-import org.elasticsearch.test.junit.annotations.TestLogging;
+import org.elasticsearch.test.RequiresScripts;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
 
@@ -46,7 +47,7 @@ import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.*;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAllSuccessful;
 
-
+@RequiresScripts(context = ScriptContext.AGGS)
 @ElasticsearchIntegrationTest.SuiteScopeTest
 public class MinDocCountTests extends AbstractTermsTests {
 

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/RangeTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/RangeTests.java
@@ -20,6 +20,7 @@ package org.elasticsearch.search.aggregations.bucket;
 
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.aggregations.Aggregator.SubAggCollectionMode;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.bucket.range.Range;
@@ -27,6 +28,7 @@ import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.aggregations.metrics.avg.Avg;
 import org.elasticsearch.search.aggregations.metrics.sum.Sum;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.RequiresScripts;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
@@ -42,10 +44,8 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
 
-/**
- *
- */
 @ElasticsearchIntegrationTest.SuiteScopeTest
+@RequiresScripts(context = ScriptContext.AGGS)
 public class RangeTests extends ElasticsearchIntegrationTest {
 
     private static final String SINGLE_VALUED_FIELD_NAME = "l_value";

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/SignificantTermsSignificanceScoreTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/SignificantTermsSignificanceScoreTests.java
@@ -31,8 +31,8 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.query.FilterBuilders;
 import org.elasticsearch.index.query.QueryParsingException;
 import org.elasticsearch.plugins.AbstractPlugin;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptModule;
-import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.bucket.filter.FilterAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.filter.InternalFilter;
@@ -47,6 +47,7 @@ import org.elasticsearch.search.aggregations.bucket.terms.StringTerms;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsBuilder;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.RequiresScripts;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -56,17 +57,12 @@ import java.util.concurrent.ExecutionException;
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_REPLICAS;
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.elasticsearch.script.ScriptService.*;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
-import static org.hamcrest.Matchers.closeTo;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.*;
 
-/**
- *
- */
-@ElasticsearchIntegrationTest.ClusterScope(scope = ElasticsearchIntegrationTest.Scope.SUITE)
+@RequiresScripts(type = {ScriptType.INDEXED, ScriptType.INLINE}, context = ScriptContext.AGGS)
 public class SignificantTermsSignificanceScoreTests extends ElasticsearchIntegrationTest {
 
     static final String INDEX_NAME = "testidx";
@@ -552,7 +548,7 @@ public class SignificantTermsSignificanceScoreTests extends ElasticsearchIntegra
                 } else {
                     script = "return param*(_subset_freq + _subset_size + _superset_freq + _superset_size)/param";
                 }
-                client().prepareIndex().setIndex(ScriptService.SCRIPT_INDEX).setType(ScriptService.DEFAULT_LANG).setId("my_script")
+                client().prepareIndex().setIndex(SCRIPT_INDEX).setType(DEFAULT_LANG).setId("my_script")
                         .setSource(XContentFactory.jsonBuilder().startObject()
                                 .field("script", script)
                                 .endObject()).get();

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/StringTermsTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/StringTermsTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.index.mapper.internal.FieldNamesFieldMapper;
 import org.elasticsearch.index.mapper.internal.IndexFieldMapper;
 import org.elasticsearch.index.query.FilterBuilders;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.aggregations.Aggregator.SubAggCollectionMode;
 import org.elasticsearch.search.aggregations.bucket.filter.Filter;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
@@ -36,43 +37,29 @@ import org.elasticsearch.search.aggregations.metrics.stats.extended.ExtendedStat
 import org.elasticsearch.search.aggregations.metrics.sum.Sum;
 import org.elasticsearch.search.aggregations.metrics.valuecount.ValueCount;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.RequiresScripts;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.text.NumberFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
+import java.util.*;
 import java.util.regex.Pattern;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.FilterBuilders.termFilter;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
-import static org.elasticsearch.search.aggregations.AggregationBuilders.avg;
-import static org.elasticsearch.search.aggregations.AggregationBuilders.count;
-import static org.elasticsearch.search.aggregations.AggregationBuilders.extendedStats;
-import static org.elasticsearch.search.aggregations.AggregationBuilders.filter;
-import static org.elasticsearch.search.aggregations.AggregationBuilders.histogram;
-import static org.elasticsearch.search.aggregations.AggregationBuilders.stats;
-import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
-import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.*;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
 
-/**
- *
- */
 @ElasticsearchIntegrationTest.SuiteScopeTest
 @TestLogging("org.elasticsearch.action.search:TRACE,org.elasticsearch.search:TRACE")
+@RequiresScripts(context = ScriptContext.AGGS)
 public class StringTermsTests extends AbstractTermsTests {
 
     private static final String SINGLE_VALUED_FIELD_NAME = "s_value";

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/TopHitsTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/TopHitsTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.query.FilterBuilders;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHitField;
 import org.elasticsearch.search.SearchHits;
@@ -40,15 +41,14 @@ import org.elasticsearch.search.highlight.HighlightField;
 import org.elasticsearch.search.sort.SortBuilders;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.RequiresScripts;
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
-import static org.elasticsearch.common.xcontent.XContentFactory.smileBuilder;
-import static org.elasticsearch.common.xcontent.XContentFactory.yamlBuilder;
+import static org.elasticsearch.common.xcontent.XContentFactory.*;
 import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
 import static org.elasticsearch.index.query.QueryBuilders.nestedQuery;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.*;
@@ -57,9 +57,7 @@ import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
 
-/**
- *
- */
+@RequiresScripts(context = {ScriptContext.SEARCH, ScriptContext.AGGS})
 @ElasticsearchIntegrationTest.SuiteScopeTest()
 public class TopHitsTests extends ElasticsearchIntegrationTest {
 

--- a/src/test/java/org/elasticsearch/search/aggregations/metrics/AvgTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/metrics/AvgTests.java
@@ -19,8 +19,10 @@
 package org.elasticsearch.search.aggregations.metrics;
 
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.metrics.avg.Avg;
+import org.elasticsearch.test.RequiresScripts;
 import org.junit.Test;
 
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
@@ -28,9 +30,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.avg;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.histogram;
 import static org.hamcrest.Matchers.*;
 
-/**
- *
- */
+@RequiresScripts(context = ScriptContext.AGGS)
 public class AvgTests extends AbstractNumericTests {
 
     @Test

--- a/src/test/java/org/elasticsearch/search/aggregations/metrics/CardinalityTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/metrics/CardinalityTests.java
@@ -23,10 +23,12 @@ import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.aggregations.Aggregator.SubAggCollectionMode;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.aggregations.metrics.cardinality.Cardinality;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.RequiresScripts;
 import org.junit.Test;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
@@ -38,6 +40,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.core.IsNull.notNullValue;
 
 @ElasticsearchIntegrationTest.SuiteScopeTest
+@RequiresScripts(context = ScriptContext.AGGS)
 public class CardinalityTests extends ElasticsearchIntegrationTest {
 
     @Override

--- a/src/test/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsTests.java
@@ -20,8 +20,10 @@ package org.elasticsearch.search.aggregations.metrics;
 
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.ShardSearchFailure;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.metrics.stats.extended.ExtendedStats;
+import org.elasticsearch.test.RequiresScripts;
 import org.junit.Test;
 
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
@@ -29,9 +31,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.extended
 import static org.elasticsearch.search.aggregations.AggregationBuilders.histogram;
 import static org.hamcrest.Matchers.*;
 
-/**
- *
- */
+@RequiresScripts(context = ScriptContext.AGGS)
 public class ExtendedStatsTests extends AbstractNumericTests {
 
     private static double stdDev(int... vals) {

--- a/src/test/java/org/elasticsearch/search/aggregations/metrics/MaxTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/metrics/MaxTests.java
@@ -19,8 +19,10 @@
 package org.elasticsearch.search.aggregations.metrics;
 
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.metrics.max.Max;
+import org.elasticsearch.test.RequiresScripts;
 import org.junit.Test;
 
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
@@ -29,9 +31,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.max;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 
-/**
- *
- */
+@RequiresScripts(context = ScriptContext.AGGS)
 public class MaxTests extends AbstractNumericTests {
 
     @Test

--- a/src/test/java/org/elasticsearch/search/aggregations/metrics/MinTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/metrics/MinTests.java
@@ -19,8 +19,10 @@
 package org.elasticsearch.search.aggregations.metrics;
 
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.metrics.min.Min;
+import org.elasticsearch.test.RequiresScripts;
 import org.junit.Test;
 
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
@@ -29,9 +31,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.min;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 
-/**
- *
- */
+@RequiresScripts(context = ScriptContext.AGGS)
 public class MinTests extends AbstractNumericTests {
 
     @Test

--- a/src/test/java/org/elasticsearch/search/aggregations/metrics/PercentileRanksTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/metrics/PercentileRanksTests.java
@@ -21,11 +21,13 @@ package org.elasticsearch.search.aggregations.metrics;
 import com.google.common.collect.Lists;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram.Order;
 import org.elasticsearch.search.aggregations.metrics.percentiles.Percentile;
 import org.elasticsearch.search.aggregations.metrics.percentiles.PercentileRanks;
 import org.elasticsearch.search.aggregations.metrics.percentiles.PercentileRanksBuilder;
+import org.elasticsearch.test.RequiresScripts;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -36,9 +38,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.histogra
 import static org.elasticsearch.search.aggregations.AggregationBuilders.percentileRanks;
 import static org.hamcrest.Matchers.*;
 
-/**
- *
- */
+@RequiresScripts(context = ScriptContext.AGGS)
 public class PercentileRanksTests extends AbstractNumericTests {
 
     private static double[] randomPercents(long minValue, long maxValue) {

--- a/src/test/java/org/elasticsearch/search/aggregations/metrics/PercentilesTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/metrics/PercentilesTests.java
@@ -19,14 +19,15 @@
 package org.elasticsearch.search.aggregations.metrics;
 
 import com.google.common.collect.Lists;
-
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram.Order;
 import org.elasticsearch.search.aggregations.metrics.percentiles.Percentile;
 import org.elasticsearch.search.aggregations.metrics.percentiles.Percentiles;
 import org.elasticsearch.search.aggregations.metrics.percentiles.PercentilesBuilder;
+import org.elasticsearch.test.RequiresScripts;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -37,9 +38,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.histogra
 import static org.elasticsearch.search.aggregations.AggregationBuilders.percentiles;
 import static org.hamcrest.Matchers.*;
 
-/**
- *
- */
+@RequiresScripts(context = ScriptContext.AGGS)
 public class PercentilesTests extends AbstractNumericTests {
 
     private static double[] randomPercentiles() {

--- a/src/test/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricTests.java
@@ -19,16 +19,12 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.indexedscripts.put.PutIndexedScriptResponse;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.groovy.GroovyScriptEngineService;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.Aggregations;
@@ -36,26 +32,24 @@ import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram.Bucket;
 import org.elasticsearch.search.aggregations.metrics.scripted.ScriptedMetric;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
-import org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
-import org.elasticsearch.test.ElasticsearchIntegrationTest.Scope;
+import org.elasticsearch.test.RequiresScripts;
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
+import static org.elasticsearch.script.ScriptService.ScriptType;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.histogram;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.scriptedMetric;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
-import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.lessThanOrEqualTo;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.*;
 
-@ClusterScope(scope = Scope.SUITE)
 @ElasticsearchIntegrationTest.SuiteScopeTest
+@RequiresScripts(type = {ScriptType.INDEXED, ScriptType.INLINE}, context = ScriptContext.AGGS)
 public class ScriptedMetricTests extends ElasticsearchIntegrationTest {
 
     private static long numDocs;
@@ -110,11 +104,10 @@ public class ScriptedMetricTests extends ElasticsearchIntegrationTest {
 
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {
-        Settings settings = ImmutableSettings.settingsBuilder()
+        return ImmutableSettings.settingsBuilder()
                 .put(super.nodeSettings(nodeOrdinal))
                 .put("path.conf", getResource("/org/elasticsearch/search/aggregations/metrics/scripted/conf"))
                 .build();
-        return settings;
     }
 
     @Test

--- a/src/test/java/org/elasticsearch/search/aggregations/metrics/StatsTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/metrics/StatsTests.java
@@ -20,8 +20,10 @@ package org.elasticsearch.search.aggregations.metrics;
 
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.ShardSearchFailure;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.metrics.stats.Stats;
+import org.elasticsearch.test.RequiresScripts;
 import org.junit.Test;
 
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
@@ -29,9 +31,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.histogra
 import static org.elasticsearch.search.aggregations.AggregationBuilders.stats;
 import static org.hamcrest.Matchers.*;
 
-/**
- *
- */
+@RequiresScripts(context = ScriptContext.AGGS)
 public class StatsTests extends AbstractNumericTests {
 
     @Test

--- a/src/test/java/org/elasticsearch/search/aggregations/metrics/SumTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/metrics/SumTests.java
@@ -19,8 +19,10 @@
 package org.elasticsearch.search.aggregations.metrics;
 
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.metrics.sum.Sum;
+import org.elasticsearch.test.RequiresScripts;
 import org.junit.Test;
 
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
@@ -29,9 +31,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 
-/**
- *
- */
+@RequiresScripts(context = ScriptContext.AGGS)
 public class SumTests extends AbstractNumericTests {
 
     @Test

--- a/src/test/java/org/elasticsearch/search/aggregations/metrics/ValueCountTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/metrics/ValueCountTests.java
@@ -19,8 +19,10 @@
 package org.elasticsearch.search.aggregations.metrics;
 
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.aggregations.metrics.valuecount.ValueCount;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.RequiresScripts;
 import org.junit.Test;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
@@ -29,10 +31,8 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.count;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 
-/**
- *
- */
 @ElasticsearchIntegrationTest.SuiteScopeTest
+@RequiresScripts(context = ScriptContext.AGGS)
 public class ValueCountTests extends ElasticsearchIntegrationTest {
 
     @Override

--- a/src/test/java/org/elasticsearch/search/child/SimpleChildQuerySearchTests.java
+++ b/src/test/java/org/elasticsearch/search/child/SimpleChildQuerySearchTests.java
@@ -21,7 +21,6 @@ package org.elasticsearch.search.child;
 import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
-import org.elasticsearch.action.admin.cluster.stats.ClusterStatsResponse;
 import org.elasticsearch.action.admin.indices.cache.clear.ClearIndicesCacheResponse;
 import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsResponse;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingResponse;
@@ -44,10 +43,12 @@ import org.elasticsearch.index.mapper.MergeMappingException;
 import org.elasticsearch.index.query.*;
 import org.elasticsearch.index.search.child.ScoreType;
 import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.facet.terms.TermsFacet;
 import org.elasticsearch.search.sort.SortBuilders;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.RequiresScripts;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
@@ -64,16 +65,13 @@ import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilde
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.FilterBuilders.*;
 import static org.elasticsearch.index.query.QueryBuilders.*;
-import static org.elasticsearch.index.query.QueryBuilders.constantScoreQuery;
 import static org.elasticsearch.index.query.functionscore.ScoreFunctionBuilders.factorFunction;
 import static org.elasticsearch.index.query.functionscore.ScoreFunctionBuilders.scriptFunction;
 import static org.elasticsearch.search.facet.FacetBuilders.termsFacet;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.*;
 import static org.hamcrest.Matchers.*;
 
-/**
- *
- */
+@RequiresScripts(context = ScriptContext.SEARCH)
 public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
 
     @Test

--- a/src/test/java/org/elasticsearch/search/facet/SimpleFacetsTests.java
+++ b/src/test/java/org/elasticsearch/search/facet/SimpleFacetsTests.java
@@ -30,6 +30,7 @@ import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.joda.Joda;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.facet.datehistogram.DateHistogramFacet;
 import org.elasticsearch.search.facet.filter.FilterFacet;
 import org.elasticsearch.search.facet.histogram.HistogramFacet;
@@ -42,6 +43,7 @@ import org.elasticsearch.search.facet.terms.doubles.InternalDoubleTermsFacet;
 import org.elasticsearch.search.facet.terms.longs.InternalLongTermsFacet;
 import org.elasticsearch.search.facet.termsstats.TermsStatsFacet;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.RequiresScripts;
 import org.joda.time.DateTimeZone;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
@@ -60,10 +62,7 @@ import static org.elasticsearch.search.facet.FacetBuilders.*;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.*;
 import static org.hamcrest.Matchers.*;
 
-/**
- *
- */
-
+@RequiresScripts(context = ScriptContext.AGGS)
 public class SimpleFacetsTests extends ElasticsearchIntegrationTest {
     private int numRuns = -1;
 

--- a/src/test/java/org/elasticsearch/search/fields/SearchFieldsTests.java
+++ b/src/test/java/org/elasticsearch/search/fields/SearchFieldsTests.java
@@ -33,10 +33,12 @@ import org.elasticsearch.common.joda.Joda;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHitField;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.RequiresScripts;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.Test;
@@ -50,9 +52,7 @@ import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.*;
 import static org.hamcrest.Matchers.*;
 
-/**
- *
- */
+@RequiresScripts(context = ScriptContext.SEARCH)
 public class SearchFieldsTests extends ElasticsearchIntegrationTest {
 
     @Test

--- a/src/test/java/org/elasticsearch/search/functionscore/FunctionScoreBackwardCompatibilityTests.java
+++ b/src/test/java/org/elasticsearch/search/functionscore/FunctionScoreBackwardCompatibilityTests.java
@@ -18,15 +18,14 @@
  */
 package org.elasticsearch.search.functionscore;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.settings.ImmutableSettings;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.test.ElasticsearchBackwardsCompatIntegrationTest;
+import org.elasticsearch.test.RequiresScripts;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.junit.Test;
 
@@ -43,9 +42,8 @@ import static org.elasticsearch.index.query.functionscore.ScoreFunctionBuilders.
 import static org.elasticsearch.search.builder.SearchSourceBuilder.searchSource;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.*;
 
-/**
- */
 @TestLogging("index.translog.fs:TRACE")
+@RequiresScripts(context = ScriptContext.SEARCH)
 public class FunctionScoreBackwardCompatibilityTests extends ElasticsearchBackwardsCompatIntegrationTest {
 
     /**
@@ -104,24 +102,6 @@ public class FunctionScoreBackwardCompatibilityTests extends ElasticsearchBackwa
         } while (upgraded);
         client().admin().indices().prepareUpdateSettings("test").setSettings(ImmutableSettings.builder().put(EnableAllocationDecider.INDEX_ROUTING_ALLOCATION_ENABLE, "all")).get();
         logger.debug("done function_score while upgrading");
-    }
-
-    @Override
-    protected Settings nodeSettings(int nodeOrdinal) {
-        //enable scripting on the internal nodes
-        return ImmutableSettings.builder().put(super.nodeSettings(nodeOrdinal)).put("script.inline", "on").build();
-    }
-
-    @Override
-    protected Settings externalNodeSettings(int nodeOrdinal) {
-        //enable scripting on the external nodes using the proper setting depending on the bwc version
-        ImmutableSettings.Builder builder = ImmutableSettings.builder().put(super.externalNodeSettings(nodeOrdinal));
-        if (compatibilityVersion().before(Version.V_1_6_0)) {
-            builder.put(ScriptService.DISABLE_DYNAMIC_SCRIPTING_SETTING, false);
-        } else {
-            builder.put("script.inline", "on");
-        }
-        return builder.build();
     }
 
     private void checkFunctionScoreStillWorks(String... ids) throws ExecutionException, InterruptedException, IOException {

--- a/src/test/java/org/elasticsearch/search/functionscore/FunctionScoreTests.java
+++ b/src/test/java/org/elasticsearch/search/functionscore/FunctionScoreTests.java
@@ -29,9 +29,11 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.query.functionscore.FunctionScoreQueryBuilder;
 import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilder;
 import org.elasticsearch.index.query.functionscore.weight.WeightBuilder;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.RequiresScripts;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -50,8 +52,8 @@ import static org.elasticsearch.search.builder.SearchSourceBuilder.searchSource;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.*;
-import static org.hamcrest.Matchers.is;
 
+@RequiresScripts(context = {ScriptContext.SEARCH, ScriptContext.AGGS})
 public class FunctionScoreTests extends ElasticsearchIntegrationTest {
 
     static final String TYPE = "type";

--- a/src/test/java/org/elasticsearch/search/functionscore/RandomScoreFunctionTests.java
+++ b/src/test/java/org/elasticsearch/search/functionscore/RandomScoreFunctionTests.java
@@ -21,8 +21,10 @@ package org.elasticsearch.search.functionscore;
 import org.apache.lucene.util.ArrayUtil;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.index.query.functionscore.random.RandomScoreFunctionBuilder;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.RequiresScripts;
 import org.hamcrest.CoreMatchers;
 import org.junit.Ignore;
 
@@ -37,7 +39,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcke
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.*;
 
-
+@RequiresScripts(context = ScriptContext.SEARCH)
 public class RandomScoreFunctionTests extends ElasticsearchIntegrationTest {
 
     public void testConsistentHitsWithSameSeed() throws Exception {

--- a/src/test/java/org/elasticsearch/search/geo/GeoDistanceFacetTests.java
+++ b/src/test/java/org/elasticsearch/search/geo/GeoDistanceFacetTests.java
@@ -23,8 +23,10 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.facet.geodistance.GeoDistanceFacet;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.RequiresScripts;
 import org.junit.Test;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
@@ -33,9 +35,7 @@ import static org.elasticsearch.search.facet.FacetBuilders.geoDistanceFacet;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.*;
 
-/**
- *
- */
+@RequiresScripts(context = ScriptContext.AGGS)
 public class GeoDistanceFacetTests extends ElasticsearchIntegrationTest {
 
     @Test

--- a/src/test/java/org/elasticsearch/search/geo/GeoDistanceTests.java
+++ b/src/test/java/org/elasticsearch/search/geo/GeoDistanceTests.java
@@ -31,10 +31,12 @@ import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.query.FilterBuilders;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.sort.SortBuilders;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.RequiresScripts;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -49,8 +51,7 @@ import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.*;
 import static org.hamcrest.Matchers.*;
 
-/**
- */
+@RequiresScripts(context = ScriptContext.SEARCH)
 public class GeoDistanceTests extends ElasticsearchIntegrationTest {
 
     @Test

--- a/src/test/java/org/elasticsearch/search/innerhits/InnerHitsTests.java
+++ b/src/test/java/org/elasticsearch/search/innerhits/InnerHitsTests.java
@@ -25,11 +25,13 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.support.QueryInnerHitBuilder;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.fetch.innerhits.InnerHitsBuilder;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.RequiresScripts;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -43,8 +45,7 @@ import static org.elasticsearch.index.query.QueryBuilders.*;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.*;
 import static org.hamcrest.Matchers.*;
 
-/**
- */
+@RequiresScripts(context = ScriptContext.SEARCH)
 public class InnerHitsTests extends ElasticsearchIntegrationTest {
 
     @Test

--- a/src/test/java/org/elasticsearch/search/query/SearchQueryTests.java
+++ b/src/test/java/org/elasticsearch/search/query/SearchQueryTests.java
@@ -37,10 +37,12 @@ import org.elasticsearch.index.query.*;
 import org.elasticsearch.index.query.CommonTermsQueryBuilder.Operator;
 import org.elasticsearch.index.query.MatchQueryBuilder.Type;
 import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.facet.FacetBuilders;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.RequiresScripts;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.format.ISODateTimeFormat;
@@ -62,7 +64,7 @@ import static org.elasticsearch.index.query.functionscore.ScoreFunctionBuilders.
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.*;
 import static org.hamcrest.Matchers.*;
 
-
+@RequiresScripts(context = ScriptContext.SEARCH)
 public class SearchQueryTests extends ElasticsearchIntegrationTest {
 
     @Override

--- a/src/test/java/org/elasticsearch/search/rescore/QueryRescorerTests.java
+++ b/src/test/java/org/elasticsearch/search/rescore/QueryRescorerTests.java
@@ -28,17 +28,19 @@ import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.common.lucene.search.function.CombineFunction;
-import org.elasticsearch.common.settings.ImmutableSettings.Builder;
 import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.ImmutableSettings.Builder;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.query.MatchQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilders;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.rescore.RescoreBuilder.QueryRescorer;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.RequiresScripts;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -49,9 +51,7 @@ import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.*;
 import static org.hamcrest.Matchers.*;
 
-/**
- *
- */
+@RequiresScripts(context = ScriptContext.SEARCH)
 public class QueryRescorerTests extends ElasticsearchIntegrationTest {
 
     @Test

--- a/src/test/java/org/elasticsearch/search/scriptfilter/ScriptFilterSearchTests.java
+++ b/src/test/java/org/elasticsearch/search/scriptfilter/ScriptFilterSearchTests.java
@@ -22,10 +22,10 @@ package org.elasticsearch.search.scriptfilter;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.settings.ImmutableSettings;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.script.groovy.GroovyScriptEngineService;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.RequiresScripts;
 import org.junit.Test;
 
 import java.util.concurrent.atomic.AtomicInteger;
@@ -36,16 +36,8 @@ import static org.elasticsearch.index.query.QueryBuilders.*;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.equalTo;
 
-/**
- *
- */
-@ElasticsearchIntegrationTest.ClusterScope(scope=ElasticsearchIntegrationTest.Scope.SUITE)
+@RequiresScripts(context = ScriptContext.SEARCH)
 public class ScriptFilterSearchTests extends ElasticsearchIntegrationTest {
-
-    @Override
-    protected Settings nodeSettings(int nodeOrdinal) {
-        return ImmutableSettings.settingsBuilder().put(super.nodeSettings(nodeOrdinal)).put(GroovyScriptEngineService.GROOVY_SCRIPT_SANDBOX_ENABLED, false).build();
-    }
 
     @Test
     public void testCustomScriptBoost() throws Exception {

--- a/src/test/java/org/elasticsearch/search/sort/SimpleSortTests.java
+++ b/src/test/java/org/elasticsearch/search/sort/SimpleSortTests.java
@@ -43,9 +43,11 @@ import org.elasticsearch.index.mapper.Uid;
 import org.elasticsearch.index.query.FilterBuilders;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilders;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHitField;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.RequiresScripts;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -63,9 +65,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.*;
 import static org.hamcrest.Matchers.*;
 
 
-/**
- *
- */
+@RequiresScripts(context = ScriptContext.SEARCH)
 public class SimpleSortTests extends ElasticsearchIntegrationTest {
 
     @TestLogging("action.search.type:TRACE")

--- a/src/test/java/org/elasticsearch/search/stats/SearchStatsTests.java
+++ b/src/test/java/org/elasticsearch/search/stats/SearchStatsTests.java
@@ -32,7 +32,9 @@ import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.search.stats.SearchStats.Stats;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.RequiresScripts;
 import org.junit.Test;
 
 import java.util.HashSet;
@@ -44,8 +46,7 @@ import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.*;
 import static org.hamcrest.Matchers.*;
 
-/**
- */
+@RequiresScripts(context = ScriptContext.SEARCH)
 public class SearchStatsTests extends ElasticsearchIntegrationTest {
 
     @Override

--- a/src/test/java/org/elasticsearch/search/suggest/SuggestSearchTests.java
+++ b/src/test/java/org/elasticsearch/search/suggest/SuggestSearchTests.java
@@ -33,11 +33,13 @@ import org.elasticsearch.action.suggest.SuggestRequestBuilder;
 import org.elasticsearch.action.suggest.SuggestResponse;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.suggest.SuggestBuilder.SuggestionBuilder;
 import org.elasticsearch.search.suggest.phrase.PhraseSuggestionBuilder;
 import org.elasticsearch.search.suggest.phrase.PhraseSuggestionBuilder.DirectCandidateGenerator;
 import org.elasticsearch.search.suggest.term.TermSuggestionBuilder;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.RequiresScripts;
 import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.junit.Test;
 
@@ -60,6 +62,7 @@ import static org.hamcrest.Matchers.*;
  * possible these tests should declare for the first request, make the request, modify the configuration for the next request, make that
  * request, modify again, request again, etc.  This makes it very obvious what changes between requests.
  */
+@RequiresScripts(context = ScriptContext.SEARCH)
 public class SuggestSearchTests extends ElasticsearchIntegrationTest {
 
     @Test // see #3196

--- a/src/test/java/org/elasticsearch/search/timeout/SearchTimeoutTests.java
+++ b/src/test/java/org/elasticsearch/search/timeout/SearchTimeoutTests.java
@@ -20,10 +20,9 @@
 package org.elasticsearch.search.timeout;
 
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.common.settings.ImmutableSettings;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.script.groovy.GroovyScriptEngineService;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.RequiresScripts;
 import org.junit.Test;
 
 import static org.elasticsearch.index.query.FilterBuilders.scriptFilter;
@@ -31,15 +30,8 @@ import static org.elasticsearch.index.query.QueryBuilders.filteredQuery;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.hamcrest.Matchers.equalTo;
 
-/**
- */
-@ElasticsearchIntegrationTest.ClusterScope(scope=ElasticsearchIntegrationTest.Scope.SUITE)
+@RequiresScripts(context = ScriptContext.SEARCH)
 public class SearchTimeoutTests extends ElasticsearchIntegrationTest {
-
-    @Override
-    protected Settings nodeSettings(int nodeOrdinal) {
-        return ImmutableSettings.settingsBuilder().put(super.nodeSettings(nodeOrdinal)).put(GroovyScriptEngineService.GROOVY_SCRIPT_SANDBOX_ENABLED, false).build();
-    }
 
     @Test
     public void simpleTimeoutTest() throws Exception {

--- a/src/test/java/org/elasticsearch/test/ElasticsearchSingleNodeTest.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchSingleNodeTest.java
@@ -126,17 +126,17 @@ public abstract class ElasticsearchSingleNodeTest extends ElasticsearchTestCase 
 
     private static Node newNode(boolean localGateway) {
         Node build = NodeBuilder.nodeBuilder().local(true).data(true).settings(ImmutableSettings.builder()
-                .put(ClusterName.SETTING, clusterName())
+            .put(ClusterName.SETTING, clusterName())
             .put("node.name", nodeName())
-                .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
-                .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
-                .put("script.inline", "on")
-                .put("script.indexed", "on")
-                .put(EsExecutors.PROCESSORS, 1) // limit the number of threads created
+            .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put(EsExecutors.PROCESSORS, 1) // limit the number of threads created
             .put("http.enabled", false)
-                .put("index.store.type", "ram")
+            .put("index.store.type", "ram")
             .put("config.ignore_system_properties", true) // make sure we get what we set :)
-            .put("gateway.type", localGateway ? "local" : "none")).build();
+            .put("gateway.type", localGateway ? "local" : "none")
+            //@RequiresScript is not supported here, inline scripts are always on
+            .put("script.inline", "on")).build();
         build.start();
         assertThat(DiscoveryNode.localNode(build.settings()), is(true));
         return build;

--- a/src/test/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/src/test/java/org/elasticsearch/test/InternalTestCluster.java
@@ -199,12 +199,12 @@ public final class InternalTestCluster extends TestCluster {
 
     public InternalTestCluster(long clusterSeed, int minNumDataNodes, int maxNumDataNodes, String clusterName, int numClientNodes,
                                boolean enableHttpPipelining, int jvmOrdinal, String nodePrefix) {
-        this(clusterSeed, minNumDataNodes, maxNumDataNodes, clusterName, DEFAULT_SETTINGS_SOURCE, numClientNodes, enableHttpPipelining, jvmOrdinal, nodePrefix);
+        this(clusterSeed, minNumDataNodes, maxNumDataNodes, clusterName, DEFAULT_SETTINGS_SOURCE, numClientNodes, enableHttpPipelining, jvmOrdinal, nodePrefix, null);
     }
 
     public InternalTestCluster(long clusterSeed,
                                int minNumDataNodes, int maxNumDataNodes, String clusterName, SettingsSource settingsSource, int numClientNodes,
-                                boolean enableHttpPipelining, int jvmOrdinal, String nodePrefix) {
+                                boolean enableHttpPipelining, int jvmOrdinal, String nodePrefix, RequiresScripts requiresScripts) {
         super(clusterSeed);
         this.clusterName = clusterName;
 
@@ -292,6 +292,7 @@ public final class InternalTestCluster extends TestCluster {
         }
         // always reduce this - it can make tests really slow
         builder.put(RecoverySettings.INDICES_RECOVERY_RETRY_DELAY_STATE_SYNC, TimeValue.timeValueMillis(RandomInts.randomIntBetween(random, 20, 50)));
+        ScriptSettingsHelper.addScriptSettings(builder, random, requiresScripts);
         defaultSettings = builder.build();
         executor = EsExecutors.newCached(0, TimeUnit.SECONDS, EsExecutors.daemonThreadFactory("test_" + clusterName));
         this.hasFilterCache = random.nextBoolean();

--- a/src/test/java/org/elasticsearch/test/RequiresScripts.java
+++ b/src/test/java/org/elasticsearch/test/RequiresScripts.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test;
+
+import org.elasticsearch.script.ScriptContext;
+import org.elasticsearch.script.groovy.GroovyScriptEngineService;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static org.elasticsearch.script.ScriptService.ScriptType;
+
+/**
+ * Annotation used to mark tests that make use of scripts as part of their execution.
+ * The default script settings are randomized, hence tests that need certain script features turned on need to declare
+ * them explicitly, by specifying which languages, which type of script and which operations they use.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
+public @interface RequiresScripts {
+
+    String[] lang() default GroovyScriptEngineService.NAME;
+
+    ScriptType[] type() default ScriptType.INLINE;
+
+    ScriptContext[] context();
+}

--- a/src/test/java/org/elasticsearch/test/ScriptSettingsHelper.java
+++ b/src/test/java/org/elasticsearch/test/ScriptSettingsHelper.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test;
+
+import com.carrotsearch.randomizedtesting.generators.RandomInts;
+import com.carrotsearch.randomizedtesting.generators.RandomPicks;
+import com.google.common.collect.Sets;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.script.ScriptContext;
+import org.elasticsearch.script.ScriptModes;
+import org.elasticsearch.script.ScriptService;
+
+import java.util.Random;
+import java.util.Set;
+
+import static org.elasticsearch.test.ElasticsearchTestCase.randomFrom;
+
+class ScriptSettingsHelper {
+
+    public static void addScriptSettings(ImmutableSettings.Builder builder, Random random, RequiresScripts requiresScripts) {
+        if (requiresScripts == null) {
+            //randomize script settings if scripting is not required (annotation is not there)
+            if (random.nextBoolean()) {
+                randomScriptTypeSetting(builder, random);
+            }
+            if (random.nextBoolean()) {
+                randomScriptContextSetting(builder, random);
+            }
+        } else {
+            addScriptSettings(builder, random, requiresScripts.lang(), requiresScripts.type(), requiresScripts.context());
+        }
+    }
+
+    private static void addScriptSettings(ImmutableSettings.Builder builder, Random random, String[] langs, ScriptService.ScriptType[] scriptTypes, ScriptContext[] scriptContexts) {
+        int randomInt = RandomInts.randomIntBetween(random, 1, 3);
+        switch(randomInt) {
+            case 1:
+                //enable scripts for any lang, required sources only, any operation
+                for (ScriptService.ScriptType scriptType : scriptTypes) {
+                    builder.put(ScriptModes.SCRIPT_SETTINGS_PREFIX + scriptType, "on");
+                }
+                break;
+            case 2:
+                //per operation settings have the precedence over script type ones, hence we can randomize
+                if (random.nextBoolean()) {
+                    randomScriptTypeSetting(builder, random);
+                }
+                for (ScriptContext scriptContext : scriptContexts) {
+                    //enable scripts for any lang, any source, required operations only
+                    builder.put(ScriptModes.SCRIPT_SETTINGS_PREFIX + scriptContext, "on");
+                }
+                break;
+            case 3:
+                //per engine settings have the precedence over operation based ones and script type based ones, hence we can randomize
+                if (random.nextBoolean()) {
+                    randomScriptTypeSetting(builder, random);
+                }
+                if (random.nextBoolean()) {
+                    randomScriptContextSetting(builder, random);
+                }
+                //enable scripts for specific lang only, required sources and required operations
+                Set<ScriptContext> requiredScriptContextSet = Sets.newHashSet(scriptContexts);
+                for (String lang : langs) {
+                    for (ScriptService.ScriptType scriptType : scriptTypes) {
+                        for (ScriptContext scriptContext : ScriptContext.values()) {
+                            if (requiredScriptContextSet.contains(scriptContext)) {
+                                builder.put(ScriptModes.ENGINE_SETTINGS_PREFIX + "." + lang + "." + scriptType + "." + scriptContext , "on");
+                            } else {
+                                //randomize non required operations
+                                builder.put(ScriptModes.ENGINE_SETTINGS_PREFIX + "." + lang + "." + scriptType + "." + scriptContext , randomFrom("on", "off", "sandbox"));
+                            }
+                        }
+                    }
+                }
+                break;
+        }
+    }
+
+    private static void randomScriptTypeSetting(ImmutableSettings.Builder builder, Random random) {
+        builder.put(ScriptModes.SCRIPT_SETTINGS_PREFIX + RandomPicks.randomFrom(random, ScriptService.ScriptType.values()), RandomPicks.randomFrom(random, new String[]{"on", "off", "sandbox"}));
+    }
+
+    private static void randomScriptContextSetting(ImmutableSettings.Builder builder, Random random) {
+        builder.put(ScriptModes.SCRIPT_SETTINGS_PREFIX + RandomPicks.randomFrom(random, ScriptContext.values()), RandomPicks.randomFrom(random, new String[]{"on", "off", "sandbox"}));
+    }
+}

--- a/src/test/java/org/elasticsearch/test/rest/ElasticsearchRestTests.java
+++ b/src/test/java/org/elasticsearch/test/rest/ElasticsearchRestTests.java
@@ -30,8 +30,12 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.node.internal.InternalNode;
+import org.elasticsearch.script.ScriptContext;
+import org.elasticsearch.script.groovy.GroovyScriptEngineService;
+import org.elasticsearch.script.mustache.MustacheScriptEngineService;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
+import org.elasticsearch.test.RequiresScripts;
 import org.elasticsearch.test.rest.client.RestException;
 import org.elasticsearch.test.rest.parser.RestTestParseException;
 import org.elasticsearch.test.rest.parser.RestTestSuiteParser;
@@ -51,6 +55,8 @@ import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
 import java.util.*;
 
+import static org.elasticsearch.script.ScriptService.ScriptType;
+
 /**
  * Runs the clients test suite against an elasticsearch cluster.
  */
@@ -59,6 +65,8 @@ import java.util.*;
 //@ReplicateOnEachVm
 @AbstractRandomizedTest.Rest
 @ClusterScope(randomDynamicTemplates = false)
+@RequiresScripts(lang = {GroovyScriptEngineService.NAME, MustacheScriptEngineService.NAME}, type = {ScriptType.INDEXED, ScriptType.INLINE},
+        context = {ScriptContext.AGGS, ScriptContext.MAPPING, ScriptContext.SEARCH, ScriptContext.UPDATE} )
 public class ElasticsearchRestTests extends ElasticsearchIntegrationTest {
 
     /**

--- a/src/test/java/org/elasticsearch/test/test/InternalTestClusterTests.java
+++ b/src/test/java/org/elasticsearch/test/test/InternalTestClusterTests.java
@@ -25,7 +25,6 @@ import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.elasticsearch.test.InternalTestCluster;
-import org.elasticsearch.test.SettingsSource;
 
 import java.io.IOException;
 import java.util.Iterator;
@@ -47,15 +46,13 @@ public class InternalTestClusterTests extends ElasticsearchTestCase {
         int minNumDataNodes = randomIntBetween(0, 9);
         int maxNumDataNodes = randomIntBetween(minNumDataNodes, 10);
         String clusterName = randomRealisticUnicodeOfCodepointLengthBetween(1, 10);
-        SettingsSource settingsSource = SettingsSource.EMPTY;
         int numClientNodes = randomIntBetween(0, 10);
-        boolean enableRandomBenchNodes = randomBoolean();
         boolean enableHttpPipelining = randomBoolean();
         int jvmOrdinal = randomIntBetween(0, 10);
         String nodePrefix = randomRealisticUnicodeOfCodepointLengthBetween(1, 10);
 
-        InternalTestCluster cluster0 = new InternalTestCluster(clusterSeed, minNumDataNodes, maxNumDataNodes, clusterName, settingsSource, numClientNodes, enableHttpPipelining, jvmOrdinal, nodePrefix);
-        InternalTestCluster cluster1 = new InternalTestCluster(clusterSeed, minNumDataNodes, maxNumDataNodes, clusterName, settingsSource, numClientNodes, enableHttpPipelining, jvmOrdinal, nodePrefix);
+        InternalTestCluster cluster0 = new InternalTestCluster(clusterSeed, minNumDataNodes, maxNumDataNodes, clusterName, numClientNodes, enableHttpPipelining, jvmOrdinal, nodePrefix);
+        InternalTestCluster cluster1 = new InternalTestCluster(clusterSeed, minNumDataNodes, maxNumDataNodes, clusterName, numClientNodes, enableHttpPipelining, jvmOrdinal, nodePrefix);
         assertClusters(cluster0, cluster1, true);
 
     }
@@ -91,15 +88,13 @@ public class InternalTestClusterTests extends ElasticsearchTestCase {
         while (clusterName.equals(clusterName1)) {
             clusterName1 = clusterName("shared", Integer.toString(CHILD_JVM_ID), clusterSeed);   // spin until the time changes
         }
-        SettingsSource settingsSource = SettingsSource.EMPTY;
         int numClientNodes = randomIntBetween(0, 2);
-        boolean enableRandomBenchNodes = randomBoolean();
         boolean enableHttpPipelining = randomBoolean();
         int jvmOrdinal = randomIntBetween(0, 10);
         String nodePrefix = "foobar";
 
-        InternalTestCluster cluster0 = new InternalTestCluster(clusterSeed, minNumDataNodes, maxNumDataNodes, clusterName, settingsSource, numClientNodes, enableHttpPipelining, jvmOrdinal, nodePrefix);
-        InternalTestCluster cluster1 = new InternalTestCluster(clusterSeed, minNumDataNodes, maxNumDataNodes, clusterName1, settingsSource, numClientNodes, enableHttpPipelining, jvmOrdinal, nodePrefix);
+        InternalTestCluster cluster0 = new InternalTestCluster(clusterSeed, minNumDataNodes, maxNumDataNodes, clusterName, numClientNodes, enableHttpPipelining, jvmOrdinal, nodePrefix);
+        InternalTestCluster cluster1 = new InternalTestCluster(clusterSeed, minNumDataNodes, maxNumDataNodes, clusterName1, numClientNodes, enableHttpPipelining, jvmOrdinal, nodePrefix);
 
         assertClusters(cluster0, cluster1, false);
         long seed = randomLong();

--- a/src/test/java/org/elasticsearch/test/test/SuiteScopeClusterTests.java
+++ b/src/test/java/org/elasticsearch/test/test/SuiteScopeClusterTests.java
@@ -28,8 +28,8 @@ import java.io.IOException;
 import static org.hamcrest.Matchers.equalTo;
 
 /**
- * This test ensures that the cluster initializion for suite scope is not influencing
- * the tests random sequence due to initializtion using the same random instance.
+ * This test ensures that the cluster initialization for suite scope is not influencing
+ * the tests random sequence due to initialization using the same random instance.
  */
 @ElasticsearchIntegrationTest.ClusterScope(scope = ElasticsearchIntegrationTest.Scope.SUITE)
 public class SuiteScopeClusterTests extends ElasticsearchIntegrationTest {

--- a/src/test/java/org/elasticsearch/update/UpdateTests.java
+++ b/src/test/java/org/elasticsearch/update/UpdateTests.java
@@ -38,8 +38,10 @@ import org.elasticsearch.index.VersionType;
 import org.elasticsearch.index.engine.DocumentMissingException;
 import org.elasticsearch.index.engine.VersionConflictEngineException;
 import org.elasticsearch.index.merge.policy.MergePolicyModule;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.RequiresScripts;
 import org.elasticsearch.test.index.merge.NoMergePolicyProvider;
 import org.junit.Test;
 
@@ -57,6 +59,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcke
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertThrows;
 import static org.hamcrest.Matchers.*;
 
+@RequiresScripts(context = ScriptContext.UPDATE)
 public class UpdateTests extends ElasticsearchIntegrationTest {
 
     private void createTestIndex() throws Exception {

--- a/src/test/java/org/elasticsearch/validate/SimpleValidateQueryTests.java
+++ b/src/test/java/org/elasticsearch/validate/SimpleValidateQueryTests.java
@@ -31,8 +31,10 @@ import org.elasticsearch.index.query.FilterBuilders;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.indices.IndexMissingException;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
+import org.elasticsearch.test.RequiresScripts;
 import org.hamcrest.Matcher;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -46,10 +48,8 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcke
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.*;
 
-/**
- *
- */
 @ClusterScope(randomDynamicTemplates = false)
+@RequiresScripts(context = ScriptContext.SEARCH)
 public class SimpleValidateQueryTests extends ElasticsearchIntegrationTest {
 
     @Test


### PR DESCRIPTION
All of our tests have been running with dynamic scripts always on for a long while now, mainly for simplicity and historical reasons.

This commit introduces a new annotation that let each test declare which script features it requires. The infra will make sure that those features will be on, and will randomize the remaining settings. Same logic gets applied to bw comp tests, with the only difference that the new fine-grained settings are used only when supported on external nodes (otherwise the previous `script.disable_dynamic` is set).

`ElasticsearchSingleNodeTest` stays with all inline scripts enabled for simplicity.
