### PR TITLE
Remove unused code from TransportShardReplicationOperationAction

### DIFF
--- a/src/main/java/org/elasticsearch/action/support/replication/TransportShardReplicationOperationAction.java
+++ b/src/main/java/org/elasticsearch/action/support/replication/TransportShardReplicationOperationAction.java
@@ -649,44 +649,7 @@ public abstract class TransportShardReplicationOperationAction<Request extends S
 
                 });
             } else {
-                if (internalRequest.request().operationThreaded()) {
-                    try {
-                        threadPool.executor(executor).execute(new AbstractRunnable() {
-                            @Override
-                            protected void doRun() {
-                                try {
-                                    shardOperationOnReplica(shardRequest);
-                                    state.onReplicaSuccess();
-                                } catch (Throwable e) {
-                                    state.onReplicaFailure(nodeId, e);
-                                    failReplicaIfNeeded(shard.index(), shard.id(), e);
-                                }
-                            }
-
-                            // we must never reject on because of thread pool capacity on replicas
-                            @Override
-                            public boolean isForceExecution() {
-                                return true;
-                            }
-
-                            @Override
-                            public void onFailure(Throwable t) {
-                                state.onReplicaFailure(nodeId, t);
-                            }
-                        });
-                    } catch (Throwable e) {
-                        failReplicaIfNeeded(shard.index(), shard.id(), e);
-                        state.onReplicaFailure(nodeId, e);
-                    }
-                } else {
-                    try {
-                        shardOperationOnReplica(shardRequest);
-                        state.onReplicaSuccess();
-                    } catch (Throwable e) {
-                        failReplicaIfNeeded(shard.index(), shard.id(), e);
-                        state.onReplicaFailure(nodeId, e);
-                    }
-                }
+                throw new ElasticsearchIllegalStateException("detected primary and replica of shard [" + shard.index() + "][" + shard.id() + "] on same node!");
             }
         }
 


### PR DESCRIPTION
This code can only be executed if primary and replica were on the same node
in which case an exception or something of the likes would be more appropriate. 
I still find it a little tricky to figure out how replica requests end up in the indexing threadpool and will try to make a pr for that as well.
