### PR TITLE
inner_hits: Ignore object fields.

### DIFF
--- a/src/test/java/org/elasticsearch/search/innerhits/InnerHitsTests.java
+++ b/src/test/java/org/elasticsearch/search/innerhits/InnerHitsTests.java
@@ -851,13 +851,13 @@ public class InnerHitsTests extends ElasticsearchIntegrationTest {
         assertAcked(prepareCreate("articles")
                         .addMapping("article", jsonBuilder().startObject()
                                         .startObject("properties")
-                                            .startObject("comments")
-                                                .field("type", "object")
-                                                .startObject("properties")
-                                                    .startObject("messages").field("type", "nested").endObject()
-                                                .endObject()
-                                                .endObject()
-                                            .endObject()
+                                        .startObject("comments")
+                                        .field("type", "object")
+                                        .startObject("properties")
+                                        .startObject("messages").field("type", "nested").endObject()
+                                        .endObject()
+                                        .endObject()
+                                        .endObject()
                                         .endObject()
                         )
         );
@@ -865,7 +865,12 @@ public class InnerHitsTests extends ElasticsearchIntegrationTest {
         List<IndexRequestBuilder> requests = new ArrayList<>();
         requests.add(client().prepareIndex("articles", "article", "1").setSource(jsonBuilder().startObject()
                 .field("title", "quick brown fox")
-                .startObject("comments").startObject("messages").field("message", "fox eat quick").endObject().endObject()
+                .startObject("comments")
+                    .startArray("messages")
+                        .startObject().field("message", "fox eat quick").endObject()
+                        .startObject().field("message", "bear eat quick").endObject()
+                    .endArray()
+                .endObject()
                 .endObject()));
         indexRandom(true, requests);
 
@@ -877,11 +882,21 @@ public class InnerHitsTests extends ElasticsearchIntegrationTest {
         assertThat(response.getHits().getAt(0).id(), equalTo("1"));
         assertThat(response.getHits().getAt(0).getInnerHits().get("comments.messages").getTotalHits(), equalTo(1l));
         assertThat(response.getHits().getAt(0).getInnerHits().get("comments.messages").getAt(0).id(), equalTo("1"));
-        assertThat(response.getHits().getAt(0).getInnerHits().get("comments.messages").getAt(0).getNestedIdentity().getField().string(), equalTo("comments"));
+        assertThat(response.getHits().getAt(0).getInnerHits().get("comments.messages").getAt(0).getNestedIdentity().getField().string(), equalTo("comments.messages"));
         assertThat(response.getHits().getAt(0).getInnerHits().get("comments.messages").getAt(0).getNestedIdentity().getOffset(), equalTo(0));
-        assertThat(response.getHits().getAt(0).getInnerHits().get("comments.messages").getAt(0).getNestedIdentity().getChild().getField().string(), equalTo("messages"));
-        assertThat(response.getHits().getAt(0).getInnerHits().get("comments.messages").getAt(0).getNestedIdentity().getChild().getOffset(), equalTo(0));
-        assertThat(response.getHits().getAt(0).getInnerHits().get("comments.messages").getAt(0).getNestedIdentity().getChild().getChild(), nullValue());
+        assertThat(response.getHits().getAt(0).getInnerHits().get("comments.messages").getAt(0).getNestedIdentity().getChild(), nullValue());
+
+        response = client().prepareSearch("articles")
+                .setQuery(nestedQuery("comments.messages", matchQuery("comments.messages.message", "bear")).innerHit(new QueryInnerHitBuilder()))
+                .get();
+        assertNoFailures(response);
+        assertHitCount(response, 1);
+        assertThat(response.getHits().getAt(0).id(), equalTo("1"));
+        assertThat(response.getHits().getAt(0).getInnerHits().get("comments.messages").getTotalHits(), equalTo(1l));
+        assertThat(response.getHits().getAt(0).getInnerHits().get("comments.messages").getAt(0).id(), equalTo("1"));
+        assertThat(response.getHits().getAt(0).getInnerHits().get("comments.messages").getAt(0).getNestedIdentity().getField().string(), equalTo("comments.messages"));
+        assertThat(response.getHits().getAt(0).getInnerHits().get("comments.messages").getAt(0).getNestedIdentity().getOffset(), equalTo(1));
+        assertThat(response.getHits().getAt(0).getInnerHits().get("comments.messages").getAt(0).getNestedIdentity().getChild(), nullValue());
     }
 
 }


### PR DESCRIPTION
Step over object fields when creating the nested identify and just use the object fieldname as a prefix for the nested field.

Closes #10629
