### PR TITLE
Deprecate `async` replication

### DIFF
--- a/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
+++ b/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
@@ -424,12 +424,19 @@ public class BulkRequest extends ActionRequest<BulkRequest> implements Composite
 
     /**
      * Set the replication type for this operation.
+     * @deprecated will be removed in 2.0.0. See https://github.com/elastic/elasticsearch/pull/10171
      */
+    @Deprecated
     public BulkRequest replicationType(ReplicationType replicationType) {
         this.replicationType = replicationType;
         return this;
     }
 
+    /**
+     * Get the replication type for this operation.
+     * @deprecated will be removed in 2.0.0. See https://github.com/elastic/elasticsearch/pull/10171
+     */
+    @Deprecated
     public ReplicationType replicationType() {
         return this.replicationType;
     }

--- a/src/main/java/org/elasticsearch/action/bulk/BulkRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/bulk/BulkRequestBuilder.java
@@ -112,7 +112,9 @@ public class BulkRequestBuilder extends ActionRequestBuilder<BulkRequest, BulkRe
 
     /**
      * Set the replication type for this operation.
+     * @deprecated will be removed in 2.0.0. See https://github.com/elastic/elasticsearch/pull/10171
      */
+    @Deprecated
     public BulkRequestBuilder setReplicationType(ReplicationType replicationType) {
         request.replicationType(replicationType);
         return this;

--- a/src/main/java/org/elasticsearch/action/support/replication/IndicesReplicationOperationRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/support/replication/IndicesReplicationOperationRequestBuilder.java
@@ -71,7 +71,9 @@ public abstract class IndicesReplicationOperationRequestBuilder<Request extends 
 
     /**
      * Sets the replication type.
+     * @deprecated will be removed in 2.0.0. See https://github.com/elastic/elasticsearch/pull/10171
      */
+    @Deprecated
     @SuppressWarnings("unchecked")
     public RequestBuilder setReplicationType(ReplicationType replicationType) {
         request.replicationType(replicationType);
@@ -80,7 +82,9 @@ public abstract class IndicesReplicationOperationRequestBuilder<Request extends 
 
     /**
      * Sets the replication type.
+     * @deprecated will be removed in 2.0.0. See https://github.com/elastic/elasticsearch/pull/10171
      */
+    @Deprecated
     @SuppressWarnings("unchecked")
     public RequestBuilder setReplicationType(String replicationType) {
         request.replicationType(replicationType);

--- a/src/main/java/org/elasticsearch/action/support/replication/ReplicationType.java
+++ b/src/main/java/org/elasticsearch/action/support/replication/ReplicationType.java
@@ -23,7 +23,9 @@ import org.elasticsearch.ElasticsearchIllegalArgumentException;
 
 /**
  * The type of replication to perform.
+ * @deprecated will be removed in 2.0.0. See https://github.com/elastic/elasticsearch/pull/10171
  */
+@Deprecated
 public enum ReplicationType {
     /**
      * Sync replication, wait till all replicas have performed the operation.

--- a/src/main/java/org/elasticsearch/action/support/replication/ShardReplicationOperationRequest.java
+++ b/src/main/java/org/elasticsearch/action/support/replication/ShardReplicationOperationRequest.java
@@ -151,14 +151,18 @@ public abstract class ShardReplicationOperationRequest<T extends ShardReplicatio
 
     /**
      * The replication type.
+     * @deprecated will be removed in 2.0.0. See https://github.com/elastic/elasticsearch/pull/10171
      */
+    @Deprecated
     public ReplicationType replicationType() {
         return this.replicationType;
     }
 
     /**
      * Sets the replication type.
+     * @deprecated will be removed in 2.0.0. See https://github.com/elastic/elasticsearch/pull/10171
      */
+    @Deprecated
     @SuppressWarnings("unchecked")
     public final T replicationType(ReplicationType replicationType) {
         this.replicationType = replicationType;
@@ -167,7 +171,9 @@ public abstract class ShardReplicationOperationRequest<T extends ShardReplicatio
 
     /**
      * Sets the replication type.
+     * @deprecated will be removed in 2.0.0. See https://github.com/elastic/elasticsearch/pull/10171
      */
+    @Deprecated
     public final T replicationType(String replicationType) {
         return replicationType(ReplicationType.fromString(replicationType));
     }

--- a/src/main/java/org/elasticsearch/action/support/replication/ShardReplicationOperationRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/support/replication/ShardReplicationOperationRequestBuilder.java
@@ -70,7 +70,9 @@ public abstract class ShardReplicationOperationRequestBuilder<Request extends Sh
 
     /**
      * Sets the replication type.
+     * @deprecated will be removed in 2.0.0. See https://github.com/elastic/elasticsearch/pull/10171
      */
+    @Deprecated
     @SuppressWarnings("unchecked")
     public RequestBuilder setReplicationType(ReplicationType replicationType) {
         request.replicationType(replicationType);
@@ -79,7 +81,9 @@ public abstract class ShardReplicationOperationRequestBuilder<Request extends Sh
 
     /**
      * Sets the replication type.
+     * @deprecated will be removed in 2.0.0. See https://github.com/elastic/elasticsearch/pull/10171
      */
+    @Deprecated
     @SuppressWarnings("unchecked")
     public RequestBuilder setReplicationType(String replicationType) {
         request.replicationType(replicationType);

--- a/src/main/java/org/elasticsearch/action/update/UpdateRequest.java
+++ b/src/main/java/org/elasticsearch/action/update/UpdateRequest.java
@@ -375,14 +375,18 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest> 
 
     /**
      * The replication type.
+     * @deprecated will be removed in 2.0.0. See https://github.com/elastic/elasticsearch/pull/10171
      */
+    @Deprecated
     public ReplicationType replicationType() {
         return this.replicationType;
     }
 
     /**
      * Sets the replication type.
+     * @deprecated will be removed in 2.0.0. See https://github.com/elastic/elasticsearch/pull/10171
      */
+    @Deprecated
     public UpdateRequest replicationType(ReplicationType replicationType) {
         this.replicationType = replicationType;
         return this;

--- a/src/main/java/org/elasticsearch/action/update/UpdateRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/update/UpdateRequestBuilder.java
@@ -165,7 +165,9 @@ public class UpdateRequestBuilder extends InstanceShardOperationRequestBuilder<U
 
     /**
      * Sets the replication type.
+     * @deprecated will be removed in 2.0.0. See https://github.com/elastic/elasticsearch/pull/10171
      */
+    @Deprecated
     public UpdateRequestBuilder setReplicationType(ReplicationType replicationType) {
         request.replicationType(replicationType);
         return this;


### PR DESCRIPTION
Follow up for PR #10171.

As we discussed https://github.com/elastic/elasticsearch/issues/10114#issuecomment-87989649, we should also mark the code as deprecated so plugin developers know in advance that they need to adapt their code.

I also added a `log` when using `replication` parameter in REST APIs but as `info` Level. I wonder if I should better log that as a `WARN` if `debug` level is set? So people in debug mode will see this information as a `WARN` while it won't pollute logs for each call when in default `INFO` log level.
