### PR TITLE
Fix to pom.xml to allow eclipse maven integration using m2e

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1599,6 +1599,32 @@
                                         <execute/>
                                     </action>
                                 </pluginExecution>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>org.apache.maven.plugins</groupId>
+                                        <artifactId>maven-antrun-plugin</artifactId>
+                                        <versionRange>[1.0.0,)</versionRange>
+                                        <goals>
+                                            <goal>run</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <execute/>
+                                    </action>
+                                </pluginExecution>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>org.apache.maven.plugins</groupId>
+                                        <artifactId>maven-resources-plugin</artifactId>
+                                        <versionRange>[1.0.0,)</versionRange>
+                                        <goals>
+                                            <goal>copy-resources</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                    	<ignore/>
+                                    </action>
+                                </pluginExecution>
                             </pluginExecutions>
                         </lifecycleMappingMetadata>
                     </configuration>


### PR DESCRIPTION
Although eclipse currently works with the `mvn eclipse:eclipse` command, this will allow people to enable the m2e maven integration in eclipse.

The fix only changes the eclipse lifecycle mapping plugin so will not affect anything outside of the eclipse build. It instructs eclipse to execute the antrun plugin during an incremental or full build in the IDE and to ignore the maven-resources-plugin. The resources plugin is only used for the rpm and deb packaging so is not required for the IDE build.
