### PR TITLE
Tests: Add shortcut "all" to skip version ranges in rest tests

### DIFF
--- a/rest-api-spec/test/cluster.put_settings/10_basic.yaml
+++ b/rest-api-spec/test/cluster.put_settings/10_basic.yaml
@@ -1,7 +1,7 @@
 ---
 setup:
   - skip:
-      version:  " - "
+      version:  "all"
       reason:  leaves transient metadata behind, need to fix it
 ---
 "Test put settings":

--- a/rest-api-spec/test/indices.put_settings/all_path_options.yaml
+++ b/rest-api-spec/test/indices.put_settings/all_path_options.yaml
@@ -81,7 +81,7 @@ setup:
 ---
 "put settings in list of indices":
   - skip:
-      version: " - "
+      version: "all"
       reason:  list of indices not implemented yet
   - do:
       indices.put_settings:

--- a/rest-api-spec/test/update/85_fields_meta.yaml
+++ b/rest-api-spec/test/update/85_fields_meta.yaml
@@ -2,7 +2,7 @@
 "Metadata Fields":
 
   - skip:
-      version:  " - "
+      version:  "all"
       reason:   "Update doesn't return metadata fields, waiting for #3259"
 
   - do:

--- a/src/test/java/org/elasticsearch/test/rest/section/SkipSection.java
+++ b/src/test/java/org/elasticsearch/test/rest/section/SkipSection.java
@@ -97,6 +97,9 @@ public class SkipSection {
         if (versionRange == null) {
             return new Version[] { null, null };
         }
+        if (versionRange.trim().equals("all")) {
+            return new Version[]{VersionUtils.getFirstVersion(), Version.CURRENT};
+        }
         String[] skipVersions = versionRange.split("-");
         if (skipVersions.length > 2) {
             throw new IllegalArgumentException("version range malformed: " + versionRange);

--- a/src/test/java/org/elasticsearch/test/rest/test/SkipSectionParserTests.java
+++ b/src/test/java/org/elasticsearch/test/rest/test/SkipSectionParserTests.java
@@ -49,6 +49,23 @@ public class SkipSectionParserTests extends AbstractParserTests {
         assertThat(skipSection.getReason(), equalTo("Delete ignores the parent param"));
     }
 
+    public void testParseSkipSectionAllVersions() throws Exception {
+        parser = YamlXContent.yamlXContent.createParser(
+            "version:     \" all \"\n" +
+            "reason:      Delete ignores the parent param"
+        );
+
+        SkipSectionParser skipSectionParser = new SkipSectionParser();
+
+        SkipSection skipSection = skipSectionParser.parse(new RestTestSuiteParseContext("api", "suite", parser));
+
+        assertThat(skipSection, notNullValue());
+        assertThat(skipSection.getLowerVersion(), equalTo(VersionUtils.getFirstVersion()));
+        assertThat(skipSection.getUpperVersion(), equalTo(Version.CURRENT));
+        assertThat(skipSection.getFeatures().size(), equalTo(0));
+        assertThat(skipSection.getReason(), equalTo("Delete ignores the parent param"));
+    }
+
     @Test
     public void testParseSkipSectionFeatureNoVersion() throws Exception {
         parser = YamlXContent.yamlXContent.createParser(


### PR DESCRIPTION
This was suggested on #10656 as cleaner than " - " to indicate all
versions should be skipped.
