### PR TITLE
Miscellaneous additional logging and cleanups

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/indices/flush/FlushRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/flush/FlushRequest.java
@@ -108,4 +108,10 @@ public class FlushRequest extends BroadcastOperationRequest<FlushRequest> {
         waitIfOngoing = in.readBoolean();
     }
 
+    @Override
+    public String toString() {
+        return "FlushRequest{" +
+                "waitIfOngoing=" + waitIfOngoing +
+                ", force=" + force + "}";
+    }
 }

--- a/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -147,6 +147,7 @@ public class InternalEngine extends Engine {
                 }
             }
         }
+        logger.trace("created new InternalEngine");
     }
 
     private SearcherManager createSearcherManager() throws EngineException {

--- a/src/main/java/org/elasticsearch/index/engine/ShadowEngine.java
+++ b/src/main/java/org/elasticsearch/index/engine/ShadowEngine.java
@@ -90,6 +90,7 @@ public class ShadowEngine extends Engine {
         } catch (IOException ex) {
             throw new EngineCreationFailureException(shardId, "failed to open index reader", ex);
         }
+        logger.trace("created new ShadowEngine");
     }
 
 

--- a/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -561,7 +561,7 @@ public class IndexShard extends AbstractIndexShardComponent {
     public void refresh(String source) throws ElasticsearchException {
         verifyNotClosed();
         if (logger.isTraceEnabled()) {
-            logger.trace("refresh with soruce: {}", source);
+            logger.trace("refresh with source: {}", source);
         }
         long time = System.nanoTime();
         engine().refresh(source);

--- a/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -291,7 +291,11 @@ public class IndicesService extends AbstractLifecycleComponent<IndicesService> i
 
         indicesLifecycle.beforeIndexCreated(index, settings);
 
-        logger.debug("creating Index [{}], shards [{}]/[{}]", sIndexName, settings.get(SETTING_NUMBER_OF_SHARDS), settings.get(SETTING_NUMBER_OF_REPLICAS));
+        logger.debug("creating Index [{}], shards [{}]/[{}{}]",
+                sIndexName,
+                settings.get(SETTING_NUMBER_OF_SHARDS),
+                settings.get(SETTING_NUMBER_OF_REPLICAS),
+                IndexMetaData.isIndexUsingShadowReplicas(settings) ? "s" : "");
 
         Settings indexSettings = settingsBuilder()
                 .put(this.settings)

--- a/src/test/java/org/elasticsearch/index/IndexWithShadowReplicasTests.java
+++ b/src/test/java/org/elasticsearch/index/IndexWithShadowReplicasTests.java
@@ -47,10 +47,7 @@ import java.util.concurrent.ExecutionException;
 import static com.google.common.collect.Lists.newArrayList;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.*;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.*;
 
 /**
  * Tests for indices that use shadow replicas and a shared filesystem
@@ -120,7 +117,7 @@ public class IndexWithShadowReplicasTests extends ElasticsearchIntegrationTest {
 
     }
 
-        @Test
+    @Test
     public void testIndexWithFewDocuments() throws Exception {
         Settings nodeSettings = ImmutableSettings.builder()
                 .put("node.add_id_to_custom_path", false)


### PR DESCRIPTION
This fixes an issue where this was logged:

```
[node_t1] [test][0] flush with org.elasticsearch.action.admin.indices.flush.FlushRequest@65f6f1e
```

by adding a .toString() method to FlushRequest.

It also changes:

```
creating Index [test], shards [1]/[2]
```

to:

```
creating Index [test], shards [1]/[2s]
```

If shadow replicas are being used.
