### PR TITLE
Validate number_of_shards/_replicas without index setting prefix

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequest.java
@@ -106,18 +106,6 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
         if (index == null) {
             validationException = addValidationError("index is missing", validationException);
         }
-        ImmutableSettings.Builder updatedSettingsBuilder = ImmutableSettings.settingsBuilder();
-        updatedSettingsBuilder.put(settings).normalizePrefix(IndexMetaData.INDEX_SETTING_PREFIX);
-        settings = updatedSettingsBuilder.build();
-
-        Integer number_of_primaries = settings.getAsInt(IndexMetaData.SETTING_NUMBER_OF_SHARDS, null);
-        Integer number_of_replicas = settings.getAsInt(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, null);
-        if (number_of_primaries != null && number_of_primaries <= 0) {
-            validationException = addValidationError("index must have 1 or more primary shards", validationException);
-        }
-        if (number_of_replicas != null && number_of_replicas < 0) {
-            validationException = addValidationError("index must have 0 or more replica shards", validationException);
-        }
         return validationException;
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequest.java
@@ -106,6 +106,10 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
         if (index == null) {
             validationException = addValidationError("index is missing", validationException);
         }
+        ImmutableSettings.Builder updatedSettingsBuilder = ImmutableSettings.settingsBuilder();
+        updatedSettingsBuilder.put(settings).normalizePrefix(IndexMetaData.INDEX_SETTING_PREFIX);
+        settings = updatedSettingsBuilder.build();
+
         Integer number_of_primaries = settings.getAsInt(IndexMetaData.SETTING_NUMBER_OF_SHARDS, null);
         Integer number_of_replicas = settings.getAsInt(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, null);
         if (number_of_primaries != null && number_of_primaries <= 0) {

--- a/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
@@ -559,13 +559,12 @@ public class MetaDataCreateIndexService extends AbstractComponent {
 
     public void validateIndexSettings(String indexName, Settings settings) throws IndexCreationException {
         String customPath = settings.get(IndexMetaData.SETTING_DATA_PATH, null);
+        List<String> validationErrors = Lists.newArrayList();
         if (customPath != null && nodeEnv.isCustomPathsEnabled() == false) {
-            throw new IndexCreationException(new Index(indexName),
-                new ElasticsearchIllegalArgumentException("custom data_paths for indices is disabled"));
+            validationErrors.add("custom data_paths for indices is disabled");
         }
         Integer number_of_primaries = settings.getAsInt(IndexMetaData.SETTING_NUMBER_OF_SHARDS, null);
         Integer number_of_replicas = settings.getAsInt(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, null);
-        List<String> validationErrors = Lists.newArrayList();
         if (number_of_primaries != null && number_of_primaries <= 0) {
             validationErrors.add("index must have 1 or more primary shards");
         }

--- a/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
@@ -32,7 +32,6 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.action.admin.indices.create.CreateIndexClusterStateUpdateRequest;
-import org.elasticsearch.bootstrap.Elasticsearch;
 import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;

--- a/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
@@ -32,6 +32,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.action.admin.indices.create.CreateIndexClusterStateUpdateRequest;
+import org.elasticsearch.bootstrap.Elasticsearch;
 import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -558,6 +559,24 @@ public class MetaDataCreateIndexService extends AbstractComponent {
         if (customPath != null && nodeEnv.isCustomPathsEnabled() == false) {
             throw new IndexCreationException(new Index(request.index()),
                     new ElasticsearchIllegalArgumentException("custom data_paths for indices is disabled"));
+        }
+
+        validateNumberOfShards(request.settings());
+        validateNumberOfReplicas(request.settings());
+
+    }
+
+    public void validateNumberOfShards(Settings settings) throws ElasticsearchException {
+        Integer number_of_primaries = settings.getAsInt(IndexMetaData.SETTING_NUMBER_OF_SHARDS, null);
+        if (number_of_primaries != null && number_of_primaries <= 0) {
+            throw new ElasticsearchIllegalArgumentException("index must have 1 or more primary shards");
+        }
+    }
+
+    public void validateNumberOfReplicas(Settings settings) throws ElasticsearchException {
+        Integer number_of_replicas = settings.getAsInt(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, null);
+        if (number_of_replicas != null && number_of_replicas < 0) {
+            throw new ElasticsearchIllegalArgumentException("index must have 0 or more replica shards");
         }
     }
 

--- a/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
@@ -339,8 +339,7 @@ public class MetaDataCreateIndexService extends AbstractComponent {
                     if (request.index().equals(ScriptService.SCRIPT_INDEX)) {
                         indexSettingsBuilder.put(SETTING_NUMBER_OF_REPLICAS, settings.getAsInt(SETTING_NUMBER_OF_REPLICAS, 0));
                         indexSettingsBuilder.put(SETTING_AUTO_EXPAND_REPLICAS, "0-all");
-                    }
-                    else {
+                    } else {
                         if (indexSettingsBuilder.get(SETTING_NUMBER_OF_REPLICAS) == null) {
                             if (request.index().equals(riverIndexName)) {
                                 indexSettingsBuilder.put(SETTING_NUMBER_OF_REPLICAS, settings.getAsInt(SETTING_NUMBER_OF_REPLICAS, 1));
@@ -427,7 +426,7 @@ public class MetaDataCreateIndexService extends AbstractComponent {
                     }
                     for (Alias alias : request.aliases()) {
                         AliasMetaData aliasMetaData = AliasMetaData.builder(alias.name()).filter(alias.filter())
-                                .indexRouting(alias.indexRouting()).searchRouting(alias.searchRouting()).build();
+                            .indexRouting(alias.indexRouting()).searchRouting(alias.searchRouting()).build();
                         indexMetaDataBuilder.putAlias(aliasMetaData);
                     }
 
@@ -446,11 +445,11 @@ public class MetaDataCreateIndexService extends AbstractComponent {
                     }
 
                     indexService.indicesLifecycle().beforeIndexAddedToCluster(new Index(request.index()),
-                            indexMetaData.settings());
+                        indexMetaData.settings());
 
                     MetaData newMetaData = MetaData.builder(currentState.metaData())
-                            .put(indexMetaData, false)
-                            .build();
+                        .put(indexMetaData, false)
+                        .build();
 
                     logger.info("[{}] creating index, cause [{}], templates {}, shards [{}]/[{}], mappings {}", request.index(), request.cause(), templateNames, indexMetaData.numberOfShards(), indexMetaData.numberOfReplicas(), mappings.keySet());
 
@@ -468,7 +467,7 @@ public class MetaDataCreateIndexService extends AbstractComponent {
 
                     if (request.state() == State.OPEN) {
                         RoutingTable.Builder routingTableBuilder = RoutingTable.builder(updatedState.routingTable())
-                                .addAsNew(updatedState.metaData().index(request.index()));
+                            .addAsNew(updatedState.metaData().index(request.index()));
                         RoutingAllocation.Result routingResult = allocationService.reroute(ClusterState.builder(updatedState).routingTable(routingTableBuilder).build());
                         updatedState = ClusterState.builder(updatedState).routingResult(routingResult).build();
                     }
@@ -558,7 +557,7 @@ public class MetaDataCreateIndexService extends AbstractComponent {
         validateIndexSettings(request.index(), request.settings());
     }
 
-    public void validateIndexSettings(String indexName, Settings settings) throws ElasticsearchException {
+    public void validateIndexSettings(String indexName, Settings settings) throws IndexCreationException {
         String customPath = settings.get(IndexMetaData.SETTING_DATA_PATH, null);
         if (customPath != null && nodeEnv.isCustomPathsEnabled() == false) {
             throw new IndexCreationException(new Index(indexName),
@@ -574,7 +573,8 @@ public class MetaDataCreateIndexService extends AbstractComponent {
            validationErrors.add("index must have 0 or more replica shards");
         }
         if (validationErrors.isEmpty() == false) {
-            throw new ElasticsearchIllegalArgumentException(getMessage(validationErrors));
+            throw new IndexCreationException(new Index(indexName),
+                new ElasticsearchIllegalArgumentException(getMessage(validationErrors)));
         }
     }
 

--- a/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -190,6 +190,7 @@ public class RestoreService extends AbstractComponent implements ClusterStateLis
                                 // Index doesn't exist - create it and start recovery
                                 // Make sure that the index we are about to create has a validate name
                                 createIndexService.validateIndexName(renamedIndex, currentState);
+                                createIndexService.validateNumberOfReplicas(request.indexSettings);
                                 IndexMetaData.Builder indexMdBuilder = IndexMetaData.builder(snapshotIndexMetaData).state(IndexMetaData.State.OPEN).index(renamedIndex);
                                 indexMdBuilder.settings(ImmutableSettings.settingsBuilder().put(snapshotIndexMetaData.settings()).put(IndexMetaData.SETTING_UUID, Strings.randomBase64UUID()));
                                 if (!request.includeAliases() && !snapshotIndexMetaData.aliases().isEmpty()) {

--- a/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -190,7 +190,7 @@ public class RestoreService extends AbstractComponent implements ClusterStateLis
                                 // Index doesn't exist - create it and start recovery
                                 // Make sure that the index we are about to create has a validate name
                                 createIndexService.validateIndexName(renamedIndex, currentState);
-                                createIndexService.validateIndexSettings(renamedIndex, request.indexSettings);
+                                createIndexService.validateIndexSettings(renamedIndex, snapshotIndexMetaData.settings());
                                 IndexMetaData.Builder indexMdBuilder = IndexMetaData.builder(snapshotIndexMetaData).state(IndexMetaData.State.OPEN).index(renamedIndex);
                                 indexMdBuilder.settings(ImmutableSettings.settingsBuilder().put(snapshotIndexMetaData.settings()).put(IndexMetaData.SETTING_UUID, Strings.randomBase64UUID()));
                                 if (!request.includeAliases() && !snapshotIndexMetaData.aliases().isEmpty()) {

--- a/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -190,7 +190,7 @@ public class RestoreService extends AbstractComponent implements ClusterStateLis
                                 // Index doesn't exist - create it and start recovery
                                 // Make sure that the index we are about to create has a validate name
                                 createIndexService.validateIndexName(renamedIndex, currentState);
-                                createIndexService.validateNumberOfReplicas(request.indexSettings);
+                                createIndexService.validateIndexSettings(renamedIndex, request.indexSettings);
                                 IndexMetaData.Builder indexMdBuilder = IndexMetaData.builder(snapshotIndexMetaData).state(IndexMetaData.State.OPEN).index(renamedIndex);
                                 indexMdBuilder.settings(ImmutableSettings.settingsBuilder().put(snapshotIndexMetaData.settings()).put(IndexMetaData.SETTING_UUID, Strings.randomBase64UUID()));
                                 if (!request.includeAliases() && !snapshotIndexMetaData.aliases().isEmpty()) {

--- a/src/test/java/org/elasticsearch/action/admin/indices/create/CreateIndexTests.java
+++ b/src/test/java/org/elasticsearch/action/admin/indices/create/CreateIndexTests.java
@@ -139,7 +139,7 @@ public class CreateIndexTests extends ElasticsearchIntegrationTest{
             assertThat("message contains error about shard count: " + e.getMessage(),
                     e.getMessage().contains("index must have 1 or more primary shards"), equalTo(true));
             assertThat("message contains error about shard count: " + e.getMessage(),
-                e.getMessage().contains("index must have 0 or more replica shards"), equalTo(false));
+                e.getMessage().contains("index must have 0 or more replica shards"), equalTo(true));
         }
     }
 
@@ -176,7 +176,7 @@ public class CreateIndexTests extends ElasticsearchIntegrationTest{
             assertThat("message contains error about shard count: " + e.getMessage(),
                 e.getMessage().contains("index must have 1 or more primary shards"), equalTo(true));
             assertThat("message contains error about shard count: " + e.getMessage(),
-                e.getMessage().contains("index must have 0 or more replica shards"), equalTo(false));
+                e.getMessage().contains("index must have 0 or more replica shards"), equalTo(true));
         }
     }
 

--- a/src/test/java/org/elasticsearch/action/admin/indices/create/CreateIndexTests.java
+++ b/src/test/java/org/elasticsearch/action/admin/indices/create/CreateIndexTests.java
@@ -106,8 +106,8 @@ public class CreateIndexTests extends ElasticsearchIntegrationTest{
     public void testInvalidShardCountSettings() throws Exception {
         try {
             prepareCreate("test").setSettings(ImmutableSettings.builder()
-                    .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, randomIntBetween(-10, 0))
-                    .build())
+                .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, randomIntBetween(-10, 0))
+                .build())
             .get();
             fail("should have thrown an exception about the primary shard count");
         } catch (ActionRequestValidationException e) {
@@ -117,8 +117,8 @@ public class CreateIndexTests extends ElasticsearchIntegrationTest{
 
         try {
             prepareCreate("test").setSettings(ImmutableSettings.builder()
-                    .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, randomIntBetween(-10, -1))
-                    .build())
+                .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, randomIntBetween(-10, -1))
+                .build())
                     .get();
             fail("should have thrown an exception about the replica shard count");
         } catch (ActionRequestValidationException e) {
@@ -128,16 +128,34 @@ public class CreateIndexTests extends ElasticsearchIntegrationTest{
 
         try {
             prepareCreate("test").setSettings(ImmutableSettings.builder()
-                    .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, randomIntBetween(-10, 0))
-                    .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, randomIntBetween(-10, -1))
-                    .build())
+                .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, randomIntBetween(-10, 0))
+                .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, randomIntBetween(-10, -1))
+                .build())
                     .get();
             fail("should have thrown an exception about the shard count");
         } catch (ActionRequestValidationException e) {
             assertThat("message contains error about shard count: " + e.getMessage(),
                     e.getMessage().contains("index must have 1 or more primary shards"), equalTo(true));
             assertThat("message contains error about shard count: " + e.getMessage(),
-                    e.getMessage().contains("index must have 0 or more replica shards"), equalTo(true));
+                e.getMessage().contains("index must have 0 or more replica shards"), equalTo(true));
         }
     }
+
+    @Test
+    public void testInvalidShardCountSettingsWithoutPrefix() throws Exception {
+        try {
+            prepareCreate("test").setSettings(ImmutableSettings.builder()
+                .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS.substring(IndexMetaData.INDEX_SETTING_PREFIX.length()), randomIntBetween(-10, 0))
+                .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS.substring(IndexMetaData.INDEX_SETTING_PREFIX.length()), randomIntBetween(-10, -1))
+                .build())
+                .get();
+            fail("should have thrown an exception about the shard count");
+        } catch (ActionRequestValidationException e) {
+            assertThat("message contains error about shard count: " + e.getMessage(),
+                e.getMessage().contains("index must have 1 or more primary shards"), equalTo(true));
+            assertThat("message contains error about shard count: " + e.getMessage(),
+                e.getMessage().contains("index must have 0 or more replica shards"), equalTo(true));
+        }
+    }
+
 }

