### PR TITLE
Sync translog before closing engine

### DIFF
--- a/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -902,6 +902,11 @@ public class InternalEngine extends Engine {
         if (isClosed.compareAndSet(false, true)) {
             assert rwl.isWriteLockedByCurrentThread() || failEngineLock.isHeldByCurrentThread() : "Either the write lock must be held or the engine must be currently be failing itself";
             try {
+                try {
+                    translog.sync();
+                } catch (IOException ex) {
+                    logger.warn("failed to sync translog");
+                }
                 this.versionMap.clear();
                 logger.trace("close searcherManager");
                 try {


### PR DESCRIPTION
If the translog is buffered we must make sure everything is synced to disk
before we rollback the writer otherwise we open a window for potential dataloss due
to stupid errors preventing the translog from being closed.
