### PR TITLE
Query refactoring: Introduce toQuery() and fromXContent() methods in QueryBuilders and QueryParsers

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/BaseQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/BaseQueryBuilder.java
@@ -69,7 +69,11 @@ public abstract class BaseQueryBuilder implements QueryBuilder {
         return builder;
     }
 
-    public abstract Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException;
+    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
+        return parseContext.indexQueryParserService().queryParser(parserName()).parse(parseContext);
+    }
+
+    protected abstract String parserName();
 
     protected abstract void doXContent(XContentBuilder builder, Params params) throws IOException;
 }

--- a/src/main/java/org/elasticsearch/index/query/BaseQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/BaseQueryBuilder.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.search.Query;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -67,6 +68,8 @@ public abstract class BaseQueryBuilder implements QueryBuilder {
         builder.endObject();
         return builder;
     }
+
+    public abstract Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException;
 
     protected abstract void doXContent(XContentBuilder builder, Params params) throws IOException;
 }

--- a/src/main/java/org/elasticsearch/index/query/BaseQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/BaseQueryBuilder.java
@@ -73,6 +73,9 @@ public abstract class BaseQueryBuilder implements QueryBuilder {
         return parseContext.indexQueryParserService().queryParser(parserName()).parse(parseContext);
     }
 
+    /**
+     * @return the name of the parser class the default toQuery() method delegates to
+     */
     protected abstract String parserName();
 
     protected abstract void doXContent(XContentBuilder builder, Params params) throws IOException;

