### PR TITLE
Refactor MatchAllQueryBuilder, TermQueryBuilder, IdsQueryBuilder

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
@@ -47,9 +47,9 @@ import java.util.Objects;
  */
 public class IdsQueryBuilder extends BaseQueryBuilder implements QueryParser, BoostableQueryBuilder<IdsQueryBuilder>, Streamable {
 
-    private Collection<String> types = new ArrayList<String>();
+    private Collection<String> types = new ArrayList<>();
 
-    private Collection<String> values = new ArrayList<String>();
+    private Collection<String> values = new ArrayList<>();
 
     private float boost = 1.0f;
 
@@ -80,7 +80,7 @@ public class IdsQueryBuilder extends BaseQueryBuilder implements QueryParser, Bo
         return addIds(ids);
     }
 
-    Collection<String> getIds() {
+    Collection<String> ids() {
         return this.values;
     }
 
@@ -94,7 +94,7 @@ public class IdsQueryBuilder extends BaseQueryBuilder implements QueryParser, Bo
         return this;
     }
 
-    public float getBoost() {
+    public float boost() {
         return this.boost;
     }
 
@@ -138,7 +138,7 @@ public class IdsQueryBuilder extends BaseQueryBuilder implements QueryParser, Bo
     public String[] names() {
         return new String[]{NAME};
     }
-    
+
     @Override
     public Query parse(QueryParseContext parseContext) throws IOException, QueryParsingException {
         IdsQueryBuilder query = new IdsQueryBuilder();
@@ -202,12 +202,12 @@ public class IdsQueryBuilder extends BaseQueryBuilder implements QueryParser, Bo
 
     public Query toQuery(QueryParseContext parseContext) throws IOException, QueryParsingException {
         ArrayList<BytesRef> ids = new ArrayList<BytesRef>();
-        
+
         for (String value : this.values) {
             BytesRef ref = new BytesRef(value);
             ids.add(ref);
         }
-        
+
         if (ids.isEmpty()) {
             return Queries.newMatchNoDocsQuery();
         }
@@ -258,8 +258,7 @@ public class IdsQueryBuilder extends BaseQueryBuilder implements QueryParser, Bo
 
     @Override
     public int hashCode() {
-        int hash = super.hashCode();
-        hash = maybeHashcode(hash, values);
+        int hash = maybeHashcode(1, values);
         hash = maybeHashcode(hash, types);
         hash = maybeHashcode(hash, queryName);
         hash = maybeHashcode(hash, boost);

--- a/src/main/java/org/elasticsearch/index/query/MatchAllQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/MatchAllQueryBuilder.java
@@ -31,11 +31,10 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
+import java.util.Objects;
 
 /**
  * A query that matches on all documents.
- *
- *
  */
 public class MatchAllQueryBuilder extends BaseQueryBuilder implements QueryParser, BoostableQueryBuilder<MatchAllQueryBuilder>, Streamable {
 
@@ -125,5 +124,32 @@ public class MatchAllQueryBuilder extends BaseQueryBuilder implements QueryParse
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeFloat(this.boost);
+    }
+    
+    @Override
+    public int hashCode() {
+        int hash = super.hashCode();
+        hash = maybeHashcode(hash, boost);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+
+        MatchAllQueryBuilder other = (MatchAllQueryBuilder) obj;
+        return Objects.equals(boost, other.boost);
+    }
+    
+    /**
+     * Return a prime (31) times the staring hash and object's hash, if non-null
+     */
+    private int maybeHashcode(int startingHash, Object obj) {
+        return 31 * startingHash + ((obj == null) ? 0 : obj.hashCode());
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/MatchAllQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/MatchAllQueryBuilder.java
@@ -59,7 +59,7 @@ public class MatchAllQueryBuilder extends BaseQueryBuilder implements QueryParse
     /**
      * @return the boost for this query.
      */
-    public float getBoost() {
+    public float boost() {
         return this.boost;
     }
 
@@ -89,8 +89,6 @@ public class MatchAllQueryBuilder extends BaseQueryBuilder implements QueryParse
             return Queries.newMatchAllQuery();
         }
 
-        //LUCENE 4 UPGRADE norms field is not supported anymore need to find another way or drop the functionality
-        //MatchAllDocsQuery query = new MatchAllDocsQuery(normsField);
         MatchAllDocsQuery query = new MatchAllDocsQuery();
         query.setBoost(boost);
         return query;
@@ -108,7 +106,7 @@ public class MatchAllQueryBuilder extends BaseQueryBuilder implements QueryParse
                 currentFieldName = parser.currentName();
             } else if (token.isValue()) {
                 if ("boost".equals(currentFieldName)) {
-                    boost = parser.floatValue();
+                    this.boost = parser.floatValue();
                 } else {
                     throw new QueryParsingException(parseContext.index(), "[match_all] query does not support [" + currentFieldName + "]");
                 }
@@ -125,12 +123,10 @@ public class MatchAllQueryBuilder extends BaseQueryBuilder implements QueryParse
     public void writeTo(StreamOutput out) throws IOException {
         out.writeFloat(this.boost);
     }
-    
+
     @Override
     public int hashCode() {
-        int hash = super.hashCode();
-        hash = maybeHashcode(hash, boost);
-        return hash;
+        return Float.hashCode(boost);
     }
 
     @Override
@@ -145,11 +141,5 @@ public class MatchAllQueryBuilder extends BaseQueryBuilder implements QueryParse
         MatchAllQueryBuilder other = (MatchAllQueryBuilder) obj;
         return Objects.equals(boost, other.boost);
     }
-    
-    /**
-     * Return a prime (31) times the staring hash and object's hash, if non-null
-     */
-    private int maybeHashcode(int startingHash, Object obj) {
-        return 31 * startingHash + ((obj == null) ? 0 : obj.hashCode());
-    }
+
 }

--- a/src/main/java/org/elasticsearch/index/query/TermQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/TermQueryBuilder.java
@@ -222,9 +222,9 @@ public class TermQueryBuilder extends BaseQueryBuilder implements QueryParser, S
                     currentFieldName = parser.currentName();
                 } else {
                     if ("term".equals(currentFieldName)) {
-                        value = parser.objectBytes();
+                        value = parser.objectText();
                     } else if ("value".equals(currentFieldName)) {
-                        value = parser.objectBytes();
+                        value = parser.objectText();
                     } else if ("boost".equals(currentFieldName)) {
                         boost = parser.floatValue();
                     } else if ("_name".equals(currentFieldName)) {
@@ -236,7 +236,7 @@ public class TermQueryBuilder extends BaseQueryBuilder implements QueryParser, S
             }
             parser.nextToken();
         } else {
-            value = parser.text();
+            value = parser.objectText();
             // move to the next token
             parser.nextToken();
         }
@@ -275,7 +275,7 @@ public class TermQueryBuilder extends BaseQueryBuilder implements QueryParser, S
         out.writeFloat(boost);
         out.writeOptionalString(queryName);
     }
-    
+
     @Override
     public int hashCode() {
         int hash = super.hashCode();
@@ -301,7 +301,7 @@ public class TermQueryBuilder extends BaseQueryBuilder implements QueryParser, S
                Objects.equals(boost, other.boost)&&
                Objects.equals(queryName, other.queryName);
     }
-    
+
     /**
      * Return a prime (31) times the staring hash and object's hash, if non-null
      */

--- a/src/main/java/org/elasticsearch/index/query/TermQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/TermQueryBuilder.java
@@ -129,14 +129,14 @@ public class TermQueryBuilder extends BaseQueryBuilder implements QueryParser, S
     /**
      * @return the fieldname for this query
      */
-    public String getFieldName() {
+    public String fieldName() {
         return this.fieldName;
     }
 
     /**
      * @return the value
      */
-    public Object getValue() {
+    public Object value() {
         return this.value;
     }
 
@@ -153,7 +153,7 @@ public class TermQueryBuilder extends BaseQueryBuilder implements QueryParser, S
     /**
      * @return the boost factor of this query
      */
-    public float getBoost() {
+    public float boost() {
         return this.boost;
     }
 
@@ -168,7 +168,7 @@ public class TermQueryBuilder extends BaseQueryBuilder implements QueryParser, S
     /**
      * @return the query name of this query
      */
-    public String getQueryName() {
+    public String queryName() {
         return this.queryName;
     }
 
@@ -278,8 +278,7 @@ public class TermQueryBuilder extends BaseQueryBuilder implements QueryParser, S
 
     @Override
     public int hashCode() {
-        int hash = super.hashCode();
-        hash = maybeHashcode(hash, fieldName);
+        int hash = maybeHashcode(1, fieldName);
         hash = maybeHashcode(hash, value);
         hash = maybeHashcode(hash, boost);
         hash = maybeHashcode(hash, queryName);

--- a/src/main/java/org/elasticsearch/index/query/TermQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/TermQueryBuilder.java
@@ -32,6 +32,7 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.mapper.MapperService;
 
 import java.io.IOException;
+import java.util.Objects;
 
 /**
  * A Query that matches documents containing a term.
@@ -273,5 +274,38 @@ public class TermQueryBuilder extends BaseQueryBuilder implements QueryParser, S
         out.writeGenericValue(value);
         out.writeFloat(boost);
         out.writeOptionalString(queryName);
+    }
+    
+    @Override
+    public int hashCode() {
+        int hash = super.hashCode();
+        hash = maybeHashcode(hash, fieldName);
+        hash = maybeHashcode(hash, value);
+        hash = maybeHashcode(hash, boost);
+        hash = maybeHashcode(hash, queryName);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+
+        TermQueryBuilder other = (TermQueryBuilder) obj;
+        return Objects.equals(fieldName, other.fieldName) &&
+               Objects.equals(value, other.value) &&
+               Objects.equals(boost, other.boost)&&
+               Objects.equals(queryName, other.queryName);
+    }
+    
+    /**
+     * Return a prime (31) times the staring hash and object's hash, if non-null
+     */
+    private int maybeHashcode(int startingHash, Object obj) {
+        return 31 * startingHash + ((obj == null) ? 0 : obj.hashCode());
     }
 }

--- a/src/test/java/org/elasticsearch/index/query/MatchAllQueryBuilderTest.java
+++ b/src/test/java/org/elasticsearch/index/query/MatchAllQueryBuilderTest.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query;
+
+import org.apache.lucene.search.Query;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.common.inject.AbstractModule;
+import org.elasticsearch.common.inject.Injector;
+import org.elasticsearch.common.inject.ModulesBuilder;
+import org.elasticsearch.common.inject.util.Providers;
+import org.elasticsearch.common.io.stream.BytesStreamInput;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.settings.SettingsModule;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.env.EnvironmentModule;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexNameModule;
+import org.elasticsearch.index.analysis.AnalysisModule;
+import org.elasticsearch.index.cache.IndexCacheModule;
+import org.elasticsearch.index.query.functionscore.FunctionScoreModule;
+import org.elasticsearch.index.settings.IndexSettingsModule;
+import org.elasticsearch.index.similarity.SimilarityModule;
+import org.elasticsearch.indices.breaker.CircuitBreakerService;
+import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
+import org.elasticsearch.indices.query.IndicesQueriesModule;
+import org.elasticsearch.script.ScriptModule;
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.threadpool.ThreadPoolModule;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+
+import static org.hamcrest.Matchers.*;
+
+public class MatchAllQueryBuilderTest extends ElasticsearchTestCase {
+
+    private static final String MATCH_ALL_BOOST_1_5 = "{\"match_all\":{\"boost\":1.5}}";
+    private QueryParseContext context;
+    private Injector injector;
+    private MatchAllQueryBuilder testQuery;
+    private XContentParser parser;
+
+    @Before
+    public void setup() throws IOException {
+        Settings settings = ImmutableSettings.settingsBuilder()
+                .put("path.conf", this.getResourcePath("config"))
+                .put("name", getClass().getName())
+                .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
+                .build();
+
+        Index index = new Index("test");
+        injector = new ModulesBuilder().add(
+                new EnvironmentModule(new Environment(settings)),
+                new SettingsModule(settings),
+                new ThreadPoolModule(settings),
+                new IndicesQueriesModule(),
+                new ScriptModule(settings),
+                new IndexSettingsModule(index, settings),
+                new IndexCacheModule(settings),
+                new AnalysisModule(settings),
+                new SimilarityModule(settings),
+                new IndexNameModule(index),
+                new IndexQueryParserModule(settings),
+                new FunctionScoreModule(),
+                new AbstractModule() {
+                    @Override
+                    protected void configure() {
+                        bind(ClusterService.class).toProvider(Providers.of((ClusterService) null));
+                        bind(CircuitBreakerService.class).to(NoneCircuitBreakerService.class);
+                    }
+                }
+        ).createInjector();
+
+        IndexQueryParserService queryParserService = injector.getInstance(IndexQueryParserService.class);
+        context = new QueryParseContext(index, queryParserService);
+        testQuery = createTestQuery();
+        String contentString = createXContent(testQuery).string();
+        parser = XContentFactory.xContent(contentString).createParser(contentString);
+    }
+
+    @Override
+    @After
+    public void tearDown() throws Exception {
+        super.tearDown();
+        terminate(injector.getInstance(ThreadPool.class));
+    }
+
+    @Test
+    public void testToXContent() throws IOException {
+        XContentBuilder content = createXContent(new MatchAllQueryBuilder().boost(1.5f));
+        assertEquals(content.string(), MATCH_ALL_BOOST_1_5);
+    }
+
+    @Test
+    public void testFromXContent() throws IOException {
+        context.reset(parser);
+        MatchAllQueryBuilder newMatchAllQuery = injector.getInstance(MatchAllQueryBuilder.class);
+        newMatchAllQuery.fromXContent(context);
+        // compare these
+        assertThat(testQuery.getBoost(), is(newMatchAllQuery.getBoost()));
+    }
+
+    @Test
+    public void testToQuery() throws IOException {
+        context.reset(parser);
+        MatchAllQueryBuilder newMatchAllQuery = injector.getInstance(MatchAllQueryBuilder.class);
+        newMatchAllQuery.fromXContent(context);
+        Query query = newMatchAllQuery.toQuery(context);
+        // compare these
+        assertThat(query.getBoost(), is(testQuery.getBoost()));
+    }
+
+    @Test
+    public void testSerialization() throws IOException {
+        context.reset(parser);
+
+        BytesStreamOutput output = new BytesStreamOutput();
+        testQuery.writeTo(output);
+
+        BytesStreamInput bytesStreamInput = new BytesStreamInput(output.bytes());
+        MatchAllQueryBuilder deserializedQuery = new MatchAllQueryBuilder();
+        deserializedQuery.readFrom(bytesStreamInput);
+
+        assertThat(deserializedQuery.getBoost(), equalTo(testQuery.getBoost()));
+        assertThat(createXContent(testQuery).string(), is(createXContent(deserializedQuery).string()));
+    }
+
+    private MatchAllQueryBuilder createTestQuery() {
+        MatchAllQueryBuilder query = new MatchAllQueryBuilder();
+        if (randomBoolean()) {
+            query.boost(2.0f / randomIntBetween(1, 20));
+        }
+        return query;
+    }
+
+    private XContentBuilder createXContent(BaseQueryBuilder query) throws IOException {
+        XContentBuilder content = XContentFactory.jsonBuilder();
+        content.startObject();
+        query.doXContent(content, null);
+        content.endObject();
+        content.close();
+        return content;
+    }
+}

--- a/src/test/java/org/elasticsearch/index/query/TermQueryBuilderTest.java
+++ b/src/test/java/org/elasticsearch/index/query/TermQueryBuilderTest.java
@@ -58,15 +58,17 @@ import org.junit.Test;
 import java.io.IOException;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.is;
 
 public class TermQueryBuilderTest extends ElasticsearchTestCase {
 
-    private QueryParseContext context;
-    private Injector injector;
     private TermQueryBuilder testQuery;
+
     private XContentParser parser;
+
+    protected QueryParseContext context;
+
+    protected Injector injector;
 
     @Before
     public void setup() throws IOException {
@@ -113,6 +115,12 @@ public class TermQueryBuilderTest extends ElasticsearchTestCase {
         terminate(injector.getInstance(ThreadPool.class));
     }
 
+    XContentBuilder createXContent(BaseQueryBuilder query) throws IOException {
+        XContentBuilder content = XContentFactory.jsonBuilder();
+        query.toXContent(content, null);
+        return content;
+    }
+
     @Test
     public void testToXContent() throws IOException {
         XContentBuilder content = createXContent(new TermQueryBuilder("user", "christoph").boost(1.5f).queryName("theName"));
@@ -124,6 +132,7 @@ public class TermQueryBuilderTest extends ElasticsearchTestCase {
         context.reset(parser);
         assertThat(parser.nextToken(), is(XContentParser.Token.START_OBJECT));
         assertThat(parser.nextToken(), is(XContentParser.Token.FIELD_NAME));
+        assertThat(parser.currentName(), is(TermQueryBuilder.NAME));
         assertThat(parser.nextToken(), is(XContentParser.Token.START_OBJECT));
         TermQueryBuilder newQuery = injector.getInstance(TermQueryBuilder.class);
         newQuery.fromXContent(context);
@@ -136,6 +145,7 @@ public class TermQueryBuilderTest extends ElasticsearchTestCase {
         context.reset(parser);
         assertThat(parser.nextToken(), is(XContentParser.Token.START_OBJECT));
         assertThat(parser.nextToken(), is(XContentParser.Token.FIELD_NAME));
+        assertThat(parser.currentName(), is(TermQueryBuilder.NAME));
         assertThat(parser.nextToken(), is(XContentParser.Token.START_OBJECT));
         TermQueryBuilder newQuery = injector.getInstance(TermQueryBuilder.class);
         newQuery.fromXContent(context);
@@ -166,14 +176,5 @@ public class TermQueryBuilderTest extends ElasticsearchTestCase {
             query.queryName(randomAsciiOfLength(8));
         }
         return query;
-    }
-
-    private XContentBuilder createXContent(BaseQueryBuilder query) throws IOException {
-        XContentBuilder content = XContentFactory.jsonBuilder();
-        content.startObject();
-        query.doXContent(content, null);
-        content.endObject();
-        content.close();
-        return content;
     }
 }

--- a/src/test/java/org/elasticsearch/index/query/TermQueryBuilderTest.java
+++ b/src/test/java/org/elasticsearch/index/query/TermQueryBuilderTest.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query;
+
+import org.apache.lucene.search.Query;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.common.inject.AbstractModule;
+import org.elasticsearch.common.inject.Injector;
+import org.elasticsearch.common.inject.ModulesBuilder;
+import org.elasticsearch.common.inject.util.Providers;
+import org.elasticsearch.common.io.stream.BytesStreamInput;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.settings.SettingsModule;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.env.EnvironmentModule;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexNameModule;
+import org.elasticsearch.index.analysis.AnalysisModule;
+import org.elasticsearch.index.cache.IndexCacheModule;
+import org.elasticsearch.index.query.functionscore.FunctionScoreModule;
+import org.elasticsearch.index.settings.IndexSettingsModule;
+import org.elasticsearch.index.similarity.SimilarityModule;
+import org.elasticsearch.indices.breaker.CircuitBreakerService;
+import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
+import org.elasticsearch.indices.query.IndicesQueriesModule;
+import org.elasticsearch.script.ScriptModule;
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.threadpool.ThreadPoolModule;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+
+import static org.hamcrest.Matchers.*;
+
+public class TermQueryBuilderTest extends ElasticsearchTestCase {
+
+    private QueryParseContext context;
+    private Injector injector;
+    private TermQueryBuilder testQuery;
+    private XContentParser parser;
+
+    @Before
+    public void setup() throws IOException {
+        Settings settings = ImmutableSettings.settingsBuilder()
+                .put("path.conf", this.getResourcePath("config"))
+                .put("name", getClass().getName())
+                .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
+                .build();
+
+        Index index = new Index("test");
+        injector = new ModulesBuilder().add(
+                new EnvironmentModule(new Environment(settings)),
+                new SettingsModule(settings),
+                new ThreadPoolModule(settings),
+                new IndicesQueriesModule(),
+                new ScriptModule(settings),
+                new IndexSettingsModule(index, settings),
+                new IndexCacheModule(settings),
+                new AnalysisModule(settings),
+                new SimilarityModule(settings),
+                new IndexNameModule(index),
+                new IndexQueryParserModule(settings),
+                new FunctionScoreModule(),
+                new AbstractModule() {
+                    @Override
+                    protected void configure() {
+                        bind(ClusterService.class).toProvider(Providers.of((ClusterService) null));
+                        bind(CircuitBreakerService.class).to(NoneCircuitBreakerService.class);
+                    }
+                }
+        ).createInjector();
+
+        IndexQueryParserService queryParserService = injector.getInstance(IndexQueryParserService.class);
+        context = new QueryParseContext(index, queryParserService);
+        testQuery = createTestQuery();
+        String contentString = createXContent(testQuery).string();
+        parser = XContentFactory.xContent(contentString).createParser(contentString);
+    }
+
+    @Override
+    @After
+    public void tearDown() throws Exception {
+        super.tearDown();
+        terminate(injector.getInstance(ThreadPool.class));
+    }
+
+    @Test
+    public void testToXContent() throws IOException {
+        XContentBuilder content = createXContent(new TermQueryBuilder("user", "christoph").boost(1.5f).queryName("theName"));
+        assertThat(content.string(), is("{\"term\":{\"user\":{\"value\":\"christoph\",\"boost\":1.5,\"_name\":\"theName\"}}}"));
+    }
+
+    @Test
+    public void testFromXContent() throws IOException {
+        context.reset(parser);
+        assertThat(parser.nextToken(), is(XContentParser.Token.START_OBJECT));
+        assertThat(parser.nextToken(), is(XContentParser.Token.FIELD_NAME));
+        assertThat(parser.nextToken(), is(XContentParser.Token.START_OBJECT));
+        TermQueryBuilder newQuery = injector.getInstance(TermQueryBuilder.class);
+        newQuery.fromXContent(context);
+        // compare these
+        assertThat(testQuery.getBoost(), is(newQuery.getBoost()));
+    }
+
+    @Test
+    public void testToQuery() throws IOException {
+        context.reset(parser);
+        assertThat(parser.nextToken(), is(XContentParser.Token.START_OBJECT));
+        assertThat(parser.nextToken(), is(XContentParser.Token.FIELD_NAME));
+        assertThat(parser.nextToken(), is(XContentParser.Token.START_OBJECT));
+        TermQueryBuilder newQuery = injector.getInstance(TermQueryBuilder.class);
+        newQuery.fromXContent(context);
+        Query query = newQuery.toQuery(context);
+        // compare these
+        assertThat(query.getBoost(), is(testQuery.getBoost()));
+    }
+
+    @Test
+    public void testSerialization() throws IOException {
+        BytesStreamOutput output = new BytesStreamOutput();
+        testQuery.writeTo(output);
+
+        BytesStreamInput bytesStreamInput = new BytesStreamInput(output.bytes());
+        TermQueryBuilder deserializedQuery = new TermQueryBuilder();
+        deserializedQuery.readFrom(bytesStreamInput);
+
+        assertThat(deserializedQuery.getBoost(), equalTo(testQuery.getBoost()));
+        assertThat(createXContent(testQuery).string(), is(createXContent(deserializedQuery).string()));
+    }
+
+    private TermQueryBuilder createTestQuery() {
+        TermQueryBuilder query = new TermQueryBuilder(randomAsciiOfLength(8), randomAsciiOfLength(8));
+        if (randomBoolean()) {
+            query.boost(2.0f / randomIntBetween(1, 20));
+        }
+        if (randomBoolean()) {
+            query.queryName(randomAsciiOfLength(8));
+        }
+        return query;
+    }
+
+    private XContentBuilder createXContent(BaseQueryBuilder query) throws IOException {
+        XContentBuilder content = XContentFactory.jsonBuilder();
+        content.startObject();
+        query.doXContent(content, null);
+        content.endObject();
+        content.close();
+        return content;
+    }
+}

--- a/src/test/java/org/elasticsearch/stresstest/fullrestart/FullRestartStressTest.java
+++ b/src/test/java/org/elasticsearch/stresstest/fullrestart/FullRestartStressTest.java
@@ -147,7 +147,7 @@ public class FullRestartStressTest {
             // verify search
             for (int i = 0; i < (nodes.length * 5); i++) {
                 // do a search with norms field, so we don't rely on match all filtering cache
-                SearchResponse search = client.client().prepareSearch().setQuery(matchAllQuery().normsField("field")).execute().actionGet();
+                SearchResponse search = client.client().prepareSearch().setQuery(matchAllQuery()).execute().actionGet();
                 logger.debug("index_count [{}], expected_count [{}]", search.getHits().totalHits(), indexCounter.get());
                 if (count.getCount() != indexCounter.get()) {
                     logger.warn("!!! search does not match, index_count [{}], expected_count [{}]", search.getHits().totalHits(), indexCounter.get());


### PR DESCRIPTION
MatchAllQueryBuilder, TermQueryBuilder, IdsQueryBuilder now include the fromXContent, doXContent and toQuery methods suggested in #9901. Also implementing the Streamable interface and adding unit tests for the serialization and parsing.

NOTE: this PR is against the feature/query-parse-refactoring branch.
