### PR TITLE
Change environment variable for terrible JVM workaround

### DIFF
--- a/src/main/java/org/elasticsearch/bootstrap/JVMCheck.java
+++ b/src/main/java/org/elasticsearch/bootstrap/JVMCheck.java
@@ -68,7 +68,7 @@ public class JVMCheck {
             if (workAround != null) {
                 sb.append(System.lineSeparator());
                 sb.append("If you absolutely cannot upgrade, please add ").append(workAround);
-                sb.append(" to the JVM_OPTS environment variable.");
+                sb.append(" to the JAVA_OPTS environment variable.");
                 sb.append(System.lineSeparator());
                 sb.append("Upgrading is preferred, this workaround will result in degraded performance.");
             }


### PR DESCRIPTION
If the JVM check fails, the "if you absolutely cannot upgrade" message mentions adding a workaround flag to the JVM_OPTS environment variable. Shouldn't this be the JAVA_OPTS environment variable instead? I had to modify JAVA_OPTS to get the workaround to work (at least when launching through elasticsearch.bat on Windows).
