### PR TITLE
Add CommitStats to supply information about the current commit point

### DIFF
--- a/rest-api-spec/test/indices.stats/12_level.yaml
+++ b/rest-api-spec/test/indices.stats/12_level.yaml
@@ -66,4 +66,6 @@ setup:
   - is_true:  indices.test2.total.docs
   - is_true:  indices.test2.total.docs
   - is_true:  indices.test2.shards
+  - is_true:  indices.test1.shards.0.0.commit.id
+  - is_true:  indices.test2.shards.0.0.commit.id
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/stats/ShardStats.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/stats/ShardStats.java
@@ -81,9 +81,7 @@ public class ShardStats extends BroadcastShardOperationResponse implements ToXCo
         super.readFrom(in);
         shardRouting = readShardRoutingEntry(in);
         commonStats = CommonStats.readCommonStats(in);
-        if (in.readBoolean()) {
-            commitStats = CommitStats.readCommitStatsFrom(in);
-        }
+        commitStats = CommitStats.readOptionalCommitStatsFrom(in);
     }
 
     @Override
@@ -91,12 +89,7 @@ public class ShardStats extends BroadcastShardOperationResponse implements ToXCo
         super.writeTo(out);
         shardRouting.writeTo(out);
         commonStats.writeTo(out);
-        if (commitStats == null) {
-            out.writeBoolean(false);
-        } else {
-            out.writeBoolean(true);
-            commitStats.writeTo(out);
-        }
+        out.writeOptionalStreamable(commitStats);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/indices/stats/ShardStats.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/stats/ShardStats.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.xcontent.XContentBuilderString;
 import org.elasticsearch.index.shard.IndexShard;
 
 import java.io.IOException;
+import java.util.Map;
 
 import static org.elasticsearch.cluster.routing.ImmutableShardRouting.readShardRoutingEntry;
 
@@ -39,6 +40,8 @@ public class ShardStats extends BroadcastShardOperationResponse implements ToXCo
     private ShardRouting shardRouting;
 
     CommonStats stats;
+
+    Map<String, String> commitData
 
     ShardStats() {
     }

--- a/src/main/java/org/elasticsearch/index/engine/CommitStats.java
+++ b/src/main/java/org/elasticsearch/index/engine/CommitStats.java
@@ -56,6 +56,11 @@ public final class CommitStats implements Streamable, ToXContent {
         return commitStats;
     }
 
+    public static CommitStats readOptionalCommitStatsFrom(StreamInput in) throws IOException {
+        return in.readOptionalStreamable(new CommitStats());
+    }
+
+
     public Map<String, String> getUserData() {
         return userData;
     }

--- a/src/main/java/org/elasticsearch/index/engine/CommitStats.java
+++ b/src/main/java/org/elasticsearch/index/engine/CommitStats.java
@@ -19,28 +19,31 @@
 package org.elasticsearch.index.engine;
 
 import org.apache.lucene.index.SegmentInfos;
+import org.elasticsearch.common.Base64;
 import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentBuilderString;
 
 import java.io.IOException;
 import java.util.Map;
 
+/** a class the returns dynamic information with respect to the last commit point of this shard */
 public class CommitStats implements Streamable, ToXContent {
 
-    Map<String, String> userData;
-    long generation;
-    String id; // lucene commit id in base 64;
+    private Map<String, String> userData;
+    private long generation;
+    private String id; // lucene commit id in base 64;
 
     public CommitStats(SegmentInfos segmentInfos) {
         // clone the map to protect against concurrent changes
         userData = MapBuilder.<String, String>newMapBuilder().putAll(segmentInfos.getUserData()).immutableMap();
         // lucene calls the current generation, last generation.
         generation = segmentInfos.getLastGeneration();
-        id = segmentInfos.getSegmentsFileName();
+        id = Base64.encodeBytes(segmentInfos.getId());
     }
 
     private CommitStats() {
@@ -53,18 +56,55 @@ public class CommitStats implements Streamable, ToXContent {
         return commitStats;
     }
 
+    public Map<String, String> getUserData() {
+        return userData;
+    }
+
+    public long getGeneration() {
+        return generation;
+    }
+
+    /** base64 version of the commit id (see {@link SegmentInfos#getId()} */
+    public String getId() {
+        return id;
+    }
+
     @Override
     public void readFrom(StreamInput in) throws IOException {
-
+        MapBuilder<String, String> builder = MapBuilder.newMapBuilder();
+        for (int i = in.readVInt(); i > 0; i--) {
+            builder.put(in.readString(), in.readOptionalString());
+        }
+        userData = builder.immutableMap();
+        generation = in.readLong();
+        id = in.readString();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
+        out.writeVInt(userData.size());
+        for (Map.Entry<String, String> entry : userData.entrySet()) {
+            out.writeString(entry.getKey());
+            out.writeOptionalString(entry.getValue());
+        }
+        out.writeLong(generation);
+        out.writeString(id);
+    }
 
+    static final class Fields {
+        static final XContentBuilderString GENERATION = new XContentBuilderString("generation");
+        static final XContentBuilderString USER_DATA = new XContentBuilderString("user_data");
+        static final XContentBuilderString ID = new XContentBuilderString("id");
+        static final XContentBuilderString COMMIT = new XContentBuilderString("commit");
     }
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        return null;
+        builder.startObject(Fields.COMMIT);
+        builder.field(Fields.ID, id);
+        builder.field(Fields.GENERATION, generation);
+        builder.field(Fields.USER_DATA, userData);
+        builder.endObject();
+        return builder;
     }
 }

