### PR TITLE
Matched queries: Remove redundant and broken code

### DIFF
--- a/src/main/java/org/elasticsearch/search/fetch/matchedqueries/MatchedQueriesFetchSubPhase.java
+++ b/src/main/java/org/elasticsearch/search/fetch/matchedqueries/MatchedQueriesFetchSubPhase.java
@@ -20,8 +20,6 @@ package org.elasticsearch.search.fetch.matchedqueries;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
-import org.apache.lucene.index.Term;
-import org.apache.lucene.queries.TermFilter;
 import org.apache.lucene.search.DocIdSet;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.Filter;
@@ -29,8 +27,6 @@ import org.apache.lucene.util.Bits;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.lucene.docset.DocIdSets;
-import org.elasticsearch.index.mapper.Uid;
-import org.elasticsearch.index.mapper.internal.UidFieldMapper;
 import org.elasticsearch.search.SearchParseElement;
 import org.elasticsearch.search.fetch.FetchSubPhase;
 import org.elasticsearch.search.internal.InternalSearchHit;
@@ -71,16 +67,10 @@ public class MatchedQueriesFetchSubPhase implements FetchSubPhase {
         List<String> matchedQueries = Lists.newArrayListWithCapacity(2);
 
         try {
-            DocIdSet docAndNestedDocsIdSet = null;
-            if (context.mapperService().documentMapper(hitContext.hit().type()).hasNestedObjects()) {
-                // Both main and nested Lucene docs have a _uid field
-                Filter docAndNestedDocsFilter = new TermFilter(new Term(UidFieldMapper.NAME, Uid.createUidAsBytes(hitContext.hit().type(), hitContext.hit().id())));
-                docAndNestedDocsIdSet = docAndNestedDocsFilter.getDocIdSet(hitContext.readerContext(), null);
-            }
-            addMatchedQueries(hitContext, context.parsedQuery().namedFilters(), matchedQueries, docAndNestedDocsIdSet);
+            addMatchedQueries(hitContext, context.parsedQuery().namedFilters(), matchedQueries);
 
             if (context.parsedPostFilter() != null) {
-                addMatchedQueries(hitContext, context.parsedPostFilter().namedFilters(), matchedQueries, docAndNestedDocsIdSet);
+                addMatchedQueries(hitContext, context.parsedPostFilter().namedFilters(), matchedQueries);
             }
         } catch (IOException e) {
             throw ExceptionsHelper.convertToElastic(e);
@@ -91,40 +81,23 @@ public class MatchedQueriesFetchSubPhase implements FetchSubPhase {
         hitContext.hit().matchedQueries(matchedQueries.toArray(new String[matchedQueries.size()]));
     }
 
-    private void addMatchedQueries(HitContext hitContext, ImmutableMap<String, Filter> namedFiltersAndQueries, List<String> matchedQueries, DocIdSet docAndNestedDocsIdSet) throws IOException {
+    private void addMatchedQueries(HitContext hitContext, ImmutableMap<String, Filter> namedFiltersAndQueries, List<String> matchedQueries) throws IOException {
         for (Map.Entry<String, Filter> entry : namedFiltersAndQueries.entrySet()) {
             String name = entry.getKey();
             Filter filter = entry.getValue();
 
             DocIdSet filterDocIdSet = filter.getDocIdSet(hitContext.readerContext(), null); // null is fine, since we filter by hitContext.docId()
             if (!DocIdSets.isEmpty(filterDocIdSet)) {
-                if (!DocIdSets.isEmpty(docAndNestedDocsIdSet)) {
-                    DocIdSetIterator filterIterator = filterDocIdSet.iterator();
-                    DocIdSetIterator docAndNestedDocsIterator = docAndNestedDocsIdSet.iterator();
-                    if (filterIterator != null && docAndNestedDocsIterator != null) {
-                        int matchedDocId = -1;
-                        for (int docId = docAndNestedDocsIterator.nextDoc(); docId < DocIdSetIterator.NO_MORE_DOCS; docId = docAndNestedDocsIterator.nextDoc()) {
-                            if (docId != matchedDocId) {
-                                matchedDocId = filterIterator.advance(docId);
-                            }
-                            if (matchedDocId == docId) {
-                                matchedQueries.add(name);
-                                break;
-                            }
-                        }
+                Bits bits = filterDocIdSet.bits();
+                if (bits != null) {
+                    if (bits.get(hitContext.docId())) {
+                        matchedQueries.add(name);
                     }
                 } else {
-                    Bits bits = filterDocIdSet.bits();
-                    if (bits != null) {
-                        if (bits.get(hitContext.docId())) {
+                    DocIdSetIterator iterator = filterDocIdSet.iterator();
+                    if (iterator != null) {
+                        if (iterator.advance(hitContext.docId()) == hitContext.docId()) {
                             matchedQueries.add(name);
-                        }
-                    } else {
-                        DocIdSetIterator iterator = filterDocIdSet.iterator();
-                        if (iterator != null) {
-                            if (iterator.advance(hitContext.docId()) == hitContext.docId()) {
-                                matchedQueries.add(name);
-                            }
                         }
                     }
                 }

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/TopHitsTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/TopHitsTests.java
@@ -63,13 +63,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcke
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.emptyArray;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
-import static org.hamcrest.Matchers.sameInstance;
+import static org.hamcrest.Matchers.*;
 
 /**
  *
@@ -776,7 +770,7 @@ public class TopHitsTests extends ElasticsearchIntegrationTest {
         assertThat(topReviewers.getHits().getAt(0).getNestedIdentity().getChild().getOffset(), equalTo(0));
     }
 
-    @Test @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/10661")
+    @Test
     public void testNestedFetchFeatures() {
         String hlType = randomFrom("plain", "fvh", "postings");
         HighlightBuilder.Field hlField = new HighlightBuilder.Field("comments.message")
@@ -826,7 +820,7 @@ public class TopHitsTests extends ElasticsearchIntegrationTest {
         assertThat(version, equalTo(1l));
 
         // Can't use named queries for the same reason explain doesn't work:
-        assertThat(searchHit.matchedQueries(), emptyArray());
+        assertThat(searchHit.matchedQueries(), arrayContaining("test"));
 
         SearchHitField field = searchHit.field("comments.user");
         assertThat(field.getValue().toString(), equalTo("a"));


### PR DESCRIPTION
Because the fetch phase now has nested doc support, the logic that deals with detecting if a named nested query/filter matches with a hit can be removed.

PR for #10661
