### PR TITLE
Fix typos for gateway.recover_after_time

### DIFF
--- a/docs/reference/modules/gateway.asciidoc
+++ b/docs/reference/modules/gateway.asciidoc
@@ -43,7 +43,7 @@ once all `gateway.recover_after...nodes` conditions are met.
 The `gateway.expected_nodes` allows to set how many data and master
 eligible nodes are expected to be in the cluster, and once met, the
 `gateway.recover_after_time` is ignored and recovery starts.
-Setting `gateway.expected_nodes` also defaults `gateway.recovery_after_time` to `5m` The `gateway.expected_data_nodes` and `gateway.expected_master_nodes`
+Setting `gateway.expected_nodes` also defaults `gateway.recover_after_time` to `5m` The `gateway.expected_data_nodes` and `gateway.expected_master_nodes`
 settings are also supported. For example setting:
 
 [source,js]

--- a/src/main/java/org/elasticsearch/gateway/GatewayService.java
+++ b/src/main/java/org/elasticsearch/gateway/GatewayService.java
@@ -151,7 +151,7 @@ public class GatewayService extends AbstractLifecycleComponent<GatewayService> i
             if (expectedNodes == -1 && expectedMasterNodes == -1 && expectedDataNodes == -1) {
                 // no expected is set, honor the setting if they are there
                 enforceRecoverAfterTime = true;
-                reason = "recovery_after_time was set to [" + recoverAfterTime + "]";
+                reason = "recover_after_time was set to [" + recoverAfterTime + "]";
             } else {
                 // one of the expected is set, see if all of them meet the need, and ignore the timeout in this case
                 enforceRecoverAfterTime = false;
@@ -181,7 +181,7 @@ public class GatewayService extends AbstractLifecycleComponent<GatewayService> i
                     @Override
                     public void run() {
                         if (recovered.compareAndSet(false, true)) {
-                            logger.info("recovery_after_time [{}] elapsed. performing state recovery...", recoverAfterTime);
+                            logger.info("recover_after_time [{}] elapsed. performing state recovery...", recoverAfterTime);
                             gateway.performStateRecovery(recoveryListener);
                         }
                     }


### PR DESCRIPTION
There were a few references to the setting `gateway.recovery_after_time`, which should instead be `gateway.recover_after_time`.

I'm new to contributing to Elasticsearch, so I'm not sure if I need to submit similar changes to the elasticsearch/docs repository as well. Let me know if so and I'll be happy to make them there as well.
