### PR TITLE
Update readme with direct link to the upgrade section

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -208,7 +208,7 @@ running the Elasticsearch test suite.
 
 h3. Upgrading to Elasticsearch 1.x?
 
-In order to ensure a smooth upgrade process from earlier versions of Elasticsearch (< 1.0.0), it is recommended to perform a full cluster restart. Please see the "Upgrading" section of the "setup reference":http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/setup.html.
+In order to ensure a smooth upgrade process from earlier versions of Elasticsearch (< 1.0.0), it is recommended to perform a full cluster restart. Please see the "setup reference":http://www.elastic.co/guide/en/elasticsearch/reference/current/setup-upgrade.html for more details on the upgrade process.
 
 h1. License
 


### PR DESCRIPTION
I was looking this over and thought that it would be slightly nicer to include a direct link to the "Upgrading" section. This also changes the domain from `elasticsearch.org` to `elastic.co`.