--- a/src/main/java/org/elasticsearch/index/query/BaseQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/BaseQueryParser.java
@@ -24,14 +24,14 @@ import org.apache.lucene.search.Query;
 import java.io.IOException;
 
 /**
- * This class with method impl is an intermediate step in the refactoring.
- * Method should be should be overwritten for all queries that already implement the toQuery/fromXContent split correctly.
- * To be removed once all queries are refactored.
+ * Class used during the query parsers refactoring.
+ * All query parsers that have a refactored "fromXContent" method can be changed to extend this instead of {@link BaseQueryParserTemp}.
+ * Keeps old {@link QueryParser#parse(QueryParseContext)} method as a stub delegating to
+ * {@link QueryParser#fromXContent(QueryParseContext)} and {@link QueryBuilder#toQuery(QueryParseContext)}}
  */
 public abstract class BaseQueryParser implements QueryParser {
 
-    public QueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
-        Query query = parse(parseContext);
-        return new QueryWrappingQueryBuilder(query);
+    public final Query parse(QueryParseContext parseContext) throws IOException, QueryParsingException {
+        return fromXContent(parseContext).toQuery(parseContext);
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/BaseQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/BaseQueryParser.java
@@ -20,22 +20,22 @@
 package org.elasticsearch.index.query;
 
 import org.apache.lucene.search.Query;
-import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.xcontent.ToXContent;
-import org.elasticsearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 
-/**
- * Base interface for all classes producing lucene queries. 
- * Supports conversion to BytesReference and creation of lucene Query objects.
- */
-public interface QueryBuilder extends ToXContent { 
+public abstract class BaseQueryParser implements QueryParser {
 
-    BytesReference buildAsBytes() throws ElasticsearchException;
+    public abstract String[] names();
 
-    BytesReference buildAsBytes(XContentType contentType) throws ElasticsearchException;
+    public abstract Query parse(QueryParseContext parseContext) throws IOException, QueryParsingException;
 
-    Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException;
+    /**
+     * this method impl is an intermediate step in the refactoring that should be overwritten
+     * by all queries that already implement the toQuery/fromXContent split correctly
+     * To be removed once all queries are refactored
+     */
+    public QueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
+            Query query = parse(parseContext);
+            return new QueryWrappingQueryBuilder(query);
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/BaseQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/BaseQueryParser.java
@@ -23,19 +23,15 @@ import org.apache.lucene.search.Query;
 
 import java.io.IOException;
 
+/**
+ * This class with method impl is an intermediate step in the refactoring.
+ * Method should be should be overwritten for all queries that already implement the toQuery/fromXContent split correctly.
+ * To be removed once all queries are refactored.
+ */
 public abstract class BaseQueryParser implements QueryParser {
 
-    public abstract String[] names();
-
-    public abstract Query parse(QueryParseContext parseContext) throws IOException, QueryParsingException;
-
-    /**
-     * this method impl is an intermediate step in the refactoring that should be overwritten
-     * by all queries that already implement the toQuery/fromXContent split correctly
-     * To be removed once all queries are refactored
-     */
     public QueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
-            Query query = parse(parseContext);
-            return new QueryWrappingQueryBuilder(query);
+        Query query = parse(parseContext);
+        return new QueryWrappingQueryBuilder(query);
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/BaseQueryParserTemp.java
+++ b/src/main/java/org/elasticsearch/index/query/BaseQueryParserTemp.java
@@ -24,14 +24,14 @@ import org.apache.lucene.search.Query;
 import java.io.IOException;
 
 /**
- * Class used during the query parsers refactoring.
- * All query parsers that have a refactored "toXContent" method can be changed to extend this instead of {@link BaseQueryParser}.
- * Keeps old {@link QueryParser#parse(QueryParseContext)} method as a stub delegating to
- * {@link QueryParser#fromXContent(QueryParseContext)} and {@link QueryBuilder#toQuery(QueryParseContext)}}
+ * This class with method impl is an intermediate step in the refactoring.
+ * Method should be should be overwritten for all queries that already implement the toQuery/fromXContent split correctly.
+ * To be removed once all queries are refactored.
  */
-public abstract class FutureBaseQueryParser implements QueryParser {
+public abstract class BaseQueryParserTemp implements QueryParser {
 
-    public final Query parse(QueryParseContext parseContext) throws IOException, QueryParsingException {
-        return fromXContent(parseContext).toQuery(parseContext);
+    public QueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
+        Query query = parse(parseContext);
+        return new QueryWrappingQueryBuilder(query);
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/BoolQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/BoolQueryBuilder.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.index.query;
 
 import org.apache.lucene.search.MatchAllDocsQuery;
-import org.apache.lucene.search.Query;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -186,8 +185,7 @@ public class BoolQueryBuilder extends BaseQueryBuilder implements BoostableQuery
         }
     }
 
-    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
-        return parseContext.indexQueryParserService().queryParser(BoolQueryParser.NAME).parse(parseContext);
+    final protected String parserName() {
+        return BoolQueryParser.NAME;
     }
-
 }

--- a/src/main/java/org/elasticsearch/index/query/BoolQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/BoolQueryBuilder.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.query;
 
 import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.Query;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -42,7 +43,7 @@ public class BoolQueryBuilder extends BaseQueryBuilder implements BoostableQuery
     private Boolean disableCoord;
 
     private String minimumShouldMatch;
-    
+
     private Boolean adjustPureNegative;
 
     private String queryName;
@@ -126,7 +127,7 @@ public class BoolQueryBuilder extends BaseQueryBuilder implements BoostableQuery
     public boolean hasClauses() {
         return !(mustClauses.isEmpty() && shouldClauses.isEmpty() && mustNotClauses.isEmpty());
     }
-    
+
     /**
      * If a boolean query contains only negative ("must not") clauses should the
      * BooleanQuery be enhanced with a {@link MatchAllDocsQuery} in order to act
@@ -183,6 +184,10 @@ public class BoolQueryBuilder extends BaseQueryBuilder implements BoostableQuery
             }
             builder.endArray();
         }
+    }
+
+    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
+        return parseContext.indexQueryParserService().queryParser(BoolQueryParser.NAME).parse(parseContext);
     }
 
 }

--- a/src/main/java/org/elasticsearch/index/query/BoolQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/BoolQueryParser.java
@@ -37,7 +37,7 @@ import static org.elasticsearch.common.lucene.search.Queries.fixNegativeQueryIfN
 /**
  *
  */
-public class BoolQueryParser extends BaseQueryParser {
+public class BoolQueryParser extends BaseQueryParserTemp {
 
     public static final String NAME = "bool";
 

--- a/src/main/java/org/elasticsearch/index/query/BoolQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/BoolQueryParser.java
@@ -37,7 +37,7 @@ import static org.elasticsearch.common.lucene.search.Queries.fixNegativeQueryIfN
 /**
  *
  */
-public class BoolQueryParser implements QueryParser {
+public class BoolQueryParser extends BaseQueryParser {
 
     public static final String NAME = "bool";
 
@@ -62,7 +62,7 @@ public class BoolQueryParser implements QueryParser {
         List<BooleanClause> clauses = newArrayList();
         boolean adjustPureNegative = true;
         String queryName = null;
-        
+
         String currentFieldName = null;
         XContentParser.Token token;
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {

--- a/src/main/java/org/elasticsearch/index/query/BoostingQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/BoostingQueryBuilder.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.search.Query;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
@@ -97,8 +96,7 @@ public class BoostingQueryBuilder extends BaseQueryBuilder implements BoostableQ
         builder.endObject();
     }
 
-    @Override
-    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
-        return new BoostingQueryParser().parse(parseContext);
+    final protected String parserName() {
+        return BoostingQueryParser.NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/BoostingQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/BoostingQueryBuilder.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.search.Query;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
@@ -94,5 +95,10 @@ public class BoostingQueryBuilder extends BaseQueryBuilder implements BoostableQ
             builder.field("boost", boost);
         }
         builder.endObject();
+    }
+
+    @Override
+    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
+        return new BoostingQueryParser().parse(parseContext);
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/BoostingQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/BoostingQueryParser.java
@@ -29,7 +29,7 @@ import java.io.IOException;
 /**
  *
  */
-public class BoostingQueryParser extends BaseQueryParser {
+public class BoostingQueryParser extends BaseQueryParserTemp {
 
     public static final String NAME = "boosting";
 

--- a/src/main/java/org/elasticsearch/index/query/BoostingQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/BoostingQueryParser.java
@@ -29,7 +29,7 @@ import java.io.IOException;
 /**
  *
  */
-public class BoostingQueryParser implements QueryParser {
+public class BoostingQueryParser extends BaseQueryParser {
 
     public static final String NAME = "boosting";
 

--- a/src/main/java/org/elasticsearch/index/query/CommonTermsQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/CommonTermsQueryBuilder.java
@@ -19,7 +19,9 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.search.Query;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.similarities.Similarity;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
@@ -200,8 +202,7 @@ public class CommonTermsQueryBuilder extends BaseQueryBuilder implements Boostab
         builder.endObject();
     }
 
-    @Override
-    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
-        return new CommonTermsQueryParser().parse(parseContext);
+    final protected String parserName() {
+        return CommonTermsQueryParser.NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/CommonTermsQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/CommonTermsQueryBuilder.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.search.Query;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
@@ -197,5 +198,10 @@ public class CommonTermsQueryBuilder extends BaseQueryBuilder implements Boostab
 
         builder.endObject();
         builder.endObject();
+    }
+
+    @Override
+    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
+        return new CommonTermsQueryParser().parse(parseContext);
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/CommonTermsQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/CommonTermsQueryParser.java
@@ -39,7 +39,7 @@ import java.io.IOException;
 /**
  *
  */
-public class CommonTermsQueryParser extends BaseQueryParser {
+public class CommonTermsQueryParser extends BaseQueryParserTemp {
 
     public static final String NAME = "common";
 

--- a/src/main/java/org/elasticsearch/index/query/CommonTermsQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/CommonTermsQueryParser.java
@@ -39,7 +39,7 @@ import java.io.IOException;
 /**
  *
  */
-public class CommonTermsQueryParser implements QueryParser {
+public class CommonTermsQueryParser extends BaseQueryParser {
 
     public static final String NAME = "common";
 

--- a/src/main/java/org/elasticsearch/index/query/ConstantScoreQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/ConstantScoreQueryBuilder.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.search.Query;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -35,7 +36,7 @@ public class ConstantScoreQueryBuilder extends BaseQueryBuilder implements Boost
     private final QueryBuilder queryBuilder;
 
     private float boost = -1;
-    
+
 
     /**
      * A query that wraps a filter and simply returns a constant score equal to the
@@ -56,7 +57,7 @@ public class ConstantScoreQueryBuilder extends BaseQueryBuilder implements Boost
     public ConstantScoreQueryBuilder(QueryBuilder queryBuilder) {
         this.filterBuilder = null;
         this.queryBuilder = queryBuilder;
-    }    
+    }
 
     /**
      * Sets the boost for this query.  Documents matching this query will (in addition to the normal
@@ -77,12 +78,17 @@ public class ConstantScoreQueryBuilder extends BaseQueryBuilder implements Boost
             queryBuilder.toXContent(builder, params);
         } else {
             builder.field("filter");
-            filterBuilder.toXContent(builder, params);  
+            filterBuilder.toXContent(builder, params);
         }
-        
+
         if (boost != -1) {
             builder.field("boost", boost);
         }
         builder.endObject();
+    }
+
+    @Override
+    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
+        return new ConstantScoreQueryParser().parse(parseContext);
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/ConstantScoreQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/ConstantScoreQueryBuilder.java
@@ -87,8 +87,7 @@ public class ConstantScoreQueryBuilder extends BaseQueryBuilder implements Boost
         builder.endObject();
     }
 
-    @Override
-    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
-        return new ConstantScoreQueryParser().parse(parseContext);
+    final protected String parserName() {
+        return ConstantScoreQueryParser.NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/ConstantScoreQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/ConstantScoreQueryParser.java
@@ -33,7 +33,7 @@ import java.io.IOException;
 /**
  *
  */
-public class ConstantScoreQueryParser implements QueryParser {
+public class ConstantScoreQueryParser extends BaseQueryParser {
 
     public static final String NAME = "constant_score";
 

--- a/src/main/java/org/elasticsearch/index/query/ConstantScoreQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/ConstantScoreQueryParser.java
@@ -33,7 +33,7 @@ import java.io.IOException;
 /**
  *
  */
-public class ConstantScoreQueryParser extends BaseQueryParser {
+public class ConstantScoreQueryParser extends BaseQueryParserTemp {
 
     public static final String NAME = "constant_score";
 

--- a/src/main/java/org/elasticsearch/index/query/DisMaxQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/DisMaxQueryBuilder.java
@@ -101,8 +101,7 @@ public class DisMaxQueryBuilder extends BaseQueryBuilder implements BoostableQue
         builder.endObject();
     }
 
-    @Override
-    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
-        return new DisMaxQueryParser().parse(parseContext);
+    final protected String parserName() {
+        return DisMaxQueryParser.NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/DisMaxQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/DisMaxQueryBuilder.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.search.Query;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -98,5 +99,10 @@ public class DisMaxQueryBuilder extends BaseQueryBuilder implements BoostableQue
         }
         builder.endArray();
         builder.endObject();
+    }
+
+    @Override
+    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
+        return new DisMaxQueryParser().parse(parseContext);
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/DisMaxQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/DisMaxQueryParser.java
@@ -33,7 +33,7 @@ import static com.google.common.collect.Lists.newArrayList;
 /**
  *
  */
-public class DisMaxQueryParser implements QueryParser {
+public class DisMaxQueryParser extends BaseQueryParser {
 
     public static final String NAME = "dis_max";
 

--- a/src/main/java/org/elasticsearch/index/query/DisMaxQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/DisMaxQueryParser.java
@@ -33,7 +33,7 @@ import static com.google.common.collect.Lists.newArrayList;
 /**
  *
  */
-public class DisMaxQueryParser extends BaseQueryParser {
+public class DisMaxQueryParser extends BaseQueryParserTemp {
 
     public static final String NAME = "dis_max";
 

--- a/src/main/java/org/elasticsearch/index/query/FieldMaskingSpanQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/FieldMaskingSpanQueryBuilder.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.search.Query;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -72,8 +71,7 @@ public class FieldMaskingSpanQueryBuilder extends BaseQueryBuilder implements Sp
         builder.endObject();
     }
 
-    @Override
-    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
-        return new FieldMaskingSpanQueryParser().parse(parseContext);
+    final protected String parserName() {
+        return FieldMaskingSpanQueryParser.NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/FieldMaskingSpanQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/FieldMaskingSpanQueryBuilder.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.search.Query;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -69,5 +70,10 @@ public class FieldMaskingSpanQueryBuilder extends BaseQueryBuilder implements Sp
             builder.field("_name", queryName);
         }
         builder.endObject();
+    }
+
+    @Override
+    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
+        return new FieldMaskingSpanQueryParser().parse(parseContext);
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/FieldMaskingSpanQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/FieldMaskingSpanQueryParser.java
@@ -32,7 +32,7 @@ import java.io.IOException;
 /**
  *
  */
-public class FieldMaskingSpanQueryParser implements QueryParser {
+public class FieldMaskingSpanQueryParser extends BaseQueryParser {
 
     public static final String NAME = "field_masking_span";
 

--- a/src/main/java/org/elasticsearch/index/query/FieldMaskingSpanQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/FieldMaskingSpanQueryParser.java
@@ -32,7 +32,7 @@ import java.io.IOException;
 /**
  *
  */
-public class FieldMaskingSpanQueryParser extends BaseQueryParser {
+public class FieldMaskingSpanQueryParser extends BaseQueryParserTemp {
 
     public static final String NAME = "field_masking_span";
 

--- a/src/main/java/org/elasticsearch/index/query/FilteredQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/FilteredQueryBuilder.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.search.Query;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
@@ -87,8 +86,7 @@ public class FilteredQueryBuilder extends BaseQueryBuilder implements BoostableQ
         builder.endObject();
     }
 
-    @Override
-    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
-        return new FilteredQueryParser().parse(parseContext);
+    final protected String parserName() {
+        return FilteredQueryParser.NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/FilteredQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/FilteredQueryBuilder.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.search.Query;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
@@ -84,5 +85,10 @@ public class FilteredQueryBuilder extends BaseQueryBuilder implements BoostableQ
             builder.field("_name", queryName);
         }
         builder.endObject();
+    }
+
+    @Override
+    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
+        return new FilteredQueryParser().parse(parseContext);
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/FilteredQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/FilteredQueryParser.java
@@ -41,7 +41,7 @@ import java.io.IOException;
 /**
  *
  */
-public class FilteredQueryParser implements QueryParser {
+public class FilteredQueryParser extends BaseQueryParser {
 
     public static final String NAME = "filtered";
 

--- a/src/main/java/org/elasticsearch/index/query/FilteredQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/FilteredQueryParser.java
@@ -41,7 +41,7 @@ import java.io.IOException;
 /**
  *
  */
-public class FilteredQueryParser extends BaseQueryParser {
+public class FilteredQueryParser extends BaseQueryParserTemp {
 
     public static final String NAME = "filtered";
 

--- a/src/main/java/org/elasticsearch/index/query/FutureBaseQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/FutureBaseQueryParser.java
@@ -20,29 +20,18 @@
 package org.elasticsearch.index.query;
 
 import org.apache.lucene.search.Query;
-import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.xcontent.ToXContent;
-import org.elasticsearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 
 /**
- * Base interface for all classes producing lucene queries.
- * Supports conversion to BytesReference and creation of lucene Query objects.
+ * Class used during the query parsers refactoring.
+ * All query parsers that have a refactored "toXContent" method can be changed to extend this instead of {@link BaseQueryParser}.
+ * Keeps old {@link QueryParser#parse(QueryParseContext)} method as a stub delegating to
+ * {@link QueryParser#fromXContent(QueryParseContext)} and {@link QueryBuilder#toQuery(QueryParseContext)}}
  */
-public interface QueryBuilder extends ToXContent {
+public abstract class FutureBaseQueryParser implements QueryParser {
 
-    BytesReference buildAsBytes() throws ElasticsearchException;
-
-    BytesReference buildAsBytes(XContentType contentType) throws ElasticsearchException;
-
-    /**
-     * Create a {@link Query} based on this QueryBuilder
-     * @param parseContext additional information needed to construct the queries
-     * @return the {@link Query}
-     * @throws QueryParsingException
-     * @throws IOException
-     */
-    Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException;
+    public final Query parse(QueryParseContext parseContext) throws IOException, QueryParsingException {
+        return fromXContent(parseContext).toQuery(parseContext);
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/FuzzyQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/FuzzyQueryBuilder.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.search.Query;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
@@ -129,8 +128,7 @@ public class FuzzyQueryBuilder extends BaseQueryBuilder implements MultiTermQuer
         builder.endObject();
     }
 
-    @Override
-    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
-        return new FuzzyQueryParser().parse(parseContext);
+    final protected String parserName() {
+        return FuzzyQueryParser.NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/FuzzyQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/FuzzyQueryBuilder.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.search.Query;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
@@ -42,7 +43,7 @@ public class FuzzyQueryBuilder extends BaseQueryBuilder implements MultiTermQuer
     private Integer prefixLength;
 
     private Integer maxExpansions;
-    
+
     //LUCENE 4 UPGRADE  we need a testcase for this + documentation
     private Boolean transpositions;
 
@@ -83,7 +84,7 @@ public class FuzzyQueryBuilder extends BaseQueryBuilder implements MultiTermQuer
         this.maxExpansions = maxExpansions;
         return this;
     }
-    
+
     public FuzzyQueryBuilder transpositions(boolean transpositions) {
       this.transpositions = transpositions;
       return this;
@@ -126,5 +127,10 @@ public class FuzzyQueryBuilder extends BaseQueryBuilder implements MultiTermQuer
             builder.endObject();
         }
         builder.endObject();
+    }
+
+    @Override
+    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
+        return new FuzzyQueryParser().parse(parseContext);
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/FuzzyQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/FuzzyQueryParser.java
@@ -35,7 +35,7 @@ import java.io.IOException;
 /**
  *
  */
-public class FuzzyQueryParser extends BaseQueryParser {
+public class FuzzyQueryParser extends BaseQueryParserTemp {
 
     public static final String NAME = "fuzzy";
     private static final Fuzziness DEFAULT_FUZZINESS = Fuzziness.AUTO;

--- a/src/main/java/org/elasticsearch/index/query/FuzzyQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/FuzzyQueryParser.java
@@ -35,7 +35,7 @@ import java.io.IOException;
 /**
  *
  */
-public class FuzzyQueryParser implements QueryParser {
+public class FuzzyQueryParser extends BaseQueryParser {
 
     public static final String NAME = "fuzzy";
     private static final Fuzziness DEFAULT_FUZZINESS = Fuzziness.AUTO;

--- a/src/main/java/org/elasticsearch/index/query/GeoShapeQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoShapeQueryBuilder.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.search.Query;
 import org.elasticsearch.common.geo.SpatialStrategy;
 import org.elasticsearch.common.geo.builders.ShapeBuilder;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -164,4 +165,8 @@ public class GeoShapeQueryBuilder extends BaseQueryBuilder implements BoostableQ
         builder.endObject();
     }
 
+    @Override
+    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
+        return new GeoShapeQueryParser().parse(parseContext);
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/GeoShapeQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoShapeQueryBuilder.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.search.Query;
 import org.elasticsearch.common.geo.SpatialStrategy;
 import org.elasticsearch.common.geo.builders.ShapeBuilder;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -165,8 +164,7 @@ public class GeoShapeQueryBuilder extends BaseQueryBuilder implements BoostableQ
         builder.endObject();
     }
 
-    @Override
-    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
-        return new GeoShapeQueryParser().parse(parseContext);
+    final protected String parserName() {
+        return GeoShapeQueryParser.NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/GeoShapeQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoShapeQueryParser.java
@@ -42,7 +42,7 @@ import org.elasticsearch.index.search.shape.ShapeFetchService;
 
 import java.io.IOException;
 
-public class GeoShapeQueryParser implements QueryParser {
+public class GeoShapeQueryParser extends BaseQueryParser {
 
     public static final String NAME = "geo_shape";
 
@@ -181,7 +181,7 @@ public class GeoShapeQueryParser implements QueryParser {
     public void setFetchService(@Nullable ShapeFetchService fetchService) {
         this.fetchService = fetchService;
     }
-    
+
     public static SpatialArgs getArgs(ShapeBuilder shape, ShapeRelation relation) {
         switch(relation) {
         case DISJOINT:
@@ -192,7 +192,7 @@ public class GeoShapeQueryParser implements QueryParser {
             return new SpatialArgs(SpatialOperation.IsWithin, shape.build());
         default:
             throw new ElasticsearchIllegalArgumentException("");
-        
+
         }
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/GeoShapeQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoShapeQueryParser.java
@@ -42,7 +42,7 @@ import org.elasticsearch.index.search.shape.ShapeFetchService;
 
 import java.io.IOException;
 
-public class GeoShapeQueryParser extends BaseQueryParser {
+public class GeoShapeQueryParser extends BaseQueryParserTemp {
 
     public static final String NAME = "geo_shape";
 

--- a/src/main/java/org/elasticsearch/index/query/HasChildQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/HasChildQueryBuilder.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.search.Query;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.query.support.QueryInnerHitBuilder;
 
@@ -143,8 +142,7 @@ public class HasChildQueryBuilder extends BaseQueryBuilder implements BoostableQ
         builder.endObject();
     }
 
-    @Override
-    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
-        return parseContext.indexQueryParserService().queryParser(HasChildQueryParser.NAME).parse(parseContext);
+    final protected String parserName() {
+        return HasChildQueryParser.NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/HasChildQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/HasChildQueryBuilder.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.search.Query;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.query.support.QueryInnerHitBuilder;
 
@@ -140,5 +141,10 @@ public class HasChildQueryBuilder extends BaseQueryBuilder implements BoostableQ
             builder.endObject();
         }
         builder.endObject();
+    }
+
+    @Override
+    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
+        return parseContext.indexQueryParserService().queryParser(HasChildQueryParser.NAME).parse(parseContext);
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/HasChildQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/HasChildQueryParser.java
@@ -47,7 +47,7 @@ import static org.elasticsearch.index.query.QueryParserUtils.ensureNotDeleteByQu
 /**
  *
  */
-public class HasChildQueryParser implements QueryParser {
+public class HasChildQueryParser extends BaseQueryParser {
 
     public static final String NAME = "has_child";
 

--- a/src/main/java/org/elasticsearch/index/query/HasChildQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/HasChildQueryParser.java
@@ -47,7 +47,7 @@ import static org.elasticsearch.index.query.QueryParserUtils.ensureNotDeleteByQu
 /**
  *
  */
-public class HasChildQueryParser extends BaseQueryParser {
+public class HasChildQueryParser extends BaseQueryParserTemp {
 
     public static final String NAME = "has_child";
 

--- a/src/main/java/org/elasticsearch/index/query/HasParentQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/HasParentQueryBuilder.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.search.Query;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.query.support.QueryInnerHitBuilder;
 
@@ -95,6 +96,11 @@ public class HasParentQueryBuilder extends BaseQueryBuilder implements Boostable
             builder.endObject();
         }
         builder.endObject();
+    }
+
+    @Override
+    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
+        return parseContext.indexQueryParserService().queryParser(HasParentQueryParser.NAME).parse(parseContext);
     }
 }
 

--- a/src/main/java/org/elasticsearch/index/query/HasParentQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/HasParentQueryBuilder.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.search.Query;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.query.support.QueryInnerHitBuilder;
 
@@ -98,9 +97,8 @@ public class HasParentQueryBuilder extends BaseQueryBuilder implements Boostable
         builder.endObject();
     }
 
-    @Override
-    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
-        return parseContext.indexQueryParserService().queryParser(HasParentQueryParser.NAME).parse(parseContext);
+    final protected String parserName() {
+        return HasParentQueryParser.NAME;
     }
 }
 

--- a/src/main/java/org/elasticsearch/index/query/HasParentQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/HasParentQueryParser.java
@@ -45,7 +45,7 @@ import java.util.Set;
 
 import static org.elasticsearch.index.query.QueryParserUtils.ensureNotDeleteByQuery;
 
-public class HasParentQueryParser extends BaseQueryParser {
+public class HasParentQueryParser extends BaseQueryParserTemp {
 
     public static final String NAME = "has_parent";
 

--- a/src/main/java/org/elasticsearch/index/query/HasParentQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/HasParentQueryParser.java
@@ -45,7 +45,7 @@ import java.util.Set;
 
 import static org.elasticsearch.index.query.QueryParserUtils.ensureNotDeleteByQuery;
 
-public class HasParentQueryParser implements QueryParser {
+public class HasParentQueryParser extends BaseQueryParser {
 
     public static final String NAME = "has_parent";
 

--- a/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.search.Query;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -105,8 +104,7 @@ public class IdsQueryBuilder extends BaseQueryBuilder implements BoostableQueryB
         builder.endObject();
     }
 
-    @Override
-    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
-        return new IdsQueryParser().parse(parseContext);
+    final protected String parserName() {
+        return IdsQueryParser.NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.search.Query;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -102,5 +103,10 @@ public class IdsQueryBuilder extends BaseQueryBuilder implements BoostableQueryB
             builder.field("_name", queryName);
         }
         builder.endObject();
+    }
+
+    @Override
+    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
+        return new IdsQueryParser().parse(parseContext);
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/IdsQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/IdsQueryParser.java
@@ -40,7 +40,7 @@ import java.util.List;
 /**
  *
  */
-public class IdsQueryParser extends BaseQueryParser {
+public class IdsQueryParser extends BaseQueryParserTemp {
 
     public static final String NAME = "ids";
 

--- a/src/main/java/org/elasticsearch/index/query/IdsQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/IdsQueryParser.java
@@ -21,6 +21,7 @@ package org.elasticsearch.index.query;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
+
 import org.apache.lucene.queries.TermsFilter;
 import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.Query;
@@ -39,7 +40,7 @@ import java.util.List;
 /**
  *
  */
-public class IdsQueryParser implements QueryParser {
+public class IdsQueryParser extends BaseQueryParser {
 
     public static final String NAME = "ids";
 

--- a/src/main/java/org/elasticsearch/index/query/IndicesQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/IndicesQueryBuilder.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.search.Query;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -86,8 +85,7 @@ public class IndicesQueryBuilder extends BaseQueryBuilder {
         builder.endObject();
     }
 
-    @Override
-    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
-        return parseContext.indexQueryParserService().queryParser(IndicesQueryParser.NAME).parse(parseContext);
+    final protected String parserName() {
+        return IndicesQueryParser.NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/IndicesQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/IndicesQueryBuilder.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.search.Query;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -83,5 +84,10 @@ public class IndicesQueryBuilder extends BaseQueryBuilder {
             builder.field("_name", queryName);
         }
         builder.endObject();
+    }
+
+    @Override
+    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
+        return parseContext.indexQueryParserService().queryParser(IndicesQueryParser.NAME).parse(parseContext);
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/IndicesQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/IndicesQueryParser.java
@@ -35,7 +35,7 @@ import java.util.Collection;
 
 /**
  */
-public class IndicesQueryParser extends BaseQueryParser {
+public class IndicesQueryParser extends BaseQueryParserTemp {
 
     public static final String NAME = "indices";
 

--- a/src/main/java/org/elasticsearch/index/query/IndicesQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/IndicesQueryParser.java
@@ -35,7 +35,7 @@ import java.util.Collection;
 
 /**
  */
-public class IndicesQueryParser implements QueryParser {
+public class IndicesQueryParser extends BaseQueryParser {
 
     public static final String NAME = "indices";
 

--- a/src/main/java/org/elasticsearch/index/query/MatchAllQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/MatchAllQueryBuilder.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.search.Query;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -65,8 +64,7 @@ public class MatchAllQueryBuilder extends BaseQueryBuilder implements BoostableQ
         builder.endObject();
     }
 
-    @Override
-    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
-        return new MatchAllQueryParser().parse(parseContext);
+    final protected String parserName() {
+        return MatchAllQueryParser.NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/MatchAllQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/MatchAllQueryBuilder.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.search.Query;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -62,5 +63,10 @@ public class MatchAllQueryBuilder extends BaseQueryBuilder implements BoostableQ
             builder.field("norms_field", normsField);
         }
         builder.endObject();
+    }
+
+    @Override
+    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
+        return new MatchAllQueryParser().parse(parseContext);
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/MatchAllQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MatchAllQueryParser.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 /**
  *
  */
-public class MatchAllQueryParser extends BaseQueryParser {
+public class MatchAllQueryParser extends BaseQueryParserTemp {
 
     public static final String NAME = "match_all";
 

--- a/src/main/java/org/elasticsearch/index/query/MatchAllQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MatchAllQueryParser.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 /**
  *
  */
-public class MatchAllQueryParser implements QueryParser {
+public class MatchAllQueryParser extends BaseQueryParser {
 
     public static final String NAME = "match_all";
 

--- a/src/main/java/org/elasticsearch/index/query/MatchQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/MatchQueryBuilder.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.search.Query;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
@@ -278,8 +277,7 @@ public class MatchQueryBuilder extends BaseQueryBuilder implements BoostableQuer
         builder.endObject();
     }
 
-    @Override
-    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
-        return new MatchQueryParser().parse(parseContext);
+    final protected String parserName() {
+        return MatchQueryParser.NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/MatchQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/MatchQueryBuilder.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.search.Query;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
@@ -275,5 +276,10 @@ public class MatchQueryBuilder extends BaseQueryBuilder implements BoostableQuer
 
         builder.endObject();
         builder.endObject();
+    }
+
+    @Override
+    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
+        return new MatchQueryParser().parse(parseContext);
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/MatchQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MatchQueryParser.java
@@ -35,7 +35,7 @@ import java.io.IOException;
 /**
  *
  */
-public class MatchQueryParser extends BaseQueryParser {
+public class MatchQueryParser extends BaseQueryParserTemp {
 
     public static final String NAME = "match";
 

--- a/src/main/java/org/elasticsearch/index/query/MatchQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MatchQueryParser.java
@@ -35,7 +35,7 @@ import java.io.IOException;
 /**
  *
  */
-public class MatchQueryParser implements QueryParser {
+public class MatchQueryParser extends BaseQueryParser {
 
     public static final String NAME = "match";
 

--- a/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilder.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.search.Query;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.action.get.MultiGetRequest;
 import org.elasticsearch.common.Nullable;
@@ -437,5 +438,10 @@ public class MoreLikeThisQueryBuilder extends BaseQueryBuilder implements Boosta
             builder.field("include", include);
         }
         builder.endObject();
+    }
+
+    @Override
+    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
+        return new MoreLikeThisQueryParser().parse(parseContext);
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilder.java
@@ -19,13 +19,16 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.search.Query;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.action.get.MultiGetRequest;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.lucene.uid.Versions;
-import org.elasticsearch.common.xcontent.*;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.search.fetch.source.FetchSourceContext;
 
@@ -440,8 +443,7 @@ public class MoreLikeThisQueryBuilder extends BaseQueryBuilder implements Boosta
         builder.endObject();
     }
 
-    @Override
-    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
-        return new MoreLikeThisQueryParser().parse(parseContext);
+    final protected String parserName() {
+        return MoreLikeThisQueryParser.NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryParser.java
@@ -21,6 +21,7 @@ package org.elasticsearch.index.query;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.queries.TermsFilter;
 import org.apache.lucene.search.BooleanClause;
@@ -53,7 +54,7 @@ import static org.elasticsearch.index.mapper.Uid.createUidAsBytes;
 /**
  *
  */
-public class MoreLikeThisQueryParser implements QueryParser {
+public class MoreLikeThisQueryParser extends BaseQueryParser {
 
     public static final String NAME = "mlt";
     private MoreLikeThisFetchService fetchService = null;

--- a/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryParser.java
@@ -54,7 +54,7 @@ import static org.elasticsearch.index.mapper.Uid.createUidAsBytes;
 /**
  *
  */
-public class MoreLikeThisQueryParser extends BaseQueryParser {
+public class MoreLikeThisQueryParser extends BaseQueryParserTemp {
 
     public static final String NAME = "mlt";
     private MoreLikeThisFetchService fetchService = null;

--- a/src/main/java/org/elasticsearch/index/query/MultiMatchQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/MultiMatchQueryBuilder.java
@@ -22,7 +22,6 @@ package org.elasticsearch.index.query;
 import com.carrotsearch.hppc.ObjectFloatOpenHashMap;
 import com.google.common.collect.Lists;
 
-import org.apache.lucene.search.Query;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.unit.Fuzziness;
@@ -406,8 +405,7 @@ public class MultiMatchQueryBuilder extends BaseQueryBuilder implements Boostabl
         builder.endObject();
     }
 
-    @Override
-    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
-        return new MultiMatchQueryParser().parse(parseContext);
+    final protected String parserName() {
+        return MultiMatchQueryParser.NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/MultiMatchQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/MultiMatchQueryBuilder.java
@@ -21,6 +21,8 @@ package org.elasticsearch.index.query;
 
 import com.carrotsearch.hppc.ObjectFloatOpenHashMap;
 import com.google.common.collect.Lists;
+
+import org.apache.lucene.search.Query;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.unit.Fuzziness;
@@ -404,4 +406,8 @@ public class MultiMatchQueryBuilder extends BaseQueryBuilder implements Boostabl
         builder.endObject();
     }
 
+    @Override
+    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
+        return new MultiMatchQueryParser().parse(parseContext);
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/MultiMatchQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MultiMatchQueryParser.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.query;
 
 import com.google.common.collect.Maps;
+
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.inject.Inject;
@@ -36,7 +37,7 @@ import java.util.Map;
 /**
  * Same as {@link MatchQueryParser} but has support for multiple fields.
  */
-public class MultiMatchQueryParser implements QueryParser {
+public class MultiMatchQueryParser extends BaseQueryParser {
 
     public static final String NAME = "multi_match";
 

--- a/src/main/java/org/elasticsearch/index/query/MultiMatchQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MultiMatchQueryParser.java
@@ -37,7 +37,7 @@ import java.util.Map;
 /**
  * Same as {@link MatchQueryParser} but has support for multiple fields.
  */
-public class MultiMatchQueryParser extends BaseQueryParser {
+public class MultiMatchQueryParser extends BaseQueryParserTemp {
 
     public static final String NAME = "multi_match";
 

--- a/src/main/java/org/elasticsearch/index/query/NestedQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/NestedQueryBuilder.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.search.Query;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.query.support.QueryInnerHitBuilder;
 
@@ -114,8 +113,7 @@ public class NestedQueryBuilder extends BaseQueryBuilder implements BoostableQue
         builder.endObject();
     }
 
-    @Override
-    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
-        return parseContext.indexQueryParserService().queryParser(NestedQueryParser.NAME).parse(parseContext);
+    final protected String parserName() {
+        return NestedQueryParser.NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/NestedQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/NestedQueryBuilder.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.search.Query;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.query.support.QueryInnerHitBuilder;
 
@@ -113,4 +114,8 @@ public class NestedQueryBuilder extends BaseQueryBuilder implements BoostableQue
         builder.endObject();
     }
 
+    @Override
+    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
+        return parseContext.indexQueryParserService().queryParser(NestedQueryParser.NAME).parse(parseContext);
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/NestedQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/NestedQueryParser.java
@@ -37,7 +37,7 @@ import org.elasticsearch.search.internal.SubSearchContext;
 
 import java.io.IOException;
 
-public class NestedQueryParser extends BaseQueryParser {
+public class NestedQueryParser extends BaseQueryParserTemp {
 
     public static final String NAME = "nested";
 

--- a/src/main/java/org/elasticsearch/index/query/NestedQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/NestedQueryParser.java
@@ -37,7 +37,7 @@ import org.elasticsearch.search.internal.SubSearchContext;
 
 import java.io.IOException;
 
-public class NestedQueryParser implements QueryParser {
+public class NestedQueryParser extends BaseQueryParser {
 
     public static final String NAME = "nested";
 

--- a/src/main/java/org/elasticsearch/index/query/PrefixQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/PrefixQueryBuilder.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.search.Query;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -97,8 +96,7 @@ public class PrefixQueryBuilder extends BaseQueryBuilder implements MultiTermQue
         builder.endObject();
     }
 
-    @Override
-    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
-        return new PrefixQueryParser().parse(parseContext);
+    final protected String parserName() {
+        return PrefixQueryParser.NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/PrefixQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/PrefixQueryBuilder.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.search.Query;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -94,5 +95,10 @@ public class PrefixQueryBuilder extends BaseQueryBuilder implements MultiTermQue
             builder.endObject();
         }
         builder.endObject();
+    }
+
+    @Override
+    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
+        return new PrefixQueryParser().parse(parseContext);
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/PrefixQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/PrefixQueryParser.java
@@ -34,7 +34,7 @@ import java.io.IOException;
 /**
  *
  */
-public class PrefixQueryParser extends BaseQueryParser {
+public class PrefixQueryParser extends BaseQueryParserTemp {
 
     public static final String NAME = "prefix";
 

--- a/src/main/java/org/elasticsearch/index/query/PrefixQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/PrefixQueryParser.java
@@ -34,7 +34,7 @@ import java.io.IOException;
 /**
  *
  */
-public class PrefixQueryParser implements QueryParser {
+public class PrefixQueryParser extends BaseQueryParser {
 
     public static final String NAME = "prefix";
 

--- a/src/main/java/org/elasticsearch/index/query/QueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryBuilder.java
@@ -28,14 +28,21 @@ import org.elasticsearch.common.xcontent.XContentType;
 import java.io.IOException;
 
 /**
- * Base interface for all classes producing lucene queries. 
+ * Base interface for all classes producing lucene queries.
  * Supports conversion to BytesReference and creation of lucene Query objects.
  */
-public interface QueryBuilder extends ToXContent { 
+public interface QueryBuilder extends ToXContent {
 
     BytesReference buildAsBytes() throws ElasticsearchException;
 
     BytesReference buildAsBytes(XContentType contentType) throws ElasticsearchException;
 
+    /**
+     * Create a new lucene query from this QueryBuilder.
+     * @param parseContext
+     * @return
+     * @throws QueryParsingException
+     * @throws IOException
+     */
     Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException;
 }

--- a/src/main/java/org/elasticsearch/index/query/QueryParseContext.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryParseContext.java
@@ -285,9 +285,8 @@ public class QueryParseContext {
         innerHitsContext.addInnerHitDefinition(name, context);
     }
 
-    @Nullable
-    public Query parseInnerQuery() throws IOException, QueryParsingException {
-        // move to START object
+    public QueryBuilder toQueryBuilder() throws IOException {
+     // move to START object
         XContentParser.Token token;
         if (parser.currentToken() != XContentParser.Token.START_OBJECT) {
             token = parser.nextToken();
@@ -310,11 +309,19 @@ public class QueryParseContext {
         if (queryParser == null) {
             throw new QueryParsingException(index, "No query registered for [" + queryName + "]");
         }
-        Query result = queryParser.parse(this);
+        QueryBuilder result = queryParser.fromXContent(this);
         if (parser.currentToken() == XContentParser.Token.END_OBJECT || parser.currentToken() == XContentParser.Token.END_ARRAY) {
             // if we are at END_OBJECT, move to the next one...
             parser.nextToken();
         }
+        return result;
+    }
+
+    @Nullable
+    public Query parseInnerQuery() throws IOException, QueryParsingException {
+        QueryBuilder builder = toQueryBuilder();
+
+        Query result = builder.toQuery(this);
         if (result instanceof NoCacheQuery) {
             propagateNoCache = true;
         }
@@ -481,4 +488,5 @@ public class QueryParseContext {
     public NestedScope nestedScope() {
         return nestedScope;
     }
+
 }

--- a/src/main/java/org/elasticsearch/index/query/QueryParseContext.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryParseContext.java
@@ -338,7 +338,7 @@ public class QueryParseContext {
      * Checks if the given lucene query should be cached or wrapped, sets flags in this QueryParseContext accordingly
      * @param query
      */
-    public void checkCachable(Query query) {
+    void checkCachable(Query query) {
         if (query instanceof NoCacheQuery) {
             propagateNoCache = true;
         }

--- a/src/main/java/org/elasticsearch/index/query/QueryParseContext.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryParseContext.java
@@ -286,7 +286,7 @@ public class QueryParseContext {
     }
 
     public QueryBuilder toQueryBuilder() throws IOException {
-     // move to START object
+        // move to START object
         XContentParser.Token token;
         if (parser.currentToken() != XContentParser.Token.START_OBJECT) {
             token = parser.nextToken();
@@ -332,9 +332,12 @@ public class QueryParseContext {
         }
         if (CustomQueryWrappingFilter.shouldUseCustomQueryWrappingFilter(query)) {
             requireCustomQueryWrappingFilter = true;
-            // If later on, either directly or indirectly this query gets wrapped in a query filter it must never
-            // get cached even if a filter higher up the chain is configured to do this. This will happen, because
-            // the result filter will be instance of NoCacheFilter (CustomQueryWrappingFilter) which will in
+            // If later on, either directly or indirectly this query gets
+            // wrapped in a query filter it must never
+            // get cached even if a filter higher up the chain is configured to
+            // do this. This will happen, because
+            // the result filter will be instance of NoCacheFilter
+            // (CustomQueryWrappingFilter) which will in
             // #executeFilterParser() set propagateNoCache to true.
         }
     }

--- a/src/main/java/org/elasticsearch/index/query/QueryParseContext.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryParseContext.java
@@ -285,7 +285,11 @@ public class QueryParseContext {
         innerHitsContext.addInnerHitDefinition(name, context);
     }
 
-    public QueryBuilder toQueryBuilder() throws IOException {
+    /**
+     * @return a new QueryBuilder based on the current state of the parser
+     * @throws IOException
+     */
+    public QueryBuilder parseInnerQueryBuilder() throws IOException {
         // move to START object
         XContentParser.Token token;
         if (parser.currentToken() != XContentParser.Token.START_OBJECT) {
@@ -317,15 +321,23 @@ public class QueryParseContext {
         return result;
     }
 
+    /**
+     * @deprecated replaced by calls to parseInnerQueryBuilder() and checkCachable() for the resulting queries
+     */
     @Nullable
+    @Deprecated
     public Query parseInnerQuery() throws IOException, QueryParsingException {
-        QueryBuilder builder = toQueryBuilder();
+        QueryBuilder builder = parseInnerQueryBuilder();
 
         Query result = builder.toQuery(this);
         checkCachable(result);
         return result;
     }
 
+    /**
+     * Checks if the given lucene query should be cached or wrapped, sets flags in this QueryParseContext accordingly
+     * @param query
+     */
     public void checkCachable(Query query) {
         if (query instanceof NoCacheQuery) {
             propagateNoCache = true;

--- a/src/main/java/org/elasticsearch/index/query/QueryParseContext.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryParseContext.java
@@ -156,7 +156,7 @@ public class QueryParseContext {
     public XContentParser parser() {
         return parser;
     }
-    
+
     public IndexQueryParserService indexQueryParserService() {
         return indexQueryParser;
     }
@@ -322,17 +322,21 @@ public class QueryParseContext {
         QueryBuilder builder = toQueryBuilder();
 
         Query result = builder.toQuery(this);
-        if (result instanceof NoCacheQuery) {
+        checkCachable(result);
+        return result;
+    }
+
+    public void checkCachable(Query query) {
+        if (query instanceof NoCacheQuery) {
             propagateNoCache = true;
         }
-        if (CustomQueryWrappingFilter.shouldUseCustomQueryWrappingFilter(result)) {
+        if (CustomQueryWrappingFilter.shouldUseCustomQueryWrappingFilter(query)) {
             requireCustomQueryWrappingFilter = true;
             // If later on, either directly or indirectly this query gets wrapped in a query filter it must never
             // get cached even if a filter higher up the chain is configured to do this. This will happen, because
             // the result filter will be instance of NoCacheFilter (CustomQueryWrappingFilter) which will in
             // #executeFilterParser() set propagateNoCache to true.
         }
-        return result;
     }
 
     @Nullable

--- a/src/main/java/org/elasticsearch/index/query/QueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryParser.java
@@ -35,13 +35,27 @@ public interface QueryParser {
     String[] names();
 
     /**
-     * Parses the into a query from the current parser location. Will be at "START_OBJECT" location,
-     * and should end when the token is at the matching "END_OBJECT".
+     * Parses the into a query from the current parser location. Will be at
+     * "START_OBJECT" location, and should end when the token is at the matching
+     * "END_OBJECT".
      * <p/>
-     * Returns <tt>null</tt> if this query should be ignored in the context of the DSL.
+     * Returns <tt>null</tt> if this query should be ignored in the context of
+     * the DSL.
      */
     @Nullable
     Query parse(QueryParseContext parseContext) throws IOException, QueryParsingException;
 
+    /**
+     * Create a new QueryBuilder from the query as XContent stored int the
+     * parseContext
+     *
+     * @param parseContext
+     *            the input parse context. The state on the parser contained in
+     *            this context will be changed as a side effect of this method
+     *            call
+     * @return the new QueryBuilder
+     * @throws IOException
+     * @throws QueryParsingException
+     */
     QueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException;
 }

--- a/src/main/java/org/elasticsearch/index/query/QueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryParser.java
@@ -42,4 +42,6 @@ public interface QueryParser {
      */
     @Nullable
     Query parse(QueryParseContext parseContext) throws IOException, QueryParsingException;
+
+    QueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException;
 }

--- a/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
@@ -21,7 +21,6 @@ package org.elasticsearch.index.query;
 
 import com.carrotsearch.hppc.ObjectFloatOpenHashMap;
 
-import org.apache.lucene.search.Query;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
@@ -435,8 +434,7 @@ public class QueryStringQueryBuilder extends BaseQueryBuilder implements Boostab
         builder.endObject();
     }
 
-    @Override
-    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
-        return parseContext.indexQueryParserService().queryParser(QueryStringQueryParser.NAME).parse(parseContext);
+    final protected String parserName() {
+        return QueryStringQueryParser.NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
@@ -21,6 +21,7 @@ package org.elasticsearch.index.query;
 
 import com.carrotsearch.hppc.ObjectFloatOpenHashMap;
 
+import org.apache.lucene.search.Query;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
@@ -432,5 +433,10 @@ public class QueryStringQueryBuilder extends BaseQueryBuilder implements Boostab
             builder.field("time_zone", timeZone);
         }
         builder.endObject();
+    }
+
+    @Override
+    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
+        return parseContext.indexQueryParserService().queryParser(QueryStringQueryParser.NAME).parse(parseContext);
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/QueryStringQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryStringQueryParser.java
@@ -47,7 +47,7 @@ import static org.elasticsearch.common.lucene.search.Queries.fixNegativeQueryIfN
 /**
  *
  */
-public class QueryStringQueryParser extends BaseQueryParser {
+public class QueryStringQueryParser extends BaseQueryParserTemp {
 
     public static final String NAME = "query_string";
     private static final ParseField FUZZINESS = Fuzziness.FIELD.withDeprecation("fuzzy_min_sim");

--- a/src/main/java/org/elasticsearch/index/query/QueryStringQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryStringQueryParser.java
@@ -47,7 +47,7 @@ import static org.elasticsearch.common.lucene.search.Queries.fixNegativeQueryIfN
 /**
  *
  */
-public class QueryStringQueryParser implements QueryParser {
+public class QueryStringQueryParser extends BaseQueryParser {
 
     public static final String NAME = "query_string";
     private static final ParseField FUZZINESS = Fuzziness.FIELD.withDeprecation("fuzzy_min_sim");

--- a/src/main/java/org/elasticsearch/index/query/QueryWrappingQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryWrappingQueryBuilder.java
@@ -20,22 +20,30 @@
 package org.elasticsearch.index.query;
 
 import org.apache.lucene.search.Query;
-import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.xcontent.ToXContent;
-import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 
 /**
- * Base interface for all classes producing lucene queries. 
- * Supports conversion to BytesReference and creation of lucene Query objects.
+ * Temporary wrapper for keeping pre-parsed lucene query in a QueryBuilder field in nested queries.
+ * Can be removed after query refactoring is done.
  */
-public interface QueryBuilder extends ToXContent { 
+public class QueryWrappingQueryBuilder extends BaseQueryBuilder {
+    
+    private Query query;
 
-    BytesReference buildAsBytes() throws ElasticsearchException;
+    public QueryWrappingQueryBuilder(Query query) {
+        this.query = query;
+    }
 
-    BytesReference buildAsBytes(XContentType contentType) throws ElasticsearchException;
+    @Override
+    protected void doXContent(XContentBuilder builder, Params params) throws IOException {
+        throw new org.apache.commons.lang3.NotImplementedException("Not Implemented");
+    }
 
-    Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException;
+    @Override
+    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
+        return this.query;
+    }
+
 }

--- a/src/main/java/org/elasticsearch/index/query/QueryWrappingQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryWrappingQueryBuilder.java
@@ -48,6 +48,6 @@ public class QueryWrappingQueryBuilder extends BaseQueryBuilder {
 
     final protected String parserName() {
         // this should not be called since we overwrite BaseQueryBuilder#toQuery() in this class
-        return null;
+        throw new UnsupportedOperationException();
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/QueryWrappingQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryWrappingQueryBuilder.java
@@ -38,7 +38,7 @@ public class QueryWrappingQueryBuilder extends BaseQueryBuilder {
 
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
-        throw new org.apache.commons.lang3.NotImplementedException("Not Implemented");
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/QueryWrappingQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryWrappingQueryBuilder.java
@@ -29,7 +29,7 @@ import java.io.IOException;
  * Can be removed after query refactoring is done.
  */
 public class QueryWrappingQueryBuilder extends BaseQueryBuilder {
-    
+
     private Query query;
 
     public QueryWrappingQueryBuilder(Query query) {
@@ -46,4 +46,8 @@ public class QueryWrappingQueryBuilder extends BaseQueryBuilder {
         return this.query;
     }
 
+    final protected String parserName() {
+        // this should not be called since we overwrite BaseQueryBuilder#toQuery() in this class
+        return null;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.search.Query;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -427,5 +428,10 @@ public class RangeQueryBuilder extends BaseQueryBuilder implements MultiTermQuer
         }
         builder.endObject();
         builder.endObject();
+    }
+
+    @Override
+    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
+        return new RangeQueryParser().parse(parseContext);
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.search.Query;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -431,7 +430,8 @@ public class RangeQueryBuilder extends BaseQueryBuilder implements MultiTermQuer
     }
 
     @Override
-    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
-        return new RangeQueryParser().parse(parseContext);
+    protected String parserName() {
+        return RangeQueryParser.NAME;
     }
+
 }

--- a/src/main/java/org/elasticsearch/index/query/RangeQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/RangeQueryParser.java
@@ -36,7 +36,7 @@ import java.io.IOException;
 /**
  *
  */
-public class RangeQueryParser implements QueryParser {
+public class RangeQueryParser extends BaseQueryParser {
 
     public static final String NAME = "range";
 

--- a/src/main/java/org/elasticsearch/index/query/RangeQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/RangeQueryParser.java
@@ -36,7 +36,7 @@ import java.io.IOException;
 /**
  *
  */
-public class RangeQueryParser extends BaseQueryParser {
+public class RangeQueryParser extends BaseQueryParserTemp {
 
     public static final String NAME = "range";
 

--- a/src/main/java/org/elasticsearch/index/query/RegexpQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/RegexpQueryBuilder.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.search.Query;
 import org.apache.lucene.util.automaton.Operations;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
@@ -123,5 +124,10 @@ public class RegexpQueryBuilder extends BaseQueryBuilder implements BoostableQue
             builder.endObject();
         }
         builder.endObject();
+    }
+
+    @Override
+    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
+        return new RegexpQueryParser().parse(parseContext);
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/RegexpQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/RegexpQueryBuilder.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.search.Query;
 import org.apache.lucene.util.automaton.Operations;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
@@ -127,7 +126,7 @@ public class RegexpQueryBuilder extends BaseQueryBuilder implements BoostableQue
     }
 
     @Override
-    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
-        return new RegexpQueryParser().parse(parseContext);
+    protected String parserName() {
+        return RegexpQueryParser.NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/RegexpQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/RegexpQueryParser.java
@@ -36,7 +36,7 @@ import java.io.IOException;
 /**
  *
  */
-public class RegexpQueryParser implements QueryParser {
+public class RegexpQueryParser extends BaseQueryParser {
 
     public static final String NAME = "regexp";
 

--- a/src/main/java/org/elasticsearch/index/query/RegexpQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/RegexpQueryParser.java
@@ -36,7 +36,7 @@ import java.io.IOException;
 /**
  *
  */
-public class RegexpQueryParser extends BaseQueryParser {
+public class RegexpQueryParser extends BaseQueryParserTemp {
 
     public static final String NAME = "regexp";
 

--- a/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.search.Query;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -201,7 +200,7 @@ public class SimpleQueryStringBuilder extends BaseQueryBuilder {
     }
 
     @Override
-    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
-        return parseContext.indexQueryParserService().queryParser(SimpleQueryStringParser.NAME).parse(parseContext);
+    protected String parserName() {
+        return SimpleQueryStringParser.NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.search.Query;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -197,5 +198,10 @@ public class SimpleQueryStringBuilder extends BaseQueryBuilder {
         }
 
         builder.endObject();
+    }
+
+    @Override
+    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
+        return parseContext.indexQueryParserService().queryParser(SimpleQueryStringParser.NAME).parse(parseContext);
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/SimpleQueryStringParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SimpleQueryStringParser.java
@@ -69,7 +69,7 @@ import java.util.Map;
  * {@code fields} - fields to search, defaults to _all if not set, allows
  * boosting a field with ^n
  */
-public class SimpleQueryStringParser extends BaseQueryParser {
+public class SimpleQueryStringParser extends BaseQueryParserTemp {
 
     public static final String NAME = "simple_query_string";
 

--- a/src/main/java/org/elasticsearch/index/query/SimpleQueryStringParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SimpleQueryStringParser.java
@@ -69,7 +69,7 @@ import java.util.Map;
  * {@code fields} - fields to search, defaults to _all if not set, allows
  * boosting a field with ^n
  */
-public class SimpleQueryStringParser implements QueryParser {
+public class SimpleQueryStringParser extends BaseQueryParser {
 
     public static final String NAME = "simple_query_string";
 

--- a/src/main/java/org/elasticsearch/index/query/SpanFirstQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanFirstQueryBuilder.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.search.Query;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -72,7 +71,7 @@ public class SpanFirstQueryBuilder extends BaseQueryBuilder implements SpanQuery
     }
 
     @Override
-    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
-        return new SpanFirstQueryParser().parse(parseContext);
+    protected String parserName() {
+        return SpanFirstQueryParser.NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/SpanFirstQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanFirstQueryBuilder.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.search.Query;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -68,5 +69,10 @@ public class SpanFirstQueryBuilder extends BaseQueryBuilder implements SpanQuery
             builder.field("name", queryName);
         }
         builder.endObject();
+    }
+
+    @Override
+    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
+        return new SpanFirstQueryParser().parse(parseContext);
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/SpanFirstQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanFirstQueryParser.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 /**
  *
  */
-public class SpanFirstQueryParser implements QueryParser {
+public class SpanFirstQueryParser extends BaseQueryParser {
 
     public static final String NAME = "span_first";
 

--- a/src/main/java/org/elasticsearch/index/query/SpanFirstQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanFirstQueryParser.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 /**
  *
  */
-public class SpanFirstQueryParser extends BaseQueryParser {
+public class SpanFirstQueryParser extends BaseQueryParserTemp {
 
     public static final String NAME = "span_first";
 

--- a/src/main/java/org/elasticsearch/index/query/SpanMultiTermQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanMultiTermQueryBuilder.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.search.Query;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -44,7 +43,7 @@ public class SpanMultiTermQueryBuilder extends BaseQueryBuilder implements SpanQ
     }
 
     @Override
-    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
-        return new SpanMultiTermQueryParser().parse(parseContext);
+    protected String parserName() {
+        return SpanMultiTermQueryParser.NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/SpanMultiTermQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanMultiTermQueryBuilder.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.search.Query;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -42,4 +43,8 @@ public class SpanMultiTermQueryBuilder extends BaseQueryBuilder implements SpanQ
         builder.endObject();
     }
 
+    @Override
+    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
+        return new SpanMultiTermQueryParser().parse(parseContext);
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/SpanMultiTermQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanMultiTermQueryParser.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 /**
  *
  */
-public class SpanMultiTermQueryParser implements QueryParser {
+public class SpanMultiTermQueryParser extends BaseQueryParser {
 
     public static final String NAME = "span_multi";
     public static final String MATCH_NAME = "match";

--- a/src/main/java/org/elasticsearch/index/query/SpanMultiTermQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanMultiTermQueryParser.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 /**
  *
  */
-public class SpanMultiTermQueryParser extends BaseQueryParser {
+public class SpanMultiTermQueryParser extends BaseQueryParserTemp {
 
     public static final String NAME = "span_multi";
     public static final String MATCH_NAME = "match";

--- a/src/main/java/org/elasticsearch/index/query/SpanNearQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanNearQueryBuilder.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.search.Query;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
@@ -108,7 +107,7 @@ public class SpanNearQueryBuilder extends BaseQueryBuilder implements SpanQueryB
     }
 
     @Override
-    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
-        return new SpanNearQueryParser().parse(parseContext);
+    protected String parserName() {
+        return SpanNearQueryParser.NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/SpanNearQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanNearQueryBuilder.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.search.Query;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
@@ -104,5 +105,10 @@ public class SpanNearQueryBuilder extends BaseQueryBuilder implements SpanQueryB
             builder.field("_name", queryName);
         }
         builder.endObject();
+    }
+
+    @Override
+    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
+        return new SpanNearQueryParser().parse(parseContext);
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/SpanNearQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanNearQueryParser.java
@@ -34,7 +34,7 @@ import static com.google.common.collect.Lists.newArrayList;
 /**
  *
  */
-public class SpanNearQueryParser extends BaseQueryParser {
+public class SpanNearQueryParser extends BaseQueryParserTemp {
 
     public static final String NAME = "span_near";
 

--- a/src/main/java/org/elasticsearch/index/query/SpanNearQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanNearQueryParser.java
@@ -34,7 +34,7 @@ import static com.google.common.collect.Lists.newArrayList;
 /**
  *
  */
-public class SpanNearQueryParser implements QueryParser {
+public class SpanNearQueryParser extends BaseQueryParser {
 
     public static final String NAME = "span_near";
 

--- a/src/main/java/org/elasticsearch/index/query/SpanNotQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanNotQueryBuilder.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.search.Query;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
@@ -122,7 +121,7 @@ public class SpanNotQueryBuilder extends BaseQueryBuilder implements SpanQueryBu
     }
 
     @Override
-    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
-        return new SpanNotQueryParser().parse(parseContext);
+    protected String parserName() {
+        return SpanNotQueryParser.NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/SpanNotQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanNotQueryBuilder.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.search.Query;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
@@ -118,5 +119,10 @@ public class SpanNotQueryBuilder extends BaseQueryBuilder implements SpanQueryBu
             builder.field("_name", queryName);
         }
         builder.endObject();
+    }
+
+    @Override
+    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
+        return new SpanNotQueryParser().parse(parseContext);
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/SpanNotQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanNotQueryParser.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 /**
  *
  */
-public class SpanNotQueryParser implements QueryParser {
+public class SpanNotQueryParser extends BaseQueryParser {
 
     public static final String NAME = "span_not";
 

--- a/src/main/java/org/elasticsearch/index/query/SpanNotQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanNotQueryParser.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 /**
  *
  */
-public class SpanNotQueryParser extends BaseQueryParser {
+public class SpanNotQueryParser extends BaseQueryParserTemp {
 
     public static final String NAME = "span_not";
 

--- a/src/main/java/org/elasticsearch/index/query/SpanOrQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanOrQueryBuilder.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.search.Query;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
@@ -73,5 +74,10 @@ public class SpanOrQueryBuilder extends BaseQueryBuilder implements SpanQueryBui
             builder.field("_name", queryName);
         }
         builder.endObject();
+    }
+
+    @Override
+    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
+        return new SpanOrQueryParser().parse(parseContext);
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/SpanOrQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanOrQueryBuilder.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.search.Query;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
@@ -77,7 +76,7 @@ public class SpanOrQueryBuilder extends BaseQueryBuilder implements SpanQueryBui
     }
 
     @Override
-    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
-        return new SpanOrQueryParser().parse(parseContext);
+    protected String parserName() {
+        return SpanOrQueryParser.NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/SpanOrQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanOrQueryParser.java
@@ -34,7 +34,7 @@ import static com.google.common.collect.Lists.newArrayList;
 /**
  *
  */
-public class SpanOrQueryParser extends BaseQueryParser {
+public class SpanOrQueryParser extends BaseQueryParserTemp {
 
     public static final String NAME = "span_or";
 

--- a/src/main/java/org/elasticsearch/index/query/SpanOrQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanOrQueryParser.java
@@ -34,7 +34,7 @@ import static com.google.common.collect.Lists.newArrayList;
 /**
  *
  */
-public class SpanOrQueryParser implements QueryParser {
+public class SpanOrQueryParser extends BaseQueryParser {
 
     public static final String NAME = "span_or";
 

--- a/src/main/java/org/elasticsearch/index/query/SpanTermQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanTermQueryBuilder.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.search.Query;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -96,7 +95,7 @@ public class SpanTermQueryBuilder extends BaseQueryBuilder implements SpanQueryB
     }
 
     @Override
-    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
-        return new SpanTermQueryParser().parse(parseContext);
+    protected String parserName() {
+        return SpanTermQueryParser.NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/SpanTermQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanTermQueryBuilder.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.search.Query;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -92,5 +93,10 @@ public class SpanTermQueryBuilder extends BaseQueryBuilder implements SpanQueryB
             builder.endObject();
         }
         builder.endObject();
+    }
+
+    @Override
+    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
+        return new SpanTermQueryParser().parse(parseContext);
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/SpanTermQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanTermQueryParser.java
@@ -33,7 +33,7 @@ import java.io.IOException;
 /**
  *
  */
-public class SpanTermQueryParser extends BaseQueryParser {
+public class SpanTermQueryParser extends BaseQueryParserTemp {
 
     public static final String NAME = "span_term";
 

--- a/src/main/java/org/elasticsearch/index/query/SpanTermQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanTermQueryParser.java
@@ -33,7 +33,7 @@ import java.io.IOException;
 /**
  *
  */
-public class SpanTermQueryParser implements QueryParser {
+public class SpanTermQueryParser extends BaseQueryParser {
 
     public static final String NAME = "span_term";
 

--- a/src/main/java/org/elasticsearch/index/query/TemplateQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/TemplateQueryBuilder.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.search.Query;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.script.ScriptService;
@@ -76,5 +77,10 @@ public class TemplateQueryBuilder extends BaseQueryBuilder {
         builder.field(fieldname, template);
         builder.field(TemplateQueryParser.PARAMS, vars);
         builder.endObject();
+    }
+
+    @Override
+    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
+        return parseContext.indexQueryParserService().queryParser(TemplateQueryParser.NAME).parse(parseContext);
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/TemplateQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/TemplateQueryBuilder.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.search.Query;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.script.ScriptService;
@@ -80,7 +79,7 @@ public class TemplateQueryBuilder extends BaseQueryBuilder {
     }
 
     @Override
-    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
-        return parseContext.indexQueryParserService().queryParser(TemplateQueryParser.NAME).parse(parseContext);
+    protected String parserName() {
+        return TemplateQueryParser.NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/TemplateQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TemplateQueryParser.java
@@ -38,7 +38,7 @@ import java.util.Map;
  * In the simplest case, parse template string and variables from the request, compile the template and
  * execute the template against the given variables.
  * */
-public class TemplateQueryParser extends BaseQueryParser {
+public class TemplateQueryParser extends BaseQueryParserTemp {
 
     /** Name to reference this type of query. */
     public static final String NAME = "template";

--- a/src/main/java/org/elasticsearch/index/query/TemplateQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TemplateQueryParser.java
@@ -38,7 +38,7 @@ import java.util.Map;
  * In the simplest case, parse template string and variables from the request, compile the template and
  * execute the template against the given variables.
  * */
-public class TemplateQueryParser implements QueryParser {
+public class TemplateQueryParser extends BaseQueryParser {
 
     /** Name to reference this type of query. */
     public static final String NAME = "template";

--- a/src/main/java/org/elasticsearch/index/query/TermQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/TermQueryBuilder.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.search.Query;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -148,7 +147,7 @@ public class TermQueryBuilder extends BaseQueryBuilder implements BoostableQuery
     }
 
     @Override
-    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
-        return new TermQueryParser().parse(parseContext);
+    protected String parserName() {
+        return TermQueryParser.NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/TermQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/TermQueryBuilder.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.search.Query;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -144,5 +145,10 @@ public class TermQueryBuilder extends BaseQueryBuilder implements BoostableQuery
             builder.endObject();
         }
         builder.endObject();
+    }
+
+    @Override
+    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
+        return new TermQueryParser().parse(parseContext);
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/TermQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TermQueryParser.java
@@ -32,7 +32,7 @@ import java.io.IOException;
 /**
  *
  */
-public class TermQueryParser implements QueryParser {
+public class TermQueryParser extends BaseQueryParser {
 
     public static final String NAME = "term";
 

--- a/src/main/java/org/elasticsearch/index/query/TermQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TermQueryParser.java
@@ -32,7 +32,7 @@ import java.io.IOException;
 /**
  *
  */
-public class TermQueryParser extends BaseQueryParser {
+public class TermQueryParser extends BaseQueryParserTemp {
 
     public static final String NAME = "term";
 

--- a/src/main/java/org/elasticsearch/index/query/TermsQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/TermsQueryBuilder.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.search.Query;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -189,5 +190,10 @@ public class TermsQueryBuilder extends BaseQueryBuilder implements BoostableQuer
         }
 
         builder.endObject();
+    }
+
+    @Override
+    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
+        return new TermsQueryParser().parse(parseContext);
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/TermsQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/TermsQueryBuilder.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.search.Query;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -193,7 +192,7 @@ public class TermsQueryBuilder extends BaseQueryBuilder implements BoostableQuer
     }
 
     @Override
-    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
-        return new TermsQueryParser().parse(parseContext);
+    protected String parserName() {
+        return TermsQueryParser.NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/TermsQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TermsQueryParser.java
@@ -44,7 +44,7 @@ import static org.elasticsearch.common.lucene.search.Queries.fixNegativeQueryIfN
  * }
  * </pre>
  */
-public class TermsQueryParser implements QueryParser {
+public class TermsQueryParser extends BaseQueryParser {
 
     public static final String NAME = "terms";
 

--- a/src/main/java/org/elasticsearch/index/query/TermsQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TermsQueryParser.java
@@ -44,7 +44,7 @@ import static org.elasticsearch.common.lucene.search.Queries.fixNegativeQueryIfN
  * }
  * </pre>
  */
-public class TermsQueryParser extends BaseQueryParser {
+public class TermsQueryParser extends BaseQueryParserTemp {
 
     public static final String NAME = "terms";
 

--- a/src/main/java/org/elasticsearch/index/query/TopChildrenQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/TopChildrenQueryBuilder.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.search.Query;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -116,7 +115,7 @@ public class TopChildrenQueryBuilder extends BaseQueryBuilder implements Boostab
     }
 
     @Override
-    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
-        return new TopChildrenQueryParser().parse(parseContext);
+    protected String parserName() {
+        return TopChildrenQueryParser.NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/TopChildrenQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/TopChildrenQueryBuilder.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.search.Query;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -112,5 +113,10 @@ public class TopChildrenQueryBuilder extends BaseQueryBuilder implements Boostab
             builder.field("_name", queryName);
         }
         builder.endObject();
+    }
+
+    @Override
+    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
+        return new TopChildrenQueryParser().parse(parseContext);
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/TopChildrenQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TopChildrenQueryParser.java
@@ -40,7 +40,7 @@ import static org.elasticsearch.index.query.QueryParserUtils.ensureNotDeleteByQu
 /**
  *
  */
-public class TopChildrenQueryParser extends BaseQueryParser {
+public class TopChildrenQueryParser extends BaseQueryParserTemp {
 
     public static final String NAME = "top_children";
 

--- a/src/main/java/org/elasticsearch/index/query/TopChildrenQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TopChildrenQueryParser.java
@@ -40,7 +40,7 @@ import static org.elasticsearch.index.query.QueryParserUtils.ensureNotDeleteByQu
 /**
  *
  */
-public class TopChildrenQueryParser implements QueryParser {
+public class TopChildrenQueryParser extends BaseQueryParser {
 
     public static final String NAME = "top_children";
 

--- a/src/main/java/org/elasticsearch/index/query/WildcardQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/WildcardQueryBuilder.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.search.Query;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -104,5 +105,10 @@ public class WildcardQueryBuilder extends BaseQueryBuilder implements MultiTermQ
             builder.endObject();
         }
         builder.endObject();
+    }
+
+    @Override
+    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
+        return new WildcardQueryParser().parse(parseContext);
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/WildcardQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/WildcardQueryBuilder.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.search.Query;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -108,7 +107,7 @@ public class WildcardQueryBuilder extends BaseQueryBuilder implements MultiTermQ
     }
 
     @Override
-    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
-        return new WildcardQueryParser().parse(parseContext);
+    protected String parserName() {
+        return WildcardQueryParser.NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/WildcardQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/WildcardQueryParser.java
@@ -33,7 +33,7 @@ import java.io.IOException;
 /**
  *
  */
-public class WildcardQueryParser implements QueryParser {
+public class WildcardQueryParser extends BaseQueryParser {
 
     public static final String NAME = "wildcard";
 

--- a/src/main/java/org/elasticsearch/index/query/WildcardQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/WildcardQueryParser.java
@@ -33,7 +33,7 @@ import java.io.IOException;
 /**
  *
  */
-public class WildcardQueryParser extends BaseQueryParser {
+public class WildcardQueryParser extends BaseQueryParserTemp {
 
     public static final String NAME = "wildcard";
 

--- a/src/main/java/org/elasticsearch/index/query/WrapperQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/WrapperQueryBuilder.java
@@ -27,7 +27,6 @@ package org.elasticsearch.index.query;
 
 import com.google.common.base.Charsets;
 
-import org.apache.lucene.search.Query;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -75,7 +74,7 @@ public class WrapperQueryBuilder extends BaseQueryBuilder {
     }
 
     @Override
-    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
-        return new WrapperQueryParser().parse(parseContext);
+    protected String parserName() {
+        return WrapperQueryParser.NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/WrapperQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/WrapperQueryBuilder.java
@@ -26,6 +26,8 @@ package org.elasticsearch.index.query;
  */
 
 import com.google.common.base.Charsets;
+
+import org.apache.lucene.search.Query;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -70,5 +72,10 @@ public class WrapperQueryBuilder extends BaseQueryBuilder {
         builder.startObject(WrapperQueryParser.NAME);
         builder.field("query", source, offset, length);
         builder.endObject();
+    }
+
+    @Override
+    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
+        return new WrapperQueryParser().parse(parseContext);
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/WrapperQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/WrapperQueryParser.java
@@ -29,7 +29,7 @@ import java.io.IOException;
 /**
  * Query parser for JSON Queries.
  */
-public class WrapperQueryParser extends BaseQueryParser {
+public class WrapperQueryParser extends BaseQueryParserTemp {
 
     public static final String NAME = "wrapper";
 

--- a/src/main/java/org/elasticsearch/index/query/WrapperQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/WrapperQueryParser.java
@@ -29,7 +29,7 @@ import java.io.IOException;
 /**
  * Query parser for JSON Queries.
  */
-public class WrapperQueryParser implements QueryParser {
+public class WrapperQueryParser extends BaseQueryParser {
 
     public static final String NAME = "wrapper";
 

--- a/src/main/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilder.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.query.functionscore;
 
+import org.apache.lucene.search.Query;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.common.lucene.search.function.CombineFunction;
 import org.elasticsearch.common.lucene.search.function.FunctionScoreQuery;
@@ -26,7 +27,10 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.query.BaseQueryBuilder;
 import org.elasticsearch.index.query.BoostableQueryBuilder;
 import org.elasticsearch.index.query.FilterBuilder;
+import org.elasticsearch.index.query.MultiMatchQueryParser;
 import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryParseContext;
+import org.elasticsearch.index.query.QueryParsingException;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -226,5 +230,10 @@ public class FunctionScoreQueryBuilder extends BaseQueryBuilder implements Boost
     public FunctionScoreQueryBuilder setMinScore(float minScore) {
         this.minScore = minScore;
         return this;
+    }
+
+    @Override
+    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
+        return parseContext.indexQueryParserService().queryParser(FunctionScoreQueryParser.NAME).parse(parseContext);
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilder.java
@@ -19,18 +19,13 @@
 
 package org.elasticsearch.index.query.functionscore;
 
-import org.apache.lucene.search.Query;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.common.lucene.search.function.CombineFunction;
-import org.elasticsearch.common.lucene.search.function.FunctionScoreQuery;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.query.BaseQueryBuilder;
 import org.elasticsearch.index.query.BoostableQueryBuilder;
 import org.elasticsearch.index.query.FilterBuilder;
-import org.elasticsearch.index.query.MultiMatchQueryParser;
 import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.QueryParseContext;
-import org.elasticsearch.index.query.QueryParsingException;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -233,7 +228,7 @@ public class FunctionScoreQueryBuilder extends BaseQueryBuilder implements Boost
     }
 
     @Override
-    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
-        return parseContext.indexQueryParserService().queryParser(FunctionScoreQueryParser.NAME).parse(parseContext);
+    protected String parserName() {
+        return FunctionScoreQueryParser.NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryParser.java
@@ -21,6 +21,7 @@ package org.elasticsearch.index.query.functionscore;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMap.Builder;
+
 import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.Filter;
 import org.apache.lucene.search.FilteredQuery;
@@ -37,9 +38,11 @@ import org.elasticsearch.common.lucene.search.function.FunctionScoreQuery;
 import org.elasticsearch.common.lucene.search.function.ScoreFunction;
 import org.elasticsearch.common.lucene.search.function.WeightFactorFunction;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryParseContext;
 import org.elasticsearch.index.query.QueryParser;
 import org.elasticsearch.index.query.QueryParsingException;
+import org.elasticsearch.index.query.QueryWrappingQueryBuilder;
 import org.elasticsearch.index.query.functionscore.factor.FactorParser;
 
 import java.io.IOException;
@@ -264,5 +267,11 @@ public class FunctionScoreQueryParser implements QueryParser {
             throw new QueryParsingException(parseContext.index(), NAME + " illegal boost_mode [" + boostMode + "]");
         }
         return cf;
+    }
+
+    @Override
+    public QueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
+        Query query = parse(parseContext);
+        return new QueryWrappingQueryBuilder(query);
     }
 }

--- a/src/test/java/org/elasticsearch/index/query/guice/MyJsonQueryParser.java
+++ b/src/test/java/org/elasticsearch/index/query/guice/MyJsonQueryParser.java
@@ -25,9 +25,11 @@ import org.elasticsearch.common.inject.assistedinject.Assisted;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.AbstractIndexComponent;
 import org.elasticsearch.index.Index;
+import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryParseContext;
 import org.elasticsearch.index.query.QueryParser;
 import org.elasticsearch.index.query.QueryParsingException;
+import org.elasticsearch.index.query.QueryWrappingQueryBuilder;
 import org.elasticsearch.index.settings.IndexSettings;
 
 import java.io.IOException;
@@ -60,5 +62,11 @@ public class MyJsonQueryParser extends AbstractIndexComponent implements QueryPa
 
     public Settings settings() {
         return settings;
+    }
+
+    @Override
+    public QueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
+        Query query = parse(parseContext);
+        return new QueryWrappingQueryBuilder(query);
     }
 }

--- a/src/test/java/org/elasticsearch/index/query/plugin/PluginJsonQueryParser.java
+++ b/src/test/java/org/elasticsearch/index/query/plugin/PluginJsonQueryParser.java
@@ -25,9 +25,11 @@ import org.elasticsearch.common.inject.assistedinject.Assisted;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.AbstractIndexComponent;
 import org.elasticsearch.index.Index;
+import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryParseContext;
 import org.elasticsearch.index.query.QueryParser;
 import org.elasticsearch.index.query.QueryParsingException;
+import org.elasticsearch.index.query.QueryWrappingQueryBuilder;
 import org.elasticsearch.index.settings.IndexSettings;
 
 import java.io.IOException;
@@ -60,5 +62,11 @@ public class PluginJsonQueryParser extends AbstractIndexComponent implements Que
 
     public Settings settings() {
         return settings;
+    }
+
+    @Override
+    public QueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
+        Query query = parse(parseContext);
+        return new QueryWrappingQueryBuilder(query);
     }
 }


### PR DESCRIPTION
The currently planed refactoring of search queries layed out in #9901 and currently tracked in #10217 requires the current "parse()" methods into two methods, first a "fromXContent(...)" method that allows parsing to an intermediate query representation and second a "Query toQuery(...)" method these parsed query objects that create the actual lucene queries.

This PR is a first step in that direction as it introduces the interface changes necessary for the further refactoring. It introduces the new interface methods while for now keeping the old Builder/Parser API still in place by delegating the new "toQuery()" implementations to the existing "parse()" methods, and by introducing a "catch-all" "fromXContent()" implementation in a BaseQueryParser that returns a temporary QueryBuilder wrapper implementation. This allows us to refactor the existing QueryBuilders step by step while already beeing able to start refactoring queries with nested inner queries.
