### PR TITLE
add list parse methods to XContentParser

### DIFF
--- a/src/main/java/org/elasticsearch/common/xcontent/XContentParser.java
+++ b/src/main/java/org/elasticsearch/common/xcontent/XContentParser.java
@@ -23,6 +23,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.lease.Releasable;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -133,6 +134,14 @@ public interface XContentParser extends Releasable {
     Map<String, Object> mapAndClose() throws IOException;
 
     Map<String, Object> mapOrderedAndClose() throws IOException;
+
+    List<Object> list() throws IOException;
+
+    List<Object> listOrderedMap() throws IOException;
+
+    List<Object> listAndClose() throws IOException;
+
+    List<Object> listOrderedMapAndClose() throws IOException;
 
     String text() throws IOException;
 

--- a/src/main/java/org/elasticsearch/common/xcontent/support/AbstractXContentParser.java
+++ b/src/main/java/org/elasticsearch/common/xcontent/support/AbstractXContentParser.java
@@ -231,7 +231,33 @@ public abstract class AbstractXContentParser implements XContentParser {
         }
     }
 
+    @Override
+    public List<Object> list() throws IOException {
+        return readList(this);
+    }
 
+    @Override
+    public List<Object> listOrderedMap() throws IOException {
+        return readListOrderedMap(this);
+    }
+
+    @Override
+    public List<Object> listAndClose() throws IOException {
+        try {
+            return list();
+        } finally {
+            close();
+        }
+    }
+
+    @Override
+    public List<Object> listOrderedMapAndClose() throws IOException {
+        try {
+            return listOrderedMap();
+        } finally {
+            close();
+        }
+    }
     static interface MapFactory {
         Map<String, Object> newMap();
     }
@@ -258,6 +284,14 @@ public abstract class AbstractXContentParser implements XContentParser {
         return readMap(parser, ORDERED_MAP_FACTORY);
     }
 
+    static List<Object> readList(XContentParser parser) throws IOException {
+        return readList(parser, SIMPLE_MAP_FACTORY);
+    }
+
+    static List<Object> readListOrderedMap(XContentParser parser) throws IOException {
+        return readList(parser, ORDERED_MAP_FACTORY);
+    }
+
     static Map<String, Object> readMap(XContentParser parser, MapFactory mapFactory) throws IOException {
         Map<String, Object> map = mapFactory.newMap();
         XContentParser.Token token = parser.currentToken();
@@ -278,15 +312,16 @@ public abstract class AbstractXContentParser implements XContentParser {
         return map;
     }
 
-    private static List<Object> readList(XContentParser parser, MapFactory mapFactory, XContentParser.Token token) throws IOException {
+    static List<Object> readList(XContentParser parser, MapFactory mapFactory) throws IOException {
         ArrayList<Object> list = new ArrayList<>();
+        XContentParser.Token token;
         while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
             list.add(readValue(parser, mapFactory, token));
         }
         return list;
     }
 
-    private static Object readValue(XContentParser parser, MapFactory mapFactory, XContentParser.Token token) throws IOException {
+    static Object readValue(XContentParser parser, MapFactory mapFactory, XContentParser.Token token) throws IOException {
         if (token == XContentParser.Token.VALUE_NULL) {
             return null;
         } else if (token == XContentParser.Token.VALUE_STRING) {
@@ -307,7 +342,7 @@ public abstract class AbstractXContentParser implements XContentParser {
         } else if (token == XContentParser.Token.START_OBJECT) {
             return readMap(parser, mapFactory);
         } else if (token == XContentParser.Token.START_ARRAY) {
-            return readList(parser, mapFactory, token);
+            return readList(parser, mapFactory);
         } else if (token == XContentParser.Token.VALUE_EMBEDDED_OBJECT) {
             return parser.binaryValue();
         }


### PR DESCRIPTION
In XContentParser, maps can be parsed, but no lists. List parsing can be useful when non-ES JSON must be parsed, e.g. from external data input. This pull request adds some API methods to parse lists, in analogy to the methods for map parsing. Two private access modifiers are removed from readList() and readValue() in order to allow cleaner subclassing of AbstractXContentParser.
