### PR TITLE
recovery state: fix concurrent access to file list

### DIFF
--- a/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java
@@ -858,7 +858,7 @@ public class RecoveryState implements ToXContent, Streamable {
         }
 
         @Override
-        public void readFrom(StreamInput in) throws IOException {
+        public synchronized void readFrom(StreamInput in) throws IOException {
             super.readFrom(in);
             int size = in.readVInt();
             for (int i = 0; i < size; i++) {

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java
@@ -870,9 +870,9 @@ public class RecoveryState implements ToXContent, Streamable {
         }
 
         @Override
-        public void writeTo(StreamOutput out) throws IOException {
+        public synchronized void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
-            final File[] files = fileDetails().toArray(new File[0]);
+            final File[] files = fileDetails.values().toArray(new File[0]);
             out.writeVInt(files.length);
             for (File file : files) {
                 file.writeTo(out);

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java
@@ -872,7 +872,7 @@ public class RecoveryState implements ToXContent, Streamable {
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
-            final File[] files = fileDetails.values().toArray(new File[0]);
+            final File[] files = fileDetails().toArray(new File[0]);
             out.writeVInt(files.length);
             for (File file : files) {
                 file.writeTo(out);

--- a/src/test/java/org/elasticsearch/indices/recovery/RecoveryStateTest.java
+++ b/src/test/java/org/elasticsearch/indices/recovery/RecoveryStateTest.java
@@ -27,7 +27,6 @@ import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.transport.DummyTransportAddress;
-import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.recovery.RecoveryState.*;
 import org.elasticsearch.test.ElasticsearchTestCase;
@@ -37,7 +36,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 


### PR DESCRIPTION
A shard recovery response might serialize a shard state at the same time that it is
modified by the recovery process. The test
RelocationTests.testMoveShardsWhileRelocation
failed because of this with a ConcurrentModificationException.
