### PR TITLE
[TEST] move FakeRestRequest to org.elasticsearch.test.rest

### DIFF
--- a/src/test/java/org/elasticsearch/common/settings/SettingsFilterTests.java
+++ b/src/test/java/org/elasticsearch/common/settings/SettingsFilterTests.java
@@ -20,7 +20,7 @@ package org.elasticsearch.common.settings;
 
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
-import org.elasticsearch.rest.FakeRestRequest;
+import org.elasticsearch.test.rest.FakeRestRequest;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.junit.Test;

--- a/src/test/java/org/elasticsearch/rest/BytesRestResponseTests.java
+++ b/src/test/java/org/elasticsearch/rest/BytesRestResponseTests.java
@@ -21,6 +21,7 @@ package org.elasticsearch.rest;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.test.rest.FakeRestRequest;
 import org.junit.Test;
 
 import java.io.FileNotFoundException;

--- a/src/test/java/org/elasticsearch/rest/HeadersAndContextCopyClientTests.java
+++ b/src/test/java/org/elasticsearch/rest/HeadersAndContextCopyClientTests.java
@@ -39,6 +39,7 @@ import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.test.rest.FakeRestRequest;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.Test;
 

--- a/src/test/java/org/elasticsearch/rest/RestFilterChainTests.java
+++ b/src/test/java/org/elasticsearch/rest/RestFilterChainTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.test.rest.FakeRestRequest;
 import org.junit.Test;
 
 import java.io.IOException;

--- a/src/test/java/org/elasticsearch/test/rest/FakeRestRequest.java
+++ b/src/test/java/org/elasticsearch/test/rest/FakeRestRequest.java
@@ -17,9 +17,10 @@
  * under the License.
  */
 
-package org.elasticsearch.rest;
+package org.elasticsearch.test.rest;
 
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.rest.RestRequest;
 
 import java.util.HashMap;
 import java.util.Map;


### PR DESCRIPTION
FakeRestRequest is used by a few tests and can also be leveraged by
tests outside of elasticsearch. Moving the package will mean the class
gets exported as part of the test jar.
