### PR TITLE
Indexed scripts/templates: return response body when script is not found

### DIFF
--- a/rest-api-spec/test/script/10_basic.yaml
+++ b/rest-api-spec/test/script/10_basic.yaml
@@ -15,7 +15,22 @@
      get_script:
        id: "1"
        lang: "groovy"
+  - match: { found: true }
+  - match: { lang: groovy }
+  - match: { _id: "1" }
+  - match: { _version: 1 }
   - match: { "script":  "_score * doc[\"myParent.weight\"].value" }
+
+  - do:
+     catch: missing
+     get_script:
+       id: "2"
+       lang: "groovy"
+  - match: { found: false }
+  - match: { lang: groovy }
+  - match: { _id: "2" }
+  - is_false: _version
+  - is_false: script
 
   - do:
      delete_script:
@@ -24,6 +39,17 @@
   - match: { found: true }
   - match: { _index: ".scripts" }
   - match: { _id: "1" }
+  - match: { _version: 2 }
+
+  - do:
+     catch: missing
+     delete_script:
+       id: "non_existing"
+       lang: "groovy"
+  - match: { found: false }
+  - match: { _index: ".scripts" }
+  - match: { _id: "non_existing" }
+  - match: { _version: 1 }
 
   - do:
       catch: request

--- a/rest-api-spec/test/template/10_basic.yaml
+++ b/rest-api-spec/test/template/10_basic.yaml
@@ -10,8 +10,21 @@
   - do:
      get_template:
        id: 1
+  - match: { found: true }
+  - match: { lang: mustache }
+  - match: { _id: "1" }
+  - match: { _version: 1 }
   - match: { template: /.*query\S\S\S\Smatch_all.*/ }
 
+  - do:
+     catch: missing
+     get_template:
+       id: 2
+  - match: { found: false }
+  - match: { lang: mustache }
+  - match: { _id: "2" }
+  - is_false: _version
+  - is_false: template
 
   - do:
      delete_template:
@@ -19,6 +32,16 @@
   - match: { found: true }
   - match: { _index: ".scripts" }
   - match: { _id: "1" }
+  - match: { _version: 2}
+
+  - do:
+    catch: missing
+    delete_template:
+      id: "non_existing"
+  - match: { found: false }
+  - match: { _index: ".scripts" }
+  - match: { _id: "non_existing" }
+  - match: { _version: 1 }
 
   - do:
       catch: request

--- a/src/main/java/org/elasticsearch/rest/action/template/RestGetSearchTemplateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/template/RestGetSearchTemplateAction.java
@@ -21,6 +21,7 @@ package org.elasticsearch.rest.action.template;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentBuilderString;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.script.RestGetIndexedScriptAction;
@@ -45,7 +46,9 @@ public class RestGetSearchTemplateAction extends RestGetIndexedScriptAction {
     }
 
     @Override
-    protected String getScriptFieldName() {
-        return "template";
+    protected XContentBuilderString getScriptFieldName() {
+        return TEMPLATE;
     }
+
+    private static final XContentBuilderString TEMPLATE = new XContentBuilderString("template");
 }


### PR DESCRIPTION
Align get indexed scripts and get search template apis to our get api, which returns a response body when the document is not found, with a found boolean flag. Also, return metadata info all the time too.

Closes #7325
