### PR TITLE
Update to Lucene 5.1 snapshot r1671277

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <lucene.version>5.1.0</lucene.version>
-        <lucene.maven.version>5.1.0-snapshot-1662607</lucene.maven.version>
+        <lucene.maven.version>5.1.0-snapshot-1671277</lucene.maven.version>
         <tests.jvms>auto</tests.jvms>
         <tests.shuffle>true</tests.shuffle>
         <tests.output>onerror</tests.output>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <repository>
             <id>lucene-snapshots</id>
             <name>Lucene Snapshots</name>
-            <url>https://download.elastic.co/lucenesnapshots/1662607</url>
+            <url>https://download.elastic.co/lucenesnapshots/1671277</url>
         </repository>
     </repositories>
 

--- a/src/main/java/org/apache/lucene/search/postingshighlight/XPostingsHighlighter.java
+++ b/src/main/java/org/apache/lucene/search/postingshighlight/XPostingsHighlighter.java
@@ -421,6 +421,10 @@ public class XPostingsHighlighter {
             if (t == null) {
                 continue; // nothing to do
             }
+            if (!t.hasOffsets()) {
+                // no offsets available
+                throw new IllegalArgumentException("field '" + field + "' was indexed without offsets, cannot highlight");
+            }
             if (leaf != lastLeaf) {
                 termsEnum = t.iterator(null);
                 postings = new PostingsEnum[terms.length];
@@ -479,10 +483,7 @@ public class XPostingsHighlighter {
                     continue; // term not found
                 }
                 de = postings[i] = termsEnum.postings(null, null, PostingsEnum.OFFSETS);
-                if (de == null) {
-                    // no positions available
-                    throw new IllegalArgumentException("field '" + field + "' was indexed without offsets, cannot highlight");
-                }
+                assert de != null;
                 pDoc = de.advance(doc);
             } else {
                 pDoc = de.docID();
@@ -522,9 +523,7 @@ public class XPostingsHighlighter {
             final PostingsEnum dp = off.dp;
 
             int start = dp.startOffset();
-            if (start == -1) {
-                throw new IllegalArgumentException("field '" + field + "' was indexed without offsets, cannot highlight");
-            }
+            assert start >= 0;
             int end = dp.endOffset();
             // LUCENE-5166: this hit would span the content limit... however more valid
             // hits may exist (they are sorted by start). so we pretend like we never

--- a/src/main/java/org/elasticsearch/index/codec/postingsformat/BloomFilterPostingsFormat.java
+++ b/src/main/java/org/elasticsearch/index/codec/postingsformat/BloomFilterPostingsFormat.java
@@ -396,7 +396,7 @@ public class BloomFilterPostingsFormat extends PostingsFormat {
                         break;
                     }
                     if (bloomFilter == null) {
-                        bloomFilter = bloomFilterFactory.createFilter(state.segmentInfo.getDocCount());
+                        bloomFilter = bloomFilterFactory.createFilter(state.segmentInfo.maxDoc());
                         assert bloomFilters.containsKey(field) == false;
                         bloomFilters.put(fieldInfo, bloomFilter);
                     }

--- a/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -350,7 +350,7 @@ public abstract class Engine implements Closeable {
                     segment = new Segment(info.info.name);
                     segment.search = false;
                     segment.committed = true;
-                    segment.docCount = info.info.getDocCount();
+                    segment.docCount = info.info.maxDoc();
                     segment.delDocCount = info.getDelCount();
                     segment.version = info.info.getVersion();
                     segment.compound = info.info.getUseCompoundFile();

--- a/src/main/java/org/elasticsearch/index/merge/policy/VersionFieldUpgrader.java
+++ b/src/main/java/org/elasticsearch/index/merge/policy/VersionFieldUpgrader.java
@@ -134,7 +134,7 @@ class VersionFieldUpgrader extends FilterCodecReader {
                 PostingsEnum dpe = null;
                 for (BytesRef uid = uids.next(); uid != null; uid = uids.next()) {
                     dpe = uids.postings(reader.getLiveDocs(), dpe, PostingsEnum.PAYLOADS);
-                    assert dpe != null : "field has payloads";
+                    assert terms.hasPayloads() : "field has payloads";
                     for (int doc = dpe.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = dpe.nextDoc()) {
                         dpe.nextPosition();
                         final BytesRef payload = dpe.getPayload();

--- a/src/main/java/org/elasticsearch/search/lookup/IndexFieldTerm.java
+++ b/src/main/java/org/elasticsearch/search/lookup/IndexFieldTerm.java
@@ -72,7 +72,7 @@ public class IndexFieldTerm implements Iterable<TermPosition> {
             if (!shouldRetrieveFrequenciesOnly()) {
                 postings = getPostings(getLucenePositionsFlags(flags), reader);
             }
-            
+
             if (postings == null) {
                 postings = getPostings(getLuceneFrequencyFlag(flags), reader);
                 if (postings != null) {
@@ -149,7 +149,7 @@ public class IndexFieldTerm implements Iterable<TermPosition> {
                     public long cost() {
                         return empty.cost();
                     }
-                    
+
                     @Override
                     public int freq() throws IOException {
                         return 1;
@@ -245,14 +245,10 @@ public class IndexFieldTerm implements Iterable<TermPosition> {
         identifier = new Term(fieldName, (String) term);
         this.flags = flags;
         boolean doRecord = ((flags & IndexLookup.FLAG_CACHE) > 0);
-        if (withPositions()) {
-            if (!doRecord) {
-                iterator = new PositionIterator(this);
-            } else {
-                iterator = new CachedPositionIterator(this);
-            }
-        } else {
+        if (!doRecord) {
             iterator = new PositionIterator(this);
+        } else {
+            iterator = new CachedPositionIterator(this);
         }
         setNextReader(indexLookup.getReader());
         setNextDoc(indexLookup.getDocId());
@@ -262,22 +258,6 @@ public class IndexFieldTerm implements Iterable<TermPosition> {
         } catch (IOException e) {
             throw new ElasticsearchException("Cannot get term statistics: ", e);
         }
-    }
-
-    private boolean withPositions() {
-        return shouldRetrievePositions() || shouldRetrieveOffsets() || shouldRetrievePayloads();
-    }
-
-    protected boolean shouldRetrievePositions() {
-        return (flags & IndexLookup.FLAG_POSITIONS) > 0;
-    }
-
-    protected boolean shouldRetrieveOffsets() {
-        return (flags & IndexLookup.FLAG_OFFSETS) > 0;
-    }
-
-    protected boolean shouldRetrievePayloads() {
-        return (flags & IndexLookup.FLAG_PAYLOADS) > 0;
     }
 
     public int tf() throws IOException {

--- a/src/test/java/org/elasticsearch/count/query/CountQueryTests.java
+++ b/src/test/java/org/elasticsearch/count/query/CountQueryTests.java
@@ -77,7 +77,7 @@ public class CountQueryTests extends ElasticsearchIntegrationTest {
         assertThat(countResponse.getFailedShards(), equalTo(countResponse.getShardFailures().length));
         for (ShardOperationFailedException shardFailure : countResponse.getShardFailures()) {
             assertThat(shardFailure.status(), equalTo(RestStatus.INTERNAL_SERVER_ERROR));
-            assertThat(shardFailure.reason(), containsString("[field \"field1\" was indexed without position data; cannot run PhraseQuery (term=quick)]"));
+            assertThat(shardFailure.reason(), containsString("[field \"field1\" was indexed without position data; cannot run PhraseQuery"));
         }
     }
 

--- a/src/test/java/org/elasticsearch/index/store/StoreTest.java
+++ b/src/test/java/org/elasticsearch/index/store/StoreTest.java
@@ -204,7 +204,7 @@ public class StoreTest extends ElasticsearchLuceneTestCase {
                         output.writeInt(version.minor);
                         output.writeInt(version.bugfix);
                         assert version.prerelease == 0;
-                        output.writeInt(si.getDocCount());
+                        output.writeInt(si.maxDoc());
 
                         output.writeByte((byte) (si.getUseCompoundFile() ? SegmentInfo.YES : SegmentInfo.NO));
                         output.writeStringStringMap(si.getDiagnostics());

--- a/src/test/java/org/elasticsearch/script/IndexLookupTests.java
+++ b/src/test/java/org/elasticsearch/script/IndexLookupTests.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.script;
 
-import org.apache.lucene.util.LuceneTestCase.AwaitsFix;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.ShardSearchFailure;
@@ -31,7 +30,6 @@ import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilders;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.hamcrest.Matchers;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -45,7 +43,6 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcke
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.hamcrest.Matchers.equalTo;
 
-@AwaitsFix(bugUrl="https://issues.apache.org/jira/browse/LUCENE-6271")
 public class IndexLookupTests extends ElasticsearchIntegrationTest {
 
     String includeAllFlag = "_FREQUENCIES | _OFFSETS | _PAYLOADS | _POSITIONS | _CACHE";

--- a/src/test/java/org/elasticsearch/search/query/SearchQueryTests.java
+++ b/src/test/java/org/elasticsearch/search/query/SearchQueryTests.java
@@ -171,7 +171,7 @@ public class SearchQueryTests extends ElasticsearchIntegrationTest {
 
         assertFailures(client().prepareSearch().setQuery(matchQuery("field1", "quick brown").type(Type.PHRASE).slop(0)),
                     RestStatus.INTERNAL_SERVER_ERROR,
-                    containsString("field \"field1\" was indexed without position data; cannot run PhraseQuery (term=quick"));
+                    containsString("field \"field1\" was indexed without position data; cannot run PhraseQuery"));
     }
 
     @Test // see #3521
@@ -482,7 +482,7 @@ public class SearchQueryTests extends ElasticsearchIntegrationTest {
                     client().prepareSearch().setQuery(matchQuery("field1", "quick brown").type(MatchQueryBuilder.Type.PHRASE).slop(0)).get();
                     fail("SearchPhaseExecutionException should have been thrown");
                 } catch (SearchPhaseExecutionException e) {
-                    assertTrue(e.getMessage().endsWith("IllegalStateException[field \"field1\" was indexed without position data; cannot run PhraseQuery (term=quick)]; }"));
+                    assertTrue(e.getMessage().contains("IllegalStateException[field \"field1\" was indexed without position data; cannot run PhraseQuery"));
                 }
                 cluster().wipeIndices("test");
             } catch (MapperParsingException ex) {


### PR DESCRIPTION
Upgrades to latest snapshot of lucene 5.1 release branch.

We actually have interesting stuff in 5.2, but I wanted to do this step first. It helps test the lucene release and allows us to deal with changes to the new PostingsEnum api in 5.1, without also having to tackle differences in Spans and other things in 5.2 at the same time.
