### PR TITLE
Remove content thread safe from REST layer

### DIFF
--- a/src/main/java/org/elasticsearch/http/netty/NettyHttpChannel.java
+++ b/src/main/java/org/elasticsearch/http/netty/NettyHttpChannel.java
@@ -137,11 +137,7 @@ public class NettyHttpChannel extends HttpChannel {
         ChannelBuffer buffer;
         boolean addedReleaseListener = false;
         try {
-            if (response.contentThreadSafe()) {
-                buffer = content.toChannelBuffer();
-            } else {
-                buffer = content.copyBytesArray().toChannelBuffer();
-            }
+            buffer = content.toChannelBuffer();
             resp.setContent(buffer);
 
             // If our response doesn't specify a content-type header, set one
@@ -180,7 +176,7 @@ public class NettyHttpChannel extends HttpChannel {
                 future = channel.write(resp);
             }
 
-            if (response.contentThreadSafe() && content instanceof Releasable) {
+            if (content instanceof Releasable) {
                 future.addListener(new ReleaseChannelFutureListener((Releasable) content));
                 addedReleaseListener = true;
             }

--- a/src/main/java/org/elasticsearch/rest/BytesRestResponse.java
+++ b/src/main/java/org/elasticsearch/rest/BytesRestResponse.java
@@ -34,48 +34,46 @@ public class BytesRestResponse extends RestResponse {
 
     private final RestStatus status;
     private final BytesReference content;
-    private final boolean contentThreadSafe;
     private final String contentType;
 
     public BytesRestResponse(RestStatus status) {
-        this(status, TEXT_CONTENT_TYPE, BytesArray.EMPTY, true);
+        this(status, TEXT_CONTENT_TYPE, BytesArray.EMPTY);
     }
 
     /**
      * Creates a new response based on {@link XContentBuilder}.
      */
     public BytesRestResponse(RestStatus status, XContentBuilder builder) {
-        this(status, builder.contentType().restContentType(), builder.bytes(), true);
+        this(status, builder.contentType().restContentType(), builder.bytes());
     }
 
     /**
      * Creates a new plain text response.
      */
     public BytesRestResponse(RestStatus status, String content) {
-        this(status, TEXT_CONTENT_TYPE, new BytesArray(content), true);
+        this(status, TEXT_CONTENT_TYPE, new BytesArray(content));
     }
 
     /**
      * Creates a new plain text response.
      */
     public BytesRestResponse(RestStatus status, String contentType, String content) {
-        this(status, contentType, new BytesArray(content), true);
+        this(status, contentType, new BytesArray(content));
     }
 
     /**
      * Creates a binary response.
      */
     public BytesRestResponse(RestStatus status, String contentType, byte[] content) {
-        this(status, contentType, new BytesArray(content), true);
+        this(status, contentType, new BytesArray(content));
     }
 
     /**
      * Creates a binary response.
      */
-    public BytesRestResponse(RestStatus status, String contentType, BytesReference content, boolean contentThreadSafe) {
+    public BytesRestResponse(RestStatus status, String contentType, BytesReference content) {
         this.status = status;
         this.content = content;
-        this.contentThreadSafe = contentThreadSafe;
         this.contentType = contentType;
     }
 
@@ -96,17 +94,11 @@ public class BytesRestResponse extends RestResponse {
         if (t instanceof HasRestHeaders) {
             addHeaders(((HasRestHeaders) t).getHeaders());
         }
-        this.contentThreadSafe = true;
     }
 
     @Override
     public String contentType() {
         return this.contentType;
-    }
-
-    @Override
-    public boolean contentThreadSafe() {
-        return this.contentThreadSafe;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/rest/RestResponse.java
+++ b/src/main/java/org/elasticsearch/rest/RestResponse.java
@@ -43,11 +43,6 @@ public abstract class RestResponse implements HasRestHeaders {
     public abstract String contentType();
 
     /**
-     * Can the content byte[] be used only with this thread (<tt>false</tt>), or by any thread (<tt>true</tt>).
-     */
-    public abstract boolean contentThreadSafe();
-
-    /**
      * The response content. Note, if the content is {@link org.elasticsearch.common.lease.Releasable} it
      * should automatically be released when done by the channel sending it.
      */

--- a/src/main/java/org/elasticsearch/rest/action/cat/AbstractCatAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/AbstractCatAction.java
@@ -61,7 +61,7 @@ public abstract class AbstractCatAction extends BaseRestHandler {
                 out.append("\n");
             }
             out.close();
-            channel.sendResponse(new BytesRestResponse(RestStatus.OK, BytesRestResponse.TEXT_CONTENT_TYPE, bytesOutput.bytes(), true));
+            channel.sendResponse(new BytesRestResponse(RestStatus.OK, BytesRestResponse.TEXT_CONTENT_TYPE, bytesOutput.bytes()));
         } else {
             doRequest(request, channel, client);
         }

--- a/src/main/java/org/elasticsearch/rest/action/support/RestTable.java
+++ b/src/main/java/org/elasticsearch/rest/action/support/RestTable.java
@@ -93,7 +93,7 @@ public class RestTable {
             out.append("\n");
         }
         out.close();
-        return new BytesRestResponse(RestStatus.OK, BytesRestResponse.TEXT_CONTENT_TYPE, bytesOut.bytes(), true);
+        return new BytesRestResponse(RestStatus.OK, BytesRestResponse.TEXT_CONTENT_TYPE, bytesOut.bytes());
     }
 
     private static List<DisplayHeader> buildDisplayHeaders(Table table, RestRequest request) {

--- a/src/test/java/org/elasticsearch/rest/RestFilterChainTests.java
+++ b/src/test/java/org/elasticsearch/rest/RestFilterChainTests.java
@@ -254,11 +254,6 @@ public class RestFilterChainTests extends ElasticsearchTestCase {
         }
 
         @Override
-        public boolean contentThreadSafe() {
-            return false;
-        }
-
-        @Override
         public BytesReference content() {
             return null;
         }


### PR DESCRIPTION
there is no need for this anymore, for some time, since in netty now we rely on copying over the buffer and reusing it
