### PR TITLE
Update forbiddenapis to version 1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1410,7 +1410,7 @@
             <plugin>
                 <groupId>de.thetaphi</groupId>
                 <artifactId>forbiddenapis</artifactId>
-                <version>1.7</version>
+                <version>1.8</version>
 
                 <executions>
                     <execution>


### PR DESCRIPTION
Update forbidden-apis plugin to 1.8:
- Initial support for Java 9 including JIGSAW
- Errors are now reported sorted by line numbers and correctly grouped (synthetic methods/lambdas)
- Package-level forbids: Deny all classes from a package: `org.hatedpkg.**` (also other globs work)
- In addition to file-level excludes, forbiddenapis now supports fine granular excludes using Java annotations. You can use the one shipped, but define your own, e.g. inside elasticsearch and pass its name to forbidden (e.g. using a glob: `**.SuppressForbidden` would any annotation in any package to suppress errors). Annotation need to be on class level, no runtime annotation required.

This pull request does not yet use the new features, it just updates dependency.
