### PR TITLE
Add check to MetaData#concreteIndices to prevent NPE

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
@@ -102,7 +102,6 @@ public class MetaData implements Iterable<IndexMetaData> {
         registerFactory(RepositoriesMetaData.TYPE, RepositoriesMetaData.FACTORY);
         registerFactory(SnapshotMetaData.TYPE, SnapshotMetaData.FACTORY);
         registerFactory(RestoreMetaData.TYPE, RestoreMetaData.FACTORY);
-        registerFactory(BenchmarkMetaData.TYPE, BenchmarkMetaData.FACTORY);
     }
 
     /**

--- a/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
@@ -102,6 +102,7 @@ public class MetaData implements Iterable<IndexMetaData> {
         registerFactory(RepositoriesMetaData.TYPE, RepositoriesMetaData.FACTORY);
         registerFactory(SnapshotMetaData.TYPE, SnapshotMetaData.FACTORY);
         registerFactory(RestoreMetaData.TYPE, RestoreMetaData.FACTORY);
+        registerFactory(BenchmarkMetaData.TYPE, BenchmarkMetaData.FACTORY);
     }
 
     /**
@@ -674,6 +675,16 @@ public class MetaData implements Iterable<IndexMetaData> {
 
             aliasesOrIndices = convertFromWildcards(aliasesOrIndices, indicesOptions);
         }
+
+        if (aliasesOrIndices == null || aliasesOrIndices.length == 0) {
+            if (!indicesOptions.allowNoIndices()) {
+                throw new ElasticsearchIllegalArgumentException("Null or zero length argument for list of index or alias names "
+                        + "not allowed for indices options with " + indicesOptions.toString());
+            } else {
+                return Strings.EMPTY_ARRAY;
+            }
+        }
+
         boolean failClosed = indicesOptions.forbidClosedIndices() && !indicesOptions.ignoreUnavailable();
 
         // optimize for single element index (common case)
@@ -1058,7 +1069,7 @@ public class MetaData implements Iterable<IndexMetaData> {
      * @param types the array containing index names
      * @return true if the provided array maps to all indices, false otherwise
      */
-    public boolean isAllTypes(String[] types) {
+    public static boolean isAllTypes(String[] types) {
         return types == null || types.length == 0 || isExplicitAllPattern(types);
     }
 

--- a/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
@@ -677,8 +677,7 @@ public class MetaData implements Iterable<IndexMetaData> {
 
         if (aliasesOrIndices == null || aliasesOrIndices.length == 0) {
             if (!indicesOptions.allowNoIndices()) {
-                throw new ElasticsearchIllegalArgumentException("Null or zero length argument for list of index or alias names "
-                        + "not allowed for indices options with " + indicesOptions.toString());
+                throw new ElasticsearchIllegalArgumentException("No indices were specified and wildcard expansion is disabled.");
             } else {
                 return Strings.EMPTY_ARRAY;
             }

--- a/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
@@ -677,7 +677,7 @@ public class MetaData implements Iterable<IndexMetaData> {
 
         if (aliasesOrIndices == null || aliasesOrIndices.length == 0) {
             if (!indicesOptions.allowNoIndices()) {
-                throw new ElasticsearchIllegalArgumentException("No indices were specified and wildcard expansion is disabled.");
+                throw new ElasticsearchIllegalArgumentException("no indices were specified and wildcard expansion is disabled.");
             } else {
                 return Strings.EMPTY_ARRAY;
             }

--- a/src/test/java/org/elasticsearch/cluster/metadata/MetaDataTests.java
+++ b/src/test/java/org/elasticsearch/cluster/metadata/MetaDataTests.java
@@ -593,7 +593,7 @@ public class MetaDataTests extends ElasticsearchTestCase {
     }
 
     /**
-     * test resolving _all pattern (null, empty arry or "_all") for random IndicesOptions
+     * test resolving _all pattern (null, empty array or "_all") for random IndicesOptions
      */
     @Test
     public void testConcreteIndicesAllPatternRandom() {
@@ -668,17 +668,18 @@ public class MetaDataTests extends ElasticsearchTestCase {
      * test resolving wildcard pattern that matches no index of alias for random IndicesOptions
      */
     @Test
-    public void testConcreteIndicesWildcardEmptyRandom() {
+    public void testConcreteIndicesWildcardNoMatch() {
         for (int i = 0; i < 10; i++) {
             IndicesOptions indicesOptions = IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean());
             MetaData metadata = MetaData.builder().build();
 
-            // with existing indices, asking for non existing wildcard pattern should return empty list or exception
             metadata = MetaData.builder()
                     .put(indexBuilder("aaa").state(State.OPEN).putAlias(AliasMetaData.builder("aaa_alias1")))
                     .put(indexBuilder("bbb").state(State.OPEN).putAlias(AliasMetaData.builder("bbb_alias1")))
                     .put(indexBuilder("ccc").state(State.CLOSE).putAlias(AliasMetaData.builder("ccc_alias1")))
                     .build();
+
+            // asking for non existing wildcard pattern should return empty list or exception
             if (indicesOptions.allowNoIndices()) {
                 String[] concreteIndices = metadata.concreteIndices(indicesOptions, "Foo*");
                 assertThat(concreteIndices, notNullValue());


### PR DESCRIPTION
There is a current edge case in resolving concrete aliases or index names in MetaData that can lead to NullPointerException when the IndicesOptions don't allow wildcard expansion and the method is called with `aliasesOrIndices` argument `null` or emtpy list. This adds checks and randomized tests that catch this.

Closes #10339
