### PR TITLE
Warning in documentation for deprecation of rivers

### DIFF
--- a/docs/river/index.asciidoc
+++ b/docs/river/index.asciidoc
@@ -3,6 +3,8 @@
 
 == Intro
 
+WARNING: Rivers have been deprecated. Refer to the github issue https://github.com/elastic/elasticsearch/issues/10345
+
 A river is a pluggable service running within elasticsearch cluster
 pulling data (or being pushed with data) that is then indexed into the
 cluster.


### PR DESCRIPTION
Adding a warning in the documentation on the wiki to inform users that rivers are being deprecated.

Related to #10345
