### PR TITLE
Improve exception handling in transport local execution

### DIFF
--- a/src/test/java/org/elasticsearch/transport/AbstractSimpleTransportTests.java
+++ b/src/test/java/org/elasticsearch/transport/AbstractSimpleTransportTests.java
@@ -216,7 +216,7 @@ public abstract class AbstractSimpleTransportTests extends ElasticsearchTestCase
     @Test
     public void testLocalNodeConnection() throws InterruptedException {
         assertTrue("serviceA is not connected to nodeA", serviceA.nodeConnected(nodeA));
-        if (((TransportService) serviceA).getLocalNodeId() != null) {
+        if (((TransportService) serviceA).getLocalNode() != null) {
             // this should be a noop
             serviceA.disconnectFromNode(nodeA);
         }


### PR DESCRIPTION
Local execution of transport messages failures can create a more detailed remote transport exceptions. Also, when failing to handle an exception, the error should be logged, and not call the handler again with another exception
