### PR TITLE
Single value numeric queries shouldn't be handled by NumericRangeQuery

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/core/ByteFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/ByteFieldMapper.java
@@ -209,13 +209,6 @@ public class ByteFieldMapper extends NumberFieldMapper<Byte> {
     }
 
     @Override
-    public Filter termFilter(Object value, @Nullable QueryParseContext context) {
-        int iValue = parseValueAsInt(value);
-        return NumericRangeFilter.newIntRange(names.indexName(), precisionStep,
-                iValue, iValue, true, true);
-    }
-
-    @Override
     public Filter rangeFilter(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, @Nullable QueryParseContext context) {
         return NumericRangeFilter.newIntRange(names.indexName(), precisionStep,
                 lowerTerm == null ? null : parseValueAsInt(lowerTerm),

--- a/src/main/java/org/elasticsearch/index/mapper/core/ByteFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/ByteFieldMapper.java
@@ -201,13 +201,6 @@ public class ByteFieldMapper extends NumberFieldMapper<Byte> {
     }
 
     @Override
-    public Query termQuery(Object value, @Nullable QueryParseContext context) {
-        int iValue = parseValue(value);
-        return NumericRangeQuery.newIntRange(names.indexName(), precisionStep,
-                iValue, iValue, true, true);
-    }
-
-    @Override
     public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, @Nullable QueryParseContext context) {
         return NumericRangeQuery.newIntRange(names.indexName(), precisionStep,
                 lowerTerm == null ? null : parseValueAsInt(lowerTerm),

--- a/src/main/java/org/elasticsearch/index/mapper/core/DateFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/DateFieldMapper.java
@@ -317,13 +317,6 @@ public class DateFieldMapper extends NumberFieldMapper<Long> {
     }
 
     @Override
-    public Filter termFilter(Object value, @Nullable QueryParseContext context) {
-        final long lValue = parseToMilliseconds(value);
-        return NumericRangeFilter.newLongRange(names.indexName(), precisionStep,
-                lValue, lValue, true, true);
-    }
-
-    @Override
     public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, @Nullable QueryParseContext context) {
         return rangeQuery(lowerTerm, upperTerm, includeLower, includeUpper, null, null, context);
     }

--- a/src/main/java/org/elasticsearch/index/mapper/core/DateFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/DateFieldMapper.java
@@ -297,13 +297,6 @@ public class DateFieldMapper extends NumberFieldMapper<Long> {
                 true, true);
     }
 
-    @Override
-    public Query termQuery(Object value, @Nullable QueryParseContext context) {
-        long lValue = parseToMilliseconds(value);
-        return NumericRangeQuery.newLongRange(names.indexName(), precisionStep,
-                lValue, lValue, true, true);
-    }
-
     public long parseToMilliseconds(Object value) {
         return parseToMilliseconds(value, false, null, dateMathParser);
     }

--- a/src/main/java/org/elasticsearch/index/mapper/core/DoubleFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/DoubleFieldMapper.java
@@ -192,13 +192,6 @@ public class DoubleFieldMapper extends NumberFieldMapper<Double> {
     }
 
     @Override
-    public Query termQuery(Object value, @Nullable QueryParseContext context) {
-        double dValue = parseDoubleValue(value);
-        return NumericRangeQuery.newDoubleRange(names.indexName(), precisionStep,
-                dValue, dValue, true, true);
-    }
-
-    @Override
     public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, @Nullable QueryParseContext context) {
         return NumericRangeQuery.newDoubleRange(names.indexName(), precisionStep,
                 lowerTerm == null ? null : parseDoubleValue(lowerTerm),

--- a/src/main/java/org/elasticsearch/index/mapper/core/DoubleFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/DoubleFieldMapper.java
@@ -200,13 +200,6 @@ public class DoubleFieldMapper extends NumberFieldMapper<Double> {
     }
 
     @Override
-    public Filter termFilter(Object value, @Nullable QueryParseContext context) {
-        double dValue = parseDoubleValue(value);
-        return NumericRangeFilter.newDoubleRange(names.indexName(), precisionStep,
-                dValue, dValue, true, true);
-    }
-
-    @Override
     public Filter rangeFilter(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, @Nullable QueryParseContext context) {
         return NumericRangeFilter.newDoubleRange(names.indexName(), precisionStep,
                 lowerTerm == null ? null : parseDoubleValue(lowerTerm),

--- a/src/main/java/org/elasticsearch/index/mapper/core/FloatFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/FloatFieldMapper.java
@@ -210,13 +210,6 @@ public class FloatFieldMapper extends NumberFieldMapper<Float> {
     }
 
     @Override
-    public Filter termFilter(Object value, @Nullable QueryParseContext context) {
-        float fValue = parseValue(value);
-        return NumericRangeFilter.newFloatRange(names.indexName(), precisionStep,
-                fValue, fValue, true, true);
-    }
-
-    @Override
     public Filter rangeFilter(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, @Nullable QueryParseContext context) {
         return NumericRangeFilter.newFloatRange(names.indexName(), precisionStep,
                 lowerTerm == null ? null : parseValue(lowerTerm),

--- a/src/main/java/org/elasticsearch/index/mapper/core/FloatFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/FloatFieldMapper.java
@@ -202,13 +202,6 @@ public class FloatFieldMapper extends NumberFieldMapper<Float> {
     }
 
     @Override
-    public Query termQuery(Object value, @Nullable QueryParseContext context) {
-        float fValue = parseValue(value);
-        return NumericRangeQuery.newFloatRange(names.indexName(), precisionStep,
-                fValue, fValue, true, true);
-    }
-
-    @Override
     public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, @Nullable QueryParseContext context) {
         return NumericRangeQuery.newFloatRange(names.indexName(), precisionStep,
                 lowerTerm == null ? null : parseValue(lowerTerm),

--- a/src/main/java/org/elasticsearch/index/mapper/core/IntegerFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/IntegerFieldMapper.java
@@ -196,13 +196,6 @@ public class IntegerFieldMapper extends NumberFieldMapper<Integer> {
     }
 
     @Override
-    public Query termQuery(Object value, @Nullable QueryParseContext context) {
-        int iValue = parseValue(value);
-        return NumericRangeQuery.newIntRange(names.indexName(), precisionStep,
-                iValue, iValue, true, true);
-    }
-
-    @Override
     public Filter termFilter(Object value, @Nullable QueryParseContext context) {
         int iValue = parseValue(value);
         return NumericRangeFilter.newIntRange(names.indexName(), precisionStep,

--- a/src/main/java/org/elasticsearch/index/mapper/core/IntegerFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/IntegerFieldMapper.java
@@ -196,13 +196,6 @@ public class IntegerFieldMapper extends NumberFieldMapper<Integer> {
     }
 
     @Override
-    public Filter termFilter(Object value, @Nullable QueryParseContext context) {
-        int iValue = parseValue(value);
-        return NumericRangeFilter.newIntRange(names.indexName(), precisionStep,
-                iValue, iValue, true, true);
-    }
-
-    @Override
     public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, @Nullable QueryParseContext context) {
         return NumericRangeQuery.newIntRange(names.indexName(), precisionStep,
                 lowerTerm == null ? null : parseValue(lowerTerm),

--- a/src/main/java/org/elasticsearch/index/mapper/core/LongFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/LongFieldMapper.java
@@ -185,14 +185,6 @@ public class LongFieldMapper extends NumberFieldMapper<Long> {
                 true, true);
     }
 
-
-    @Override
-    public Filter termFilter(Object value, @Nullable QueryParseContext context) {
-        long iValue = parseLongValue(value);
-        return NumericRangeFilter.newLongRange(names.indexName(), precisionStep,
-                iValue, iValue, true, true);
-    }
-
     @Override
     public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, @Nullable QueryParseContext context) {
         return NumericRangeQuery.newLongRange(names.indexName(), precisionStep,

--- a/src/main/java/org/elasticsearch/index/mapper/core/LongFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/LongFieldMapper.java
@@ -185,12 +185,6 @@ public class LongFieldMapper extends NumberFieldMapper<Long> {
                 true, true);
     }
 
-    @Override
-    public Query termQuery(Object value, @Nullable QueryParseContext context) {
-        long iValue = parseLongValue(value);
-        return NumericRangeQuery.newLongRange(names.indexName(), precisionStep,
-                iValue, iValue, true, true);
-    }
 
     @Override
     public Filter termFilter(Object value, @Nullable QueryParseContext context) {

--- a/src/main/java/org/elasticsearch/index/mapper/core/NumberFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/NumberFieldMapper.java
@@ -33,8 +33,11 @@ import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.IndexableFieldType;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.Filter;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.store.ByteArrayDataOutput;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
@@ -271,13 +274,10 @@ public abstract class NumberFieldMapper<T extends Number> extends AbstractFieldM
         return true;
     }
 
-    /**
-     * Numeric field level query are basically range queries with same value and included. That's the recommended
-     * way to execute it.
-     */
     @Override
-    public Query termQuery(Object value, @Nullable QueryParseContext context) {
-        return rangeQuery(value, value, true, true, context);
+    public final Query termQuery(Object value, @Nullable QueryParseContext context) {
+        TermQuery scoringQuery = new TermQuery(new Term(names.indexName(), indexedValueForSearch(value)));
+        return new ConstantScoreQuery(scoringQuery);
     }
 
     /**

--- a/src/main/java/org/elasticsearch/index/mapper/core/NumberFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/NumberFieldMapper.java
@@ -280,13 +280,12 @@ public abstract class NumberFieldMapper<T extends Number> extends AbstractFieldM
         return new ConstantScoreQuery(scoringQuery);
     }
 
-    /**
-     * Numeric field level filter are basically range queries with same value and included. That's the recommended
-     * way to execute it.
-     */
     @Override
-    public Filter termFilter(Object value, @Nullable QueryParseContext context) {
-        return rangeFilter(value, value, true, true, context);
+    public final Filter termFilter(Object value, @Nullable QueryParseContext context) {
+        // Made this method final because previously many subclasses duplicated
+        // the same code, returning a NumericRangeFilter, which should be less
+        // efficient than super's default impl of a single TermFilter.
+        return super.termFilter(value, context);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/mapper/core/ShortFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/ShortFieldMapper.java
@@ -210,13 +210,6 @@ public class ShortFieldMapper extends NumberFieldMapper<Short> {
     }
 
     @Override
-    public Filter termFilter(Object value, @Nullable QueryParseContext context) {
-        int iValue = parseValueAsInt(value);
-        return NumericRangeFilter.newIntRange(names.indexName(), precisionStep,
-                iValue, iValue, true, true);
-    }
-
-    @Override
     public Filter rangeFilter(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, @Nullable QueryParseContext context) {
         return NumericRangeFilter.newIntRange(names.indexName(), precisionStep,
                 lowerTerm == null ? null : parseValueAsInt(lowerTerm),

--- a/src/main/java/org/elasticsearch/index/mapper/core/ShortFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/ShortFieldMapper.java
@@ -202,13 +202,6 @@ public class ShortFieldMapper extends NumberFieldMapper<Short> {
     }
 
     @Override
-    public Query termQuery(Object value, @Nullable QueryParseContext context) {
-        int iValue = parseValueAsInt(value);
-        return NumericRangeQuery.newIntRange(names.indexName(), precisionStep,
-                iValue, iValue, true, true);
-    }
-
-    @Override
     public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, @Nullable QueryParseContext context) {
         return NumericRangeQuery.newIntRange(names.indexName(), precisionStep,
                 lowerTerm == null ? null : parseValueAsInt(lowerTerm),

--- a/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
+++ b/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
@@ -480,25 +480,25 @@ public class SimpleIndexQueryParserTests extends ElasticsearchSingleNodeTest {
     public void testTermQueryBuilder() throws IOException {
         IndexQueryParserService queryParser = queryParser();
         Query parsedQuery = queryParser.parse(termQuery("age", 34).buildAsBytes()).query();
-        assertThat(parsedQuery, instanceOf(NumericRangeQuery.class));
-        NumericRangeQuery fieldQuery = (NumericRangeQuery) parsedQuery;
-        assertThat(fieldQuery.getMin().intValue(), equalTo(34));
-        assertThat(fieldQuery.getMax().intValue(), equalTo(34));
-        assertThat(fieldQuery.includesMax(), equalTo(true));
-        assertThat(fieldQuery.includesMin(), equalTo(true));
+        TermQuery fieldQuery = unwrapTermQuery(parsedQuery, true);
+        assertThat(fieldQuery.getTerm().bytes(), equalTo(indexedValueForSearch(34l)));
     }
 
     @Test
     public void testTermQuery() throws IOException {
         IndexQueryParserService queryParser = queryParser();
         String query = copyToStringFromClasspath("/org/elasticsearch/index/query/term.json");
-        Query parsedQuery = queryParser.parse(query).query();
-        assertThat(parsedQuery, instanceOf(NumericRangeQuery.class));
-        NumericRangeQuery fieldQuery = (NumericRangeQuery) parsedQuery;
-        assertThat(fieldQuery.getMin().intValue(), equalTo(34));
-        assertThat(fieldQuery.getMax().intValue(), equalTo(34));
-        assertThat(fieldQuery.includesMax(), equalTo(true));
-        assertThat(fieldQuery.includesMin(), equalTo(true));
+        TermQuery fieldQuery = unwrapTermQuery(queryParser.parse(query).query(), true);
+        assertThat(fieldQuery.getTerm().bytes(), equalTo(indexedValueForSearch(34l)));
+    }
+
+    private static TermQuery unwrapTermQuery(Query q, boolean expectConstantWrapper) {
+        if (expectConstantWrapper) {
+            assertThat(q, instanceOf(ConstantScoreQuery.class));
+            q = ((ConstantScoreQuery) q).getQuery();
+        }
+        assertThat(q, instanceOf(TermQuery.class));
+        return (TermQuery) q;
     }
 
     @Test
@@ -559,14 +559,19 @@ public class SimpleIndexQueryParserTests extends ElasticsearchSingleNodeTest {
     @Test
     public void testTermWithBoostQueryBuilder() throws IOException {
         IndexQueryParserService queryParser = queryParser();
+
         Query parsedQuery = queryParser.parse(termQuery("age", 34).boost(2.0f)).query();
-        assertThat(parsedQuery, instanceOf(NumericRangeQuery.class));
-        NumericRangeQuery fieldQuery = (NumericRangeQuery) parsedQuery;
-        assertThat(fieldQuery.getMin().intValue(), equalTo(34));
-        assertThat(fieldQuery.getMax().intValue(), equalTo(34));
-        assertThat(fieldQuery.includesMax(), equalTo(true));
-        assertThat(fieldQuery.includesMin(), equalTo(true));
-        assertThat((double) fieldQuery.getBoost(), closeTo(2.0, 0.01));
+        TermQuery fieldQuery = unwrapTermQuery(parsedQuery, true);
+        assertThat(fieldQuery.getTerm().bytes(), equalTo(indexedValueForSearch(34l)));
+        assertThat((double) parsedQuery.getBoost(), closeTo(2.0, 0.01));
+    }
+
+    private BytesRef indexedValueForSearch(long value) {
+        BytesRefBuilder bytesRef = new BytesRefBuilder();
+        NumericUtils.longToPrefixCoded(value, 0, bytesRef); // 0 because of
+                                                            // exact
+                                                            // match
+        return bytesRef.get();
     }
 
     @Test
@@ -574,13 +579,9 @@ public class SimpleIndexQueryParserTests extends ElasticsearchSingleNodeTest {
         IndexQueryParserService queryParser = queryParser();
         String query = copyToStringFromClasspath("/org/elasticsearch/index/query/term-with-boost.json");
         Query parsedQuery = queryParser.parse(query).query();
-        assertThat(parsedQuery, instanceOf(NumericRangeQuery.class));
-        NumericRangeQuery fieldQuery = (NumericRangeQuery) parsedQuery;
-        assertThat(fieldQuery.getMin().intValue(), equalTo(34));
-        assertThat(fieldQuery.getMax().intValue(), equalTo(34));
-        assertThat(fieldQuery.includesMax(), equalTo(true));
-        assertThat(fieldQuery.includesMin(), equalTo(true));
-        assertThat((double) fieldQuery.getBoost(), closeTo(2.0, 0.01));
+        TermQuery fieldQuery = unwrapTermQuery(parsedQuery, true);
+        assertThat(fieldQuery.getTerm().bytes(), equalTo(indexedValueForSearch(34l)));
+        assertThat((double) parsedQuery.getBoost(), closeTo(2.0, 0.01));
     }
 
     @Test

--- a/src/test/java/org/elasticsearch/percolator/PercolatorTests.java
+++ b/src/test/java/org/elasticsearch/percolator/PercolatorTests.java
@@ -18,8 +18,6 @@
  */
 package org.elasticsearch.percolator;
 
-import com.google.common.base.Predicate;
-
 import org.elasticsearch.action.ShardOperationFailedException;
 import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
 import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsResponse;
@@ -32,9 +30,9 @@ import org.elasticsearch.action.percolate.PercolateResponse;
 import org.elasticsearch.action.percolate.PercolateSourceBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.client.Client;
 import org.elasticsearch.client.Requests;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.lucene.search.function.CombineFunction;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.ImmutableSettings.Builder;
 import org.elasticsearch.common.unit.TimeValue;
@@ -1329,7 +1327,9 @@ public class PercolatorTests extends ElasticsearchIntegrationTest {
                     .setSortByScore(true)
                     .setSize(size)
                     .setPercolateDoc(docBuilder().setDoc("field", "value"))
-                    .setPercolateQuery(QueryBuilders.functionScoreQuery(matchQuery("field1", value), scriptFunction("doc['level'].value")))
+                    .setPercolateQuery(
+                            QueryBuilders.functionScoreQuery(matchQuery("field1", value), scriptFunction("doc['level'].value")).boostMode(
+                                    CombineFunction.REPLACE))
                     .execute().actionGet();
 
             assertMatchCount(response, levels.size());

--- a/src/test/java/org/elasticsearch/validate/SimpleValidateQueryTests.java
+++ b/src/test/java/org/elasticsearch/validate/SimpleValidateQueryTests.java
@@ -54,7 +54,9 @@ import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF
 import static org.elasticsearch.index.query.QueryBuilders.queryStringQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
 
 /**
  *
@@ -167,14 +169,15 @@ public class SimpleValidateQueryTests extends ElasticsearchIntegrationTest {
                         FilterBuilders.termFilter("bar", "2"),
                         FilterBuilders.termFilter("baz", "3")
                 )
-        ), equalTo(filtered("filtered(foo:1)->" + filter(filter("bar:[2 TO 2]") + " " + filter("baz:3"))) + typeFilter));
+        ), equalTo(filtered("filtered(foo:1)->" + filter(filter("bar:`   ") + " " + filter("baz:3")))
+                        + typeFilter));
 
         assertExplanation(QueryBuilders.filteredQuery(
                 QueryBuilders.termQuery("foo", "1"),
                 FilterBuilders.orFilter(
                         FilterBuilders.termFilter("bar", "2")
                 )
-        ), equalTo(filtered("filtered(foo:1)->" + filter(filter("bar:[2 TO 2]"))) + typeFilter));
+        ), equalTo(filtered("filtered(foo:1)->" + filter(filter("bar:`   "))) + typeFilter));
 
         assertExplanation(QueryBuilders.filteredQuery(
                 QueryBuilders.matchAllQuery(),
@@ -212,7 +215,9 @@ public class SimpleValidateQueryTests extends ElasticsearchIntegrationTest {
                         FilterBuilders.termFilter("bar", "2"),
                         FilterBuilders.termFilter("baz", "3")
                 )
-        ), equalTo(filtered("filtered(foo:1)->" + filter("+" + filter("bar:[2 TO 2]") + " +" + filter("baz:3"))) + typeFilter));
+            ), equalTo(filtered("filtered(foo:1)->"
+                        + filter("+" + filter("bar:`   ") + " +" + filter("baz:3")))
+                        + typeFilter));
 
         assertExplanation(QueryBuilders.constantScoreQuery(FilterBuilders.termsFilter("foo", "1", "2", "3")),
                 equalTo(filtered("ConstantScore(" + filter("foo:1 foo:2 foo:3") + ")") + typeFilter));


### PR DESCRIPTION
For performance reasons this change uses a TermQuery wrapped in a ConstantScoreQuery instead of a NumericRangeQuery with start and end values the same.

Closes #10646
