### PR TITLE
[BUILD] Restrict read permission to project.basedir

### DIFF
--- a/dev-tools/tests.policy
+++ b/dev-tools/tests.policy
@@ -22,8 +22,16 @@
 // everything not allowed here is forbidden!
 
 grant {
-  // permissions for file access, write access only to sandbox:
-  permission java.io.FilePermission "<<ALL FILES>>", "read";
+
+  // contain read access to only what we need:
+  // project base directory
+  permission java.io.FilePermission "${project.basedir}${/}-", "read";
+  // mvn custom ./m2/repository for dependency jars
+  permission java.io.FilePermission "${m2.repository}{/}-", "read";
+  // maven default repo for settings.xml etc.
+  permission java.io.FilePermission "${user.home}${/}.m2${/}-", "read";
+  // system jar resources
+  permission java.io.FilePermission "${java.home}${/}-", "read";
   permission java.io.FilePermission "${junit4.childvm.cwd}", "read,write";
   permission java.io.FilePermission "${junit4.childvm.cwd}${/}-", "read,write,delete";
   permission java.io.FilePermission "${junit4.tempDir}${/}*", "read,write,delete";

--- a/pom.xml
+++ b/pom.xml
@@ -600,6 +600,8 @@
                                 <tests.version>${project.version}</tests.version>
                                 <tests.locale>${tests.locale}</tests.locale>
                                 <tests.timezone>${tests.timezone}</tests.timezone>
+                                <project.basedir>${project.basedir}</project.basedir>
+                                <m2.repository>${settings.localRepository}</m2.repository>
                                 <es.node.local>${env.ES_TEST_LOCAL}</es.node.local>
                                 <es.node.mode>${es.node.mode}</es.node.mode>
                                 <es.logger.level>${es.logger.level}</es.logger.level>

--- a/src/test/java/org/elasticsearch/common/jna/NativesTests.java
+++ b/src/test/java/org/elasticsearch/common/jna/NativesTests.java
@@ -46,6 +46,7 @@ public class NativesTests extends ElasticsearchTestCase {
 
     @Before
     public void saveProperties() {
+        assumeTrue("Natives can't load libraries from path if security manager is enabled.", System.getSecurityManager() == null);
         for (String p : JNA_INVARIANT_PROPERTIES) {
             properties.put(p, System.getProperty(p));
         }


### PR DESCRIPTION
This prevents reads from anywhere outside of the elasticsearch
clone when running tests with security manager enabled.

I would really appreciate if folks could test this with `mvn clean test  -Dtests.security.manager=true` all tests pass for me here on linux and macos
