### PR TITLE
Added context for significant_terms scoring

### DIFF
--- a/docs/reference/search/aggregations/bucket/significantterms-aggregation.asciidoc
+++ b/docs/reference/search/aggregations/bucket/significantterms-aggregation.asciidoc
@@ -369,6 +369,7 @@ Parameters need to be set as follows:
 Available parameters in the script are
 
 [horizontal]
+`_term`:: The term being scored (this can be either a java String or a Long depending on the choice of field)
 `_subset_freq`:: Number of documents the term appears in in the subset.
 `_superset_freq`:: Number of documents the term appears in in the superset.
 `_subset_size`:: Number of documents in the subset.

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/InternalSignificantTerms.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/InternalSignificantTerms.java
@@ -88,7 +88,7 @@ public abstract class InternalSignificantTerms extends InternalMultiBucketAggreg
         }
 
         public void updateScore(SignificanceHeuristic significanceHeuristic) {
-            score = significanceHeuristic.getScore(subsetDf, subsetSize, supersetDf, supersetSize);
+            score = significanceHeuristic.getScore(getKey(), subsetDf, subsetSize, supersetDf, supersetSize);
         }
 
         @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/ChiSquare.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/ChiSquare.java
@@ -68,7 +68,7 @@ public class ChiSquare extends NXYSignificanceHeuristic {
      * see "Information Retrieval", Manning et al., Eq. 13.19
      */
     @Override
-    public double getScore(long subsetFreq, long subsetSize, long supersetFreq, long supersetSize) {
+    public double getScore(Object term, long subsetFreq, long subsetSize, long supersetFreq, long supersetSize) {
         Frequencies frequencies = computeNxys(subsetFreq, subsetSize, supersetFreq, supersetSize, "ChiSquare");
 
         // here we check if the term appears more often in subset than in background without subset.

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/GND.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/GND.java
@@ -72,7 +72,7 @@ public class GND extends NXYSignificanceHeuristic {
      * link: http://arxiv.org/pdf/cs/0412098v3.pdf
      */
     @Override
-    public double getScore(long subsetFreq, long subsetSize, long supersetFreq, long supersetSize) {
+    public double getScore(Object term, long subsetFreq, long subsetSize, long supersetFreq, long supersetSize) {
 
         Frequencies frequencies = computeNxys(subsetFreq, subsetSize, supersetFreq, supersetSize, "GND");
         double fx = frequencies.N1_;

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/JLHScore.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/JLHScore.java
@@ -21,7 +21,6 @@
 package org.elasticsearch.search.aggregations.bucket.significant.heuristics;
 
 
-import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -61,7 +60,7 @@ public class JLHScore extends SignificanceHeuristic {
      * of the significant terms feature.
      */
     @Override
-    public double getScore(long subsetFreq, long subsetSize, long supersetFreq, long supersetSize) {
+    public double getScore(Object term, long subsetFreq, long subsetSize, long supersetFreq, long supersetSize) {
         checkFrequencyValidity(subsetFreq, subsetSize, supersetFreq, supersetSize, "JLHScore");
         if ((subsetSize == 0) || (supersetSize == 0)) {
             // avoid any divide by zero issues

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/MutualInformation.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/MutualInformation.java
@@ -70,7 +70,7 @@ public class MutualInformation extends NXYSignificanceHeuristic {
      * see "Information Retrieval", Manning et al., Eq. 13.17
      */
     @Override
-    public double getScore(long subsetFreq, long subsetSize, long supersetFreq, long supersetSize) {
+    public double getScore(Object term, long subsetFreq, long subsetSize, long supersetFreq, long supersetSize) {
         Frequencies frequencies = computeNxys(subsetFreq, subsetSize, supersetFreq, supersetSize, "MutualInformation");
 
         double score = (getMITerm(frequencies.N00, frequencies.N0_, frequencies.N_0, frequencies.N) +

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/PercentageScore.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/PercentageScore.java
@@ -59,7 +59,7 @@ public class PercentageScore extends SignificanceHeuristic {
      * of all occurrences of a term are found in the sample. 
      */
     @Override
-    public double getScore(long subsetFreq, long subsetSize, long supersetFreq, long supersetSize) {
+    public double getScore(Object term, long subsetFreq, long subsetSize, long supersetFreq, long supersetSize) {
         checkFrequencyValidity(subsetFreq, subsetSize, supersetFreq, supersetSize, "PercentageScore");
         if (supersetFreq == 0) {
             // avoid a divide by zero issue

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/SignificanceHeuristic.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/SignificanceHeuristic.java
@@ -28,13 +28,14 @@ import java.io.IOException;
 
 public abstract class SignificanceHeuristic {
     /**
+     * @param term   The term to be scored
      * @param subsetFreq   The frequency of the term in the selected sample
      * @param subsetSize   The size of the selected sample (typically number of docs)
      * @param supersetFreq The frequency of the term in the superset from which the sample was taken
      * @param supersetSize The size of the superset from which the sample was taken  (typically number of docs)
      * @return a "significance" score
      */
-    public abstract double getScore(long subsetFreq, long subsetSize, long supersetFreq, long supersetSize);
+    public abstract double getScore(Object term, long subsetFreq, long subsetSize, long supersetFreq, long supersetSize);
 
     abstract public void writeTo(StreamOutput out) throws IOException;
 


### PR DESCRIPTION
Scoring heuristics can now see the value of the term being scored.
Scripted heuristic can access the raw value through the variable _term.

Closes #10613
