### PR TITLE
Fix typo in JVM checker user help.

### DIFF
--- a/src/main/java/org/elasticsearch/bootstrap/JVMCheck.java
+++ b/src/main/java/org/elasticsearch/bootstrap/JVMCheck.java
@@ -68,7 +68,7 @@ public class JVMCheck {
             if (workAround != null) {
                 sb.append(System.lineSeparator());
                 sb.append("If you absolutely cannot upgrade, please add ").append(workAround);
-                sb.append(" to the JVM_OPTS environment variable.");
+                sb.append(" to the JAVA_OPTS environment variable.");
                 sb.append(System.lineSeparator());
                 sb.append("Upgrading is preferred, this workaround will result in degraded performance.");
             }


### PR DESCRIPTION
When checking the JVM currently running ES we provide the user with
help on which environment variable to use to disable the check in
case the check fails. The variable we point to however is the wrong
one.

(As discussed by mail previously.)
