### PR TITLE
Refactor state format to use incremental state IDs

### DIFF
--- a/src/main/java/org/elasticsearch/gateway/MetaDataStateFormat.java
+++ b/src/main/java/org/elasticsearch/gateway/MetaDataStateFormat.java
@@ -56,17 +56,19 @@ public abstract class MetaDataStateFormat<T> {
     private static final int STATE_FILE_VERSION = 0;
     private static final int BUFFER_SIZE = 4096;
     private final XContentType format;
-    private final boolean deleteOldFiles;
+    private final String prefix;
+    private final Pattern stateFilePattern;
+
 
     /**
      * Creates a new {@link MetaDataStateFormat} instance
      * @param format the format of the x-content
-     * @param deleteOldFiles if <code>true</code> write operations will
-     *                       clean up old files written with this format.
      */
-    protected MetaDataStateFormat(XContentType format, boolean deleteOldFiles) {
+    protected MetaDataStateFormat(XContentType format, String prefix) {
         this.format = format;
-        this.deleteOldFiles = deleteOldFiles;
+        this.prefix = prefix;
+        this.stateFilePattern = Pattern.compile(Pattern.quote(prefix) + "(\\d+)(" + MetaDataStateFormat.STATE_FILE_EXTENSION + ")?");
+
     }
 
     /**
@@ -83,15 +85,16 @@ public abstract class MetaDataStateFormat<T> {
      * it's target filename of the pattern <tt>{prefix}{version}.st</tt>.
      *
      * @param state the state object to write
-     * @param prefix the state names prefix used to compose the file name.
      * @param version the version of the state
      * @param locations the locations where the state should be written to.
      * @throws IOException if an IOException occurs
      */
-    public final void write(final T state, final String prefix, final long version, final Path... locations) throws IOException {
+    public final void write(final T state, final long version, final Path... locations) throws IOException {
         Preconditions.checkArgument(locations != null, "Locations must not be null");
         Preconditions.checkArgument(locations.length > 0, "One or more locations required");
-        String fileName = prefix + version + STATE_FILE_EXTENSION;
+        final long maxStateId = findMaxStateId(prefix, locations)+1;
+        assert maxStateId >= 0 : "maxStateId must be positive but was: [" + maxStateId + "]";
+        final String fileName = prefix + maxStateId + STATE_FILE_EXTENSION;
         Path stateLocation = locations[0].resolve(STATE_DIR_NAME);
         Files.createDirectories(stateLocation);
         final Path tmpStatePath = stateLocation.resolve(fileName + ".tmp");
@@ -136,9 +139,7 @@ public abstract class MetaDataStateFormat<T> {
         } finally {
             Files.deleteIfExists(tmpStatePath);
         }
-        if (deleteOldFiles) {
-            cleanupOldFiles(prefix, fileName, locations);
-        }
+        cleanupOldFiles(prefix, fileName, locations);
     }
 
     protected XContentBuilder newXContentBuilder(XContentType type, OutputStream stream ) throws IOException {
@@ -161,17 +162,14 @@ public abstract class MetaDataStateFormat<T> {
      * Reads the state from a given file and compares the expected version against the actual version of
      * the state.
      */
-    public final T read(Path file, long expectedVersion) throws IOException {
+    public final T read(Path file) throws IOException {
         try (Directory dir = newDirectory(file.getParent())) {
             try (final IndexInput indexInput = dir.openInput(file.getFileName().toString(), IOContext.DEFAULT)) {
                  // We checksum the entire file before we even go and parse it. If it's corrupted we barf right here.
                 CodecUtil.checksumEntireFile(indexInput);
                 CodecUtil.checkHeader(indexInput, STATE_FILE_CODEC, STATE_FILE_VERSION, STATE_FILE_VERSION);
                 final XContentType xContentType = XContentType.values()[indexInput.readInt()];
-                final long version = indexInput.readLong();
-                if (version != expectedVersion) {
-                    throw new CorruptStateException("State version mismatch expected: " + expectedVersion + " but was: " + version);
-                }
+                indexInput.readLong(); // version currently unused
                 long filePointer = indexInput.getFilePointer();
                 long contentSize = indexInput.length() - CodecUtil.footerLength() - filePointer;
                 try (IndexInput slice = indexInput.slice("state_xcontent", filePointer, contentSize)) {
@@ -210,25 +208,38 @@ public abstract class MetaDataStateFormat<T> {
         }
     }
 
+    long findMaxStateId(final String prefix, Path... locations) throws IOException {
+        long maxId = -1;
+        for (Path dataLocation : locations) {
+            final Path resolve = dataLocation.resolve(STATE_DIR_NAME);
+            if (Files.exists(resolve)) {
+                try (DirectoryStream<Path> stream = Files.newDirectoryStream(resolve, prefix + "*")) {
+                    for (Path stateFile : stream) {
+                        final Matcher matcher = stateFilePattern.matcher(stateFile.getFileName().toString());
+                        if (matcher.matches()) {
+                            final long id = Long.parseLong(matcher.group(1));
+                            maxId = Math.max(maxId, id);
+                        }
+                    }
+                }
+            }
+        }
+        return maxId;
+    }
+
     /**
      * Tries to load the latest state from the given data-locations. It tries to load the latest state determined by
      * the states version from one or more data directories and if none of the latest states can be loaded an exception
      * is thrown to prevent accidentally loading a previous state and silently omitting the latest state.
      *
      * @param logger an elasticsearch logger instance
-     * @param format the actual metastate format to use
-     * @param pattern the file name pattern to identify files belonging to this pattern and to read the version from.
-     *                The first capture group should return the version of the file. If the second capture group is has a
-     *                null value the files is considered a legacy file and will be treated as if the file contains a plain
-     *                x-content payload.
-     * @param stateType the state type we are loading. used for logging contenxt only.
      * @param dataLocations the data-locations to try.
      * @return the latest state or <code>null</code> if no state was found.
      */
-    public static <T> T loadLatestState(ESLogger logger, MetaDataStateFormat<T> format, Pattern pattern, String stateType, Path... dataLocations) throws IOException {
-        List<PathAndVersion> files = new ArrayList<>();
-        long maxVersion = -1;
-        boolean maxVersionIsLegacy = true;
+    public  T loadLatestState(ESLogger logger, Path... dataLocations) throws IOException {
+        List<PathAndStateId> files = new ArrayList<>();
+        long maxStateId = -1;
+        boolean maxStateIdIsLegacy = true;
         if (dataLocations != null) { // select all eligable files first
             for (Path dataLocation : dataLocations) {
                 final Path stateDir = dataLocation.resolve(STATE_DIR_NAME);
@@ -238,13 +249,13 @@ public abstract class MetaDataStateFormat<T> {
                 // now, iterate over the current versions, and find latest one
                 try (DirectoryStream<Path> paths = Files.newDirectoryStream(stateDir)) { // we don't pass a glob since we need the group part for parsing
                     for (Path stateFile : paths) {
-                        final Matcher matcher = pattern.matcher(stateFile.getFileName().toString());
+                        final Matcher matcher = stateFilePattern.matcher(stateFile.getFileName().toString());
                         if (matcher.matches()) {
-                            final long version = Long.parseLong(matcher.group(1));
-                            maxVersion = Math.max(maxVersion, version);
+                            final long stateId = Long.parseLong(matcher.group(1));
+                            maxStateId = Math.max(maxStateId, stateId);
                             final boolean legacy = MetaDataStateFormat.STATE_FILE_EXTENSION.equals(matcher.group(2)) == false;
-                            maxVersionIsLegacy &= legacy; // on purpose, see NOTE below
-                            PathAndVersion pav = new PathAndVersion(stateFile, version, legacy);
+                            maxStateIdIsLegacy &= legacy; // on purpose, see NOTE below
+                            PathAndStateId pav = new PathAndStateId(stateFile, stateId, legacy);
                             logger.trace("found state file: {}", pav);
                             files.add(pav);
                         }
@@ -259,30 +270,30 @@ public abstract class MetaDataStateFormat<T> {
         //       new format (ie. legacy == false) then we know that the latest version state ought to use this new format.
         //       In case the state file with the latest version does not use the new format while older state files do,
         //       the list below will be empty and loading the state will fail
-        for (PathAndVersion pathAndVersion : Collections2.filter(files, new VersionAndLegacyPredicate(maxVersion, maxVersionIsLegacy))) {
+        for (PathAndStateId pathAndStateId : Collections2.filter(files, new StateIdAndLegacyPredicate(maxStateId, maxStateIdIsLegacy))) {
             try {
-                final Path stateFile = pathAndVersion.file;
-                final long version = pathAndVersion.version;
+                final Path stateFile = pathAndStateId.file;
+                final long id = pathAndStateId.id;
                 final XContentParser parser;
-                if (pathAndVersion.legacy) { // read the legacy format -- plain XContent
+                if (pathAndStateId.legacy) { // read the legacy format -- plain XContent
                     final byte[] data = Files.readAllBytes(stateFile);
                     if (data.length == 0) {
-                        logger.debug("{}: no data for [{}], ignoring...", stateType, stateFile.toAbsolutePath());
+                        logger.debug("{}: no data for [{}], ignoring...", prefix, stateFile.toAbsolutePath());
                         continue;
                     }
                     parser = XContentHelper.createParser(data, 0, data.length);
-                    state = format.fromXContent(parser);
+                    state = fromXContent(parser);
                     if (state == null) {
-                        logger.debug("{}: no data for [{}], ignoring...", stateType, stateFile.toAbsolutePath());
+                        logger.debug("{}: no data for [{}], ignoring...", prefix, stateFile.toAbsolutePath());
                     }
                 } else {
-                    state = format.read(stateFile, version);
-                    logger.trace("state version [{}] read from [{}]", version, stateFile.getFileName());
+                    state = read(stateFile);
+                    logger.trace("state id [{}] read from [{}]", id, stateFile.getFileName());
                 }
                 return state;
             } catch (Throwable e) {
                 exceptions.add(e);
-                logger.debug("{}: failed to read [{}], ignoring...", e, pathAndVersion.file.toAbsolutePath(), stateType);
+                logger.debug("{}: failed to read [{}], ignoring...", e, pathAndStateId.file.toAbsolutePath(), prefix);
             }
         }
         // if we reach this something went wrong
@@ -295,42 +306,42 @@ public abstract class MetaDataStateFormat<T> {
     }
 
     /**
-     * Filters out all {@link MetaDataStateFormat.PathAndVersion} instances with a different version than
+     * Filters out all {@link org.elasticsearch.gateway.MetaDataStateFormat.PathAndStateId} instances with a different id than
      * the given one.
      */
-    private static final class VersionAndLegacyPredicate implements Predicate<PathAndVersion> {
-        private final long version;
+    private static final class StateIdAndLegacyPredicate implements Predicate<PathAndStateId> {
+        private final long id;
         private final boolean legacy;
 
-        VersionAndLegacyPredicate(long version, boolean legacy) {
-            this.version = version;
+        StateIdAndLegacyPredicate(long id, boolean legacy) {
+            this.id = id;
             this.legacy = legacy;
         }
 
         @Override
-        public boolean apply(PathAndVersion input) {
-            return input.version == version && input.legacy == legacy;
+        public boolean apply(PathAndStateId input) {
+            return input.id == id && input.legacy == legacy;
         }
     }
 
     /**
-     * Internal struct-like class that holds the parsed state version, the file
+     * Internal struct-like class that holds the parsed state id, the file
      * and a flag if the file is a legacy state ie. pre 1.5
      */
-    private static class PathAndVersion {
+    private static class PathAndStateId {
         final Path file;
-        final long version;
+        final long id;
         final boolean legacy;
 
-        private PathAndVersion(Path file, long version, boolean legacy) {
+        private PathAndStateId(Path file, long id, boolean legacy) {
             this.file = file;
-            this.version = version;
+            this.id = id;
             this.legacy = legacy;
         }
 
         @Override
         public String toString() {
-            return "[version:" + version + ", legacy:" + legacy + ", file:" + file.toAbsolutePath() + "]";
+            return "[id:" + id + ", legacy:" + legacy + ", file:" + file.toAbsolutePath() + "]";
         }
     }
 

--- a/src/main/java/org/elasticsearch/gateway/TransportNodesListGatewayStartedShards.java
+++ b/src/main/java/org/elasticsearch/gateway/TransportNodesListGatewayStartedShards.java
@@ -42,10 +42,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 
 /**
@@ -120,7 +117,7 @@ public class TransportNodesListGatewayStartedShards extends TransportNodesOperat
             final ShardId shardId = request.getShardId();
             final String indexUUID = request.getIndexUUID();
             logger.trace("{} loading local shard state info", shardId);
-            ShardStateMetaData shardStateMetaData = ShardStateMetaData.load(logger, request.shardId, nodeEnv.shardPaths(request.shardId));
+            final ShardStateMetaData shardStateMetaData = ShardStateMetaData.FORMAT.loadLatestState(logger, nodeEnv.shardPaths(request.shardId));
             if (shardStateMetaData != null) {
                 // old shard metadata doesn't have the actual index UUID so we need to check if the actual uuid in the metadata
                 // is equal to IndexMetaData.INDEX_UUID_NA_VALUE otherwise this shard doesn't belong to the requested index.

--- a/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -1274,7 +1274,8 @@ public class IndexShard extends AbstractIndexShardComponent {
                     return;
                 }
                 final ShardStateMetaData newShardStateMetadata = new ShardStateMetaData(newRouting.version(), newRouting.primary(), getIndexUUID());
-                ShardStateMetaData.write(logger, writeReason, shardId, newShardStateMetadata, currentRouting != null, nodeEnv.shardPaths(shardId));
+                logger.trace("{} writing shard state, reason [{}]", shardId, writeReason);
+                ShardStateMetaData.FORMAT.write(newShardStateMetadata, newShardStateMetadata.version, nodeEnv.shardPaths(shardId));
             } catch (IOException e) { // this is how we used to handle it.... :(
                 logger.warn("failed to write shard state", e);
                 // we failed to write the shard state, we will try and write

--- a/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -20,24 +20,23 @@ package org.elasticsearch.index.shard;
 
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.ElasticsearchIllegalStateException;
-import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.routing.MutableShardRouting;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
+import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.indices.IndicesService;
-import org.elasticsearch.indices.cluster.IndicesClusterStateService;
 import org.elasticsearch.test.ElasticsearchSingleNodeTest;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Set;
 
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 
 /**
  * Simple unit-test IndexShard related operations.
@@ -72,18 +71,18 @@ public class IndexShardTests extends ElasticsearchSingleNodeTest {
             long version = between(1, Integer.MAX_VALUE / 2);
             boolean primary = randomBoolean();
             ShardStateMetaData state1 = new ShardStateMetaData(version, primary, "foo");
-            ShardStateMetaData.write(logger, "foo", id, state1, randomBoolean(), env.shardPaths(id));
-            ShardStateMetaData shardStateMetaData = ShardStateMetaData.load(logger, id, env.shardPaths(id));
+            write(state1, env.shardPaths(id));
+            ShardStateMetaData shardStateMetaData = load(logger, env.shardPaths(id));
             assertEquals(shardStateMetaData, state1);
 
             ShardStateMetaData state2 = new ShardStateMetaData(version, primary, "foo");
-            ShardStateMetaData.write(logger, "foo", id, state2, randomBoolean(), env.shardPaths(id));
-            shardStateMetaData = ShardStateMetaData.load(logger, id, env.shardPaths(id));
+            write(state2, env.shardPaths(id));
+            shardStateMetaData = load(logger, env.shardPaths(id));
             assertEquals(shardStateMetaData, state1);
 
             ShardStateMetaData state3 = new ShardStateMetaData(version + 1, primary, "foo");
-            ShardStateMetaData.write(logger, "foo", id, state3, randomBoolean(), env.shardPaths(id));
-            shardStateMetaData = ShardStateMetaData.load(logger, id, env.shardPaths(id));
+            write(state3, env.shardPaths(id));
+            shardStateMetaData = load(logger, env.shardPaths(id));
             assertEquals(shardStateMetaData, state3);
             assertEquals("foo", state3.indexUUID);
         }
@@ -96,44 +95,44 @@ public class IndexShardTests extends ElasticsearchSingleNodeTest {
         NodeEnvironment env = getInstanceFromNode(NodeEnvironment.class);
         IndexService test = indicesService.indexService("test");
         IndexShard shard = test.shard(0);
-        ShardStateMetaData shardStateMetaData = ShardStateMetaData.load(logger, shard.shardId, env.shardPaths(shard.shardId));
+        ShardStateMetaData shardStateMetaData = load(logger, env.shardPaths(shard.shardId));
         assertEquals(getShardStateMetadata(shard), shardStateMetaData);
         ShardRouting routing = new MutableShardRouting(shard.shardRouting, shard.shardRouting.version()+1);
         shard.updateRoutingEntry(routing, true);
 
-        shardStateMetaData = ShardStateMetaData.load(logger, shard.shardId, env.shardPaths(shard.shardId));
+        shardStateMetaData = load(logger, env.shardPaths(shard.shardId));
         assertEquals(shardStateMetaData, getShardStateMetadata(shard));
         assertEquals(shardStateMetaData, new ShardStateMetaData(routing.version(), routing.primary(), shard.indexSettings.get(IndexMetaData.SETTING_UUID)));
 
         routing = new MutableShardRouting(shard.shardRouting, shard.shardRouting.version()+1);
         shard.updateRoutingEntry(routing, true);
-        shardStateMetaData = ShardStateMetaData.load(logger, shard.shardId, env.shardPaths(shard.shardId));
+        shardStateMetaData = load(logger, env.shardPaths(shard.shardId));
         assertEquals(shardStateMetaData, getShardStateMetadata(shard));
         assertEquals(shardStateMetaData, new ShardStateMetaData(routing.version(), routing.primary(), shard.indexSettings.get(IndexMetaData.SETTING_UUID)));
 
         routing = new MutableShardRouting(shard.shardRouting, shard.shardRouting.version()+1);
         shard.updateRoutingEntry(routing, true);
-        shardStateMetaData = ShardStateMetaData.load(logger, shard.shardId, env.shardPaths(shard.shardId));
+        shardStateMetaData = load(logger, env.shardPaths(shard.shardId));
         assertEquals(shardStateMetaData, getShardStateMetadata(shard));
         assertEquals(shardStateMetaData, new ShardStateMetaData(routing.version(), routing.primary(), shard.indexSettings.get(IndexMetaData.SETTING_UUID)));
 
         // test if we still write it even if the shard is not active
         MutableShardRouting inactiveRouting = new MutableShardRouting(shard.shardRouting.index(), shard.shardRouting.shardId().id(), shard.shardRouting.currentNodeId(), true, ShardRoutingState.INITIALIZING, shard.shardRouting.version() + 1);
         shard.persistMetadata(inactiveRouting, shard.shardRouting);
-        shardStateMetaData = ShardStateMetaData.load(logger, shard.shardId, env.shardPaths(shard.shardId));
+        shardStateMetaData = load(logger, env.shardPaths(shard.shardId));
         assertEquals("inactive shard state shouldn't be persisted", shardStateMetaData, getShardStateMetadata(shard));
         assertEquals("inactive shard state shouldn't be persisted", shardStateMetaData, new ShardStateMetaData(routing.version(), routing.primary(), shard.indexSettings.get(IndexMetaData.SETTING_UUID)));
 
 
         shard.updateRoutingEntry(new MutableShardRouting(shard.shardRouting, shard.shardRouting.version()+1), false);
-        shardStateMetaData = ShardStateMetaData.load(logger, shard.shardId, env.shardPaths(shard.shardId));
+        shardStateMetaData = load(logger, env.shardPaths(shard.shardId));
         assertFalse("shard state persisted despite of persist=false", shardStateMetaData.equals(getShardStateMetadata(shard)));
         assertEquals("shard state persisted despite of persist=false", shardStateMetaData, new ShardStateMetaData(routing.version(), routing.primary(), shard.indexSettings.get(IndexMetaData.SETTING_UUID)));
 
 
         routing = new MutableShardRouting(shard.shardRouting, shard.shardRouting.version()+1);
         shard.updateRoutingEntry(routing, true);
-        shardStateMetaData = ShardStateMetaData.load(logger, shard.shardId, env.shardPaths(shard.shardId));
+        shardStateMetaData = load(logger, env.shardPaths(shard.shardId));
         assertEquals(shardStateMetaData, getShardStateMetadata(shard));
         assertEquals(shardStateMetaData, new ShardStateMetaData(routing.version(), routing.primary(), shard.indexSettings.get(IndexMetaData.SETTING_UUID)));
     }
@@ -153,14 +152,14 @@ public class IndexShardTests extends ElasticsearchSingleNodeTest {
         }
 
         ShardRouting routing = shard.routingEntry();
-        ShardStateMetaData shardStateMetaData = ShardStateMetaData.load(logger, shard.shardId, env.shardPaths(shard.shardId));
+        ShardStateMetaData shardStateMetaData = load(logger, env.shardPaths(shard.shardId));
         assertEquals(shardStateMetaData, getShardStateMetadata(shard));
 
         routing = new MutableShardRouting(shard.shardId.index().getName(), shard.shardId.id(), routing.currentNodeId(), routing.primary(), ShardRoutingState.INITIALIZING, shard.shardRouting.version()+1);
         shard.updateRoutingEntry(routing, true);
         shard.deleteShardState();
 
-        assertNull("no shard state expected after delete on initializing", ShardStateMetaData.load(logger, shard.shardId, env.shardPaths(shard.shardId)));
+        assertNull("no shard state expected after delete on initializing", load(logger, env.shardPaths(shard.shardId)));
 
 
 
@@ -192,5 +191,14 @@ public class IndexShardTests extends ElasticsearchSingleNodeTest {
         }
         assertTrue("more than one unique hashcode expected but got: " + hashCodes.size(), hashCodes.size() > 1);
 
+    }
+
+    public static ShardStateMetaData load(ESLogger logger, Path... shardPaths) throws IOException {
+        return ShardStateMetaData.FORMAT.loadLatestState(logger, shardPaths);
+    }
+
+    public static void write(ShardStateMetaData shardStateMetaData,
+                             Path... shardPaths) throws IOException {
+        ShardStateMetaData.FORMAT.write(shardStateMetaData, shardStateMetaData.version, shardPaths);
     }
 }


### PR DESCRIPTION
Today there is a chance that the state version for shard, index or cluster
state goes backwards or is reset on a full restart etc. depending on
several factors not related to the state. To prevent any collisions
with already existing state files and to maintain write-once properties
this change introductes an incremental state ID instead of using the plain
state version. This also fixes a bug when the previous legacy state had a
greater version than the current state which causes an exception on node
startup or if left-over files are present.
