### PR TITLE
Aggregations: Add autocorrelation agg

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,6 +201,14 @@
         </dependency>
         <!-- Lucene spatial -->
 
+        <!-- Needed for ACF and FFT reducers -->
+        <dependency>
+            <groupId>com.github.wendykierp</groupId>
+            <artifactId>JTransforms</artifactId>
+            <version>3.0</version>
+        </dependency>
+        <!-- End Reducers -->
+
 
         <!-- START: dependencies that are shaded -->
         <dependency>

--- a/src/main/java/org/elasticsearch/action/percolate/PercolateShardResponse.java
+++ b/src/main/java/org/elasticsearch/action/percolate/PercolateShardResponse.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.action.percolate;
 
 import com.google.common.collect.ImmutableList;
+
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -26,6 +27,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.percolator.PercolateContext;
 import org.elasticsearch.search.aggregations.InternalAggregations;
+import org.elasticsearch.search.aggregations.reducers.SiblingReducer;
 import org.elasticsearch.search.highlight.HighlightField;
 import org.elasticsearch.search.query.QuerySearchResult;
 
@@ -51,6 +53,7 @@ public class PercolateShardResponse extends BroadcastShardOperationResponse {
     private int requestedSize;
 
     private InternalAggregations aggregations;
+    private List<SiblingReducer> reducers;
 
     PercolateShardResponse() {
         hls = new ArrayList<>();
@@ -68,6 +71,9 @@ public class PercolateShardResponse extends BroadcastShardOperationResponse {
         if (result != null) {
             if (result.aggregations() != null) {
                 this.aggregations = (InternalAggregations) result.aggregations();
+            }
+            if (result.reducers() != null) {
+                this.reducers = result.reducers();
             }
         }
     }
@@ -110,6 +116,10 @@ public class PercolateShardResponse extends BroadcastShardOperationResponse {
 
     public InternalAggregations aggregations() {
         return aggregations;
+    }
+
+    public List<SiblingReducer> reducers() {
+        return reducers;
     }
 
     public byte percolatorTypeId() {

--- a/src/main/java/org/elasticsearch/search/aggregations/AbstractAggregationBuilder.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/AbstractAggregationBuilder.java
@@ -25,7 +25,7 @@ import org.elasticsearch.common.xcontent.ToXContent;
  */
 public abstract class AbstractAggregationBuilder implements ToXContent {
 
-    private final String name;
+    protected final String name;
     protected final String type;
 
     /**

--- a/src/main/java/org/elasticsearch/search/aggregations/AggregationModule.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/AggregationModule.java
@@ -56,6 +56,7 @@ import org.elasticsearch.search.aggregations.metrics.sum.SumParser;
 import org.elasticsearch.search.aggregations.metrics.tophits.TopHitsParser;
 import org.elasticsearch.search.aggregations.metrics.valuecount.ValueCountParser;
 import org.elasticsearch.search.aggregations.reducers.Reducer;
+import org.elasticsearch.search.aggregations.reducers.bucketmetrics.MaxBucketParser;
 import org.elasticsearch.search.aggregations.reducers.derivative.DerivativeParser;
 
 import java.util.List;
@@ -101,6 +102,7 @@ public class AggregationModule extends AbstractModule implements SpawnModules{
         aggParsers.add(ChildrenParser.class);
 
         reducerParsers.add(DerivativeParser.class);
+        reducerParsers.add(MaxBucketParser.class);
     }
 
     /**

--- a/src/main/java/org/elasticsearch/search/aggregations/AggregationModule.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/AggregationModule.java
@@ -56,7 +56,9 @@ import org.elasticsearch.search.aggregations.metrics.sum.SumParser;
 import org.elasticsearch.search.aggregations.metrics.tophits.TopHitsParser;
 import org.elasticsearch.search.aggregations.metrics.valuecount.ValueCountParser;
 import org.elasticsearch.search.aggregations.reducers.Reducer;
+import org.elasticsearch.search.aggregations.reducers.acf.InternalAcfValues;
 import org.elasticsearch.search.aggregations.reducers.bucketmetrics.MaxBucketParser;
+import org.elasticsearch.search.aggregations.reducers.acf.AcfParser;
 import org.elasticsearch.search.aggregations.reducers.derivative.DerivativeParser;
 
 import java.util.List;
@@ -103,6 +105,7 @@ public class AggregationModule extends AbstractModule implements SpawnModules{
 
         reducerParsers.add(DerivativeParser.class);
         reducerParsers.add(MaxBucketParser.class);
+        reducerParsers.add(AcfParser.class);
     }
 
     /**

--- a/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactories.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactories.java
@@ -213,14 +213,18 @@ public class AggregatorFactories {
                 temporarilyMarked.add(factory);
                 String[] bucketsPaths = factory.getBucketsPaths();
                 for (String bucketsPath : bucketsPaths) {
-                    ReducerFactory matchingFactory = reducerFactoriesMap.get(bucketsPath);
-                    if (bucketsPath.equals("_count") || bucketsPath.equals("_key") || aggFactoryNames.contains(bucketsPath)) {
+                    int aggSepIndex = bucketsPath.indexOf('>');
+                    String firstAggName = aggSepIndex == -1 ? bucketsPath : bucketsPath.substring(0, aggSepIndex);
+                    if (bucketsPath.equals("_count") || bucketsPath.equals("_key") || aggFactoryNames.contains(firstAggName)) {
                         continue;
-                    } else if (matchingFactory != null) {
-                        resolveReducerOrder(aggFactoryNames, reducerFactoriesMap, orderedReducers, unmarkedFactories, temporarilyMarked,
-                                matchingFactory);
                     } else {
-                        throw new ElasticsearchIllegalStateException("No reducer found for path [" + bucketsPath + "]");
+                        ReducerFactory matchingFactory = reducerFactoriesMap.get(firstAggName);
+                        if (matchingFactory != null) {
+                            resolveReducerOrder(aggFactoryNames, reducerFactoriesMap, orderedReducers, unmarkedFactories,
+                                    temporarilyMarked, matchingFactory);
+                        } else {
+                            throw new ElasticsearchIllegalStateException("No aggregation found for path [" + bucketsPath + "]");
+                        }
                     }
                 }
                 unmarkedFactories.remove(factory);

--- a/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactories.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactories.java
@@ -56,7 +56,7 @@ public class AggregatorFactories {
     public List<Reducer> createReducers() throws IOException {
         List<Reducer> reducers = new ArrayList<>();
         for (ReducerFactory factory : this.reducerFactories) {
-            reducers.add(factory.create(null, null, false)); // NOCOMIT add context, parent etc.
+            reducers.add(factory.create());
         }
         return reducers;
     }

--- a/src/main/java/org/elasticsearch/search/aggregations/InternalAggregation.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/InternalAggregation.java
@@ -255,6 +255,7 @@ public abstract class InternalAggregation implements Aggregation, ToXContent, St
         public static final XContentBuilderString VALUE = new XContentBuilderString("value");
         public static final XContentBuilderString VALUES = new XContentBuilderString("values");
         public static final XContentBuilderString VALUE_AS_STRING = new XContentBuilderString("value_as_string");
+        public static final XContentBuilderString VALUES_AS_STRING = new XContentBuilderString("values_as_string");
         public static final XContentBuilderString DOC_COUNT = new XContentBuilderString("doc_count");
         public static final XContentBuilderString KEY = new XContentBuilderString("key");
         public static final XContentBuilderString KEY_AS_STRING = new XContentBuilderString("key_as_string");

--- a/src/main/java/org/elasticsearch/search/aggregations/TransportAggregationModule.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/TransportAggregationModule.java
@@ -58,6 +58,8 @@ import org.elasticsearch.search.aggregations.metrics.sum.InternalSum;
 import org.elasticsearch.search.aggregations.metrics.tophits.InternalTopHits;
 import org.elasticsearch.search.aggregations.metrics.valuecount.InternalValueCount;
 import org.elasticsearch.search.aggregations.reducers.InternalSimpleValue;
+import org.elasticsearch.search.aggregations.reducers.bucketmetrics.InternalBucketMetricValue;
+import org.elasticsearch.search.aggregations.reducers.bucketmetrics.MaxBucketReducer;
 import org.elasticsearch.search.aggregations.reducers.derivative.DerivativeReducer;
 
 /**
@@ -104,10 +106,12 @@ public class TransportAggregationModule extends AbstractModule implements SpawnM
         InternalTopHits.registerStreams();
         InternalGeoBounds.registerStream();
         InternalChildren.registerStream();
-        InternalSimpleValue.registerStreams();
 
         // Reducers
         DerivativeReducer.registerStreams();
+        InternalSimpleValue.registerStreams();
+        InternalBucketMetricValue.registerStreams();
+        MaxBucketReducer.registerStreams();
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/TransportAggregationModule.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/TransportAggregationModule.java
@@ -58,8 +58,10 @@ import org.elasticsearch.search.aggregations.metrics.sum.InternalSum;
 import org.elasticsearch.search.aggregations.metrics.tophits.InternalTopHits;
 import org.elasticsearch.search.aggregations.metrics.valuecount.InternalValueCount;
 import org.elasticsearch.search.aggregations.reducers.InternalSimpleValue;
+import org.elasticsearch.search.aggregations.reducers.acf.InternalAcfValues;
 import org.elasticsearch.search.aggregations.reducers.bucketmetrics.InternalBucketMetricValue;
 import org.elasticsearch.search.aggregations.reducers.bucketmetrics.MaxBucketReducer;
+import org.elasticsearch.search.aggregations.reducers.acf.AcfReducer;
 import org.elasticsearch.search.aggregations.reducers.derivative.DerivativeReducer;
 
 /**
@@ -106,12 +108,14 @@ public class TransportAggregationModule extends AbstractModule implements SpawnM
         InternalTopHits.registerStreams();
         InternalGeoBounds.registerStream();
         InternalChildren.registerStream();
+        InternalAcfValues.registerStreams();        // Reducer, but output behaves as an agg (e.g. can be top-level)
 
         // Reducers
         DerivativeReducer.registerStreams();
         InternalSimpleValue.registerStreams();
         InternalBucketMetricValue.registerStreams();
         MaxBucketReducer.registerStreams();
+        AcfReducer.registerStreams();
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/reducers/Reducer.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/reducers/Reducer.java
@@ -19,11 +19,14 @@
 
 package org.elasticsearch.search.aggregations.reducers;
 
+import com.google.common.base.Function;
+
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregation.ReduceContext;
 import org.elasticsearch.search.aggregations.InternalAggregation.Type;
@@ -65,6 +68,13 @@ public abstract class Reducer implements Streamable {
         ReducerFactory parse(String reducerName, XContentParser parser, SearchContext context) throws IOException;
 
     }
+
+    public static final Function<Aggregation, InternalAggregation> FUNCTION = new Function<Aggregation, InternalAggregation>() {
+        @Override
+        public InternalAggregation apply(Aggregation input) {
+            return (InternalAggregation) input;
+        }
+    };
 
     private String name;
     private String[] bucketsPaths;

--- a/src/main/java/org/elasticsearch/search/aggregations/reducers/ReducerBuilder.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/reducers/ReducerBuilder.java
@@ -21,6 +21,7 @@ package org.elasticsearch.search.aggregations.reducers;
 
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
 
 import java.io.IOException;
 import java.util.Map;
@@ -28,19 +29,17 @@ import java.util.Map;
 /**
  * A base class for all reducer builders.
  */
-public abstract class ReducerBuilder<B extends ReducerBuilder<B>> implements ToXContent {
+public abstract class ReducerBuilder<B extends ReducerBuilder<B>> extends AbstractAggregationBuilder implements ToXContent {
 
-    private final String name;
-    protected final String type;
     private String[] bucketsPaths;
     private Map<String, Object> metaData;
+
 
     /**
      * Sole constructor, typically used by sub-classes.
      */
     protected ReducerBuilder(String name, String type) {
-        this.name = name;
-        this.type = type;
+        super(name, type);
     }
 
     /**

--- a/src/main/java/org/elasticsearch/search/aggregations/reducers/ReducerBuilders.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/reducers/ReducerBuilders.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.search.aggregations.reducers;
 
+import org.elasticsearch.search.aggregations.reducers.acf.AcfBuilder;
 import org.elasticsearch.search.aggregations.reducers.derivative.DerivativeBuilder;
 
 public final class ReducerBuilders {
@@ -28,5 +29,9 @@ public final class ReducerBuilders {
 
     public static final DerivativeBuilder derivative(String name) {
         return new DerivativeBuilder(name);
+    }
+
+    public static final AcfBuilder acf(String name) {
+        return new AcfBuilder(name);
     }
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/reducers/ReducerFactory.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/reducers/ReducerFactory.java
@@ -20,7 +20,6 @@ package org.elasticsearch.search.aggregations.reducers;
 
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
-import org.elasticsearch.search.aggregations.support.AggregationContext;
 
 import java.io.IOException;
 import java.util.List;
@@ -62,8 +61,7 @@ public abstract class ReducerFactory {
         doValidate(parent, factories, reducerFactories);
     }
 
-    protected abstract Reducer createInternal(AggregationContext context, Aggregator parent, boolean collectsFromSingleBucket,
-            Map<String, Object> metaData) throws IOException;
+    protected abstract Reducer createInternal(Map<String, Object> metaData) throws IOException;
 
     /**
      * Creates the reducer
@@ -81,8 +79,8 @@ public abstract class ReducerFactory {
      * 
      * @return The created aggregator
      */
-    public final Reducer create(AggregationContext context, Aggregator parent, boolean collectsFromSingleBucket) throws IOException {
-        Reducer aggregator = createInternal(context, parent, collectsFromSingleBucket, this.metaData);
+    public final Reducer create() throws IOException {
+        Reducer aggregator = createInternal(this.metaData);
         return aggregator;
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/reducers/SiblingReducer.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/reducers/SiblingReducer.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.reducers;
+
+import org.elasticsearch.search.aggregations.Aggregation;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.InternalAggregation.ReduceContext;
+import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
+import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation.Bucket;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public abstract class SiblingReducer extends Reducer {
+
+    protected SiblingReducer() { // for Serialisation
+        super();
+    }
+
+    protected SiblingReducer(String name, String[] bucketsPaths, Map<String, Object> metaData) {
+        super(name, bucketsPaths, metaData);
+    }
+
+    @Override
+    public InternalAggregation reduce(InternalAggregation aggregation, ReduceContext reduceContext) {
+        InternalMultiBucketAggregation multiBucketsAgg = (InternalMultiBucketAggregation) aggregation;
+        List<? extends Bucket> buckets = multiBucketsAgg.getBuckets();
+        List<Bucket> newBuckets = new ArrayList<>();
+        for (int i = 0; i < buckets.size(); i++) {
+            Bucket bucket = buckets.get(i);
+            InternalAggregation aggToAdd = doReduce(bucket.getAggregations().asList(), reduceContext);
+            Bucket newBucket = bucket; // NOCOMMIT Add aggToAdd to bucket using factory methods from https://github.com/elastic/elasticsearch/pull/9996
+            newBuckets.add(newBucket);
+        }
+
+        return multiBucketsAgg; // NOCOMMIT recreate agg with newBuckets using factory methods from https://github.com/elastic/elasticsearch/pull/9996
+    }
+
+    public abstract InternalAggregation doReduce(List<Aggregation> aggregations, ReduceContext context);
+}

--- a/src/main/java/org/elasticsearch/search/aggregations/reducers/acf/AcfBuilder.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/reducers/acf/AcfBuilder.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.reducers.acf;
+
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.search.aggregations.reducers.ReducerBuilder;
+
+import java.io.IOException;
+
+import static org.elasticsearch.search.aggregations.reducers.BucketHelpers.GapPolicy;
+
+public class AcfBuilder extends ReducerBuilder<AcfBuilder> {
+
+    private String format;
+    private GapPolicy gapPolicy;
+    private Boolean zeroPad = true;
+    private Boolean normalize = true;
+    private Boolean zeroMean = true;
+    private Integer window = 5;
+
+    public AcfBuilder(String name) {
+        super(name, AcfReducer.TYPE.name());
+    }
+
+    public AcfBuilder format(String format) {
+        this.format = format;
+        return this;
+    }
+
+    public AcfBuilder gapPolicy(GapPolicy gapPolicy) {
+        this.gapPolicy = gapPolicy;
+        return this;
+    }
+
+    public AcfBuilder settings(AcfSettings settings) {
+        this.zeroPad = settings.isZeroPad();
+        this.normalize = settings.isNormalize();
+        this.zeroMean = settings.isZeroMean();
+        this.window = settings.getWindow();
+        return this;
+    }
+
+    public AcfBuilder zeroPad(boolean zeroPad) {
+        this.zeroPad = zeroPad;
+        return this;
+    }
+
+    public AcfBuilder normalize(boolean normalize) {
+        this.normalize = normalize;
+        return this;
+    }
+
+    public AcfBuilder zeroMean(boolean zeroMean) {
+        this.zeroMean = zeroMean;
+        return this;
+    }
+
+    public AcfBuilder window(int window) {
+        this.window = window;
+        return this;
+    }
+
+    @Override
+    protected XContentBuilder internalXContent(XContentBuilder builder, Params params) throws IOException {
+        if (format != null) {
+            builder.field(AcfParser.FORMAT.getPreferredName(), format);
+        }
+        if (gapPolicy != null) {
+            builder.field(AcfParser.GAP_POLICY.getPreferredName(), gapPolicy.getName());
+        }
+        if (zeroPad != null) {
+            builder.field(AcfParser.ZERO_PAD.getPreferredName(), zeroPad);
+        }
+        if (normalize != null) {
+            builder.field(AcfParser.NORMALIZE.getPreferredName(), normalize);
+        }
+        if (zeroMean != null) {
+            builder.field(AcfParser.ZERO_MEAN.getPreferredName(), zeroMean);
+        }
+        if (window != null) {
+            builder.field(AcfParser.WINDOW.getPreferredName(), window);
+        }
+        return builder;
+    }
+
+}

--- a/src/main/java/org/elasticsearch/search/aggregations/reducers/acf/AcfParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/reducers/acf/AcfParser.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.reducers.acf;
+
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.search.SearchParseException;
+import org.elasticsearch.search.aggregations.reducers.Reducer;
+import org.elasticsearch.search.aggregations.reducers.ReducerFactory;
+import org.elasticsearch.search.aggregations.support.format.ValueFormat;
+import org.elasticsearch.search.aggregations.support.format.ValueFormatter;
+import org.elasticsearch.search.internal.SearchContext;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.elasticsearch.search.aggregations.reducers.BucketHelpers.GapPolicy;
+
+public class AcfParser implements Reducer.Parser {
+
+    public static final ParseField FORMAT = new ParseField("format");
+    public static final ParseField GAP_POLICY = new ParseField("gap_policy");
+    public static final ParseField ZERO_PAD = new ParseField("zero_pad");
+    public static final ParseField NORMALIZE = new ParseField("normalize");
+    public static final ParseField ZERO_MEAN = new ParseField("zero_mean");
+    public static final ParseField WINDOW = new ParseField("window");
+
+
+
+    @Override
+    public String type() {
+        return AcfReducer.TYPE.name();
+    }
+
+    @Override
+    public ReducerFactory parse(String reducerName, XContentParser parser, SearchContext context) throws IOException {
+        XContentParser.Token token;
+        String currentFieldName = null;
+        String[] bucketsPaths = null;
+        String format = null;
+        GapPolicy gapPolicy = GapPolicy.IGNORE;
+
+        Boolean zeroPad = null;
+        Boolean normalize = null;
+        Boolean zeroMean = null;
+        Integer window = null;
+
+
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                currentFieldName = parser.currentName();
+            } else if (token == XContentParser.Token.VALUE_STRING) {
+                if (FORMAT.match(currentFieldName)) {
+                    format = parser.text();
+                } else if (BUCKETS_PATH.match(currentFieldName)) {
+                    bucketsPaths = new String[] { parser.text() };
+                } else if (GAP_POLICY.match(currentFieldName)) {
+                    gapPolicy = GapPolicy.parse(context, parser.text());
+                } else {
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + reducerName + "]: ["
+                            + currentFieldName + "].");
+                }
+            } else if (token == XContentParser.Token.VALUE_BOOLEAN) {
+                if (ZERO_PAD.match(currentFieldName)) {
+                    zeroPad = parser.booleanValue();
+                } else if (ZERO_MEAN.match(currentFieldName)) {
+                    zeroMean = parser.booleanValue();
+                } else if (NORMALIZE.match(currentFieldName)) {
+                    normalize = parser.booleanValue();
+                } else {
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + reducerName + "]: ["
+                            + currentFieldName + "].");
+                }
+            } else if (token == XContentParser.Token.VALUE_NUMBER) {
+                if (WINDOW.match(currentFieldName)) {
+                    window = parser.intValue();
+                }  else {
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + reducerName + "]: ["
+                            + currentFieldName + "].");
+                }
+            }else if (token == XContentParser.Token.START_ARRAY) {
+                if (BUCKETS_PATH.match(currentFieldName)) {
+                    List<String> paths = new ArrayList<>();
+                    while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
+                        String path = parser.text();
+                        paths.add(path);
+                    }
+                    bucketsPaths = paths.toArray(new String[paths.size()]);
+                } else {
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + reducerName + "]: ["
+                            + currentFieldName + "].");
+                }
+            } else {
+                throw new SearchParseException(context, "Unexpected token " + token + " in [" + reducerName + "].");
+            }
+        }
+
+        if (bucketsPaths == null) {
+            throw new SearchParseException(context, "Missing required field [" + BUCKETS_PATH.getPreferredName()
+                    + "] for derivative aggregation [" + reducerName + "]");
+        }
+
+        ValueFormatter formatter = null;
+        if (format != null) {
+            formatter = ValueFormat.Patternable.Number.format(format).formatter();
+        }
+
+        AcfSettings acfSettings = new AcfSettings();
+
+        // Then set individual flags if user specified
+        if (zeroPad != null) {
+            acfSettings.setZeroPad(zeroPad);
+        }
+
+        if (normalize != null) {
+            acfSettings.setNormalize(normalize);
+        }
+
+        if (zeroMean != null) {
+            acfSettings.setZeroMean(zeroMean);
+        }
+
+        if (window != null) {
+            acfSettings.setWindow(window);
+        }
+
+        return new AcfReducer.Factory(reducerName, bucketsPaths, formatter, gapPolicy, acfSettings);
+    }
+
+}

--- a/src/main/java/org/elasticsearch/search/aggregations/reducers/acf/AcfReducer.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/reducers/acf/AcfReducer.java
@@ -1,0 +1,262 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.reducers.acf;
+
+import com.google.common.base.Function;
+import org.elasticsearch.ElasticsearchIllegalStateException;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.search.aggregations.*;
+import org.elasticsearch.search.aggregations.InternalAggregation.ReduceContext;
+import org.elasticsearch.search.aggregations.InternalAggregation.Type;
+import org.elasticsearch.search.aggregations.bucket.histogram.HistogramAggregator;
+import org.elasticsearch.search.aggregations.bucket.histogram.InternalHistogram;
+import org.elasticsearch.search.aggregations.reducers.*;
+import org.elasticsearch.search.aggregations.reducers.BucketHelpers.GapPolicy;
+import org.elasticsearch.search.aggregations.support.AggregationPath;
+import org.elasticsearch.search.aggregations.support.format.ValueFormatter;
+import org.elasticsearch.search.aggregations.support.format.ValueFormatterStreams;
+import org.jtransforms.fft.DoubleFFT_1D;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.search.aggregations.reducers.BucketHelpers.resolveBucketValue;
+
+
+public class AcfReducer extends SiblingReducer {
+
+    public final static Type TYPE = new Type("acf");
+
+    public final static ReducerStreams.Stream STREAM = new ReducerStreams.Stream() {
+        @Override
+        public AcfReducer readResult(StreamInput in) throws IOException {
+            AcfReducer result = new AcfReducer();
+            result.readFrom(in);
+            return result;
+        }
+    };
+
+    public static void registerStreams() {
+        ReducerStreams.registerStream(STREAM, TYPE.stream());
+    }
+
+
+    private ValueFormatter formatter;
+    private GapPolicy gapPolicy;
+    private AcfSettings settings;
+
+    public AcfReducer() {
+    }
+
+    public AcfReducer(String name, String[] bucketsPaths, @Nullable ValueFormatter formatter, GapPolicy gapPolicy,
+                      AcfSettings settings,  Map<String, Object> metadata) {
+        super(name, bucketsPaths, metadata);
+        this.formatter = formatter;
+        this.gapPolicy = gapPolicy;
+        this.settings = settings;
+    }
+
+    @Override
+    public Type type() {
+        return TYPE;
+    }
+
+    @Override
+    public InternalAggregation doReduce(Aggregations aggregations, ReduceContext context) {
+
+        List<String> bucketsPath = AggregationPath.parse(bucketsPaths()[0]).getPathElementsAsStringList();
+
+        int window = settings.getWindow();
+
+        for (Aggregation aggregation : aggregations) {
+            if (aggregation.getName().equals(bucketsPath.get(0))) {
+
+                bucketsPath = bucketsPath.subList(1, bucketsPath.size());
+
+                InternalHistogram histo = (InternalHistogram) aggregation;
+                List<? extends InternalHistogram.Bucket> buckets = histo.getBuckets();
+
+                double[] values;
+                if (settings.isZeroPad()) {
+                    // we need to pad with `n` zeros so that it doesn't wrap
+                    // But ideally we pad with a power of 2 for performance
+                    // (although JTransforms supports non-power 2... TODO benchmark if it matters?)
+                    int pad = Integer.highestOneBit((window * 2) - 1);
+                    values = new double[pad << 1];
+                } else {
+                    values = new double[window];
+                }
+
+
+                int counter = 0;
+                for (int i = buckets.size() - window; i < window; i++) {
+                    values[counter] = resolveBucketValue(histo, buckets.get(i), bucketsPath.get(0), gapPolicy);
+                    counter += 1;
+                }
+
+                // Consumes values and updates in place
+                fftAutoCorrelate(values);
+
+                if (settings.isZeroPad()) {
+                    values = Arrays.copyOfRange(values, 0, settings.getWindow());
+                }
+
+                return new InternalAcfValues(name(), values, formatter, Collections.EMPTY_LIST, metaData());
+
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Find the autocorrelation for a time series.  Assumes no gaps in the data!
+     *
+     * @param values Data in time-domain.  Values are consumed and updated in-place! The
+     *               autocorrelation result will be in <code>values</code> after the method returns.
+     */
+    private void fftAutoCorrelate(double[] values) {
+
+        DoubleFFT_1D fft = new DoubleFFT_1D(values.length);
+        int window = settings.getWindow();
+
+        // FFT returns complex numbers in the original array, layout depends on odd/even-ness of length
+        fft.realForward(values);
+
+        // calculate the power spectral density.  Autocovariance is the inverse FFT of the PSD
+        computePSD(values);
+
+        // invert to get back to time-domain
+        fft.realInverse(values, true);
+
+        // If we zero-padded, we need to calculate a mask to correct the AC.
+        // Mask is set to 1 where original signal was, 0 for padding
+        // The mask goes through the same FFT->PSD->iFFT process
+        if (settings.isZeroPad()) {
+            double[] mask = new double[values.length];
+            Arrays.fill(mask, 0, window, 1.0);
+
+            fft.realForward(mask);
+            computePSD(mask);
+            fft.realInverse(mask, true);
+
+            for (int i = 0; i < window; i++) {
+                values[i] /= mask[i];
+            }
+        }
+
+        // Normalization converts the autocovariance into an autocorrelation
+        if (settings.isNormalize()) {
+            // Divide by variance.  Use window as size, since we may have padded
+            for (int i = 1; i < window; i++) {
+                values[i] /= values[0];
+            }
+            values[0] = 1;
+        }
+    }
+
+    /**
+     * Computer power spectral density of the FFT.
+     *
+     * @param values array containing a freq-domain series from an FFT.
+     *               This is consumed and updated in-place!
+     */
+    private void computePSD(double[] values){
+        int length = values.length;
+
+        // First FFT bin is 0Hz.
+        // zeroing out the first bin is equivalent to "centering" the series.  E.g. dividing by the mean
+        if (settings.isZeroMean()) {
+            values[0] = 0;
+        } else {
+            // Calculate the PSD if we don't want to zero it out
+            values[0] = Math.pow(values[0], 2);
+        }
+
+        if (length % 2 == 0) {
+            values[1] = Math.pow(values[1], 2);
+            //values[1] = 0;
+
+            for (int i = 2; i < length; i += 2) {
+                // PSD is the magnitude of the complex number, squared
+                // psd = (sqrt(r^2 + i^2))^2
+                //     = r^2 + i^2
+                values[i] = Math.pow(values[i], 2) + Math.pow(values[i+1], 2);
+                values[i+1] = 0;
+            }
+        } else {
+            int i = 2;
+            for (; i < length - 1; i += 2) {
+                values[i] = Math.pow(values[i], 2) + Math.pow(values[i+1], 2);
+                values[i+1] = 0;
+            }
+
+            // Last real component is at end of array, but corresponding imaginary is at second index position
+            values[i] = Math.pow(values[i], 2) + Math.pow(values[1], 2);
+            values[1] = 0;
+        }
+    }
+
+
+    @Override
+    public void doReadFrom(StreamInput in) throws IOException {
+        formatter = ValueFormatterStreams.readOptional(in);
+        gapPolicy = GapPolicy.readFrom(in);
+        settings = AcfSettings.doReadFrom(in);
+    }
+
+    @Override
+    public void doWriteTo(StreamOutput out) throws IOException {
+        ValueFormatterStreams.writeOptional(formatter, out);
+        gapPolicy.writeTo(out);
+        settings.writeTo(out);
+    }
+
+    public static class Factory extends ReducerFactory {
+
+        private final ValueFormatter formatter;
+        private GapPolicy gapPolicy;
+        private AcfSettings settings;
+
+        public Factory(String name, String[] bucketsPaths, @Nullable ValueFormatter formatter, GapPolicy gapPolicy,
+                        AcfSettings settings) {
+            super(name, TYPE.name(), bucketsPaths);
+            this.formatter = formatter;
+            this.gapPolicy = gapPolicy;
+            this.settings = settings;
+        }
+
+        @Override
+        protected Reducer createInternal(Map<String, Object> metaData) throws IOException {
+            return new AcfReducer(name, bucketsPaths, formatter, gapPolicy, settings, metaData);
+        }
+
+        @Override
+        public void doValidate(AggregatorFactory parent, AggregatorFactory[] aggFactories, List<ReducerFactory> reducerFactories) {
+            //nocommit
+            //TODO this never seems to get called?
+        }
+
+    }
+}

--- a/src/main/java/org/elasticsearch/search/aggregations/reducers/acf/AcfSettings.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/reducers/acf/AcfSettings.java
@@ -1,0 +1,88 @@
+package org.elasticsearch.search.aggregations.reducers.acf;
+
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Streamable;
+
+import java.io.IOException;
+
+public class AcfSettings implements Streamable {
+
+    public enum Mode {
+        STATISTICAL, SIGNAL
+    }
+
+    private boolean zeroPad = true;
+    private boolean normalize = true;
+    private boolean zeroMean = true;
+    private int window = 5;
+
+
+    public AcfSettings() {}
+
+    public AcfSettings(int window, boolean zeroPad, boolean zeroMean, boolean normalize) {
+        this.window = window;
+        this.zeroPad = zeroPad;
+        this.zeroMean = zeroMean;
+        this.normalize = normalize;
+    }
+
+    public boolean isZeroPad() {
+        return zeroPad;
+    }
+
+    public void setZeroPad(boolean zeroPad) {
+        this.zeroPad = zeroPad;
+    }
+
+    public boolean isNormalize() {
+        return normalize;
+    }
+
+    public void setNormalize(boolean normalize) {
+        this.normalize = normalize;
+    }
+
+    public boolean isZeroMean() {
+        return zeroMean;
+    }
+
+    public void setZeroMean(boolean zeroMean) {
+        this.zeroMean = zeroMean;
+    }
+
+    public int getWindow() {
+        return window;
+    }
+
+    public void setWindow(int window) {
+        this.window = window;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVInt(window);
+        out.writeBoolean(zeroPad);
+        out.writeBoolean(zeroMean);
+        out.writeBoolean(normalize);
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        window = in.readVInt();
+        zeroPad = in.readBoolean();
+        zeroMean = in.readBoolean();
+        normalize = in.readBoolean();
+    }
+
+    // nocommit
+    // TODO this seems a lot more convenient, but should I rely on the Serializable interface instead?
+    // See AcfReducer.doReadFrom for usage
+    public static AcfSettings doReadFrom(StreamInput in) throws IOException {
+        return new AcfSettings(in.readVInt(), in.readBoolean(), in.readBoolean(), in.readBoolean());
+    }
+
+
+
+}

--- a/src/main/java/org/elasticsearch/search/aggregations/reducers/acf/InternalAcfValues.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/reducers/acf/InternalAcfValues.java
@@ -1,0 +1,91 @@
+package org.elasticsearch.search.aggregations.reducers.acf;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.elasticsearch.common.inject.internal.Nullable;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.search.aggregations.AggregationStreams;
+import org.elasticsearch.search.aggregations.metrics.InternalNumericMetricsAggregation;
+import org.elasticsearch.search.aggregations.metrics.max.InternalMax;
+import org.elasticsearch.search.aggregations.reducers.Reducer;
+import org.elasticsearch.search.aggregations.support.format.ValueFormatter;
+import org.elasticsearch.search.aggregations.support.format.ValueFormatterStreams;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public class InternalAcfValues extends InternalNumericMetricsAggregation.MultiValue {
+
+    public final static Type TYPE = new Type("acf_values");
+
+    public final static AggregationStreams.Stream STREAM = new AggregationStreams.Stream() {
+        @Override
+        public InternalAcfValues readResult(StreamInput in) throws IOException {
+            InternalAcfValues result = new InternalAcfValues();
+            result.readFrom(in);
+            return result;
+        }
+    };
+
+    public static void registerStreams() {
+        AggregationStreams.registerStream(STREAM, TYPE.stream());
+    }
+
+    private double[] values;
+
+    InternalAcfValues() {} // for serialization
+
+    @Override
+    public double value(String name) {
+        return values[Integer.parseInt(name)];
+    }
+
+    public double[] values() {
+        return values;
+    }
+
+    public InternalAcfValues(String name, double[] values, @Nullable ValueFormatter formatter, List<Reducer> reducers, Map<String, Object> metaData) {
+        super(name, reducers, metaData);
+        this.valueFormatter = formatter;
+        this.values = values;
+    }
+
+    @Override
+    public Type type() {
+        return TYPE;
+    }
+
+    @Override
+    public InternalMax doReduce(ReduceContext reduceContext) {
+        throw new UnsupportedOperationException("Not supported");
+    }
+
+    @Override
+    protected void doReadFrom(StreamInput in) throws IOException {
+        valueFormatter = ValueFormatterStreams.readOptional(in);
+        values = in.readDoubleArray();
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        ValueFormatterStreams.writeOptional(valueFormatter, out);
+        out.writeDoubleArray(values);
+    }
+
+    @Override
+    public XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
+        //nocommit this all needs a closer look
+        // TODO
+        builder.array(CommonFields.VALUES, ArrayUtils.toObject(values));
+        if (valueFormatter != null) {
+            String[] stringValues = new String[values.length];
+            for (int i = 0; i < values.length; i++) {
+                stringValues[i] = valueFormatter.format(values[i]);
+            }
+            builder.array(CommonFields.VALUES_AS_STRING, stringValues);
+        }
+        return builder;
+    }
+}

--- a/src/main/java/org/elasticsearch/search/aggregations/reducers/bucketmetrics/InternalBucketMetricValue.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/reducers/bucketmetrics/InternalBucketMetricValue.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.reducers.bucketmetrics;
+
+import org.elasticsearch.ElasticsearchIllegalArgumentException;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.search.aggregations.AggregationStreams;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.metrics.InternalNumericMetricsAggregation;
+import org.elasticsearch.search.aggregations.reducers.Reducer;
+import org.elasticsearch.search.aggregations.support.format.ValueFormatter;
+import org.elasticsearch.search.aggregations.support.format.ValueFormatterStreams;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public class InternalBucketMetricValue extends InternalNumericMetricsAggregation.SingleValue {
+
+    public final static Type TYPE = new Type("bucket_metric_value");
+
+    public final static AggregationStreams.Stream STREAM = new AggregationStreams.Stream() {
+        @Override
+        public InternalBucketMetricValue readResult(StreamInput in) throws IOException {
+            InternalBucketMetricValue result = new InternalBucketMetricValue();
+            result.readFrom(in);
+            return result;
+        }
+    };
+
+    public static void registerStreams() {
+        AggregationStreams.registerStream(STREAM, TYPE.stream());
+    }
+
+    private double value;
+
+    private String[] keys;
+
+    protected InternalBucketMetricValue() {
+        super();
+    }
+
+    public InternalBucketMetricValue(String name, String[] keys, double value, @Nullable ValueFormatter formatter,
+            List<Reducer> reducers, Map<String, Object> metaData) {
+        super(name, reducers, metaData);
+        this.keys = keys;
+        this.value = value;
+        this.valueFormatter = formatter;
+    }
+
+    @Override
+    public Type type() {
+        return TYPE;
+    }
+
+    @Override
+    public double value() {
+        return value;
+    }
+
+    public String[] keys() {
+        return keys;
+    }
+
+    @Override
+    public InternalAggregation doReduce(ReduceContext reduceContext) {
+        throw new UnsupportedOperationException("Not supported");
+    }
+
+    @Override
+    public Object getProperty(List<String> path) {
+        if (path.isEmpty()) {
+            return this;
+        } else if (path.size() == 1 && "value".equals(path.get(0))) {
+            return value();
+        } else if (path.size() == 1 && "keys".equals(path.get(0))) {
+            return keys();
+        } else {
+            throw new ElasticsearchIllegalArgumentException("path not supported for [" + getName() + "]: " + path);
+        }
+    }
+
+    @Override
+    protected void doReadFrom(StreamInput in) throws IOException {
+        valueFormatter = ValueFormatterStreams.readOptional(in);
+        value = in.readDouble();
+        keys = in.readStringArray();
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        ValueFormatterStreams.writeOptional(valueFormatter, out);
+        out.writeDouble(value);
+        out.writeStringArray(keys);
+    }
+
+    @Override
+    public XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
+        boolean hasValue = !Double.isInfinite(value);
+        builder.field(CommonFields.VALUE, hasValue ? value : null);
+        if (hasValue && valueFormatter != null) {
+            builder.field(CommonFields.VALUE_AS_STRING, valueFormatter.format(value));
+        }
+        builder.startArray("keys");
+        for (String key : keys) {
+            builder.value(key);
+        }
+        builder.endArray();
+        return builder;
+    }
+
+}

--- a/src/main/java/org/elasticsearch/search/aggregations/reducers/bucketmetrics/MaxBucketParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/reducers/bucketmetrics/MaxBucketParser.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.reducers.bucketmetrics;
+
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.search.SearchParseException;
+import org.elasticsearch.search.aggregations.reducers.Reducer;
+import org.elasticsearch.search.aggregations.reducers.ReducerFactory;
+import org.elasticsearch.search.aggregations.support.format.ValueFormat;
+import org.elasticsearch.search.aggregations.support.format.ValueFormatter;
+import org.elasticsearch.search.internal.SearchContext;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class MaxBucketParser implements Reducer.Parser {
+    public static final ParseField FORMAT = new ParseField("format");
+
+    @Override
+    public String type() {
+        return MaxBucketReducer.TYPE.name();
+    }
+
+    @Override
+    public ReducerFactory parse(String reducerName, XContentParser parser, SearchContext context) throws IOException {
+        XContentParser.Token token;
+        String currentFieldName = null;
+        String[] bucketsPaths = null;
+        String format = null;
+
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                currentFieldName = parser.currentName();
+            } else if (token == XContentParser.Token.VALUE_STRING) {
+                if (FORMAT.match(currentFieldName)) {
+                    format = parser.text();
+                } else if (BUCKETS_PATH.match(currentFieldName)) {
+                    bucketsPaths = new String[] { parser.text() };
+                } else {
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + reducerName + "]: ["
+                            + currentFieldName + "].");
+                }
+            } else if (token == XContentParser.Token.START_ARRAY) {
+                if (BUCKETS_PATH.match(currentFieldName)) {
+                    List<String> paths = new ArrayList<>();
+                    while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
+                        String path = parser.text();
+                        paths.add(path);
+                    }
+                    bucketsPaths = paths.toArray(new String[paths.size()]);
+                } else {
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + reducerName + "]: ["
+                            + currentFieldName + "].");
+                }
+            } else {
+                throw new SearchParseException(context, "Unexpected token " + token + " in [" + reducerName + "].");
+            }
+        }
+
+        if (bucketsPaths == null) {
+            throw new SearchParseException(context, "Missing required field [" + BUCKETS_PATH.getPreferredName()
+                    + "] for derivative aggregation [" + reducerName + "]");
+        }
+
+        ValueFormatter formatter = null;
+        if (format != null) {
+            formatter = ValueFormat.Patternable.Number.format(format).formatter();
+        }
+
+        return new MaxBucketReducer.Factory(reducerName, bucketsPaths, formatter);
+    }
+
+}

