### PR TITLE
Deprecate rivers

### DIFF
--- a/docs/reference/modules/plugins.asciidoc
+++ b/docs/reference/modules/plugins.asciidoc
@@ -217,6 +217,8 @@ You can disable that check using `plugins.check_lucene: false`.
 [[river]]
 ==== River Plugins
 
+deprecated[1.5.0,Rivers have been deprecated.  See https://www.elastic.co/blog/deprecating_rivers for more details]
+
 .Supported by Elasticsearch
 * https://github.com/elasticsearch/elasticsearch-river-couchdb[CouchDB River Plugin]
 * https://github.com/elasticsearch/elasticsearch-river-rabbitmq[RabbitMQ River Plugin]

--- a/src/main/java/org/elasticsearch/river/AbstractRiverComponent.java
+++ b/src/main/java/org/elasticsearch/river/AbstractRiverComponent.java
@@ -23,8 +23,9 @@ import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
 
 /**
- *
+ * @deprecated See blog post https://www.elastic.co/blog/deprecating_rivers
  */
+@Deprecated
 public class AbstractRiverComponent implements RiverComponent {
 
     protected final ESLogger logger;

--- a/src/main/java/org/elasticsearch/river/River.java
+++ b/src/main/java/org/elasticsearch/river/River.java
@@ -22,7 +22,9 @@ package org.elasticsearch.river;
 /**
  * Allows to import data into elasticsearch via plugin
  * Gets allocated on a node and eventually automatically re-allocated if needed
+ * @deprecated See blog post https://www.elastic.co/blog/deprecating_rivers
  */
+@Deprecated
 public interface River extends RiverComponent {
 
     /**

--- a/src/main/java/org/elasticsearch/river/RiverComponent.java
+++ b/src/main/java/org/elasticsearch/river/RiverComponent.java
@@ -20,8 +20,9 @@
 package org.elasticsearch.river;
 
 /**
- *
+ * @deprecated See blog post https://www.elastic.co/blog/deprecating_rivers
  */
+@Deprecated
 public interface RiverComponent {
 
     RiverName riverName();

--- a/src/main/java/org/elasticsearch/river/RiverName.java
+++ b/src/main/java/org/elasticsearch/river/RiverName.java
@@ -22,8 +22,9 @@ package org.elasticsearch.river;
 import java.io.Serializable;
 
 /**
- *
+ * @deprecated See blog post https://www.elastic.co/blog/deprecating_rivers
  */
+@Deprecated
 public class RiverName implements Serializable {
 
     private final String type;

--- a/src/main/java/org/elasticsearch/river/RiversService.java
+++ b/src/main/java/org/elasticsearch/river/RiversService.java
@@ -126,6 +126,7 @@ public class RiversService extends AbstractLifecycleComponent<RiversService> {
             return;
         }
 
+        logger.info("rivers have been deprecated. Read https://www.elastic.co/blog/deprecating_rivers");
         logger.debug("creating river [{}][{}]", riverName.type(), riverName.name());
 
         try {


### PR DESCRIPTION
- In code, we mark River class as deprecated
- We log that information when a cluster is still using it
- We add this information in the plugins list as well
