### PR TITLE
Scripting: move ScriptType outside of ScriptService, to its own class file

### DIFF
--- a/src/main/java/org/elasticsearch/action/search/SearchRequest.java
+++ b/src/main/java/org/elasticsearch/action/search/SearchRequest.java
@@ -35,7 +35,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
-import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.Scroll;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 
@@ -71,7 +71,7 @@ public class SearchRequest extends ActionRequest<SearchRequest> implements Indic
 
     private BytesReference templateSource;
     private String templateName;
-    private ScriptService.ScriptType templateType;
+    private ScriptType templateType;
     private Map<String, Object> templateParams = Collections.emptyMap();
 
     private BytesReference source;
@@ -397,7 +397,7 @@ public class SearchRequest extends ActionRequest<SearchRequest> implements Indic
         this.templateName = templateName;
     }
 
-    public void templateType(ScriptService.ScriptType templateType) {
+    public void templateType(ScriptType templateType) {
         this.templateType = templateType;
     }
 
@@ -418,7 +418,7 @@ public class SearchRequest extends ActionRequest<SearchRequest> implements Indic
     /**
      * The name of the stored template
      */
-    public ScriptService.ScriptType templateType() {
+    public ScriptType templateType() {
         return templateType;
     }
 
@@ -519,7 +519,7 @@ public class SearchRequest extends ActionRequest<SearchRequest> implements Indic
 
         templateSource = in.readBytesReference();
         templateName = in.readOptionalString();
-        templateType = ScriptService.ScriptType.readFrom(in);
+        templateType = ScriptType.readFrom(in);
         if (in.readBoolean()) {
             templateParams = (Map<String, Object>) in.readGenericValue();
         }
@@ -552,7 +552,7 @@ public class SearchRequest extends ActionRequest<SearchRequest> implements Indic
 
         out.writeBytesReference(templateSource);
         out.writeOptionalString(templateName);
-        ScriptService.ScriptType.writeTo(templateType, out);
+        ScriptType.writeTo(templateType, out);
         boolean existTemplateParams = templateParams != null;
         out.writeBoolean(existTemplateParams);
         if (existTemplateParams) {

--- a/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
@@ -30,7 +30,7 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.query.FilterBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.Scroll;
 import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
@@ -940,7 +940,7 @@ public class SearchRequestBuilder extends ActionRequestBuilder<SearchRequest, Se
         return this;
     }
 
-    public SearchRequestBuilder setTemplateType(ScriptService.ScriptType templateType) {
+    public SearchRequestBuilder setTemplateType(ScriptType templateType) {
         request.templateType(templateType);
         return this;
     }

--- a/src/main/java/org/elasticsearch/action/update/UpdateRequest.java
+++ b/src/main/java/org/elasticsearch/action/update/UpdateRequest.java
@@ -39,7 +39,7 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.script.ScriptParameterParser;
 import org.elasticsearch.script.ScriptParameterParser.ScriptParameterValue;
-import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.script.ScriptType;
 
 import java.io.IOException;
 import java.util.Map;
@@ -61,7 +61,7 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest> 
     @Nullable
     String script;
     @Nullable
-    ScriptService.ScriptType scriptType;
+    ScriptType scriptType;
     @Nullable
     String scriptLang;
     @Nullable
@@ -209,7 +209,7 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest> 
         return this.script;
     }
 
-    public ScriptService.ScriptType scriptType() { return this.scriptType; }
+    public ScriptType scriptType() { return this.scriptType; }
 
     public Map<String, Object> scriptParams() {
         return this.scriptParams;
@@ -219,7 +219,7 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest> 
      * The script to execute. Note, make sure not to send different script each times and instead
      * use script params if possible with the same (automatically compiled) script.
      */
-    public UpdateRequest script(String script, ScriptService.ScriptType scriptType) {
+    public UpdateRequest script(String script, ScriptType scriptType) {
         this.script = script;
         this.scriptType = scriptType;
         return this;
@@ -231,7 +231,7 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest> 
      */
     public UpdateRequest script(String script) {
         this.script = script;
-        this.scriptType = ScriptService.ScriptType.INLINE;
+        this.scriptType = ScriptType.INLINE;
         return this;
     }
 
@@ -275,7 +275,7 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest> 
      * The script to execute. Note, make sure not to send different script each times and instead
      * use script params if possible with the same (automatically compiled) script.
      */
-    public UpdateRequest script(String script, ScriptService.ScriptType scriptType, @Nullable Map<String, Object> scriptParams) {
+    public UpdateRequest script(String script, ScriptType scriptType, @Nullable Map<String, Object> scriptParams) {
         this.script = script;
         this.scriptType = scriptType;
         if (this.scriptParams != null) {
@@ -295,7 +295,7 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest> 
      * @param scriptType   The script type
      * @param scriptParams The script parameters
      */
-    public UpdateRequest script(String script, @Nullable String scriptLang, ScriptService.ScriptType scriptType, @Nullable Map<String, Object> scriptParams) {
+    public UpdateRequest script(String script, @Nullable String scriptLang, ScriptType scriptType, @Nullable Map<String, Object> scriptParams) {
         this.script = script;
         this.scriptLang = scriptLang;
         this.scriptType = scriptType;
@@ -641,7 +641,7 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest> 
         parent = in.readOptionalString();
         script = in.readOptionalString();
         if(Strings.hasLength(script)) {
-            scriptType = ScriptService.ScriptType.readFrom(in);
+            scriptType = ScriptType.readFrom(in);
         }
         scriptLang = in.readOptionalString();
         scriptParams = in.readMap();
@@ -679,7 +679,7 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest> 
         out.writeOptionalString(parent);
         out.writeOptionalString(script);
         if (Strings.hasLength(script)) {
-            ScriptService.ScriptType.writeTo(scriptType, out);
+            ScriptType.writeTo(scriptType, out);
         }
         out.writeOptionalString(scriptLang);
         out.writeMap(scriptParams);

--- a/src/main/java/org/elasticsearch/action/update/UpdateRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/update/UpdateRequestBuilder.java
@@ -28,7 +28,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.VersionType;
-import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.script.ScriptType;
 
 import java.util.Map;
 
@@ -84,7 +84,7 @@ public class UpdateRequestBuilder extends InstanceShardOperationRequestBuilder<U
      * @see #setScriptLang(String)
      * @see #setScriptParams(Map)
      */
-    public UpdateRequestBuilder setScript(String script, ScriptService.ScriptType scriptType) {
+    public UpdateRequestBuilder setScript(String script, ScriptType scriptType) {
         request.script(script, scriptType);
         return this;
     }

--- a/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
@@ -66,7 +66,7 @@ import org.elasticsearch.index.mapper.object.RootObjectMapper;
 import org.elasticsearch.script.ExecutableScript;
 import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptService;
-import org.elasticsearch.script.ScriptService.ScriptType;
+import org.elasticsearch.script.ScriptType;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/main/java/org/elasticsearch/index/mapper/DocumentMapperParser.java
+++ b/src/main/java/org/elasticsearch/index/mapper/DocumentMapperParser.java
@@ -74,7 +74,7 @@ import org.elasticsearch.index.similarity.SimilarityLookupService;
 import org.elasticsearch.script.ScriptParameterParser;
 import org.elasticsearch.script.ScriptParameterParser.ScriptParameterValue;
 import org.elasticsearch.script.ScriptService;
-import org.elasticsearch.script.ScriptService.ScriptType;
+import org.elasticsearch.script.ScriptType;
 
 import java.util.Iterator;
 import java.util.List;

--- a/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
@@ -23,7 +23,7 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.geo.builders.ShapeBuilder;
 import org.elasticsearch.index.query.functionscore.FunctionScoreQueryBuilder;
 import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilder;
-import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.script.ScriptType;
 
 import java.util.Collection;
 import java.util.Map;
@@ -641,7 +641,7 @@ public abstract class QueryBuilders {
     /**
      * Facilitates creating template query requests
      */
-    public static TemplateQueryBuilder templateQuery(String template, ScriptService.ScriptType templateType, Map<String, Object> vars) {
+    public static TemplateQueryBuilder templateQuery(String template, ScriptType templateType, Map<String, Object> vars) {
         return new TemplateQueryBuilder(template, templateType, vars);
     }
 

--- a/src/main/java/org/elasticsearch/index/query/ScriptFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/ScriptFilterParser.java
@@ -75,7 +75,7 @@ public class ScriptFilterParser implements FilterParser {
 
         String filterName = null;
         String currentFieldName = null;
-        ScriptService.ScriptType scriptType = null;
+        ScriptType scriptType = null;
 
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
             if (token == XContentParser.Token.FIELD_NAME) {
@@ -131,7 +131,7 @@ public class ScriptFilterParser implements FilterParser {
 
         private final SearchScript searchScript;
 
-        public ScriptFilter(String scriptLang, String script, ScriptService.ScriptType scriptType, Map<String, Object> params, ScriptService scriptService, SearchLookup searchLookup) {
+        public ScriptFilter(String scriptLang, String script, ScriptType scriptType, Map<String, Object> params, ScriptService scriptService, SearchLookup searchLookup) {
             this.script = script;
             this.params = params;
             this.searchScript = scriptService.search(searchLookup, scriptLang, script, scriptType, ScriptContext.Standard.SEARCH, newHashMap(params));

--- a/src/main/java/org/elasticsearch/index/query/TemplateQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/TemplateQueryBuilder.java
@@ -20,7 +20,7 @@ package org.elasticsearch.index.query;
 
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.script.ScriptType;
 
 import java.io.IOException;
 import java.util.Map;
@@ -35,14 +35,14 @@ public class TemplateQueryBuilder extends BaseQueryBuilder {
     /** Template to fill.*/
     private String template;
 
-    private ScriptService.ScriptType templateType;
+    private ScriptType templateType;
 
     /**
      * @param template the template to use for that query.
      * @param vars the parameters to fill the template with.
      * */
     public TemplateQueryBuilder(String template, Map<String, Object> vars) {
-        this(template, ScriptService.ScriptType.INLINE, vars);
+        this(template, ScriptType.INLINE, vars);
     }
 
     /**
@@ -50,7 +50,7 @@ public class TemplateQueryBuilder extends BaseQueryBuilder {
      * @param vars the parameters to fill the template with.
      * @param templateType what kind of template (INLINE,FILE,ID)
      * */
-    public TemplateQueryBuilder(String template, ScriptService.ScriptType templateType, Map<String, Object> vars) {
+    public TemplateQueryBuilder(String template, ScriptType templateType, Map<String, Object> vars) {
         this.template = template;
         this.vars =vars;
         this.templateType = templateType;

--- a/src/main/java/org/elasticsearch/index/query/TemplateQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TemplateQueryParser.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.script.ExecutableScript;
 import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.script.mustache.MustacheScriptEngineService;
 
 import java.io.IOException;
@@ -49,11 +50,11 @@ public class TemplateQueryParser implements QueryParser {
 
     private final ScriptService scriptService;
 
-    private final static Map<String,ScriptService.ScriptType> parametersToTypes = new HashMap<>();
+    private final static Map<String,ScriptType> parametersToTypes = new HashMap<>();
     static {
-        parametersToTypes.put("query", ScriptService.ScriptType.INLINE);
-        parametersToTypes.put("file", ScriptService.ScriptType.FILE);
-        parametersToTypes.put("id", ScriptService.ScriptType.INDEXED);
+        parametersToTypes.put("query", ScriptType.INLINE);
+        parametersToTypes.put("file", ScriptType.FILE);
+        parametersToTypes.put("id", ScriptType.INDEXED);
     }
 
     @Inject
@@ -90,9 +91,9 @@ public class TemplateQueryParser implements QueryParser {
 
     public static TemplateContext parse(XContentParser parser, String paramsFieldname, String ... parameters) throws IOException {
 
-        Map<String,ScriptService.ScriptType> parameterMap = new HashMap<>(parametersToTypes);
+        Map<String,ScriptType> parameterMap = new HashMap<>(parametersToTypes);
         for (String parameter : parameters) {
-            parameterMap.put(parameter, ScriptService.ScriptType.INLINE);
+            parameterMap.put(parameter, ScriptType.INLINE);
         }
         return parse(parser,paramsFieldname,parameterMap);
     }
@@ -101,13 +102,13 @@ public class TemplateQueryParser implements QueryParser {
         return parse(parser,paramsFieldname,parametersToTypes);
     }
 
-    public static TemplateContext parse(XContentParser parser, String paramsFieldname, Map<String,ScriptService.ScriptType> parameterMap) throws IOException {
+    public static TemplateContext parse(XContentParser parser, String paramsFieldname, Map<String,ScriptType> parameterMap) throws IOException {
         Map<String, Object> params = null;
         String templateNameOrTemplateContent = null;
 
         String currentFieldName = null;
         XContentParser.Token token;
-        ScriptService.ScriptType type = null;
+        ScriptType type = null;
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
@@ -131,9 +132,9 @@ public class TemplateQueryParser implements QueryParser {
     public static class TemplateContext {
         private Map<String, Object> params;
         private String template;
-        private ScriptService.ScriptType type;
+        private ScriptType type;
 
-        public TemplateContext(ScriptService.ScriptType type, String template, Map<String, Object> params) {
+        public TemplateContext(ScriptType type, String template, Map<String, Object> params) {
             this.params = params;
             this.template = template;
             this.type = type;
@@ -147,7 +148,7 @@ public class TemplateQueryParser implements QueryParser {
             return template;
         }
 
-        public ScriptService.ScriptType scriptType(){
+        public ScriptType scriptType(){
             return type;
         }
 

--- a/src/main/java/org/elasticsearch/index/query/functionscore/script/ScriptScoreFunctionParser.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/script/ScriptScoreFunctionParser.java
@@ -30,7 +30,6 @@ import org.elasticsearch.index.query.QueryParsingException;
 import org.elasticsearch.index.query.functionscore.ScoreFunctionParser;
 import org.elasticsearch.script.*;
 import org.elasticsearch.script.ScriptParameterParser.ScriptParameterValue;
-import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.script.SearchScript;
 
 import java.io.IOException;
@@ -57,7 +56,7 @@ public class ScriptScoreFunctionParser implements ScoreFunctionParser {
         ScriptParameterParser scriptParameterParser = new ScriptParameterParser();
         String script = null;
         Map<String, Object> vars = null;
-        ScriptService.ScriptType scriptType = null;
+        ScriptType scriptType = null;
         String currentFieldName = null;
         XContentParser.Token token;
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {

--- a/src/main/java/org/elasticsearch/script/ScriptContextRegistry.java
+++ b/src/main/java/org/elasticsearch/script/ScriptContextRegistry.java
@@ -78,7 +78,7 @@ public final class ScriptContextRegistry {
 
     private static ImmutableSet<String> reservedScriptContexts() {
         ImmutableSet.Builder<String> builder = ImmutableSet.builder();
-        for (ScriptService.ScriptType scriptType : ScriptService.ScriptType.values()) {
+        for (ScriptType scriptType : ScriptType.values()) {
             builder.add(scriptType.toString());
         }
         for (ScriptContext.Standard scriptContext : ScriptContext.Standard.values()) {

--- a/src/main/java/org/elasticsearch/script/ScriptModes.java
+++ b/src/main/java/org/elasticsearch/script/ScriptModes.java
@@ -24,7 +24,6 @@ import com.google.common.collect.Maps;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.script.ScriptService.ScriptType;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/src/main/java/org/elasticsearch/script/ScriptParameterParser.java
+++ b/src/main/java/org/elasticsearch/script/ScriptParameterParser.java
@@ -23,7 +23,6 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.xcontent.ToXContent.Params;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.script.ScriptService.ScriptType;
 
 import java.io.IOException;
 import java.util.*;

--- a/src/main/java/org/elasticsearch/script/ScriptService.java
+++ b/src/main/java/org/elasticsearch/script/ScriptService.java
@@ -47,8 +47,6 @@ import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.Streams;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
@@ -70,7 +68,6 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
@@ -521,63 +518,6 @@ public class ScriptService extends AbstractComponent implements Closeable {
             onFileInit(file);
         }
 
-    }
-
-    /**
-     * The type of a script, more specifically where it gets loaded from:
-     * - provided dynamically at request time
-     * - loaded from an index
-     * - loaded from file
-     */
-    public static enum ScriptType {
-
-        INLINE,
-        INDEXED,
-        FILE;
-
-        private static final int INLINE_VAL = 0;
-        private static final int INDEXED_VAL = 1;
-        private static final int FILE_VAL = 2;
-
-        public static ScriptType readFrom(StreamInput in) throws IOException {
-            int scriptTypeVal = in.readVInt();
-            switch (scriptTypeVal) {
-                case INDEXED_VAL:
-                    return INDEXED;
-                case INLINE_VAL:
-                    return INLINE;
-                case FILE_VAL:
-                    return FILE;
-                default:
-                    throw new ElasticsearchIllegalArgumentException("Unexpected value read for ScriptType got [" + scriptTypeVal +
-                            "] expected one of [" + INLINE_VAL + "," + INDEXED_VAL + "," + FILE_VAL + "]");
-            }
-        }
-
-        public static void writeTo(ScriptType scriptType, StreamOutput out) throws IOException{
-            if (scriptType != null) {
-                switch (scriptType){
-                    case INDEXED:
-                        out.writeVInt(INDEXED_VAL);
-                        return;
-                    case INLINE:
-                        out.writeVInt(INLINE_VAL);
-                        return;
-                    case FILE:
-                        out.writeVInt(FILE_VAL);
-                        return;
-                    default:
-                        throw new ElasticsearchIllegalStateException("Unknown ScriptType " + scriptType);
-                }
-            } else {
-                out.writeVInt(INLINE_VAL); //Default to inline
-            }
-        }
-
-        @Override
-        public String toString() {
-            return name().toLowerCase(Locale.ROOT);
-        }
     }
 
     private static CacheKey newCacheKey(ScriptEngineService engineService, String script) {

--- a/src/main/java/org/elasticsearch/script/ScriptType.java
+++ b/src/main/java/org/elasticsearch/script/ScriptType.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.script;
+
+import org.elasticsearch.ElasticsearchIllegalArgumentException;
+import org.elasticsearch.ElasticsearchIllegalStateException;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+import java.util.Locale;
+
+/**
+ * The type of a script, more specifically where it gets loaded from:
+ * - provided dynamically at request time
+ * - loaded from an index
+ * - loaded from file
+ */
+public enum ScriptType {
+
+    INLINE,
+    INDEXED,
+    FILE;
+
+    private static final int INLINE_VAL = 0;
+    private static final int INDEXED_VAL = 1;
+    private static final int FILE_VAL = 2;
+
+    public static ScriptType readFrom(StreamInput in) throws IOException {
+        int scriptTypeVal = in.readVInt();
+        switch (scriptTypeVal) {
+            case INDEXED_VAL:
+                return INDEXED;
+            case INLINE_VAL:
+                return INLINE;
+            case FILE_VAL:
+                return FILE;
+            default:
+                throw new ElasticsearchIllegalArgumentException("Unexpected value read for ScriptType got [" + scriptTypeVal +
+                        "] expected one of [" + INLINE_VAL + "," + INDEXED_VAL + "," + FILE_VAL + "]");
+        }
+    }
+
+    public static void writeTo(ScriptType scriptType, StreamOutput out) throws IOException{
+        if (scriptType != null) {
+            switch (scriptType){
+                case INDEXED:
+                    out.writeVInt(INDEXED_VAL);
+                    return;
+                case INLINE:
+                    out.writeVInt(INLINE_VAL);
+                    return;
+                case FILE:
+                    out.writeVInt(FILE_VAL);
+                    return;
+                default:
+                    throw new ElasticsearchIllegalStateException("Unknown ScriptType " + scriptType);
+            }
+        } else {
+            out.writeVInt(INLINE_VAL); //Default to inline
+        }
+    }
+
+    @Override
+    public String toString() {
+        return name().toLowerCase(Locale.ROOT);
+    }
+}

--- a/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/src/main/java/org/elasticsearch/search/SearchService.java
@@ -70,10 +70,7 @@ import org.elasticsearch.indices.IndicesWarmer;
 import org.elasticsearch.indices.IndicesWarmer.TerminationHandle;
 import org.elasticsearch.indices.IndicesWarmer.WarmerContext;
 import org.elasticsearch.indices.cache.query.IndicesQueryCache;
-import org.elasticsearch.script.ExecutableScript;
-import org.elasticsearch.script.ScriptContext;
-import org.elasticsearch.script.ScriptService;
-import org.elasticsearch.script.ScriptContextRegistry;
+import org.elasticsearch.script.*;
 import org.elasticsearch.script.mustache.MustacheScriptEngineService;
 import org.elasticsearch.search.dfs.CachedDfSource;
 import org.elasticsearch.search.dfs.DfsPhase;
@@ -665,7 +662,7 @@ public class SearchService extends AbstractLifecycleComponent<SearchService> {
                 parser = XContentFactory.xContent(request.templateSource()).createParser(request.templateSource());
                 templateContext = TemplateQueryParser.parse(parser, "params", "template");
 
-                if (templateContext.scriptType() == ScriptService.ScriptType.INLINE) {
+                if (templateContext.scriptType() == ScriptType.INLINE) {
                     //Try to double parse for nested template id/file
                     parser = null;
                     try {
@@ -674,11 +671,11 @@ public class SearchService extends AbstractLifecycleComponent<SearchService> {
                     } catch (ElasticsearchParseException epe) {
                         //This was an non-nested template, the parse failure was due to this, it is safe to assume this refers to a file
                         //for backwards compatibility and keep going
-                        templateContext = new TemplateQueryParser.TemplateContext(ScriptService.ScriptType.FILE, templateContext.template(), templateContext.params());
+                        templateContext = new TemplateQueryParser.TemplateContext(ScriptType.FILE, templateContext.template(), templateContext.params());
                     }
                     if (parser != null) {
                         TemplateQueryParser.TemplateContext innerContext = TemplateQueryParser.parse(parser, "params");
-                        if (hasLength(innerContext.template()) && !innerContext.scriptType().equals(ScriptService.ScriptType.INLINE)) {
+                        if (hasLength(innerContext.template()) && !innerContext.scriptType().equals(ScriptType.INLINE)) {
                             //An inner template referring to a filename or id
                             templateContext = new TemplateQueryParser.TemplateContext(innerContext.scriptType(), innerContext.template(), templateContext.params());
                         }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/ScriptHeuristic.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/ScriptHeuristic.java
@@ -47,13 +47,13 @@ public class ScriptHeuristic extends SignificanceHeuristic {
     ExecutableScript script = null;
     String scriptLang;
     String scriptString;
-    ScriptService.ScriptType scriptType;
+    ScriptType scriptType;
     Map<String, Object> params;
 
     public static final SignificanceHeuristicStreams.Stream STREAM = new SignificanceHeuristicStreams.Stream() {
         @Override
         public SignificanceHeuristic readResult(StreamInput in) throws IOException {
-            return new ScriptHeuristic(null, in.readOptionalString(), in.readString(), ScriptService.ScriptType.readFrom(in), in.readMap());
+            return new ScriptHeuristic(null, in.readOptionalString(), in.readString(), ScriptType.readFrom(in), in.readMap());
         }
 
         @Override
@@ -62,7 +62,7 @@ public class ScriptHeuristic extends SignificanceHeuristic {
         }
     };
 
-    public ScriptHeuristic(ExecutableScript searchScript, String scriptLang, String scriptString, ScriptService.ScriptType scriptType, Map<String, Object> params) {
+    public ScriptHeuristic(ExecutableScript searchScript, String scriptLang, String scriptString, ScriptType scriptType, Map<String, Object> params) {
         subsetSizeHolder = new LongAccessor();
         supersetSizeHolder = new LongAccessor();
         subsetDfHolder = new LongAccessor();
@@ -121,7 +121,7 @@ public class ScriptHeuristic extends SignificanceHeuristic {
         out.writeString(STREAM.getName());
         out.writeOptionalString(scriptLang);
         out.writeString(scriptString);
-        ScriptService.ScriptType.writeTo(scriptType, out);
+        ScriptType.writeTo(scriptType, out);
         out.writeMap(params);
     }
 
@@ -140,7 +140,7 @@ public class ScriptHeuristic extends SignificanceHeuristic {
             XContentParser.Token token;
             Map<String, Object> params = new HashMap<>();
             String currentFieldName = null;
-            ScriptService.ScriptType scriptType = ScriptService.ScriptType.INLINE;
+            ScriptType scriptType = ScriptType.INLINE;
             ScriptParameterParser scriptParameterParser = new ScriptParameterParser();
             while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
                 if (token.equals(XContentParser.Token.FIELD_NAME)) {

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/scripted/InternalScriptedMetric.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/scripted/InternalScriptedMetric.java
@@ -25,7 +25,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.script.ExecutableScript;
 import org.elasticsearch.script.ScriptContext;
-import org.elasticsearch.script.ScriptService.ScriptType;
+import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.aggregations.AggregationStreams;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.metrics.InternalMetricsAggregation;

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/scripted/ScriptedMetricAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/scripted/ScriptedMetricAggregator.java
@@ -24,7 +24,7 @@ import org.elasticsearch.script.ExecutableScript;
 import org.elasticsearch.script.LeafSearchScript;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.script.*;
-import org.elasticsearch.script.ScriptService.ScriptType;
+import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.SearchParseException;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactory;

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/scripted/ScriptedMetricParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/scripted/ScriptedMetricParser.java
@@ -23,7 +23,7 @@ import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.script.ScriptParameterParser;
 import org.elasticsearch.script.ScriptParameterParser.ScriptParameterValue;
-import org.elasticsearch.script.ScriptService.ScriptType;
+import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.SearchParseException;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactory;

--- a/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceParser.java
@@ -63,7 +63,7 @@ public class ValuesSourceParser<VS extends ValuesSource> {
     private static class Input {
         String field = null;
         String script = null;
-        ScriptService.ScriptType scriptType = null;
+        ScriptType scriptType = null;
         String lang = null;
         Map<String, Object> params = null;
         ValueType valueType = null;

--- a/src/main/java/org/elasticsearch/search/fetch/script/ScriptFieldsParseElement.java
+++ b/src/main/java/org/elasticsearch/search/fetch/script/ScriptFieldsParseElement.java
@@ -54,7 +54,7 @@ public class ScriptFieldsParseElement implements SearchParseElement {
                 String fieldName = currentFieldName;
                 ScriptParameterParser scriptParameterParser = new ScriptParameterParser();
                 String script = null;
-                ScriptService.ScriptType scriptType = null;
+                ScriptType scriptType = null;
                 Map<String, Object> params = null;
                 boolean ignoreException = false;
                 while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {

--- a/src/main/java/org/elasticsearch/search/internal/ShardSearchLocalRequest.java
+++ b/src/main/java/org/elasticsearch/search/internal/ShardSearchLocalRequest.java
@@ -28,7 +28,7 @@ import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.shard.ShardId;
-import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.Scroll;
 
 import java.io.IOException;
@@ -77,7 +77,7 @@ public class ShardSearchLocalRequest implements ShardSearchRequest {
     private BytesReference extraSource;
     private BytesReference templateSource;
     private String templateName;
-    private ScriptService.ScriptType templateType;
+    private ScriptType templateType;
     private Map<String, Object> templateParams;
     private Boolean queryCache;
 
@@ -178,7 +178,7 @@ public class ShardSearchLocalRequest implements ShardSearchRequest {
     }
 
     @Override
-    public ScriptService.ScriptType templateType() {
+    public ScriptType templateType() {
         return templateType;
     }
 
@@ -221,7 +221,7 @@ public class ShardSearchLocalRequest implements ShardSearchRequest {
 
         templateSource = in.readBytesReference();
         templateName = in.readOptionalString();
-        templateType = ScriptService.ScriptType.readFrom(in);
+        templateType = ScriptType.readFrom(in);
         if (in.readBoolean()) {
             templateParams = (Map<String, Object>) in.readGenericValue();
         }
@@ -251,7 +251,7 @@ public class ShardSearchLocalRequest implements ShardSearchRequest {
 
         out.writeBytesReference(templateSource);
         out.writeOptionalString(templateName);
-        ScriptService.ScriptType.writeTo(templateType, out);
+        ScriptType.writeTo(templateType, out);
         boolean existTemplateParams = templateParams != null;
         out.writeBoolean(existTemplateParams);
         if (existTemplateParams) {

--- a/src/main/java/org/elasticsearch/search/internal/ShardSearchRequest.java
+++ b/src/main/java/org/elasticsearch/search/internal/ShardSearchRequest.java
@@ -21,7 +21,7 @@ package org.elasticsearch.search.internal;
 
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.Scroll;
 
 import java.io.IOException;
@@ -56,7 +56,7 @@ public interface ShardSearchRequest {
 
     String templateName();
 
-    ScriptService.ScriptType templateType();
+    ScriptType templateType();
 
     Map<String, Object> templateParams();
 

--- a/src/main/java/org/elasticsearch/search/internal/ShardSearchTransportRequest.java
+++ b/src/main/java/org/elasticsearch/search/internal/ShardSearchTransportRequest.java
@@ -28,7 +28,7 @@ import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.Scroll;
 import org.elasticsearch.transport.TransportRequest;
 
@@ -128,7 +128,7 @@ public class ShardSearchTransportRequest extends TransportRequest implements Sha
     }
 
     @Override
-    public ScriptService.ScriptType templateType() {
+    public ScriptType templateType() {
         return shardSearchLocalRequest.templateType();
     }
 

--- a/src/main/java/org/elasticsearch/search/sort/ScriptSortParser.java
+++ b/src/main/java/org/elasticsearch/search/sort/ScriptSortParser.java
@@ -34,10 +34,7 @@ import org.elasticsearch.index.fielddata.fieldcomparator.BytesRefFieldComparator
 import org.elasticsearch.index.fielddata.fieldcomparator.DoubleValuesComparatorSource;
 import org.elasticsearch.index.query.support.NestedInnerQueryParseSupport;
 import org.elasticsearch.index.search.nested.NonNestedDocsFilter;
-import org.elasticsearch.script.LeafSearchScript;
-import org.elasticsearch.script.ScriptService;
-import org.elasticsearch.script.ScriptContext;
-import org.elasticsearch.script.SearchScript;
+import org.elasticsearch.script.*;
 import org.elasticsearch.search.MultiValueMode;
 import org.elasticsearch.search.SearchParseException;
 import org.elasticsearch.search.internal.SearchContext;
@@ -70,7 +67,7 @@ public class ScriptSortParser implements SortParser {
 
         XContentParser.Token token;
         String currentName = parser.currentName();
-        ScriptService.ScriptType scriptType = ScriptService.ScriptType.INLINE;
+        ScriptType scriptType = ScriptType.INLINE;
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentName = parser.currentName();
@@ -90,13 +87,13 @@ public class ScriptSortParser implements SortParser {
                     reverse = "desc".equals(parser.text());
                 } else if (ScriptService.SCRIPT_INLINE.match(currentName)) {
                     script = parser.text();
-                    scriptType = ScriptService.ScriptType.INLINE;
+                    scriptType = ScriptType.INLINE;
                 } else if (ScriptService.SCRIPT_ID.match(currentName)) {
                     script = parser.text();
-                    scriptType = ScriptService.ScriptType.INDEXED;
+                    scriptType = ScriptType.INDEXED;
                 } else if (ScriptService.SCRIPT_FILE.match(currentName)) {
                     script = parser.text();
-                    scriptType = ScriptService.ScriptType.FILE;
+                    scriptType = ScriptType.FILE;
                 } else if (ScriptService.SCRIPT_LANG.match(currentName)) {
                     scriptLang = parser.text();
                 } else if ("type".equals(currentName)) {

--- a/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestParser.java
+++ b/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestParser.java
@@ -31,7 +31,7 @@ import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.script.CompiledScript;
 import org.elasticsearch.script.ScriptContext;
-import org.elasticsearch.script.ScriptService.ScriptType;
+import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.script.mustache.MustacheScriptEngineService;
 import org.elasticsearch.search.suggest.SuggestContextParser;
 import org.elasticsearch.search.suggest.SuggestUtils;

--- a/src/test/java/org/elasticsearch/cluster/NoMasterNodeTests.java
+++ b/src/test/java/org/elasticsearch/cluster/NoMasterNodeTests.java
@@ -35,7 +35,7 @@ import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.discovery.DiscoverySettings;
 import org.elasticsearch.discovery.MasterNotDiscoveredException;
 import org.elasticsearch.rest.RestStatus;
-import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
 import org.junit.Test;
@@ -134,11 +134,11 @@ public class NoMasterNodeTests extends ElasticsearchIntegrationTest {
         );
 
         checkWriteAction(false, timeout,
-                client().prepareUpdate("test", "type1", "1").setScript("test script", ScriptService.ScriptType.INLINE).setTimeout(timeout));
+                client().prepareUpdate("test", "type1", "1").setScript("test script", ScriptType.INLINE).setTimeout(timeout));
 
 
         checkWriteAction(autoCreateIndex, timeout,
-                client().prepareUpdate("no_index", "type1", "1").setScript("test script", ScriptService.ScriptType.INLINE).setTimeout(timeout));
+                client().prepareUpdate("no_index", "type1", "1").setScript("test script", ScriptType.INLINE).setTimeout(timeout));
 
 
         checkWriteAction(false, timeout,

--- a/src/test/java/org/elasticsearch/document/BulkTests.java
+++ b/src/test/java/org/elasticsearch/document/BulkTests.java
@@ -42,7 +42,7 @@ import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.index.query.QueryBuilders;
-import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.junit.Test;
 
@@ -83,9 +83,9 @@ public class BulkTests extends ElasticsearchIntegrationTest {
 
         bulkResponse = client().prepareBulk()
                 .add(client().prepareUpdate().setIndex(indexOrAlias()).setType("type1").setId("1")
-                        .setScript("ctx._source.field += 1", ScriptService.ScriptType.INLINE))
+                        .setScript("ctx._source.field += 1", ScriptType.INLINE))
                 .add(client().prepareUpdate().setIndex(indexOrAlias()).setType("type1").setId("2")
-                        .setScript("ctx._source.field += 1", ScriptService.ScriptType.INLINE).setRetryOnConflict(3))
+                        .setScript("ctx._source.field += 1", ScriptType.INLINE).setRetryOnConflict(3))
                 .add(client().prepareUpdate().setIndex(indexOrAlias()).setType("type1").setId("3").setDoc(jsonBuilder().startObject().field("field1", "test").endObject()))
                 .execute().actionGet();
 
@@ -118,12 +118,12 @@ public class BulkTests extends ElasticsearchIntegrationTest {
 
         bulkResponse = client().prepareBulk()
                 .add(client().prepareUpdate().setIndex(indexOrAlias()).setType("type1").setId("6")
-                        .setScript("ctx._source.field += 1", ScriptService.ScriptType.INLINE)
+                        .setScript("ctx._source.field += 1", ScriptType.INLINE)
                         .setUpsert(jsonBuilder().startObject().field("field", 0).endObject()))
                 .add(client().prepareUpdate().setIndex(indexOrAlias()).setType("type1").setId("7")
-                        .setScript("ctx._source.field += 1", ScriptService.ScriptType.INLINE))
+                        .setScript("ctx._source.field += 1", ScriptType.INLINE))
                 .add(client().prepareUpdate().setIndex(indexOrAlias()).setType("type1").setId("2")
-                        .setScript("ctx._source.field += 1", ScriptService.ScriptType.INLINE))
+                        .setScript("ctx._source.field += 1", ScriptType.INLINE))
                 .execute().actionGet();
 
         assertThat(bulkResponse.hasFailures(), equalTo(true));
@@ -216,11 +216,11 @@ public class BulkTests extends ElasticsearchIntegrationTest {
 
         bulkResponse = client().prepareBulk()
                 .add(client().prepareUpdate().setIndex("test").setType("type1").setId("1")
-                        .setScript("ctx._source.field += a", ScriptService.ScriptType.INLINE).setFields("field"))
+                        .setScript("ctx._source.field += a", ScriptType.INLINE).setFields("field"))
                 .add(client().prepareUpdate().setIndex("test").setType("type1").setId("2")
-                        .setScript("ctx._source.field += 1", ScriptService.ScriptType.INLINE).setFields("field"))
+                        .setScript("ctx._source.field += 1", ScriptType.INLINE).setFields("field"))
                 .add(client().prepareUpdate().setIndex("test").setType("type1").setId("3")
-                        .setScript("ctx._source.field += a", ScriptService.ScriptType.INLINE).setFields("field"))
+                        .setScript("ctx._source.field += a", ScriptType.INLINE).setFields("field"))
                 .execute().actionGet();
 
         assertThat(bulkResponse.hasFailures(), equalTo(true));
@@ -254,7 +254,7 @@ public class BulkTests extends ElasticsearchIntegrationTest {
             builder.add(
                     client().prepareUpdate()
                             .setIndex("test").setType("type1").setId(Integer.toString(i))
-                            .setScript("ctx._source.counter += 1", ScriptService.ScriptType.INLINE).setFields("counter")
+                            .setScript("ctx._source.counter += 1", ScriptType.INLINE).setFields("counter")
                             .setUpsert(jsonBuilder().startObject().field("counter", 1).endObject())
             );
         }
@@ -285,7 +285,7 @@ public class BulkTests extends ElasticsearchIntegrationTest {
             UpdateRequestBuilder updateBuilder = client().prepareUpdate()
                     .setIndex("test").setType("type1").setId(Integer.toString(i)).setFields("counter");
             if (i % 2 == 0) {
-                updateBuilder.setScript("ctx._source.counter += 1", ScriptService.ScriptType.INLINE);
+                updateBuilder.setScript("ctx._source.counter += 1", ScriptType.INLINE);
             } else {
                 updateBuilder.setDoc(jsonBuilder().startObject().field("counter", 2).endObject());
             }
@@ -315,7 +315,7 @@ public class BulkTests extends ElasticsearchIntegrationTest {
         for (int i = (numDocs / 2); i < maxDocs; i++) {
             builder.add(
                     client().prepareUpdate()
-                            .setIndex("test").setType("type1").setId(Integer.toString(i)).setScript("ctx._source.counter += 1", ScriptService.ScriptType.INLINE)
+                            .setIndex("test").setType("type1").setId(Integer.toString(i)).setScript("ctx._source.counter += 1", ScriptType.INLINE)
             );
         }
         response = builder.execute().actionGet();
@@ -340,7 +340,7 @@ public class BulkTests extends ElasticsearchIntegrationTest {
             builder.add(
                     client().prepareUpdate()
                             .setIndex("test").setType("type1").setId(Integer.toString(i))
-                            .setScript("ctx.op = \"none\"", ScriptService.ScriptType.INLINE)
+                            .setScript("ctx.op = \"none\"", ScriptType.INLINE)
             );
         }
         response = builder.execute().actionGet();
@@ -359,7 +359,7 @@ public class BulkTests extends ElasticsearchIntegrationTest {
             builder.add(
                     client().prepareUpdate()
                             .setIndex("test").setType("type1").setId(Integer.toString(i))
-                            .setScript("ctx.op = \"delete\"", ScriptService.ScriptType.INLINE)
+                            .setScript("ctx.op = \"delete\"", ScriptType.INLINE)
             );
         }
         response = builder.execute().actionGet();

--- a/src/test/java/org/elasticsearch/index/query/TemplateQueryTest.java
+++ b/src/test/java/org/elasticsearch/index/query/TemplateQueryTest.java
@@ -30,6 +30,7 @@ import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.script.mustache.MustacheScriptEngineService;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.junit.Before;
@@ -133,7 +134,7 @@ public class TemplateQueryTest extends ElasticsearchIntegrationTest {
         vars.put("template", "all");
 
         TemplateQueryBuilder builder = new TemplateQueryBuilder(
-                "storedTemplate", ScriptService.ScriptType.FILE, vars);
+                "storedTemplate", ScriptType.FILE, vars);
         SearchResponse sr = client().prepareSearch().setQuery(builder)
                 .execute().actionGet();
         assertHitCount(sr, 2);
@@ -212,14 +213,14 @@ public class TemplateQueryTest extends ElasticsearchIntegrationTest {
         templateParams.put("myValue", "foo");
 
         SearchResponse searchResponse = client().prepareSearch("test").setTypes("type").setTemplateName("full-query-template")
-                .setTemplateParams(templateParams).setTemplateType(ScriptService.ScriptType.FILE).get();
+                .setTemplateParams(templateParams).setTemplateType(ScriptType.FILE).get();
         assertHitCount(searchResponse, 4);
         // size kicks in here...
         assertThat(searchResponse.getHits().getHits().length, is(2));
 
         templateParams.put("myField", "otherField");
         searchResponse = client().prepareSearch("test").setTypes("type").setTemplateName("full-query-template")
-                .setTemplateParams(templateParams).setTemplateType(ScriptService.ScriptType.FILE).get();
+                .setTemplateParams(templateParams).setTemplateType(ScriptType.FILE).get();
         assertHitCount(searchResponse, 1);
     }
 
@@ -267,7 +268,7 @@ public class TemplateQueryTest extends ElasticsearchIntegrationTest {
         templateParams.put("fieldParam", "foo");
 
         SearchResponse searchResponse = client().prepareSearch("test").setTypes("type").
-                setTemplateName("testTemplate").setTemplateType(ScriptService.ScriptType.INDEXED).setTemplateParams(templateParams).get();
+                setTemplateName("testTemplate").setTemplateType(ScriptType.INDEXED).setTemplateParams(templateParams).get();
         assertHitCount(searchResponse, 4);
 
         DeleteIndexedScriptResponse deleteResponse = client().prepareDeleteIndexedScript(MustacheScriptEngineService.NAME,"testTemplate").get();
@@ -277,7 +278,7 @@ public class TemplateQueryTest extends ElasticsearchIntegrationTest {
         assertFalse(getResponse.isExists());
 
         client().prepareSearch("test").setTypes("type").
-                setTemplateName("/template_index/mustache/1000").setTemplateType(ScriptService.ScriptType.INDEXED).setTemplateParams(templateParams).get();
+                setTemplateName("/template_index/mustache/1000").setTemplateType(ScriptType.INDEXED).setTemplateParams(templateParams).get();
     }
 
     @Test
@@ -325,12 +326,12 @@ public class TemplateQueryTest extends ElasticsearchIntegrationTest {
         templateParams.put("fieldParam", "foo");
 
         SearchResponse searchResponse = client().prepareSearch("test").setTypes("type").
-                setTemplateName("/mustache/1a").setTemplateType(ScriptService.ScriptType.INDEXED).setTemplateParams(templateParams).get();
+                setTemplateName("/mustache/1a").setTemplateType(ScriptType.INDEXED).setTemplateParams(templateParams).get();
         assertHitCount(searchResponse, 4);
 
         try {
             client().prepareSearch("test").setTypes("type").
-                    setTemplateName("/template_index/mustache/1000").setTemplateType(ScriptService.ScriptType.INDEXED).setTemplateParams(templateParams).get();
+                    setTemplateName("/template_index/mustache/1000").setTemplateType(ScriptType.INDEXED).setTemplateParams(templateParams).get();
             fail("shouldn't get here");
         } catch (SearchPhaseExecutionException spee) {
             //all good
@@ -338,26 +339,26 @@ public class TemplateQueryTest extends ElasticsearchIntegrationTest {
 
         try {
             searchResponse = client().prepareSearch("test").setTypes("type").
-                    setTemplateName("/myindex/mustache/1").setTemplateType(ScriptService.ScriptType.INDEXED).setTemplateParams(templateParams).get();
+                    setTemplateName("/myindex/mustache/1").setTemplateType(ScriptType.INDEXED).setTemplateParams(templateParams).get();
             assertFailures(searchResponse);
         } catch (SearchPhaseExecutionException spee) {
             //all good
         }
 
         searchResponse = client().prepareSearch("test").setTypes("type").
-                setTemplateName("1a").setTemplateType(ScriptService.ScriptType.INDEXED).setTemplateParams(templateParams).get();
+                setTemplateName("1a").setTemplateType(ScriptType.INDEXED).setTemplateParams(templateParams).get();
         assertHitCount(searchResponse, 4);
 
         templateParams.put("fieldParam", "bar");
         searchResponse = client().prepareSearch("test").setTypes("type").
-                setTemplateName("/mustache/2").setTemplateType(ScriptService.ScriptType.INDEXED).setTemplateParams(templateParams).get();
+                setTemplateName("/mustache/2").setTemplateType(ScriptType.INDEXED).setTemplateParams(templateParams).get();
         assertHitCount(searchResponse, 1);
 
         Map<String, Object> vars = new HashMap<>();
         vars.put("fieldParam", "bar");
 
         TemplateQueryBuilder builder = new TemplateQueryBuilder(
-                "3", ScriptService.ScriptType.INDEXED, vars);
+                "3", ScriptType.INDEXED, vars);
         SearchResponse sr = client().prepareSearch().setQuery(builder)
                 .execute().actionGet();
         assertHitCount(sr, 1);
@@ -398,7 +399,7 @@ public class TemplateQueryTest extends ElasticsearchIntegrationTest {
       arrayTemplateParams.put("fieldParam", fieldParams);
 
       SearchResponse searchResponse = client().prepareSearch("test").setTypes("type").
-              setTemplateName("/mustache/4").setTemplateType(ScriptService.ScriptType.INDEXED).setTemplateParams(arrayTemplateParams).get();
+              setTemplateName("/mustache/4").setTemplateType(ScriptType.INDEXED).setTemplateParams(arrayTemplateParams).get();
       assertHitCount(searchResponse, 5);
     }
 

--- a/src/test/java/org/elasticsearch/routing/AliasRoutingTests.java
+++ b/src/test/java/org/elasticsearch/routing/AliasRoutingTests.java
@@ -23,7 +23,7 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.query.QueryBuilders;
-import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.junit.Test;
 
@@ -67,7 +67,7 @@ public class AliasRoutingTests extends ElasticsearchIntegrationTest {
         logger.info("--> updating with id [1] and routing through alias");
         client().prepareUpdate("alias0", "type1", "1")
                 .setUpsert(XContentFactory.jsonBuilder().startObject().field("field", 1).endObject())
-                .setScript("ctx._source.field = 'value2'", ScriptService.ScriptType.INLINE)
+                .setScript("ctx._source.field = 'value2'", ScriptType.INLINE)
                 .execute().actionGet();
         for (int i = 0; i < 5; i++) {
             assertThat(client().prepareGet("alias0", "type1", "1").execute().actionGet().isExists(), equalTo(true));

--- a/src/test/java/org/elasticsearch/script/CustomScriptContextTests.java
+++ b/src/test/java/org/elasticsearch/script/CustomScriptContextTests.java
@@ -53,7 +53,7 @@ public class CustomScriptContextTests extends ElasticsearchIntegrationTest {
     public void testCustomScriptContextsSettings() {
         ScriptService scriptService = internalCluster().getInstance(ScriptService.class);
         for (String lang : LANG_SET) {
-            for (ScriptService.ScriptType scriptType : ScriptService.ScriptType.values()) {
+            for (ScriptType scriptType : ScriptType.values()) {
                 try {
                     scriptService.compile(lang, "test", scriptType, new ScriptContext.Plugin(PLUGIN_NAME, "custom_globally_disabled_op"));
                     fail("script compilation should have been rejected");
@@ -64,20 +64,20 @@ public class CustomScriptContextTests extends ElasticsearchIntegrationTest {
         }
 
         try {
-            scriptService.compile("expression", "1", ScriptService.ScriptType.INLINE, new ScriptContext.Plugin(PLUGIN_NAME, "custom_exp_disabled_op"));
+            scriptService.compile("expression", "1", ScriptType.INLINE, new ScriptContext.Plugin(PLUGIN_NAME, "custom_exp_disabled_op"));
             fail("script compilation should have been rejected");
         } catch(ScriptException e) {
             assertThat(e.getMessage(), containsString("scripts of type [inline], operation [" + PLUGIN_NAME + "_custom_exp_disabled_op] and lang [expression] are disabled"));
         }
 
-        CompiledScript compiledScript = scriptService.compile("expression", "1", ScriptService.ScriptType.INLINE, randomFrom(ScriptContext.Standard.values()));
+        CompiledScript compiledScript = scriptService.compile("expression", "1", ScriptType.INLINE, randomFrom(ScriptContext.Standard.values()));
         assertThat(compiledScript, notNullValue());
 
-        compiledScript = scriptService.compile("mustache", "1", ScriptService.ScriptType.INLINE, new ScriptContext.Plugin(PLUGIN_NAME, "custom_exp_disabled_op"));
+        compiledScript = scriptService.compile("mustache", "1", ScriptType.INLINE, new ScriptContext.Plugin(PLUGIN_NAME, "custom_exp_disabled_op"));
         assertThat(compiledScript, notNullValue());
 
         for (String lang : LANG_SET) {
-            compiledScript = scriptService.compile(lang, "1", ScriptService.ScriptType.INLINE, new ScriptContext.Plugin(PLUGIN_NAME, "custom_op"));
+            compiledScript = scriptService.compile(lang, "1", ScriptType.INLINE, new ScriptContext.Plugin(PLUGIN_NAME, "custom_op"));
             assertThat(compiledScript, notNullValue());
         }
     }
@@ -86,7 +86,7 @@ public class CustomScriptContextTests extends ElasticsearchIntegrationTest {
     public void testCompileNonRegisteredPluginContext() {
         ScriptService scriptService = internalCluster().getInstance(ScriptService.class);
         try {
-            scriptService.compile(randomFrom(LANG_SET.toArray(new String[LANG_SET.size()])), "test", randomFrom(ScriptService.ScriptType.values()), new ScriptContext.Plugin("test", "unknown"));
+            scriptService.compile(randomFrom(LANG_SET.toArray(new String[LANG_SET.size()])), "test", randomFrom(ScriptType.values()), new ScriptContext.Plugin("test", "unknown"));
             fail("script compilation should have been rejected");
         } catch(ElasticsearchIllegalArgumentException e) {
             assertThat(e.getMessage(), containsString("script context [test_unknown] not supported"));
@@ -97,7 +97,7 @@ public class CustomScriptContextTests extends ElasticsearchIntegrationTest {
     public void testCompileNonRegisteredScriptContext() {
         ScriptService scriptService = internalCluster().getInstance(ScriptService.class);
         try {
-            scriptService.compile(randomFrom(LANG_SET.toArray(new String[LANG_SET.size()])), "test", randomFrom(ScriptService.ScriptType.values()), new ScriptContext() {
+            scriptService.compile(randomFrom(LANG_SET.toArray(new String[LANG_SET.size()])), "test", randomFrom(ScriptType.values()), new ScriptContext() {
                 @Override
                 public String getKey() {
                     return "test";

--- a/src/test/java/org/elasticsearch/script/IndexedScriptTests.java
+++ b/src/test/java/org/elasticsearch/script/IndexedScriptTests.java
@@ -96,7 +96,7 @@ public class IndexedScriptTests extends ElasticsearchIntegrationTest {
         }
         client().prepareIndex("test", "scriptTest", "1").setSource("{\"theField\":\"foo\"}").get();
         try {
-            client().prepareUpdate("test", "scriptTest", "1").setScript("script1", ScriptService.ScriptType.INDEXED).setScriptLang(GroovyScriptEngineService.NAME).get();
+            client().prepareUpdate("test", "scriptTest", "1").setScript("script1", ScriptType.INDEXED).setScriptLang(GroovyScriptEngineService.NAME).get();
             fail("update script should have been rejected");
         } catch(Exception e) {
             assertThat(e.getMessage(), containsString("failed to execute script"));
@@ -129,7 +129,7 @@ public class IndexedScriptTests extends ElasticsearchIntegrationTest {
         }
         client().prepareIndex("test", "scriptTest", "1").setSource("{\"theField\":\"foo\"}").get();
         try {
-            client().prepareUpdate("test", "scriptTest", "1").setScript("script1", ScriptService.ScriptType.INDEXED).setScriptLang(ExpressionScriptEngineService.NAME).get();
+            client().prepareUpdate("test", "scriptTest", "1").setScript("script1", ScriptType.INDEXED).setScriptLang(ExpressionScriptEngineService.NAME).get();
             fail("update script should have been rejected");
         } catch(Exception e) {
             assertThat(e.getMessage(), containsString("failed to execute script"));

--- a/src/test/java/org/elasticsearch/script/NativeScriptTests.java
+++ b/src/test/java/org/elasticsearch/script/NativeScriptTests.java
@@ -29,7 +29,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsModule;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.node.settings.NodeSettingsService;
-import org.elasticsearch.script.ScriptService.ScriptType;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.threadpool.ThreadPoolModule;

--- a/src/test/java/org/elasticsearch/script/OnDiskScriptTests.java
+++ b/src/test/java/org/elasticsearch/script/OnDiskScriptTests.java
@@ -138,7 +138,7 @@ public class OnDiskScriptTests extends ElasticsearchIntegrationTest {
             assertThat(ExceptionsHelper.detailedMessage(e), containsString("scripts of type [file], operation [search] and lang [mustache] are disabled"));
         }
         try {
-            client().prepareUpdate("test", "scriptTest", "1").setScript("script1", ScriptService.ScriptType.FILE).setScriptLang(MustacheScriptEngineService.NAME).get();
+            client().prepareUpdate("test", "scriptTest", "1").setScript("script1", ScriptType.FILE).setScriptLang(MustacheScriptEngineService.NAME).get();
             fail("update script should have been rejected");
         } catch(Exception e) {
             assertThat(e.getMessage(), containsString("failed to execute script"));

--- a/src/test/java/org/elasticsearch/script/ScriptModesTests.java
+++ b/src/test/java/org/elasticsearch/script/ScriptModesTests.java
@@ -23,7 +23,6 @@ import com.google.common.collect.*;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.settings.ImmutableSettings;
-import org.elasticsearch.script.ScriptService.ScriptType;
 import org.elasticsearch.script.expression.ExpressionScriptEngineService;
 import org.elasticsearch.script.groovy.GroovyScriptEngineService;
 import org.elasticsearch.script.mustache.MustacheScriptEngineService;

--- a/src/test/java/org/elasticsearch/script/ScriptParameterParserTest.java
+++ b/src/test/java/org/elasticsearch/script/ScriptParameterParserTest.java
@@ -27,7 +27,6 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentParser.Token;
 import org.elasticsearch.script.ScriptParameterParser.ScriptParameterParseException;
 import org.elasticsearch.script.ScriptParameterParser.ScriptParameterValue;
-import org.elasticsearch.script.ScriptService.ScriptType;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.junit.Test;
 

--- a/src/test/java/org/elasticsearch/script/ScriptServiceTests.java
+++ b/src/test/java/org/elasticsearch/script/ScriptServiceTests.java
@@ -27,7 +27,6 @@ import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.node.settings.NodeSettingsService;
-import org.elasticsearch.script.ScriptService.ScriptType;
 import org.elasticsearch.script.expression.ExpressionScriptEngineService;
 import org.elasticsearch.script.groovy.GroovyScriptEngineService;
 import org.elasticsearch.script.mustache.MustacheScriptEngineService;

--- a/src/test/java/org/elasticsearch/update/UpdateByNativeScriptTests.java
+++ b/src/test/java/org/elasticsearch/update/UpdateByNativeScriptTests.java
@@ -57,7 +57,7 @@ public class UpdateByNativeScriptTests extends ElasticsearchIntegrationTest {
         Map<String, Object> params = Maps.newHashMap();
         params.put("foo", "SETVALUE");
         client().prepareUpdate("test", "type", "1")
-                .setScript("custom", ScriptService.ScriptType.INLINE)
+                .setScript("custom", ScriptType.INLINE)
                 .setScriptLang(NativeScriptEngineService.NAME).setScriptParams(params).get();
 
         Map<String, Object> data = client().prepareGet("test", "type", "1").get().getSource();


### PR DESCRIPTION
Opening this up for discussion. I find it very weird that java api users have to import some `ScriptService` inner class when using scripts. `ScriptType` should belong to its own class, at the same level of `ScriptContext` (`org.elasticsearch.script` package).

The only problem with this change is that it breaks the Java api and plugins, as `ScriptType` needs to passed in as argument when using scripts. That is why the change is targeted for 2.0.
