### PR TITLE
Detect "tag" fields and disable term frequency check

### DIFF
--- a/src/main/java/org/elasticsearch/action/termvectors/TermVectorsFields.java
+++ b/src/main/java/org/elasticsearch/action/termvectors/TermVectorsFields.java
@@ -212,9 +212,9 @@ public final class TermVectorsFields extends Fields {
             this.hasOffsets = perFieldTermVectorInput.readBoolean();
             this.hasPayloads = perFieldTermVectorInput.readBoolean();
             // read the field statistics
-            this.sumTotalTermFreq = hasFieldStatistic ? readPotentiallyNegativeVLong(perFieldTermVectorInput) : -1;
-            this.sumDocFreq = hasFieldStatistic ? readPotentiallyNegativeVLong(perFieldTermVectorInput) : -1;
-            this.docCount = hasFieldStatistic ? readPotentiallyNegativeVInt(perFieldTermVectorInput) : -1;
+            this.sumTotalTermFreq = readPotentiallyNegativeVLong(perFieldTermVectorInput);
+            this.sumDocFreq = readPotentiallyNegativeVLong(perFieldTermVectorInput);
+            this.docCount = readPotentiallyNegativeVInt(perFieldTermVectorInput);
         }
 
         @Override
@@ -243,10 +243,8 @@ public final class TermVectorsFields extends Fields {
                         // ...then the value.
                         perFieldTermVectorInput.readBytes(spare.bytes(), 0, termVectorSize);
                         spare.setLength(termVectorSize);
-                        if (hasTermStatistic) {
-                            docFreq = readPotentiallyNegativeVInt(perFieldTermVectorInput);
-                            totalTermFrequency = readPotentiallyNegativeVLong(perFieldTermVectorInput);
-                        }
+                        docFreq = readPotentiallyNegativeVInt(perFieldTermVectorInput);
+                        totalTermFrequency = readPotentiallyNegativeVLong(perFieldTermVectorInput);
 
                         freq = readPotentiallyNegativeVInt(perFieldTermVectorInput);
                         // grow the arrays to read the values. this is just

--- a/src/main/java/org/elasticsearch/action/termvectors/TermVectorsWriter.java
+++ b/src/main/java/org/elasticsearch/action/termvectors/TermVectorsWriter.java
@@ -74,12 +74,13 @@ final class TermVectorsWriter {
             boolean positions = flags.contains(Flag.Positions) && fieldTermVector.hasPositions();
             boolean offsets = flags.contains(Flag.Offsets) && fieldTermVector.hasOffsets();
             boolean payloads = flags.contains(Flag.Payloads) && fieldTermVector.hasPayloads();
+            boolean hasFreqs = topLevelTerms.hasFreqs();
 
             long termsSize = fieldTermVector.size();
             if (hasScores) {
                 termsSize = Math.min(termsSize, termVectorsFilter.size(field));
             }
-            startField(field, termsSize, positions, offsets, payloads);
+            startField(field, termsSize, positions, offsets, payloads, hasFreqs);
 
             if (flags.contains(Flag.FieldStatistics)) {
                 if (dfs != null) {
@@ -87,8 +88,6 @@ final class TermVectorsWriter {
                 } else {
                     writeFieldStatistics(topLevelTerms);
                 }
-            } else { // write document level stats
-                writeFieldStatistics(fieldTermVector);
             }
             TermsEnum iterator = fieldTermVector.iterator();
             final boolean useDocsAndPos = positions || offsets || payloads;
@@ -110,8 +109,6 @@ final class TermVectorsWriter {
                     } else {
                         writeTermStatistics(topLevelIterator);
                     }
-                } else { // write document level stats
-                    writeTermStatistics(iterator);
                 }
                 if (useDocsAndPos) {
                     // given we have pos or offsets
@@ -214,7 +211,7 @@ final class TermVectorsWriter {
         }
     }
 
-    private void startField(String fieldName, long termsSize, boolean writePositions, boolean writeOffsets, boolean writePayloads)
+    private void startField(String fieldName, long termsSize, boolean writePositions, boolean writeOffsets, boolean writePayloads, boolean hasFreqs)
             throws IOException {
         fields.add(fieldName);
         fieldOffset.add(output.position());
@@ -223,6 +220,7 @@ final class TermVectorsWriter {
         output.writeBoolean(writePositions);
         output.writeBoolean(writeOffsets);
         output.writeBoolean(writePayloads);
+        output.writeBoolean(hasFreqs);
     }
 
     private void startTerm(BytesRef term) throws IOException {

--- a/src/main/java/org/elasticsearch/action/termvectors/TermVectorsWriter.java
+++ b/src/main/java/org/elasticsearch/action/termvectors/TermVectorsWriter.java
@@ -87,6 +87,8 @@ final class TermVectorsWriter {
                 } else {
                     writeFieldStatistics(topLevelTerms);
                 }
+            } else { // write document level stats
+                writeFieldStatistics(fieldTermVector);
             }
             TermsEnum iterator = fieldTermVector.iterator();
             final boolean useDocsAndPos = positions || offsets || payloads;
@@ -108,6 +110,8 @@ final class TermVectorsWriter {
                     } else {
                         writeTermStatistics(topLevelIterator);
                     }
+                } else { // write document level stats
+                    writeTermStatistics(iterator);
                 }
                 if (useDocsAndPos) {
                     // given we have pos or offsets

--- a/src/main/java/org/elasticsearch/common/lucene/search/XMoreLikeThis.java
+++ b/src/main/java/org/elasticsearch/common/lucene/search/XMoreLikeThis.java
@@ -875,6 +875,7 @@ public final class XMoreLikeThis {
             }
 
             PostingsEnum docs = termsEnum.postings(null, null);
+            docs.nextDoc();
             final int freq = docs.freq();
 
             // increment frequency

--- a/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryParser.java
@@ -322,7 +322,7 @@ public class MoreLikeThisQueryParser implements QueryParser {
                 .positions(false)
                 .offsets(false)
                 .payloads(false)
-                .fieldStatistics(false)
+                .fieldStatistics(true)
                 .termStatistics(false);
     }
 


### PR DESCRIPTION
With the current default value of `min_term_freq == 2`, the common use case of
performing MLT on a tag field (a field which only contains unique values)
results in an empty result set. Instead of changing the default value of
`min_term_freq`, this commit proposes to automatically detect such a tag
field, and in this case to skip the term frequency check altogether.
