### PR TITLE
Fix tokenizer settings in SynonymTokenFilterFactory

### DIFF
--- a/src/main/java/org/elasticsearch/index/analysis/SynonymTokenFilterFactory.java
+++ b/src/main/java/org/elasticsearch/index/analysis/SynonymTokenFilterFactory.java
@@ -33,6 +33,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.assistedinject.Assisted;
 import org.elasticsearch.common.io.FastStringReader;
 import org.elasticsearch.common.lucene.Lucene;
+import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.index.Index;
@@ -80,7 +81,8 @@ public class SynonymTokenFilterFactory extends AbstractTokenFilterFactory {
         if (tokenizerFactoryFactory == null) {
             throw new ElasticsearchIllegalArgumentException("failed to find tokenizer [" + tokenizerName + "] for synonym token filter");
         }
-        final TokenizerFactory tokenizerFactory = tokenizerFactoryFactory.create(tokenizerName, indexSettings);
+
+        final TokenizerFactory tokenizerFactory = tokenizerFactoryFactory.create(tokenizerName, ImmutableSettings.builder().put(indexSettings).put(settings).build());
 
         Analyzer analyzer = new Analyzer() {
             @Override

--- a/src/test/java/org/elasticsearch/index/analysis/synonyms/SynonymsAnalysisTest.java
+++ b/src/test/java/org/elasticsearch/index/analysis/synonyms/SynonymsAnalysisTest.java
@@ -83,6 +83,7 @@ public class SynonymsAnalysisTest extends ElasticsearchTestCase {
         match("synonymAnalyzer_file", "kimchy is the dude abides", "shay is the elasticsearch man!");
         match("synonymAnalyzerWordnet", "abstain", "abstain refrain desist");
         match("synonymAnalyzerWordnet_file", "abstain", "abstain refrain desist");
+        match("synonymAnalyzerWithsettings", "kimchy", "sha hay");
 
     }
 

--- a/src/test/java/org/elasticsearch/index/analysis/synonyms/synonyms.json
+++ b/src/test/java/org/elasticsearch/index/analysis/synonyms/synonyms.json
@@ -17,6 +17,17 @@
                 "synonymAnalyzerWordnet_file":{
                     "tokenizer":"standard",
                     "filter":[ "synonymWordnet_file" ]
+                },
+                "synonymAnalyzerWithsettings":{
+                    "tokenizer":"trigram",
+                    "filter":["synonymWithTokenizerSettings"]
+                }
+            },
+            "tokenizer":{
+                "trigram" : {
+                    "type" : "ngram",
+                    "min_gram" : 3,
+                    "max_gram" : 3
                 }
             },
             "filter":{
@@ -45,6 +56,15 @@
                     "type":"synonym",
                     "format":"wordnet",
                     "synonyms_path":"org/elasticsearch/index/analysis/synonyms/synonyms_wordnet.txt"
+                },
+                "synonymWithTokenizerSettings":{
+                    "type":"synonym",
+                    "synonyms":[
+                        "kimchy => shay"
+                    ],
+                    "tokenizer" : "trigram",
+                    "min_gram" : 3,
+                    "max_gram" : 3
                 }
             }
         }


### PR DESCRIPTION
Add test for synonym with tokenizer settings and fix.

Reported by Elasticsearch ML.

At Elasticsearch 1.3, the following setting works.  "bigramTokenizer" of synonymTest gets (min_gram/max_gram) settings.

```
curl -XPUT localhost:9200/test -d '{
  "settings" : {
    "analysis" : {
      "analyzer" : {
        "bigram_analyzer" : {
          "type" : "custom",
          "tokenizer" : "bigramTokenizer",
          "filter" : ["synonymTest"]
        }
      },
      "tokenizer" : {
          "bigramTokenizer" : {
          "type" : "ngram",
          "min_gram" : 2,
          "max_gram" : 2
        }
      },
      "filter" : {
        "synonymTest" : {
          "type" : "synonym",
          "synonyms_path" : "synonym.txt",
          "tokenizer" : "bigramTokenizer",
          "min_gram" : 2,
          "max_gram" : 2
        }
      }
    }
  }
}'
```

At Elasticsearch 1.5, it does not work. 
