### PR TITLE
Remove deprecated methods from ScriptService

### DIFF
--- a/docs/reference/migration/migrate_2_0.asciidoc
+++ b/docs/reference/migration/migrate_2_0.asciidoc
@@ -344,6 +344,12 @@ Deprecated script parameters `id`, `file`, and `scriptField` have been removed
 from all scriptable APIs. `script_id`, `script_file` and `script` should be used
 in their place.
 
+=== Plugins making use of scripts
+
+Plugins that make use of scripts must register their own script context through
+`ScriptModule`. Script contexts can be used as part of fine-grained settings to
+enable/disable scripts selectively.
+
 === Thrift and memcached transport
 
 The thrift and memcached transport plugins are no longer supported.  Instead, use

--- a/src/main/java/org/elasticsearch/script/ScriptContext.java
+++ b/src/main/java/org/elasticsearch/script/ScriptContext.java
@@ -38,14 +38,7 @@ public interface ScriptContext {
      */
     enum Standard implements ScriptContext {
 
-        AGGS("aggs"), MAPPING("mapping"), SEARCH("search"), UPDATE("update"),
-        /**
-         * Generic custom operation exposed via plugin
-         *
-         * @deprecated create a new {@link org.elasticsearch.script.ScriptContext.Plugin} instance instead
-         */
-        @Deprecated
-        GENERIC_PLUGIN("plugin");
+        AGGS("aggs"), MAPPING("mapping"), SEARCH("search"), UPDATE("update");
 
         private final String key;
 

--- a/src/main/java/org/elasticsearch/script/ScriptService.java
+++ b/src/main/java/org/elasticsearch/script/ScriptService.java
@@ -216,18 +216,6 @@ public class ScriptService extends AbstractComponent implements Closeable {
 
     /**
      * Checks if a script can be executed and compiles it if needed, or returns the previously compiled and cached script.
-     * Doesn't require to specify a script context in order to maintain backwards compatibility, internally uses
-     * the {@link org.elasticsearch.script.ScriptContext.Standard#GENERIC_PLUGIN} default context, assuming that it can only be called from plugins.
-     *
-     * @deprecated use the method variant that accepts the {@link ScriptContext} argument too: {@link #compile(String, String, ScriptType, ScriptContext)}
-     */
-    @Deprecated
-    public CompiledScript compile(String lang,  String script, ScriptType scriptType) {
-        return compile(lang, script, scriptType, ScriptContext.Standard.GENERIC_PLUGIN);
-    }
-
-    /**
-     * Checks if a script can be executed and compiles it if needed, or returns the previously compiled and cached script.
      */
     public CompiledScript compile(String lang,  String script, ScriptType scriptType, ScriptContext scriptContext) {
         assert script != null;
@@ -395,18 +383,6 @@ public class ScriptService extends AbstractComponent implements Closeable {
     }
 
     /**
-     * Compiles (or retrieves from cache) and executes the provided script.
-     * Doesn't require to specify a script context in order to maintain backwards compatibility, internally uses
-     * the {@link org.elasticsearch.script.ScriptContext.Standard#GENERIC_PLUGIN} default context, assuming that it can only be called from plugins.
-     *
-     * @deprecated use the method variant that accepts the {@link ScriptContext} argument too: {@link #executable(String, String, ScriptType, ScriptContext, Map)}
-     */
-    @Deprecated
-    public ExecutableScript executable(String lang, String script, ScriptType scriptType, Map<String, Object> vars) {
-        return executable(lang, script, scriptType, ScriptContext.Standard.GENERIC_PLUGIN, vars);
-    }
-
-    /**
      * Compiles (or retrieves from cache) and executes the provided script
      */
     public ExecutableScript executable(String lang, String script, ScriptType scriptType, ScriptContext scriptContext, Map<String, Object> vars) {
@@ -418,18 +394,6 @@ public class ScriptService extends AbstractComponent implements Closeable {
      */
     public ExecutableScript executable(CompiledScript compiledScript, Map<String, Object> vars) {
         return getScriptEngineServiceForLang(compiledScript.lang()).executable(compiledScript.compiled(), vars);
-    }
-
-    /**
-     * Compiles (or retrieves from cache) and executes the provided search script
-     * Doesn't require to specify a script context in order to maintain backwards compatibility, internally uses
-     * the {@link org.elasticsearch.script.ScriptContext.Standard#GENERIC_PLUGIN} default context, assuming that it can only be called from plugins.
-     *
-     * @deprecated use the method variant that accepts the {@link ScriptContext} argument too: {@link #search(SearchLookup, String, String, ScriptType, ScriptContext, Map)}
-     */
-    @Deprecated
-    public SearchScript search(SearchLookup lookup, String lang, String script, ScriptType scriptType, @Nullable Map<String, Object> vars) {
-        return search(lookup, lang, script, scriptType, ScriptContext.Standard.GENERIC_PLUGIN, vars);
     }
 
     /**


### PR DESCRIPTION
Removed the following methods from `ScriptService`, which don't require the `ScriptContext` argument:

```
public CompiledScript compile(String lang,  String script, ScriptType scriptType)

public ExecutableScript executable(String lang, String script, ScriptType scriptType, Map<String, Object> vars)

public SearchScript search(SearchLookup lookup, String lang, String script, ScriptType scriptType, @Nullable Map<String, Object> vars)
```

Also removed the `ScriptContext.Standard.GENERIC_PLUGIN` enum value, as it was used only for backwards compatibility.

 Plugins that make use of scripts should declare their own script contexts through `ScriptModule#registerScriptContext` and use them when compiling/executing scripts.
