### PR TITLE
Scripting: add plugins category to supported scripted ops and related fine-grained settings

### DIFF
--- a/docs/reference/modules/scripting.asciidoc
+++ b/docs/reference/modules/scripting.asciidoc
@@ -302,12 +302,13 @@ supported operations are:
 | `mapping` |Mappings (script transform feature)
 | `search`  |Search api, Percolator api and Suggester api (e.g filters, script_fields)
 | `update`  |Update api
+| `plugins` |Any plugin that makes use of scripts
 |=======================================================================
 
 The following example disables scripting for `update` and `mapping` operations,
 regardless of the script source, for any engine. Scripts can still be
-executed from sandboxed languages as part of `aggregations` and `search`
-operations though, as the above defaults still get applied.
+executed from sandboxed languages as part of `aggregations`, `search`
+and `plugins` operations though, as the above defaults still get applied.
 
 [source,yaml]
 -----------------------------------
@@ -327,14 +328,17 @@ script.engine.groovy.file.aggs: on
 script.engine.groovy.file.mapping: on
 script.engine.groovy.file.search: on
 script.engine.groovy.file.update: on
+script.engine.groovy.file.plugins: on
 script.engine.groovy.indexed.aggs: on
 script.engine.groovy.indexed.mapping: off
 script.engine.groovy.indexed.search: on
 script.engine.groovy.indexed.update: off
+script.engine.groovy.indexed.plugins: off
 script.engine.groovy.inline.aggs: on
 script.engine.groovy.inline.mapping: off
 script.engine.groovy.inline.search: off
 script.engine.groovy.inline.update: off
+script.engine.groovy.inline.plugins: off
 
 -----------------------------------
 

--- a/src/main/java/org/elasticsearch/script/ScriptContext.java
+++ b/src/main/java/org/elasticsearch/script/ScriptContext.java
@@ -29,7 +29,8 @@ public enum ScriptContext {
     MAPPING,
     UPDATE,
     SEARCH,
-    AGGS;
+    AGGS,
+    PLUGINS;
 
     @Override
     public String toString() {


### PR DESCRIPTION
Plugins can make use of scripts and expose custom scripting features. Fine-grained settings introduced with #10116 don't support any custom use of scripts, hence plugins are forced to choose between update, mapping, search and aggs. This commit introduces a new generic plugins category that can be used by plugins.

Fine-grained settings apply as well: `script.plugins: off` disables any script type, for any language, only when scripts are used from plugins. `script.engine.groovy.inline.plugins: off` disables scripts when used as part of plugins, only for inline scripts and groovy language.

Relates to #10347
