### PR TITLE
Use static logger name in Engine.java

### DIFF
--- a/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -88,7 +88,8 @@ public abstract class Engine implements Closeable {
         this.engineConfig = engineConfig;
         this.shardId = engineConfig.getShardId();
         this.store = engineConfig.getStore();
-        this.logger = Loggers.getLogger(getClass(), engineConfig.getIndexSettings(), engineConfig.getShardId());
+        this.logger = Loggers.getLogger(Engine.class, // we use the engine class directly here to make sure all subclasses have the same logger name
+                engineConfig.getIndexSettings(), engineConfig.getShardId());
         this.failedEngineListener = engineConfig.getFailedEngineListener();
         this.deletionPolicy = engineConfig.getDeletionPolicy();
     }


### PR DESCRIPTION
To ensure subclasses like MockInternalEngine which is in a different
package (test.engine) are logging under the same logger name this commit
moves to a static logger class to determin the logger name. This way
all subclasses of engine will log under `index.engine` which also plays
nicely with `@TestLogging` where log messages sometimes disappeared since
they were enabled for the `index.engine` package but not for `test.engine`
