### PR TITLE
Make APIs work per-segment like Lucene's Collector.

### DIFF
--- a/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
+++ b/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
@@ -42,11 +42,11 @@ import org.elasticsearch.index.mapper.internal.ParentFieldMapper;
 import org.elasticsearch.index.mapper.internal.RoutingFieldMapper;
 import org.elasticsearch.index.mapper.internal.TTLFieldMapper;
 import org.elasticsearch.index.mapper.internal.TimestampFieldMapper;
-import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.script.ExecutableScript;
-import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.script.ScriptContext;
+import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.fetch.source.FetchSourceContext;
 import org.elasticsearch.search.lookup.SourceLookup;
 
@@ -276,7 +276,7 @@ public class UpdateHelper extends AbstractComponent {
         Map<String, GetField> fields = null;
         if (request.fields() != null && request.fields().length > 0) {
             SourceLookup sourceLookup = new SourceLookup();
-            sourceLookup.setNextSource(source);
+            sourceLookup.setSource(source);
             for (String field : request.fields()) {
                 if (field.equals("_source")) {
                     sourceRequested = true;

--- a/src/main/java/org/elasticsearch/common/lucene/search/function/BoostScoreFunction.java
+++ b/src/main/java/org/elasticsearch/common/lucene/search/function/BoostScoreFunction.java
@@ -21,7 +21,6 @@ package org.elasticsearch.common.lucene.search.function;
 
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.Explanation;
-import org.elasticsearch.ElasticsearchIllegalArgumentException;
 
 /**
  *
@@ -43,20 +42,21 @@ public class BoostScoreFunction extends ScoreFunction {
     }
 
     @Override
-    public void setNextReader(LeafReaderContext context) {
-        // nothing to do here...
-    }
-    
-    @Override
-    public double score(int docId, float subQueryScore) {
-        return boost;
-    }
+    public LeafScoreFunction getLeafScoreFunction(LeafReaderContext ctx) {
+        return new LeafScoreFunction() {
 
-    @Override
-    public Explanation explainScore(int docId, Explanation subQueryScore) {
-        Explanation exp = new Explanation(boost, "static boost factor");
-        exp.addDetail(new Explanation(boost, "boostFactor"));
-        return exp;
+            @Override
+            public double score(int docId, float subQueryScore) {
+                return boost;
+            }
+
+            @Override
+            public Explanation explainScore(int docId, Explanation subQueryScore) {
+                Explanation exp = new Explanation(boost, "static boost factor");
+                exp.addDetail(new Explanation(boost, "boostFactor"));
+                return exp;
+            }
+        };
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/common/lucene/search/function/FieldValueFactorFunction.java
+++ b/src/main/java/org/elasticsearch/common/lucene/search/function/FieldValueFactorFunction.java
@@ -37,7 +37,6 @@ public class FieldValueFactorFunction extends ScoreFunction {
     private final float boostFactor;
     private final Modifier modifier;
     private final IndexNumericFieldData indexFieldData;
-    private SortedNumericDoubleValues values;
 
     public FieldValueFactorFunction(String field, float boostFactor, Modifier modifierType, IndexNumericFieldData indexFieldData) {
         super(CombineFunction.MULT);
@@ -48,36 +47,38 @@ public class FieldValueFactorFunction extends ScoreFunction {
     }
 
     @Override
-    public void setNextReader(LeafReaderContext context) {
-        this.values = this.indexFieldData.load(context).getDoubleValues();
-    }
+    public LeafScoreFunction getLeafScoreFunction(LeafReaderContext ctx) {
+        final SortedNumericDoubleValues values = this.indexFieldData.load(ctx).getDoubleValues();
+        return new LeafScoreFunction() {
 
-    @Override
-    public double score(int docId, float subQueryScore) {
-        this.values.setDocument(docId);
-        final int numValues = this.values.count();
-        if (numValues > 0) {
-            double val = this.values.valueAt(0) * boostFactor;
-            double result = modifier.apply(val);
-            if (Double.isNaN(result) || Double.isInfinite(result)) {
-                throw new ElasticsearchException("Result of field modification [" + modifier.toString() +
-                        "(" + val + ")] must be a number");
+            @Override
+            public double score(int docId, float subQueryScore) {
+                values.setDocument(docId);
+                final int numValues = values.count();
+                if (numValues > 0) {
+                    double val = values.valueAt(0) * boostFactor;
+                    double result = modifier.apply(val);
+                    if (Double.isNaN(result) || Double.isInfinite(result)) {
+                        throw new ElasticsearchException("Result of field modification [" + modifier.toString() +
+                                "(" + val + ")] must be a number");
+                    }
+                    return result;
+                } else {
+                    throw new ElasticsearchException("Missing value for field [" + field + "]");
+                }
             }
-            return result;
-        } else {
-            throw new ElasticsearchException("Missing value for field [" + field + "]");
-        }
-    }
 
-    @Override
-    public Explanation explainScore(int docId, Explanation subQueryScore) {
-        Explanation exp = new Explanation();
-        String modifierStr = modifier != null ? modifier.toString() : "";
-        double score = score(docId, subQueryScore.getValue());
-        exp.setValue(CombineFunction.toFloat(score));
-        exp.setDescription("field value function: " +
-                modifierStr + "(" + "doc['" + field + "'].value * factor=" + boostFactor + ")");
-        return exp;
+            @Override
+            public Explanation explainScore(int docId, Explanation subQueryScore) {
+                Explanation exp = new Explanation();
+                String modifierStr = modifier != null ? modifier.toString() : "";
+                double score = score(docId, subQueryScore.getValue());
+                exp.setValue(CombineFunction.toFloat(score));
+                exp.setDescription("field value function: " +
+                        modifierStr + "(" + "doc['" + field + "'].value * factor=" + boostFactor + ")");
+                return exp;
+            }
+        };
     }
 
     /**

--- a/src/main/java/org/elasticsearch/common/lucene/search/function/FiltersFunctionScoreQuery.java
+++ b/src/main/java/org/elasticsearch/common/lucene/search/function/FiltersFunctionScoreQuery.java
@@ -124,18 +124,16 @@ public class FiltersFunctionScoreQuery extends Query {
         // TODO: needsScores
         // if we dont need scores, just return the underlying Weight?
         Weight subQueryWeight = subQuery.createWeight(searcher, needsScores);
-        return new CustomBoostFactorWeight(this, subQueryWeight, filterFunctions.length);
+        return new CustomBoostFactorWeight(this, subQueryWeight);
     }
 
     class CustomBoostFactorWeight extends Weight {
 
         final Weight subQueryWeight;
-        final Bits[] docSets;
 
-        public CustomBoostFactorWeight(Query parent, Weight subQueryWeight, int filterFunctionLength) throws IOException {
+        public CustomBoostFactorWeight(Query parent, Weight subQueryWeight) throws IOException {
             super(parent);
             this.subQueryWeight = subQueryWeight;
-            this.docSets = new Bits[filterFunctionLength];
         }
 
         @Override
@@ -159,12 +157,14 @@ public class FiltersFunctionScoreQuery extends Query {
             if (subQueryScorer == null) {
                 return null;
             }
+            final LeafScoreFunction[] functions = new LeafScoreFunction[filterFunctions.length];
+            final Bits[] docSets = new Bits[filterFunctions.length];
             for (int i = 0; i < filterFunctions.length; i++) {
                 FilterFunction filterFunction = filterFunctions[i];
-                filterFunction.function.setNextReader(context);
+                functions[i] = filterFunction.function.getLeafScoreFunction(context);
                 docSets[i] = DocIdSets.asSequentialAccessBits(context.reader().maxDoc(), filterFunction.filter.getDocIdSet(context, acceptDocs));
             }
-            return new FiltersFunctionFactorScorer(this, subQueryScorer, scoreMode, filterFunctions, maxBoost, docSets, combineFunction, minScore);
+            return new FiltersFunctionFactorScorer(this, subQueryScorer, scoreMode, filterFunctions, maxBoost, functions, docSets, combineFunction, minScore);
         }
 
         @Override
@@ -188,8 +188,7 @@ public class FiltersFunctionScoreQuery extends Query {
                 Bits docSet = DocIdSets.asSequentialAccessBits(context.reader().maxDoc(),
                         filterFunction.filter.getDocIdSet(context, context.reader().getLiveDocs()));
                 if (docSet.get(doc)) {
-                    filterFunction.function.setNextReader(context);
-                    Explanation functionExplanation = filterFunction.function.explainScore(doc, subQueryExpl);
+                    Explanation functionExplanation = filterFunction.function.getLeafScoreFunction(context).explainScore(doc, subQueryExpl);
                     double factor = functionExplanation.getValue();
                     float sc = CombineFunction.toFloat(factor);
                     ComplexExplanation filterExplanation = new ComplexExplanation(true, sc, "function score, product of:");
@@ -255,13 +254,15 @@ public class FiltersFunctionScoreQuery extends Query {
     static class FiltersFunctionFactorScorer extends CustomBoostFactorScorer {
         private final FilterFunction[] filterFunctions;
         private final ScoreMode scoreMode;
+        private final LeafScoreFunction[] functions;
         private final Bits[] docSets;
 
         private FiltersFunctionFactorScorer(CustomBoostFactorWeight w, Scorer scorer, ScoreMode scoreMode, FilterFunction[] filterFunctions,
-                                            float maxBoost, Bits[] docSets, CombineFunction scoreCombiner, Float minScore) throws IOException {
+                                            float maxBoost, LeafScoreFunction[] functions, Bits[] docSets, CombineFunction scoreCombiner, Float minScore) throws IOException {
             super(w, scorer, maxBoost, scoreCombiner, minScore);
             this.scoreMode = scoreMode;
             this.filterFunctions = filterFunctions;
+            this.functions = functions;
             this.docSets = docSets;
         }
 
@@ -273,7 +274,7 @@ public class FiltersFunctionScoreQuery extends Query {
             if (scoreMode == ScoreMode.First) {
                 for (int i = 0; i < filterFunctions.length; i++) {
                     if (docSets[i].get(docId)) {
-                        factor = filterFunctions[i].function.score(docId, subQueryScore);
+                        factor = functions[i].score(docId, subQueryScore);
                         break;
                     }
                 }
@@ -281,7 +282,7 @@ public class FiltersFunctionScoreQuery extends Query {
                 double maxFactor = Double.NEGATIVE_INFINITY;
                 for (int i = 0; i < filterFunctions.length; i++) {
                     if (docSets[i].get(docId)) {
-                        maxFactor = Math.max(filterFunctions[i].function.score(docId, subQueryScore), maxFactor);
+                        maxFactor = Math.max(functions[i].score(docId, subQueryScore), maxFactor);
                     }
                 }
                 if (maxFactor != Float.NEGATIVE_INFINITY) {
@@ -291,7 +292,7 @@ public class FiltersFunctionScoreQuery extends Query {
                 double minFactor = Double.POSITIVE_INFINITY;
                 for (int i = 0; i < filterFunctions.length; i++) {
                     if (docSets[i].get(docId)) {
-                        minFactor = Math.min(filterFunctions[i].function.score(docId, subQueryScore), minFactor);
+                        minFactor = Math.min(functions[i].score(docId, subQueryScore), minFactor);
                     }
                 }
                 if (minFactor != Float.POSITIVE_INFINITY) {
@@ -300,7 +301,7 @@ public class FiltersFunctionScoreQuery extends Query {
             } else if (scoreMode == ScoreMode.Multiply) {
                 for (int i = 0; i < filterFunctions.length; i++) {
                     if (docSets[i].get(docId)) {
-                        factor *= filterFunctions[i].function.score(docId, subQueryScore);
+                        factor *= functions[i].score(docId, subQueryScore);
                     }
                 }
             } else { // Avg / Total
@@ -308,7 +309,7 @@ public class FiltersFunctionScoreQuery extends Query {
                 float weightSum = 0;
                 for (int i = 0; i < filterFunctions.length; i++) {
                     if (docSets[i].get(docId)) {
-                        totalFactor += filterFunctions[i].function.score(docId, subQueryScore);
+                        totalFactor += functions[i].score(docId, subQueryScore);
                         if (filterFunctions[i].function instanceof WeightFactorFunction) {
                             weightSum+= ((WeightFactorFunction)filterFunctions[i].function).getWeight();
                         } else {

--- a/src/main/java/org/elasticsearch/common/lucene/search/function/FunctionScoreQuery.java
+++ b/src/main/java/org/elasticsearch/common/lucene/search/function/FunctionScoreQuery.java
@@ -125,10 +125,11 @@ public class FunctionScoreQuery extends Query {
             if (subQueryScorer == null) {
                 return null;
             }
+            LeafScoreFunction leafFunction = null;
             if (function != null) {
-                function.setNextReader(context);
+                leafFunction = function.getLeafScoreFunction(context);
             }
-            return new FunctionFactorScorer(this, subQueryScorer, function, maxBoost, combineFunction, minScore);
+            return new FunctionFactorScorer(this, subQueryScorer, leafFunction, maxBoost, combineFunction, minScore);
         }
 
         @Override
@@ -138,8 +139,7 @@ public class FunctionScoreQuery extends Query {
                 return subQueryExpl;
             }
             if (function != null) {
-                function.setNextReader(context);
-                Explanation functionExplanation = function.explainScore(doc, subQueryExpl);
+                Explanation functionExplanation = function.getLeafScoreFunction(context).explainScore(doc, subQueryExpl);
                 return combineFunction.explain(getBoost(), subQueryExpl, functionExplanation, maxBoost);
             } else {
                 return subQueryExpl;
@@ -149,9 +149,9 @@ public class FunctionScoreQuery extends Query {
 
     static class FunctionFactorScorer extends CustomBoostFactorScorer {
 
-        private final ScoreFunction function;
+        private final LeafScoreFunction function;
 
-        private FunctionFactorScorer(CustomBoostFactorWeight w, Scorer scorer, ScoreFunction function, float maxBoost, CombineFunction scoreCombiner, Float minScore)
+        private FunctionFactorScorer(CustomBoostFactorWeight w, Scorer scorer, LeafScoreFunction function, float maxBoost, CombineFunction scoreCombiner, Float minScore)
                 throws IOException {
             super(w, scorer, maxBoost, scoreCombiner, minScore);
             this.function = function;

--- a/src/main/java/org/elasticsearch/common/lucene/search/function/LeafScoreFunction.java
+++ b/src/main/java/org/elasticsearch/common/lucene/search/function/LeafScoreFunction.java
@@ -16,15 +16,18 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.elasticsearch.search.aggregations.support;
 
-import org.elasticsearch.script.SearchScript;
+package org.elasticsearch.common.lucene.search.function;
 
-/**
- *
- */
-public interface ScriptValues {
+import org.apache.lucene.search.Explanation;
 
-    SearchScript script();
+import java.io.IOException;
+
+/** Per-leaf {@link ScoreFunction}. */
+public abstract class LeafScoreFunction {
+
+    public abstract double score(int docId, float subQueryScore);
+
+    public abstract Explanation explainScore(int docId, Explanation subQueryScore) throws IOException;
 
 }

--- a/src/main/java/org/elasticsearch/common/lucene/search/function/RandomScoreFunction.java
+++ b/src/main/java/org/elasticsearch/common/lucene/search/function/RandomScoreFunction.java
@@ -33,7 +33,6 @@ public class RandomScoreFunction extends ScoreFunction {
     private int originalSeed;
     private int saltedSeed;
     private final IndexFieldData<?> uidFieldData;
-    private SortedBinaryDocValues uidByteData;
 
     /**
      * Default constructor. Only useful for constructing as a placeholder, but should not be used for actual scoring.
@@ -59,23 +58,27 @@ public class RandomScoreFunction extends ScoreFunction {
     }
 
     @Override
-    public void setNextReader(LeafReaderContext context) {
-        AtomicFieldData leafData = uidFieldData.load(context);
-        uidByteData = leafData.getBytesValues();
+    public LeafScoreFunction getLeafScoreFunction(LeafReaderContext ctx) {
+        AtomicFieldData leafData = uidFieldData.load(ctx);
+        final SortedBinaryDocValues uidByteData = leafData.getBytesValues();
         if (uidByteData == null) throw new NullPointerException("failed to get uid byte data");
+
+        return new LeafScoreFunction() {
+
+            @Override
+            public double score(int docId, float subQueryScore) {
+                uidByteData.setDocument(docId);
+                int hash = StringHelper.murmurhash3_x86_32(uidByteData.valueAt(0), saltedSeed);
+                return (hash & 0x00FFFFFF) / (float)(1 << 24); // only use the lower 24 bits to construct a float from 0.0-1.0
+            }
+
+            @Override
+            public Explanation explainScore(int docId, Explanation subQueryScore) {
+                Explanation exp = new Explanation();
+                exp.setDescription("random score function (seed: " + originalSeed + ")");
+                return exp;
+            }
+        };
     }
 
-    @Override
-    public double score(int docId, float subQueryScore) {
-        uidByteData.setDocument(docId);
-        int hash = StringHelper.murmurhash3_x86_32(uidByteData.valueAt(0), saltedSeed);
-        return (hash & 0x00FFFFFF) / (float)(1 << 24); // only use the lower 24 bits to construct a float from 0.0-1.0
-    }
-
-    @Override
-    public Explanation explainScore(int docId, Explanation subQueryScore) {
-        Explanation exp = new Explanation();
-        exp.setDescription("random score function (seed: " + originalSeed + ")");
-        return exp;
-    }
 }

--- a/src/main/java/org/elasticsearch/common/lucene/search/function/ScoreFunction.java
+++ b/src/main/java/org/elasticsearch/common/lucene/search/function/ScoreFunction.java
@@ -19,27 +19,24 @@
 
 package org.elasticsearch.common.lucene.search.function;
 
-import org.apache.lucene.search.Explanation;
-import org.elasticsearch.common.lucene.ReaderContextAware;
+import org.apache.lucene.index.LeafReaderContext;
 
 import java.io.IOException;
 
 /**
  *
  */
-public abstract class ScoreFunction implements ReaderContextAware {
+public abstract class ScoreFunction {
 
     private final CombineFunction scoreCombiner;
 
-    public abstract double score(int docId, float subQueryScore);
-
-    public abstract Explanation explainScore(int docId, Explanation subQueryScore) throws IOException;
+    protected ScoreFunction(CombineFunction scoreCombiner) {
+        this.scoreCombiner = scoreCombiner;
+    }
 
     public CombineFunction getDefaultScoreCombiner() {
         return scoreCombiner;
     }
 
-    protected ScoreFunction(CombineFunction scoreCombiner) {
-        this.scoreCombiner = scoreCombiner;
-    }
+    public abstract LeafScoreFunction getLeafScoreFunction(LeafReaderContext ctx) throws IOException;
 }

--- a/src/main/java/org/elasticsearch/common/lucene/search/function/ScriptScoreFunction.java
+++ b/src/main/java/org/elasticsearch/common/lucene/search/function/ScriptScoreFunction.java
@@ -22,9 +22,9 @@ package org.elasticsearch.common.lucene.search.function;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.Explanation;
 import org.apache.lucene.search.Scorer;
-import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.script.ScriptException;
 import org.elasticsearch.script.ExplainableSearchScript;
+import org.elasticsearch.script.LeafSearchScript;
+import org.elasticsearch.script.ScriptException;
 import org.elasticsearch.script.SearchScript;
 
 import java.io.IOException;
@@ -75,57 +75,56 @@ public class ScriptScoreFunction extends ScoreFunction {
 
     private final Map<String, Object> params;
 
-    private final CannedScorer scorer;
-
     private final SearchScript script;
-    
+
 
     public ScriptScoreFunction(String sScript, Map<String, Object> params, SearchScript script) {
         super(CombineFunction.REPLACE);
         this.sScript = sScript;
         this.params = params;
         this.script = script;
-        this.scorer = new CannedScorer();
-        script.setScorer(scorer);
     }
 
     @Override
-    public void setNextReader(LeafReaderContext ctx) throws IOException {
-        script.setNextReader(ctx);
-    }
-
-    @Override
-    public double score(int docId, float subQueryScore) {
-        script.setNextDocId(docId);
-        scorer.docid = docId;
-        scorer.score = subQueryScore;
-        double result = script.runAsDouble();
-        if (Double.isNaN(result)) {
-            throw new ScriptException("script_score returned NaN");
-        }
-        return result;
-    }
-
-    @Override
-    public Explanation explainScore(int docId, Explanation subQueryScore) throws IOException {
-        Explanation exp;
-        if (script instanceof ExplainableSearchScript) {
-            script.setNextDocId(docId);
-            scorer.docid = docId;
-            scorer.score = subQueryScore.getValue();
-            exp = ((ExplainableSearchScript) script).explain(subQueryScore);
-        } else {
-            double score = score(docId, subQueryScore.getValue());
-            String explanation = "script score function, computed with script:\"" + sScript;
-            if (params != null) {
-                explanation += "\" and parameters: \n" + params.toString();
+    public LeafScoreFunction getLeafScoreFunction(LeafReaderContext ctx) throws IOException {
+        final LeafSearchScript leafScript = script.getLeafSearchScript(ctx);
+        final CannedScorer scorer = new CannedScorer();
+        leafScript.setScorer(scorer);
+        return new LeafScoreFunction() {
+            @Override
+            public double score(int docId, float subQueryScore) {
+                leafScript.setDocument(docId);
+                scorer.docid = docId;
+                scorer.score = subQueryScore;
+                double result = leafScript.runAsDouble();
+                if (Double.isNaN(result)) {
+                    throw new ScriptException("script_score returned NaN");
+                }
+                return result;
             }
-            exp = new Explanation(CombineFunction.toFloat(score), explanation);
-            Explanation scoreExp = new Explanation(subQueryScore.getValue(), "_score: ");
-            scoreExp.addDetail(subQueryScore);
-            exp.addDetail(scoreExp);
-        }
-        return exp;
+
+            @Override
+            public Explanation explainScore(int docId, Explanation subQueryScore) throws IOException {
+                Explanation exp;
+                if (leafScript instanceof ExplainableSearchScript) {
+                    leafScript.setDocument(docId);
+                    scorer.docid = docId;
+                    scorer.score = subQueryScore.getValue();
+                    exp = ((ExplainableSearchScript) leafScript).explain(subQueryScore);
+                } else {
+                    double score = score(docId, subQueryScore.getValue());
+                    String explanation = "script score function, computed with script:\"" + sScript;
+                    if (params != null) {
+                        explanation += "\" and parameters: \n" + params.toString();
+                    }
+                    exp = new Explanation(CombineFunction.toFloat(score), explanation);
+                    Explanation scoreExp = new Explanation(subQueryScore.getValue(), "_score: ");
+                    scoreExp.addDetail(subQueryScore);
+                    exp.addDetail(scoreExp);
+                }
+                return exp;
+            }
+        };
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/common/lucene/search/function/WeightFactorFunction.java
+++ b/src/main/java/org/elasticsearch/common/lucene/search/function/WeightFactorFunction.java
@@ -55,23 +55,24 @@ public class WeightFactorFunction extends ScoreFunction {
     }
 
     @Override
-    public void setNextReader(LeafReaderContext context) throws IOException {
-        scoreFunction.setNextReader(context);
-    }
+    public LeafScoreFunction getLeafScoreFunction(LeafReaderContext ctx) throws IOException {
+        final LeafScoreFunction leafFunction = scoreFunction.getLeafScoreFunction(ctx);
+        return new LeafScoreFunction() {
+            @Override
+            public double score(int docId, float subQueryScore) {
+                return leafFunction.score(docId, subQueryScore) * getWeight();
+            }
 
-    @Override
-    public double score(int docId, float subQueryScore) {
-        return scoreFunction.score(docId, subQueryScore) * getWeight();
-    }
-
-    @Override
-    public Explanation explainScore(int docId, Explanation subQueryScore) throws IOException {
-        Explanation functionScoreExplanation;
-        Explanation functionExplanation = scoreFunction.explainScore(docId, subQueryScore);
-        functionScoreExplanation = new ComplexExplanation(true, functionExplanation.getValue() * (float) getWeight(), "product of:");
-        functionScoreExplanation.addDetail(functionExplanation);
-        functionScoreExplanation.addDetail(explainWeight());
-        return functionScoreExplanation;
+            @Override
+            public Explanation explainScore(int docId, Explanation subQueryScore) throws IOException {
+                Explanation functionScoreExplanation;
+                Explanation functionExplanation = leafFunction.explainScore(docId, subQueryScore);
+                functionScoreExplanation = new ComplexExplanation(true, functionExplanation.getValue() * (float) getWeight(), "product of:");
+                functionScoreExplanation.addDetail(functionExplanation);
+                functionScoreExplanation.addDetail(explainWeight());
+                return functionScoreExplanation;
+            }
+        };
     }
 
     public Explanation explainWeight() {
@@ -89,18 +90,18 @@ public class WeightFactorFunction extends ScoreFunction {
         }
 
         @Override
-        public void setNextReader(LeafReaderContext context) {
+        public LeafScoreFunction getLeafScoreFunction(LeafReaderContext ctx) {
+            return new LeafScoreFunction() {
+                @Override
+                public double score(int docId, float subQueryScore) {
+                    return 1.0;
+                }
 
-        }
-
-        @Override
-        public double score(int docId, float subQueryScore) {
-            return 1.0;
-        }
-
-        @Override
-        public Explanation explainScore(int docId, Explanation subQueryScore) {
-            return new Explanation(1.0f, "constant score 1.0 - no function provided");
+                @Override
+                public Explanation explainScore(int docId, Explanation subQueryScore) {
+                    return new Explanation(1.0f, "constant score 1.0 - no function provided");
+                }
+            };
         }
     }
 }

--- a/src/main/java/org/elasticsearch/index/get/ShardGetService.java
+++ b/src/main/java/org/elasticsearch/index/get/ShardGetService.java
@@ -21,6 +21,7 @@ package org.elasticsearch.index.get;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
+
 import org.apache.lucene.index.Term;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
@@ -51,6 +52,7 @@ import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.fetch.source.FetchSourceContext;
+import org.elasticsearch.search.lookup.LeafSearchLookup;
 import org.elasticsearch.search.lookup.SearchLookup;
 
 import java.io.IOException;
@@ -238,7 +240,7 @@ public class ShardGetService extends AbstractIndexShardComponent {
                         } else {
                             if (searchLookup == null) {
                                 searchLookup = new SearchLookup(mapperService, fieldDataService, new String[]{type});
-                                searchLookup.source().setNextSource(source.source);
+                                searchLookup.source().setSource(source.source);
                             }
 
                             FieldMapper<?> fieldMapper = docMapper.mappers().smartNameFieldMapper(field);
@@ -370,9 +372,9 @@ public class ShardGetService extends AbstractIndexShardComponent {
                 } else if (!fieldMapper.mapper().fieldType().stored() && !fieldMapper.mapper().isGenerated()) {
                     if (searchLookup == null) {
                         searchLookup = new SearchLookup(mapperService, fieldDataService, new String[]{type});
-                        searchLookup.setNextReader(docIdAndVersion.context);
-                        searchLookup.source().setNextSource(source);
-                        searchLookup.setNextDocId(docIdAndVersion.docId);
+                        LeafSearchLookup leafSearchLookup = searchLookup.getLeafSearchLookup(docIdAndVersion.context);
+                        searchLookup.source().setSource(source);
+                        leafSearchLookup.setDocument(docIdAndVersion.docId);
                     }
 
                     List<Object> values = searchLookup.source().extractRawValues(field);

--- a/src/main/java/org/elasticsearch/index/query/ScriptFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/ScriptFilterParser.java
@@ -168,23 +168,23 @@ public class ScriptFilterParser implements FilterParser {
 
         @Override
         public DocIdSet getDocIdSet(LeafReaderContext context, Bits acceptDocs) throws IOException {
-            searchScript.setNextReader(context);
+            final LeafSearchScript leafScript = searchScript.getLeafSearchScript(context);
             // LUCENE 4 UPGRADE: we can simply wrap this here since it is not cacheable and if we are not top level we will get a null passed anyway 
-            return BitsFilteredDocIdSet.wrap(new ScriptDocSet(context.reader().maxDoc(), acceptDocs, searchScript), acceptDocs);
+            return BitsFilteredDocIdSet.wrap(new ScriptDocSet(context.reader().maxDoc(), acceptDocs, leafScript), acceptDocs);
         }
 
         static class ScriptDocSet extends DocValuesDocIdSet {
 
-            private final SearchScript searchScript;
+            private final LeafSearchScript searchScript;
 
-            public ScriptDocSet(int maxDoc, @Nullable Bits acceptDocs, SearchScript searchScript) {
+            public ScriptDocSet(int maxDoc, @Nullable Bits acceptDocs, LeafSearchScript searchScript) {
                 super(maxDoc, acceptDocs);
                 this.searchScript = searchScript;
             }
 
             @Override
             protected boolean matchDoc(int doc) {
-                searchScript.setNextDocId(doc);
+                searchScript.setDocument(doc);
                 Object val = searchScript.run();
                 if (val == null) {
                     return false;

--- a/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionParser.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionParser.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.geo.GeoDistance;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.GeoUtils;
 import org.elasticsearch.common.lucene.search.function.CombineFunction;
+import org.elasticsearch.common.lucene.search.function.LeafScoreFunction;
 import org.elasticsearch.common.lucene.search.function.ScoreFunction;
 import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.common.unit.TimeValue;
@@ -38,6 +39,7 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.fielddata.IndexGeoPointFieldData;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData;
 import org.elasticsearch.index.fielddata.MultiGeoPointValues;
+import org.elasticsearch.index.fielddata.NumericDoubleValues;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MapperService;
@@ -57,30 +59,30 @@ import java.util.Locale;
 /**
  * This class provides the basic functionality needed for adding a decay
  * function.
- * 
+ *
  * This parser parses this kind of input
- * 
+ *
  * <pre>
  * {@code}
- * { 
+ * {
  *      "fieldname1" : {
- *          "origin" = "someValue", 
+ *          "origin" = "someValue",
  *          "scale" = "someValue"
- *      } 
- *      
+ *      }
+ *
  * }
  * </pre>
- * 
+ *
  * "origin" here refers to the reference point and "scale" to the level of
  * uncertainty you have in your origin.
  * <p>
- * 
+ *
  * For example, you might want to retrieve an event that took place around the
  * 20 May 2010 somewhere near Berlin. You are mainly interested in events that
  * are close to the 20 May 2010 but you are unsure about your guess, maybe it
  * was a week before or after that. Your "origin" for the date field would be
  * "20 May 2010" and your "scale" would be "7d".
- * 
+ *
  * This class parses the input and creates a scoring function from the
  * parameters origin and scale.
  * <p>
@@ -92,7 +94,7 @@ import java.util.Locale;
  * for an example. The parser furthermore needs to be registered in the
  * {@link org.elasticsearch.index.query.functionscore.FunctionScoreModule
  * FunctionScoreModule}.
- * 
+ *
  * **/
 
 public abstract class DecayFunctionParser implements ScoreFunctionParser {
@@ -106,18 +108,18 @@ public abstract class DecayFunctionParser implements ScoreFunctionParser {
 
     /**
      * Parses bodies of the kind
-     * 
+     *
      * <pre>
      * {@code}
-     * { 
+     * {
      *      "fieldname1" : {
-     *          "origin" = "someValue", 
+     *          "origin" = "someValue",
      *          "scale" = "someValue"
-     *      } 
-     *      
+     *      }
+     *
      * }
      * </pre>
-     * 
+     *
      * */
     @Override
     public ScoreFunction parse(QueryParseContext parseContext, XContentParser parser) throws IOException, QueryParsingException {
@@ -283,7 +285,6 @@ public abstract class DecayFunctionParser implements ScoreFunctionParser {
 
         private final GeoPoint origin;
         private final IndexGeoPointFieldData fieldData;
-        private MultiGeoPointValues geoPointValues = null;
 
         private static final GeoDistance distFunction = GeoDistance.DEFAULT;
 
@@ -295,31 +296,35 @@ public abstract class DecayFunctionParser implements ScoreFunctionParser {
         }
 
         @Override
-        public void setNextReader(LeafReaderContext context) {
-            geoPointValues = fieldData.load(context).getGeoPointValues();
-        }
+        protected NumericDoubleValues distance(LeafReaderContext context) {
+            final MultiGeoPointValues geoPointValues = fieldData.load(context).getGeoPointValues();
+            return new NumericDoubleValues() {
 
-        @Override
-        protected double distance(int docId) {
-            geoPointValues.setDocument(docId);
-            final int num = geoPointValues.count();
-            if (num > 0) {
-                double value = mode.startDouble();
-                for (int i = 0; i < num; i++) {
-                    GeoPoint other = geoPointValues.valueAt(i);
-                    value = mode.apply(Math.max(0.0d, distFunction.calculate(origin.lat(), origin.lon(), other.lat(), other.lon(),
-                            DistanceUnit.METERS) - offset), value);
+                @Override
+                public double get(int docID) {
+                    geoPointValues.setDocument(docID);
+                    final int num = geoPointValues.count();
+                    if (num > 0) {
+                        double value = mode.startDouble();
+                        for (int i = 0; i < num; i++) {
+                            GeoPoint other = geoPointValues.valueAt(i);
+                            value = mode.apply(Math.max(0.0d, distFunction.calculate(origin.lat(), origin.lon(), other.lat(), other.lon(),
+                                    DistanceUnit.METERS) - offset), value);
+                        }
+                        return mode.reduce(value, num);
+                    } else {
+                        return 0.0;
+                    }
                 }
-                return mode.reduce(value, num);
-            } else {
-                return 0.0;
-            }
+
+            };
         }
 
         @Override
-        protected String getDistanceString(int docId) {
+        protected String getDistanceString(LeafReaderContext ctx, int docId) {
             StringBuilder values = new StringBuilder(mode.name());
             values.append(" of: [");
+            final MultiGeoPointValues geoPointValues = fieldData.load(ctx).getGeoPointValues();
             geoPointValues.setDocument(docId);
             final int num = geoPointValues.count();
             if (num > 0) {
@@ -348,7 +353,6 @@ public abstract class DecayFunctionParser implements ScoreFunctionParser {
 
         private final IndexNumericFieldData fieldData;
         private final double origin;
-        private SortedNumericDoubleValues doubleValues;
 
         public NumericFieldDataScoreFunction(double origin, double scale, double decay, double offset, DecayFunction func,
                 IndexNumericFieldData fieldData, MultiValueMode mode) {
@@ -358,31 +362,33 @@ public abstract class DecayFunctionParser implements ScoreFunctionParser {
         }
 
         @Override
-        public void setNextReader(LeafReaderContext context) {
-            this.doubleValues = this.fieldData.load(context).getDoubleValues();
-        }
-
-        @Override
-        protected double distance(int docId) {
-            doubleValues.setDocument(docId);
-            final int num = doubleValues.count();
-            if (num > 0) {
-                double value = mode.startDouble();
-                for (int i = 0; i < num; i++) {
-                    final double other = doubleValues.valueAt(i);
-                    value = mode.apply(Math.max(0.0d, Math.abs(other - origin) - offset), value);
+        protected NumericDoubleValues distance(LeafReaderContext context) {
+            final SortedNumericDoubleValues doubleValues = fieldData.load(context).getDoubleValues();
+            return new NumericDoubleValues() {
+                @Override
+                public double get(int docID) {
+                    doubleValues.setDocument(docID);
+                    final int num = doubleValues.count();
+                    if (num > 0) {
+                        double value = mode.startDouble();
+                        for (int i = 0; i < num; i++) {
+                            final double other = doubleValues.valueAt(i);
+                            value = mode.apply(Math.max(0.0d, Math.abs(other - origin) - offset), value);
+                        }
+                        return mode.reduce(value, num);
+                    } else {
+                        return 0.0;
+                    }
                 }
-                return mode.reduce(value, num);
-            } else {
-                return 0.0;
-            }
+            };
         }
 
         @Override
-        protected String getDistanceString(int docId) {
+        protected String getDistanceString(LeafReaderContext ctx, int docId) {
 
             StringBuilder values = new StringBuilder(mode.name());
             values.append("[");
+            final SortedNumericDoubleValues doubleValues = fieldData.load(ctx).getDoubleValues();
             doubleValues.setDocument(docId);
             final int num = doubleValues.count();
             if (num > 0) {
@@ -410,7 +416,7 @@ public abstract class DecayFunctionParser implements ScoreFunctionParser {
 
     /**
      * This is the base class for scoring a single field.
-     * 
+     *
      * */
     public static abstract class AbstractDistanceScoreFunction extends ScoreFunction {
 
@@ -437,33 +443,39 @@ public abstract class DecayFunctionParser implements ScoreFunctionParser {
             this.offset = offset;
         }
 
-        @Override
-        public double score(int docId, float subQueryScore) {
-            double value = distance(docId);
-            return func.evaluate(value, scale);
-        }
-
         /**
          * This function computes the distance from a defined origin. Since
          * the value of the document is read from the index, it cannot be
          * guaranteed that the value actually exists. If it does not, we assume
          * the user handles this case in the query and return 0.
          * */
-        protected abstract double distance(int docId);
-
-        protected abstract String getDistanceString(int docId);
-
-        protected abstract String getFieldName();
+        protected abstract NumericDoubleValues distance(LeafReaderContext context);
 
         @Override
-        public Explanation explainScore(int docId, Explanation subQueryScore) {
-            ComplexExplanation ce = new ComplexExplanation();
-            ce.setValue(CombineFunction.toFloat(score(docId, subQueryScore.getValue())));
-            ce.setMatch(true);
-            ce.setDescription("Function for field " + getFieldName() + ":");
-            ce.addDetail(func.explainFunction(getDistanceString(docId), distance(docId), scale));
-            return ce;
+        public final LeafScoreFunction getLeafScoreFunction(final LeafReaderContext ctx) {
+            final NumericDoubleValues distance = distance(ctx);
+            return new LeafScoreFunction() {
+
+                @Override
+                public double score(int docId, float subQueryScore) {
+                    return func.evaluate(distance.get(docId), scale);
+                }
+
+                @Override
+                public Explanation explainScore(int docId, Explanation subQueryScore) throws IOException {
+                    ComplexExplanation ce = new ComplexExplanation();
+                    ce.setValue(CombineFunction.toFloat(score(docId, subQueryScore.getValue())));
+                    ce.setMatch(true);
+                    ce.setDescription("Function for field " + getFieldName() + ":");
+                    ce.addDetail(func.explainFunction(getDistanceString(ctx, docId), distance.get(docId), scale));
+                    return ce;
+                }
+            };
         }
+
+        protected abstract String getDistanceString(LeafReaderContext ctx, int docId);
+
+        protected abstract String getFieldName();
     }
 
 }

--- a/src/main/java/org/elasticsearch/percolator/PercolateContext.java
+++ b/src/main/java/org/elasticsearch/percolator/PercolateContext.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.percolator;
 
 import com.google.common.collect.ImmutableList;
+
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.LeafReaderContext;
@@ -60,6 +61,7 @@ import org.elasticsearch.search.fetch.script.ScriptFieldsContext;
 import org.elasticsearch.search.fetch.source.FetchSourceContext;
 import org.elasticsearch.search.highlight.SearchContextHighlight;
 import org.elasticsearch.search.internal.*;
+import org.elasticsearch.search.lookup.LeafSearchLookup;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.search.query.QuerySearchResult;
 import org.elasticsearch.search.rescore.RescoreSearchContext;
@@ -136,9 +138,9 @@ public class PercolateContext extends SearchContext {
 
         IndexReader indexReader = docSearcher.reader();
         LeafReaderContext atomicReaderContext = indexReader.leaves().get(0);
-        lookup().setNextReader(atomicReaderContext);
-        lookup().setNextDocId(0);
-        lookup().source().setNextSource(parsedDocument.source());
+        LeafSearchLookup leafLookup = lookup().getLeafSearchLookup(atomicReaderContext);
+        leafLookup.setDocument(0);
+        leafLookup.source().setSource(parsedDocument.source());
 
         Map<String, SearchHitField> fields = new HashMap<>();
         for (IndexableField field : parsedDocument.rootDoc().getFields()) {

--- a/src/main/java/org/elasticsearch/script/AbstractSearchScript.java
+++ b/src/main/java/org/elasticsearch/script/AbstractSearchScript.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.script;
 
-import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.Scorer;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.search.lookup.*;
@@ -36,16 +35,16 @@ import java.util.Map;
  * <p/>
  * <p>The use is required to implement the {@link #run()} method.
  */
-public abstract class AbstractSearchScript extends AbstractExecutableScript implements SearchScript {
+public abstract class AbstractSearchScript extends AbstractExecutableScript implements LeafSearchScript {
 
-    private SearchLookup lookup;
+    private LeafSearchLookup lookup;
     private Scorer scorer;
 
     /**
      * Returns the doc lookup allowing to access field data (cached) values as well as the current document score
      * (where applicable).
      */
-    protected final DocLookup doc() {
+    protected final LeafDocLookup doc() {
         return lookup.doc();
     }
 
@@ -87,18 +86,18 @@ public abstract class AbstractSearchScript extends AbstractExecutableScript impl
     /**
      * Allows to access statistics on terms and fields.
      */
-    protected final IndexLookup indexLookup() {
+    protected final LeafIndexLookup indexLookup() {
         return lookup.indexLookup();
     }
 
     /**
      * Allows to access the *stored* fields.
      */
-    protected final FieldsLookup fields() {
+    protected final LeafFieldsLookup fields() {
         return lookup.fields();
     }
 
-    void setLookup(SearchLookup lookup) {
+    void setLookup(LeafSearchLookup lookup) {
         this.lookup = lookup;
     }
 
@@ -108,18 +107,13 @@ public abstract class AbstractSearchScript extends AbstractExecutableScript impl
     }
 
     @Override
-    public void setNextReader(LeafReaderContext context) {
-        lookup.setNextReader(context);
+    public void setDocument(int doc) {
+        lookup.setDocument(doc);
     }
 
     @Override
-    public void setNextDocId(int doc) {
-        lookup.setNextDocId(doc);
-    }
-
-    @Override
-    public void setNextSource(Map<String, Object> source) {
-        lookup.source().setNextSource(source);
+    public void setSource(Map<String, Object> source) {
+        lookup.source().setSource(source);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/script/ExplainableSearchScript.java
+++ b/src/main/java/org/elasticsearch/script/ExplainableSearchScript.java
@@ -47,7 +47,7 @@ import java.io.IOException;
  * This is currently not used inside elasticsearch but it is used, see for example here:
  * https://github.com/elasticsearch/elasticsearch/issues/8561
  */
-public interface ExplainableSearchScript extends SearchScript {
+public interface ExplainableSearchScript extends LeafSearchScript {
 
     /**
      * Build the explanation of the current document being scored

--- a/src/main/java/org/elasticsearch/script/LeafSearchScript.java
+++ b/src/main/java/org/elasticsearch/script/LeafSearchScript.java
@@ -16,16 +16,26 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.elasticsearch.common.lucene;
 
-import org.apache.lucene.index.LeafReaderContext;
+package org.elasticsearch.script;
 
-import java.io.IOException;
+import org.elasticsearch.common.lucene.ScorerAware;
+
+import java.util.Map;
 
 /**
- *
+ * A per-segment {@link SearchScript}.
  */
-public interface ReaderContextAware {
+public interface LeafSearchScript extends ScorerAware, ExecutableScript {
 
-    public void setNextReader(LeafReaderContext reader) throws IOException;
+    void setDocument(int doc);
+
+    void setSource(Map<String, Object> source);
+
+    float runAsFloat();
+
+    long runAsLong();
+
+    double runAsDouble();
+
 }

--- a/src/main/java/org/elasticsearch/script/SearchScript.java
+++ b/src/main/java/org/elasticsearch/script/SearchScript.java
@@ -18,23 +18,15 @@
  */
 package org.elasticsearch.script;
 
-import org.elasticsearch.common.lucene.ReaderContextAware;
-import org.elasticsearch.common.lucene.ScorerAware;
+import org.apache.lucene.index.LeafReaderContext;
 
-import java.util.Map;
+import java.io.IOException;
 
 /**
  * A search script.
  */
-public interface SearchScript extends ExecutableScript, ReaderContextAware, ScorerAware {
+public interface SearchScript {
 
-    void setNextDocId(int doc);
+    LeafSearchScript getLeafSearchScript(LeafReaderContext context) throws IOException;
 
-    void setNextSource(Map<String, Object> source);
-
-    float runAsFloat();
-
-    long runAsLong();
-
-    double runAsDouble();
 }

--- a/src/main/java/org/elasticsearch/script/expression/ExpressionScript.java
+++ b/src/main/java/org/elasticsearch/script/expression/ExpressionScript.java
@@ -26,6 +26,9 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.queries.function.FunctionValues;
 import org.apache.lucene.queries.function.ValueSource;
 import org.apache.lucene.search.Scorer;
+import org.elasticsearch.ElasticsearchIllegalStateException;
+import org.elasticsearch.common.lucene.Lucene;
+import org.elasticsearch.script.LeafSearchScript;
 import org.elasticsearch.script.SearchScript;
 
 import java.io.IOException;
@@ -42,75 +45,75 @@ class ExpressionScript implements SearchScript {
     final SimpleBindings bindings;
     final ValueSource source;
     final ReplaceableConstValueSource specialValue; // _value
-    Map<String, Scorer> context;
     Scorer scorer;
-    FunctionValues values;
     int docid;
 
     ExpressionScript(Expression e, SimpleBindings b, ReplaceableConstValueSource v) {
         expression = e;
         bindings = b;
-        context = Collections.EMPTY_MAP;
         source = expression.getValueSource(bindings);
         specialValue = v;
     }
 
-    double evaluate() {
-        return values.doubleVal(docid);
+    @Override
+    public LeafSearchScript getLeafSearchScript(final LeafReaderContext leaf) throws IOException {
+        return new LeafSearchScript() {
+
+            FunctionValues values = source.getValues(Collections.singletonMap("scorer", Lucene.illegalScorer("Scores are not available in the current context")), leaf);
+
+            double evaluate() {
+                return values.doubleVal(docid);
+            }
+
+            @Override
+            public Object run() { return new Double(evaluate()); }
+
+            @Override
+            public float runAsFloat() { return (float)evaluate();}
+
+            @Override
+            public long runAsLong() { return (long)evaluate(); }
+
+            @Override
+            public double runAsDouble() { return evaluate(); }
+
+            @Override
+            public Object unwrap(Object value) { return value; }
+
+            @Override
+            public void setDocument(int d) {
+                docid = d;
+            }
+
+            @Override
+            public void setScorer(Scorer s) {
+                scorer = s;
+                try {
+                    // We have a new binding for the scorer so we need to reset the values
+                    values = source.getValues(Collections.singletonMap("scorer", scorer), leaf);
+                } catch (IOException e) {
+                    throw new ElasticsearchIllegalStateException("Can't get values", e);
+                }
+            }
+
+            @Override
+            public void setSource(Map<String, Object> source) {
+                // noop: expressions don't use source data
+            }
+
+            @Override
+            public void setNextVar(String name, Object value) {
+                assert(specialValue != null);
+                // this should only be used for the special "_value" variable used in aggregations
+                assert(name.equals("_value"));
+
+                if (value instanceof Number) {
+                    specialValue.setValue(((Number)value).doubleValue());
+                } else {
+                    throw new ExpressionScriptExecutionException("Cannot use expression with text variable");
+                }
+            }
+        };
     }
-
-    @Override
-    public Object run() { return new Double(evaluate()); }
-
-    @Override
-    public float runAsFloat() { return (float)evaluate();}
-
-    @Override
-    public long runAsLong() { return (long)evaluate(); }
-
-    @Override
-    public double runAsDouble() { return evaluate(); }
-
-    @Override
-    public Object unwrap(Object value) { return value; }
-
-    @Override
-    public void setNextDocId(int d) {
-        docid = d;
-    }
-
-    @Override
-    public void setNextReader(LeafReaderContext leaf) {
-        try {
-            values = source.getValues(context, leaf);
-        } catch (IOException e) {
-            throw new ExpressionScriptExecutionException("Expression failed to bind for segment", e);
-        }
-    }
-
-    @Override
-    public void setScorer(Scorer s) {
-        scorer = s;
-        context = Collections.singletonMap("scorer", scorer);
-    }
-
-    @Override
-    public void setNextSource(Map<String, Object> source) {
-        // noop: expressions don't use source data
-    }
-
-    @Override
-    public void setNextVar(String name, Object value) {
-        assert(specialValue != null);
-        // this should only be used for the special "_value" variable used in aggregations
-        assert(name.equals("_value"));
-
-        if (value instanceof Number) {
-            specialValue.setValue(((Number)value).doubleValue());
-        } else {
-            throw new ExpressionScriptExecutionException("Cannot use expression with text variable");
-        }
-    }
-
 
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/scripted/ScriptedMetricAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/scripted/ScriptedMetricAggregator.java
@@ -21,6 +21,7 @@ package org.elasticsearch.search.aggregations.metrics.scripted;
 
 import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.script.ExecutableScript;
+import org.elasticsearch.script.LeafSearchScript;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.script.ScriptService.ScriptType;
 import org.elasticsearch.script.ScriptContext;
@@ -93,13 +94,13 @@ public class ScriptedMetricAggregator extends MetricsAggregator {
     @Override
     public LeafBucketCollector getLeafCollector(LeafReaderContext ctx,
             final LeafBucketCollector sub) throws IOException {
-        mapScript.setNextReader(ctx);
+        final LeafSearchScript leafMapScript = mapScript.getLeafSearchScript(ctx);
         return new LeafBucketCollectorBase(sub, mapScript) {
             @Override
             public void collect(int doc, long bucket) throws IOException {
                 assert bucket == 0 : bucket;
-                mapScript.setNextDocId(doc);
-                mapScript.run();
+                leafMapScript.setDocument(doc);
+                leafMapScript.run();
             }
         };
     }

--- a/src/main/java/org/elasticsearch/search/aggregations/support/values/ScriptBytesValues.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/support/values/ScriptBytesValues.java
@@ -22,8 +22,7 @@ import org.apache.lucene.search.Scorer;
 import org.elasticsearch.common.lucene.ScorerAware;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.index.fielddata.SortingBinaryDocValues;
-import org.elasticsearch.script.SearchScript;
-import org.elasticsearch.search.aggregations.support.ScriptValues;
+import org.elasticsearch.script.LeafSearchScript;
 
 import java.lang.reflect.Array;
 import java.util.Collection;
@@ -31,18 +30,13 @@ import java.util.Collection;
 /**
  * {@link SortedBinaryDocValues} implementation that reads values from a script.
  */
-public class ScriptBytesValues extends SortingBinaryDocValues implements ScriptValues, ScorerAware {
+public class ScriptBytesValues extends SortingBinaryDocValues implements ScorerAware {
 
-    private final SearchScript script;
+    private final LeafSearchScript script;
 
-    public ScriptBytesValues(SearchScript script) {
+    public ScriptBytesValues(LeafSearchScript script) {
         super();
         this.script = script;
-    }
-
-    @Override
-    public SearchScript script() {
-        return script;
     }
 
     private void set(int i, Object o) {
@@ -55,7 +49,7 @@ public class ScriptBytesValues extends SortingBinaryDocValues implements ScriptV
 
     @Override
     public void setDocument(int docId) {
-        script.setNextDocId(docId);
+        script.setDocument(docId);
         final Object value = script.run();
 
         if (value == null) {

--- a/src/main/java/org/elasticsearch/search/aggregations/support/values/ScriptDoubleValues.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/support/values/ScriptDoubleValues.java
@@ -21,9 +21,8 @@ package org.elasticsearch.search.aggregations.support.values;
 import org.apache.lucene.search.Scorer;
 import org.elasticsearch.common.lucene.ScorerAware;
 import org.elasticsearch.index.fielddata.SortingNumericDoubleValues;
-import org.elasticsearch.script.SearchScript;
+import org.elasticsearch.script.LeafSearchScript;
 import org.elasticsearch.search.aggregations.AggregationExecutionException;
-import org.elasticsearch.search.aggregations.support.ScriptValues;
 
 import java.lang.reflect.Array;
 import java.util.Collection;
@@ -32,23 +31,18 @@ import java.util.Iterator;
 /**
  * {@link DoubleValues} implementation which is based on a script
  */
-public class ScriptDoubleValues extends SortingNumericDoubleValues implements ScriptValues, ScorerAware {
+public class ScriptDoubleValues extends SortingNumericDoubleValues implements ScorerAware {
 
-    final SearchScript script;
+    final LeafSearchScript script;
 
-    public ScriptDoubleValues(SearchScript script) {
+    public ScriptDoubleValues(LeafSearchScript script) {
         super();
         this.script = script;
     }
 
     @Override
-    public SearchScript script() {
-        return script;
-    }
-
-    @Override
     public void setDocument(int docId) {
-        script.setNextDocId(docId);
+        script.setDocument(docId);
         final Object value = script.run();
 
         if (value == null) {

--- a/src/main/java/org/elasticsearch/search/aggregations/support/values/ScriptLongValues.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/support/values/ScriptLongValues.java
@@ -22,9 +22,8 @@ import org.apache.lucene.search.Scorer;
 import org.apache.lucene.util.LongValues;
 import org.elasticsearch.common.lucene.ScorerAware;
 import org.elasticsearch.index.fielddata.SortingNumericDocValues;
-import org.elasticsearch.script.SearchScript;
+import org.elasticsearch.script.LeafSearchScript;
 import org.elasticsearch.search.aggregations.AggregationExecutionException;
-import org.elasticsearch.search.aggregations.support.ScriptValues;
 
 import java.lang.reflect.Array;
 import java.util.Collection;
@@ -33,23 +32,18 @@ import java.util.Iterator;
 /**
  * {@link LongValues} implementation which is based on a script
  */
-public class ScriptLongValues extends SortingNumericDocValues implements ScriptValues, ScorerAware {
+public class ScriptLongValues extends SortingNumericDocValues implements ScorerAware {
 
-    final SearchScript script;
+    final LeafSearchScript script;
 
-    public ScriptLongValues(SearchScript script) {
+    public ScriptLongValues(LeafSearchScript script) {
         super();
         this.script = script;
     }
 
     @Override
-    public SearchScript script() {
-        return script;
-    }
-
-    @Override
     public void setDocument(int docId) {
-        script.setNextDocId(docId);
+        script.setDocument(docId);
         final Object value = script.run();
 
         if (value == null) {

--- a/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
+++ b/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
@@ -21,6 +21,7 @@ package org.elasticsearch.search.fetch;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.ReaderUtil;
 import org.apache.lucene.search.DocIdSetIterator;
@@ -61,6 +62,8 @@ import org.elasticsearch.search.internal.InternalSearchHit;
 import org.elasticsearch.search.internal.InternalSearchHitField;
 import org.elasticsearch.search.internal.InternalSearchHits;
 import org.elasticsearch.search.internal.SearchContext;
+import org.elasticsearch.search.lookup.LeafSearchLookup;
+import org.elasticsearch.search.lookup.SourceLookup;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -238,10 +241,10 @@ public class FetchPhase implements SearchPhase {
         InternalSearchHit searchHit = new InternalSearchHit(docId, fieldsVisitor.uid().id(), typeText, searchFields);
 
         // go over and extract fields that are not mapped / stored
-        context.lookup().setNextReader(subReaderContext);
-        context.lookup().setNextDocId(subDocId);
+        SourceLookup sourceLookup = context.lookup().source();
+        sourceLookup.setSegmentAndDocument(subReaderContext, subDocId);
         if (fieldsVisitor.source() != null) {
-            context.lookup().source().setNextSource(fieldsVisitor.source());
+            sourceLookup.setSource(fieldsVisitor.source());
         }
         if (extractFieldNames != null) {
             for (String extractFieldName : extractFieldNames) {
@@ -281,8 +284,8 @@ public class FetchPhase implements SearchPhase {
 
         Map<String, SearchHitField> searchFields = getSearchFields(context, nestedSubDocId, loadAllStored, fieldNames, subReaderContext);
         DocumentMapper documentMapper = context.mapperService().documentMapper(rootFieldsVisitor.uid().type());
-        context.lookup().setNextReader(subReaderContext);
-        context.lookup().setNextDocId(nestedSubDocId);
+        SourceLookup sourceLookup = context.lookup().source();
+        sourceLookup.setSegmentAndDocument(subReaderContext, nestedSubDocId);
 
         ObjectMapper nestedObjectMapper = documentMapper.findNestedObjectMapper(nestedSubDocId, context.bitsetFilterCache(), subReaderContext);
         assert nestedObjectMapper != null;
@@ -313,11 +316,11 @@ public class FetchPhase implements SearchPhase {
                 nested = nested.getChild();
             } while (nested != null);
 
-            context.lookup().source().setNextSource(sourceAsMap);
+            context.lookup().source().setSource(sourceAsMap);
             XContentType contentType = tuple.v1();
             BytesReference nestedSource = contentBuilder(contentType).map(sourceAsMap).bytes();
-            context.lookup().source().setNextSource(nestedSource);
-            context.lookup().source().setNextSourceContentType(contentType);
+            context.lookup().source().setSource(nestedSource);
+            context.lookup().source().setSourceContentType(contentType);
         }
 
         InternalSearchHit searchHit = new InternalSearchHit(nestedTopDocId, rootFieldsVisitor.uid().id(), documentMapper.typeText(), nestedIdentity, searchFields);

--- a/src/main/java/org/elasticsearch/search/fetch/script/ScriptFieldsFetchSubPhase.java
+++ b/src/main/java/org/elasticsearch/search/fetch/script/ScriptFieldsFetchSubPhase.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableMap;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchIllegalStateException;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.script.LeafSearchScript;
 import org.elasticsearch.search.SearchHitField;
 import org.elasticsearch.search.SearchParseElement;
 import org.elasticsearch.search.fetch.FetchSubPhase;
@@ -72,17 +73,18 @@ public class ScriptFieldsFetchSubPhase implements FetchSubPhase {
     @Override
     public void hitExecute(SearchContext context, HitContext hitContext) throws ElasticsearchException {
         for (ScriptFieldsContext.ScriptField scriptField : context.scriptFields().fields()) {
+            LeafSearchScript leafScript;
             try {
-                scriptField.script().setNextReader(hitContext.readerContext());
-            } catch (IOException e) {
-                throw new ElasticsearchIllegalStateException("IOException while calling setNextReader", e);
+                leafScript = scriptField.script().getLeafSearchScript(hitContext.readerContext());
+            } catch (IOException e1) {
+                throw new ElasticsearchIllegalStateException("Failed to load script", e1);
             }
-            scriptField.script().setNextDocId(hitContext.docId());
+            leafScript.setDocument(hitContext.docId());
 
             Object value;
             try {
-                value = scriptField.script().run();
-                value = scriptField.script().unwrap(value);
+                value = leafScript.run();
+                value = leafScript.unwrap(value);
             } catch (RuntimeException e) {
                 if (scriptField.ignoreException()) {
                     continue;

--- a/src/main/java/org/elasticsearch/search/highlight/HighlightUtils.java
+++ b/src/main/java/org/elasticsearch/search/highlight/HighlightUtils.java
@@ -20,6 +20,8 @@ package org.elasticsearch.search.highlight;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+
+import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.highlight.DefaultEncoder;
 import org.apache.lucene.search.highlight.Encoder;
 import org.apache.lucene.search.highlight.SimpleHTMLEncoder;
@@ -28,6 +30,7 @@ import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.search.fetch.FetchSubPhase;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.lookup.SearchLookup;
+import org.elasticsearch.search.lookup.SourceLookup;
 
 import java.io.IOException;
 import java.util.List;
@@ -54,10 +57,9 @@ public final class HighlightUtils {
                 textsToHighlight = ImmutableList.of();
             }
         } else {
-            SearchLookup lookup = searchContext.lookup();
-            lookup.setNextReader(hitContext.readerContext());
-            lookup.setNextDocId(hitContext.docId());
-            textsToHighlight = lookup.source().extractRawValues(hitContext.getSourcePath(mapper.names().sourcePath()));
+            SourceLookup sourceLookup = searchContext.lookup().source();
+            sourceLookup.setSegmentAndDocument(hitContext.readerContext(), hitContext.docId());
+            textsToHighlight = sourceLookup.extractRawValues(hitContext.getSourcePath(mapper.names().sourcePath()));
         }
         assert textsToHighlight != null;
         return textsToHighlight;

--- a/src/main/java/org/elasticsearch/search/highlight/vectorhighlight/SourceScoreOrderFragmentsBuilder.java
+++ b/src/main/java/org/elasticsearch/search/highlight/vectorhighlight/SourceScoreOrderFragmentsBuilder.java
@@ -30,6 +30,7 @@ import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.search.fetch.FetchSubPhase;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.lookup.SearchLookup;
+import org.elasticsearch.search.lookup.SourceLookup;
 
 import java.io.IOException;
 import java.util.List;
@@ -56,11 +57,10 @@ public class SourceScoreOrderFragmentsBuilder extends ScoreOrderFragmentsBuilder
     @Override
     protected Field[] getFields(IndexReader reader, int docId, String fieldName) throws IOException {
         // we know its low level reader, and matching docId, since that's how we call the highlighter with
-        SearchLookup lookup = searchContext.lookup();
-        lookup.setNextReader((LeafReaderContext) reader.getContext());
-        lookup.setNextDocId(docId);
+        SourceLookup sourceLookup = searchContext.lookup().source();
+        sourceLookup.setSegmentAndDocument((LeafReaderContext) reader.getContext(), docId);
 
-        List<Object> values = lookup.source().extractRawValues(hitContext.getSourcePath(mapper.names().sourcePath()));
+        List<Object> values = sourceLookup.extractRawValues(hitContext.getSourcePath(mapper.names().sourcePath()));
         Field[] fields = new Field[values.size()];
         for (int i = 0; i < values.size(); i++) {
             fields[i] = new Field(mapper.names().indexName(), values.get(i).toString(), TextField.TYPE_NOT_STORED);

--- a/src/main/java/org/elasticsearch/search/highlight/vectorhighlight/SourceSimpleFragmentsBuilder.java
+++ b/src/main/java/org/elasticsearch/search/highlight/vectorhighlight/SourceSimpleFragmentsBuilder.java
@@ -27,6 +27,7 @@ import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.search.fetch.FetchSubPhase;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.lookup.SearchLookup;
+import org.elasticsearch.search.lookup.SourceLookup;
 
 import java.io.IOException;
 import java.util.List;
@@ -52,11 +53,10 @@ public class SourceSimpleFragmentsBuilder extends SimpleFragmentsBuilder {
     @Override
     protected Field[] getFields(IndexReader reader, int docId, String fieldName) throws IOException {
         // we know its low level reader, and matching docId, since that's how we call the highlighter with
-        SearchLookup lookup = searchContext.lookup();
-        lookup.setNextReader((LeafReaderContext) reader.getContext());
-        lookup.setNextDocId(docId);
+        SourceLookup sourceLookup = searchContext.lookup().source();
+        sourceLookup.setSegmentAndDocument((LeafReaderContext) reader.getContext(), docId);
 
-        List<Object> values = lookup.source().extractRawValues(hitContext.getSourcePath(mapper.names().sourcePath()));
+        List<Object> values = sourceLookup.extractRawValues(hitContext.getSourcePath(mapper.names().sourcePath()));
         if (values.isEmpty()) {
             return EMPTY_FIELDS;
         }

--- a/src/main/java/org/elasticsearch/search/lookup/DocLookup.java
+++ b/src/main/java/org/elasticsearch/search/lookup/DocLookup.java
@@ -18,36 +18,21 @@
  */
 package org.elasticsearch.search.lookup;
 
-import com.google.common.collect.Maps;
-import org.elasticsearch.ElasticsearchIllegalArgumentException;
+import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.index.fielddata.IndexFieldDataService;
-import org.elasticsearch.index.fielddata.ScriptDocValues;
-import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MapperService;
-import org.apache.lucene.index.LeafReaderContext;
-
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Map;
-import java.util.Set;
 
 /**
  *
  */
-public class DocLookup implements Map {
-
-    private final Map<String, ScriptDocValues> localCacheFieldData = Maps.newHashMapWithExpectedSize(4);
+public class DocLookup {
 
     private final MapperService mapperService;
     private final IndexFieldDataService fieldDataService;
 
     @Nullable
     private final String[] types;
-
-    private LeafReaderContext reader;
-
-    private int docId = -1;
 
     DocLookup(MapperService mapperService, IndexFieldDataService fieldDataService, @Nullable String[] types) {
         this.mapperService = mapperService;
@@ -63,97 +48,7 @@ public class DocLookup implements Map {
         return this.fieldDataService;
     }
 
-    public void setNextReader(LeafReaderContext context) {
-        if (this.reader == context) { // if we are called with the same reader, don't invalidate source
-            return;
-        }
-        this.reader = context;
-        this.docId = -1;
-        localCacheFieldData.clear();
-    }
-
-    public void setNextDocId(int docId) {
-        this.docId = docId;
-    }
-
-    @Override
-    public Object get(Object key) {
-        // assume its a string...
-        String fieldName = key.toString();
-        ScriptDocValues scriptValues = localCacheFieldData.get(fieldName);
-        if (scriptValues == null) {
-            FieldMapper mapper = mapperService.smartNameFieldMapper(fieldName, types);
-            if (mapper == null) {
-                throw new ElasticsearchIllegalArgumentException("No field found for [" + fieldName + "] in mapping with types " + Arrays.toString(types) + "");
-            }
-            scriptValues = fieldDataService.getForField(mapper).load(reader).getScriptValues();
-            localCacheFieldData.put(fieldName, scriptValues);
-        }
-        scriptValues.setNextDocId(docId);
-        return scriptValues;
-    }
-
-    @Override
-    public boolean containsKey(Object key) {
-        // assume its a string...
-        String fieldName = key.toString();
-        ScriptDocValues scriptValues = localCacheFieldData.get(fieldName);
-        if (scriptValues == null) {
-            FieldMapper mapper = mapperService.smartNameFieldMapper(fieldName, types);
-            if (mapper == null) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    @Override
-    public int size() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public boolean isEmpty() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public boolean containsValue(Object value) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Object put(Object key, Object value) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Object remove(Object key) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void putAll(Map m) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void clear() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Set keySet() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Collection values() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Set entrySet() {
-        throw new UnsupportedOperationException();
+    public LeafDocLookup getLeafDocLookup(LeafReaderContext context) {
+        return new LeafDocLookup(mapperService, fieldDataService, types, context);
     }
 }

--- a/src/main/java/org/elasticsearch/search/lookup/FieldsLookup.java
+++ b/src/main/java/org/elasticsearch/search/lookup/FieldsLookup.java
@@ -18,158 +18,26 @@
  */
 package org.elasticsearch.search.lookup;
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
-import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
-import org.elasticsearch.ElasticsearchIllegalArgumentException;
-import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.Nullable;
-import org.elasticsearch.index.fieldvisitor.SingleFieldsVisitor;
-import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MapperService;
-
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Map;
-import java.util.Set;
 
 /**
  *
  */
-public class FieldsLookup implements Map {
+public class FieldsLookup {
 
     private final MapperService mapperService;
-
     @Nullable
     private final String[] types;
-
-    private LeafReader reader;
-
-    private int docId = -1;
-
-    private final Map<String, FieldLookup> cachedFieldData = Maps.newHashMap();
-
-    private final SingleFieldsVisitor fieldVisitor;
 
     FieldsLookup(MapperService mapperService, @Nullable String[] types) {
         this.mapperService = mapperService;
         this.types = types;
-        this.fieldVisitor = new SingleFieldsVisitor(null);
     }
 
-    public void setNextReader(LeafReaderContext context) {
-        if (this.reader == context.reader()) { // if we are called with the same reader, don't invalidate source
-            return;
-        }
-        this.reader = context.reader();
-        clearCache();
-        this.docId = -1;
-    }
-
-    public void setNextDocId(int docId) {
-        if (this.docId == docId) { // if we are called with the same docId, don't invalidate source
-            return;
-        }
-        this.docId = docId;
-        clearCache();
-    }
-
-
-    @Override
-    public Object get(Object key) {
-        return loadFieldData(key.toString());
-    }
-
-    @Override
-    public boolean containsKey(Object key) {
-        try {
-            loadFieldData(key.toString());
-            return true;
-        } catch (Exception e) {
-            return false;
-        }
-    }
-
-    @Override
-    public int size() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public boolean isEmpty() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Set keySet() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Collection values() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Set entrySet() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Object put(Object key, Object value) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Object remove(Object key) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void clear() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void putAll(Map m) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public boolean containsValue(Object value) {
-        throw new UnsupportedOperationException();
-    }
-
-    private FieldLookup loadFieldData(String name) {
-        FieldLookup data = cachedFieldData.get(name);
-        if (data == null) {
-            FieldMapper mapper = mapperService.smartNameFieldMapper(name, types);
-            if (mapper == null) {
-                throw new ElasticsearchIllegalArgumentException("No field found for [" + name + "] in mapping with types " + Arrays.toString(types) + "");
-            }
-            data = new FieldLookup(mapper);
-            cachedFieldData.put(name, data);
-        }
-        if (data.fields() == null) {
-            String fieldName = data.mapper().names().indexName();
-            fieldVisitor.reset(fieldName);
-            try {
-                reader.document(docId, fieldVisitor);
-                fieldVisitor.postProcess(data.mapper());
-                data.fields(ImmutableMap.of(name, fieldVisitor.fields().get(data.mapper().names().indexName())));
-            } catch (IOException e) {
-                throw new ElasticsearchParseException("failed to load field [" + name + "]", e);
-            }
-        }
-        return data;
-    }
-
-    private void clearCache() {
-        for (Entry<String, FieldLookup> entry : cachedFieldData.entrySet()) {
-            entry.getValue().clear();
-        }
+    public LeafFieldsLookup getLeafFieldsLookup(LeafReaderContext context) {
+        return new LeafFieldsLookup(mapperService, types, context.reader());
     }
 
 }

--- a/src/main/java/org/elasticsearch/search/lookup/IndexField.java
+++ b/src/main/java/org/elasticsearch/search/lookup/IndexField.java
@@ -46,7 +46,7 @@ public class IndexField extends MinimalMap<String, IndexFieldTerm> {
      * The holds the current reader. We need it to populate the field
      * statistics. We just delegate all requests there
      */
-    private IndexLookup indexLookup;
+    private final LeafIndexLookup indexLookup;
 
     /*
      * General field statistics such as number of documents containing the
@@ -55,20 +55,11 @@ public class IndexField extends MinimalMap<String, IndexFieldTerm> {
     private final CollectionStatistics fieldStats;
 
     /*
-     * Uodate posting lists in all TermInfo objects
-     */
-    void setReader(LeafReader reader) {
-        for (IndexFieldTerm ti : terms.values()) {
-            ti.setNextReader(reader);
-        }
-    }
-
-    /*
      * Represents a field in a document. Can be used to return information on
      * statistics of this field. Information on specific terms in this field can
      * be accessed by calling get(String term).
      */
-    public IndexField(String fieldName, IndexLookup indexLookup) throws IOException {
+    public IndexField(String fieldName, LeafIndexLookup indexLookup) throws IOException {
 
         assert fieldName != null;
         this.fieldName = fieldName;
@@ -131,7 +122,7 @@ public class IndexField extends MinimalMap<String, IndexFieldTerm> {
 
     public void setDocIdInTerms(int docId) {
         for (IndexFieldTerm ti : terms.values()) {
-            ti.setNextDoc(docId);
+            ti.setDocument(docId);
         }
     }
 

--- a/src/main/java/org/elasticsearch/search/lookup/IndexFieldTerm.java
+++ b/src/main/java/org/elasticsearch/search/lookup/IndexFieldTerm.java
@@ -65,7 +65,7 @@ public class IndexFieldTerm implements Iterable<TermPosition> {
 
     // when the reader changes, we have to get the posting list for this term
     // and reader
-    void setNextReader(LeafReader reader) {
+    private void setReader(LeafReader reader) {
         try {
             postings = getPostings(convertToLuceneFlags(flags), reader);
 
@@ -153,7 +153,7 @@ public class IndexFieldTerm implements Iterable<TermPosition> {
 
     private int freq = 0;
 
-    public void setNextDoc(int docId) {
+    public void setDocument(int docId) {
         assert (postings != null);
         try {
             // we try to advance to the current document.
@@ -172,7 +172,7 @@ public class IndexFieldTerm implements Iterable<TermPosition> {
         }
     }
 
-    public IndexFieldTerm(String term, String fieldName, IndexLookup indexLookup, int flags) {
+    public IndexFieldTerm(String term, String fieldName, LeafIndexLookup indexLookup, int flags) {
         assert fieldName != null;
         this.fieldName = fieldName;
         assert term != null;
@@ -186,8 +186,8 @@ public class IndexFieldTerm implements Iterable<TermPosition> {
         } else {
             iterator = new CachedPositionIterator(this);
         }
-        setNextReader(indexLookup.getReader());
-        setNextDoc(indexLookup.getDocId());
+        setReader(indexLookup.getReader());
+        setDocument(indexLookup.getDocId());
         try {
             termStats = indexLookup.getIndexSearcher().termStatistics(identifier,
                     TermContext.build(indexLookup.getReaderContext(), identifier));

--- a/src/main/java/org/elasticsearch/search/lookup/IndexLookup.java
+++ b/src/main/java/org/elasticsearch/search/lookup/IndexLookup.java
@@ -19,16 +19,10 @@
 package org.elasticsearch.search.lookup;
 
 import com.google.common.collect.ImmutableMap.Builder;
-import org.apache.lucene.index.*;
-import org.apache.lucene.search.IndexSearcher;
-import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.common.util.MinimalMap;
 
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
+import org.apache.lucene.index.LeafReaderContext;
 
-public class IndexLookup extends MinimalMap<String, IndexField> {
+public class IndexLookup {
 
     /**
      * Flag to pass to {@link IndexField#get(String, flags)} if you require
@@ -61,60 +55,6 @@ public class IndexLookup extends MinimalMap<String, IndexField> {
      */
     public static final int FLAG_CACHE = 32;
 
-    // Current reader from which we can get the term vectors. No info on term
-    // and field statistics.
-    private LeafReader reader;
-
-    // The parent reader from which we can get proper field and term
-    // statistics
-    private CompositeReader parentReader;
-
-    // we need this later to get the field and term statistics of the shard
-    private IndexSearcher indexSearcher;
-
-    // we need this later to get the term statistics of the shard
-    private IndexReaderContext indexReaderContext;
-
-    // current docId
-    private int docId = -1;
-
-    // stores the objects that are used in the script. we maintain this map
-    // because we do not want to re-initialize the objects each time a field is
-    // accessed
-    private final Map<String, IndexField> indexFields = new HashMap<>();
-
-    // number of documents per shard. cached here because the computation is
-    // expensive
-    private int numDocs = -1;
-
-    // the maximum doc number of the shard.
-    private int maxDoc = -1;
-
-    // number of deleted documents per shard. cached here because the
-    // computation is expensive
-    private int numDeletedDocs = -1;
-
-    public int numDocs() {
-        if (numDocs == -1) {
-            numDocs = parentReader.numDocs();
-        }
-        return numDocs;
-    }
-
-    public int maxDoc() {
-        if (maxDoc == -1) {
-            maxDoc = parentReader.maxDoc();
-        }
-        return maxDoc;
-    }
-
-    public int numDeletedDocs() {
-        if (numDeletedDocs == -1) {
-            numDeletedDocs = parentReader.numDeletedDocs();
-        }
-        return numDeletedDocs;
-    }
-
     public IndexLookup(Builder<String, Object> builder) {
         builder.put("_FREQUENCIES", IndexLookup.FLAG_FREQUENCIES);
         builder.put("_POSITIONS", IndexLookup.FLAG_POSITIONS);
@@ -123,119 +63,8 @@ public class IndexLookup extends MinimalMap<String, IndexField> {
         builder.put("_CACHE", IndexLookup.FLAG_CACHE);
     }
 
-    public void setNextReader(LeafReaderContext context) {
-        if (reader == context.reader()) { // if we are called with the same
-                                          // reader, nothing to do
-            return;
-        }
-        // check if we have to invalidate all field and shard stats - only if
-        // parent reader changed
-        if (context.parent != null) {
-            if (parentReader == null) {
-                parentReader = context.parent.reader();
-                indexSearcher = new IndexSearcher(parentReader);
-                indexReaderContext = context.parent;
-            } else {
-                // parent reader may only be set once. TODO we could also call
-                // indexFields.clear() here instead of assertion just to be on
-                // the save side
-                assert (parentReader == context.parent.reader());
-            }
-        } else {
-            assert parentReader == null;
-        }
-        reader = context.reader();
-        docId = -1;
-        setReaderInFields();
+    public LeafIndexLookup getLeafIndexLookup(LeafReaderContext context) {
+        return new LeafIndexLookup(context);
     }
 
-    protected void setReaderInFields() {
-        for (IndexField stat : indexFields.values()) {
-            stat.setReader(reader);
-        }
-    }
-
-    public void setNextDocId(int docId) {
-        if (this.docId == docId) { // if we are called with the same docId,
-                                   // nothing to do
-            return;
-        }
-        // We assume that docs are processed in ascending order of id. If this
-        // is not the case, we would have to re initialize all posting lists in
-        // IndexFieldTerm. TODO: Instead of assert we could also call
-        // setReaderInFields(); here?
-        if (this.docId > docId) {
-            // This might happen if the same SearchLookup is used in different
-            // phases, such as score and fetch phase.
-            // In this case we do not want to re initialize posting list etc.
-            // because we do not even know if term and field statistics will be
-            // needed in this new phase.
-            // Therefore we just remove all IndexFieldTerms.
-            indexFields.clear();
-        }
-        this.docId = docId;
-        setNextDocIdInFields();
-    }
-
-    protected void setNextDocIdInFields() {
-        for (IndexField stat : indexFields.values()) {
-            stat.setDocIdInTerms(this.docId);
-        }
-    }
-
-    /*
-     * TODO: here might be potential for running time improvement? If we knew in
-     * advance which terms are requested, we could provide an array which the
-     * user could then iterate over.
-     */
-    @Override
-    public IndexField get(Object key) {
-        String stringField = (String) key;
-        IndexField indexField = indexFields.get(key);
-        if (indexField == null) {
-            try {
-                indexField = new IndexField(stringField, this);
-                indexFields.put(stringField, indexField);
-            } catch (IOException e) {
-                throw new ElasticsearchException(e.getMessage());
-            }
-        }
-        return indexField;
-    }
-
-    /*
-     * Get the lucene term vectors. See
-     * https://lucene.apache.org/core/4_0_0/core/org/apache/lucene/index/Fields.html
-     * *
-     */
-    public Fields termVectors() throws IOException {
-        assert reader != null;
-        return reader.getTermVectors(docId);
-    }
-
-    LeafReader getReader() {
-        return reader;
-    }
-
-    public int getDocId() {
-        return docId;
-    }
-
-    public IndexReader getParentReader() {
-        if (parentReader == null) {
-            return reader;
-        }
-        return parentReader;
-    }
-
-    public IndexSearcher getIndexSearcher() {
-        if (indexSearcher == null) {
-            return new IndexSearcher(reader);
-        }
-        return indexSearcher;
-    }
-
-    public IndexReaderContext getReaderContext() {
-        return indexReaderContext;
-    }
 }

--- a/src/main/java/org/elasticsearch/search/lookup/LeafDocLookup.java
+++ b/src/main/java/org/elasticsearch/search/lookup/LeafDocLookup.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.search.lookup;
+
+import com.google.common.collect.Maps;
+import org.elasticsearch.ElasticsearchIllegalArgumentException;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.index.fielddata.IndexFieldDataService;
+import org.elasticsearch.index.fielddata.ScriptDocValues;
+import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MapperService;
+import org.apache.lucene.index.LeafReaderContext;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ *
+ */
+public class LeafDocLookup implements Map {
+
+    private final Map<String, ScriptDocValues> localCacheFieldData = Maps.newHashMapWithExpectedSize(4);
+
+    private final MapperService mapperService;
+    private final IndexFieldDataService fieldDataService;
+
+    @Nullable
+    private final String[] types;
+
+    private final LeafReaderContext reader;
+
+    private int docId = -1;
+
+    LeafDocLookup(MapperService mapperService, IndexFieldDataService fieldDataService, @Nullable String[] types, LeafReaderContext reader) {
+        this.mapperService = mapperService;
+        this.fieldDataService = fieldDataService;
+        this.types = types;
+        this.reader = reader;
+    }
+
+    public MapperService mapperService() {
+        return this.mapperService;
+    }
+
+    public IndexFieldDataService fieldDataService() {
+        return this.fieldDataService;
+    }
+
+    public void setDocument(int docId) {
+        this.docId = docId;
+    }
+
+    @Override
+    public Object get(Object key) {
+        // assume its a string...
+        String fieldName = key.toString();
+        ScriptDocValues scriptValues = localCacheFieldData.get(fieldName);
+        if (scriptValues == null) {
+            FieldMapper mapper = mapperService.smartNameFieldMapper(fieldName, types);
+            if (mapper == null) {
+                throw new ElasticsearchIllegalArgumentException("No field found for [" + fieldName + "] in mapping with types " + Arrays.toString(types) + "");
+            }
+            scriptValues = fieldDataService.getForField(mapper).load(reader).getScriptValues();
+            localCacheFieldData.put(fieldName, scriptValues);
+        }
+        scriptValues.setNextDocId(docId);
+        return scriptValues;
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        // assume its a string...
+        String fieldName = key.toString();
+        ScriptDocValues scriptValues = localCacheFieldData.get(fieldName);
+        if (scriptValues == null) {
+            FieldMapper mapper = mapperService.smartNameFieldMapper(fieldName, types);
+            if (mapper == null) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public int size() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object put(Object key, Object value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object remove(Object key) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void putAll(Map m) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void clear() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Set keySet() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Collection values() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Set entrySet() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/main/java/org/elasticsearch/search/lookup/LeafFieldsLookup.java
+++ b/src/main/java/org/elasticsearch/search/lookup/LeafFieldsLookup.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.search.lookup;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+
+import org.apache.lucene.index.LeafReader;
+import org.elasticsearch.ElasticsearchIllegalArgumentException;
+import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.index.fieldvisitor.SingleFieldsVisitor;
+import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MapperService;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ *
+ */
+public class LeafFieldsLookup implements Map {
+
+    private final MapperService mapperService;
+
+    @Nullable
+    private final String[] types;
+
+    private final LeafReader reader;
+
+    private int docId = -1;
+
+    private final Map<String, FieldLookup> cachedFieldData = Maps.newHashMap();
+
+    private final SingleFieldsVisitor fieldVisitor;
+
+    LeafFieldsLookup(MapperService mapperService, @Nullable String[] types, LeafReader reader) {
+        this.mapperService = mapperService;
+        this.types = types;
+        this.reader = reader;
+        this.fieldVisitor = new SingleFieldsVisitor(null);
+    }
+
+    public void setDocument(int docId) {
+        if (this.docId == docId) { // if we are called with the same docId, don't invalidate source
+            return;
+        }
+        this.docId = docId;
+        clearCache();
+    }
+
+
+    @Override
+    public Object get(Object key) {
+        return loadFieldData(key.toString());
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        try {
+            loadFieldData(key.toString());
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    @Override
+    public int size() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Set keySet() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Collection values() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Set entrySet() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object put(Object key, Object value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object remove(Object key) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void clear() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void putAll(Map m) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        throw new UnsupportedOperationException();
+    }
+
+    private FieldLookup loadFieldData(String name) {
+        FieldLookup data = cachedFieldData.get(name);
+        if (data == null) {
+            FieldMapper mapper = mapperService.smartNameFieldMapper(name, types);
+            if (mapper == null) {
+                throw new ElasticsearchIllegalArgumentException("No field found for [" + name + "] in mapping with types " + Arrays.toString(types) + "");
+            }
+            data = new FieldLookup(mapper);
+            cachedFieldData.put(name, data);
+        }
+        if (data.fields() == null) {
+            String fieldName = data.mapper().names().indexName();
+            fieldVisitor.reset(fieldName);
+            try {
+                reader.document(docId, fieldVisitor);
+                fieldVisitor.postProcess(data.mapper());
+                data.fields(ImmutableMap.of(name, fieldVisitor.fields().get(data.mapper().names().indexName())));
+            } catch (IOException e) {
+                throw new ElasticsearchParseException("failed to load field [" + name + "]", e);
+            }
+        }
+        return data;
+    }
+
+    private void clearCache() {
+        for (Entry<String, FieldLookup> entry : cachedFieldData.entrySet()) {
+            entry.getValue().clear();
+        }
+    }
+
+}

--- a/src/main/java/org/elasticsearch/search/lookup/LeafIndexLookup.java
+++ b/src/main/java/org/elasticsearch/search/lookup/LeafIndexLookup.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.search.lookup;
+
+import org.apache.lucene.index.CompositeReader;
+import org.apache.lucene.index.Fields;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexReaderContext;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.IndexSearcher;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.util.MinimalMap;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class LeafIndexLookup extends MinimalMap<String, IndexField> {
+
+    // Current reader from which we can get the term vectors. No info on term
+    // and field statistics.
+    private final LeafReader reader;
+
+    // The parent reader from which we can get proper field and term
+    // statistics
+    private final CompositeReader parentReader;
+
+    // we need this later to get the field and term statistics of the shard
+    private final IndexSearcher indexSearcher;
+
+    // we need this later to get the term statistics of the shard
+    private final IndexReaderContext indexReaderContext;
+
+    // current docId
+    private int docId = -1;
+
+    // stores the objects that are used in the script. we maintain this map
+    // because we do not want to re-initialize the objects each time a field is
+    // accessed
+    private final Map<String, IndexField> indexFields = new HashMap<>();
+
+    // number of documents per shard. cached here because the computation is
+    // expensive
+    private int numDocs = -1;
+
+    // the maximum doc number of the shard.
+    private int maxDoc = -1;
+
+    // number of deleted documents per shard. cached here because the
+    // computation is expensive
+    private int numDeletedDocs = -1;
+
+    public int numDocs() {
+        if (numDocs == -1) {
+            numDocs = parentReader.numDocs();
+        }
+        return numDocs;
+    }
+
+    public int maxDoc() {
+        if (maxDoc == -1) {
+            maxDoc = parentReader.maxDoc();
+        }
+        return maxDoc;
+    }
+
+    public int numDeletedDocs() {
+        if (numDeletedDocs == -1) {
+            numDeletedDocs = parentReader.numDeletedDocs();
+        }
+        return numDeletedDocs;
+    }
+
+    public LeafIndexLookup(LeafReaderContext ctx) {
+        reader = ctx.reader();
+        if (ctx.parent != null) {
+            parentReader = ctx.parent.reader();
+            indexSearcher = new IndexSearcher(parentReader);
+            indexReaderContext = ctx.parent;
+        } else {
+            parentReader = null;
+            indexSearcher = null;
+            indexReaderContext = null;
+        }
+    }
+
+    public void setDocument(int docId) {
+        if (this.docId == docId) { // if we are called with the same docId,
+                                   // nothing to do
+            return;
+        }
+        // We assume that docs are processed in ascending order of id. If this
+        // is not the case, we would have to re initialize all posting lists in
+        // IndexFieldTerm. TODO: Instead of assert we could also call
+        // setReaderInFields(); here?
+        if (this.docId > docId) {
+            // This might happen if the same SearchLookup is used in different
+            // phases, such as score and fetch phase.
+            // In this case we do not want to re initialize posting list etc.
+            // because we do not even know if term and field statistics will be
+            // needed in this new phase.
+            // Therefore we just remove all IndexFieldTerms.
+            indexFields.clear();
+        }
+        this.docId = docId;
+        setNextDocIdInFields();
+    }
+
+    protected void setNextDocIdInFields() {
+        for (IndexField stat : indexFields.values()) {
+            stat.setDocIdInTerms(this.docId);
+        }
+    }
+
+    /*
+     * TODO: here might be potential for running time improvement? If we knew in
+     * advance which terms are requested, we could provide an array which the
+     * user could then iterate over.
+     */
+    @Override
+    public IndexField get(Object key) {
+        String stringField = (String) key;
+        IndexField indexField = indexFields.get(key);
+        if (indexField == null) {
+            try {
+                indexField = new IndexField(stringField, this);
+                indexFields.put(stringField, indexField);
+            } catch (IOException e) {
+                throw new ElasticsearchException(e.getMessage());
+            }
+        }
+        return indexField;
+    }
+
+    /*
+     * Get the lucene term vectors. See
+     * https://lucene.apache.org/core/4_0_0/core/org/apache/lucene/index/Fields.html
+     * *
+     */
+    public Fields termVectors() throws IOException {
+        assert reader != null;
+        return reader.getTermVectors(docId);
+    }
+
+    LeafReader getReader() {
+        return reader;
+    }
+
+    public int getDocId() {
+        return docId;
+    }
+
+    public IndexReader getParentReader() {
+        if (parentReader == null) {
+            return reader;
+        }
+        return parentReader;
+    }
+
+    public IndexSearcher getIndexSearcher() {
+        if (indexSearcher == null) {
+            return new IndexSearcher(reader);
+        }
+        return indexSearcher;
+    }
+
+    public IndexReaderContext getReaderContext() {
+        return indexReaderContext;
+    }
+}

--- a/src/main/java/org/elasticsearch/search/lookup/LeafSearchLookup.java
+++ b/src/main/java/org/elasticsearch/search/lookup/LeafSearchLookup.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.lookup;
+
+import com.google.common.collect.ImmutableMap;
+
+import org.apache.lucene.index.LeafReaderContext;
+
+import java.util.Map;
+
+/**
+ * Per-segment version of {@link SearchLookup}.
+ */
+public class LeafSearchLookup {
+
+    final LeafReaderContext ctx;
+    final LeafDocLookup docMap;
+    final SourceLookup sourceLookup;
+    final LeafFieldsLookup fieldsLookup;
+    final LeafIndexLookup indexLookup;
+    final ImmutableMap<String, Object> asMap;
+
+    public LeafSearchLookup(LeafReaderContext ctx, LeafDocLookup docMap, SourceLookup sourceLookup,
+            LeafFieldsLookup fieldsLookup, LeafIndexLookup indexLookup, Map<String, Object> topLevelMap) {
+        this.ctx = ctx;
+        this.docMap = docMap;
+        this.sourceLookup = sourceLookup;
+        this.fieldsLookup = fieldsLookup;
+        this.indexLookup = indexLookup;
+
+        ImmutableMap.Builder<String, Object> builder = ImmutableMap.builder();
+        builder.putAll(topLevelMap);
+        builder.put("doc", docMap);
+        builder.put("_doc", docMap);
+        builder.put("_source", sourceLookup);
+        builder.put("_fields", fieldsLookup);
+        builder.put("_index", indexLookup);
+        asMap = builder.build();
+    }
+
+    public ImmutableMap<String, Object> asMap() {
+        return this.asMap;
+    }
+
+    public SourceLookup source() {
+        return this.sourceLookup;
+    }
+
+    public LeafIndexLookup indexLookup() {
+        return this.indexLookup;
+    }
+
+    public LeafFieldsLookup fields() {
+        return this.fieldsLookup;
+    }
+
+    public LeafDocLookup doc() {
+        return this.docMap;
+    }
+
+    public void setDocument(int docId) {
+        docMap.setDocument(docId);
+        sourceLookup.setSegmentAndDocument(ctx, docId);
+        fieldsLookup.setDocument(docId);
+        indexLookup.setDocument(docId);
+    }
+}

--- a/src/main/java/org/elasticsearch/search/lookup/SearchLookup.java
+++ b/src/main/java/org/elasticsearch/search/lookup/SearchLookup.java
@@ -35,9 +35,9 @@ public class SearchLookup {
     final SourceLookup sourceLookup;
 
     final FieldsLookup fieldsLookup;
-    
+
     final IndexLookup indexLookup;
-    
+
     final ImmutableMap<String, Object> asMap;
 
     public SearchLookup(MapperService mapperService, IndexFieldDataService fieldDataService, @Nullable String[] types) {
@@ -46,46 +46,23 @@ public class SearchLookup {
         sourceLookup = new SourceLookup();
         fieldsLookup = new FieldsLookup(mapperService, types);
         indexLookup = new IndexLookup(builder);
-        
-        builder.put("doc", docMap);
-        builder.put("_doc", docMap);
-        builder.put("_source", sourceLookup);
-        builder.put("_fields", fieldsLookup);
-        builder.put("_index", indexLookup);
         asMap = builder.build();
     }
 
-    public ImmutableMap<String, Object> asMap() {
-        return this.asMap;
-    }
-
-    public SourceLookup source() {
-        return this.sourceLookup;
-    }
-    
-    public IndexLookup indexLookup() {
-        return this.indexLookup;
-    }
-
-    public FieldsLookup fields() {
-        return this.fieldsLookup;
+    public LeafSearchLookup getLeafSearchLookup(LeafReaderContext context) {
+        return new LeafSearchLookup(context,
+                docMap.getLeafDocLookup(context),
+                sourceLookup,
+                fieldsLookup.getLeafFieldsLookup(context),
+                indexLookup.getLeafIndexLookup(context),
+                asMap);
     }
 
     public DocLookup doc() {
-        return this.docMap;
+        return docMap;
     }
 
-    public void setNextReader(LeafReaderContext context) {
-        docMap.setNextReader(context);
-        sourceLookup.setNextReader(context);
-        fieldsLookup.setNextReader(context);
-        indexLookup.setNextReader(context);
-    }
-
-    public void setNextDocId(int docId) {
-        docMap.setNextDocId(docId);
-        sourceLookup.setNextDocId(docId);
-        fieldsLookup.setNextDocId(docId);
-        indexLookup.setNextDocId(docId);
+    public SourceLookup source() {
+        return sourceLookup;
     }
 }

--- a/src/main/java/org/elasticsearch/search/lookup/SourceLookup.java
+++ b/src/main/java/org/elasticsearch/search/lookup/SourceLookup.java
@@ -99,34 +99,26 @@ public class SourceLookup implements Map {
         return sourceAsMapAndType(bytes, offset, length).v2();
     }
 
-    public void setNextReader(LeafReaderContext context) {
-        if (this.reader == context.reader()) { // if we are called with the same reader, don't invalidate source
+    public void setSegmentAndDocument(LeafReaderContext context, int docId) {
+        if (this.reader == context.reader() && this.docId == docId) {
+            // if we are called with the same document, don't invalidate source
             return;
         }
         this.reader = context.reader();
         this.source = null;
         this.sourceAsBytes = null;
-        this.docId = -1;
-    }
-
-    public void setNextDocId(int docId) {
-        if (this.docId == docId) { // if we are called with the same docId, don't invalidate source
-            return;
-        }
         this.docId = docId;
-        this.sourceAsBytes = null;
-        this.source = null;
     }
 
-    public void setNextSource(BytesReference source) {
+    public void setSource(BytesReference source) {
         this.sourceAsBytes = source;
     }
 
-    public void setNextSourceContentType(XContentType sourceContentType) {
+    public void setSourceContentType(XContentType sourceContentType) {
         this.sourceContentType = sourceContentType;
     }
 
-    public void setNextSource(Map<String, Object> source) {
+    public void setSource(Map<String, Object> source) {
         this.source = source;
     }
 

--- a/src/test/java/org/elasticsearch/script/expression/ExpressionScriptTests.java
+++ b/src/test/java/org/elasticsearch/script/expression/ExpressionScriptTests.java
@@ -38,6 +38,7 @@ import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 
@@ -80,6 +81,7 @@ public class ExpressionScriptTests extends ElasticsearchIntegrationTest {
         req.setQuery(QueryBuilders.functionScoreQuery(QueryBuilders.termQuery("text", "hello"), score).boostMode("replace"));
         req.setSearchType(SearchType.DFS_QUERY_THEN_FETCH); // make sure DF is consistent
         SearchResponse rsp = req.get();
+        assertSearchResponse(rsp);
         SearchHits hits = rsp.getHits();
         assertEquals(3, hits.getTotalHits());
         assertEquals("1", hits.getAt(0).getId());

--- a/src/test/java/org/elasticsearch/search/aggregations/support/ScriptValuesTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/support/ScriptValuesTests.java
@@ -20,10 +20,10 @@
 package org.elasticsearch.search.aggregations.support;
 
 import com.carrotsearch.randomizedtesting.generators.RandomStrings;
-import org.apache.lucene.index.LeafReaderContext;
+
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.script.SearchScript;
+import org.elasticsearch.script.LeafSearchScript;
 import org.elasticsearch.search.aggregations.support.values.ScriptBytesValues;
 import org.elasticsearch.search.aggregations.support.values.ScriptDoubleValues;
 import org.elasticsearch.search.aggregations.support.values.ScriptLongValues;
@@ -35,7 +35,7 @@ import java.util.Map;
 
 public class ScriptValuesTests extends ElasticsearchTestCase {
 
-    private static class FakeSearchScript implements SearchScript {
+    private static class FakeSearchScript implements LeafSearchScript {
         
         private final Object[][] values;
         int index;
@@ -65,20 +65,16 @@ public class ScriptValuesTests extends ElasticsearchTestCase {
         }
 
         @Override
-        public void setNextReader(LeafReaderContext reader) {
-        }
-
-        @Override
         public void setScorer(Scorer scorer) {
         }
 
         @Override
-        public void setNextDocId(int doc) {
+        public void setDocument(int doc) {
             index = doc;
         }
 
         @Override
-        public void setNextSource(Map<String, Object> source) {
+        public void setSource(Map<String, Object> source) {
         }
 
         @Override

--- a/src/test/java/org/elasticsearch/search/functionscore/ExplainableScriptTests.java
+++ b/src/test/java/org/elasticsearch/search/functionscore/ExplainableScriptTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.search.functionscore;
 
+import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.Explanation;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
@@ -28,8 +29,10 @@ import org.elasticsearch.common.lucene.search.function.CombineFunction;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.script.AbstractDoubleSearchScript;
+import org.elasticsearch.script.AbstractSearchScript;
 import org.elasticsearch.script.ExecutableScript;
 import org.elasticsearch.script.ExplainableSearchScript;
+import org.elasticsearch.script.LeafSearchScript;
 import org.elasticsearch.script.NativeScriptFactory;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
@@ -101,12 +104,7 @@ public class ExplainableScriptTests extends ElasticsearchIntegrationTest {
         }
     }
 
-    static class MyScript extends AbstractDoubleSearchScript implements ExplainableSearchScript {
-
-        @Override
-        public double runAsDouble() {
-            return ((Number) ((ScriptDocValues) doc().get("number_field")).getValues().get(0)).doubleValue();
-        }
+    static class MyScript extends AbstractDoubleSearchScript implements ExplainableSearchScript, ExecutableScript {
 
         @Override
         public Explanation explain(Explanation subQueryScore) throws IOException {
@@ -115,6 +113,11 @@ public class ExplainableScriptTests extends ElasticsearchIntegrationTest {
             scoreExp.addDetail(subQueryScore);
             exp.addDetail(scoreExp);
             return exp;
+        }
+
+        @Override
+        public double runAsDouble() {
+            return ((Number) ((ScriptDocValues) doc().get("number_field")).getValues().get(0)).doubleValue();
         }
     }
 }


### PR DESCRIPTION
We still have a lot of APIs that use setNextReader in order to change the
current segment that should be considered. This commit moves such APIs to
getLeafXXX() instead to be more in-line with Lucene 5's collector API.

I also renamed setDocId to setDocument to be more in-line with the doc values
APIs.
