### PR TITLE
Cleanup JVM info and stats

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodes.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodes.java
@@ -548,13 +548,13 @@ public class ClusterStatsNodes implements ToXContent, Streamable {
             if (js == null) {
                 return;
             }
-            if (js.threads() != null) {
-                threads += js.threads().count();
+            if (js.getThreads() != null) {
+                threads += js.getThreads().getCount();
             }
-            maxUptime = Math.max(maxUptime, js.uptime().millis());
-            if (js.mem() != null) {
-                heapUsed += js.mem().getHeapUsed().bytes();
-                heapMax += js.mem().getHeapMax().bytes();
+            maxUptime = Math.max(maxUptime, js.getUptime().millis());
+            if (js.getMem() != null) {
+                heapUsed += js.getMem().getHeapUsed().bytes();
+                heapMax += js.getMem().getHeapMax().bytes();
             }
         }
 
@@ -640,9 +640,9 @@ public class ClusterStatsNodes implements ToXContent, Streamable {
 
         JvmVersion(JvmInfo jvmInfo) {
             version = jvmInfo.version();
-            vmName = jvmInfo.vmName();
-            vmVersion = jvmInfo.vmVersion();
-            vmVendor = jvmInfo.vmVendor();
+            vmName = jvmInfo.getVmName();
+            vmVersion = jvmInfo.getVmVersion();
+            vmVendor = jvmInfo.getVmVendor();
         }
 
         JvmVersion() {

--- a/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
+++ b/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
@@ -182,7 +182,7 @@ public class Bootstrap {
         }
 
         // warn if running using the client VM
-        if (JvmInfo.jvmInfo().vmName().toLowerCase(Locale.ROOT).contains("client")) {
+        if (JvmInfo.jvmInfo().getVmName().toLowerCase(Locale.ROOT).contains("client")) {
             ESLogger logger = Loggers.getLogger(Bootstrap.class);
             logger.warn("jvm uses the client vm, make sure to run `java` with the server vm for best performance by adding `-server` to the command line");
         }

--- a/src/main/java/org/elasticsearch/http/netty/NettyHttpServerTransport.java
+++ b/src/main/java/org/elasticsearch/http/netty/NettyHttpServerTransport.java
@@ -168,9 +168,9 @@ public class NettyHttpServerTransport extends AbstractLifecycleComponent<HttpSer
         this.detailedErrorsEnabled = settings.getAsBoolean(SETTING_HTTP_DETAILED_ERRORS_ENABLED, true);
 
         long defaultReceiverPredictor = 512 * 1024;
-        if (JvmInfo.jvmInfo().mem().directMemoryMax().bytes() > 0) {
+        if (JvmInfo.jvmInfo().getMem().getDirectMemoryMax().bytes() > 0) {
             // we can guess a better default...
-            long l = (long) ((0.3 * JvmInfo.jvmInfo().mem().directMemoryMax().bytes()) / workerCount);
+            long l = (long) ((0.3 * JvmInfo.jvmInfo().getMem().getDirectMemoryMax().bytes()) / workerCount);
             defaultReceiverPredictor = Math.min(defaultReceiverPredictor, Math.max(l, 64 * 1024));
         }
 

--- a/src/main/java/org/elasticsearch/indices/memory/IndexingMemoryController.java
+++ b/src/main/java/org/elasticsearch/indices/memory/IndexingMemoryController.java
@@ -77,7 +77,7 @@ public class IndexingMemoryController extends AbstractLifecycleComponent<Indexin
         String indexingBufferSetting = this.settings.get("indices.memory.index_buffer_size", "10%");
         if (indexingBufferSetting.endsWith("%")) {
             double percent = Double.parseDouble(indexingBufferSetting.substring(0, indexingBufferSetting.length() - 1));
-            indexingBuffer = new ByteSizeValue((long) (((double) JvmInfo.jvmInfo().mem().heapMax().bytes()) * (percent / 100)));
+            indexingBuffer = new ByteSizeValue((long) (((double) JvmInfo.jvmInfo().getMem().getHeapMax().bytes()) * (percent / 100)));
             ByteSizeValue minIndexingBuffer = this.settings.getAsBytesSize("indices.memory.min_index_buffer_size", new ByteSizeValue(48, ByteSizeUnit.MB));
             ByteSizeValue maxIndexingBuffer = this.settings.getAsBytesSize("indices.memory.max_index_buffer_size", null);
 
@@ -99,7 +99,7 @@ public class IndexingMemoryController extends AbstractLifecycleComponent<Indexin
         String translogBufferSetting = this.settings.get("indices.memory.translog_buffer_size", "1%");
         if (translogBufferSetting.endsWith("%")) {
             double percent = Double.parseDouble(translogBufferSetting.substring(0, translogBufferSetting.length() - 1));
-            translogBuffer = new ByteSizeValue((long) (((double) JvmInfo.jvmInfo().mem().heapMax().bytes()) * (percent / 100)));
+            translogBuffer = new ByteSizeValue((long) (((double) JvmInfo.jvmInfo().getMem().getHeapMax().bytes()) * (percent / 100)));
             ByteSizeValue minTranslogBuffer = this.settings.getAsBytesSize("indices.memory.min_translog_buffer_size", new ByteSizeValue(256, ByteSizeUnit.KB));
             ByteSizeValue maxTranslogBuffer = this.settings.getAsBytesSize("indices.memory.max_translog_buffer_size", null);
 

--- a/src/main/java/org/elasticsearch/monitor/jvm/JvmInfo.java
+++ b/src/main/java/org/elasticsearch/monitor/jvm/JvmInfo.java
@@ -208,76 +208,40 @@ public class JvmInfo implements Streamable, Serializable, ToXContent {
         }
     }
 
-    public String vmName() {
-        return vmName;
-    }
-
     public String getVmName() {
-        return vmName;
-    }
-
-    public String vmVersion() {
-        return vmVersion;
+        return this.vmName;
     }
 
     public String getVmVersion() {
-        return vmVersion;
-    }
-
-    public String vmVendor() {
-        return vmVendor;
+        return this.vmVersion;
     }
 
     public String getVmVendor() {
-        return vmVendor;
-    }
-
-    public long startTime() {
-        return startTime;
+        return this.vmVendor;
     }
 
     public long getStartTime() {
-        return startTime;
-    }
-
-    public Mem mem() {
-        return mem;
+        return this.startTime;
     }
 
     public Mem getMem() {
-        return mem();
-    }
-
-    public String[] inputArguments() {
-        return inputArguments;
+        return this.mem;
     }
 
     public String[] getInputArguments() {
-        return inputArguments;
-    }
-
-    public String bootClassPath() {
-        return bootClassPath;
+        return this.inputArguments;
     }
 
     public String getBootClassPath() {
-        return bootClassPath;
-    }
-
-    public String classPath() {
-        return classPath;
+        return this.bootClassPath;
     }
 
     public String getClassPath() {
-        return classPath;
-    }
-
-    public Map<String, String> systemProperties() {
-        return systemProperties;
+        return this.classPath;
     }
 
     public Map<String, String> getSystemProperties() {
-        return systemProperties;
+        return this.systemProperties;
     }
 
     @Override
@@ -396,50 +360,24 @@ public class JvmInfo implements Streamable, Serializable, ToXContent {
         Mem() {
         }
 
-        public ByteSizeValue heapInit() {
+        public ByteSizeValue getHeapInit() {
             return new ByteSizeValue(heapInit);
         }
 
-        public ByteSizeValue getHeapInit() {
-            return heapInit();
-        }
-
-        public ByteSizeValue heapMax() {
+        public ByteSizeValue getHeapMax() {
             return new ByteSizeValue(heapMax);
         }
 
-        public ByteSizeValue getHeapMax() {
-            return heapMax();
-        }
-
-        public ByteSizeValue nonHeapInit() {
+        public ByteSizeValue getNonHeapInit() {
             return new ByteSizeValue(nonHeapInit);
         }
 
-        public ByteSizeValue getNonHeapInit() {
-            return nonHeapInit();
-        }
-
-        public ByteSizeValue nonHeapMax() {
+        public ByteSizeValue getNonHeapMax() {
             return new ByteSizeValue(nonHeapMax);
         }
 
-        public ByteSizeValue getNonHeapMax() {
-            return nonHeapMax();
-        }
-
-        public ByteSizeValue directMemoryMax() {
-            return new ByteSizeValue(directMemoryMax);
-        }
-
         public ByteSizeValue getDirectMemoryMax() {
-            return directMemoryMax();
-        }
-
-        public static Mem readMem(StreamInput in) throws IOException {
-            Mem mem = new Mem();
-            mem.readFrom(in);
-            return mem;
+            return new ByteSizeValue(directMemoryMax);
         }
 
         @Override

--- a/src/main/java/org/elasticsearch/monitor/jvm/JvmMonitorService.java
+++ b/src/main/java/org/elasticsearch/monitor/jvm/JvmMonitorService.java
@@ -29,9 +29,7 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.FutureUtils;
 import org.elasticsearch.threadpool.ThreadPool;
 
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ScheduledFuture;
 
 import static org.elasticsearch.common.unit.TimeValue.timeValueSeconds;
@@ -107,7 +105,7 @@ public class JvmMonitorService extends AbstractLifecycleComponent<JvmMonitorServ
 
         this.gcThresholds = gcThresholds.immutableMap();
 
-        logger.debug("enabled [{}], last_gc_enabled [{}], interval [{}], gc_threshold [{}]", enabled, JvmStats.isLastGcEnabled(), interval, this.gcThresholds);
+        logger.debug("enabled [{}], interval [{}], gc_threshold [{}]", enabled, interval, this.gcThresholds);
     }
 
     @Override
@@ -133,10 +131,7 @@ public class JvmMonitorService extends AbstractLifecycleComponent<JvmMonitorServ
     private class JvmMonitor implements Runnable {
 
         private JvmStats lastJvmStats = jvmStats();
-
         private long seq = 0;
-
-        private final Set<DeadlockAnalyzer.Deadlock> lastSeenDeadlocks = new HashSet<>();
 
         public JvmMonitor() {
         }
@@ -144,7 +139,6 @@ public class JvmMonitorService extends AbstractLifecycleComponent<JvmMonitorServ
         @Override
         public void run() {
             try {
-//            monitorDeadlock();
                 monitorLongGc();
             } catch (Throwable t) {
                 logger.debug("failed to monitor", t);
@@ -155,8 +149,8 @@ public class JvmMonitorService extends AbstractLifecycleComponent<JvmMonitorServ
             seq++;
             JvmStats currentJvmStats = jvmStats();
 
-            for (int i = 0; i < currentJvmStats.gc().collectors().length; i++) {
-                GarbageCollector gc = currentJvmStats.gc().collectors()[i];
+            for (int i = 0; i < currentJvmStats.getGc().getCollectors().length; i++) {
+                GarbageCollector gc = currentJvmStats.getGc().getCollectors()[i];
                 GarbageCollector prevGc = lastJvmStats.gc.collectors[i];
 
                 // no collection has happened
@@ -169,44 +163,22 @@ public class JvmMonitorService extends AbstractLifecycleComponent<JvmMonitorServ
                     continue;
                 }
 
-                GcThreshold gcThreshold = gcThresholds.get(gc.name());
+                GcThreshold gcThreshold = gcThresholds.get(gc.getName());
                 if (gcThreshold == null) {
                     gcThreshold = gcThresholds.get("default");
-                }
-
-                if (gc.lastGc() != null && prevGc.lastGc() != null) {
-                    GarbageCollector.LastGc lastGc = gc.lastGc();
-                    if (lastGc.startTime == prevGc.lastGc().startTime()) {
-                        // we already handled this one...
-                        continue;
-                    }
-                    // Ignore any duration > 1hr; getLastGcInfo occasionally returns total crap
-                    if (lastGc.duration().hoursFrac() > 1) {
-                        continue;
-                    }
-                    if (lastGc.duration().millis() > gcThreshold.warnThreshold) {
-                        logger.warn("[last_gc][{}][{}][{}] duration [{}], collections [{}], total [{}]/[{}], reclaimed [{}], leaving [{}][{}]/[{}]",
-                                gc.name(), seq, gc.getCollectionCount(), lastGc.duration(), collections, TimeValue.timeValueMillis(collectionTime), gc.collectionTime(), lastGc.reclaimed(), lastGc.afterUsed(), lastGc.max());
-                    } else if (lastGc.duration().millis() > gcThreshold.infoThreshold) {
-                        logger.info("[last_gc][{}][{}][{}] duration [{}], collections [{}], total [{}]/[{}], reclaimed [{}], leaving [{}]/[{}]",
-                                gc.name(), seq, gc.getCollectionCount(), lastGc.duration(), collections, TimeValue.timeValueMillis(collectionTime), gc.collectionTime(), lastGc.reclaimed(), lastGc.afterUsed(), lastGc.max());
-                    } else if (lastGc.duration().millis() > gcThreshold.debugThreshold && logger.isDebugEnabled()) {
-                        logger.debug("[last_gc][{}][{}][{}] duration [{}], collections [{}], total [{}]/[{}], reclaimed [{}], leaving [{}]/[{}]",
-                                gc.name(), seq, gc.getCollectionCount(), lastGc.duration(), collections, TimeValue.timeValueMillis(collectionTime), gc.collectionTime(), lastGc.reclaimed(), lastGc.afterUsed(), lastGc.max());
-                    }
                 }
 
                 long avgCollectionTime = collectionTime / collections;
 
                 if (avgCollectionTime > gcThreshold.warnThreshold) {
                     logger.warn("[gc][{}][{}][{}] duration [{}], collections [{}]/[{}], total [{}]/[{}], memory [{}]->[{}]/[{}], all_pools {}",
-                            gc.name(), seq, gc.collectionCount(), TimeValue.timeValueMillis(collectionTime), collections, TimeValue.timeValueMillis(currentJvmStats.timestamp() - lastJvmStats.timestamp()), TimeValue.timeValueMillis(collectionTime), gc.collectionTime(), lastJvmStats.mem().heapUsed(), currentJvmStats.mem().heapUsed(), JvmInfo.jvmInfo().mem().heapMax(), buildPools(lastJvmStats, currentJvmStats));
+                            gc.getName(), seq, gc.getCollectionCount(), TimeValue.timeValueMillis(collectionTime), collections, TimeValue.timeValueMillis(currentJvmStats.getTimestamp() - lastJvmStats.getTimestamp()), TimeValue.timeValueMillis(collectionTime), gc.getCollectionTime(), lastJvmStats.getMem().getHeapUsed(), currentJvmStats.getMem().getHeapUsed(), JvmInfo.jvmInfo().getMem().getHeapMax(), buildPools(lastJvmStats, currentJvmStats));
                 } else if (avgCollectionTime > gcThreshold.infoThreshold) {
                     logger.info("[gc][{}][{}][{}] duration [{}], collections [{}]/[{}], total [{}]/[{}], memory [{}]->[{}]/[{}], all_pools {}",
-                            gc.name(), seq, gc.collectionCount(), TimeValue.timeValueMillis(collectionTime), collections, TimeValue.timeValueMillis(currentJvmStats.timestamp() - lastJvmStats.timestamp()), TimeValue.timeValueMillis(collectionTime), gc.collectionTime(), lastJvmStats.mem().heapUsed(), currentJvmStats.mem().heapUsed(), JvmInfo.jvmInfo().mem().heapMax(), buildPools(lastJvmStats, currentJvmStats));
+                            gc.getName(), seq, gc.getCollectionCount(), TimeValue.timeValueMillis(collectionTime), collections, TimeValue.timeValueMillis(currentJvmStats.getTimestamp() - lastJvmStats.getTimestamp()), TimeValue.timeValueMillis(collectionTime), gc.getCollectionTime(), lastJvmStats.getMem().getHeapUsed(), currentJvmStats.getMem().getHeapUsed(), JvmInfo.jvmInfo().getMem().getHeapMax(), buildPools(lastJvmStats, currentJvmStats));
                 } else if (avgCollectionTime > gcThreshold.debugThreshold && logger.isDebugEnabled()) {
                     logger.debug("[gc][{}][{}][{}] duration [{}], collections [{}]/[{}], total [{}]/[{}], memory [{}]->[{}]/[{}], all_pools {}",
-                            gc.name(), seq, gc.collectionCount(), TimeValue.timeValueMillis(collectionTime), collections, TimeValue.timeValueMillis(currentJvmStats.timestamp() - lastJvmStats.timestamp()), TimeValue.timeValueMillis(collectionTime), gc.collectionTime(), lastJvmStats.mem().heapUsed(), currentJvmStats.mem().heapUsed(), JvmInfo.jvmInfo().mem().heapMax(), buildPools(lastJvmStats, currentJvmStats));
+                            gc.getName(), seq, gc.getCollectionCount(), TimeValue.timeValueMillis(collectionTime), collections, TimeValue.timeValueMillis(currentJvmStats.getTimestamp() - lastJvmStats.getTimestamp()), TimeValue.timeValueMillis(collectionTime), gc.getCollectionTime(), lastJvmStats.getMem().getHeapUsed(), currentJvmStats.getMem().getHeapUsed(), JvmInfo.jvmInfo().getMem().getHeapMax(), buildPools(lastJvmStats, currentJvmStats));
                 }
             }
             lastJvmStats = currentJvmStats;
@@ -214,16 +186,16 @@ public class JvmMonitorService extends AbstractLifecycleComponent<JvmMonitorServ
 
         private String buildPools(JvmStats prev, JvmStats current) {
             StringBuilder sb = new StringBuilder();
-            for (JvmStats.MemoryPool currentPool : current.mem()) {
+            for (JvmStats.MemoryPool currentPool : current.getMem()) {
                 JvmStats.MemoryPool prevPool = null;
-                for (JvmStats.MemoryPool pool : prev.mem()) {
+                for (JvmStats.MemoryPool pool : prev.getMem()) {
                     if (pool.getName().equals(currentPool.getName())) {
                         prevPool = pool;
                         break;
                     }
                 }
-                sb.append("{[").append(currentPool.name())
-                        .append("] [").append(prevPool == null ? "?" : prevPool.used()).append("]->[").append(currentPool.used()).append("]/[").append(currentPool.getMax()).append("]}");
+                sb.append("{[").append(currentPool.getName())
+                        .append("] [").append(prevPool == null ? "?" : prevPool.getUsed()).append("]->[").append(currentPool.getUsed()).append("]/[").append(currentPool.getMax()).append("]}");
             }
             return sb.toString();
         }

--- a/src/main/java/org/elasticsearch/monitor/jvm/JvmService.java
+++ b/src/main/java/org/elasticsearch/monitor/jvm/JvmService.java
@@ -51,7 +51,7 @@ public class JvmService extends AbstractComponent {
     }
 
     public synchronized JvmStats stats() {
-        if ((System.currentTimeMillis() - jvmStats.timestamp()) > refreshInterval.millis()) {
+        if ((System.currentTimeMillis() - jvmStats.getTimestamp()) > refreshInterval.millis()) {
             jvmStats = JvmStats.jvmStats();
         }
         return jvmStats;

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
@@ -249,7 +249,7 @@ public class RestNodesAction extends AbstractCatAction {
             table.addCell(jvmInfo == null ? null : jvmInfo.version());
             table.addCell(fsStats == null ? null : fsStats.getTotal().getAvailable());
             table.addCell(jvmStats == null ? null : jvmStats.getMem().getHeapUsed());
-            table.addCell(jvmStats == null ? null : jvmStats.getMem().getHeapUsedPrecent());
+            table.addCell(jvmStats == null ? null : jvmStats.getMem().getHeapUsedPercent());
             table.addCell(jvmInfo == null ? null : jvmInfo.getMem().getHeapMax());
             table.addCell(osStats == null ? null : osStats.getMem() == null ? null : osStats.getMem().used());
             table.addCell(osStats == null ? null : osStats.getMem() == null ? null : osStats.getMem().usedPercent());
@@ -260,7 +260,7 @@ public class RestNodesAction extends AbstractCatAction {
             table.addCell(processInfo == null ? null : processInfo.getMaxFileDescriptors());
 
             table.addCell(osStats == null ? null : osStats.getLoadAverage().length < 1 ? null : String.format(Locale.ROOT, "%.2f", osStats.getLoadAverage()[0]));
-            table.addCell(jvmStats == null ? null : jvmStats.uptime());
+            table.addCell(jvmStats == null ? null : jvmStats.getUptime());
             table.addCell(node.clientNode() ? "c" : node.dataNode() ? "d" : "-");
             table.addCell(masterId == null ? "x" : masterId.equals(node.id()) ? "*" : node.masterNode() ? "m" : "-");
             table.addCell(node.name());

--- a/src/main/java/org/elasticsearch/transport/netty/NettyTransport.java
+++ b/src/main/java/org/elasticsearch/transport/netty/NettyTransport.java
@@ -77,7 +77,6 @@ import java.nio.channels.CancelledKeyException;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -195,9 +194,9 @@ public class NettyTransport extends AbstractLifecycleComponent<Transport> implem
         }
 
         long defaultReceiverPredictor = 512 * 1024;
-        if (JvmInfo.jvmInfo().mem().directMemoryMax().bytes() > 0) {
+        if (JvmInfo.jvmInfo().getMem().getDirectMemoryMax().bytes() > 0) {
             // we can guess a better default...
-            long l = (long) ((0.3 * JvmInfo.jvmInfo().mem().directMemoryMax().bytes()) / workerCount);
+            long l = (long) ((0.3 * JvmInfo.jvmInfo().getMem().getDirectMemoryMax().bytes()) / workerCount);
             defaultReceiverPredictor = Math.min(defaultReceiverPredictor, Math.max(l, 64 * 1024));
         }
 

--- a/src/main/java/org/elasticsearch/transport/netty/SizeHeaderFrameDecoder.java
+++ b/src/main/java/org/elasticsearch/transport/netty/SizeHeaderFrameDecoder.java
@@ -36,7 +36,7 @@ import java.io.StreamCorruptedException;
  */
 public class SizeHeaderFrameDecoder extends FrameDecoder {
 
-    private static final long NINETY_PER_HEAP_SIZE = (long) (JvmInfo.jvmInfo().mem().heapMax().bytes() * 0.9);
+    private static final long NINETY_PER_HEAP_SIZE = (long) (JvmInfo.jvmInfo().getMem().getHeapMax().bytes() * 0.9);
 
     @Override
     protected Object decode(ChannelHandlerContext ctx, Channel channel, ChannelBuffer buffer) throws Exception {

--- a/src/test/java/org/elasticsearch/benchmark/search/scroll/ScrollSearchBenchmark.java
+++ b/src/test/java/org/elasticsearch/benchmark/search/scroll/ScrollSearchBenchmark.java
@@ -127,9 +127,9 @@ public class ScrollSearchBenchmark {
             }
             if (scrollRequestCounter % 20 == 0) {
                 long avgTimeSpent = sumTimeSpent / 20;
-                JvmStats.Mem mem = JvmStats.jvmStats().mem();
+                JvmStats.Mem mem = JvmStats.jvmStats().getMem();
                 System.out.printf(Locale.ENGLISH, "Cursor location=%d, avg time spent=%d ms\n", (requestSize * scrollRequestCounter), (avgTimeSpent));
-                System.out.printf(Locale.ENGLISH, "heap max=%s, used=%s, percentage=%d\n", mem.getHeapMax(), mem.getHeapUsed(), mem.getHeapUsedPrecent());
+                System.out.printf(Locale.ENGLISH, "heap max=%s, used=%s, percentage=%d\n", mem.getHeapMax(), mem.getHeapUsed(), mem.getHeapUsedPercent());
                 sumTimeSpent = 0;
             }
             if (searchResponse.getHits().hits().length == 0) {


### PR DESCRIPTION
Remove reflection since its not needed with Java 7, remove lastGcInfo since its not used, and move to only provide getters
