### PR TITLE
Make `routing_nodes` an independent metric option in cluster state api

### DIFF
--- a/rest-api-spec/api/cluster.state.json
+++ b/rest-api-spec/api/cluster.state.json
@@ -16,7 +16,7 @@
         },
         "metric" : {
           "type" : "list",
-          "options" : ["_all", "blocks", "metadata", "nodes", "routing_table", "master_node", "version"],
+          "options" : ["_all", "blocks", "metadata", "nodes", "routing_table", "routing_nodes", "master_node", "version"],
           "description" : "Limit the information returned to the specified metrics"
         }
       },

--- a/rest-api-spec/test/cluster.state/20_filtering.yaml
+++ b/rest-api-spec/test/cluster.state/20_filtering.yaml
@@ -84,6 +84,18 @@ setup:
   - is_true: routing_nodes
 
 ---
+"Filtering the cluster state by routing nodes only should work":
+  - do:
+      cluster.state:
+        metric: [ routing_nodes ]
+
+  - is_false: blocks
+  - is_false: nodes
+  - is_false: metadata
+  - is_false: routing_table
+  - is_true: routing_nodes
+
+---
 "Filtering the cluster state by indices should work in routing table and metadata":
   - do:
       index:

--- a/src/main/java/org/elasticsearch/cluster/ClusterState.java
+++ b/src/main/java/org/elasticsearch/cluster/ClusterState.java
@@ -261,6 +261,7 @@ public class ClusterState implements ToXContent {
         NODES("nodes"),
         METADATA("metadata"),
         ROUTING_TABLE("routing_table"),
+        ROUTING_NODES("routing_nodes"),
         CUSTOMS("customs");
 
         private static Map<String, Metric> valueToEnum;
@@ -465,7 +466,8 @@ public class ClusterState implements ToXContent {
         }
 
         // routing nodes
-        if (metrics.contains(Metric.ROUTING_TABLE)) {
+        // keep ROUTING_TABLE for backward compatibility
+        if (metrics.contains(Metric.ROUTING_TABLE) || metrics.contains(Metric.ROUTING_NODES)) {
             builder.startObject("routing_nodes");
             builder.startArray("unassigned");
             for (ShardRouting shardRouting : readOnlyRoutingNodes().unassigned()) {

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/state/RestClusterStateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/state/RestClusterStateAction.java
@@ -72,7 +72,7 @@ public class RestClusterStateAction extends BaseRestHandler {
             EnumSet<ClusterState.Metric> metrics = ClusterState.Metric.parseString(request.param("metric"), true);
             // do not ask for what we do not need.
             clusterStateRequest.nodes(metrics.contains(ClusterState.Metric.NODES) || metrics.contains(ClusterState.Metric.MASTER_NODE));
-            clusterStateRequest.routingTable(metrics.contains(ClusterState.Metric.ROUTING_TABLE));
+            clusterStateRequest.routingTable(metrics.contains(ClusterState.Metric.ROUTING_TABLE) || metrics.contains(ClusterState.Metric.ROUTING_NODES));
             clusterStateRequest.metaData(metrics.contains(ClusterState.Metric.METADATA));
             clusterStateRequest.blocks(metrics.contains(ClusterState.Metric.BLOCKS));
         }


### PR DESCRIPTION
closes #10352
