### PR TITLE
Internal: Explicitely opt-out for the Lucene query cache.

### DIFF
--- a/src/main/java/org/elasticsearch/index/engine/EngineSearcherFactory.java
+++ b/src/main/java/org/elasticsearch/index/engine/EngineSearcherFactory.java
@@ -41,6 +41,9 @@ public class EngineSearcherFactory extends SearcherFactory {
     @Override
     public IndexSearcher newSearcher(IndexReader reader) throws IOException {
         IndexSearcher searcher = new IndexSearcher(reader);
+        // Explicitely opt-out for the query cache since it would not play
+        // well with NoCacheFilter
+        searcher.setQueryCache(null);
         searcher.setSimilarity(engineConfig.getSimilarity());
         return searcher;
     }

--- a/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -1014,8 +1014,7 @@ public class InternalEngine extends Engine {
 
         @Override
         public IndexSearcher newSearcher(IndexReader reader) throws IOException {
-            IndexSearcher searcher = new IndexSearcher(reader);
-            searcher.setSimilarity(engineConfig.getSimilarity());
+            IndexSearcher searcher = super.newSearcher(reader);
             if (warmer != null) {
                 // we need to pass a custom searcher that does not release anything on Engine.Search Release,
                 // we will release explicitly


### PR DESCRIPTION
Even though the default query cache is not on by default, it might change in
the future so we should opt out as it would not play well with NoCacheFilter
(which we should aim at removing).
