### PR TITLE
Query refactoring: MatchAllQueryBuilder

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/MatchAllQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/MatchAllQueryBuilder.java
@@ -91,7 +91,7 @@ public class MatchAllQueryBuilder extends BaseQueryBuilder implements Streamable
 
     @Override
     public int hashCode() {
-        return (boost != +0.0f ? Float.floatToIntBits(boost) : 0);
+        return boost != +0.0f ? Float.floatToIntBits(boost) : 0;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/MatchAllQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/MatchAllQueryBuilder.java
@@ -35,7 +35,7 @@ import java.util.Objects;
  */
 public class MatchAllQueryBuilder extends BaseQueryBuilder implements Streamable, BoostableQueryBuilder<MatchAllQueryBuilder> {
 
-    float boost = 1.0f;
+    private float boost = 1.0f;
 
     /**
      * Sets the boost for this query.  Documents matching this query will (in addition to the normal
@@ -45,6 +45,13 @@ public class MatchAllQueryBuilder extends BaseQueryBuilder implements Streamable
     public MatchAllQueryBuilder boost(float boost) {
         this.boost = boost;
         return this;
+    }
+
+    /**
+     * Gets the boost for this query.
+     */
+    public float boost() {
+        return this.boost;
     }
 
     @Override
@@ -72,21 +79,6 @@ public class MatchAllQueryBuilder extends BaseQueryBuilder implements Streamable
     }
 
     @Override
-    public int hashCode() {
-        return Float.hashCode(this.boost);
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        this.boost = in.readFloat();
-    }
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        out.writeFloat(this.boost);
-    }
-
-    @Override
     public boolean equals(Object obj) {
         if (this == obj) {
             return true;
@@ -98,5 +90,20 @@ public class MatchAllQueryBuilder extends BaseQueryBuilder implements Streamable
 
         MatchAllQueryBuilder other = (MatchAllQueryBuilder) obj;
         return Objects.equals(boost, other.boost);
+    }
+
+    @Override
+    public int hashCode() {
+        return Float.floatToIntBits(this.boost);
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        this.boost = in.readFloat();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeFloat(this.boost);
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/MatchAllQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/MatchAllQueryBuilder.java
@@ -28,7 +28,6 @@ import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
-import java.util.Objects;
 
 /**
  * A query that matches on all documents.
@@ -89,7 +88,7 @@ public class MatchAllQueryBuilder extends BaseQueryBuilder implements Streamable
         }
 
         MatchAllQueryBuilder other = (MatchAllQueryBuilder) obj;
-        return Objects.equals(boost, other.boost);
+        return (Float.floatToIntBits(this.boost) == Float.floatToIntBits(other.boost()));
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/MatchAllQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/MatchAllQueryBuilder.java
@@ -78,20 +78,20 @@ public class MatchAllQueryBuilder extends BaseQueryBuilder implements Streamable
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
+    public boolean equals(Object o) {
+        if (this == o) {
             return true;
         }
-        if (obj instanceof MatchAllQueryBuilder) {
-            MatchAllQueryBuilder other = (MatchAllQueryBuilder) obj;
-            return (Float.floatToIntBits(this.boost) == Float.floatToIntBits(other.boost()));
+        if (o == null || getClass() != o.getClass()) {
+            return false;
         }
-        return false;
+        MatchAllQueryBuilder that = (MatchAllQueryBuilder) o;
+        return Float.compare(that.boost, boost) == 0;
     }
 
     @Override
     public int hashCode() {
-        return Float.floatToIntBits(this.boost);
+        return (boost != +0.0f ? Float.floatToIntBits(boost) : 0);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/MatchAllQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/MatchAllQueryBuilder.java
@@ -82,13 +82,11 @@ public class MatchAllQueryBuilder extends BaseQueryBuilder implements Streamable
         if (this == obj) {
             return true;
         }
-
-        if (getClass() != obj.getClass()) {
-            return false;
+        if (obj instanceof MatchAllQueryBuilder) {
+            MatchAllQueryBuilder other = (MatchAllQueryBuilder) obj;
+            return (Float.floatToIntBits(this.boost) == Float.floatToIntBits(other.boost()));
         }
-
-        MatchAllQueryBuilder other = (MatchAllQueryBuilder) obj;
-        return (Float.floatToIntBits(this.boost) == Float.floatToIntBits(other.boost()));
+        return false;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/MatchAllQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MatchAllQueryParser.java
@@ -19,17 +19,15 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
 
 /**
- *
+ * Parser code for MatchAllQuery
  */
 public class MatchAllQueryParser extends BaseQueryParserTemp {
 
@@ -44,32 +42,28 @@ public class MatchAllQueryParser extends BaseQueryParserTemp {
         return new String[]{NAME, Strings.toCamelCase(NAME)};
     }
 
-    @Override
-    public Query parse(QueryParseContext parseContext) throws IOException, QueryParsingException {
+    public MatchAllQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException {
+        MatchAllQueryBuilder queryBuilder = new MatchAllQueryBuilder();
         XContentParser parser = parseContext.parser();
 
-        float boost = 1.0f;
         String currentFieldName = null;
-
         XContentParser.Token token;
         while (((token = parser.nextToken()) != XContentParser.Token.END_OBJECT && token != XContentParser.Token.END_ARRAY)) {
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
             } else if (token.isValue()) {
                 if ("boost".equals(currentFieldName)) {
-                    boost = parser.floatValue();
+                    queryBuilder.boost = parser.floatValue();
                 } else {
                     throw new QueryParsingException(parseContext.index(), "[match_all] query does not support [" + currentFieldName + "]");
                 }
             }
         }
+        return queryBuilder;
+    }
 
-        if (boost == 1.0f) {
-            return Queries.newMatchAllQuery();
-        }
-
-        MatchAllDocsQuery query = new MatchAllDocsQuery();
-        query.setBoost(boost);
-        return query;
+    @Override
+    public Query parse(QueryParseContext parseContext) throws IOException, QueryParsingException {
+        return fromXContent(parseContext).toQuery(parseContext);
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/MatchAllQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MatchAllQueryParser.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.search.Query;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -29,7 +28,7 @@ import java.io.IOException;
 /**
  * Parser code for MatchAllQuery
  */
-public class MatchAllQueryParser extends BaseQueryParserTemp {
+public class MatchAllQueryParser extends BaseQueryParser {
 
     public static final String NAME = "match_all";
 
@@ -53,17 +52,12 @@ public class MatchAllQueryParser extends BaseQueryParserTemp {
                 currentFieldName = parser.currentName();
             } else if (token.isValue()) {
                 if ("boost".equals(currentFieldName)) {
-                    queryBuilder.boost = parser.floatValue();
+                    queryBuilder.boost(parser.floatValue());
                 } else {
                     throw new QueryParsingException(parseContext.index(), "[match_all] query does not support [" + currentFieldName + "]");
                 }
             }
         }
         return queryBuilder;
-    }
-
-    @Override
-    public Query parse(QueryParseContext parseContext) throws IOException, QueryParsingException {
-        return fromXContent(parseContext).toQuery(parseContext);
     }
 }

--- a/src/test/java/org/elasticsearch/index/query/BaseQueryTest.java
+++ b/src/test/java/org/elasticsearch/index/query/BaseQueryTest.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.common.inject.AbstractModule;
+import org.elasticsearch.common.inject.Injector;
+import org.elasticsearch.common.inject.ModulesBuilder;
+import org.elasticsearch.common.inject.util.Providers;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.settings.SettingsModule;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.env.EnvironmentModule;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexNameModule;
+import org.elasticsearch.index.analysis.AnalysisModule;
+import org.elasticsearch.index.cache.IndexCacheModule;
+import org.elasticsearch.index.query.functionscore.FunctionScoreModule;
+import org.elasticsearch.index.settings.IndexSettingsModule;
+import org.elasticsearch.index.similarity.SimilarityModule;
+import org.elasticsearch.indices.breaker.CircuitBreakerService;
+import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
+import org.elasticsearch.indices.query.IndicesQueriesModule;
+import org.elasticsearch.script.ScriptModule;
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.threadpool.ThreadPoolModule;
+import org.junit.After;
+import org.junit.Before;
+
+import java.io.IOException;
+
+public abstract class BaseQueryTest extends ElasticsearchTestCase {
+
+    protected QueryParseContext context;
+    protected Injector injector;
+    protected XContentParser parser;
+
+    @Before
+    public void setupBase() throws IOException {
+        Settings settings = ImmutableSettings.settingsBuilder()
+                .put("name", getClass().getName())
+                .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
+                .build();
+
+        Index index = new Index("test");
+        injector = new ModulesBuilder().add(
+                new EnvironmentModule(new Environment(settings)),
+                new SettingsModule(settings),
+                new ThreadPoolModule(settings),
+                new IndicesQueriesModule(),
+                new ScriptModule(settings),
+                new IndexSettingsModule(index, settings),
+                new IndexCacheModule(settings),
+                new AnalysisModule(settings),
+                new SimilarityModule(settings),
+                new IndexNameModule(index),
+                new IndexQueryParserModule(settings),
+                new FunctionScoreModule(),
+                new AbstractModule() {
+                    @Override
+                    protected void configure() {
+                        bind(ClusterService.class).toProvider(Providers.of((ClusterService) null));
+                        bind(CircuitBreakerService.class).to(NoneCircuitBreakerService.class);
+                    }
+                }
+        ).createInjector();
+
+        IndexQueryParserService queryParserService = injector.getInstance(IndexQueryParserService.class);
+        context = new QueryParseContext(index, queryParserService);
+    }
+
+    @Override
+    @After
+    public void tearDown() throws Exception {
+        super.tearDown();
+        terminate(injector.getInstance(ThreadPool.class));
+    }
+}

--- a/src/test/java/org/elasticsearch/index/query/BaseQueryTestCase.java
+++ b/src/test/java/org/elasticsearch/index/query/BaseQueryTestCase.java
@@ -114,7 +114,7 @@ public abstract class BaseQueryTestCase<QB extends BaseQueryBuilder & Streamable
     public void setUp() throws Exception {
         super.setUp();
         context = new QueryParseContext(index, queryParserService);
-        testQuery = createRandomTestQuery();
+        testQuery = createTestQueryBuilder();
         String contentString = testQuery.toString();
         parser = XContentFactory.xContent(contentString).createParser(contentString);
         context.reset(parser);
@@ -126,10 +126,9 @@ public abstract class BaseQueryTestCase<QB extends BaseQueryBuilder & Streamable
     }
 
     /**
-     * Create a random query for the type that is being tested
-     * @return a randomized query
+     * Create the query that is being tested
      */
-    protected abstract QB createRandomTestQuery();
+    protected abstract QB createTestQueryBuilder();
 
     /**
      * Subclass should handle assertions on the lucene query produced by the query builder under test here

--- a/src/test/java/org/elasticsearch/index/query/BaseQueryTestCase.java
+++ b/src/test/java/org/elasticsearch/index/query/BaseQueryTestCase.java
@@ -48,7 +48,6 @@ import org.elasticsearch.test.ElasticsearchTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.threadpool.ThreadPoolModule;
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;

--- a/src/test/java/org/elasticsearch/index/query/BaseQueryTestCase.java
+++ b/src/test/java/org/elasticsearch/index/query/BaseQueryTestCase.java
@@ -47,9 +47,9 @@ import org.elasticsearch.script.ScriptModule;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.threadpool.ThreadPoolModule;
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -60,18 +60,18 @@ import static org.hamcrest.Matchers.is;
 @Ignore
 public abstract class BaseQueryTestCase<T extends BaseQueryBuilder> extends ElasticsearchTestCase {
 
-    protected static Injector injector;
-    private static IndexQueryParserService queryParserService;
-    private static Index index;
+    private Injector injector;
+    private IndexQueryParserService queryParserService;
+    private Index index;
     protected QueryParseContext context;
     protected XContentParser parser;
 
     protected T testQuery;
 
-    @BeforeClass
-    public static void init() {
+    @Before
+    public void init() throws IOException {
         Settings settings = ImmutableSettings.settingsBuilder()
-                .put("name", BaseQueryTestCase.class.getName()+"_"+randomInt())
+                .put("name", getClass().getName())
                 .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
                 .build();
 
@@ -99,10 +99,7 @@ public abstract class BaseQueryTestCase<T extends BaseQueryBuilder> extends Elas
         ).createInjector();
 
         queryParserService = injector.getInstance(IndexQueryParserService.class);
-    }
 
-    @Before
-    public void setUpTest() throws IOException {
         context = new QueryParseContext(index, queryParserService);
         testQuery = createRandomTestQuery();
         String contentString = testQuery.toString();
@@ -129,8 +126,10 @@ public abstract class BaseQueryTestCase<T extends BaseQueryBuilder> extends Elas
         assertThat((T) newQuery, is(testQuery));
     }
 
-    @AfterClass
-    public static void cleanUp() throws Exception {
+    @After
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
         terminate(injector.getInstance(ThreadPool.class));
     }
 }

--- a/src/test/java/org/elasticsearch/index/query/MatchAllQueryBuilderTest.java
+++ b/src/test/java/org/elasticsearch/index/query/MatchAllQueryBuilderTest.java
@@ -30,8 +30,7 @@ import static org.hamcrest.Matchers.*;
 public class MatchAllQueryBuilderTest extends BaseQueryTestCase<MatchAllQueryBuilder> {
 
     @Override
-    public void assertLuceneQuery(MatchAllQueryBuilder queryBuilder) throws IOException {
-        Query query = queryBuilder.toQuery(context);
+    protected void assertLuceneQuery(MatchAllQueryBuilder queryBuilder, Query query) throws IOException {
         if (queryBuilder.boost() != 1.0f) {
             assertThat(query, instanceOf(MatchAllDocsQuery.class));
         } else {
@@ -41,7 +40,7 @@ public class MatchAllQueryBuilderTest extends BaseQueryTestCase<MatchAllQueryBui
     }
 
     @Override
-    public MatchAllQueryBuilder createEmptyQueryBuilder() {
+    protected MatchAllQueryBuilder createEmptyQueryBuilder() {
         return new MatchAllQueryBuilder();
     }
 
@@ -49,7 +48,7 @@ public class MatchAllQueryBuilderTest extends BaseQueryTestCase<MatchAllQueryBui
      * @return a MatchAllQuery with random boost between 0.1f and 2.0f
      */
     @Override
-    public MatchAllQueryBuilder createTestQueryBuilder() {
+    protected MatchAllQueryBuilder createTestQueryBuilder() {
         MatchAllQueryBuilder query = new MatchAllQueryBuilder();
         if (randomBoolean()) {
             query.boost(2.0f / randomIntBetween(1, 20));

--- a/src/test/java/org/elasticsearch/index/query/MatchAllQueryBuilderTest.java
+++ b/src/test/java/org/elasticsearch/index/query/MatchAllQueryBuilderTest.java
@@ -22,8 +22,6 @@ package org.elasticsearch.index.query;
 import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
-import org.elasticsearch.common.io.stream.BytesStreamInput;
-import org.elasticsearch.common.io.stream.BytesStreamOutput;
 
 import java.io.IOException;
 
@@ -42,15 +40,8 @@ public class MatchAllQueryBuilderTest extends BaseQueryTestCase<MatchAllQueryBui
     }
 
     @Override
-    public void doSerialize(BytesStreamOutput output) throws IOException {
-        testQuery.writeTo(output);
-    }
-
-    @Override
-    public QueryBuilder doDeserialize(BytesStreamInput in) throws IOException {
-        MatchAllQueryBuilder query = new MatchAllQueryBuilder();
-        query.readFrom(in);
-        return query;
+    public MatchAllQueryBuilder createEmptyBuilder() {
+        return new MatchAllQueryBuilder();
     }
 
     /**

--- a/src/test/java/org/elasticsearch/index/query/MatchAllQueryBuilderTest.java
+++ b/src/test/java/org/elasticsearch/index/query/MatchAllQueryBuilderTest.java
@@ -19,8 +19,6 @@
 
 package org.elasticsearch.index.query;
 
-import com.carrotsearch.randomizedtesting.annotations.Repeat;
-
 import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;

--- a/src/test/java/org/elasticsearch/index/query/MatchAllQueryBuilderTest.java
+++ b/src/test/java/org/elasticsearch/index/query/MatchAllQueryBuilderTest.java
@@ -24,19 +24,15 @@ import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.io.stream.BytesStreamInput;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
-import org.junit.Test;
 
 import java.io.IOException;
 
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 
 public class MatchAllQueryBuilderTest extends BaseQueryTestCase<MatchAllQueryBuilder> {
 
-    @Test
-    public void testToQuery() throws IOException {
-        MatchAllQueryBuilder newMatchAllQuery = new MatchAllQueryParser().fromXContent(context);
-        Query query = newMatchAllQuery.toQuery(context);
+    @Override
+    public void doQueryAsserts(Query query) throws IOException {
         if (testQuery.boost() != 1.0f) {
             assertThat(query, instanceOf(MatchAllDocsQuery.class));
         } else {
@@ -45,17 +41,16 @@ public class MatchAllQueryBuilderTest extends BaseQueryTestCase<MatchAllQueryBui
         assertThat(query.getBoost(), is(testQuery.boost()));
     }
 
-    @Test
-    public void testSerialization() throws IOException {
-        BytesStreamOutput output = new BytesStreamOutput();
+    @Override
+    public void doSerialize(BytesStreamOutput output) throws IOException {
         testQuery.writeTo(output);
+    }
 
-        BytesStreamInput bytesStreamInput = new BytesStreamInput(output.bytes());
-        MatchAllQueryBuilder deserializedQuery = new MatchAllQueryBuilder();
-        deserializedQuery.readFrom(bytesStreamInput);
-
-        assertEquals(deserializedQuery, testQuery);
-        assertNotSame(deserializedQuery, testQuery);
+    @Override
+    public QueryBuilder doDeserialize(BytesStreamInput in) throws IOException {
+        MatchAllQueryBuilder query = new MatchAllQueryBuilder();
+        query.readFrom(in);
+        return query;
     }
 
     /**
@@ -68,4 +63,5 @@ public class MatchAllQueryBuilderTest extends BaseQueryTestCase<MatchAllQueryBui
         }
         return query;
     }
+
 }

--- a/src/test/java/org/elasticsearch/index/query/MatchAllQueryBuilderTest.java
+++ b/src/test/java/org/elasticsearch/index/query/MatchAllQueryBuilderTest.java
@@ -48,7 +48,8 @@ public class MatchAllQueryBuilderTest extends BaseQueryTestCase<MatchAllQueryBui
     /**
      * @return a MatchAllQuery with random boost between 0.1f and 2.0f
      */
-    public MatchAllQueryBuilder createRandomTestQuery() {
+    @Override
+    public MatchAllQueryBuilder createTestQueryBuilder() {
         MatchAllQueryBuilder query = new MatchAllQueryBuilder();
         if (randomBoolean()) {
             query.boost(2.0f / randomIntBetween(1, 20));

--- a/src/test/java/org/elasticsearch/index/query/MatchAllQueryBuilderTest.java
+++ b/src/test/java/org/elasticsearch/index/query/MatchAllQueryBuilderTest.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query;
+
+import org.apache.lucene.search.Query;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.common.inject.AbstractModule;
+import org.elasticsearch.common.inject.Injector;
+import org.elasticsearch.common.inject.ModulesBuilder;
+import org.elasticsearch.common.inject.util.Providers;
+import org.elasticsearch.common.io.stream.BytesStreamInput;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.settings.SettingsModule;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.env.EnvironmentModule;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexNameModule;
+import org.elasticsearch.index.analysis.AnalysisModule;
+import org.elasticsearch.index.cache.IndexCacheModule;
+import org.elasticsearch.index.query.functionscore.FunctionScoreModule;
+import org.elasticsearch.index.settings.IndexSettingsModule;
+import org.elasticsearch.index.similarity.SimilarityModule;
+import org.elasticsearch.indices.breaker.CircuitBreakerService;
+import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
+import org.elasticsearch.indices.query.IndicesQueriesModule;
+import org.elasticsearch.script.ScriptModule;
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.threadpool.ThreadPoolModule;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.*;
+
+public class MatchAllQueryBuilderTest extends ElasticsearchTestCase {
+
+    protected QueryParseContext context;
+
+    protected Injector injector;
+
+    private XContentParser parser;
+
+    private MatchAllQueryBuilder testQuery;
+
+    @Before
+    public void setup() throws IOException {
+        Settings settings = ImmutableSettings.settingsBuilder()
+                .put("path.conf", this.getResourcePath("config"))
+                .put("name", getClass().getName())
+                .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
+                .build();
+
+        Index index = new Index("test");
+        injector = new ModulesBuilder().add(
+                new EnvironmentModule(new Environment(settings)),
+                new SettingsModule(settings),
+                new ThreadPoolModule(settings),
+                new IndicesQueriesModule(),
+                new ScriptModule(settings),
+                new IndexSettingsModule(index, settings),
+                new IndexCacheModule(settings),
+                new AnalysisModule(settings),
+                new SimilarityModule(settings),
+                new IndexNameModule(index),
+                new IndexQueryParserModule(settings),
+                new FunctionScoreModule(),
+                new AbstractModule() {
+                    @Override
+                    protected void configure() {
+                        bind(ClusterService.class).toProvider(Providers.of((ClusterService) null));
+                        bind(CircuitBreakerService.class).to(NoneCircuitBreakerService.class);
+                    }
+                }
+        ).createInjector();
+
+        IndexQueryParserService queryParserService = injector.getInstance(IndexQueryParserService.class);
+        context = new QueryParseContext(index, queryParserService);
+
+        testQuery = createTestQuery();
+        String contentString = testQuery.toString();
+        parser = XContentFactory.xContent(contentString).createParser(contentString);
+        context.reset(parser);
+    }
+
+    @Override
+    @After
+    public void tearDown() throws Exception {
+        super.tearDown();
+        terminate(injector.getInstance(ThreadPool.class));
+    }
+
+    @Test
+    public void testFromXContent() throws IOException {
+        MatchAllQueryBuilder newMatchAllQuery = new MatchAllQueryParser().fromXContent(context);
+        // compare these
+        assertThat(testQuery, is(newMatchAllQuery));
+    }
+
+    @Test
+    public void testToQuery() throws IOException {
+        MatchAllQueryBuilder newMatchAllQuery = new MatchAllQueryParser().fromXContent(context);
+        Query query = newMatchAllQuery.toQuery(context);
+        // compare these
+        assertThat(query.getBoost(), is(testQuery.boost));
+    }
+
+    @Test
+    public void testSerialization() throws IOException {
+        BytesStreamOutput output = new BytesStreamOutput();
+        testQuery.writeTo(output);
+
+        BytesStreamInput bytesStreamInput = new BytesStreamInput(output.bytes());
+        MatchAllQueryBuilder deserializedQuery = new MatchAllQueryBuilder();
+        deserializedQuery.readFrom(bytesStreamInput);
+
+        assertEquals(deserializedQuery, testQuery);
+        assertNotSame(deserializedQuery, testQuery);
+    }
+
+    /**
+     * @return a MatchAllQuery with random boost between 0.1f and 2.0f
+     */
+    public static MatchAllQueryBuilder createTestQuery() {
+        MatchAllQueryBuilder query = new MatchAllQueryBuilder();
+        if (randomBoolean()) {
+            query.boost(2.0f / randomIntBetween(1, 20));
+        }
+        return query;
+    }
+}

--- a/src/test/java/org/elasticsearch/index/query/MatchAllQueryBuilderTest.java
+++ b/src/test/java/org/elasticsearch/index/query/MatchAllQueryBuilderTest.java
@@ -19,13 +19,13 @@
 
 package org.elasticsearch.index.query;
 
+import com.carrotsearch.randomizedtesting.annotations.Repeat;
+
 import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.io.stream.BytesStreamInput;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
-import org.elasticsearch.common.xcontent.XContentFactory;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -33,23 +33,7 @@ import java.io.IOException;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
-public class MatchAllQueryBuilderTest extends BaseQueryTest {
-
-    protected MatchAllQueryBuilder testQuery;
-
-    @Before
-    public void setUpTest() throws IOException {
-        testQuery = createTestQuery();
-        String contentString = testQuery.toString();
-        parser = XContentFactory.xContent(contentString).createParser(contentString);
-        context.reset(parser);
-    }
-
-    @Test
-    public void testFromXContent() throws IOException {
-        MatchAllQueryBuilder newMatchAllQuery = new MatchAllQueryParser().fromXContent(context);
-        assertThat(testQuery, is(newMatchAllQuery));
-    }
+public class MatchAllQueryBuilderTest extends BaseQueryTestCase<MatchAllQueryBuilder> {
 
     @Test
     public void testToQuery() throws IOException {
@@ -79,7 +63,7 @@ public class MatchAllQueryBuilderTest extends BaseQueryTest {
     /**
      * @return a MatchAllQuery with random boost between 0.1f and 2.0f
      */
-    public static MatchAllQueryBuilder createTestQuery() {
+    public MatchAllQueryBuilder createRandomTestQuery() {
         MatchAllQueryBuilder query = new MatchAllQueryBuilder();
         if (randomBoolean()) {
             query.boost(2.0f / randomIntBetween(1, 20));

--- a/src/test/java/org/elasticsearch/index/query/MatchAllQueryBuilderTest.java
+++ b/src/test/java/org/elasticsearch/index/query/MatchAllQueryBuilderTest.java
@@ -30,17 +30,18 @@ import static org.hamcrest.Matchers.*;
 public class MatchAllQueryBuilderTest extends BaseQueryTestCase<MatchAllQueryBuilder> {
 
     @Override
-    public void doQueryAsserts(Query query) throws IOException {
-        if (testQuery.boost() != 1.0f) {
+    public void assertLuceneQuery(MatchAllQueryBuilder queryBuilder) throws IOException {
+        Query query = queryBuilder.toQuery(context);
+        if (queryBuilder.boost() != 1.0f) {
             assertThat(query, instanceOf(MatchAllDocsQuery.class));
         } else {
             assertThat(query, instanceOf(ConstantScoreQuery.class));
         }
-        assertThat(query.getBoost(), is(testQuery.boost()));
+        assertThat(query.getBoost(), is(queryBuilder.boost()));
     }
 
     @Override
-    public MatchAllQueryBuilder createEmptyBuilder() {
+    public MatchAllQueryBuilder createEmptyQueryBuilder() {
         return new MatchAllQueryBuilder();
     }
 


### PR DESCRIPTION
Split the `parse(QueryParseContext ctx)` method into a parsing and a query building part, adding Streamable for serialization and hashCode(), equals() for better testing.
Add basic unit test for Builder and Parser.

PR goes agains query-refacoring feature branch.
