### PR TITLE
AbstractBlobContainer.deleteByPrefix() should not list all blobs

### DIFF
--- a/src/main/java/org/elasticsearch/common/blobstore/BlobContainer.java
+++ b/src/main/java/org/elasticsearch/common/blobstore/BlobContainer.java
@@ -30,13 +30,6 @@ import java.io.OutputStream;
  */
 public interface BlobContainer {
 
-    interface BlobNameFilter {
-        /**
-         * Return <tt>false</tt> if the blob should be filtered.
-         */
-        boolean accept(String blobName);
-    }
-
     BlobPath path();
 
     boolean blobExists(String blobName);
@@ -62,11 +55,6 @@ public interface BlobContainer {
      * Deletes all blobs in the container that match the specified prefix.
      */
     void deleteBlobsByPrefix(String blobNamePrefix) throws IOException;
-
-    /**
-     * Deletes all blobs in the container that match the supplied filter.
-     */
-    void deleteBlobsByFilter(BlobNameFilter filter) throws IOException;
 
     /**
      * Lists all blobs in the container

--- a/src/main/java/org/elasticsearch/common/blobstore/support/AbstractBlobContainer.java
+++ b/src/main/java/org/elasticsearch/common/blobstore/support/AbstractBlobContainer.java
@@ -24,7 +24,7 @@ import org.elasticsearch.common.blobstore.BlobContainer;
 import org.elasticsearch.common.blobstore.BlobMetaData;
 import org.elasticsearch.common.blobstore.BlobPath;
 
-import java.io.*;
+import java.io.IOException;
 
 /**
  *
@@ -43,35 +43,10 @@ public abstract class AbstractBlobContainer implements BlobContainer {
     }
 
     @Override
-    public ImmutableMap<String, BlobMetaData> listBlobsByPrefix(String blobNamePrefix) throws IOException {
-        ImmutableMap<String, BlobMetaData> allBlobs = listBlobs();
-        ImmutableMap.Builder<String, BlobMetaData> blobs = ImmutableMap.builder();
-        for (BlobMetaData blob : allBlobs.values()) {
-            if (blob.name().startsWith(blobNamePrefix)) {
-                blobs.put(blob.name(), blob);
-            }
-        }
-        return blobs.build();
-    }
-
-    @Override
     public void deleteBlobsByPrefix(final String blobNamePrefix) throws IOException {
-        deleteBlobsByFilter(new BlobNameFilter() {
-            @Override
-            public boolean accept(String blobName) {
-                return blobName.startsWith(blobNamePrefix);
-            }
-        });
-    }
-
-    @Override
-    public void deleteBlobsByFilter(BlobNameFilter filter) throws IOException {
-        ImmutableMap<String, BlobMetaData> blobs = listBlobs();
+        ImmutableMap<String, BlobMetaData> blobs = listBlobsByPrefix(blobNamePrefix);
         for (BlobMetaData blob : blobs.values()) {
-            if (filter.accept(blob.name())) {
-                deleteBlob(blob.name());
-            }
+            deleteBlob(blob.name());
         }
     }
-
 }

--- a/src/main/java/org/elasticsearch/common/blobstore/url/URLBlobContainer.java
+++ b/src/main/java/org/elasticsearch/common/blobstore/url/URLBlobContainer.java
@@ -69,6 +69,14 @@ public class URLBlobContainer extends AbstractBlobContainer {
         throw new UnsupportedOperationException("URL repository doesn't support this operation");
     }
 
+    /**
+     * This operation is not supported by URLBlobContainer
+     */
+    @Override
+    public ImmutableMap<String, BlobMetaData> listBlobsByPrefix(String blobNamePrefix) throws IOException {
+        throw new UnsupportedOperationException("URL repository doesn't support this operation");
+    }
+
     @Override
     public void move(String from, String to) throws IOException {
         throw new UnsupportedOperationException("URL repository doesn't support this operation");

--- a/src/test/java/org/elasticsearch/snapshots/mockstore/BlobContainerWrapper.java
+++ b/src/test/java/org/elasticsearch/snapshots/mockstore/BlobContainerWrapper.java
@@ -19,9 +19,9 @@
 package org.elasticsearch.snapshots.mockstore;
 
 import com.google.common.collect.ImmutableMap;
+import org.elasticsearch.common.blobstore.BlobContainer;
 import org.elasticsearch.common.blobstore.BlobMetaData;
 import org.elasticsearch.common.blobstore.BlobPath;
-import org.elasticsearch.common.blobstore.BlobContainer;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -65,11 +65,6 @@ public class BlobContainerWrapper implements BlobContainer {
     @Override
     public void deleteBlobsByPrefix(String blobNamePrefix) throws IOException {
         delegate.deleteBlobsByPrefix(blobNamePrefix);
-    }
-
-    @Override
-    public void deleteBlobsByFilter(BlobNameFilter filter) throws IOException {
-        delegate.deleteBlobsByFilter(filter);
     }
 
     @Override

--- a/src/test/java/org/elasticsearch/snapshots/mockstore/MockRepository.java
+++ b/src/test/java/org/elasticsearch/snapshots/mockstore/MockRepository.java
@@ -21,15 +21,14 @@ package org.elasticsearch.snapshots.mockstore;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.metadata.SnapshotId;
+import org.elasticsearch.common.blobstore.BlobContainer;
 import org.elasticsearch.common.blobstore.BlobMetaData;
 import org.elasticsearch.common.blobstore.BlobPath;
 import org.elasticsearch.common.blobstore.BlobStore;
-import org.elasticsearch.common.blobstore.BlobContainer;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.snapshots.IndexShardRepository;
@@ -49,7 +48,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static com.carrotsearch.randomizedtesting.RandomizedTest.randomAsciiOfLength;
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 
 /**
@@ -289,12 +287,6 @@ public class MockRepository extends FsRepository {
             public void deleteBlobsByPrefix(String blobNamePrefix) throws IOException {
                 maybeIOExceptionOrBlock(blobNamePrefix);
                 super.deleteBlobsByPrefix(blobNamePrefix);
-            }
-
-            @Override
-            public void deleteBlobsByFilter(BlobNameFilter filter) throws IOException {
-                maybeIOExceptionOrBlock("");
-                super.deleteBlobsByFilter(filter);
             }
 
             @Override


### PR DESCRIPTION
The current implementation of AbstractBlobContainer.deleteByPrefix() calls AbstractBlobContainer.deleteBlobsByFilter() which calls BlobContainer.listBlobs() for deleting files, resulting in loading all files in order to delete few of them. This can be improved by calling BlobContainer.listBlobsByPrefix() directly.

This problem happened in #10344 when the repository verification process tries to delete a blob prefixed by "tests-" to ensure that the repository is accessible for the node. When doing so we have the following calling graph: BlobStoreRepository.endVerification() -> BlobContainer.deleteByPrefix() -> AbstractBlobContainer.deleteByPrefix() -> AbstractBlobContainer.deleteBlobsByFilter() -> BlobContainer.listBlobs()... and boom.

Also, AbstractBlobContainer.listBlobsByPrefix() and BlobContainer.deleteBlobsByFilter() can be removed because it has the same drawbacks as AbstractBlobContainer.deleteByPrefix() and also lists all blobs. Listing blobs by prefix can be done at the FsBlobContainer level.

The commit c623d90 will go in 1.5, 1.x and master, the commit 6bcc6e7 in 1.x and master only because it will break plugins.

Related to #10344 
