### PR TITLE
[DOCS] Be explicit about scan doing no scoring

### DIFF
--- a/docs/reference/search/request/scroll.asciidoc
+++ b/docs/reference/search/request/scroll.asciidoc
@@ -92,9 +92,9 @@ cost.
 
 Normally, you just want to retrieve all results and the order doesn't matter.
 Scrolling can be combined with the <<scan,`scan`>> search type to disable
-sorting and to return results in the most efficient way possible.  All that is
-needed is to add `search_type=scan` to the query string of the initial search
-request:
+any scoring or sorting and to return results in the most efficient way
+possible.  All that is needed is to add `search_type=scan` to the query string
+of the initial search request:
 
 [source,js]
 --------------------------------------------------
@@ -114,7 +114,8 @@ curl 'localhost:9200/twitter/tweet/_search?scroll=1m&search_type=scan' <1> -d '
 A scanning scroll request differs from a standard scroll request in four
 ways:
 
-* Sorting is disabled. Results are returned in the order they appear in the index.
+* No score is calculated and sorting is disabled. Results are returned in
+  the order they appear in the index.
 
 * Aggregations are not supported.
 
@@ -125,6 +126,9 @@ ways:
 * The <<search-request-from-size,`size` parameter>> controls the number of
   results *per shard*, not per request, so a `size` of `10` which hits 5
   shards will return a maximum of 50 results per `scroll` request.
+
+If you want the scoring to happen, even without sorting on it, set the
+`track_scores` parameter to `true`.
 
 [[scroll-search-context]]
 ==== Keeping the search context alive


### PR DESCRIPTION
The scroll page doesn't explicitly mention that `search_type=scan` also means no scoring, not just no sorting and it can lead to confusion, for example https://github.com/elastic/elasticsearch-py/issues/220
