### PR TITLE
Refactor SimpleQueryStringBuilder

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/SimpleQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SimpleQueryParser.java
@@ -208,41 +208,28 @@ public class SimpleQueryParser extends org.apache.lucene.queryparser.simple.Simp
      * their default values
      */
     public static class Settings {
-        private Locale locale = Locale.ROOT;
-        private boolean lowercaseExpandedTerms = true;
-        private boolean lenient = false;
-        private boolean analyzeWildcard = false;
+        private final Locale locale;
+        private final boolean lowercaseExpandedTerms;
+        private final boolean lenient;
+        private final boolean analyzeWildcard;
 
-        public Settings() {
-
-        }
-
-        public void locale(Locale locale) {
-            this.locale = locale;
+        public Settings(Locale locale, Boolean lowercaseExpandedTerms, Boolean lenient, Boolean analyzeWildcard) {
+            this.locale = locale == null ? Locale.ROOT : locale;
+            this.lowercaseExpandedTerms = lowercaseExpandedTerms == null ? true : lowercaseExpandedTerms;
+            this.lenient = lenient == null ? false : lenient;
+            this.analyzeWildcard = analyzeWildcard == null ? false : analyzeWildcard;
         }
 
         public Locale locale() {
             return this.locale;
         }
 
-        public void lowercaseExpandedTerms(boolean lowercaseExpandedTerms) {
-            this.lowercaseExpandedTerms = lowercaseExpandedTerms;
-        }
-
         public boolean lowercaseExpandedTerms() {
             return this.lowercaseExpandedTerms;
         }
 
-        public void lenient(boolean lenient) {
-            this.lenient = lenient;
-        }
-
         public boolean lenient() {
             return this.lenient;
-        }
-
-        public void analyzeWildcard(boolean analyzeWildcard) {
-            this.analyzeWildcard = analyzeWildcard;
         }
 
         public boolean analyzeWildcard() {

--- a/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
@@ -25,19 +25,18 @@ import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.regex.Regex;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.LocaleUtils;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.mapper.MapperService;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.Map;
+import java.util.*;
 
 /**
  * SimpleQuery is a query parser that acts similar to a query_string
@@ -55,8 +54,6 @@ import java.util.Map;
  * <li>'{@code ~}N' at the end of phrases specifies near/slop query: <tt>"term1 term2"~5</tt>
  * </ul>
  * <p/>
- * See: {@link XSimpleQueryParser} for more information.
- * <p/>
  * This query supports these options:
  * <p/>
  * Required:
@@ -70,11 +67,9 @@ import java.util.Map;
  * {@code fields} - fields to search, defaults to _all if not set, allows
  * boosting a field with ^n
  **/
-public class SimpleQueryStringBuilder extends BaseQueryBuilder implements QueryParser {
-    private Map<String, Float> fields = new HashMap<>();
-    private String analyzer;
-    private Operator operator;
-    private final String queryText;
+public class SimpleQueryStringBuilder extends BaseQueryBuilder implements QueryParser, Streamable {
+    private String analyzerName;
+    private String queryText;
     private String queryName;
     private String minimumShouldMatch;
     private int flags = -1;
@@ -82,6 +77,8 @@ public class SimpleQueryStringBuilder extends BaseQueryBuilder implements QueryP
     private Boolean lenient;
     private Boolean analyzeWildcard;
     private Locale locale;
+    private Map<String, Float> fieldsAndWeights = new TreeMap<>();
+    private Operator defaultOperator;
 
     public static final String NAME = "simple_query_string";
 
@@ -92,12 +89,10 @@ public class SimpleQueryStringBuilder extends BaseQueryBuilder implements QueryP
         AND,
         OR
     }
-    
+
     @Inject
-    public SimpleQueryStringBuilder(Settings settings) {
-        this.queryText = null;
+    public SimpleQueryStringBuilder() {
     }
-    
 
     /**
      * Construct a new simple query with the given text
@@ -110,7 +105,7 @@ public class SimpleQueryStringBuilder extends BaseQueryBuilder implements QueryP
      * Add a field to run the query against
      */
     public SimpleQueryStringBuilder field(String field) {
-        this.fields.put(field, null);
+        this.fieldsAndWeights.put(field, 1.0f);
         return this;
     }
 
@@ -118,7 +113,12 @@ public class SimpleQueryStringBuilder extends BaseQueryBuilder implements QueryP
      * Add a field to run the query against with a specific boost
      */
     public SimpleQueryStringBuilder field(String field, float boost) {
-        this.fields.put(field, boost);
+        this.fieldsAndWeights.put(field, boost);
+        return this;
+    }
+
+    public SimpleQueryStringBuilder fields(Map<String, Float> fieldsAndWeights) {
+        this.fieldsAndWeights.putAll(fieldsAndWeights);
         return this;
     }
 
@@ -134,7 +134,7 @@ public class SimpleQueryStringBuilder extends BaseQueryBuilder implements QueryP
      * Specify an analyzer to use for the query
      */
     public SimpleQueryStringBuilder analyzer(String analyzer) {
-        this.analyzer = analyzer;
+        this.analyzerName = analyzer;
         return this;
     }
 
@@ -143,7 +143,7 @@ public class SimpleQueryStringBuilder extends BaseQueryBuilder implements QueryP
      * operator is specified
      */
     public SimpleQueryStringBuilder defaultOperator(Operator defaultOperator) {
-        this.operator = defaultOperator;
+        this.defaultOperator = defaultOperator;
         return this;
     }
 
@@ -163,43 +163,231 @@ public class SimpleQueryStringBuilder extends BaseQueryBuilder implements QueryP
         return this;
     }
 
+    /**
+     * Specify whether expanded terms from a wildcard should be
+     * automatically lowercased.
+     */
     public SimpleQueryStringBuilder lowercaseExpandedTerms(boolean lowercaseExpandedTerms) {
         this.lowercaseExpandedTerms = lowercaseExpandedTerms;
         return this;
     }
 
+    /**
+     * Specify the locale to use for lowercasing expanded terms
+     */
     public SimpleQueryStringBuilder locale(Locale locale) {
         this.locale = locale;
         return this;
     }
 
+    /**
+     * Specify whether the parser should treat numeric values leniently
+     */
     public SimpleQueryStringBuilder lenient(boolean lenient) {
         this.lenient = lenient;
         return this;
     }
 
+    /**
+     * Specify whether wildcards ('*' and '?') should be analyzed
+     */
     public SimpleQueryStringBuilder analyzeWildcard(boolean analyzeWildcard) {
         this.analyzeWildcard = analyzeWildcard;
         return this;
     }
 
+    /**
+     * Specify the number of clauses that must match
+     */
     public SimpleQueryStringBuilder minimumShouldMatch(String minimumShouldMatch) {
         this.minimumShouldMatch = minimumShouldMatch;
         return this;
     }
 
     @Override
-    public void doXContent(XContentBuilder builder, Params params) throws IOException {
+    public String[] names() {
+        return new String[]{NAME, Strings.toCamelCase(NAME)};
+    }
+
+    @Override
+    public Query parse(QueryParseContext parseContext)
+            throws IOException, QueryParsingException {
+        SimpleQueryStringBuilder sqsb = new SimpleQueryStringBuilder();
+        sqsb.fromXContent(parseContext);
+        return sqsb.toQuery(parseContext);
+    }
+
+    public Query toQuery(QueryParseContext parseContext) {
+        Analyzer analyzer;
+        // Use standard analyzer by default if none specified
+        if (analyzerName == null) {
+            analyzer = parseContext.mapperService().searchAnalyzer();
+        } else {
+            analyzer = parseContext.analysisService().analyzer(analyzerName);
+            if (analyzer == null) {
+                // TODO should we try to do this in fromXContent also, to make
+                // sure we can access the analyzer sooner?
+                throw new QueryParsingException(parseContext.index(),
+                        "[" + NAME + "] analyzer [" + analyzerName + "] not found");
+            }
+        }
+
+        SimpleQueryParser sqp = new SimpleQueryParser(analyzer, fieldsAndWeights, flags,
+                new SimpleQueryParser.Settings(locale, lowercaseExpandedTerms, lenient, analyzeWildcard));
+
+        if (defaultOperator != null) {
+            sqp.setDefaultOperator(defaultOperator == Operator.AND ? BooleanClause.Occur.MUST : BooleanClause.Occur.SHOULD);
+        }
+
+        Query query = sqp.parse(queryText);
+        if (queryName != null) {
+            parseContext.addNamedQuery(queryName, query);
+        }
+
+        if (minimumShouldMatch != null && query instanceof BooleanQuery) {
+            Queries.applyMinimumShouldMatch((BooleanQuery) query, minimumShouldMatch);
+        }
+        return query;
+    }
+
+    public void fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
+        XContentParser parser = parseContext.parser();
+
+        String currentFieldName = null;
+        String field = null;
+        Map<String, Float> tempFieldsToWeights = null;
+
+        XContentParser.Token token;
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                currentFieldName = parser.currentName();
+            } else if (token == XContentParser.Token.START_ARRAY) {
+                if ("fields".equals(currentFieldName)) {
+                    while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
+                        String fField = null;
+                        float fBoost = 1;
+                        char[] text = parser.textCharacters();
+                        int end = parser.textOffset() + parser.textLength();
+                        for (int i = parser.textOffset(); i < end; i++) {
+                            if (text[i] == '^') {
+                                int relativeLocation = i - parser.textOffset();
+                                fField = new String(text, parser.textOffset(),
+                                        relativeLocation);
+                                fBoost = Float.parseFloat(new String(text, i + 1, parser.textLength() - relativeLocation - 1));
+                                break;
+                            }
+                        }
+                        if (fField == null) {
+                            fField = parser.text();
+                        }
+
+                        if (tempFieldsToWeights == null) {
+                            tempFieldsToWeights = new HashMap<>();
+                        }
+
+                        if (Regex.isSimpleMatchPattern(fField)) {
+                            for (String fieldName : parseContext.mapperService().simpleMatchToIndexNames(fField)) {
+                                tempFieldsToWeights.put(fieldName, fBoost);
+                            }
+                        } else {
+                            MapperService.SmartNameFieldMappers mappers = parseContext.smartFieldMappers(fField);
+                            if (mappers != null && mappers.hasMapper()) {
+                                tempFieldsToWeights.put(mappers.mapper().names().indexName(), fBoost);
+                            } else {
+                                tempFieldsToWeights.put(fField, fBoost);
+                            }
+                        }
+                    }
+                } else {
+                    throw new QueryParsingException(parseContext.index(),
+                            "[" + NAME + "] query does not support [" + currentFieldName + "]");
+                }
+            } else if (token.isValue()) {
+                if ("query".equals(currentFieldName)) {
+                    queryText = parser.text();
+                } else if ("analyzer".equals(currentFieldName)) {
+                    analyzerName = parser.text();
+                } else if ("field".equals(currentFieldName)) {
+                    field = parser.text();
+                } else if ("default_operator".equals(currentFieldName) ||
+                        "defaultOperator".equals(currentFieldName)) {
+                    String op = parser.text();
+                    if ("or".equalsIgnoreCase(op)) {
+                        defaultOperator = Operator.OR;
+                    } else if ("and".equalsIgnoreCase(op)) {
+                        defaultOperator = Operator.AND;
+                    } else {
+                        throw new QueryParsingException(parseContext.index(),
+                                "[" + NAME + "] default operator [" + op + "] is not allowed");
+                    }
+                } else if ("flags".equals(currentFieldName)) {
+                    if (parser.currentToken() != XContentParser.Token.VALUE_NUMBER) {
+                        // Possible options are:
+                        // ALL, NONE, AND, OR, PREFIX, PHRASE, PRECEDENCE,
+                        // ESCAPE, WHITESPACE, FUZZY, NEAR, SLOP
+                        flags = SimpleQueryStringFlag.resolveFlags(parser.text());
+                    } else {
+                        flags = parser.intValue();
+                        if (flags < 0) {
+                            flags = SimpleQueryStringFlag.ALL.value();
+                        }
+                    }
+                } else if ("locale".equals(currentFieldName)) {
+                    String localeStr = parser.text();
+                    locale = LocaleUtils.parse(localeStr);
+                } else if ("lowercase_expanded_terms".equals(currentFieldName)) {
+                    lowercaseExpandedTerms = parser.booleanValue();
+                } else if ("lenient".equals(currentFieldName)) {
+                    lenient = parser.booleanValue();
+                } else if ("analyze_wildcard".equals(currentFieldName)) {
+                    analyzeWildcard = parser.booleanValue();
+                } else if ("_name".equals(currentFieldName)) {
+                    queryName = parser.text();
+                } else if ("minimum_should_match".equals(currentFieldName)) {
+                    minimumShouldMatch = parser.textOrNull();
+                } else {
+                    throw new QueryParsingException(parseContext.index(),
+                            "[" + NAME + "] unsupported field [" + parser.currentName() + "]");
+                }
+            }
+        }
+
+        // Query text is required
+        if (queryText == null) {
+            throw new QueryParsingException(parseContext.index(),
+                    "[" + NAME + "] query text missing");
+        }
+
+        // Support specifying only a field instead of a map
+        if (field == null) {
+            field = currentFieldName;
+        }
+
+        // Use the default field (_all) if no fields specified
+        if (tempFieldsToWeights == null) {
+            field = parseContext.defaultField();
+        }
+
+        // default to the singular field if no other fields parsed
+        if (tempFieldsToWeights == null) {
+            tempFieldsToWeights = Collections.singletonMap(field, 1.0F);
+        }
+        fieldsAndWeights = tempFieldsToWeights;
+    }
+
+    @Override
+    public void doXContent(XContentBuilder builder, Params params)
+            throws IOException {
         builder.startObject(SimpleQueryStringBuilder.NAME);
 
         builder.field("query", queryText);
 
-        if (fields.size() > 0) {
+        if (fieldsAndWeights.size() > 0) {
             builder.startArray("fields");
-            for (Map.Entry<String, Float> entry : fields.entrySet()) {
+            for (Map.Entry<String, Float> entry : fieldsAndWeights.entrySet()) {
                 String field = entry.getKey();
                 Float boost = entry.getValue();
-                if (boost != null) {
+                if (boost != null && boost != 1.0f) {
                     builder.value(field + "^" + boost);
                 } else {
                     builder.value(field);
@@ -212,12 +400,13 @@ public class SimpleQueryStringBuilder extends BaseQueryBuilder implements QueryP
             builder.field("flags", flags);
         }
 
-        if (analyzer != null) {
-            builder.field("analyzer", analyzer);
+        if (analyzerName != null) {
+            builder.field("analyzer", analyzerName);
         }
 
-        if (operator != null) {
-            builder.field("default_operator", operator.name().toLowerCase(Locale.ROOT));
+        if (defaultOperator != null) {
+            builder.field("default_operator",
+                    defaultOperator.name().toLowerCase(Locale.ROOT));
         }
 
         if (lowercaseExpandedTerms != null) {
@@ -246,159 +435,100 @@ public class SimpleQueryStringBuilder extends BaseQueryBuilder implements QueryP
 
         builder.endObject();
     }
-    
+
     @Override
-    public String[] names() {
-        return new String[]{NAME, Strings.toCamelCase(NAME)};
+    public void readFrom(StreamInput in) throws IOException {
+        queryText = in.readOptionalString();
+        int size = in.readInt();
+        for (int i = 0; i < size; i++) {
+            String field = in.readString();
+            Float weight = in.readFloat();
+            fieldsAndWeights.put(field, weight);
+        }
+        flags = in.readInt();
+        analyzerName = in.readOptionalString();
+        String opStr = in.readOptionalString();
+        if ("and".equals(opStr)) {
+            defaultOperator = Operator.AND;
+        }
+        if ("or".equals(opStr)) {
+            defaultOperator = Operator.OR;
+        }
+        lowercaseExpandedTerms = in.readOptionalBoolean();
+        lenient = in.readOptionalBoolean();
+        analyzeWildcard = in.readOptionalBoolean();
+        if (in.readBoolean()) {
+            String localeStr = in.readString();
+            locale = LocaleUtils.parse(localeStr);
+        }
+        queryName = in.readOptionalString();
+        minimumShouldMatch = in.readOptionalString();
     }
 
     @Override
-    public Query parse(QueryParseContext parseContext) throws IOException, QueryParsingException {
-        XContentParser parser = parseContext.parser();
-
-        String currentFieldName = null;
-        String queryBody = null;
-        String queryName = null;
-        String field = null;
-        String minimumShouldMatch = null;
-        Map<String, Float> fieldsAndWeights = null;
-        BooleanClause.Occur defaultOperator = null;
-        Analyzer analyzer = null;
-        int flags = -1;
-        SimpleQueryParser.Settings sqsSettings = new SimpleQueryParser.Settings();
-
-        XContentParser.Token token;
-        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
-            if (token == XContentParser.Token.FIELD_NAME) {
-                currentFieldName = parser.currentName();
-            } else if (token == XContentParser.Token.START_ARRAY) {
-                if ("fields".equals(currentFieldName)) {
-                    while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
-                        String fField = null;
-                        float fBoost = 1;
-                        char[] text = parser.textCharacters();
-                        int end = parser.textOffset() + parser.textLength();
-                        for (int i = parser.textOffset(); i < end; i++) {
-                            if (text[i] == '^') {
-                                int relativeLocation = i - parser.textOffset();
-                                fField = new String(text, parser.textOffset(), relativeLocation);
-                                fBoost = Float.parseFloat(new String(text, i + 1, parser.textLength() - relativeLocation - 1));
-                                break;
-                            }
-                        }
-                        if (fField == null) {
-                            fField = parser.text();
-                        }
-
-                        if (fieldsAndWeights == null) {
-                            fieldsAndWeights = new HashMap<>();
-                        }
-
-                        if (Regex.isSimpleMatchPattern(fField)) {
-                            for (String fieldName : parseContext.mapperService().simpleMatchToIndexNames(fField)) {
-                                fieldsAndWeights.put(fieldName, fBoost);
-                            }
-                        } else {
-                            MapperService.SmartNameFieldMappers mappers = parseContext.smartFieldMappers(fField);
-                            if (mappers != null && mappers.hasMapper()) {
-                                fieldsAndWeights.put(mappers.mapper().names().indexName(), fBoost);
-                            } else {
-                                fieldsAndWeights.put(fField, fBoost);
-                            }
-                        }
-                    }
-                } else {
-                    throw new QueryParsingException(parseContext.index(),
-                            "[" + NAME + "] query does not support [" + currentFieldName + "]");
-                }
-            } else if (token.isValue()) {
-                if ("query".equals(currentFieldName)) {
-                    queryBody = parser.text();
-                } else if ("analyzer".equals(currentFieldName)) {
-                    analyzer = parseContext.analysisService().analyzer(parser.text());
-                    if (analyzer == null) {
-                        throw new QueryParsingException(parseContext.index(), "[" + NAME + "] analyzer [" + parser.text() + "] not found");
-                    }
-                } else if ("field".equals(currentFieldName)) {
-                    field = parser.text();
-                } else if ("default_operator".equals(currentFieldName) || "defaultOperator".equals(currentFieldName)) {
-                    String op = parser.text();
-                    if ("or".equalsIgnoreCase(op)) {
-                        defaultOperator = BooleanClause.Occur.SHOULD;
-                    } else if ("and".equalsIgnoreCase(op)) {
-                        defaultOperator = BooleanClause.Occur.MUST;
-                    } else {
-                        throw new QueryParsingException(parseContext.index(),
-                                "[" + NAME + "] default operator [" + op + "] is not allowed");
-                    }
-                } else if ("flags".equals(currentFieldName)) {
-                    if (parser.currentToken() != XContentParser.Token.VALUE_NUMBER) {
-                        // Possible options are:
-                        // ALL, NONE, AND, OR, PREFIX, PHRASE, PRECEDENCE, ESCAPE, WHITESPACE, FUZZY, NEAR, SLOP
-                        flags = SimpleQueryStringFlag.resolveFlags(parser.text());
-                    } else {
-                        flags = parser.intValue();
-                        if (flags < 0) {
-                            flags = SimpleQueryStringFlag.ALL.value();
-                        }
-                    }
-                } else if ("locale".equals(currentFieldName)) {
-                    String localeStr = parser.text();
-                    Locale locale = LocaleUtils.parse(localeStr);
-                    sqsSettings.locale(locale);
-                } else if ("lowercase_expanded_terms".equals(currentFieldName)) {
-                    sqsSettings.lowercaseExpandedTerms(parser.booleanValue());
-                } else if ("lenient".equals(currentFieldName)) {
-                    sqsSettings.lenient(parser.booleanValue());
-                } else if ("analyze_wildcard".equals(currentFieldName)) {
-                    sqsSettings.analyzeWildcard(parser.booleanValue());
-                } else if ("_name".equals(currentFieldName)) {
-                    queryName = parser.text();
-                } else if ("minimum_should_match".equals(currentFieldName)) {
-                    minimumShouldMatch = parser.textOrNull();
-                } else {
-                    throw new QueryParsingException(parseContext.index(), "[" + NAME + "] unsupported field [" + parser.currentName() + "]");
-                }
-            }
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeOptionalString(queryText);
+        out.writeInt(fieldsAndWeights.size());
+        for (Map.Entry<String, Float> entry : fieldsAndWeights.entrySet()) {
+            out.writeString(entry.getKey());
+            out.writeFloat(entry.getValue());
         }
-
-        // Query text is required
-        if (queryBody == null) {
-            throw new QueryParsingException(parseContext.index(), "[" + NAME + "] query text missing");
-        }
-
-        // Support specifying only a field instead of a map
-        if (field == null) {
-            field = currentFieldName;
-        }
-
-        // Use the default field (_all) if no fields specified
-        if (fieldsAndWeights == null) {
-            field = parseContext.defaultField();
-        }
-
-        // Use standard analyzer by default
-        if (analyzer == null) {
-            analyzer = parseContext.mapperService().searchAnalyzer();
-        }
-
-        if (fieldsAndWeights == null) {
-            fieldsAndWeights = Collections.singletonMap(field, 1.0F);
-        }
-        SimpleQueryParser sqp = new SimpleQueryParser(analyzer, fieldsAndWeights, flags, sqsSettings);
-
+        out.writeInt(flags);
+        out.writeOptionalString(analyzerName);
+        out.writeBoolean(defaultOperator != null);
         if (defaultOperator != null) {
-            sqp.setDefaultOperator(defaultOperator);
+            out.writeString(defaultOperator.name().toLowerCase(Locale.ROOT));
         }
+        out.writeOptionalBoolean(lowercaseExpandedTerms);
+        out.writeOptionalBoolean(lenient);
+        out.writeOptionalBoolean(analyzeWildcard);
+        out.writeBoolean(locale != null);
+        if (locale != null) {
+            out.writeString(locale.toString());
+        }
+        out.writeOptionalString(queryName);
+        out.writeOptionalString(minimumShouldMatch);
+    }
 
-        Query query = sqp.parse(queryBody);
-        if (queryName != null) {
-            parseContext.addNamedQuery(queryName, query);
-        }
+    @Override
+    public int hashCode() {
+        int hash = super.hashCode();
+        hash = maybeHashcode(hash, fieldsAndWeights);
+        hash = maybeHashcode(hash, analyzerName);
+        hash = maybeHashcode(hash, defaultOperator);
+        hash = maybeHashcode(hash, queryText);
+        hash = maybeHashcode(hash, queryName);
+        hash = maybeHashcode(hash, minimumShouldMatch);
+        hash = maybeHashcode(hash, lowercaseExpandedTerms);
+        hash = maybeHashcode(hash, lenient);
+        hash = maybeHashcode(hash, analyzeWildcard);
+        hash = maybeHashcode(hash, locale);
+        return hash;
+    }
 
-        if (minimumShouldMatch != null && query instanceof BooleanQuery) {
-            Queries.applyMinimumShouldMatch((BooleanQuery) query, minimumShouldMatch);
+    /** Return a prime (31) times the staring hash and object's hash, if non-null */
+    private int maybeHashcode(int startingHash, Object obj) {
+        return 31 * startingHash + ((obj == null) ? 0 : obj.hashCode());
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
         }
-        return query;
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        SimpleQueryStringBuilder other = (SimpleQueryStringBuilder) obj;
+        return Objects.equals(fieldsAndWeights, other.fieldsAndWeights) &&
+                Objects.equals(analyzerName, other.analyzerName) &&
+                Objects.equals(defaultOperator, other.defaultOperator) &&
+                Objects.equals(queryText, other.queryText) &&
+                Objects.equals(queryName, other.queryName) &&
+                Objects.equals(minimumShouldMatch, other.minimumShouldMatch) &&
+                Objects.equals(lowercaseExpandedTerms, other.lowercaseExpandedTerms) &&
+                Objects.equals(lenient, other.lenient) &&
+                Objects.equals(analyzeWildcard, other.analyzeWildcard) &&
+                Objects.equals(locale, other.locale);
     }
 }

--- a/src/test/java/org/elasticsearch/index/query/SimpleQueryStringBuilderTests.java
+++ b/src/test/java/org/elasticsearch/index/query/SimpleQueryStringBuilderTests.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.common.inject.AbstractModule;
+import org.elasticsearch.common.inject.Injector;
+import org.elasticsearch.common.inject.ModulesBuilder;
+import org.elasticsearch.common.inject.util.Providers;
+import org.elasticsearch.common.io.stream.BytesStreamInput;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.settings.SettingsModule;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.env.EnvironmentModule;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexNameModule;
+import org.elasticsearch.index.analysis.AnalysisModule;
+import org.elasticsearch.index.cache.IndexCacheModule;
+import org.elasticsearch.index.query.functionscore.FunctionScoreModule;
+import org.elasticsearch.index.settings.IndexSettingsModule;
+import org.elasticsearch.index.similarity.SimilarityModule;
+import org.elasticsearch.indices.breaker.CircuitBreakerService;
+import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
+import org.elasticsearch.indices.query.IndicesQueriesModule;
+import org.elasticsearch.script.ScriptModule;
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.threadpool.ThreadPoolModule;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Unit tests for the SimpleQueryStringBuilder
+ */
+public class SimpleQueryStringBuilderTests extends ElasticsearchTestCase {
+
+    private static final String SQS_BODY_1_5 = "{\"simple_query_string\":{\"query\":\"foo\",\"fields\":[\"body^1.5\"]}}";
+    private QueryParseContext context;
+    private Injector injector;
+    private SimpleQueryStringBuilder testQuery;
+    private XContentParser parser;
+
+    @Before
+    public void setup() throws IOException {
+        Settings settings = ImmutableSettings.settingsBuilder()
+                .put("path.conf", this.getResourcePath("config"))
+                .put("name", getClass().getName())
+                .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
+                .build();
+
+        Index index = new Index("test");
+        injector = new ModulesBuilder().add(
+                new EnvironmentModule(new Environment(settings)),
+                new SettingsModule(settings),
+                new ThreadPoolModule(settings),
+                new IndicesQueriesModule(),
+                new ScriptModule(settings),
+                new IndexSettingsModule(index, settings),
+                new IndexCacheModule(settings),
+                new AnalysisModule(settings),
+                new SimilarityModule(settings),
+                new IndexNameModule(index),
+                new IndexQueryParserModule(settings),
+                new FunctionScoreModule(),
+                new AbstractModule() {
+                    @Override
+                    protected void configure() {
+                        bind(ClusterService.class).toProvider(Providers.of((ClusterService) null));
+                        bind(CircuitBreakerService.class).to(NoneCircuitBreakerService.class);
+                    }
+                }
+        ).createInjector();
+
+        IndexQueryParserService queryParserService = injector.getInstance(IndexQueryParserService.class);
+        context = new QueryParseContext(index, queryParserService);
+        testQuery = createTestQuery();
+        String contentString = createXContent(testQuery).string();
+        parser = XContentFactory.xContent(contentString).createParser(contentString);
+    }
+
+    @Override
+    @After
+    public void tearDown() throws Exception {
+        super.tearDown();
+        terminate(injector.getInstance(ThreadPool.class));
+    }
+
+    @Test
+    public void testToXContent() throws IOException {
+        XContentBuilder content = createXContent(new SimpleQueryStringBuilder("foo").field("body", 1.5f));
+        assertEquals(content.string(), SQS_BODY_1_5);
+    }
+
+    @Test
+    public void testSerialization() throws IOException {
+        context.reset(parser);
+
+        BytesStreamOutput output = new BytesStreamOutput();
+        testQuery.writeTo(output);
+
+        BytesStreamInput bytesStreamInput = new BytesStreamInput(output.bytes());
+        SimpleQueryStringBuilder deserializedQuery = new SimpleQueryStringBuilder();
+        deserializedQuery.readFrom(bytesStreamInput);
+
+        assertEquals(testQuery, deserializedQuery);
+        assertThat(createXContent(testQuery).string(), is(createXContent(deserializedQuery).string()));
+    }
+
+    private SimpleQueryStringBuilder createTestQuery() {
+        SimpleQueryStringBuilder query = new SimpleQueryStringBuilder("foo");
+        if (randomBoolean()) {
+            if (randomBoolean()) {
+                query.field("body");
+            } else {
+                query.field("body", randomIntBetween(1, 10));
+            }
+        }
+        if (randomBoolean()) {
+            query.analyzer("simple");
+        }
+        if (randomBoolean()) {
+            query.analyzeWildcard(randomBoolean());
+        }
+        if (randomBoolean()) {
+            query.defaultOperator(randomFrom(SimpleQueryStringBuilder.Operator.AND,
+                    SimpleQueryStringBuilder.Operator.OR));
+        }
+        if (randomBoolean()) {
+            query.flags(SimpleQueryStringFlag.WHITESPACE, SimpleQueryStringFlag.NEAR);
+        }
+        if (randomBoolean()) {
+            query.lenient(randomBoolean());
+        }
+        if (randomBoolean()) {
+            query.locale(randomLocale());
+        }
+        if (randomBoolean()) {
+            query.lowercaseExpandedTerms(randomBoolean());
+        }
+        if (randomBoolean()) {
+            query.minimumShouldMatch(randomFrom(new String[]{"1", "10%"}));
+        }
+        if (randomBoolean()) {
+            query.queryName("myquery");
+        }
+        return query;
+    }
+
+    private XContentBuilder createXContent(BaseQueryBuilder query) throws IOException {
+        XContentBuilder content = XContentFactory.jsonBuilder();
+        content.startObject();
+        query.doXContent(content, null);
+        content.endObject();
+        content.close();
+        return content;
+    }
+}

--- a/src/test/java/org/elasticsearch/index/query/SimpleQueryStringBuilderTests.java
+++ b/src/test/java/org/elasticsearch/index/query/SimpleQueryStringBuilderTests.java
@@ -177,9 +177,7 @@ public class SimpleQueryStringBuilderTests extends ElasticsearchTestCase {
 
     private XContentBuilder createXContent(BaseQueryBuilder query) throws IOException {
         XContentBuilder content = XContentFactory.jsonBuilder();
-        content.startObject();
-        query.doXContent(content, null);
-        content.endObject();
+        query.toXContent(content, null);
         content.close();
         return content;
     }


### PR DESCRIPTION
SimpleQueryStringBuilder now includes the `fromXContent`, `doXContent`,
and `toQuery` methods as well as implementing the Streamable interface.

It includes unit tests for the serialization and parsing.

Because of testing, I also implemented `hashCode` and `equals` similar
to the way that Lucene queries implement these.

_NOTE_: this PR is against the `feature/query-parse-refactoring` branch.
