### PR TITLE
Allow rebalancing primary shards on shared filesystems

### DIFF
--- a/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -1037,8 +1037,15 @@ public abstract class Engine implements Closeable {
 
     protected abstract SearcherManager getSearcherManager();
 
+    /**
+     * Method to close the engine while the write lock is held.
+     */
     protected abstract void closeNoLock(String reason) throws ElasticsearchException;
 
+    /**
+     * Flush the engine (committing segments to disk and truncating the
+     * translog) and close it.
+     */
     public void flushAndClose() throws IOException {
         if (isClosed.get() == false) {
             logger.trace("flushAndClose now acquire writeLock");
@@ -1062,7 +1069,8 @@ public abstract class Engine implements Closeable {
 
     @Override
     public void close() throws IOException {
-        if (isClosed.get() == false) { // don't acquire the write lock if we are already closed
+        // don't acquire the write lock if we are already closed
+        if (isClosed.get() == false) {
             logger.debug("close now acquiring writeLock");
             try (ReleasableLock _ = writeLock.acquire()) {
                 logger.debug("close acquired writeLock");

--- a/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -627,7 +627,7 @@ public class InternalEngine extends Engine {
             if (flushLock.tryLock() == false) {
                 // if we can't get the lock right away we block if needed otherwise barf
                 if (waitIfOngoing) {
-                    logger.trace("waiting fore in-flight flush to finish");
+                    logger.trace("waiting for in-flight flush to finish");
                     flushLock.lock();
                     logger.trace("acquired flush lock after blocking");
                 } else {
@@ -639,7 +639,7 @@ public class InternalEngine extends Engine {
             try {
                 if (commitTranslog) {
                     if (onGoingRecoveries.get() > 0) {
-                        throw new FlushNotAllowedEngineException(shardId, "Recovery is in progress, flush is not allowed");
+                        throw new FlushNotAllowedEngineException(shardId, "recovery is in progress, flush is not allowed");
                     }
 
                     if (flushNeeded || force) {
@@ -825,6 +825,7 @@ public class InternalEngine extends Engine {
 
         SnapshotIndexCommit phase1Snapshot;
         try {
+            logger.trace("[pre-phase1] performing deletion policy snapshot");
             phase1Snapshot = deletionPolicy.snapshot();
         } catch (Throwable e) {
             maybeFailEngine("recovery", e);
@@ -833,25 +834,28 @@ public class InternalEngine extends Engine {
         }
 
         try {
+            logger.trace("[phase1] performing phase 1 recovery (file recovery)");
             recoveryHandler.phase1(phase1Snapshot);
         } catch (Throwable e) {
-            maybeFailEngine("recovery phase 1", e);
+            maybeFailEngine("recovery phase 1 (file transfer)", e);
             Releasables.closeWhileHandlingException(phase1Snapshot, onGoingRecoveries);
             throw new RecoveryEngineException(shardId, 1, "Execution failed", wrapIfClosed(e));
         }
 
         Translog.Snapshot phase2Snapshot;
         try {
+            logger.trace("[pre-phase2] performing translog snapshot");
             phase2Snapshot = translog.snapshot();
         } catch (Throwable e) {
-            maybeFailEngine("snapshot recovery", e);
+            maybeFailEngine("translog snapshot", e);
             Releasables.closeWhileHandlingException(phase1Snapshot, onGoingRecoveries);
             throw new RecoveryEngineException(shardId, 2, "Snapshot failed", wrapIfClosed(e));
         }
         try {
+            logger.trace("[phase2] performing phase 2 recovery (translog replay)");
             recoveryHandler.phase2(phase2Snapshot);
         } catch (Throwable e) {
-            maybeFailEngine("recovery phase 2", e);
+            maybeFailEngine("recovery phase 2 (snapshot transfer)", e);
             Releasables.closeWhileHandlingException(phase1Snapshot, phase2Snapshot, onGoingRecoveries);
             throw new RecoveryEngineException(shardId, 2, "Execution failed", wrapIfClosed(e));
         }
@@ -861,16 +865,19 @@ public class InternalEngine extends Engine {
         boolean success = false;
         try {
             ensureOpen();
+            logger.trace("[pre-phase3] performing translog snapshot");
             phase3Snapshot = translog.snapshot(phase2Snapshot);
+            logger.trace("[phase3] performing phase 3 recovery (translog replay under write lock)");
             recoveryHandler.phase3(phase3Snapshot);
             success = true;
         } catch (Throwable e) {
-            maybeFailEngine("recovery phase 3", e);
+            maybeFailEngine("recovery phase 3 (snapshot transfer)", e);
             throw new RecoveryEngineException(shardId, 3, "Execution failed", wrapIfClosed(e));
         } finally {
             Releasables.close(success, phase1Snapshot, phase2Snapshot, phase3Snapshot,
                     onGoingRecoveries, writeLock); // hmm why can't we use try-with here?
         }
+        logger.trace("[post-recovery] recovery complete");
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/engine/SharedFSEngine.java
+++ b/src/main/java/org/elasticsearch/index/engine/SharedFSEngine.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.engine;
+
+import org.elasticsearch.common.util.concurrent.ReleasableLock;
+
+/**
+ * SharedFSEngine behaves similarly to InternalEngine, however, during
+ * recovery, it does not take a snapshot of the translog or index and it
+ * performs stage1 (file transfer) under the write lock.
+ */
+public class SharedFSEngine extends InternalEngine {
+    public SharedFSEngine(EngineConfig engineConfig, boolean skipInitialTranslogRecovery) throws EngineException {
+        super(engineConfig, skipInitialTranslogRecovery);
+    }
+
+    @Override
+    public void recover(RecoveryHandler recoveryHandler) throws EngineException {
+        store.incRef();
+        try  {
+            logger.trace("[pre-recovery] acquiring write lock");
+            try (ReleasableLock lock = writeLock.acquire()) {
+                // phase1 under lock
+                ensureOpen();
+                try {
+                    logger.trace("[phase1] performing phase 1 recovery (file recovery)");
+                    recoveryHandler.phase1(null);
+                } catch (Throwable e) {
+                    maybeFailEngine("recovery phase 1 (file transfer)", e);
+                    throw new RecoveryEngineException(shardId, 1, "Execution failed", wrapIfClosed(e));
+                }
+            }
+            try {
+                logger.trace("[phase2] performing phase 2 recovery (translog replay)");
+                recoveryHandler.phase2(null);
+            } catch (Throwable e) {
+                maybeFailEngine("recovery phase 2 (snapshot transfer)", e);
+                throw new RecoveryEngineException(shardId, 2, "Execution failed", wrapIfClosed(e));
+            }
+            try {
+                logger.trace("[phase3] performing phase 3 recovery (finalization)");
+                recoveryHandler.phase3(null);
+            } catch (Throwable e) {
+                maybeFailEngine("recovery phase 3 (finalization)", e);
+                throw new RecoveryEngineException(shardId, 3, "Execution failed", wrapIfClosed(e));
+            }
+        } finally {
+            store.decRef();
+        }
+        logger.trace("[post-recovery] recovery complete");
+    }
+}

--- a/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -116,7 +116,6 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.channels.ClosedByInterruptException;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -749,7 +748,9 @@ public class IndexShard extends AbstractIndexShardComponent {
                     if (flushEngine && this.flushOnClose) {
                         engine.flushAndClose();
                     }
-                } finally { // playing safe here and close the engine even if the above succeeds - close can be called multiple times
+                } finally {
+                    // playing safe here and close the engine even if the above
+                    // succeeds - close can be called multiple times.
                     IOUtils.close(engine);
                 }
             }
@@ -867,10 +868,14 @@ public class IndexShard extends AbstractIndexShardComponent {
     public void finalizeRecovery() {
         recoveryState().setStage(RecoveryState.Stage.FINALIZE);
         // clear unreferenced files
-        translog.clearUnreferenced();
+        clearUnreferencedTranslogs();
         engine().refresh("recovery_finalization");
         startScheduledTasksIfNeeded();
         engineConfig.setEnableGcDeletes(true);
+    }
+
+    protected void clearUnreferencedTranslogs() {
+        translog.clearUnreferenced();
     }
 
     /**
@@ -1228,7 +1233,6 @@ public class IndexShard extends AbstractIndexShardComponent {
     protected Engine newEngine(boolean skipTranslogRecovery, EngineConfig config) {
         return engineFactory.newReadWriteEngine(config, skipTranslogRecovery);
     }
-
 
     /**
      * Returns <code>true</code> iff this shard allows primary promotion, otherwise <code>false</code>

--- a/src/main/java/org/elasticsearch/index/shard/ShadowIndexShard.java
+++ b/src/main/java/org/elasticsearch/index/shard/ShadowIndexShard.java
@@ -110,6 +110,11 @@ public final class ShadowIndexShard extends IndexShard {
         return engineFactory.newReadOnlyEngine(config);
     }
 
+    @Override
+    protected void clearUnreferencedTranslogs() {
+        // no-op - Shadow replicas should never delete translogs
+    }
+
     public boolean allowsPrimaryPromotion() {
         return false;
     }

--- a/src/main/java/org/elasticsearch/index/translog/fs/FsTranslog.java
+++ b/src/main/java/org/elasticsearch/index/translog/fs/FsTranslog.java
@@ -39,7 +39,6 @@ import org.elasticsearch.index.settings.IndexSettingsService;
 import org.elasticsearch.index.shard.AbstractIndexShardComponent;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.ShardPath;
-import org.elasticsearch.index.store.IndexStore;
 import org.elasticsearch.index.translog.*;
 
 import java.io.EOFException;
@@ -47,7 +46,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.channels.ClosedChannelException;
 import java.nio.file.*;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -432,6 +430,8 @@ public class FsTranslog extends AbstractIndexShardComponent implements Translog 
                         final Matcher matcher = PARSE_ID_PATTERN.matcher(fileName);
                         if (matcher.matches()) {
                             maxId = Math.max(maxId, Long.parseLong(matcher.group(1)));
+                            logger.trace("found translog: [{}], maxId: [{}], location: [{}]",
+                                    fileName, maxId, location);
                         }
                     } catch (NumberFormatException ex) {
                         logger.warn("Couldn't parse translog id from file " + translogFile + " skipping");

--- a/src/main/java/org/elasticsearch/indices/recovery/SharedFSRecoverySourceHandler.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/SharedFSRecoverySourceHandler.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.indices.recovery;
 
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.ElasticsearchIllegalStateException;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.action.index.MappingUpdatedAction;
 import org.elasticsearch.common.logging.ESLogger;
@@ -30,6 +29,9 @@ import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.transport.TransportService;
 
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 /**
  * A recovery handler that skips phase 1 as well as sending the snapshot. During phase 3 the shard is marked
  * as relocated an closed to ensure that the engine is closed and the target can acquire the IW write lock.
@@ -38,8 +40,12 @@ public class SharedFSRecoverySourceHandler extends RecoverySourceHandler {
 
     private final IndexShard shard;
     private final StartRecoveryRequest request;
+    private final AtomicBoolean engineClosed = new AtomicBoolean(false);
 
-    public SharedFSRecoverySourceHandler(IndexShard shard, StartRecoveryRequest request, RecoverySettings recoverySettings, TransportService transportService, ClusterService clusterService, IndicesService indicesService, MappingUpdatedAction mappingUpdatedAction, ESLogger logger) {
+    public SharedFSRecoverySourceHandler(IndexShard shard, StartRecoveryRequest request,
+                                         RecoverySettings recoverySettings, TransportService transportService,
+                                         ClusterService clusterService, IndicesService indicesService,
+                                         MappingUpdatedAction mappingUpdatedAction, ESLogger logger) {
         super(shard, request, recoverySettings, transportService, clusterService, indicesService, mappingUpdatedAction, logger);
         this.shard = shard;
         this.request = request;
@@ -47,22 +53,64 @@ public class SharedFSRecoverySourceHandler extends RecoverySourceHandler {
 
     @Override
     public void phase1(SnapshotIndexCommit snapshot) throws ElasticsearchException {
-        if (request.recoveryType() == RecoveryState.Type.RELOCATION && shard.routingEntry().primary()) {
-            // here we simply fail the primary shard since we can't move them (have 2 writers open at the same time)
-            // by failing the shard we play safe and just go through the entire reallocation procedure of the primary
-            // it would be ideal to make sure we flushed the translog here but that is not possible in the current design.
-            ElasticsearchIllegalStateException exception = new ElasticsearchIllegalStateException("Can't relocate primary - failing");
-            shard.failShard("primary_relocation", exception);
-            throw exception;
+        logger.trace("{} recovery [phase1] to {}: skipping phase 1 for shared filesystem",
+                request.shardId(), request.targetNode());
+        // if we relocate we need to close the engine in order to open a new
+        // IndexWriter on the other end of the relocation
+        if (isPrimaryRelocation()) {
+            logger.debug("[phase1] closing engine on primary for shared filesystem recovery");
+            shard.engine().flush(true, true);
+            try {
+                shard.engine().close();
+                engineClosed.set(true);
+            } catch (IOException e) {
+                logger.warn("close engine failed", e);
+                shard.failShard("failed to close engine (phase1)", e);
+            }
         }
-        logger.trace("{} recovery [phase2] to {}: skipping phase 1 for shared filesystem", request.shardId(), request.targetNode());
     }
 
+    @Override
+    public void phase2(Translog.Snapshot snapshot) throws ElasticsearchException {
+        try {
+            super.phase2(snapshot);
+        } catch (Throwable t) {
+            onRecoveryFailure(t);
+            throw t;
+        }
+    }
+
+    @Override
+    public void phase3(Translog.Snapshot snapshot) throws ElasticsearchException {
+        try {
+            super.phase3(snapshot);
+        } catch (Throwable t) {
+            onRecoveryFailure(t);
+            throw t;
+        }
+    }
 
     @Override
     protected int sendSnapshot(Translog.Snapshot snapshot) throws ElasticsearchException {
-        logger.trace("{} recovery [phase3] to {}: skipping transaction log operations for file sync", shard.shardId(), request.targetNode());
+        logger.trace("{} skipping recovery of translog snapshot on shared filesystem to: {}",
+                shard.shardId(), request.targetNode());
         return 0;
     }
 
+    private boolean isPrimaryRelocation() {
+        return request.recoveryType() == RecoveryState.Type.RELOCATION && shard.routingEntry().primary();
+    }
+
+    public void onRecoveryFailure(Throwable t) {
+        if (isPrimaryRelocation() && engineClosed.get()) {
+            // If the relocation fails then the primary is closed and can't be
+            // used anymore... (because it's closed) that's a problem, so in
+            // that case, fail the shard to reallocate a new IndexShard and
+            // create a new IndexWriter
+            logger.info("recovery failed for primary shadow shard, failing shard");
+            shard.failShard("primary relocation failed on shared filesystem", t);
+        } else {
+            logger.info("recovery failed on shared filesystem", t);
+        }
+    }
 }

--- a/src/test/java/org/elasticsearch/index/IndexWithShadowReplicasTests.java
+++ b/src/test/java/org/elasticsearch/index/IndexWithShadowReplicasTests.java
@@ -19,30 +19,41 @@
 
 package org.elasticsearch.index;
 
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
 import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotResponse;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.RoutingNodes;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.discovery.Discovery;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShadowIndexShard;
 import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.indices.recovery.RecoveryTarget;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.snapshots.SnapshotState;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.elasticsearch.test.InternalTestCluster;
+import org.elasticsearch.test.transport.MockTransportService;
+import org.elasticsearch.transport.*;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
@@ -307,6 +318,174 @@ public class IndexWithShadowReplicasTests extends ElasticsearchIntegrationTest {
         assertTrue(gResp2.isExists());
         assertThat(gResp1.getField("foo").getValue().toString(), equalTo("bar"));
         assertThat(gResp2.getField("foo").getValue().toString(), equalTo("bar"));
+    }
+
+    @Test
+    public void testPrimaryRelocationWithConcurrentIndexing() throws Exception {
+        Settings nodeSettings = ImmutableSettings.builder()
+                .put("node.add_id_to_custom_path", false)
+                .put("node.enable_custom_paths", true)
+                .build();
+
+        String node1 = internalCluster().startNode(nodeSettings);
+        Path dataPath = createTempDir();
+        final String IDX = "test";
+
+        Settings idxSettings = ImmutableSettings.builder()
+                .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
+                .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 1)
+                .put(IndexMetaData.SETTING_DATA_PATH, dataPath.toAbsolutePath().toString())
+                .put(IndexMetaData.SETTING_SHADOW_REPLICAS, true)
+                .put(IndexMetaData.SETTING_SHARED_FILESYSTEM, true)
+                .build();
+
+        prepareCreate(IDX).setSettings(idxSettings).addMapping("doc", "foo", "type=string").get();
+        ensureYellow(IDX);
+        // Node1 has the primary, now node2 has the replica
+        String node2 = internalCluster().startNode(nodeSettings);
+        ensureGreen(IDX);
+        flushAndRefresh(IDX);
+        String node3 = internalCluster().startNode(nodeSettings);
+        final AtomicInteger counter = new AtomicInteger(0);
+        final CountDownLatch started = new CountDownLatch(1);
+
+        final int numPhase1Docs = scaledRandomIntBetween(25, 200);
+        final int numPhase2Docs = scaledRandomIntBetween(25, 200);
+        final CountDownLatch phase1finished = new CountDownLatch(1);
+        final CountDownLatch phase2finished = new CountDownLatch(1);
+
+        Thread thread = new Thread() {
+            @Override
+            public void run() {
+                started.countDown();
+                while (counter.get() < (numPhase1Docs + numPhase2Docs)) {
+                    final IndexResponse indexResponse = client().prepareIndex(IDX, "doc",
+                            Integer.toString(counter.incrementAndGet())).setSource("foo", "bar").get();
+                    assertEquals(indexResponse.getShardInfo().getFailed(), 0);
+                    final int docCount = counter.get();
+                    if (docCount == numPhase1Docs) {
+                        phase1finished.countDown();
+                    }
+                }
+                logger.info("--> stopping indexing thread");
+                phase2finished.countDown();
+            }
+        };
+        thread.start();
+        started.await();
+        phase1finished.await(); // wait for a certain number of documents to be indexed
+        logger.info("--> excluding {} from allocation", node1);
+        // now prevent primary from being allocated on node 1 move to node_3
+        Settings build = ImmutableSettings.builder().put("index.routing.allocation.exclude._name", node1).build();
+        client().admin().indices().prepareUpdateSettings(IDX).setSettings(build).execute().actionGet();
+        // wait for more documents to be indexed post-recovery, also waits for
+        // indexing thread to stop
+        phase2finished.await();
+        ensureGreen(IDX);
+        thread.join();
+        logger.info("--> performing query");
+        flushAndRefresh();
+
+        SearchResponse resp = client().prepareSearch(IDX).setQuery(matchAllQuery()).get();
+        assertHitCount(resp, counter.get());
+        assertHitCount(resp, numPhase1Docs + numPhase2Docs);
+    }
+
+    @Test
+    public void testPrimaryRelocationWhereRecoveryFails() throws Exception {
+        Settings nodeSettings = ImmutableSettings.builder()
+                .put("node.add_id_to_custom_path", false)
+                .put("node.enable_custom_paths", true)
+                .put(TransportModule.TRANSPORT_SERVICE_TYPE_KEY, MockTransportService.class.getName())
+                .build();
+
+        String node1 = internalCluster().startNode(nodeSettings);
+        Path dataPath = createTempDir();
+        final String IDX = "test";
+
+        Settings idxSettings = ImmutableSettings.builder()
+                .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
+                .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 1)
+                .put(IndexMetaData.SETTING_DATA_PATH, dataPath.toAbsolutePath().toString())
+                .put(IndexMetaData.SETTING_SHADOW_REPLICAS, true)
+                .put(IndexMetaData.SETTING_SHARED_FILESYSTEM, true)
+                .build();
+
+        prepareCreate(IDX).setSettings(idxSettings).addMapping("doc", "foo", "type=string").get();
+        ensureYellow(IDX);
+        // Node1 has the primary, now node2 has the replica
+        String node2 = internalCluster().startNode(nodeSettings);
+        ensureGreen(IDX);
+        flushAndRefresh(IDX);
+        String node3 = internalCluster().startNode(nodeSettings);
+        final AtomicInteger counter = new AtomicInteger(0);
+        final CountDownLatch started = new CountDownLatch(1);
+
+        final int numPhase1Docs = scaledRandomIntBetween(25, 200);
+        final int numPhase2Docs = scaledRandomIntBetween(25, 200);
+        final int numPhase3Docs = scaledRandomIntBetween(25, 200);
+        final CountDownLatch phase1finished = new CountDownLatch(1);
+        final CountDownLatch phase2finished = new CountDownLatch(1);
+        final CountDownLatch phase3finished = new CountDownLatch(1);
+
+        final AtomicBoolean keepFailing = new AtomicBoolean(true);
+
+        MockTransportService mockTransportService = ((MockTransportService) internalCluster().getInstance(TransportService.class, node1));
+        mockTransportService.addDelegate(internalCluster().getInstance(Discovery.class, node3).localNode(),
+                new MockTransportService.DelegateTransport(mockTransportService.original()) {
+
+                    @Override
+                    public void sendRequest(DiscoveryNode node, long requestId, String action,
+                                            TransportRequest request, TransportRequestOptions options)
+                            throws IOException, TransportException {
+                        if (keepFailing.get() && action.equals(RecoveryTarget.Actions.TRANSLOG_OPS)) {
+                            logger.info("--> failing translog ops");
+                            throw new ElasticsearchException("failing on purpose");
+                        }
+                        super.sendRequest(node, requestId, action, request, options);
+                    }
+                });
+
+        Thread thread = new Thread() {
+            @Override
+            public void run() {
+                started.countDown();
+                while (counter.get() < (numPhase1Docs + numPhase2Docs + numPhase3Docs)) {
+                    final IndexResponse indexResponse = client().prepareIndex(IDX, "doc",
+                            Integer.toString(counter.incrementAndGet())).setSource("foo", "bar").get();
+                    assertEquals(indexResponse.getShardInfo().getFailed(), 0);
+                    final int docCount = counter.get();
+                    if (docCount == numPhase1Docs) {
+                        phase1finished.countDown();
+                    } else if (docCount == (numPhase1Docs + numPhase2Docs)) {
+                        phase2finished.countDown();
+                    }
+                }
+                logger.info("--> stopping indexing thread");
+                phase3finished.countDown();
+            }
+        };
+        thread.start();
+        started.await();
+        phase1finished.await(); // wait for a certain number of documents to be indexed
+        logger.info("--> excluding {} from allocation", node1);
+        // now prevent primary from being allocated on node 1 move to node_3
+        Settings build = ImmutableSettings.builder().put("index.routing.allocation.exclude._name", node1).build();
+        client().admin().indices().prepareUpdateSettings(IDX).setSettings(build).execute().actionGet();
+        // wait for more documents to be indexed post-recovery, also waits for
+        // indexing thread to stop
+        phase2finished.await();
+        // stop failing
+        keepFailing.set(false);
+        // wait for more docs to be indexed
+        phase3finished.await();
+        ensureGreen(IDX);
+        thread.join();
+        logger.info("--> performing query");
+        flushAndRefresh();
+
+        SearchResponse resp = client().prepareSearch(IDX).setQuery(matchAllQuery()).get();
+        assertHitCount(resp, counter.get());
     }
 
     @Test

--- a/src/test/java/org/elasticsearch/test/engine/MockEngineFactory.java
+++ b/src/test/java/org/elasticsearch/test/engine/MockEngineFactory.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.test.engine;
 
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.engine.EngineConfig;
 import org.elasticsearch.index.engine.EngineFactory;
@@ -28,7 +29,11 @@ import org.elasticsearch.index.engine.EngineFactory;
 public final class MockEngineFactory implements EngineFactory {
     @Override
     public Engine newReadWriteEngine(EngineConfig config, boolean skipTranslogRecovery) {
-        return new MockInternalEngine(config, skipTranslogRecovery);
+        if (IndexMetaData.isOnSharedFilesystem(config.getIndexSettings())) {
+            return new MockSharedFSEngine(config, skipTranslogRecovery);
+        } else {
+            return new MockInternalEngine(config, skipTranslogRecovery);
+        }
     }
 
     @Override

--- a/src/test/java/org/elasticsearch/test/engine/MockEngineSupport.java
+++ b/src/test/java/org/elasticsearch/test/engine/MockEngineSupport.java
@@ -32,7 +32,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.engine.EngineConfig;
 import org.elasticsearch.index.engine.EngineException;
-import org.elasticsearch.index.engine.InternalEngine;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 
 import java.io.IOException;

--- a/src/test/java/org/elasticsearch/test/engine/MockSharedFSEngine.java
+++ b/src/test/java/org/elasticsearch/test/engine/MockSharedFSEngine.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test.engine;
+
+import org.apache.lucene.search.AssertingIndexSearcher;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.SearcherManager;
+import org.elasticsearch.index.engine.EngineConfig;
+import org.elasticsearch.index.engine.EngineException;
+import org.elasticsearch.index.engine.SharedFSEngine;
+
+import java.io.IOException;
+
+/**
+ * Mock engine for the SharedFSEngine
+ */
+public class MockSharedFSEngine extends SharedFSEngine {
+    private MockEngineSupport support;
+
+    public MockSharedFSEngine(EngineConfig config, boolean skipInitialTranslogRecovery) throws EngineException {
+        super(config, skipInitialTranslogRecovery);
+    }
+
+    private synchronized MockEngineSupport support() {
+        // lazy initialized since we need it already on super() ctor execution :(
+        if (support == null) {
+            support = new MockEngineSupport(config());
+        }
+        return support;
+    }
+
+    @Override
+    public void close() throws IOException {
+        switch(support().flushOrClose(this, MockEngineSupport.CloseAction.CLOSE)) {
+            case FLUSH_AND_CLOSE:
+                super.flushAndClose();
+                break;
+            case CLOSE:
+                super.close();
+                break;
+        }
+        logger.debug("Ongoing recoveries after engine close: " + onGoingRecoveries.get());
+
+    }
+
+    @Override
+    public void flushAndClose() throws IOException {
+        switch(support().flushOrClose(this, MockEngineSupport.CloseAction.FLUSH_AND_CLOSE)) {
+            case FLUSH_AND_CLOSE:
+                super.flushAndClose();
+                break;
+            case CLOSE:
+                super.close();
+                break;
+        }
+        logger.debug("Ongoing recoveries after engine close: " + onGoingRecoveries.get());
+    }
+
+    @Override
+    protected Searcher newSearcher(String source, IndexSearcher searcher, SearcherManager manager) throws EngineException {
+        final AssertingIndexSearcher assertingIndexSearcher = support().newSearcher(this, source, searcher, manager);
+        assertingIndexSearcher.setSimilarity(searcher.getSimilarity());
+        // pass the original searcher to the super.newSearcher() method to make sure this is the searcher that will
+        // be released later on. If we wrap an index reader here must not pass the wrapped version to the manager
+        // on release otherwise the reader will be closed too early. - good news, stuff will fail all over the place if we don't get this right here
+        return new AssertingSearcher(assertingIndexSearcher,
+                super.newSearcher(source, searcher, manager), shardId, MockEngineSupport.INFLIGHT_ENGINE_SEARCHERS, logger);
+    }
+}


### PR DESCRIPTION
Instead of failing the Engine for a shared filesystem, this change
allows a "soft close" of the Engine, where only the IndexWriter is
closed so that the replica can open an IndexWriter using the same
filesystem directory/mount.

Fixes #10469
