### PR TITLE
Add getter for channel in NettyTransportChannel

### DIFF
--- a/src/main/java/org/elasticsearch/transport/netty/NettyTransportChannel.java
+++ b/src/main/java/org/elasticsearch/transport/netty/NettyTransportChannel.java
@@ -140,4 +140,14 @@ public class NettyTransportChannel implements TransportChannel {
         channel.write(buffer);
         transportServiceAdapter.onResponseSent(requestId, action, error);
     }
+
+    /**
+     * Returns the underlying netty channel. This method is intended be used for access to netty to get additional
+     * details when processing the request and may be used by plugins. Responses should be sent using the methods
+     * defined in this class and not directly on the channel.
+     * @return underlying netty channel
+     */
+    public Channel getChannel() {
+        return channel;
+    }
 }


### PR DESCRIPTION
Adds a getter for the actual netty channel in NettyTransportChannel. The
channel can be used by plugins that need access into netty when processing
requests.
