### PR TITLE
Add INFO logging saying whether each path.data is on an SSD

### DIFF
--- a/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -163,6 +163,7 @@ public class NodeEnvironment extends AbstractComponent implements Closeable{
 
         this.nodeIndicesPaths = new Path[nodePaths.length];
         for (int i = 0; i < nodePaths.length; i++) {
+            logger.info("path " + nodePaths[i] + " spins?=" + IOUtils.spins(nodePaths[i]));
             nodeIndicesPaths[i] = nodePaths[i].resolve(INDICES_FOLDER);
         }
     }

--- a/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -147,28 +147,69 @@ public class NodeEnvironment extends AbstractComponent implements Closeable{
         if (logger.isDebugEnabled()) {
             logger.debug("using node location [{}], local_node_id [{}]", nodePaths, localNodeId);
         }
-        if (logger.isTraceEnabled()) {
+
+        // We do some I/O in here, so skip it if INFO is not enabled:
+        if (logger.isInfoEnabled()) {
             StringBuilder sb = new StringBuilder("node data locations details:\n");
             for (Path file : nodePaths) {
-                sb.append(" -> ")
-                        .append(file.toAbsolutePath())
-                        .append(", free_space [")
-                        .append(new ByteSizeValue(Files.getFileStore(file).getUnallocatedSpace()))
-                        .append("], usable_space [")
-                        .append(new ByteSizeValue(Files.getFileStore(file).getUsableSpace()))
-                        .append("]\n");
+                // NOTE: FSDirectory.open creates the directory up above so it will exist here:
+                sb.append(" -> ").append(file.toAbsolutePath());
+                try {
+                    FileStore fileStore = getFileStore(file);
+                    boolean spins = IOUtils.spins(file);
+                        sb.append(", free_space [")
+                          .append(new ByteSizeValue(fileStore.getUnallocatedSpace()))
+                          .append("], usable_space [")
+                          .append(new ByteSizeValue(fileStore.getUsableSpace()))
+                          .append("], total_space [")
+                          .append(new ByteSizeValue(fileStore.getTotalSpace()))
+                          .append("], spins? [")
+                          .append(spins ? "possibly" : "no")
+                          .append("], mount [")
+                          .append(fileStore)
+                          .append("], type [")
+                          .append(fileStore.type())
+                          .append(']');
+                } catch (Exception e) {
+                    sb.append(", ignoring exception gathering filesystem details: " + e);
+                }
+                sb.append('\n');
             }
-            logger.trace(sb.toString());
+            logger.info(sb.toString());
         }
 
         this.nodeIndicesPaths = new Path[nodePaths.length];
         for (int i = 0; i < nodePaths.length; i++) {
-            logger.info("path " + nodePaths[i] + " spins?=" + IOUtils.spins(nodePaths[i]));
             nodeIndicesPaths[i] = nodePaths[i].resolve(INDICES_FOLDER);
         }
     }
 
+    // NOTE: poached from Lucene's IOUtils:
 
+    // Files.getFileStore(Path) useless here!
+    // don't complain, just try it yourself
+    static FileStore getFileStore(Path path) throws IOException {
+        FileStore store = Files.getFileStore(path);
+        String mount = getMountPoint(store);
+
+        // find the "matching" FileStore from system list, it's the one we want.
+        for (FileStore fs : path.getFileSystem().getFileStores()) {
+            if (mount.equals(getMountPoint(fs))) {
+                return fs;
+            }
+        }
+
+        // fall back to crappy one we got from Files.getFileStore
+        return store;    
+    }
+
+    // NOTE: poached from Lucene's IOUtils:
+
+    // these are hacks that are not guaranteed
+    static String getMountPoint(FileStore store) {
+        String desc = store.toString();
+        return desc.substring(0, desc.lastIndexOf('(') - 1);
+    }
 
     /**
      * Deletes a shard data directory iff the shards locks were successfully acquired.

--- a/src/main/java/org/elasticsearch/index/store/fs/FsDirectoryService.java
+++ b/src/main/java/org/elasticsearch/index/store/fs/FsDirectoryService.java
@@ -24,6 +24,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.apache.lucene.store.*;
+import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.common.metrics.CounterMetric;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.settings.IndexSettings;
@@ -76,6 +77,7 @@ public abstract class FsDirectoryService extends DirectoryService implements Sto
         for (int i = 0; i < dirs.length; i++) {
             Files.createDirectories(locations[i]);
             Directory wrapped = newFSDirectory(locations[i], buildLockFactory());
+            logger.info("path " + locations[i] + " spins?=" + IOUtils.spins(wrapped));
             dirs[i] = new RateLimitedFSDirectory(wrapped, this, this) ;
         }
         return dirs;

--- a/src/main/java/org/elasticsearch/index/store/fs/FsDirectoryService.java
+++ b/src/main/java/org/elasticsearch/index/store/fs/FsDirectoryService.java
@@ -24,7 +24,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.apache.lucene.store.*;
-import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.common.metrics.CounterMetric;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.settings.IndexSettings;
@@ -77,7 +76,6 @@ public abstract class FsDirectoryService extends DirectoryService implements Sto
         for (int i = 0; i < dirs.length; i++) {
             Files.createDirectories(locations[i]);
             Directory wrapped = newFSDirectory(locations[i], buildLockFactory());
-            logger.info("path " + locations[i] + " spins?=" + IOUtils.spins(wrapped));
             dirs[i] = new RateLimitedFSDirectory(wrapped, this, this) ;
         }
         return dirs;


### PR DESCRIPTION
Recently in Lucene we added an IOUtils.spins() method, which returns true for old-fashioned spinning magnets hard drives, and false for SSDs or RAM disks.

It's best effort, but should work well on Linux.

I think we should log this?  It can be helpful when looking at a node's log to see whether it's using SSDs for not for it shards...
