### PR TITLE
Tests: Forbid tests from writing to CWD

### DIFF
--- a/dev-tools/tests.policy
+++ b/dev-tools/tests.policy
@@ -30,8 +30,8 @@ grant {
   permission java.io.FilePermission "${m2.repository}${/}-", "read";
   // system jar resources
   permission java.io.FilePermission "${java.home}${/}-", "read";
-  permission java.io.FilePermission "${junit4.childvm.cwd}", "read,write";
-  permission java.io.FilePermission "${junit4.childvm.cwd}${/}-", "read,write,delete";
+  permission java.io.FilePermission "${junit4.childvm.cwd}${/}temp", "read,write";
+  permission java.io.FilePermission "${junit4.childvm.cwd}${/}temp${/}-", "read,write,delete";
   permission java.io.FilePermission "${junit4.tempDir}${/}*", "read,write,delete";
   permission java.nio.file.LinkPermission "symbolic";
   permission groovy.security.GroovyCodeSourcePermission "/groovy/script";

--- a/pom.xml
+++ b/pom.xml
@@ -563,8 +563,8 @@
                             <haltOnFailure>${tests.failfast}</haltOnFailure>
                             <uniqueSuiteNames>false</uniqueSuiteNames>
                             <systemProperties>
-                                <java.io.tmpdir>.</java.io.tmpdir>
-                                <!-- we use '.' since this is different per JVM-->
+                                <!-- we use './temp' since this is per JVM and tests are forbidden from writing to CWD -->
+                                <java.io.tmpdir>./temp</java.io.tmpdir>
                                 <!-- RandomizedTesting library system properties -->
                                 <tests.bwc>${tests.bwc}</tests.bwc>
                                 <tests.bwc.path>${tests.bwc.path}</tests.bwc.path>

--- a/src/main/java/org/elasticsearch/http/HttpServer.java
+++ b/src/main/java/org/elasticsearch/http/HttpServer.java
@@ -195,7 +195,7 @@ public class HttpServer extends AbstractLifecycleComponent<HttpServer> {
                 return;
             }
         }
