### PR TITLE
Core: implement delete-by-query as search + delete-by-id

### DIFF
--- a/docs/reference/docs/delete-by-query.asciidoc
+++ b/docs/reference/docs/delete-by-query.asciidoc
@@ -20,7 +20,7 @@ $ curl -XDELETE 'http://localhost:9200/twitter/tweet/_query' -d '{
 --------------------------------------------------
 
 NOTE: The query being sent in the body must be nested in a `query` key, same as
-the <<search-search,search api>> works
+the <<search-search,search api>>
 
 Both above examples end up doing the same thing, which is delete all
 tweets from the twitter index for a certain user. The result of the
@@ -43,7 +43,11 @@ commands is:
 
 Note, delete by query bypasses versioning support. Also, it is not
 recommended to delete "large chunks of the data in an index", many
-times, it's better to simply reindex into a new index.
+times, it's better to simply reindex into a new index.  Finally,
+under the hood, delete by query runs a query using the most recently
+refreshed near-real-time searcher.  This means it is not real-time and
+will not delete documents that were just indexed but not yet visible
+in the current near-real-time searcher.
 
 [float]
 [[multiple-indices]]

--- a/src/test/java/org/elasticsearch/aliases/IndexAliasesTests.java
+++ b/src/test/java/org/elasticsearch/aliases/IndexAliasesTests.java
@@ -405,20 +405,33 @@ public class IndexAliasesTests extends ElasticsearchIntegrationTest {
         assertThat(client().prepareCount("bars").setQuery(QueryBuilders.matchAllQuery()).get().getCount(), equalTo(1L));
 
         logger.info("--> delete by query from a single alias");
+
+        // Must refresh before DBQ so the query sees all docs we just indexed:
+        refresh();
         client().prepareDeleteByQuery("bars").setQuery(QueryBuilders.termQuery("name", "test")).get();
+        // Must refresh after DBQ so we see the deletes:
+        refresh();
 
         logger.info("--> verify that only one record was deleted");
         assertThat(client().prepareCount("test1").setQuery(QueryBuilders.matchAllQuery()).get().getCount(), equalTo(3L));
 
         logger.info("--> delete by query from an aliases pointing to two indices");
+        // Must refresh before DBQ so the query sees all docs we just indexed:
+        refresh();
         client().prepareDeleteByQuery("foos").setQuery(QueryBuilders.matchAllQuery()).get();
+        // Must refresh after DBQ so we see the deletes:
+        refresh();
 
         logger.info("--> verify that proper records were deleted");
         SearchResponse searchResponse = client().prepareSearch("aliasToTests").setQuery(QueryBuilders.matchAllQuery()).get();
         assertHits(searchResponse.getHits(), "3", "4", "6", "7", "8");
 
         logger.info("--> delete by query from an aliases and an index");
+        // Must refresh before DBQ so the query sees all docs we just indexed:
+        refresh();
         client().prepareDeleteByQuery("tests", "test2").setQuery(QueryBuilders.matchAllQuery()).get();
+        // Must refresh after DBQ so we see the deletes:
+        refresh();
 
         logger.info("--> verify that proper records were deleted");
         searchResponse = client().prepareSearch("aliasToTests").setQuery(QueryBuilders.matchAllQuery()).get();


### PR DESCRIPTION
Here's a first cut, not yet ready (some nocommits), switching InternalEngine's DBQ impl to "run a query and delete those docs" instead of using IndexWriter's delete-by-query.  Tests pass...

I just run the query on the current NRT searcher and for each hit I pull the current version and pass that to the Delete request, but I think this means we must add VersionType param to DBQRequest (I put a nocommit), and I think it needs back-compat logic for older indices that stored version as a payload?

I also put a TODO to optimize this impl: we can use IndexWriter.tryDeleteDocument, since we already know which segment + docID we want to delete.  But I think this should come later...

There are two behavior changes here.  First, DBQ will now only delete those docs that the current NRT searcher "sees" matching the query. This means apps that want to be sure the delete "covers" anything they've indexed, must do a refresh themselves before the DBQ.  Second, they must also do a refresh after, to see the deletes reflected in searches, since DBQ no longer does so.
