### PR TITLE
[GEO] Update tree_level and precision parameter priorities

### DIFF
--- a/docs/reference/mapping/types/geo-shape-type.asciidoc
+++ b/docs/reference/mapping/types/geo-shape-type.asciidoc
@@ -46,7 +46,13 @@ via the mapping API even if you use the precision parameter.
 
 |`distance_error_pct` |Used as a hint to the PrefixTree about how
 precise it should be. Defaults to 0.025 (2.5%) with 0.5 as the maximum
-supported value.
+supported value. PERFORMANCE NOTE: This value will be default to 0 if a `precision` or
+`tree_level` definition is explicitly defined. This guarantees spatial precision
+at the level defined in the mapping. This can lead to significant memory usage
+for high resolution shapes with low error (e.g., large shapes at 1m with < 0.001 error).
+To improve indexing performance (at the cost of query accuracy) explicitly define
+`tree_level` or `precision` along with a reasonable `distance_error_pct`, noting
+that large shapes will have greater false positives.
 
 |`orientation` |Optionally define how to interpret vertex order for
 polygons / multipolygons.  This parameter defines one of two coordinate


### PR DESCRIPTION
If a user explicitly defined the tree_level or precision parameter in a geo_shape mapping their precision was always overridden by the distance_error_pct parameter (even though our docs say this parameter is a 'hint'). This lead to unexpected accuracy problems  (e.g., false positives) in the results of a geo_shape filter. (example provided in issue #9691)

This patch fixes this unexpected behavior by setting the distance_error_pct parameter to zero when the tree_level or precision parameters are provided by the user, but the distance_error_pct parameter is not. This enables a user to explicitly specify a precision and an error consciously knowing how the error factor will affect query results.

Under the covers the quadtree will now guarantee the precision defined by the user, eliminating this explanation that false positives are "like text based stemming". The docs will be updated to alert the user to exercise caution with these parameters.  Specifying a precision of "1m" for an index using large complex shapes can use a significant amount of memory.

closes #9691