-        if (!file.toAbsolutePath().startsWith(siteFile)) {
+        if (!file.toAbsolutePath().startsWith(siteFile.toAbsolutePath())) {
             channel.sendResponse(new BytesRestResponse(FORBIDDEN));
             return;
         }

--- a/src/test/java/org/elasticsearch/client/transport/TransportClientTests.java
+++ b/src/test/java/org/elasticsearch/client/transport/TransportClientTests.java
@@ -54,6 +54,7 @@ public class TransportClientTests extends ElasticsearchIntegrationTest {
         TransportClientNodesService nodeService = client.nodeService();
         Node node = nodeBuilder().data(false).settings(ImmutableSettings.builder()
                 .put(internalCluster().getDefaultSettings())
+                .put("path.home", newTempDirPath())
                 .put("node.name", "testNodeVersionIsUpdated")
                 .put("http.enabled", false)
                 .put("index.store.type", "ram")

--- a/src/test/java/org/elasticsearch/cluster/routing/RoutingBackwardCompatibilityTests.java
+++ b/src/test/java/org/elasticsearch/cluster/routing/RoutingBackwardCompatibilityTests.java
@@ -25,18 +25,21 @@ import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.test.ElasticsearchTestCase;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
+import java.nio.file.Path;
 import java.util.Arrays;
 
 public class RoutingBackwardCompatibilityTests extends ElasticsearchTestCase {
 
     public void testBackwardCompatibility() throws Exception {
-        Node node = new Node();
+        Path baseDir = newTempDirPath();
+        Node node = new Node(ImmutableSettings.builder().put("path.home", baseDir.toString()).build(), false);
         try {
             try (BufferedReader reader = new BufferedReader(new InputStreamReader(RoutingBackwardCompatibilityTests.class.getResourceAsStream("/org/elasticsearch/cluster/routing/shard_routes.txt"), "UTF-8"))) {
                 for (String line = reader.readLine(); line != null; line = reader.readLine()) {

--- a/src/test/java/org/elasticsearch/gateway/RecoveryFromGatewayTests.java
+++ b/src/test/java/org/elasticsearch/gateway/RecoveryFromGatewayTests.java
@@ -48,7 +48,10 @@ import static org.elasticsearch.index.query.QueryBuilders.termQuery;
 import static org.elasticsearch.test.ElasticsearchIntegrationTest.Scope;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
 
 /**
  *
@@ -435,11 +438,11 @@ public class RecoveryFromGatewayTests extends ElasticsearchIntegrationTest {
     public void testRecoveryDifferentNodeOrderStartup() throws Exception {
         // we need different data paths so we make sure we start the second node fresh
 
-        final String node_1 = internalCluster().startNode(settingsBuilder().put("path.data", "data/data1").build());
+        final String node_1 = internalCluster().startNode(settingsBuilder().put("path.data", newTempDirPath()).build());
 
         client().prepareIndex("test", "type1", "1").setSource("field", "value").execute().actionGet();
 
-        internalCluster().startNode(settingsBuilder().put("path.data", "data/data2").build());
+        internalCluster().startNode(settingsBuilder().put("path.data", newTempDirPath()).build());
 
         ensureGreen();
 

--- a/src/test/java/org/elasticsearch/index/engine/ShadowEngineTests.java
+++ b/src/test/java/org/elasticsearch/index/engine/ShadowEngineTests.java
@@ -24,7 +24,10 @@ import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.TextField;
-import org.apache.lucene.index.*;
+import org.apache.lucene.index.IndexDeletionPolicy;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.LiveIndexWriterConfig;
+import org.apache.lucene.index.Term;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.MockDirectoryWrapper;
@@ -69,15 +72,20 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 
-import static com.carrotsearch.randomizedtesting.RandomizedTest.*;
+import static com.carrotsearch.randomizedtesting.RandomizedTest.getRandom;
+import static com.carrotsearch.randomizedtesting.RandomizedTest.randomBoolean;
+import static com.carrotsearch.randomizedtesting.RandomizedTest.randomDouble;
+import static com.carrotsearch.randomizedtesting.RandomizedTest.randomIntBetween;
 import static org.elasticsearch.common.settings.ImmutableSettings.Builder.EMPTY_SETTINGS;
 import static org.elasticsearch.test.ElasticsearchTestCase.newTempDirPath;
 import static org.elasticsearch.test.ElasticsearchTestCase.terminate;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 
 /**
  * TODO: document me!
@@ -123,7 +131,7 @@ public class ShadowEngineTests extends ElasticsearchLuceneTestCase {
                 .put(EngineConfig.INDEX_CONCURRENCY_SETTING, indexConcurrency)
                 .build(); // TODO randomize more settings
         threadPool = new ThreadPool(getClass().getName());
-        dirPath = newTempDirPath(LifecycleScope.TEST);
+        dirPath = createTempDir();
         store = createStore(dirPath);
         storeReplica = createStore(dirPath);
         Lucene.cleanLuceneIndex(store.directory());
@@ -201,11 +209,11 @@ public class ShadowEngineTests extends ElasticsearchLuceneTestCase {
     }
 
     protected Translog createTranslog() throws IOException {
-        return new FsTranslog(shardId, EMPTY_SETTINGS, Paths.get("work/fs-translog/"));
+        return new FsTranslog(shardId, EMPTY_SETTINGS, createTempDir("translog-primary"));
     }
 
     protected Translog createTranslogReplica() throws IOException {
-        return new FsTranslog(shardId, EMPTY_SETTINGS, Paths.get("work/fs-translog/"));
+        return new FsTranslog(shardId, EMPTY_SETTINGS, createTempDir("translog-replica"));
     }
 
     protected IndexDeletionPolicy createIndexDeletionPolicy() {

--- a/src/test/java/org/elasticsearch/index/mapper/FileBasedMappingsTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/FileBasedMappingsTests.java
@@ -82,6 +82,7 @@ public class FileBasedMappingsTests extends ElasticsearchTestCase {
             Settings settings = ImmutableSettings.builder()
                     .put(ClusterName.SETTING, NAME)
                     .put("node.name", NAME)
+                    .put("path.home", newTempDirPath())
                     .put("path.conf", configDir.toAbsolutePath())
                     .put("http.enabled", false)
                     .build();

--- a/src/test/java/org/elasticsearch/index/store/distributor/DistributorTests.java
+++ b/src/test/java/org/elasticsearch/index/store/distributor/DistributorTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.store.distributor;
 
+import com.carrotsearch.randomizedtesting.LifecycleScope;
 import org.apache.lucene.store.*;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.index.shard.ShardId;
@@ -137,7 +138,7 @@ public class DistributorTests extends ElasticsearchTestCase {
 
     }
 
-    public static class FakeDirectoryService extends DirectoryService {
+    public class FakeDirectoryService extends DirectoryService {
 
         private final Directory[] directories;
 
@@ -157,14 +158,14 @@ public class DistributorTests extends ElasticsearchTestCase {
         }
     }
 
-    public static class FakeFsDirectory extends FSDirectory {
+    public class FakeFsDirectory extends FSDirectory {
 
         public int allocationCount;
         public long useableSpace;
 
 
         public FakeFsDirectory(String path, long usableSpace) throws IOException {
-            super(Paths.get(path), NoLockFactory.INSTANCE);
+            super(newTempDirPath().resolve(path), NoLockFactory.INSTANCE);
             allocationCount = 0;
             this.useableSpace = usableSpace;
         }

--- a/src/test/java/org/elasticsearch/index/translog/fs/FsBufferedTranslogTests.java
+++ b/src/test/java/org/elasticsearch/index/translog/fs/FsBufferedTranslogTests.java
@@ -19,17 +19,12 @@
 
 package org.elasticsearch.index.translog.fs;
 
-import org.apache.lucene.util.IOUtils;
-import org.elasticsearch.common.io.FileSystemUtils;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.index.translog.AbstractSimpleTranslogTests;
 import org.elasticsearch.index.translog.Translog;
-import org.junit.AfterClass;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 /**
  *
@@ -37,23 +32,13 @@ import java.nio.file.Paths;
 public class FsBufferedTranslogTests extends AbstractSimpleTranslogTests {
 
     @Override
-    protected Translog create() throws IOException {
+    protected Translog create(Path translogDir) throws IOException {
         return new FsTranslog(shardId,
                 ImmutableSettings.settingsBuilder()
                         .put("index.translog.fs.type", FsTranslogFile.Type.BUFFERED.name())
                         .put("index.translog.fs.buffer_size", 10 + randomInt(128 * 1024))
                         .build(),
-                translogFileDirectory()
+                translogDir
         );
-    }
-
-    @Override
-    protected Path translogFileDirectory() {
-        return Paths.get("data/fs-buf-translog");
-    }
-
-    @AfterClass
-    public static void cleanup() throws IOException {
-        IOUtils.rm(Paths.get("data/fs-buf-translog"));
     }
 }

--- a/src/test/java/org/elasticsearch/index/translog/fs/FsSimpleTranslogTests.java
+++ b/src/test/java/org/elasticsearch/index/translog/fs/FsSimpleTranslogTests.java
@@ -19,17 +19,12 @@
 
 package org.elasticsearch.index.translog.fs;
 
-import org.apache.lucene.util.IOUtils;
-import org.elasticsearch.common.io.FileSystemUtils;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.index.translog.AbstractSimpleTranslogTests;
 import org.elasticsearch.index.translog.Translog;
-import org.junit.AfterClass;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 /**
  *
@@ -37,19 +32,10 @@ import java.nio.file.Paths;
 public class FsSimpleTranslogTests extends AbstractSimpleTranslogTests {
 
     @Override
-    protected Translog create() throws IOException {
+    protected Translog create(Path translogDir) throws IOException {
         return new FsTranslog(shardId,
                 ImmutableSettings.settingsBuilder().put("index.translog.fs.type", FsTranslogFile.Type.SIMPLE.name()).build(),
-                translogFileDirectory());
+                translogDir);
     }
-
-    @Override
-    protected Path translogFileDirectory() {
-        return Paths.get("data/fs-simple-translog");
-    }
-
-    @AfterClass
-    public static void cleanup() throws IOException {
-        IOUtils.rm(Paths.get("data/fs-simple-translog"));
-    }
+    
 }

--- a/src/test/java/org/elasticsearch/indices/store/SimpleDistributorTests.java
+++ b/src/test/java/org/elasticsearch/indices/store/SimpleDistributorTests.java
@@ -54,9 +54,9 @@ public class SimpleDistributorTests extends ElasticsearchIntegrationTest {
         String storeString = getStoreDirectory("test", 0).toString();
         logger.info(storeString);
         Path[] dataPaths = dataPaths();
-        assertThat(storeString.toLowerCase(Locale.ROOT), startsWith("store(least_used[rate_limited(niofs(" + dataPaths[0].toAbsolutePath().toString().toLowerCase(Locale.ROOT)));
+        assertThat(storeString.toLowerCase(Locale.ROOT), startsWith("store(least_used[rate_limited(niofs(" + dataPaths[0].toAbsolutePath().normalize().toString().toLowerCase(Locale.ROOT)));
         if (dataPaths.length > 1) {
-            assertThat(storeString.toLowerCase(Locale.ROOT), containsString("), rate_limited(niofs(" + dataPaths[1].toAbsolutePath().toString().toLowerCase(Locale.ROOT)));
+            assertThat(storeString.toLowerCase(Locale.ROOT), containsString("), rate_limited(niofs(" + dataPaths[1].toAbsolutePath().normalize().toString().toLowerCase(Locale.ROOT)));
         }
         assertThat(storeString, endsWith(", type=MERGE, rate=20.0)])"));
 
@@ -64,9 +64,9 @@ public class SimpleDistributorTests extends ElasticsearchIntegrationTest {
         storeString = getStoreDirectory("test", 0).toString();
         logger.info(storeString);
         dataPaths = dataPaths();
-        assertThat(storeString.toLowerCase(Locale.ROOT), startsWith("store(random[rate_limited(niofs(" + dataPaths[0].toAbsolutePath().toString().toLowerCase(Locale.ROOT)));
+        assertThat(storeString.toLowerCase(Locale.ROOT), startsWith("store(random[rate_limited(niofs(" + dataPaths[0].toAbsolutePath().normalize().toString().toLowerCase(Locale.ROOT)));
         if (dataPaths.length > 1) {
-            assertThat(storeString.toLowerCase(Locale.ROOT), containsString("), rate_limited(niofs(" + dataPaths[1].toAbsolutePath().toString().toLowerCase(Locale.ROOT)));
+            assertThat(storeString.toLowerCase(Locale.ROOT), containsString("), rate_limited(niofs(" + dataPaths[1].toAbsolutePath().normalize().toString().toLowerCase(Locale.ROOT)));
         }
         assertThat(storeString, endsWith(", type=MERGE, rate=20.0)])"));
 
@@ -74,9 +74,9 @@ public class SimpleDistributorTests extends ElasticsearchIntegrationTest {
         storeString = getStoreDirectory("test", 0).toString();
         logger.info(storeString);
         dataPaths = dataPaths();
-        assertThat(storeString.toLowerCase(Locale.ROOT), startsWith("store(least_used[rate_limited(mmapfs(" + dataPaths[0].toAbsolutePath().toString().toLowerCase(Locale.ROOT)));
+        assertThat(storeString.toLowerCase(Locale.ROOT), startsWith("store(least_used[rate_limited(mmapfs(" + dataPaths[0].toAbsolutePath().normalize().toString().toLowerCase(Locale.ROOT)));
         if (dataPaths.length > 1) {
-            assertThat(storeString.toLowerCase(Locale.ROOT), containsString("), rate_limited(mmapfs(" + dataPaths[1].toAbsolutePath().toString().toLowerCase(Locale.ROOT)));
+            assertThat(storeString.toLowerCase(Locale.ROOT), containsString("), rate_limited(mmapfs(" + dataPaths[1].toAbsolutePath().normalize().toString().toLowerCase(Locale.ROOT)));
         }
         assertThat(storeString, endsWith(", type=MERGE, rate=20.0)])"));
 
@@ -84,9 +84,9 @@ public class SimpleDistributorTests extends ElasticsearchIntegrationTest {
         storeString = getStoreDirectory("test", 0).toString();
         logger.info(storeString);
         dataPaths = dataPaths();
-        assertThat(storeString.toLowerCase(Locale.ROOT), startsWith("store(least_used[rate_limited(simplefs(" + dataPaths[0].toAbsolutePath().toString().toLowerCase(Locale.ROOT)));
+        assertThat(storeString.toLowerCase(Locale.ROOT), startsWith("store(least_used[rate_limited(simplefs(" + dataPaths[0].toAbsolutePath().normalize().toString().toLowerCase(Locale.ROOT)));
         if (dataPaths.length > 1) {
-            assertThat(storeString.toLowerCase(Locale.ROOT), containsString("), rate_limited(simplefs(" + dataPaths[1].toAbsolutePath().toString().toLowerCase(Locale.ROOT)));
+            assertThat(storeString.toLowerCase(Locale.ROOT), containsString("), rate_limited(simplefs(" + dataPaths[1].toAbsolutePath().normalize().toString().toLowerCase(Locale.ROOT)));
         }
         assertThat(storeString, endsWith(", type=MERGE, rate=20.0)])"));
 
@@ -94,11 +94,11 @@ public class SimpleDistributorTests extends ElasticsearchIntegrationTest {
         storeString = getStoreDirectory("test", 0).toString();
         logger.info(storeString);
         dataPaths = dataPaths();
-        assertThat(storeString.toLowerCase(Locale.ROOT), startsWith("store(least_used[rate_limited(default(mmapfs(" + dataPaths[0].toAbsolutePath().toString().toLowerCase(Locale.ROOT)));
-        assertThat(storeString.toLowerCase(Locale.ROOT), containsString("),niofs(" + dataPaths[0].toAbsolutePath().toString().toLowerCase(Locale.ROOT)));
+        assertThat(storeString.toLowerCase(Locale.ROOT), startsWith("store(least_used[rate_limited(default(mmapfs(" + dataPaths[0].toAbsolutePath().normalize().toString().toLowerCase(Locale.ROOT)));
+        assertThat(storeString.toLowerCase(Locale.ROOT), containsString("),niofs(" + dataPaths[0].toAbsolutePath().normalize().toString().toLowerCase(Locale.ROOT)));
 
         if (dataPaths.length > 1) {
-            assertThat(storeString.toLowerCase(Locale.ROOT), containsString("), rate_limited(default(mmapfs(" + dataPaths[1].toAbsolutePath().toString().toLowerCase(Locale.ROOT)));
+            assertThat(storeString.toLowerCase(Locale.ROOT), containsString("), rate_limited(default(mmapfs(" + dataPaths[1].toAbsolutePath().normalize().toString().toLowerCase(Locale.ROOT)));
         }
         assertThat(storeString, endsWith(", type=MERGE, rate=20.0)])"));
 
@@ -106,9 +106,9 @@ public class SimpleDistributorTests extends ElasticsearchIntegrationTest {
         storeString = getStoreDirectory("test", 0).toString();
         logger.info(storeString);
         dataPaths = dataPaths();
-        assertThat(storeString.toLowerCase(Locale.ROOT), startsWith("store(least_used[niofs(" + dataPaths[0].toAbsolutePath().toString().toLowerCase(Locale.ROOT)));
+        assertThat(storeString.toLowerCase(Locale.ROOT), startsWith("store(least_used[niofs(" + dataPaths[0].toAbsolutePath().normalize().toString().toLowerCase(Locale.ROOT)));
         if (dataPaths.length > 1) {
-            assertThat(storeString.toLowerCase(Locale.ROOT), containsString("), niofs(" + dataPaths[1].toAbsolutePath().toString().toLowerCase(Locale.ROOT)));
+            assertThat(storeString.toLowerCase(Locale.ROOT), containsString("), niofs(" + dataPaths[1].toAbsolutePath().normalize().toString().toLowerCase(Locale.ROOT)));
         }
         assertThat(storeString, endsWith(")])"));
     }

--- a/src/test/java/org/elasticsearch/test/ElasticsearchSingleNodeTest.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchSingleNodeTest.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.test;
 
+import com.carrotsearch.randomizedtesting.LifecycleScope;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequestBuilder;
@@ -42,10 +43,15 @@ import org.elasticsearch.node.Node;
 import org.elasticsearch.node.NodeBuilder;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.junit.*;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 /**
  * A test that keep a singleton node started for all tests that can be used to get
@@ -114,15 +120,16 @@ public abstract class ElasticsearchSingleNodeTest extends ElasticsearchTestCase 
 
     private static Node newNode() {
         Node build = NodeBuilder.nodeBuilder().local(true).data(true).settings(ImmutableSettings.builder()
-                .put(ClusterName.SETTING, clusterName())
-                .put("node.name", nodeName())
-                .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
-                .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
-                .put("script.inline", "on")
-                .put("script.indexed", "on")
-                .put(EsExecutors.PROCESSORS, 1) // limit the number of threads created
-                .put("http.enabled", false)
-                .put("config.ignore_system_properties", true) // make sure we get what we set :)
+            .put(ClusterName.SETTING, clusterName())
+            .put("path.home", newTempDirPath(LifecycleScope.SUITE))
+            .put("node.name", nodeName())
+            .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put("script.inline", "on")
+            .put("script.indexed", "on")
+            .put(EsExecutors.PROCESSORS, 1) // limit the number of threads created
+            .put("http.enabled", false)
+            .put("config.ignore_system_properties", true) // make sure we get what we set :)
         ).build();
         build.start();
         assertThat(DiscoveryNode.localNode(build.settings()), is(true));

--- a/src/test/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/src/test/java/org/elasticsearch/test/InternalTestCluster.java
@@ -25,7 +25,12 @@ import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 import com.carrotsearch.randomizedtesting.generators.RandomStrings;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
-import com.google.common.collect.*;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
@@ -107,20 +112,34 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Random;
+import java.util.Set;
+import java.util.TreeMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static junit.framework.Assert.fail;
-import static org.apache.lucene.util.LuceneTestCase.*;
+import static org.apache.lucene.util.LuceneTestCase.TEST_NIGHTLY;
+import static org.apache.lucene.util.LuceneTestCase.rarely;
+import static org.apache.lucene.util.LuceneTestCase.usually;
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 import static org.elasticsearch.node.NodeBuilder.nodeBuilder;
 import static org.elasticsearch.test.ElasticsearchTestCase.assertBusy;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoTimeout;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 
@@ -198,18 +217,20 @@ public final class InternalTestCluster extends TestCluster {
      * All nodes started by the cluster will have their name set to nodePrefix followed by a positive number
      */
     private final String nodePrefix;
+    private final Path baseDir;
 
     private ServiceDisruptionScheme activeDisruptionScheme;
 
-    public InternalTestCluster(long clusterSeed, int minNumDataNodes, int maxNumDataNodes, String clusterName, int numClientNodes,
+    public InternalTestCluster(long clusterSeed, Path baseDir, int minNumDataNodes, int maxNumDataNodes, String clusterName, int numClientNodes,
                                boolean enableHttpPipelining, int jvmOrdinal, String nodePrefix) {
-        this(clusterSeed, minNumDataNodes, maxNumDataNodes, clusterName, DEFAULT_SETTINGS_SOURCE, numClientNodes, enableHttpPipelining, jvmOrdinal, nodePrefix);
+        this(clusterSeed, baseDir, minNumDataNodes, maxNumDataNodes, clusterName, DEFAULT_SETTINGS_SOURCE, numClientNodes, enableHttpPipelining, jvmOrdinal, nodePrefix);
     }
 
-    public InternalTestCluster(long clusterSeed,
+    public InternalTestCluster(long clusterSeed, Path baseDir,
                                int minNumDataNodes, int maxNumDataNodes, String clusterName, SettingsSource settingsSource, int numClientNodes,
                                 boolean enableHttpPipelining, int jvmOrdinal, String nodePrefix) {
         super(clusterSeed);
+        this.baseDir = baseDir;
         this.clusterName = clusterName;
 
         if (minNumDataNodes < 0 || maxNumDataNodes < 0) {
@@ -262,11 +283,12 @@ public final class InternalTestCluster extends TestCluster {
             if (numOfDataPaths > 0) {
                 StringBuilder dataPath = new StringBuilder();
                 for (int i = 0; i < numOfDataPaths; i++) {
-                    dataPath.append(Paths.get("data/d" + i).toAbsolutePath()).append(',');
+                    dataPath.append(baseDir.resolve("d" + i).toAbsolutePath()).append(',');
                 }
                 builder.put("path.data", dataPath.toString());
             }
         }
+        builder.put("path.home", baseDir);
         final int basePort = 9300 + (100 * (jvmOrdinal+1));
         builder.put("transport.tcp.port", basePort + "-" + (basePort+100));
         builder.put("http.port", basePort+101 + "-" + (basePort+200));
@@ -569,6 +591,7 @@ public final class InternalTestCluster extends TestCluster {
         String name = buildNodeName(nodeId);
         assert !nodes.containsKey(name);
         Settings finalSettings = settingsBuilder()
+                .put("path.home", baseDir) // allow overriding path.home
                 .put(settings)
                 .put("name", name)
                 .put("discovery.id.seed", seed)

--- a/src/test/java/org/elasticsearch/test/test/InternalTestClusterTests.java
+++ b/src/test/java/org/elasticsearch/test/test/InternalTestClusterTests.java
@@ -28,6 +28,7 @@ import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.test.SettingsSource;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Random;
@@ -54,8 +55,9 @@ public class InternalTestClusterTests extends ElasticsearchTestCase {
         int jvmOrdinal = randomIntBetween(0, 10);
         String nodePrefix = randomRealisticUnicodeOfCodepointLengthBetween(1, 10);
 
-        InternalTestCluster cluster0 = new InternalTestCluster(clusterSeed, minNumDataNodes, maxNumDataNodes, clusterName, settingsSource, numClientNodes, enableHttpPipelining, jvmOrdinal, nodePrefix);
-        InternalTestCluster cluster1 = new InternalTestCluster(clusterSeed, minNumDataNodes, maxNumDataNodes, clusterName, settingsSource, numClientNodes, enableHttpPipelining, jvmOrdinal, nodePrefix);
+        Path baseDir = newTempDirPath();
+        InternalTestCluster cluster0 = new InternalTestCluster(clusterSeed, baseDir, minNumDataNodes, maxNumDataNodes, clusterName, settingsSource, numClientNodes, enableHttpPipelining, jvmOrdinal, nodePrefix);
+        InternalTestCluster cluster1 = new InternalTestCluster(clusterSeed, baseDir, minNumDataNodes, maxNumDataNodes, clusterName, settingsSource, numClientNodes, enableHttpPipelining, jvmOrdinal, nodePrefix);
         assertClusters(cluster0, cluster1, true);
 
     }
@@ -93,13 +95,13 @@ public class InternalTestClusterTests extends ElasticsearchTestCase {
         }
         SettingsSource settingsSource = SettingsSource.EMPTY;
         int numClientNodes = randomIntBetween(0, 2);
-        boolean enableRandomBenchNodes = randomBoolean();
         boolean enableHttpPipelining = randomBoolean();
         int jvmOrdinal = randomIntBetween(0, 10);
         String nodePrefix = "foobar";
 
-        InternalTestCluster cluster0 = new InternalTestCluster(clusterSeed, minNumDataNodes, maxNumDataNodes, clusterName, settingsSource, numClientNodes, enableHttpPipelining, jvmOrdinal, nodePrefix);
-        InternalTestCluster cluster1 = new InternalTestCluster(clusterSeed, minNumDataNodes, maxNumDataNodes, clusterName1, settingsSource, numClientNodes, enableHttpPipelining, jvmOrdinal, nodePrefix);
+        Path baseDir = newTempDirPath();
+        InternalTestCluster cluster0 = new InternalTestCluster(clusterSeed, baseDir, minNumDataNodes, maxNumDataNodes, clusterName, settingsSource, numClientNodes, enableHttpPipelining, jvmOrdinal, nodePrefix);
+        InternalTestCluster cluster1 = new InternalTestCluster(clusterSeed, baseDir, minNumDataNodes, maxNumDataNodes, clusterName1, settingsSource, numClientNodes, enableHttpPipelining, jvmOrdinal, nodePrefix);
 
         assertClusters(cluster0, cluster1, false);
         long seed = randomLong();

--- a/src/test/java/org/elasticsearch/tribe/TribeTests.java
+++ b/src/test/java/org/elasticsearch/tribe/TribeTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.tribe;
 
+import com.carrotsearch.randomizedtesting.LifecycleScope;
 import com.google.common.collect.ImmutableMap;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthStatus;
@@ -69,7 +70,7 @@ public class TribeTests extends ElasticsearchIntegrationTest {
     public static void setupSecondCluster() throws Exception {
         ElasticsearchIntegrationTest.beforeClass();
         // create another cluster
-        cluster2 = new InternalTestCluster(randomLong(), 2, 2, Strings.randomBase64UUID(getRandom()), 0, false, CHILD_JVM_ID, SECOND_CLUSTER_NODE_PREFIX);
+        cluster2 = new InternalTestCluster(randomLong(), newTempDirPath(LifecycleScope.SUITE), 2, 2, Strings.randomBase64UUID(getRandom()), 0, false, CHILD_JVM_ID, SECOND_CLUSTER_NODE_PREFIX);
         cluster2.beforeTest(getRandom(), 0.1);
         cluster2.ensureAtLeastNumDataNodes(2);
     }

--- a/src/test/java/org/elasticsearch/tribe/TribeUnitTests.java
+++ b/src/test/java/org/elasticsearch/tribe/TribeUnitTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.tribe;
 
+import com.carrotsearch.randomizedtesting.LifecycleScope;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -52,11 +53,14 @@ public class TribeUnitTests extends ElasticsearchTestCase {
 
     @BeforeClass
     public static void createTribes() {
-        tribe1 = NodeBuilder.nodeBuilder().settings(ImmutableSettings.builder().put("config.ignore_system_properties", true).put("http.enabled", false)
-                .put("node.mode", NODE_MODE).put("cluster.name", "tribe1").put("node.name", "tribe1_node")).node();
-        tribe2 = NodeBuilder.nodeBuilder().settings(ImmutableSettings.builder().put("config.ignore_system_properties", true).put("http.enabled", false)
-                .put("node.mode", NODE_MODE).put("cluster.name", "tribe2").put("node.name", "tribe2_node")).node();
+        Settings baseSettings = ImmutableSettings.builder()
+            .put("config.ignore_system_properties", true)
+            .put("http.enabled", false)
+            .put("node.mode", NODE_MODE)
+            .put("path.home", newTempDirPath(LifecycleScope.SUITE)).build();
 
+        tribe1 = NodeBuilder.nodeBuilder().settings(ImmutableSettings.builder().put(baseSettings).put("cluster.name", "tribe1").put("node.name", "tribe1_node")).node();
+        tribe2 = NodeBuilder.nodeBuilder().settings(ImmutableSettings.builder().put(baseSettings).put("cluster.name", "tribe2").put("node.name", "tribe2_node")).node();
     }
 
     @AfterClass


### PR DESCRIPTION
Allowing tests writing to the working directory can mask problems.
For example, multiple tests running in the same jvm, and using the
same relative path, may cause issues if the first test to run
leaves data in the directory, and the second test does not remember
to cleanup the path before using it.

This change adds security manager rules to disallow tests writing
to the working directory. Instead, tests create a temp dir with
the existing test framework.
