### PR TITLE
Fix simple_query_string example

### DIFF
--- a/docs/reference/query-dsl/queries/simple-query-string-query.asciidoc
+++ b/docs/reference/query-dsl/queries/simple-query-string-query.asciidoc
@@ -107,7 +107,7 @@ should be enabled. It is specified as a `|`-delimited string with the
 --------------------------------------------------
 {
     "simple_query_string" : {
-        "query" : "foo | bar  & baz*",
+        "query" : "foo | bar + baz*",
         "flags" : "OR|AND|PREFIX"
     }
 }


### PR DESCRIPTION
The `&` is not part of the simple_query_string DSL