--- a/src/test/java/org/elasticsearch/action/admin/indices/create/CreateIndexTests.java
+++ b/src/test/java/org/elasticsearch/action/admin/indices/create/CreateIndexTests.java
@@ -19,8 +19,10 @@
 
 package org.elasticsearch.action.admin.indices.create;
 
+import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
+import org.elasticsearch.bootstrap.Elasticsearch;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
@@ -110,7 +112,7 @@ public class CreateIndexTests extends ElasticsearchIntegrationTest{
                 .build())
             .get();
             fail("should have thrown an exception about the primary shard count");
-        } catch (ActionRequestValidationException e) {
+        } catch (ElasticsearchIllegalArgumentException e) {
             assertThat("message contains error about shard count: " + e.getMessage(),
                     e.getMessage().contains("index must have 1 or more primary shards"), equalTo(true));
         }
@@ -121,7 +123,7 @@ public class CreateIndexTests extends ElasticsearchIntegrationTest{
                 .build())
                     .get();
             fail("should have thrown an exception about the replica shard count");
-        } catch (ActionRequestValidationException e) {
+        } catch (ElasticsearchIllegalArgumentException e) {
             assertThat("message contains error about shard count: " + e.getMessage(),
                     e.getMessage().contains("index must have 0 or more replica shards"), equalTo(true));
         }
