### PR TITLE
[Doc] Fixing typo in module.scripting

### DIFF
--- a/docs/reference/modules/scripting.asciidoc
+++ b/docs/reference/modules/scripting.asciidoc
@@ -69,7 +69,7 @@ GET /_search
 {
     "script_fields": {
         "my_field": {
-            "script_file": "my_test",
+            "script_file": "my_script",
             "params": {
               "my_var": 2
             }


### PR DESCRIPTION
Script filename in example seems to have a typo
