### PR TITLE
Internal: Fix snapshot status of version 1.1.2.

### DIFF
--- a/src/main/java/org/elasticsearch/Version.java
+++ b/src/main/java/org/elasticsearch/Version.java
@@ -178,7 +178,7 @@ public class Version {
     public static final int V_1_1_1_ID = 1010199;
     public static final Version V_1_1_1 = new Version(V_1_1_1_ID, false, org.apache.lucene.util.Version.LUCENE_4_7);
     public static final int V_1_1_2_ID = 1010299;
-    public static final Version V_1_1_2 = new Version(V_1_1_2_ID, true, org.apache.lucene.util.Version.LUCENE_4_7);
+    public static final Version V_1_1_2 = new Version(V_1_1_2_ID, false, org.apache.lucene.util.Version.LUCENE_4_7);
     public static final int V_1_2_0_ID = 1020099;
     public static final Version V_1_2_0 = new Version(V_1_2_0_ID, false, org.apache.lucene.util.Version.LUCENE_4_8);
     public static final int V_1_2_1_ID = 1020199;


### PR DESCRIPTION
org.elasticsearch.Version mistakenly tags 1.1.2 as a snapshot version while it
has been released.