@@ -133,11 +135,11 @@ public class CreateIndexTests extends ElasticsearchIntegrationTest{
                 .build())
                     .get();
             fail("should have thrown an exception about the shard count");
-        } catch (ActionRequestValidationException e) {
+        } catch (ElasticsearchIllegalArgumentException e) {
             assertThat("message contains error about shard count: " + e.getMessage(),
                     e.getMessage().contains("index must have 1 or more primary shards"), equalTo(true));
             assertThat("message contains error about shard count: " + e.getMessage(),
-                e.getMessage().contains("index must have 0 or more replica shards"), equalTo(true));
+                e.getMessage().contains("index must have 0 or more replica shards"), equalTo(false));
         }
     }
 
@@ -146,15 +148,35 @@ public class CreateIndexTests extends ElasticsearchIntegrationTest{
         try {
             prepareCreate("test").setSettings(ImmutableSettings.builder()
                 .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS.substring(IndexMetaData.INDEX_SETTING_PREFIX.length()), randomIntBetween(-10, 0))
+                .build())
+                .get();
+            fail("should have thrown an exception about the shard count");
+        } catch (ElasticsearchIllegalArgumentException e) {
+            assertThat("message contains error about shard count: " + e.getMessage(),
+                e.getMessage().contains("index must have 1 or more primary shards"), equalTo(true));
+        }
+        try {
+            prepareCreate("test").setSettings(ImmutableSettings.builder()
                 .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS.substring(IndexMetaData.INDEX_SETTING_PREFIX.length()), randomIntBetween(-10, -1))
                 .build())
                 .get();
             fail("should have thrown an exception about the shard count");
