### PR TITLE
Cluster state: return `routing_nodes` only when requested through specific flag

### DIFF
--- a/docs/reference/migration/migrate_2_0.asciidoc
+++ b/docs/reference/migration/migrate_2_0.asciidoc
@@ -371,3 +371,9 @@ over AJAX instead:
 http.cors.enabled: true
 http.cors.allow-origin: /https?:\/\/localhost(:[0-9]+)?/
 ---------------
+
+=== Cluster state REST api
+
+The cluster state api doesn't return the `routing_nodes` section anymore when
+`routing_table` is requested. The newly introduced `routing_nodes` flag can
+be used separately to control whether `routing_nodes` should be returned.

--- a/rest-api-spec/test/cluster.state/20_filtering.yaml
+++ b/rest-api-spec/test/cluster.state/20_filtering.yaml
@@ -81,7 +81,7 @@ setup:
   - is_false: nodes
   - is_false: metadata
   - is_true: routing_table
-  - is_true: routing_nodes
+  - is_false: routing_nodes
 
 ---
 "Filtering the cluster state by routing nodes only should work":

--- a/src/main/java/org/elasticsearch/cluster/ClusterState.java
+++ b/src/main/java/org/elasticsearch/cluster/ClusterState.java
@@ -464,8 +464,7 @@ public class ClusterState implements ToXContent {
         }
 
         // routing nodes
-        // gets printed out even if only routing_table was requested for bw comp reasons
-        if (metrics.contains(Metric.ROUTING_TABLE) || metrics.contains(Metric.ROUTING_NODES)) {
+        if (metrics.contains(Metric.ROUTING_NODES)) {
             builder.startObject("routing_nodes");
             builder.startArray("unassigned");
             for (ShardRouting shardRouting : readOnlyRoutingNodes().unassigned()) {


### PR DESCRIPTION
For backwards compatibility reasons routing_nodes were previously printed out when routing_table was requested, together with the actual routing_table. Now they are printed out only when requested through `routing_nodes` flag.

 Relates to #10412
