### PR TITLE
Fix updating templates.

### DIFF
--- a/src/test/java/org/elasticsearch/script/IndexedScriptTests.java
+++ b/src/test/java/org/elasticsearch/script/IndexedScriptTests.java
@@ -22,6 +22,7 @@ package org.elasticsearch.script;
 
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.action.indexedscripts.put.PutIndexedScriptResponse;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
@@ -85,6 +86,30 @@ public class IndexedScriptTests extends ElasticsearchIntegrationTest {
         SearchHit sh = searchResponse.getHits().getAt(0);
         assertThat((Integer)sh.field("test1").getValue(), equalTo(2));
         assertThat((Integer)sh.field("test2").getValue(), equalTo(6));
+    }
+
+    // Relates to #10397
+    @Test
+    public void testUpdateScripts() {
+        createIndex("test_index");
+        ensureGreen("test_index");
+        client().prepareIndex("test_index", "test_type", "1").setSource("{\"foo\":\"bar\"}").get();
+        flush("test_index");
+
+        int iterations = randomIntBetween(2, 11);
+        for (int i = 1; i < iterations; i++) {
+            PutIndexedScriptResponse response = 
+                    client().preparePutIndexedScript(GroovyScriptEngineService.NAME, "script1", "{\"script\":\"" + i + "\"}").get();
+            assertEquals(i, response.getVersion());
+            
+            String query = "{"
+                    + " \"query\" : { \"match_all\": {}}, "
+                    + " \"script_fields\" : { \"test_field\" : { \"script_id\" : \"script1\", \"lang\":\"groovy\" } } }";    
+            SearchResponse searchResponse = client().prepareSearch().setSource(query).setIndices("test_index").setTypes("test_type").get();
+            assertHitCount(searchResponse, 1);
+            SearchHit sh = searchResponse.getHits().getAt(0);
+            assertThat((Integer)sh.field("test_field").getValue(), equalTo(i));
+        }
     }
 
     @Test


### PR DESCRIPTION
Closes #10397 

When putting new templates to an index they are added to the cache
of compiled templates as a side effect of the validate method. When
updating templates they are also validated but the scripts that are
already in the cache never get updated.

@javanna Assigning to you for review as you seem to have written most of the code this PR touches, feel free to re-assign.
