### PR TITLE
Provide default paths in systemd service unit

### DIFF
--- a/src/deb/systemd/elasticsearch.service
+++ b/src/deb/systemd/elasticsearch.service
@@ -5,7 +5,13 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
-EnvironmentFile=/etc/default/elasticsearch
+Environment=CONF_FILE=/etc/elasticsearch/elasticsearch.yml
+Environment=ES_HOME=/usr/share/elasticsearch
+Environment=LOG_DIR=/var/log/elasticsearch
+Environment=DATA_DIR=/var/lib/elasticsearch
+Environment=WORK_DIR=/tmp/elasticsearch
+Environment=CONF_DIR=/etc/elasticsearch
+EnvironmentFile=-/etc/default/elasticsearch
 User=elasticsearch
 Group=elasticsearch
 ExecStart=/usr/share/elasticsearch/bin/elasticsearch            \


### PR DESCRIPTION
Those defaults are enforced by the initscript in the sysvinit world.
Without them, in a systemd system, elasticsearch starts with a broken
configuration, trying to store data in /usr/share/elasticsearch/data
etc.

Also mark /etc/default/elasticsearch optional since the above
`Environment` definitions are sufficient to run elasticsearch.

cc @abravorus @t-lo @jpountz 
