### PR TITLE
Fix possible NPE in InternalClusterService$NotifyTimeout, the `future` field is set from a different thread

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/service/InternalClusterService.java
+++ b/src/main/java/org/elasticsearch/cluster/service/InternalClusterService.java
@@ -525,7 +525,7 @@ public class InternalClusterService extends AbstractLifecycleComponent<ClusterSe
     class NotifyTimeout implements Runnable {
         final TimeoutClusterStateListener listener;
         final TimeValue timeout;
-        ScheduledFuture future;
+        volatile ScheduledFuture future;
 
         NotifyTimeout(TimeoutClusterStateListener listener, TimeValue timeout) {
             this.listener = listener;
@@ -538,7 +538,7 @@ public class InternalClusterService extends AbstractLifecycleComponent<ClusterSe
 
         @Override
         public void run() {
-            if (future.isCancelled()) {
+            if (future != null && future.isCancelled()) {
                 return;
             }
             if (lifecycle.stoppedOrClosed()) {


### PR DESCRIPTION
This is likely cause of the following failure: http://build-us-00.elastic.co/job/es_g1gc_1x_metal/7976/

```
REPRODUCE WITH  : mvn clean test -Dtests.seed=CD6728614E507BB9 -Dtests.class=org.elasticsearch.search.basic.SearchWithRandomExceptionsTests -Dtests.method="testRandomDirectoryIOExceptions" -Des.logger.level=DEBUG -Des.node.mode=local -Dtests.security.manager=false -Dtests.nightly=false -Dtests.heap.size=512m -Dtests.jvm.argline="-server -XX:+UseG1GC -XX:-UseCompressedOops -XX:+AggressiveOpts" -Dtests.locale=pl -Dtests.timezone=Pacific/Johnston -Dtests.processors=8
  1> Throwable:
  1> com.carrotsearch.randomizedtesting.UncaughtExceptionError: Captured an uncaught exception in thread: Thread[id=4658, name=elasticsearch[node_s4][generic][T#3], state=RUNNABLE, group=TGRP-SearchWithRandomExceptionsTests]
  1>     __randomizedtesting.SeedInfo.seed([CD6728614E507BB9:849B444950169018]:0)
  1> Caused by: java.lang.NullPointerException
  1>     __randomizedtesting.SeedInfo.seed([CD6728614E507BB9]:0)
  1>     org.elasticsearch.cluster.service.InternalClusterService$NotifyTimeout.run(InternalClusterService.java:532)
  1>     java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
  1>     java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
  1>     java.lang.Thread.run(Thread.java:745)
```
