### PR TITLE
Improve exception message when indexing a boolean value into a numeric field

### DIFF
--- a/src/main/java/org/elasticsearch/common/xcontent/support/AbstractXContentParser.java
+++ b/src/main/java/org/elasticsearch/common/xcontent/support/AbstractXContentParser.java
@@ -104,6 +104,8 @@ public abstract class AbstractXContentParser implements XContentParser {
         if (token == Token.VALUE_STRING) {
             checkCoerceString(coerce, Short.class);
             return Short.parseShort(text());
+        } else if (token == Token.VALUE_BOOLEAN) {
+            throw new NumberFormatException("For input boolean value: " + booleanValue());
         }
         short result = doShortValue();
         ensureNumberConversion(coerce, result, Short.class);
@@ -124,6 +126,8 @@ public abstract class AbstractXContentParser implements XContentParser {
         if (token == Token.VALUE_STRING) {
             checkCoerceString(coerce, Integer.class);
             return Integer.parseInt(text());
+        } else if (token == Token.VALUE_BOOLEAN) {
+            throw new NumberFormatException("For input boolean value: " + booleanValue());
         }
         int result = doIntValue();
         ensureNumberConversion(coerce, result, Integer.class);
@@ -143,6 +147,8 @@ public abstract class AbstractXContentParser implements XContentParser {
         if (token == Token.VALUE_STRING) {
             checkCoerceString(coerce, Long.class);
             return Long.parseLong(text());
+        } else if (token == Token.VALUE_BOOLEAN) {
+            throw new NumberFormatException("For input boolean value: " + booleanValue());
         }
         long result = doLongValue();
         ensureNumberConversion(coerce, result, Long.class);
@@ -162,6 +168,8 @@ public abstract class AbstractXContentParser implements XContentParser {
         if (token == Token.VALUE_STRING) {
             checkCoerceString(coerce, Float.class);
             return Float.parseFloat(text());
+        } else if (token == Token.VALUE_BOOLEAN) {
+            throw new NumberFormatException("For input boolean value: " + booleanValue());
         }
         return doFloatValue();
     }
@@ -180,6 +188,8 @@ public abstract class AbstractXContentParser implements XContentParser {
         if (token == Token.VALUE_STRING) {
             checkCoerceString(coerce, Double.class);
             return Double.parseDouble(text());
+        } else if (token == Token.VALUE_BOOLEAN) {
+            throw new NumberFormatException("For input boolean value: " + booleanValue());
         }
         return doDoubleValue();
     }


### PR DESCRIPTION
Makes the exception consistent with other "incorrect data type" exceptions, instead of a cryptic internal exception due to trying to derive a long from VALUE_BOOLEAN.

New exception will look like this:

```
PUT /tweets/
{
   "mappings": {
      "tweet": {
         "properties": {
            "key": {
               "type": "integer"
            }
         }
      }
   }
}

PUT /tweets/tweet/1
{ "key" : true }
```

```
{
   "error": "MapperParsingException[failed to parse [key]]; nested: NumberFormatException[For input boolean value: true]; ",
   "status": 400
}
```

Instead of the existing message:

```
{
  "error": "MapperParsingException[failed to parse [key]]; nested: JsonParseException[Current token (VALUE_TRUE) not numeric, can not use numeric value accessors\n at [Source: [B@464291b8; line: 1, column: 15]]; ",
  "status": 400
}
```

Fixes #10056