--- a/src/main/java/org/elasticsearch/index/engine/CommitStats.java
+++ b/src/main/java/org/elasticsearch/index/engine/CommitStats.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.index.engine;
 
 import org.apache.lucene.index.SegmentInfos;
+import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
@@ -31,9 +32,15 @@ import java.util.Map;
 public class CommitStats implements Streamable, ToXContent {
 
     Map<String, String> userData;
+    long generation;
+    String id; // lucene commit id in base 64;
 
     public CommitStats(SegmentInfos segmentInfos) {
-
+        // clone the map to protect against concurrent changes
+        userData = MapBuilder.<String, String>newMapBuilder().putAll(segmentInfos.getUserData()).immutableMap();
+        // lucene calls the current generation, last generation.
+        generation = segmentInfos.getLastGeneration();
+        id = segmentInfos.getSegmentsFileName();
     }
 
     private CommitStats() {

--- a/src/main/java/org/elasticsearch/index/engine/CommitStats.java
+++ b/src/main/java/org/elasticsearch/index/engine/CommitStats.java
@@ -32,7 +32,7 @@ import java.io.IOException;
 import java.util.Map;
 
 /** a class the returns dynamic information with respect to the last commit point of this shard */
-public class CommitStats implements Streamable, ToXContent {
+public final class CommitStats implements Streamable, ToXContent {
 
     private Map<String, String> userData;
     private long generation;

--- a/src/main/java/org/elasticsearch/index/engine/CommitStats.java
+++ b/src/main/java/org/elasticsearch/index/engine/CommitStats.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.index.engine;
+
+import org.apache.lucene.index.SegmentInfos;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Map;
+
+public class CommitStats implements Streamable, ToXContent {
+
+    Map<String, String> userData;
+
+    public CommitStats(SegmentInfos segmentInfos) {
+
+    }
+
+    private CommitStats() {
+
+    }
+
+    public static CommitStats readCommitStatsFrom(StreamInput in) throws IOException {
+        CommitStats commitStats = new CommitStats();
+        commitStats.readFrom(in);
+        return commitStats;
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        return null;
+    }
+}

--- a/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -137,6 +137,8 @@ public abstract class Engine implements Closeable {
         return engineConfig;
     }
 
+    protected abstract SegmentInfos getLastCommittedSegmentInfos();
+
     /** A throttling class that can be activated, causing the
      * {@code acquireThrottle} method to block on a lock when throttling
      * is enabled
@@ -280,6 +282,13 @@ public abstract class Engine implements Closeable {
             throw new EngineClosedException(shardId, failedEngine);
         }
     }
+
+    /** get commits stats for the last commit */
+    public CommitStats commitStats() {
+        return new CommitStats(getLastCommittedSegmentInfos());
+    }
+
+
 
     /**
      * Global stats on segments.

--- a/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.index.engine;
 
 import com.google.common.collect.Lists;
-
 import org.apache.lucene.index.*;
 import org.apache.lucene.index.IndexWriter.IndexReaderWarmer;
 import org.apache.lucene.search.*;
@@ -105,7 +104,7 @@ public class InternalEngine extends Engine {
     private final AtomicLong translogIdGenerator = new AtomicLong();
     private final AtomicBoolean versionMapRefreshPending = new AtomicBoolean();
 
-    private SegmentInfos lastCommittedSegmentInfos;
+    private volatile SegmentInfos lastCommittedSegmentInfos;
 
     private final IndexThrottle throttle;
 
@@ -897,6 +896,11 @@ public class InternalEngine extends Engine {
             return true;
         }
         return false;
+    }
+
+    @Override
+    protected SegmentInfos getLastCommittedSegmentInfos() {
+        return lastCommittedSegmentInfos;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/engine/ShadowEngine.java
+++ b/src/main/java/org/elasticsearch/index/engine/ShadowEngine.java
@@ -20,16 +20,12 @@
 package org.elasticsearch.index.engine;
 
 import org.apache.lucene.index.DirectoryReader;
-import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SegmentInfos;
-import org.apache.lucene.index.SegmentReader;
 import org.apache.lucene.search.SearcherFactory;
 import org.apache.lucene.search.SearcherManager;
 import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.ExceptionsHelper;
-import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.lucene.index.ElasticsearchDirectoryReader;
 import org.elasticsearch.common.util.concurrent.ReleasableLock;
@@ -38,9 +34,6 @@ import org.elasticsearch.index.deletionpolicy.SnapshotIndexCommit;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
  * ShadowEngine is a specialized engine that only allows read-only operations
@@ -64,7 +57,7 @@ public class ShadowEngine extends Engine {
 
     private volatile SearcherManager searcherManager;
 
-    private SegmentInfos lastCommittedSegmentInfos;
+    private volatile SegmentInfos lastCommittedSegmentInfos;
 
     public ShadowEngine(EngineConfig engineConfig)  {
         super(engineConfig);
@@ -220,5 +213,10 @@ public class ShadowEngine extends Engine {
     @Override
     public boolean hasUncommittedChanges() {
         return false;
+    }
+
+    @Override
+    protected SegmentInfos getLastCommittedSegmentInfos() {
+        return lastCommittedSegmentInfos;
     }
 }

--- a/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -612,8 +612,6 @@ public class IndexShard extends AbstractIndexShardComponent {
         return engine == null ? null : engine.commitStats();
     }
 
-
-
     public IndexingStats indexingStats(String... types) {
         return indexingService.stats(types);
     }
@@ -1279,7 +1277,6 @@ public class IndexShard extends AbstractIndexShardComponent {
             }
         }
     }
-
 
     private String getIndexUUID() {
         assert indexSettings.get(IndexMetaData.SETTING_UUID) != null

--- a/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -603,6 +603,17 @@ public class IndexShard extends AbstractIndexShardComponent {
         }
     }
 
+    /**
+     * @return {@link CommitStats} if engine is open, otherwise null
+     */
+    @Nullable
+    public CommitStats commitStats() {
+        Engine engine = engineUnsafe();
+        return engine == null ? null : engine.commitStats();
+    }
+
+
+
     public IndexingStats indexingStats(String... types) {
         return indexingService.stats(types);
     }

--- a/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/src/main/java/org/elasticsearch/index/store/Store.java
@@ -157,7 +157,7 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
 
     }
 
-    final void ensureOpen() { // for testing
+    final void ensureOpen() {
         if (this.refCounter.refCount() <= 0) {
             throw new AlreadyClosedException("store is already closed");
         }

--- a/src/test/java/org/elasticsearch/index/engine/ShadowEngineTests.java
+++ b/src/test/java/org/elasticsearch/index/engine/ShadowEngineTests.java
@@ -30,7 +30,6 @@ import org.apache.lucene.index.Term;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.MockDirectoryWrapper;
-import org.apache.lucene.util.TestUtil;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.Nullable;
@@ -75,11 +74,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.elasticsearch.common.settings.ImmutableSettings.Builder.EMPTY_SETTINGS;
-import static org.elasticsearch.test.ElasticsearchTestCase.terminate;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.*;
 
 /**
  * TODO: document me!
@@ -266,6 +261,30 @@ public class ShadowEngineTests extends ElasticsearchTestCase {
     protected static final BytesReference B_1 = new BytesArray(new byte[]{1});
     protected static final BytesReference B_2 = new BytesArray(new byte[]{2});
     protected static final BytesReference B_3 = new BytesArray(new byte[]{3});
+
+    public void testCommitStats() {
+        // create a doc and refresh
+        ParsedDocument doc = testParsedDocument("1", "1", "test", null, -1, -1, testDocumentWithTextField(), B_1, false);
+        primaryEngine.create(new Engine.Create(null, newUid("1"), doc));
+
+        CommitStats stats1 = replicaEngine.commitStats();
+        assertThat(stats1.getGeneration(), greaterThan(0l));
+        assertThat(stats1.getId(), notNullValue());
+        assertThat(stats1.getUserData(), hasKey(Translog.TRANSLOG_ID_KEY));
+
+        // flush the primary engine
+        primaryEngine.flush();
+        // flush on replica to make flush visible
+        replicaEngine.flush();
+
+        CommitStats stats2 = replicaEngine.commitStats();
+        assertThat(stats2.getGeneration(), greaterThan(stats1.getGeneration()));
+        assertThat(stats2.getId(), notNullValue());
+        assertThat(stats2.getId(), not(equalTo(stats1.getId())));
+        assertThat(stats2.getUserData(), hasKey(Translog.TRANSLOG_ID_KEY));
+        assertThat(stats2.getUserData().get(Translog.TRANSLOG_ID_KEY), not(equalTo(stats1.getUserData().get(Translog.TRANSLOG_ID_KEY))));
+    }
+
 
     @Test
     public void testSegments() throws Exception {


### PR DESCRIPTION
Extends ShardStats with commit specific information. We currently expose commit id, generation and the user data map.

The information is also retrievable via the Rest API by using `GET _stats?level=shards`

Example output:

```
"commit": {
     "id": "UEMxOVFVbr/AGlOLg0xytQ==",
     "generation": 3,
     "user_data": {
        "translog_id": "4"
     }
}
```
