### PR TITLE
Bring back `numeric_resolution`

### DIFF
--- a/docs/reference/mapping/types/core-types.asciidoc
+++ b/docs/reference/mapping/types/core-types.asciidoc
@@ -378,6 +378,9 @@ defaults to `true` or to the parent `object` type setting.
 
 |`ignore_malformed` |Ignored a malformed number. Defaults to `false`.
 
+|`numeric_resolution` |The unit to use when passed in a numeric values. Possible
+values include `seconds` and  `milliseconds` (default).
+
 |=======================================================================
 
 [float]

--- a/src/main/java/org/elasticsearch/index/mapper/core/DateFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/DateFieldMapper.java
@@ -488,13 +488,14 @@ public class DateFieldMapper extends NumberFieldMapper<Long> {
         }
 
         if (value != null) {
+            final long timestamp = timeUnit.toMillis(value);
             if (fieldType.indexOptions() != IndexOptions.NONE || fieldType.stored()) {
-                CustomLongNumericField field = new CustomLongNumericField(this, value, fieldType);
+                CustomLongNumericField field = new CustomLongNumericField(this, timestamp, fieldType);
                 field.setBoost(boost);
                 fields.add(field);
             }
             if (hasDocValues()) {
-                addDocValue(context, fields, value);
+                addDocValue(context, fields, timestamp);
             }
         }
     }
@@ -553,8 +554,7 @@ public class DateFieldMapper extends NumberFieldMapper<Long> {
             return dateTimeFormatter.parser().parseMillis(value);
         } catch (RuntimeException e) {
             try {
-                long time = Long.parseLong(value);
-                return timeUnit.toMillis(time);
+                return Long.parseLong(value);
             } catch (NumberFormatException e1) {
                 throw new MapperParsingException("failed to parse date field [" + value + "], tried both date format [" + dateTimeFormatter.format() + "], and timestamp number with locale [" + dateTimeFormatter.locale() + "]", e);
             }


### PR DESCRIPTION
We had an undocumented parameter called `numeric_resolution` which allows to
configure how to deal with dates when provided as a number. The default is to
handle them as milliseconds, but you can also opt-in for eg. seconds.

Close #10072
