### PR TITLE
Query refactoring: TermQueryBuilder refactoring and test

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/BaseQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/BaseQueryBuilder.java
@@ -88,7 +88,7 @@ public abstract class BaseQueryBuilder implements QueryBuilder {
     protected abstract void doXContent(XContentBuilder builder, Params params) throws IOException;
 
     @Override
-    public ActionRequestValidationException validate() {
+    public QueryValidationException validate() {
         // default impl does not validate, subclasses should override.
         //norelease to be removed once all queries support validation
         return null;

--- a/src/main/java/org/elasticsearch/index/query/BaseQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/BaseQueryBuilder.java
@@ -21,6 +21,7 @@ package org.elasticsearch.index.query;
 
 import org.apache.lucene.search.Query;
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
@@ -85,4 +86,11 @@ public abstract class BaseQueryBuilder implements QueryBuilder {
     protected abstract String parserName();
 
     protected abstract void doXContent(XContentBuilder builder, Params params) throws IOException;
+
+    @Override
+    public ActionRequestValidationException validate() {
+        // default impl does not validate, subclasses should override.
+        // TODO Remove once all queries support validation
+        return null;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/BaseQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/BaseQueryBuilder.java
@@ -90,7 +90,7 @@ public abstract class BaseQueryBuilder implements QueryBuilder {
     @Override
     public ActionRequestValidationException validate() {
         // default impl does not validate, subclasses should override.
-        // TODO Remove once all queries support validation
+        //norelease to be removed once all queries support validation
         return null;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/BaseQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/BaseQueryBuilder.java
@@ -21,7 +21,6 @@ package org.elasticsearch.index.query;
 
 import org.apache.lucene.search.Query;
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
@@ -30,7 +29,7 @@ import org.elasticsearch.common.xcontent.XContentType;
 import java.io.IOException;
 
 /**
- *
+ * Base class with common code for all {@link QueryBuilder} implementations.
  */
 public abstract class BaseQueryBuilder implements QueryBuilder {
 

--- a/src/main/java/org/elasticsearch/index/query/QueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryBuilder.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.query;
 
 import org.apache.lucene.search.Query;
+import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentType;
@@ -44,4 +45,11 @@ public interface QueryBuilder extends ToXContent {
      * @throws IOException
      */
     Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException;
+
+    /**
+     * Validate the query.
+     * @return {@code null} if query is valid, otherwise {@link ActionRequestValidationException} containing error messages,
+     * e.g. if fields that are needed to create the lucene query are missing.
+     */
+    ActionRequestValidationException validate();
 }

--- a/src/main/java/org/elasticsearch/index/query/QueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryBuilder.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.index.query;
 
 import org.apache.lucene.search.Query;
-import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentType;
@@ -48,7 +47,7 @@ public interface QueryBuilder extends ToXContent {
 
     /**
      * Validate the query.
-     * @return {@code null} if query is valid, otherwise {@link ActionRequestValidationException} containing error messages,
+     * @return a {@link QueryValidationException} containing error messages, {@code null} if query is valid.
      * e.g. if fields that are needed to create the lucene query are missing.
      */
     QueryValidationException validate();

--- a/src/main/java/org/elasticsearch/index/query/QueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryBuilder.java
@@ -51,5 +51,5 @@ public interface QueryBuilder extends ToXContent {
      * @return {@code null} if query is valid, otherwise {@link ActionRequestValidationException} containing error messages,
      * e.g. if fields that are needed to create the lucene query are missing.
      */
-    ActionRequestValidationException validate();
+    QueryValidationException validate();
 }

--- a/src/main/java/org/elasticsearch/index/query/QueryValidationException.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryValidationException.java
@@ -19,8 +19,6 @@
 
 package org.elasticsearch.index.query;
 
-import org.elasticsearch.action.ActionRequestValidationException;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -31,8 +29,9 @@ public class QueryValidationException extends IllegalArgumentException {
 
     private final List<String> validationErrors = new ArrayList<>();
 
-    public QueryValidationException() {
+    public QueryValidationException(String error) {
         super("query validation failed");
+        validationErrors.add(error);
     }
 
     public void addValidationError(String error) {
@@ -62,16 +61,17 @@ public class QueryValidationException extends IllegalArgumentException {
 
     /**
      * Helper method than can be used to add error messages to an existing {@link QueryValidationException}.
-     * When passing @null as the initial exception, a new exception is created.
-     * @param validationError the error message to add
-     * @param validationException an input exception of @null. A new exception is created in this case.
+     * When passing {@code null} as the initial exception, a new exception is created.
+     * @param validationError the error message to add to an initial exception
+     * @param validationException an initial exception. Can be {@code null}, in which case a new exception is created.
      * @return a {@link QueryValidationException} with added validation error message
      */
     public static QueryValidationException addValidationError(String validationError, QueryValidationException validationException) {
         if (validationException == null) {
-            validationException = new QueryValidationException();
+            validationException = new QueryValidationException(validationError);
+        } else {
+            validationException.addValidationError(validationError);
         }
-        validationException.addValidationError(validationError);
         return validationException;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/QueryValidationException.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryValidationException.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query;
+
+import org.elasticsearch.action.ActionRequestValidationException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This exception can be used to indicate various reasons why validation of a query has failed.
+ */
+public class QueryValidationException extends IllegalArgumentException {
+
+    private final List<String> validationErrors = new ArrayList<>();
+
+    public QueryValidationException() {
+        super("query validation failed");
+    }
+
+    public void addValidationError(String error) {
+        validationErrors.add(error);
+    }
+
+    public void addValidationErrors(Iterable<String> errors) {
+        for (String error : errors) {
+            validationErrors.add(error);
+        }
+    }
+
+    public List<String> validationErrors() {
+        return validationErrors;
+    }
+
+    @Override
+    public String getMessage() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Validation Failed: ");
+        int index = 0;
+        for (String error : validationErrors) {
+            sb.append(++index).append(": ").append(error).append(";");
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Helper method than can be used to add error messages to an existing {@link QueryValidationException}.
+     * When passing @null as the initial exception, a new exception is created.
+     * @param validationError the error message to add
+     * @param validationException an input exception of @null. A new exception is created in this case.
+     * @return a {@link QueryValidationException} with added validation error message
+     */
+    public static QueryValidationException addValidationError(String validationError, QueryValidationException validationException) {
+        if (validationException == null) {
+            validationException = new QueryValidationException();
+        }
+        validationException.addValidationError(validationError);
+        return validationException;
+    }
+}

--- a/src/main/java/org/elasticsearch/index/query/TermQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/TermQueryBuilder.java
@@ -23,8 +23,6 @@ import org.apache.lucene.index.Term;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.action.ActionRequestValidationException;
-import org.elasticsearch.action.ValidateActions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
@@ -214,13 +212,13 @@ public class TermQueryBuilder extends BaseQueryBuilder implements Streamable, Bo
     }
 
     @Override
-    public ActionRequestValidationException validate() {
-        ActionRequestValidationException validationException = null;
+    public QueryValidationException validate() {
+        QueryValidationException validationException = null;
         if (this.fieldName == null || this.fieldName.isEmpty()) {
-            validationException = ValidateActions.addValidationError("field name cannot be null or empty.", validationException);
+            validationException = QueryValidationException.addValidationError("field name cannot be null or empty.", validationException);
         }
         if (this.value == null) {
-            validationException = ValidateActions.addValidationError("value cannot be null.", validationException);
+            validationException = QueryValidationException.addValidationError("value cannot be null.", validationException);
         }
         return validationException;
     }

--- a/src/main/java/org/elasticsearch/index/query/TermQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/TermQueryBuilder.java
@@ -19,94 +19,126 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.ValidateActions;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.mapper.MapperService;
 
 import java.io.IOException;
+import java.util.Objects;
 
 /**
  * A Query that matches documents containing a term.
- *
- *
  */
-public class TermQueryBuilder extends BaseQueryBuilder implements BoostableQueryBuilder<TermQueryBuilder> {
+public class TermQueryBuilder extends BaseQueryBuilder implements Streamable, BoostableQueryBuilder<TermQueryBuilder> {
 
-    private final String name;
+    private String fieldName;
 
-    private final Object value;
+    private Object value;
 
-    private float boost = -1;
+    private float boost = 1.0f;
 
     private String queryName;
 
     /**
      * Constructs a new term query.
      *
-     * @param name  The name of the field
+     * @param fieldName  The name of the field
      * @param value The value of the term
      */
-    public TermQueryBuilder(String name, String value) {
-        this(name, (Object) value);
+    public TermQueryBuilder(String fieldName, String value) {
+        this(fieldName, (Object) value);
     }
 
     /**
      * Constructs a new term query.
      *
-     * @param name  The name of the field
+     * @param fieldName  The name of the field
      * @param value The value of the term
      */
-    public TermQueryBuilder(String name, int value) {
-        this(name, (Object) value);
+    public TermQueryBuilder(String fieldName, int value) {
+        this(fieldName, (Object) value);
     }
 
     /**
      * Constructs a new term query.
      *
-     * @param name  The name of the field
+     * @param fieldName  The name of the field
      * @param value The value of the term
      */
-    public TermQueryBuilder(String name, long value) {
-        this(name, (Object) value);
+    public TermQueryBuilder(String fieldName, long value) {
+        this(fieldName, (Object) value);
     }
 
     /**
      * Constructs a new term query.
      *
-     * @param name  The name of the field
+     * @param fieldName  The name of the field
      * @param value The value of the term
      */
-    public TermQueryBuilder(String name, float value) {
-        this(name, (Object) value);
+    public TermQueryBuilder(String fieldName, float value) {
+        this(fieldName, (Object) value);
     }
 
     /**
      * Constructs a new term query.
      *
-     * @param name  The name of the field
+     * @param fieldName  The name of the field
      * @param value The value of the term
      */
-    public TermQueryBuilder(String name, double value) {
-        this(name, (Object) value);
+    public TermQueryBuilder(String fieldName, double value) {
+        this(fieldName, (Object) value);
     }
 
     /**
      * Constructs a new term query.
      *
-     * @param name  The name of the field
+     * @param fieldName  The name of the field
      * @param value The value of the term
      */
-    public TermQueryBuilder(String name, boolean value) {
-        this(name, (Object) value);
+    public TermQueryBuilder(String fieldName, boolean value) {
+        this(fieldName, (Object) value);
     }
 
     /**
      * Constructs a new term query.
      *
-     * @param name  The name of the field
+     * @param fieldName  The name of the field
      * @param value The value of the term
      */
-    public TermQueryBuilder(String name, Object value) {
-        this.name = name;
-        this.value = value;
+    public TermQueryBuilder(String fieldName, Object value) {
+        this.fieldName = fieldName;
+        if (value instanceof String) {
+            this.value = BytesRefs.toBytesRef(value);
+        } else {
+            this.value = value;
+        }
+    }
+
+    TermQueryBuilder() {
+        // for serialization only
+    }
+
+    /**
+     * @return the field name used in this query
+     */
+    public String fieldName() {
+        return this.fieldName;
+    }
+
+    /**
+     * @return the value used in this query
+     */
+    public Object value() {
+        return this.value;
     }
 
     /**
@@ -120,22 +152,40 @@ public class TermQueryBuilder extends BaseQueryBuilder implements BoostableQuery
     }
 
     /**
-     * Sets the query name for the filter that can be used when searching for matched_filters per hit.
+     * Gets the boost for this query.
+     */
+    public float boost() {
+        return this.boost;
+    }
+
+    /**
+     * Sets the query name for the query.
      */
     public TermQueryBuilder queryName(String queryName) {
         this.queryName = queryName;
         return this;
     }
 
+    /**
+     * Gets the query name for the query.
+     */
+    public String queryName() {
+        return this.queryName;
+    }
+
     @Override
     public void doXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(TermQueryParser.NAME);
-        if (boost == -1 && queryName == null) {
-            builder.field(name, value);
+        Object valueToWrite = this.value;
+        if (valueToWrite instanceof BytesRef) {
+            valueToWrite = ((BytesRef) valueToWrite).utf8ToString();
+        }
+        if (boost == 1.0f && queryName == null) {
+            builder.field(fieldName, valueToWrite);
         } else {
-            builder.startObject(name);
-            builder.field("value", value);
-            if (boost != -1) {
+            builder.startObject(fieldName);
+            builder.field("value", valueToWrite);
+            if (boost != 1.0f) {
                 builder.field("boost", boost);
             }
             if (queryName != null) {
@@ -147,7 +197,71 @@ public class TermQueryBuilder extends BaseQueryBuilder implements BoostableQuery
     }
 
     @Override
+    public Query toQuery(QueryParseContext parseContext) {
+        Query query = null;
+        MapperService.SmartNameFieldMappers smartNameFieldMappers = parseContext.smartFieldMappers(this.fieldName);
+        if (smartNameFieldMappers != null && smartNameFieldMappers.hasMapper()) {
+            query = smartNameFieldMappers.mapper().termQuery(this.value, parseContext);
+        }
+        if (query == null) {
+            query = new TermQuery(new Term(this.fieldName, BytesRefs.toBytesRef(this.value)));
+        }
+        query.setBoost(this.boost);
+        if (this.queryName != null) {
+            parseContext.addNamedQuery(queryName, query);
+        }
+        return query;
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        ActionRequestValidationException validationException = null;
+        if (this.fieldName == null || this.fieldName.isEmpty()) {
+            validationException = ValidateActions.addValidationError("field name cannot be null or empty.", validationException);
+        }
+        if (this.value == null) {
+            validationException = ValidateActions.addValidationError("value cannot be null.", validationException);
+        }
+        return validationException;
+    }
+
+    @Override
     protected String parserName() {
         return TermQueryParser.NAME;
+    }
+
+    public void readFrom(StreamInput in) throws IOException {
+        fieldName = in.readString();
+        value = in.readGenericValue();
+        boost = in.readFloat();
+        queryName = in.readOptionalString();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(fieldName);
+        out.writeGenericValue(value);
+        out.writeFloat(boost);
+        out.writeOptionalString(queryName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(fieldName, value, boost, queryName);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        TermQueryBuilder other = (TermQueryBuilder) obj;
+        return Objects.equals(fieldName, other.fieldName) &&
+               Objects.equals(value, other.value) &&
+               Objects.equals(boost, other.boost) &&
+               Objects.equals(queryName, other.queryName);
     }
 }

--- a/src/test/java/org/elasticsearch/index/query/BaseQueryTestCase.java
+++ b/src/test/java/org/elasticsearch/index/query/BaseQueryTestCase.java
@@ -34,6 +34,7 @@ import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsModule;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.EnvironmentModule;
 import org.elasticsearch.index.Index;
@@ -56,6 +57,8 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
+
+import static org.hamcrest.Matchers.*;
 
 @Ignore
 public abstract class BaseQueryTestCase<QB extends BaseQueryBuilder & Streamable> extends ElasticsearchTestCase {
@@ -116,8 +119,11 @@ public abstract class BaseQueryTestCase<QB extends BaseQueryBuilder & Streamable
 
     /**
      * Subclass should handle assertions on the lucene query produced by the query builder under test here
+     * @param queryBuilder the original queryBuilder used in this test
+     * @param query the lucene query constructed from this
+     * @param context the {@link QueryParseContext} that can be used for assertions
      */
-    protected abstract void assertLuceneQuery(QB queryBuilder, Query query) throws IOException;
+    protected abstract void assertLuceneQuery(QB queryBuilder, Query query, QueryParseContext context) throws IOException;
 
     /**
      * Creates an empty builder of the type of query under test
@@ -130,9 +136,11 @@ public abstract class BaseQueryTestCase<QB extends BaseQueryBuilder & Streamable
      */
     @Test
     public void testFromXContent() throws IOException {
-        QueryParseContext context = new QueryParseContext(index, queryParserService);
+        QueryParseContext context = createContext();
         String contentString = testQuery.toString();
-        context.reset(XContentFactory.xContent(contentString).createParser(contentString));
+        XContentParser parser = XContentFactory.xContent(contentString).createParser(contentString);
+        context.reset(parser);
+        assertQueryHeader(parser, testQuery.parserName());
 
         QueryBuilder newQuery = queryParserService.queryParser(testQuery.parserName()).fromXContent(context);
         assertNotSame(newQuery, testQuery);
@@ -145,13 +153,13 @@ public abstract class BaseQueryTestCase<QB extends BaseQueryBuilder & Streamable
      */
     @Test
     public void testToQuery() throws IOException {
-        QueryParseContext context = new QueryParseContext(index, queryParserService);
-        assertLuceneQuery(this.testQuery, this.testQuery.toQuery(context));
+        QueryParseContext context = createContext();
+        context.setMapUnmappedFieldAsString(true);
+        assertLuceneQuery(testQuery, testQuery.toQuery(context), context);
     }
 
     /**
      * Test serialization and deserialization of the test query.
-     * @throws IOException
      */
     @Test
     public void testSerialization() throws IOException {
@@ -164,5 +172,19 @@ public abstract class BaseQueryTestCase<QB extends BaseQueryBuilder & Streamable
 
         assertEquals(deserializedQuery, testQuery);
         assertNotSame(deserializedQuery, testQuery);
+    }
+
+    /**
+     * @return a new {@link QueryParseContext} based on the base test index and queryParserService
+     */
+    protected static QueryParseContext createContext() {
+        return new QueryParseContext(index, queryParserService);
+    }
+
+    private static void assertQueryHeader(XContentParser parser, String expectedParserName) throws IOException {
+        assertThat(parser.nextToken(), is(XContentParser.Token.START_OBJECT));
+        assertThat(parser.nextToken(), is(XContentParser.Token.FIELD_NAME));
+        assertThat(parser.currentName(), is(expectedParserName));
+        assertThat(parser.nextToken(), is(XContentParser.Token.START_OBJECT));
     }
 }

--- a/src/test/java/org/elasticsearch/index/query/MatchAllQueryBuilderTest.java
+++ b/src/test/java/org/elasticsearch/index/query/MatchAllQueryBuilderTest.java
@@ -30,7 +30,7 @@ import static org.hamcrest.Matchers.is;
 public class MatchAllQueryBuilderTest extends BaseQueryTestCase<MatchAllQueryBuilder> {
 
     @Override
-    protected void assertLuceneQuery(MatchAllQueryBuilder queryBuilder, Query query) throws IOException {
+    protected void assertLuceneQuery(MatchAllQueryBuilder queryBuilder, Query query, QueryParseContext context) throws IOException {
         assertThat(query, instanceOf(MatchAllDocsQuery.class));
         assertThat(query.getBoost(), is(queryBuilder.boost()));
     }

--- a/src/test/java/org/elasticsearch/index/query/TermQueryBuilderTest.java
+++ b/src/test/java/org/elasticsearch/index/query/TermQueryBuilderTest.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query;
+
+import org.apache.lucene.search.Filter;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryWrapperFilter;
+import org.apache.lucene.search.TermQuery;
+import org.elasticsearch.common.lucene.BytesRefs;
+import org.elasticsearch.index.search.child.CustomQueryWrappingFilter;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+
+public class TermQueryBuilderTest extends BaseQueryTestCase<TermQueryBuilder> {
+
+    @Override
+    protected TermQueryBuilder createEmptyQueryBuilder() {
+        return new TermQueryBuilder();
+    }
+
+    /**
+     * @return a TermQuery with random field name and value, optional random boost and queryname
+     */
+    protected TermQueryBuilder createTestQueryBuilder() {
+        Object value = null;
+        switch (randomIntBetween(0, 3)) {
+        case 0:
+            value = randomBoolean();
+            break;
+        case 1:
+            if (randomInt(10) > 0) {
+                value = randomAsciiOfLength(8);
+            } else {
+                // generate unicode string in 10% of cases
+                value = randomUnicodeOfLength(10);
+            }
+            break;
+        case 2:
+            value = randomInt(10000);
+            break;
+        case 3:
+            value = randomDouble();
+            break;
+        }
+        TermQueryBuilder query = new TermQueryBuilder(randomAsciiOfLength(8), value);
+        if (randomBoolean()) {
+            query.boost(2.0f / randomIntBetween(1, 20));
+        }
+        if (randomBoolean()) {
+            query.queryName(randomAsciiOfLength(8));
+        }
+        return query;
+    }
+
+    @Override
+    protected void assertLuceneQuery(TermQueryBuilder queryBuilder, Query query, QueryParseContext context) throws IOException {
+        assertThat(query, instanceOf(TermQuery.class));
+        assertThat(query.getBoost(), is(queryBuilder.boost()));
+        TermQuery termQuery = (TermQuery) query;
+        assertThat(termQuery.getTerm().field(), is(queryBuilder.fieldName()));
+        assertThat(termQuery.getTerm().bytes(), is(BytesRefs.toBytesRef(queryBuilder.value())));
+        if (queryBuilder.queryName() != null) {
+            Filter namedQuery = context.copyNamedFilters().get(queryBuilder.queryName());
+            assertNotNull(namedQuery);
+            if (namedQuery instanceof CustomQueryWrappingFilter) {
+                assertThat(query, is(((CustomQueryWrappingFilter) namedQuery).getQuery()));
+            } else if (namedQuery instanceof QueryWrapperFilter) {
+                assertThat(query, is(((QueryWrapperFilter) namedQuery).getQuery()));
+            } else {
+                fail("Expected either a QueryWrapperFilter or a CustomQueryWrappingFilter to be registered under " + queryBuilder.queryName() +
+                        " in the query parse context");
+            }
+        }
+    }
+
+    @Test
+    public void testValidate() throws QueryParsingException, IOException {
+        TermQueryBuilder queryBuilder = new TermQueryBuilder("all", "good");
+        assertNull(queryBuilder.validate());
+
+        queryBuilder = new TermQueryBuilder(null, "Term");
+        assertNotNull(queryBuilder.validate());
+        assertThat(queryBuilder.validate().validationErrors().size(), is(1));
+
+        queryBuilder = new TermQueryBuilder("", "Term");
+        assertNotNull(queryBuilder.validate());
+        assertThat(queryBuilder.validate().validationErrors().size(), is(1));
+
+        queryBuilder = new TermQueryBuilder("", null);
+        assertNotNull(queryBuilder.validate());
+        assertThat(queryBuilder.validate().validationErrors().size(), is(2));
+    }
+}

--- a/src/test/java/org/elasticsearch/index/query/TermQueryBuilderTest.java
+++ b/src/test/java/org/elasticsearch/index/query/TermQueryBuilderTest.java
@@ -19,8 +19,6 @@
 
 package org.elasticsearch.index.query;
 
-import com.carrotsearch.randomizedtesting.annotations.Repeat;
-
 import org.apache.lucene.search.Filter;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryWrapperFilter;
@@ -34,7 +32,6 @@ import java.io.IOException;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
-@Repeat(iterations=20)
 public class TermQueryBuilderTest extends BaseQueryTestCase<TermQueryBuilder> {
 
     @Override

--- a/src/test/java/org/elasticsearch/index/query/TermQueryBuilderTest.java
+++ b/src/test/java/org/elasticsearch/index/query/TermQueryBuilderTest.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.index.query;
 
+import com.carrotsearch.randomizedtesting.annotations.Repeat;
+
 import org.apache.lucene.search.Filter;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryWrapperFilter;
@@ -32,6 +34,7 @@ import java.io.IOException;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
+@Repeat(iterations=20)
 public class TermQueryBuilderTest extends BaseQueryTestCase<TermQueryBuilder> {
 
     @Override


### PR DESCRIPTION
Split the parse(QueryParseContext ctx) method into a parsing and a query building part, adding Streamable for serialization and hashCode(), equals() for better testing.
Add basic unit test for Builder and Parser.

PR goes agains query-refacoring feature branch.
