### PR TITLE
[TEST] Fix shadow engine tests

### DIFF
--- a/src/main/java/org/elasticsearch/index/translog/Translog.java
+++ b/src/main/java/org/elasticsearch/index/translog/Translog.java
@@ -33,7 +33,6 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.lease.Releasable;
-import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.lucene.uid.Versions;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.index.VersionType;
@@ -41,7 +40,6 @@ import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.shard.IndexShardComponent;
 
 import java.io.Closeable;
-import java.io.EOFException;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collection;
@@ -145,10 +143,9 @@ public interface Translog extends IndexShardComponent, Closeable, Accountable {
     public Path[] locations();
 
     /**
-     * Returns the translog file with the given id as a Path. This
-     * will return a relative path.
+     * Returns the translog filename for the given id.
      */
-    Path getPath(long translogId);
+    String getFilename(long translogId);
 
     /**
      * return stats

--- a/src/test/java/org/elasticsearch/index/translog/AbstractSimpleTranslogTests.java
+++ b/src/test/java/org/elasticsearch/index/translog/AbstractSimpleTranslogTests.java
@@ -383,16 +383,16 @@ public abstract class AbstractSimpleTranslogTests extends ElasticsearchTestCase 
 
     public void assertFileIsPresent(Translog translog, long id) {
         for (Path location : translog.locations()) {
-            if (Files.exists(location.resolve(translog.getPath(id)))) {
+            if (Files.exists(location.resolve(translog.getFilename(id)))) {
                 return;
             }
         }
-        fail(translog.getPath(id) + " is not present in any location: " + Arrays.toString(translog.locations()));
+        fail(translog.getFilename(id) + " is not present in any location: " + Arrays.toString(translog.locations()));
     }
 
     public void assertFileDeleted(Translog translog, long id) {
         for (Path location : translog.locations()) {
-            assertFalse(Files.exists(location.resolve(translog.getPath(id))));
+            assertFalse(Files.exists(location.resolve(translog.getFilename(id))));
         }
     }
 

--- a/src/test/java/org/elasticsearch/test/ElasticsearchLuceneTestCase.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchLuceneTestCase.java
@@ -25,15 +25,12 @@ import com.carrotsearch.randomizedtesting.annotations.ThreadLeakLingering;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope.Scope;
 import com.carrotsearch.randomizedtesting.annotations.TimeoutSuite;
-
 import org.apache.lucene.codecs.Codec;
-import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.util.LuceneTestCase;
 import org.apache.lucene.util.LuceneTestCase.SuppressFileSystems;
 import org.apache.lucene.util.TimeUnits;
 import org.elasticsearch.test.junit.listeners.LoggingListener;
 import org.elasticsearch.test.junit.listeners.ReproduceInfoPrinter;
-import org.junit.AfterClass;
 
 
 /**
@@ -47,7 +44,7 @@ import org.junit.AfterClass;
 @ThreadLeakLingering(linger = 5000) // 5 sec lingering
 @TimeoutSuite(millis = TimeUnits.HOUR)
 @LuceneTestCase.SuppressSysoutChecks(bugUrl = "we log a lot on purpose")
-@SuppressFileSystems("ExtrasFS") // we aren't ready for this yet.
+@SuppressFileSystems("*") // we aren't ready for this yet.
 public abstract class ElasticsearchLuceneTestCase extends LuceneTestCase {
 
     private static final Codec DEFAULT_CODEC = Codec.getDefault();

--- a/src/test/java/org/elasticsearch/test/ElasticsearchTestCase.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchTestCase.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableList;
 
 import org.apache.lucene.store.MockDirectoryWrapper;
 import org.apache.lucene.util.AbstractRandomizedTest;
+import org.apache.lucene.util.LuceneTestCase;
 import org.apache.lucene.util.TimeUnits;
 import org.apache.lucene.uninverting.UninvertingReader;
 import org.elasticsearch.Version;
@@ -78,6 +79,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAllS
 @ThreadLeakLingering(linger = 5000) // 5 sec lingering
 @TimeoutSuite(millis = 20 * TimeUnits.MINUTE) // timeout the suite after 20min and fail the test.
 @Listeners(LoggingListener.class)
+@LuceneTestCase.SuppressFileSystems("*") // we aren't ready for this yet.
 public abstract class ElasticsearchTestCase extends AbstractRandomizedTest {
 
     private static Thread.UncaughtExceptionHandler defaultHandler;


### PR DESCRIPTION
After a3f0789 these tests fail because the translog getPath returns a
path that is a CWD path (even though it is unneeded).

This also adds the `@SuppressFileSystems("*")` annotation to the base classes `ElasticsearchTestCase` and `ElasticsearchLuceneTestCase`.

This is a short term fix as @rmuir is addressing this in a better way long-term.
