### PR TITLE
Refresh if many deletes in a row use up too much version map RAM

### DIFF
--- a/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -447,6 +447,7 @@ public class InternalEngine extends Engine {
         }
 
         maybePruneDeletedTombstones();
+        checkVersionMapRefresh();
     }
 
     private void maybePruneDeletedTombstones() {


### PR DESCRIPTION
Digging into #7052 I noticed that if an app does zillions of "delete by IDs" in a row, we fail to trigger a refresh when the version map is using too much RAM...