--- a/src/main/java/org/elasticsearch/search/aggregations/reducers/bucketmetrics/MaxBucketReducer.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/reducers/bucketmetrics/MaxBucketReducer.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.reducers.bucketmetrics;
+
+import org.elasticsearch.ElasticsearchIllegalStateException;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.search.aggregations.Aggregation;
+import org.elasticsearch.search.aggregations.AggregationExecutionException;
+import org.elasticsearch.search.aggregations.Aggregator;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.InternalAggregation.ReduceContext;
+import org.elasticsearch.search.aggregations.InternalAggregation.Type;
+import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
+import org.elasticsearch.search.aggregations.InvalidAggregationPathException;
+import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation.Bucket;
+import org.elasticsearch.search.aggregations.metrics.InternalNumericMetricsAggregation;
+import org.elasticsearch.search.aggregations.reducers.Reducer;
+import org.elasticsearch.search.aggregations.reducers.ReducerFactory;
+import org.elasticsearch.search.aggregations.reducers.ReducerStreams;
+import org.elasticsearch.search.aggregations.reducers.SiblingReducer;
+import org.elasticsearch.search.aggregations.reducers.derivative.DerivativeParser;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
+import org.elasticsearch.search.aggregations.support.AggregationPath;
+import org.elasticsearch.search.aggregations.support.format.ValueFormatter;
+import org.elasticsearch.search.aggregations.support.format.ValueFormatterStreams;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class MaxBucketReducer extends SiblingReducer {
+
+    public final static Type TYPE = new Type("max_bucket");
+
+    public final static ReducerStreams.Stream STREAM = new ReducerStreams.Stream() {
+        @Override
+        public MaxBucketReducer readResult(StreamInput in) throws IOException {
+            MaxBucketReducer result = new MaxBucketReducer();
+            result.readFrom(in);
+            return result;
+        }
+    };
+
+    private ValueFormatter formatter;
+
+    public static void registerStreams() {
+        ReducerStreams.registerStream(STREAM, TYPE.stream());
+    }
+
+    private MaxBucketReducer() {
+    }
+
+    protected MaxBucketReducer(String name, String[] bucketsPaths, @Nullable ValueFormatter formatter, Map<String, Object> metaData) {
+        super(name, bucketsPaths, metaData);
+        this.formatter = formatter;
+    }
+
+    @Override
+    public Type type() {
+        return TYPE;
+    }
+
+    public InternalAggregation doReduce(List<Aggregation> aggregations, ReduceContext context) {
+        List<String> maxBucketKeys = new ArrayList<>();
+        double maxValue = Double.MIN_VALUE;
+        String[] keys = maxBucketKeys.toArray(new String[maxBucketKeys.size()]);
+        List<String> bucketsPath = AggregationPath.parse(bucketsPaths()[0]).getPathElementsAsStringList();
+        for (Aggregation aggregation : aggregations) {
+            if (aggregation.getName().equals(bucketsPath.get(0))) {
+                bucketsPath = bucketsPath.subList(1, bucketsPath.size());
+                InternalMultiBucketAggregation multiBucketsAgg = (InternalMultiBucketAggregation) aggregation;
+                List<? extends Bucket> buckets = multiBucketsAgg.getBuckets();
+                for (int i = 0; i < buckets.size(); i++) {
+                    Bucket bucket = buckets.get(i);
+                    Double bucketValue = resolveBucketValue(multiBucketsAgg, bucket);
+                    if (bucketValue == null) {
+                        throw new ElasticsearchIllegalStateException("FOUND GAP IN DATA"); // NOCOMMIT deal with gaps in data
+                    } else if (bucketValue > maxValue) {
+                        maxBucketKeys.clear();
+                        maxBucketKeys.add(bucket.getKeyAsString());
+                        maxValue = bucketValue;
+                    } else if (bucketValue == maxValue) {
+                        maxBucketKeys.add(bucket.getKeyAsString());
+                    }
+                }
+            }
+        }
+        return new InternalBucketMetricValue(name(), keys, maxValue, formatter, Collections.EMPTY_LIST, metaData());
+    }
+
+    private Double resolveBucketValue(InternalMultiBucketAggregation multiBucketAggregation, InternalMultiBucketAggregation.Bucket bucket) {
+        try {
+            Object propertyValue = bucket.getProperty(multiBucketAggregation.getName(), AggregationPath.parse(bucketsPaths()[0])
+                    .getPathElementsAsStringList());
+            if (propertyValue instanceof Number) {
+                return ((Number) propertyValue).doubleValue();
+            } else if (propertyValue instanceof InternalNumericMetricsAggregation.SingleValue) {
+                return ((InternalNumericMetricsAggregation.SingleValue) propertyValue).value();
+            } else {
+                throw new AggregationExecutionException(DerivativeParser.BUCKETS_PATH.getPreferredName()
+                        + " must reference either a number value or a single value numeric metric aggregation");
+            }
+        } catch (InvalidAggregationPathException e) {
+            return null;
+        }
+    }
+
+    @Override
+    public void doReadFrom(StreamInput in) throws IOException {
+        formatter = ValueFormatterStreams.readOptional(in);
+    }
+
+    @Override
+    public void doWriteTo(StreamOutput out) throws IOException {
+        ValueFormatterStreams.writeOptional(formatter, out);
+    }
+
+    public static class Factory extends ReducerFactory {
+
+        private final ValueFormatter formatter;
+
+        public Factory(String name, String[] bucketsPaths, @Nullable ValueFormatter formatter) {
+            super(name, TYPE.name(), bucketsPaths);
+            this.formatter = formatter;
+        }
+
+        @Override
+        protected Reducer createInternal(AggregationContext context, Aggregator parent, boolean collectsFromSingleBucket,
+                Map<String, Object> metaData) throws IOException {
+            return new MaxBucketReducer(name, bucketsPaths, formatter, metaData);
+        }
+
+    }
+
+}

