### PR TITLE
Update get.asciidoc

### DIFF
--- a/docs/reference/docs/get.asciidoc
+++ b/docs/reference/docs/get.asciidoc
@@ -228,5 +228,7 @@ it's current version is equal to the specified one. This behavior is the same
 for all version types with the exception of version type `FORCE` which always
 retrieves the document.
 
-Note that even though Elasticsearch does not delete versions of documents in an index to ensure constant sequential writes, older versions of documents are treated as unreachable. Only the current version can be retrieved.
+Note that even though Elasticsearch does not delete versions of documents in
+an index to ensure constant sequential writes, older versions of documents are
+unreachable. Only the current version can be retrieved.
 

--- a/docs/reference/docs/get.asciidoc
+++ b/docs/reference/docs/get.asciidoc
@@ -228,7 +228,7 @@ it's current version is equal to the specified one. This behavior is the same
 for all version types with the exception of version type `FORCE` which always
 retrieves the document.
 
-Note that even though Elasticsearch does not delete versions of documents in
-an index to ensure constant sequential writes, older versions of documents are
-unreachable. Only the current version can be retrieved.
-
+Internally, Elasticsearch has marked the old document as deleted and added an
+entirely new document. The old version of the document doesn’t disappear
+immediately, although you won’t be able to access it. Elasticsearch cleans up
+deleted documents in the background as you continue to index more data.

--- a/docs/reference/docs/get.asciidoc
+++ b/docs/reference/docs/get.asciidoc
@@ -228,5 +228,5 @@ it's current version is equal to the specified one. This behavior is the same
 for all version types with the exception of version type `FORCE` which always
 retrieves the document.
 
-Note that Elasticsearch do not store older versions of documents. Only the current version can be retrieved.
+Note that even though Elasticsearch does not delete versions of documents in an index to ensure constant sequential writes, older versions of documents are treated as unreachable. Only the current version can be retrieved.
 


### PR DESCRIPTION
Updated to not mislead the reader that the data is actually gone when a document is updated. For example if you have 100GB of docs and update each one you'll only be able to access 100GB of the data, but there would theoretically be 200GB of doc data.
