### PR TITLE
Upgrade to Lucene 5.2 r1675100

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,8 @@
 
     <properties>
         <lucene.version>5.2.0</lucene.version>
-        <lucene.maven.version>5.2.0-snapshot-1674576</lucene.maven.version>
+        <lucene.snapshot.revision>1675100</lucene.snapshot.revision>
+        <lucene.maven.version>5.2.0-snapshot-${lucene.snapshot.revision}</lucene.maven.version>
         <testframework.version>2.1.14</testframework.version>
         <tests.jvms>auto</tests.jvms>
         <tests.shuffle>true</tests.shuffle>
@@ -71,7 +72,7 @@
         <repository>
             <id>lucene-snapshots</id>
             <name>Lucene Snapshots</name>
-            <url>https://download.elastic.co/lucenesnapshots/1674576</url>
+            <url>https://download.elastic.co/lucenesnapshots/${lucene.snapshot.revision}</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
This upgrade is for https://issues.apache.org/jira/browse/LUCENE-6442

It should improve test reproducibility, especially if you are on a mac
and want to reproduce a jenkins failure that happened on linux.