--- a/src/main/java/org/elasticsearch/search/aggregations/reducers/bucketmetrics/MaxBucketReducer.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/reducers/bucketmetrics/MaxBucketReducer.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.AggregationExecutionException;
 import org.elasticsearch.search.aggregations.Aggregator;
+import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregation.ReduceContext;
 import org.elasticsearch.search.aggregations.InternalAggregation.Type;
@@ -149,6 +150,14 @@ public class MaxBucketReducer extends SiblingReducer {
         protected Reducer createInternal(AggregationContext context, Aggregator parent, boolean collectsFromSingleBucket,
                 Map<String, Object> metaData) throws IOException {
             return new MaxBucketReducer(name, bucketsPaths, formatter, metaData);
+        }
+
+        @Override
+        public void doValidate(AggregatorFactory parent, AggregatorFactory[] aggFactories, List<ReducerFactory> reducerFactories) {
+            if (bucketsPaths.length != 1) {
+                throw new ElasticsearchIllegalStateException(Reducer.Parser.BUCKETS_PATH.getPreferredName()
+                        + " must contain a single entry for reducer [" + name + "]");
+            }
         }
 
     }

--- a/src/main/java/org/elasticsearch/search/aggregations/reducers/derivative/DerivativeReducer.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/reducers/derivative/DerivativeReducer.java
@@ -19,15 +19,12 @@
 
 package org.elasticsearch.search.aggregations.reducers.derivative;
 
