### PR TITLE
Remove unused normsField from MatchAllQuery

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/MatchAllQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/MatchAllQueryBuilder.java
@@ -30,17 +30,7 @@ import java.io.IOException;
  */
 public class MatchAllQueryBuilder extends BaseQueryBuilder implements BoostableQueryBuilder<MatchAllQueryBuilder> {
 
-    private String normsField;
-
     private float boost = -1;
-
-    /**
-     * Field used for normalization factor (document boost). Defaults to no field.
-     */
-    public MatchAllQueryBuilder normsField(String normsField) {
-        this.normsField = normsField;
-        return this;
-    }
 
     /**
      * Sets the boost for this query.  Documents matching this query will (in addition to the normal
@@ -57,9 +47,6 @@ public class MatchAllQueryBuilder extends BaseQueryBuilder implements BoostableQ
         builder.startObject(MatchAllQueryParser.NAME);
         if (boost != -1) {
             builder.field("boost", boost);
-        }
-        if (normsField != null) {
-            builder.field("norms_field", normsField);
         }
         builder.endObject();
     }

--- a/src/main/java/org/elasticsearch/index/query/MatchAllQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MatchAllQueryParser.java
@@ -68,8 +68,6 @@ public class MatchAllQueryParser implements QueryParser {
             return Queries.newMatchAllQuery();
         }
 
-        //LUCENE 4 UPGRADE norms field is not supported anymore need to find another way or drop the functionality
-        //MatchAllDocsQuery query = new MatchAllDocsQuery(normsField);
         MatchAllDocsQuery query = new MatchAllDocsQuery();
         query.setBoost(boost);
         return query;

--- a/src/test/java/org/elasticsearch/stresstest/fullrestart/FullRestartStressTest.java
+++ b/src/test/java/org/elasticsearch/stresstest/fullrestart/FullRestartStressTest.java
@@ -147,7 +147,7 @@ public class FullRestartStressTest {
             // verify search
             for (int i = 0; i < (nodes.length * 5); i++) {
                 // do a search with norms field, so we don't rely on match all filtering cache
-                SearchResponse search = client.client().prepareSearch().setQuery(matchAllQuery().normsField("field")).execute().actionGet();
+                SearchResponse search = client.client().prepareSearch().setQuery(matchAllQuery()).execute().actionGet();
                 logger.debug("index_count [{}], expected_count [{}]", search.getHits().totalHits(), indexCounter.get());
                 if (count.getCount() != indexCounter.get()) {
                     logger.warn("!!! search does not match, index_count [{}], expected_count [{}]", search.getHits().totalHits(), indexCounter.get());


### PR DESCRIPTION
The normsField in the MatchAllQuery seems unused in Lucene for quiet some time. In connection to the current refactoring we should remove it or decide what else to do with it. Not sure if setting the normsField in the FullRestartStressTest still serves its purpose of avoiding the cache.
