### PR TITLE
Cut over to IndexSearcher.count.

### DIFF
--- a/src/main/java/org/elasticsearch/search/fetch/innerhits/InnerHitsContext.java
+++ b/src/main/java/org/elasticsearch/search/fetch/innerhits/InnerHitsContext.java
@@ -25,7 +25,16 @@ import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.queries.TermFilter;
-import org.apache.lucene.search.*;
+import org.apache.lucene.search.DocIdSet;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.Filter;
+import org.apache.lucene.search.FilteredQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TopDocsCollector;
+import org.apache.lucene.search.TopFieldCollector;
+import org.apache.lucene.search.TopScoreDocCollector;
+import org.apache.lucene.search.TotalHitCountCollector;
 import org.apache.lucene.search.join.BitDocIdSetFilter;
 import org.apache.lucene.util.BitSet;
 import org.apache.lucene.util.Bits;
@@ -125,9 +134,7 @@ public final class InnerHitsContext {
             Query q = new FilteredQuery(query, new NestedChildrenFilter(parentFilter, childFilter, hitContext));
 
             if (size() == 0) {
-                TotalHitCountCollector collector = new TotalHitCountCollector();
-                context.searcher().search(q, collector);
-                return new TopDocs(collector.getTotalHits(), Lucene.EMPTY_SCORE_DOCS, 0);
+                return new TopDocs(context.searcher().count(q), Lucene.EMPTY_SCORE_DOCS, 0);
             } else {
                 int topN = from() + size();
                 TopDocsCollector topDocsCollector;

--- a/src/main/java/org/elasticsearch/search/query/QueryPhase.java
+++ b/src/main/java/org/elasticsearch/search/query/QueryPhase.java
@@ -20,10 +20,10 @@
 package org.elasticsearch.search.query;
 
 import com.google.common.collect.ImmutableMap;
+
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
-import org.apache.lucene.search.TotalHitCountCollector;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.lucene.Lucene;
@@ -109,9 +109,7 @@ public class QueryPhase implements SearchPhase {
             int numDocs = searchContext.from() + searchContext.size();
 
             if (searchContext.size() == 0) { // no matter what the value of from is
-                TotalHitCountCollector collector = new TotalHitCountCollector();
-                searchContext.searcher().search(query, collector);
-                topDocs = new TopDocs(collector.getTotalHits(), Lucene.EMPTY_SCORE_DOCS, 0);
+                topDocs = new TopDocs(searchContext.searcher().count(query), Lucene.EMPTY_SCORE_DOCS, 0);
             } else if (searchContext.searchType() == SearchType.SCAN) {
                 topDocs = searchContext.scanContext().execute(searchContext);
             } else {


### PR DESCRIPTION
There is a new IndexSearcher.count method that makes it easier to count how
many documents match a particular query.