-import com.google.common.base.Function;
 import com.google.common.collect.Lists;
 
 import org.elasticsearch.ElasticsearchIllegalStateException;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.search.aggregations.Aggregation;
-import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregation.ReduceContext;
@@ -40,7 +37,6 @@ import org.elasticsearch.search.aggregations.reducers.InternalSimpleValue;
 import org.elasticsearch.search.aggregations.reducers.Reducer;
 import org.elasticsearch.search.aggregations.reducers.ReducerFactory;
 import org.elasticsearch.search.aggregations.reducers.ReducerStreams;
-import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.format.ValueFormatter;
 import org.elasticsearch.search.aggregations.support.format.ValueFormatterStreams;
 
@@ -67,13 +63,6 @@ public class DerivativeReducer extends Reducer {
     public static void registerStreams() {
         ReducerStreams.registerStream(STREAM, TYPE.stream());
     }
-
-    private static final Function<Aggregation, InternalAggregation> FUNCTION = new Function<Aggregation, InternalAggregation>() {
-        @Override
-        public InternalAggregation apply(Aggregation input) {
-            return (InternalAggregation) input;
-        }
-    };
 
     private ValueFormatter formatter;
     private GapPolicy gapPolicy;
@@ -143,8 +132,7 @@ public class DerivativeReducer extends Reducer {
         }
 
         @Override
-        protected Reducer createInternal(AggregationContext context, Aggregator parent, boolean collectsFromSingleBucket,
-                Map<String, Object> metaData) throws IOException {
+        protected Reducer createInternal(Map<String, Object> metaData) throws IOException {
             return new DerivativeReducer(name, bucketsPaths, formatter, gapPolicy, metaData);
         }
 

--- a/src/test/java/org/elasticsearch/search/aggregations/reducers/acf/AcfTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/reducers/acf/AcfTests.java
@@ -1,0 +1,265 @@
+package org.elasticsearch.search.aggregations.reducers.acf;
+
+
+import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.search.aggregations.bucket.histogram.InternalHistogram;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.histogram;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.max;
+import static org.elasticsearch.search.aggregations.reducers.ReducerBuilders.acf;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.core.IsNull.notNullValue;
+
+
+@ElasticsearchIntegrationTest.SuiteScopeTest
+public class AcfTests  extends ElasticsearchIntegrationTest {
+
+    private static final String INTERVAL_FIELD = "interval_field";
+    private static final String VALUE_FIELD = "value_field";
+
+    private static int nonRandomSize = 50;
+    private static double[] linear = new double[nonRandomSize];
+    private static double[] cyclic1 = new double[nonRandomSize];
+
+    private static double[] linearACF = new double[nonRandomSize];
+    private static double[] linearPaddedACF;
+
+    private static double[] cyclic1ACF = new double[nonRandomSize];
+    private static double[] cyclic1PaddedACF;
+
+
+    @Override
+    public void setupSuiteScopeCluster() throws Exception {
+        createIndex("idx");
+
+        for (int i = 0; i < nonRandomSize; i++) {
+            linear[i] = i;
+        }
+
+        linearACF = circularACF(linear, true);
+        linearPaddedACF = linearACF(linear, true);
+
+        List<IndexRequestBuilder> builders = new ArrayList<>();
+        for (int i = 0; i < nonRandomSize; i++) {
+            builders.add(client().prepareIndex("idx", "linear").setSource(newDocBuilder(i, linear[i])));
+        }
+
+        indexRandom(true, builders);
+
+
+
+
+        // period of 10
+        for (int i = 0; i < nonRandomSize; i++) {
+            cyclic1[i] = i % 10;
+        }
+
+        cyclic1ACF = circularACF(cyclic1, true);
+        cyclic1PaddedACF = linearACF(cyclic1, true);
+
+        //padded = linearACF(Arrays.copyOf(cyclic1, pad << 1), true);
+        //cyclic1PaddedACF = Arrays.copyOf(padded, nonRandomSize);
+
+        builders = new ArrayList<>();
+        for (int i = 0; i < nonRandomSize; i++) {
+            builders.add(client().prepareIndex("idx", "cyclic").setSource(newDocBuilder(i, cyclic1[i])));
+        }
+
+        indexRandom(true, builders);
+
+        ensureSearchable();
+
+    }
+
+    private XContentBuilder newDocBuilder(int intervalField, double valueField) throws IOException {
+        return jsonBuilder().startObject()
+                .field(INTERVAL_FIELD, intervalField)
+                .field(VALUE_FIELD, valueField)
+                .endObject();
+    }
+
+    private double[] linearACF(double[] values, boolean normalize) {
+        int length = values.length;
+        double[] acValues = new double[length];
+
+        for (int h = 0; h < length; h++) {
+            for (int i = 0; i < length - h; i++) {
+                acValues[h] += values[i] * values[i+h] ;
+            }
+            acValues[h] /= length - h;
+        }
+
+        if (normalize) {
+            for (int i = 1; i < length; i++) {
+                acValues[i] /= acValues[0];
+            }
+            acValues[0] = 1;
+        }
+
+
+        return acValues;
+    }
+
+    private double[] circularACF(double[] values, boolean normalize) {
+
+        double[] acValues = new double[values.length];
+        for (int j = 0; j < values.length; j++) {
+            for (int i = 0; i < values.length; i++) {
+                acValues[j] += values[i] * values[(values.length + i - j) % values.length];
+            }
+        }
+
+        if (normalize) {
+            for (int i = 1; i < acValues.length; i++) {
+                acValues[i] /= acValues[0];
+            }
+            acValues[0] = 1;
+        }
+
+
+        return acValues;
+    }
+
+    @Test
+    public void simpleLinearCircular() {
+        int interval = 1;
+        int window = nonRandomSize;
+
+        SearchResponse response = client()
+                .prepareSearch("idx").setTypes("linear")
+                .addAggregation(histogram("histo").field(INTERVAL_FIELD).interval(interval).minDocCount(0).extendedBounds(0L, (long) (nonRandomSize - 1))
+                        .subAggregation(max("the_max").field(VALUE_FIELD)))
+                .addAggregation(acf("acf").setBucketsPaths("histo>the_max").normalize(true).zeroPad(false).zeroMean(false).window(window))
+                .execute().actionGet();
+
+        assertSearchResponse(response);
+
+        InternalHistogram<InternalHistogram.Bucket> histo = response.getAggregations().get("histo");
+        assertThat(histo, notNullValue());
+        assertThat(histo.getName(), equalTo("histo"));
+
+        InternalAcfValues acf = response.getAggregations().get("acf");
+        assertThat(acf, notNullValue());
+        assertThat(acf.getName(), equalTo("acf"));
+
+        double[] acfValues = acf.values();
+        assertThat(acfValues.length, equalTo(linearACF.length));
+
+        for (int i = 0; i < linearACF.length; i++) {
+            assertWithinError(i, acfValues[i], linearACF[i], 0.01 * (i + 1));    // multiply by i because error creeps up over lags
+        }
+    }
+
+    @Test
+    public void simpleLinearPaddedCircular() {
+        int interval = 1;
+        int window = nonRandomSize;
+
+        SearchResponse response = client()
+                .prepareSearch("idx").setTypes("linear")
+                .addAggregation(histogram("histo").field(INTERVAL_FIELD).interval(interval).minDocCount(0).extendedBounds(0L, (long)(nonRandomSize - 1))
+                        .subAggregation(max("the_max").field(VALUE_FIELD)))
+                .addAggregation(acf("acf").setBucketsPaths("histo>the_max").normalize(true).zeroPad(true).zeroMean(false).window(window))
+                .execute().actionGet();
+
+        assertSearchResponse(response);
+
+        InternalHistogram<InternalHistogram.Bucket> histo = response.getAggregations().get("histo");
+        assertThat(histo, notNullValue());
+        assertThat(histo.getName(), equalTo("histo"));
+
+        InternalAcfValues acf = response.getAggregations().get("acf");
+        assertThat(acf, notNullValue());
+        assertThat(acf.getName(), equalTo("acf"));
+
+        double[] acfValues = acf.values();
+        assertThat(acfValues.length, equalTo(linearPaddedACF.length));
+
+        for (int i = 0; i < linearPaddedACF.length; i++) {
+            assertWithinError(i, acfValues[i], linearPaddedACF[i], 0.05 * (i + 2));    // multiply by i because error creeps up over lags
+        }
+    }
+
+
+    @Test
+    public void simpleCyclic1CircularACF() {
+        int interval = 1;
+        int window = nonRandomSize;
+
+        SearchResponse response = client()
+                .prepareSearch("idx").setTypes("cyclic")
+                .addAggregation(histogram("histo").field(INTERVAL_FIELD).interval(interval).minDocCount(0).extendedBounds(0L, (long)(nonRandomSize - 1))
+                        .subAggregation(max("the_max").field(VALUE_FIELD)))
+                .addAggregation(acf("acf").setBucketsPaths("histo>the_max").normalize(true).zeroPad(false).zeroMean(false).window(window))
+                .execute().actionGet();
+
+        assertSearchResponse(response);
+
+        InternalHistogram<InternalHistogram.Bucket> histo = response.getAggregations().get("histo");
+        assertThat(histo, notNullValue());
+        assertThat(histo.getName(), equalTo("histo"));
+
+        InternalAcfValues acf = response.getAggregations().get("acf");
+        assertThat(acf, notNullValue());
+        assertThat(acf.getName(), equalTo("acf"));
+
+        double[] acfValues = acf.values();
+        assertThat(acfValues.length, equalTo(cyclic1ACF.length));
+
+        for (int i = 0; i < cyclic1ACF.length; i++) {
+            assertWithinError(i, acfValues[i], cyclic1ACF[i], 0.01);
+        }
+    }
+
+    @Test
+    public void simpleCyclic1PaddedCircular() {
+        int interval = 1;
+        int window = nonRandomSize;
+
+        SearchResponse response = client()
+                .prepareSearch("idx").setTypes("cyclic")
+                .addAggregation(histogram("histo").field(INTERVAL_FIELD).interval(interval).minDocCount(0).extendedBounds(0L, (long)(nonRandomSize - 1))
+                        .subAggregation(max("the_max").field(VALUE_FIELD)))
+                .addAggregation(acf("acf").setBucketsPaths("histo>the_max").normalize(true).zeroPad(true).zeroMean(false).window(window))
+                .execute().actionGet();
+
+        assertSearchResponse(response);
+
+        InternalHistogram<InternalHistogram.Bucket> histo = response.getAggregations().get("histo");
+        assertThat(histo, notNullValue());
+        assertThat(histo.getName(), equalTo("histo"));
+
+        InternalAcfValues acf = response.getAggregations().get("acf");
+        assertThat(acf, notNullValue());
+        assertThat(acf.getName(), equalTo("acf"));
+
+        double[] acfValues = acf.values();
+        assertThat(acfValues.length, equalTo(cyclic1PaddedACF.length));
+
+        for (int i = 0; i < cyclic1PaddedACF.length; i++) {
+            assertWithinError(i, acfValues[i], cyclic1PaddedACF[i], 0.01);
+        }
+    }
+
+    private void assertWithinError(int i, double expected, double actual, double errorMargin) {
+
+        // Just to avoid stupid divide-by-zero situations
+        expected += 0.000000001;
+        actual += 0.000000001;
+
+        double actualError = Math.abs((actual - expected ) / actual);
+        assertThat("Difference between expected and actual autocorrelation was not within error bounds at position [" + i +
+                "] with (", actualError, lessThan(errorMargin));
+    }
+}


### PR DESCRIPTION
WIP, putting up for discussion.

Depends on the `SiblingReducer` functionality introduced in @colings86's ["Max Aggregator" PR](https://github.com/elastic/elasticsearch/pull/10250), so any changes in that PR will need to be reflected here.   

No need for a review yet, this is largely just to test the sibling functionality.
#### Autocorrelation

Autocorrelation shows the similarity between a time series and a "lagged" version of itself at different intervals of time.  This can be used to determine if a signal has periodic elements hidden by noise.  If there is a periodic element (repeating every `n` elements), there will be a peak in the Autocorrelation every `n` lags.  This is because the original time series will "line up" with the lagged version and display a high degree of similarity, even in the presence of noise.

As an example, this "Lemmings Population" is a very noisy sine wave with a 30-day period. If you squint hard enough, you can see the sine wave.  The ACF of the series, however, clearly shows periodic elements.  The peaks are spaced ~27 days, which is very close to the actual 30-day period

![screen shot 2015-04-01 at 1 53 43 pm](https://cloud.githubusercontent.com/assets/1224228/6947964/bd57d93e-d878-11e4-94b8-80b82e5f301f.png)
#### Request

ACF is a sibling reducer, which accepts histogram or datehistogram input.

``` json
GET /test/test/_search?search_type=count
{
   "aggs": {
      "my_date_histo": {
         "date_histogram": {
            "field": "timestamp",
            "interval": "day",
            "min_doc_count": 0
         },
         "aggs": {
            "the_sum": {
               "sum": {
                  "field": "price"
               }
            }
         }
      },
      "the_acf": {
         "acf": {
            "bucketsPath": "my_date_histo.the_sum",
            "window" : 50
         }
      }
   }
}
```
##### Parameters
- `bucketsPath`: required
- `window`: size of time series to perform ACF on.  If series is length `n`, the ACF will be performed on `n - window .. n` values.  E.g. the most recent values.  Optional, defaults to `5`
- `zero_mean`: "centers" the ACF by removing the mean from the time series.  Optional, defaults to `true`
- `zero_pad`: pads the input data with zeros, up to the nearest power of two. FFTs are faster on powers of 2, and padding converts the ACF from a circular convolution to a linear convolution.  Linear are more useful for "real world" use-cases. Optional, defaults to `true`
- `normalize`: Divides all ACF values by variance, which normalizes the ACF to roughly -1..1. Optional, defaults to `true`
#### Response

``` json
{
   "took": 14,
   "timed_out": false,
   "_shards": { ... },
   "hits": { ... },
   "aggregations": {
      "my_date_histo": {
         "buckets": [ ... ]
      },
      "the_acf": {
         "values": [
            1,
            0.37343470483005364,
            -0.360763267740012,
            0.17441860465116257,
            0.5277280858676209
         ]
      }
   }
}
```
#### Todo
- Benchmark the padding vs non-padding speed, particularly if power of two matters.  JTransforms can accept any length input, but uses different radix algos which are theoretically slower.  OTOH, padding to power of two could mean more memory usage, and a bigger power-2 FFT might be slower than smaller non-power-2 FFT.  
- Add setting to disable linear convolution correction when using padding?  If you don't care about the correction, it'll save some CPU cycles by eliminating the mask (forward FFT, PSD computation, inverse FFT)
- Settings configuration is a bit wonky, talk to Colin about a better way?
- Talk to Colin about how sibling builders need to extend `AbstractAggregationBuilder`, and the need for `InternalAcfBuilder` which is registered as an aggregation (due to siblings potentially being "top level" aggs).  Unsure if this was the correct approach?
- Validate the agg structure, since this can only accept histo siblings
- More tests.  Tests are hard since the "brute force" approaches are also approximations...so we are comparing approximations against approximations.  Unsure how much we can randomize these tests for that reason.  Needs more thinking.