-        } catch (ActionRequestValidationException e) {
+        } catch (ElasticsearchIllegalArgumentException e) {
+            assertThat("message contains error about shard count: " + e.getMessage(),
+                e.getMessage().contains("index must have 0 or more replica shards"), equalTo(true));
+        }
+        try {
+            prepareCreate("test").setSettings(ImmutableSettings.builder()
+                .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS.substring(IndexMetaData.INDEX_SETTING_PREFIX.length()), randomIntBetween(-10, 0))
+                .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS.substring(IndexMetaData.INDEX_SETTING_PREFIX.length()), randomIntBetween(-10, -1))
+                .build())
+                .get();
+            fail("should have thrown an exception about the shard count");
+        } catch (ElasticsearchIllegalArgumentException e) {
             assertThat("message contains error about shard count: " + e.getMessage(),
                 e.getMessage().contains("index must have 1 or more primary shards"), equalTo(true));
             assertThat("message contains error about shard count: " + e.getMessage(),
-                e.getMessage().contains("index must have 0 or more replica shards"), equalTo(true));
+                e.getMessage().contains("index must have 0 or more replica shards"), equalTo(false));
         }
     }
 

--- a/src/test/java/org/elasticsearch/action/admin/indices/create/CreateIndexTests.java
+++ b/src/test/java/org/elasticsearch/action/admin/indices/create/CreateIndexTests.java
@@ -20,9 +20,7 @@
 package org.elasticsearch.action.admin.indices.create;
 
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
-import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
-import org.elasticsearch.bootstrap.Elasticsearch;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;

