### PR TITLE
Added an optimize_bbox option for geo_polygon filters.

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/GeoPolygonFilterBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoPolygonFilterBuilder.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.query;
 
 import com.google.common.collect.Lists;
+
 import org.elasticsearch.common.geo.GeoHashUtils;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -33,10 +34,12 @@ import java.util.List;
 public class GeoPolygonFilterBuilder extends BaseFilterBuilder {
 
     public static final String POINTS = GeoPolygonFilterParser.POINTS;
-    
+
     private final String name;
 
     private final List<GeoPoint> shell = Lists.newArrayList();
+
+    private String optimizeBbox;
 
     private Boolean cache;
     private String cacheKey;
@@ -66,7 +69,12 @@ public class GeoPolygonFilterBuilder extends BaseFilterBuilder {
         shell.add(point);
         return this;
     }
-    
+
+    public GeoPolygonFilterBuilder optimizeBbox(String optimizeBbox) {
+        this.optimizeBbox = optimizeBbox;
+        return this;
+    }
+
     /**
      * Sets the filter name for the filter that can be used when searching for matched_filters per hit.
      */
@@ -100,6 +108,9 @@ public class GeoPolygonFilterBuilder extends BaseFilterBuilder {
         builder.endArray();
         builder.endObject();
 
+        if (optimizeBbox != null) {
+            builder.field("optimize_bbox", optimizeBbox);
+        }
         if (filterName != null) {
             builder.field("_name", filterName);
         }

--- a/src/main/java/org/elasticsearch/index/query/GeoPolygonFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoPolygonFilterParser.java
@@ -74,6 +74,7 @@ public class GeoPolygonFilterParser implements FilterParser {
 
         List<GeoPoint> shell = Lists.newArrayList();
 
+        String optimizeBbox = "memory";
         boolean normalizeLon = true;
         boolean normalizeLat = true;
 
@@ -109,6 +110,8 @@ public class GeoPolygonFilterParser implements FilterParser {
                     cache = parseContext.parseFilterCachePolicy();
                 } else if ("_cache_key".equals(currentFieldName) || "_cacheKey".equals(currentFieldName)) {
                     cacheKey = new HashedBytesRef(parser.text());
+                } else if ("optimize_bbox".equals(currentFieldName)) {
+                    optimizeBbox = parser.textOrNull();
                 } else if ("normalize".equals(currentFieldName)) {
                     normalizeLat = parser.booleanValue();
                     normalizeLon = parser.booleanValue();
@@ -151,7 +154,9 @@ public class GeoPolygonFilterParser implements FilterParser {
         }
 
         IndexGeoPointFieldData indexFieldData = parseContext.getForField(mapper);
-        Filter filter = new GeoPolygonFilter(indexFieldData, shell.toArray(new GeoPoint[shell.size()]));
+        GeoPointFieldMapper geoMapper = (GeoPointFieldMapper) mapper;
+
+        Filter filter = new GeoPolygonFilter(indexFieldData, geoMapper, shell.toArray(new GeoPoint[shell.size()]), optimizeBbox);
         if (cache != null) {
             filter = parseContext.cacheFilter(filter, cacheKey, cache);
         }


### PR DESCRIPTION
This setting is analogous to the one for geo_distance filters, and defaults to "memory". Note
that the optimization will need to be updated when addressing #5968.

Closes #10356.
