### PR TITLE
Updated slow query log to add alias information

### DIFF
--- a/src/main/java/org/elasticsearch/index/search/slowlog/ShardSlowLogSearchService.java
+++ b/src/main/java/org/elasticsearch/index/search/slowlog/ShardSlowLogSearchService.java
@@ -200,6 +200,9 @@ public class ShardSlowLogSearchService extends AbstractIndexShardComponent {
                 sb.append("], ");
             }
             sb.append("search_type[").append(context.searchType()).append("], total_shards[").append(context.numberOfShards()).append("], ");
+            if ( context.aliasFilter() != null ){
+                sb.append("alias_filters[").append(context.aliasFilter().toString()).append("], ");
+            }
             if (context.request().source() != null && context.request().source().length() > 0) {
                 try {
                     sb.append("source[").append(XContentHelper.convertToJson(context.request().source(), reformat)).append("], ");


### PR DESCRIPTION
prints Filter or XBooleanFilter ( if query uses more than one alias ) in
slow query logs

https://github.com/elastic/elasticsearch/issues/10044