--- a/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreTests.java
+++ b/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreTests.java
@@ -57,7 +57,6 @@ import org.elasticsearch.index.store.support.AbstractIndexStore;
 import org.elasticsearch.indices.InvalidIndexNameException;
 import org.elasticsearch.repositories.RepositoriesService;
 import org.elasticsearch.snapshots.mockstore.MockRepositoryModule;
-import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.junit.Test;
 
 import java.nio.channels.SeekableByteChannel;

--- a/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreTests.java
+++ b/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreTests.java
@@ -1631,11 +1631,6 @@ public class SharedClusterSnapshotRestoreTests extends AbstractSnapshotTests {
                 .put(SETTING_NUMBER_OF_SHARDS, numberOfShards + 100)
                 .build();
 
-        Settings newIncorrectReplicasIndexSettings = ImmutableSettings.builder()
-            .put(newIndexSettings)
-            .put(SETTING_NUMBER_OF_REPLICAS, randomIntBetween(-10, -1))
-            .build();
-
         logger.info("--> try restoring while changing the number of shards - should fail");
         assertThrows(client.admin().cluster()
                 .prepareRestoreSnapshot("test-repo", "test-snap")
@@ -1643,7 +1638,11 @@ public class SharedClusterSnapshotRestoreTests extends AbstractSnapshotTests {
                 .setIndexSettings(newIncorrectIndexSettings)
                 .setWaitForCompletion(true), SnapshotRestoreException.class);
 
-        logger.info("--> try restoring while changing negative to the number of replicas - should fail");
+        logger.info("--> try restoring while changing the number of replicas to a negative number - should fail");
+        Settings newIncorrectReplicasIndexSettings = ImmutableSettings.builder()
+            .put(newIndexSettings)
+            .put(SETTING_NUMBER_OF_REPLICAS, randomIntBetween(-10, -1))
+            .build();
         assertThrows(client.admin().cluster()
             .prepareRestoreSnapshot("test-repo", "test-snap")
             .setIgnoreIndexSettings("index.analysis.*")

--- a/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreTests.java
+++ b/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreTests.java
@@ -1641,7 +1641,7 @@ public class SharedClusterSnapshotRestoreTests extends AbstractSnapshotTests {
         logger.info("--> try restoring while changing the number of replicas to a negative number - should fail");
         Settings newIncorrectReplicasIndexSettings = ImmutableSettings.builder()
             .put(newIndexSettings)
-            .put(SETTING_NUMBER_OF_REPLICAS, randomIntBetween(-10, -1))
+            .put(SETTING_NUMBER_OF_REPLICAS.substring(IndexMetaData.INDEX_SETTING_PREFIX.length()), randomIntBetween(-10, -1))
             .build();
         assertThrows(client.admin().cluster()
             .prepareRestoreSnapshot("test-repo", "test-snap")


### PR DESCRIPTION
Settings: validate number_of_shards/number_of_replicas without index setting prefix

normalize settings before validating

Closes #10693

Now, this PR check CreateIndexRequest only. I think we should check other API related number_of_shards/number_of_replicas.
