### PR TITLE
Simplified mapper lookups

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/DocumentFieldMappers.java
+++ b/src/main/java/org/elasticsearch/index/mapper/DocumentFieldMappers.java
@@ -78,20 +78,27 @@ public final class DocumentFieldMappers implements Iterable<FieldMapper<?>> {
         return new DocumentFieldMappers(fieldMappers, indexAnalyzer, searchAnalyzer, searchQuoteAnalyzer);
     }
 
-    // TODO: replace all uses of this with fullName, or change the meaning of name to be fullName
-    public FieldMappers name(String name) {
-        return fieldMappers.fullName(name);
-    }
-
+    /**
+     * Looks up a field by its index name.
+     *
+     * Overriding index name for a field is no longer possibly, and only supported for backcompat.
+     * This function first attempts to lookup the field by full name, and only when that fails,
+     * does a full scan of all field mappers, collecting those with this index name.
+     *
+     * This will be removed in 3.0, once backcompat for overriding index name is removed.
+     * @deprecated Use {@link #getMapper(String)}
+     */
+    @Deprecated
     public FieldMappers indexName(String indexName) {
         return fieldMappers.indexName(indexName);
     }
 
-    public FieldMappers fullName(String fullName) {
-        return fieldMappers.fullName(fullName);
+    /** Returns the mapper for the given field */
+    public FieldMapper getMapper(String field) {
+        return fieldMappers.get(field);
     }
 
-    public List<String> simpleMatchToIndexNames(String pattern) {
+    List<String> simpleMatchToIndexNames(String pattern) {
         return fieldMappers.simpleMatchToIndexNames(pattern);
     }
 
@@ -100,8 +107,7 @@ public final class DocumentFieldMappers implements Iterable<FieldMapper<?>> {
     }
 
     /**
-     * Tries to find first based on {@link #fullName(String)}, then by {@link #indexName(String)}, and last
-     * by {@link #name(String)}.
+     * Tries to find first based on fullName, then by indexName.
      */
     FieldMappers smartName(String name) {
         return fieldMappers.smartName(name);

--- a/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -692,14 +692,10 @@ public class MapperService extends AbstractIndexComponent  {
     }
 
     /**
-     * Returns smart field mappers based on a smart name. A smart name is one that can optionally be prefixed
-     * with a type (and then a '.'). If it is, then the {@link MapperService.SmartNameFieldMappers}
-     * will have the doc mapper set.
+     * Returns smart field mappers based on a smart name. A smart name is any of full name or index name.
      * <p/>
-     * <p>It also (without the optional type prefix) try and find the {@link FieldMappers} for the specific
-     * name. It will first try to find it based on the full name (with the dots if its a compound name). If
-     * it is not found, will try and find it based on the indexName (which can be controlled in the mapping),
-     * and last, will try it based no the name itself.
+     * <p>It will first try to find it based on the full name (with the dots if its a compound name). If
+     * it is not found, will try and find it based on the indexName (which can be controlled in the mapping).
      * <p/>
      * <p>If nothing is found, returns null.
      */

--- a/src/main/java/org/elasticsearch/index/query/ExistsFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/ExistsFilterParser.java
@@ -84,7 +84,7 @@ public class ExistsFilterParser implements FilterParser {
     }
 
     public static Filter newFilter(QueryParseContext parseContext, String fieldPattern, String filterName) {
-        final FieldMappers fieldNamesMappers = parseContext.mapperService().indexName(FieldNamesFieldMapper.NAME);
+        final FieldMappers fieldNamesMappers = parseContext.mapperService().fullName(FieldNamesFieldMapper.NAME);
         final FieldNamesFieldMapper fieldNamesMapper = (FieldNamesFieldMapper)fieldNamesMappers.mapper();
 
         MapperService.SmartNameObjectMapper smartNameObjectMapper = parseContext.smartObjectMapper(fieldPattern);
@@ -98,14 +98,10 @@ public class ExistsFilterParser implements FilterParser {
             // no fields exists, so we should not match anything
             return Queries.newMatchNoDocsFilter();
         }
-        MapperService.SmartNameFieldMappers nonNullFieldMappers = null;
 
         BooleanQuery boolFilter = new BooleanQuery();
         for (String field : fields) {
             MapperService.SmartNameFieldMappers smartNameFieldMappers = parseContext.smartFieldMappers(field);
-            if (smartNameFieldMappers != null) {
-                nonNullFieldMappers = smartNameFieldMappers;
-            }
             Query filter = null;
             if (fieldNamesMapper!= null && fieldNamesMapper.enabled()) {
                 final String f;

--- a/src/main/java/org/elasticsearch/index/query/MissingFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MissingFilterParser.java
@@ -95,7 +95,7 @@ public class MissingFilterParser implements FilterParser {
             throw new QueryParsingException(parseContext.index(), "missing must have either existence, or null_value, or both set to true");
         }
 
-        final FieldMappers fieldNamesMappers = parseContext.mapperService().indexName(FieldNamesFieldMapper.NAME);
+        final FieldMappers fieldNamesMappers = parseContext.mapperService().fullName(FieldNamesFieldMapper.NAME);
         final FieldNamesFieldMapper fieldNamesMapper = (FieldNamesFieldMapper)fieldNamesMappers.mapper();
         MapperService.SmartNameObjectMapper smartNameObjectMapper = parseContext.smartObjectMapper(fieldPattern);
         if (smartNameObjectMapper != null && smartNameObjectMapper.hasMapper()) {

--- a/src/main/java/org/elasticsearch/search/suggest/context/GeolocationContextMapping.java
+++ b/src/main/java/org/elasticsearch/search/suggest/context/GeolocationContextMapping.java
@@ -253,7 +253,7 @@ public class GeolocationContextMapping extends ContextMapping {
     public ContextConfig parseContext(ParseContext parseContext, XContentParser parser) throws IOException, ElasticsearchParseException {
 
         if(fieldName != null) {
-            FieldMapper<?> mapper = parseContext.docMapper().mappers().fullName(fieldName).mapper();
+            FieldMapper<?> mapper = parseContext.docMapper().mappers().getMapper(fieldName);
             if(!(mapper instanceof GeoPointFieldMapper)) {
                 throw new ElasticsearchParseException("referenced field must be mapped to geo_point");
             }

--- a/src/test/java/org/elasticsearch/index/analysis/PreBuiltAnalyzerTests.java
+++ b/src/test/java/org/elasticsearch/index/analysis/PreBuiltAnalyzerTests.java
@@ -163,7 +163,7 @@ public class PreBuiltAnalyzerTests extends ElasticsearchSingleNodeTest {
                 .endObject().endObject().string();
         DocumentMapper docMapper = createIndex("test", indexSettings).mapperService().documentMapperParser().parse(mapping);
 
-        FieldMapper fieldMapper = docMapper.mappers().name("field").mapper();
+        FieldMapper fieldMapper = docMapper.mappers().getMapper("field");
         assertThat(fieldMapper.searchAnalyzer(), instanceOf(NamedAnalyzer.class));
         NamedAnalyzer fieldMapperNamedAnalyzer = (NamedAnalyzer) fieldMapper.searchAnalyzer();
 

--- a/src/test/java/org/elasticsearch/index/mapper/FieldMappersLookupTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/FieldMappersLookupTests.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
+import org.apache.lucene.document.FieldType;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.fielddata.FieldDataType;
+import org.elasticsearch.index.mapper.core.AbstractFieldMapper;
+import org.elasticsearch.test.ElasticsearchTestCase;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+
+public class FieldMappersLookupTests extends ElasticsearchTestCase {
+
+    public void testEmpty() {
+        FieldMappersLookup lookup = new FieldMappersLookup();
+        assertNull(lookup.fullName("foo"));
+        assertNull(lookup.indexName("foo"));
+        List<String> names = lookup.simpleMatchToFullName("foo");
+        assertNotNull(names);
+        assertTrue(names.isEmpty());
+        names = lookup.simpleMatchToFullName("foo");
+        assertNotNull(names);
+        assertTrue(names.isEmpty());
+        assertNull(lookup.smartName("foo"));
+        assertNull(lookup.smartNameFieldMapper("foo"));
+        assertNull(lookup.get("foo"));
+        Iterator<FieldMapper<?>> itr = lookup.iterator();
+        assertNotNull(itr);
+        assertFalse(itr.hasNext());
+    }
+
+    public void testNewField() {
+        FieldMappersLookup lookup = new FieldMappersLookup();
+        FakeFieldMapper f = new FakeFieldMapper("foo", "bar");
+        FieldMappersLookup lookup2 = lookup.copyAndAddAll(Lists.newArrayList(f));
+        assertNull(lookup.fullName("foo"));
+        assertNull(lookup.indexName("bar"));
+
+        FieldMappers mappers = lookup2.fullName("foo");
+        assertNotNull(mappers);
+        assertEquals(1, mappers.mappers().size());
+        assertEquals(f, mappers.mapper());
+        mappers = lookup2.indexName("bar");
+        assertNotNull(mappers);
+        assertEquals(1, mappers.mappers().size());
+        assertEquals(f, mappers.mapper());
+        assertEquals(1, Iterators.size(lookup2.iterator()));
+    }
+
+    public void testExtendField() {
+        FieldMappersLookup lookup = new FieldMappersLookup();
+        FakeFieldMapper f = new FakeFieldMapper("foo", "bar");
+        FakeFieldMapper other = new FakeFieldMapper("blah", "blah");
+        lookup = lookup.copyAndAddAll(Lists.newArrayList(f, other));
+        FakeFieldMapper f2 = new FakeFieldMapper("foo", "bar");
+        FieldMappersLookup lookup2 = lookup.copyAndAddAll(Lists.newArrayList(f2));
+
+        FieldMappers mappers = lookup2.fullName("foo");
+        assertNotNull(mappers);
+        assertEquals(2, mappers.mappers().size());
+
+        mappers = lookup2.indexName("bar");
+        assertNotNull(mappers);
+        assertEquals(2, mappers.mappers().size());
+        assertEquals(3, Iterators.size(lookup2.iterator()));
+    }
+
+    public void testIndexName() {
+        FakeFieldMapper f1 = new FakeFieldMapper("foo", "foo");
+        FieldMappersLookup lookup = new FieldMappersLookup();
+        lookup = lookup.copyAndAddAll(Lists.newArrayList(f1));
+
+        FieldMappers mappers = lookup.indexName("foo");
+        assertNotNull(mappers);
+        assertEquals(1, mappers.mappers().size());
+        assertEquals(f1, mappers.mapper());
+    }
+
+    public void testSimpleMatchIndexNames() {
+        FakeFieldMapper f1 = new FakeFieldMapper("foo", "baz");
+        FakeFieldMapper f2 = new FakeFieldMapper("bar", "boo");
+        FieldMappersLookup lookup = new FieldMappersLookup();
+        lookup = lookup.copyAndAddAll(Lists.newArrayList(f1, f2));
+        List<String> names = lookup.simpleMatchToIndexNames("b*");
+        assertTrue(names.contains("baz"));
+        assertTrue(names.contains("boo"));
+    }
+
+    public void testSimpleMatchFullNames() {
+        FakeFieldMapper f1 = new FakeFieldMapper("foo", "baz");
+        FakeFieldMapper f2 = new FakeFieldMapper("bar", "boo");
+        FieldMappersLookup lookup = new FieldMappersLookup();
+        lookup = lookup.copyAndAddAll(Lists.newArrayList(f1, f2));
+        List<String> names = lookup.simpleMatchToFullName("b*");
+        assertTrue(names.contains("foo"));
+        assertTrue(names.contains("bar"));
+    }
+
+    public void testSmartName() {
+        FakeFieldMapper f1 = new FakeFieldMapper("foo", "realfoo");
+        FakeFieldMapper f2 = new FakeFieldMapper("foo", "realbar");
+        FakeFieldMapper f3 = new FakeFieldMapper("baz", "realfoo");
+        FieldMappersLookup lookup = new FieldMappersLookup();
+        lookup = lookup.copyAndAddAll(Lists.newArrayList(f1, f2, f3));
+
+        assertNotNull(lookup.smartName("foo"));
+        assertEquals(2, lookup.smartName("foo").mappers().size());
+        assertNotNull(lookup.smartName("realfoo"));
+        assertEquals(f1, lookup.smartNameFieldMapper("foo"));
+        assertEquals(f2, lookup.smartNameFieldMapper("realbar"));
+    }
+
+    public void testIteratorImmutable() {
+        FakeFieldMapper f1 = new FakeFieldMapper("foo", "bar");
+        FieldMappersLookup lookup = new FieldMappersLookup();
+        lookup = lookup.copyAndAddAll(Lists.newArrayList(f1));
+
+        try {
+            Iterator<FieldMapper<?>> itr = lookup.iterator();
+            assertTrue(itr.hasNext());
+            assertEquals(f1, itr.next());
+            itr.remove();
+            fail("remove should have failed");
+        } catch (UnsupportedOperationException e) {
+            // expected
+        }
+    }
+
+    public void testGetMapper() {
+        FakeFieldMapper f1 = new FakeFieldMapper("foo", "bar");
+        FieldMappersLookup lookup = new FieldMappersLookup();
+        lookup = lookup.copyAndAddAll(Lists.newArrayList(f1));
+
+        assertEquals(f1, lookup.get("foo"));
+        assertNull(lookup.get("bar")); // get is only by full name
+        FakeFieldMapper f2 = new FakeFieldMapper("foo", "foo");
+        lookup = lookup.copyAndAddAll(Lists.newArrayList(f2));
+        try {
+            lookup.get("foo");
+            fail("get should have enforced foo is unique");
+        } catch (IllegalStateException e) {
+            // expected
+        }
+    }
+
+    // this sucks how much must be overriden just do get a dummy field mapper...
+    static class FakeFieldMapper extends AbstractFieldMapper<String> {
+        static Settings dummySettings = ImmutableSettings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT.id).build();
+        public FakeFieldMapper(String fullName, String indexName) {
+            super(new Names(fullName, indexName, indexName, fullName), 1.0f, AbstractFieldMapper.Defaults.FIELD_TYPE, null, null, null, null, null, null, dummySettings, null, null);
+        }
+        @Override
+        public FieldType defaultFieldType() { return null; }
+        @Override
+        public FieldDataType defaultFieldDataType() { return null; }
+        @Override
+        protected String contentType() { return null; }
+        @Override
+        protected void parseCreateField(ParseContext context, List list) throws IOException {}
+        @Override
+        public String value(Object value) { return null; }
+    }
+}

--- a/src/test/java/org/elasticsearch/index/mapper/camelcase/CamelCaseFieldNameTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/camelcase/CamelCaseFieldNameTests.java
@@ -50,13 +50,13 @@ public class CamelCaseFieldNameTests extends ElasticsearchSingleNodeTest {
         assertNotNull(doc.dynamicMappingsUpdate());
         client().admin().indices().preparePutMapping("test").setType("type").setSource(doc.dynamicMappingsUpdate().toString()).get();
 
-        assertThat(documentMapper.mappers().indexName("thisIsCamelCase").isEmpty(), equalTo(false));
-        assertThat(documentMapper.mappers().indexName("this_is_camel_case"), nullValue());
+        assertNotNull(documentMapper.mappers().getMapper("thisIsCamelCase"));
+        assertNull(documentMapper.mappers().getMapper("this_is_camel_case"));
 
         documentMapper.refreshSource();
         documentMapper = index.mapperService().documentMapperParser().parse(documentMapper.mappingSource().string());
 
-        assertThat(documentMapper.mappers().indexName("thisIsCamelCase").isEmpty(), equalTo(false));
-        assertThat(documentMapper.mappers().indexName("this_is_camel_case"), nullValue());
+        assertNotNull(documentMapper.mappers().getMapper("thisIsCamelCase"));
+        assertNull(documentMapper.mappers().getMapper("this_is_camel_case"));
     }
 }

--- a/src/test/java/org/elasticsearch/index/mapper/completion/CompletionFieldMapperTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/completion/CompletionFieldMapperTests.java
@@ -45,7 +45,7 @@ public class CompletionFieldMapperTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
 
-        FieldMapper fieldMapper = defaultMapper.mappers().name("completion").mapper();
+        FieldMapper fieldMapper = defaultMapper.mappers().getMapper("completion");
         assertThat(fieldMapper, instanceOf(CompletionFieldMapper.class));
 
         CompletionFieldMapper completionFieldMapper = (CompletionFieldMapper) fieldMapper;
@@ -69,7 +69,7 @@ public class CompletionFieldMapperTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
 
-        FieldMapper fieldMapper = defaultMapper.mappers().name("completion").mapper();
+        FieldMapper fieldMapper = defaultMapper.mappers().getMapper("completion");
         assertThat(fieldMapper, instanceOf(CompletionFieldMapper.class));
 
         CompletionFieldMapper completionFieldMapper = (CompletionFieldMapper) fieldMapper;
@@ -98,7 +98,7 @@ public class CompletionFieldMapperTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
 
-        FieldMapper fieldMapper = defaultMapper.mappers().name("completion").mapper();
+        FieldMapper fieldMapper = defaultMapper.mappers().getMapper("completion");
         assertThat(fieldMapper, instanceOf(CompletionFieldMapper.class));
 
         CompletionFieldMapper completionFieldMapper = (CompletionFieldMapper) fieldMapper;

--- a/src/test/java/org/elasticsearch/index/mapper/copyto/CopyToMapperTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/copyto/CopyToMapperTests.java
@@ -84,8 +84,7 @@ public class CopyToMapperTests extends ElasticsearchSingleNodeTest {
         IndexService index = createIndex("test");
         client().admin().indices().preparePutMapping("test").setType("type1").setSource(mapping).get();
         DocumentMapper docMapper = index.mapperService().documentMapper("type1");
-        FieldMapper fieldMapper = docMapper.mappers().name("copy_test").mapper();
-        assertThat(fieldMapper, instanceOf(StringFieldMapper.class));
+        FieldMapper fieldMapper = docMapper.mappers().getMapper("copy_test");
 
         // Check json serialization
         StringFieldMapper stringFieldMapper = (StringFieldMapper) fieldMapper;
@@ -130,7 +129,7 @@ public class CopyToMapperTests extends ElasticsearchSingleNodeTest {
         assertNotNull(parsedDoc.dynamicMappingsUpdate());
         client().admin().indices().preparePutMapping("test").setType("type1").setSource(parsedDoc.dynamicMappingsUpdate().toString()).get();
 
-        fieldMapper = docMapper.mappers().name("new_field").mapper();
+        fieldMapper = docMapper.mappers().getMapper("new_field");
         assertThat(fieldMapper, instanceOf(LongFieldMapper.class));
     }
 
@@ -221,7 +220,7 @@ public class CopyToMapperTests extends ElasticsearchSingleNodeTest {
         DocumentMapperParser parser = createIndex("test").mapperService().documentMapperParser();
         DocumentMapper docMapperBefore = parser.parse(mappingBefore);
 
-        ImmutableList<String> fields = docMapperBefore.mappers().name("copy_test").mapper().copyTo().copyToFields();
+        ImmutableList<String> fields = docMapperBefore.mappers().getMapper("copy_test").copyTo().copyToFields();
 
         assertThat(fields.size(), equalTo(2));
         assertThat(fields.get(0), equalTo("foo"));
@@ -236,7 +235,7 @@ public class CopyToMapperTests extends ElasticsearchSingleNodeTest {
 
         docMapperBefore.merge(docMapperAfter.mapping(), mergeFlags().simulate(false));
 
-        fields = docMapperBefore.mappers().name("copy_test").mapper().copyTo().copyToFields();
+        fields = docMapperBefore.mappers().getMapper("copy_test").copyTo().copyToFields();
 
         assertThat(fields.size(), equalTo(2));
         assertThat(fields.get(0), equalTo("baz"));

--- a/src/test/java/org/elasticsearch/index/mapper/date/SimpleDateMappingTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/date/SimpleDateMappingTests.java
@@ -360,17 +360,17 @@ public class SimpleDateMappingTests extends ElasticsearchSingleNodeTest {
         DocumentMapper defaultMapper = mapper("type", initialMapping);
         DocumentMapper mergeMapper = mapper("type", updatedMapping);
 
-        assertThat(defaultMapper.mappers().name("field").mapper(), is(instanceOf(DateFieldMapper.class)));
-        DateFieldMapper initialDateFieldMapper = (DateFieldMapper) defaultMapper.mappers().name("field").mapper();
+        assertThat(defaultMapper.mappers().getMapper("field"), is(instanceOf(DateFieldMapper.class)));
+        DateFieldMapper initialDateFieldMapper = (DateFieldMapper) defaultMapper.mappers().getMapper("field");
         Map<String, String> config = getConfigurationViaXContent(initialDateFieldMapper);
         assertThat(config.get("format"), is("EEE MMM dd HH:mm:ss.S Z yyyy||EEE MMM dd HH:mm:ss.SSS Z yyyy"));
 
         DocumentMapper.MergeResult mergeResult = defaultMapper.merge(mergeMapper.mapping(), DocumentMapper.MergeFlags.mergeFlags().simulate(false));
 
         assertThat("Merging resulting in conflicts: " + Arrays.asList(mergeResult.conflicts()), mergeResult.hasConflicts(), is(false));
-        assertThat(defaultMapper.mappers().name("field").mapper(), is(instanceOf(DateFieldMapper.class)));
+        assertThat(defaultMapper.mappers().getMapper("field"), is(instanceOf(DateFieldMapper.class)));
 
-        DateFieldMapper mergedFieldMapper = (DateFieldMapper) defaultMapper.mappers().name("field").mapper();
+        DateFieldMapper mergedFieldMapper = (DateFieldMapper) defaultMapper.mappers().getMapper("field");
         Map<String, String> mergedConfig = getConfigurationViaXContent(mergedFieldMapper);
         assertThat(mergedConfig.get("format"), is("EEE MMM dd HH:mm:ss.S Z yyyy||EEE MMM dd HH:mm:ss.SSS Z yyyy||yyyy-MM-dd'T'HH:mm:ss.SSSZZ"));
     }

--- a/src/test/java/org/elasticsearch/index/mapper/dynamic/DynamicMappingTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/dynamic/DynamicMappingTests.java
@@ -175,7 +175,7 @@ public class DynamicMappingTests extends ElasticsearchSingleNodeTest {
     public void testDynamicMappingOnEmptyString() throws Exception {
         IndexService service = createIndex("test");
         client().prepareIndex("test", "type").setSource("empty_field", "").get();
-        FieldMappers mappers = service.mapperService().indexName("empty_field");
+        FieldMappers mappers = service.mapperService().fullName("empty_field");
         assertTrue(mappers != null && mappers.isEmpty() == false);
     }
 

--- a/src/test/java/org/elasticsearch/index/mapper/dynamictemplate/genericstore/GenericStoreDynamicTemplateTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/dynamictemplate/genericstore/GenericStoreDynamicTemplateTests.java
@@ -23,6 +23,7 @@ import org.apache.lucene.index.IndexableField;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.mapper.DocumentMapper;
+import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.FieldMappers;
 import org.elasticsearch.index.mapper.ParseContext.Document;
 import org.elasticsearch.index.mapper.ParsedDocument;
@@ -54,16 +55,14 @@ public class GenericStoreDynamicTemplateTests extends ElasticsearchSingleNodeTes
         assertThat(f.stringValue(), equalTo("some name"));
         assertThat(f.fieldType().stored(), equalTo(true));
 
-        FieldMappers fieldMappers = docMapper.mappers().fullName("name");
-        assertThat(fieldMappers.mappers().size(), equalTo(1));
-        assertThat(fieldMappers.mapper().fieldType().stored(), equalTo(true));
+        FieldMapper fieldMapper = docMapper.mappers().getMapper("name");
+        assertThat(fieldMapper.fieldType().stored(), equalTo(true));
 
         f = doc.getField("age");
         assertThat(f.name(), equalTo("age"));
         assertThat(f.fieldType().stored(), equalTo(true));
 
-        fieldMappers = docMapper.mappers().fullName("age");
-        assertThat(fieldMappers.mappers().size(), equalTo(1));
-        assertThat(fieldMappers.mapper().fieldType().stored(), equalTo(true));
+        fieldMapper = docMapper.mappers().getMapper("age");
+        assertThat(fieldMapper.fieldType().stored(), equalTo(true));
     }
 }

--- a/src/test/java/org/elasticsearch/index/mapper/dynamictemplate/pathmatch/PathMatchDynamicTemplateTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/dynamictemplate/pathmatch/PathMatchDynamicTemplateTests.java
@@ -23,6 +23,7 @@ import org.apache.lucene.index.IndexableField;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.mapper.DocumentMapper;
+import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.FieldMappers;
 import org.elasticsearch.index.mapper.MapperUtils;
 import org.elasticsearch.index.mapper.ParsedDocument;
@@ -55,29 +56,26 @@ public class PathMatchDynamicTemplateTests extends ElasticsearchSingleNodeTest {
         assertThat(f.stringValue(), equalTo("top_level"));
         assertThat(f.fieldType().stored(), equalTo(false));
 
-        FieldMappers fieldMappers = docMapper.mappers().fullName("name");
-        assertThat(fieldMappers.mappers().size(), equalTo(1));
-        assertThat(fieldMappers.mapper().fieldType().stored(), equalTo(false));
+        FieldMapper fieldMapper = docMapper.mappers().getMapper("name");
+        assertThat(fieldMapper.fieldType().stored(), equalTo(false));
 
         f = doc.getField("obj1.name");
         assertThat(f.name(), equalTo("obj1.name"));
         assertThat(f.fieldType().stored(), equalTo(true));
 
-        fieldMappers = docMapper.mappers().fullName("obj1.name");
-        assertThat(fieldMappers.mappers().size(), equalTo(1));
-        assertThat(fieldMappers.mapper().fieldType().stored(), equalTo(true));
+        fieldMapper = docMapper.mappers().getMapper("obj1.name");
+        assertThat(fieldMapper.fieldType().stored(), equalTo(true));
 
         f = doc.getField("obj1.obj2.name");
         assertThat(f.name(), equalTo("obj1.obj2.name"));
         assertThat(f.fieldType().stored(), equalTo(false));
 
-        fieldMappers = docMapper.mappers().fullName("obj1.obj2.name");
-        assertThat(fieldMappers.mappers().size(), equalTo(1));
-        assertThat(fieldMappers.mapper().fieldType().stored(), equalTo(false));
+        fieldMapper = docMapper.mappers().getMapper("obj1.obj2.name");
+        assertThat(fieldMapper.fieldType().stored(), equalTo(false));
 
         // verify more complex path_match expressions
 
-        fieldMappers = docMapper.mappers().fullName("obj3.obj4.prop1");
-        assertThat(fieldMappers.mappers().size(), equalTo(1));
+        fieldMapper = docMapper.mappers().getMapper("obj3.obj4.prop1");
+        assertNotNull(fieldMapper);
     }
 }

--- a/src/test/java/org/elasticsearch/index/mapper/dynamictemplate/simple/SimpleDynamicTemplatesTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/dynamictemplate/simple/SimpleDynamicTemplatesTests.java
@@ -84,8 +84,8 @@ public class SimpleDynamicTemplatesTests extends ElasticsearchSingleNodeTest {
         assertNotSame(IndexOptions.NONE, f.fieldType().indexOptions());
         assertThat(f.fieldType().tokenized(), equalTo(false));
 
-        FieldMappers fieldMappers = docMapper.mappers().fullName("name");
-        assertThat(fieldMappers.mappers().size(), equalTo(1));
+        FieldMapper fieldMapper = docMapper.mappers().getMapper("name");
+        assertNotNull(fieldMapper);
 
         f = doc.getField("multi1");
         assertThat(f.name(), equalTo("multi1"));
@@ -93,8 +93,8 @@ public class SimpleDynamicTemplatesTests extends ElasticsearchSingleNodeTest {
         assertNotSame(IndexOptions.NONE, f.fieldType().indexOptions());
         assertThat(f.fieldType().tokenized(), equalTo(true));
 
-        fieldMappers = docMapper.mappers().fullName("multi1");
-        assertThat(fieldMappers.mappers().size(), equalTo(1));
+        fieldMapper = docMapper.mappers().getMapper("multi1");
+        assertNotNull(fieldMapper);
 
         f = doc.getField("multi1.org");
         assertThat(f.name(), equalTo("multi1.org"));
@@ -102,8 +102,8 @@ public class SimpleDynamicTemplatesTests extends ElasticsearchSingleNodeTest {
         assertNotSame(IndexOptions.NONE, f.fieldType().indexOptions());
         assertThat(f.fieldType().tokenized(), equalTo(false));
 
-        fieldMappers = docMapper.mappers().fullName("multi1.org");
-        assertThat(fieldMappers.mappers().size(), equalTo(1));
+        fieldMapper = docMapper.mappers().getMapper("multi1.org");
+        assertNotNull(fieldMapper);
 
         f = doc.getField("multi2");
         assertThat(f.name(), equalTo("multi2"));
@@ -111,8 +111,8 @@ public class SimpleDynamicTemplatesTests extends ElasticsearchSingleNodeTest {
         assertNotSame(IndexOptions.NONE, f.fieldType().indexOptions());
         assertThat(f.fieldType().tokenized(), equalTo(true));
 
-        fieldMappers = docMapper.mappers().fullName("multi2");
-        assertThat(fieldMappers.mappers().size(), equalTo(1));
+        fieldMapper = docMapper.mappers().getMapper("multi2");
+        assertNotNull(fieldMapper);
 
         f = doc.getField("multi2.org");
         assertThat(f.name(), equalTo("multi2.org"));
@@ -120,8 +120,8 @@ public class SimpleDynamicTemplatesTests extends ElasticsearchSingleNodeTest {
         assertNotSame(IndexOptions.NONE, f.fieldType().indexOptions());
         assertThat(f.fieldType().tokenized(), equalTo(false));
 
-        fieldMappers = docMapper.mappers().fullName("multi2.org");
-        assertThat(fieldMappers.mappers().size(), equalTo(1));
+        fieldMapper = docMapper.mappers().getMapper("multi2.org");
+        assertNotNull(fieldMapper);
     }
 
     @Test
@@ -141,8 +141,8 @@ public class SimpleDynamicTemplatesTests extends ElasticsearchSingleNodeTest {
         assertNotSame(IndexOptions.NONE, f.fieldType().indexOptions());
         assertThat(f.fieldType().tokenized(), equalTo(false));
 
-        FieldMappers fieldMappers = docMapper.mappers().fullName("name");
-        assertThat(fieldMappers.mappers().size(), equalTo(1));
+        FieldMapper fieldMapper = docMapper.mappers().getMapper("name");
+        assertNotNull(fieldMapper);
 
         f = doc.getField("multi1");
         assertThat(f.name(), equalTo("multi1"));
@@ -150,8 +150,8 @@ public class SimpleDynamicTemplatesTests extends ElasticsearchSingleNodeTest {
         assertNotSame(IndexOptions.NONE, f.fieldType().indexOptions());
         assertThat(f.fieldType().tokenized(), equalTo(true));
 
-        fieldMappers = docMapper.mappers().fullName("multi1");
-        assertThat(fieldMappers.mappers().size(), equalTo(1));
+        fieldMapper = docMapper.mappers().getMapper("multi1");
+        assertNotNull(fieldMapper);
 
         f = doc.getField("multi1.org");
         assertThat(f.name(), equalTo("multi1.org"));
@@ -159,8 +159,8 @@ public class SimpleDynamicTemplatesTests extends ElasticsearchSingleNodeTest {
         assertNotSame(IndexOptions.NONE, f.fieldType().indexOptions());
         assertThat(f.fieldType().tokenized(), equalTo(false));
 
-        fieldMappers = docMapper.mappers().fullName("multi1.org");
-        assertThat(fieldMappers.mappers().size(), equalTo(1));
+        fieldMapper = docMapper.mappers().getMapper("multi1.org");
+        assertNotNull(fieldMapper);
 
         f = doc.getField("multi2");
         assertThat(f.name(), equalTo("multi2"));
@@ -168,8 +168,8 @@ public class SimpleDynamicTemplatesTests extends ElasticsearchSingleNodeTest {
         assertNotSame(IndexOptions.NONE, f.fieldType().indexOptions());
         assertThat(f.fieldType().tokenized(), equalTo(true));
 
-        fieldMappers = docMapper.mappers().fullName("multi2");
-        assertThat(fieldMappers.mappers().size(), equalTo(1));
+        fieldMapper = docMapper.mappers().getMapper("multi2");
+        assertNotNull(fieldMapper);
 
         f = doc.getField("multi2.org");
         assertThat(f.name(), equalTo("multi2.org"));
@@ -177,7 +177,7 @@ public class SimpleDynamicTemplatesTests extends ElasticsearchSingleNodeTest {
         assertNotSame(IndexOptions.NONE, f.fieldType().indexOptions());
         assertThat(f.fieldType().tokenized(), equalTo(false));
 
-        fieldMappers = docMapper.mappers().fullName("multi2.org");
-        assertThat(fieldMappers.mappers().size(), equalTo(1));
+        fieldMapper = docMapper.mappers().getMapper("multi2.org");
+        assertNotNull(fieldMapper);
     }
 }

--- a/src/test/java/org/elasticsearch/index/mapper/geo/GeoShapeFieldMapperTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/geo/GeoShapeFieldMapperTests.java
@@ -51,7 +51,7 @@ public class GeoShapeFieldMapperTests extends ElasticsearchSingleNodeTest {
                 .endObject().endObject().string();
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
-        FieldMapper fieldMapper = defaultMapper.mappers().name("location").mapper();
+        FieldMapper fieldMapper = defaultMapper.mappers().getMapper("location");
         assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
 
         GeoShapeFieldMapper geoShapeFieldMapper = (GeoShapeFieldMapper) fieldMapper;
@@ -76,7 +76,7 @@ public class GeoShapeFieldMapperTests extends ElasticsearchSingleNodeTest {
                 .endObject().endObject().string();
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
-        FieldMapper fieldMapper = defaultMapper.mappers().name("location").mapper();
+        FieldMapper fieldMapper = defaultMapper.mappers().getMapper("location");
         assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
 
         ShapeBuilder.Orientation orientation = ((GeoShapeFieldMapper)fieldMapper).orientation();
@@ -93,7 +93,7 @@ public class GeoShapeFieldMapperTests extends ElasticsearchSingleNodeTest {
                 .endObject().endObject().string();
 
         defaultMapper = createIndex("test2").mapperService().documentMapperParser().parse(mapping);
-        fieldMapper = defaultMapper.mappers().name("location").mapper();
+        fieldMapper = defaultMapper.mappers().getMapper("location");
         assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
 
         orientation = ((GeoShapeFieldMapper)fieldMapper).orientation();
@@ -114,7 +114,7 @@ public class GeoShapeFieldMapperTests extends ElasticsearchSingleNodeTest {
                 .endObject().endObject().string();
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
-        FieldMapper fieldMapper = defaultMapper.mappers().name("location").mapper();
+        FieldMapper fieldMapper = defaultMapper.mappers().getMapper("location");
         assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
 
         GeoShapeFieldMapper geoShapeFieldMapper = (GeoShapeFieldMapper) fieldMapper;
@@ -137,7 +137,7 @@ public class GeoShapeFieldMapperTests extends ElasticsearchSingleNodeTest {
                 .endObject().endObject().string();
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
-        FieldMapper fieldMapper = defaultMapper.mappers().name("location").mapper();
+        FieldMapper fieldMapper = defaultMapper.mappers().getMapper("location");
         assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
 
         GeoShapeFieldMapper geoShapeFieldMapper = (GeoShapeFieldMapper) fieldMapper;
@@ -165,7 +165,7 @@ public class GeoShapeFieldMapperTests extends ElasticsearchSingleNodeTest {
 
             
             DocumentMapper defaultMapper = parser.parse(mapping);
-            FieldMapper fieldMapper = defaultMapper.mappers().name("location").mapper();
+            FieldMapper fieldMapper = defaultMapper.mappers().getMapper("location");
             assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
 
             GeoShapeFieldMapper geoShapeFieldMapper = (GeoShapeFieldMapper) fieldMapper;
@@ -215,7 +215,7 @@ public class GeoShapeFieldMapperTests extends ElasticsearchSingleNodeTest {
                     .endObject().endObject().string();
 
             DocumentMapper defaultMapper = parser.parse(mapping);
-            FieldMapper fieldMapper = defaultMapper.mappers().name("location").mapper();
+            FieldMapper fieldMapper = defaultMapper.mappers().getMapper("location");
             assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
 
             GeoShapeFieldMapper geoShapeFieldMapper = (GeoShapeFieldMapper) fieldMapper;
@@ -239,7 +239,7 @@ public class GeoShapeFieldMapperTests extends ElasticsearchSingleNodeTest {
                     .endObject().endObject().string();
 
             DocumentMapper defaultMapper = parser.parse(mapping);
-            FieldMapper fieldMapper = defaultMapper.mappers().name("location").mapper();
+            FieldMapper fieldMapper = defaultMapper.mappers().getMapper("location");
             assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
 
             GeoShapeFieldMapper geoShapeFieldMapper = (GeoShapeFieldMapper) fieldMapper;
@@ -262,7 +262,7 @@ public class GeoShapeFieldMapperTests extends ElasticsearchSingleNodeTest {
                     .endObject().endObject().string();
 
             DocumentMapper defaultMapper = parser.parse(mapping);
-            FieldMapper fieldMapper = defaultMapper.mappers().name("location").mapper();
+            FieldMapper fieldMapper = defaultMapper.mappers().getMapper("location");
             assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
 
             GeoShapeFieldMapper geoShapeFieldMapper = (GeoShapeFieldMapper) fieldMapper;
@@ -288,7 +288,7 @@ public class GeoShapeFieldMapperTests extends ElasticsearchSingleNodeTest {
 
             
             DocumentMapper defaultMapper = parser.parse(mapping);
-            FieldMapper fieldMapper = defaultMapper.mappers().name("location").mapper();
+            FieldMapper fieldMapper = defaultMapper.mappers().getMapper("location");
             assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
 
             GeoShapeFieldMapper geoShapeFieldMapper = (GeoShapeFieldMapper) fieldMapper;
@@ -310,7 +310,7 @@ public class GeoShapeFieldMapperTests extends ElasticsearchSingleNodeTest {
                     .endObject().endObject().string();
 
             DocumentMapper defaultMapper = parser.parse(mapping);
-            FieldMapper fieldMapper = defaultMapper.mappers().name("location").mapper();
+            FieldMapper fieldMapper = defaultMapper.mappers().getMapper("location");
             assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
 
             GeoShapeFieldMapper geoShapeFieldMapper = (GeoShapeFieldMapper) fieldMapper;
@@ -347,7 +347,7 @@ public class GeoShapeFieldMapperTests extends ElasticsearchSingleNodeTest {
         assertThat("mapper [shape] has different tree_levels or precision", isIn(conflicts));
 
         // verify nothing changed
-        FieldMapper fieldMapper = stage1.mappers().name("shape").mapper();
+        FieldMapper fieldMapper = stage1.mappers().getMapper("shape");
         assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
 
         GeoShapeFieldMapper geoShapeFieldMapper = (GeoShapeFieldMapper) fieldMapper;
@@ -369,7 +369,7 @@ public class GeoShapeFieldMapperTests extends ElasticsearchSingleNodeTest {
         // verify mapping changes, and ensure no failures
         assertThat(mergeResult.hasConflicts(), equalTo(false));
 
-        fieldMapper = stage1.mappers().name("shape").mapper();
+        fieldMapper = stage1.mappers().getMapper("shape");
         assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
 
         geoShapeFieldMapper = (GeoShapeFieldMapper) fieldMapper;

--- a/src/test/java/org/elasticsearch/index/mapper/index/IndexTypeMapperTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/index/IndexTypeMapperTests.java
@@ -42,7 +42,7 @@ public class IndexTypeMapperTests extends ElasticsearchSingleNodeTest {
         DocumentMapper docMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
         IndexFieldMapper indexMapper = docMapper.rootMapper(IndexFieldMapper.class);
         assertThat(indexMapper.enabled(), equalTo(true));
-        assertThat(docMapper.mappers().indexName("_index").mapper(), instanceOf(IndexFieldMapper.class));
+        assertThat(docMapper.mappers().getMapper("_index"), instanceOf(IndexFieldMapper.class));
 
         ParsedDocument doc = docMapper.parse("type", "1", XContentFactory.jsonBuilder()
                 .startObject()

--- a/src/test/java/org/elasticsearch/index/mapper/merge/TestMergeMapperTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/merge/TestMergeMapperTests.java
@@ -116,11 +116,11 @@ public class TestMergeMapperTests extends ElasticsearchSingleNodeTest {
         DocumentMapper existing = parser.parse(mapping1);
         DocumentMapper changed = parser.parse(mapping2);
 
-        assertThat(((NamedAnalyzer) existing.mappers().name("field").mapper().searchAnalyzer()).name(), equalTo("whitespace"));
+        assertThat(((NamedAnalyzer) existing.mappers().getMapper("field").searchAnalyzer()).name(), equalTo("whitespace"));
         DocumentMapper.MergeResult mergeResult = existing.merge(changed.mapping(), mergeFlags().simulate(false));
 
         assertThat(mergeResult.hasConflicts(), equalTo(false));
-        assertThat(((NamedAnalyzer) existing.mappers().name("field").mapper().searchAnalyzer()).name(), equalTo("keyword"));
+        assertThat(((NamedAnalyzer) existing.mappers().getMapper("field").searchAnalyzer()).name(), equalTo("keyword"));
     }
 
     @Test
@@ -136,12 +136,12 @@ public class TestMergeMapperTests extends ElasticsearchSingleNodeTest {
         DocumentMapper existing = parser.parse(mapping1);
         DocumentMapper changed = parser.parse(mapping2);
 
-        assertThat(((NamedAnalyzer) existing.mappers().name("field").mapper().searchAnalyzer()).name(), equalTo("whitespace"));
+        assertThat(((NamedAnalyzer) existing.mappers().getMapper("field").searchAnalyzer()).name(), equalTo("whitespace"));
         DocumentMapper.MergeResult mergeResult = existing.merge(changed.mapping(), mergeFlags().simulate(false));
 
         assertThat(mergeResult.hasConflicts(), equalTo(false));
-        assertThat(((NamedAnalyzer) existing.mappers().name("field").mapper().searchAnalyzer()).name(), equalTo("standard"));
-        assertThat(((StringFieldMapper) (existing.mappers().name("field").mapper())).getIgnoreAbove(), equalTo(14));
+        assertThat(((NamedAnalyzer) existing.mappers().getMapper("field").searchAnalyzer()).name(), equalTo("standard"));
+        assertThat(((StringFieldMapper) (existing.mappers().getMapper("field"))).getIgnoreAbove(), equalTo(14));
     }
 
 }

--- a/src/test/java/org/elasticsearch/index/mapper/multifield/MultiFieldTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/multifield/MultiFieldTests.java
@@ -95,45 +95,45 @@ public class MultiFieldTests extends ElasticsearchSingleNodeTest {
         assertThat(f.name(), equalTo("object1.multi1.string"));
         assertThat(f.stringValue(), equalTo("2010-01-01"));
 
-        assertThat(docMapper.mappers().fullName("name").mapper(), notNullValue());
-        assertThat(docMapper.mappers().fullName("name").mapper(), instanceOf(StringFieldMapper.class));
-        assertNotSame(IndexOptions.NONE, docMapper.mappers().fullName("name").mapper().fieldType().indexOptions());
-        assertThat(docMapper.mappers().fullName("name").mapper().fieldType().stored(), equalTo(true));
-        assertThat(docMapper.mappers().fullName("name").mapper().fieldType().tokenized(), equalTo(true));
+        assertThat(docMapper.mappers().getMapper("name"), notNullValue());
+        assertThat(docMapper.mappers().getMapper("name"), instanceOf(StringFieldMapper.class));
+        assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("name").fieldType().indexOptions());
+        assertThat(docMapper.mappers().getMapper("name").fieldType().stored(), equalTo(true));
+        assertThat(docMapper.mappers().getMapper("name").fieldType().tokenized(), equalTo(true));
 
-        assertThat(docMapper.mappers().fullName("name.indexed").mapper(), notNullValue());
-        assertThat(docMapper.mappers().fullName("name.indexed").mapper(), instanceOf(StringFieldMapper.class));
-        assertNotSame(IndexOptions.NONE, docMapper.mappers().fullName("name.indexed").mapper().fieldType().indexOptions());
-        assertThat(docMapper.mappers().fullName("name.indexed").mapper().fieldType().stored(), equalTo(false));
-        assertThat(docMapper.mappers().fullName("name.indexed").mapper().fieldType().tokenized(), equalTo(true));
+        assertThat(docMapper.mappers().getMapper("name.indexed"), notNullValue());
+        assertThat(docMapper.mappers().getMapper("name.indexed"), instanceOf(StringFieldMapper.class));
+        assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("name.indexed").fieldType().indexOptions());
+        assertThat(docMapper.mappers().getMapper("name.indexed").fieldType().stored(), equalTo(false));
+        assertThat(docMapper.mappers().getMapper("name.indexed").fieldType().tokenized(), equalTo(true));
 
-        assertThat(docMapper.mappers().fullName("name.not_indexed").mapper(), notNullValue());
-        assertThat(docMapper.mappers().fullName("name.not_indexed").mapper(), instanceOf(StringFieldMapper.class));
-        assertEquals(IndexOptions.NONE, docMapper.mappers().fullName("name.not_indexed").mapper().fieldType().indexOptions());
-        assertThat(docMapper.mappers().fullName("name.not_indexed").mapper().fieldType().stored(), equalTo(true));
-        assertThat(docMapper.mappers().fullName("name.not_indexed").mapper().fieldType().tokenized(), equalTo(true));
+        assertThat(docMapper.mappers().getMapper("name.not_indexed"), notNullValue());
+        assertThat(docMapper.mappers().getMapper("name.not_indexed"), instanceOf(StringFieldMapper.class));
+        assertEquals(IndexOptions.NONE, docMapper.mappers().getMapper("name.not_indexed").fieldType().indexOptions());
+        assertThat(docMapper.mappers().getMapper("name.not_indexed").fieldType().stored(), equalTo(true));
+        assertThat(docMapper.mappers().getMapper("name.not_indexed").fieldType().tokenized(), equalTo(true));
 
-        assertThat(docMapper.mappers().fullName("name.test1").mapper(), notNullValue());
-        assertThat(docMapper.mappers().fullName("name.test1").mapper(), instanceOf(StringFieldMapper.class));
-        assertNotSame(IndexOptions.NONE, docMapper.mappers().fullName("name.test1").mapper().fieldType().indexOptions());
-        assertThat(docMapper.mappers().fullName("name.test1").mapper().fieldType().stored(), equalTo(true));
-        assertThat(docMapper.mappers().fullName("name.test1").mapper().fieldType().tokenized(), equalTo(true));
-        assertThat(docMapper.mappers().fullName("name.test1").mapper().fieldDataType().getLoading(), equalTo(FieldMapper.Loading.EAGER));
+        assertThat(docMapper.mappers().getMapper("name.test1"), notNullValue());
+        assertThat(docMapper.mappers().getMapper("name.test1"), instanceOf(StringFieldMapper.class));
+        assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("name.test1").fieldType().indexOptions());
+        assertThat(docMapper.mappers().getMapper("name.test1").fieldType().stored(), equalTo(true));
+        assertThat(docMapper.mappers().getMapper("name.test1").fieldType().tokenized(), equalTo(true));
+        assertThat(docMapper.mappers().getMapper("name.test1").fieldDataType().getLoading(), equalTo(FieldMapper.Loading.EAGER));
 
-        assertThat(docMapper.mappers().fullName("name.test2").mapper(), notNullValue());
-        assertThat(docMapper.mappers().fullName("name.test2").mapper(), instanceOf(TokenCountFieldMapper.class));
-        assertNotSame(IndexOptions.NONE, docMapper.mappers().fullName("name.test2").mapper().fieldType().indexOptions());
-        assertThat(docMapper.mappers().fullName("name.test2").mapper().fieldType().stored(), equalTo(true));
-        assertThat(docMapper.mappers().fullName("name.test2").mapper().fieldType().tokenized(), equalTo(false));
-        assertThat(((TokenCountFieldMapper) docMapper.mappers().fullName("name.test2").mapper()).analyzer(), equalTo("simple"));
-        assertThat(((TokenCountFieldMapper) docMapper.mappers().fullName("name.test2").mapper()).analyzer(), equalTo("simple"));
+        assertThat(docMapper.mappers().getMapper("name.test2"), notNullValue());
+        assertThat(docMapper.mappers().getMapper("name.test2"), instanceOf(TokenCountFieldMapper.class));
+        assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("name.test2").fieldType().indexOptions());
+        assertThat(docMapper.mappers().getMapper("name.test2").fieldType().stored(), equalTo(true));
+        assertThat(docMapper.mappers().getMapper("name.test2").fieldType().tokenized(), equalTo(false));
+        assertThat(((TokenCountFieldMapper) docMapper.mappers().getMapper("name.test2")).analyzer(), equalTo("simple"));
+        assertThat(((TokenCountFieldMapper) docMapper.mappers().getMapper("name.test2")).analyzer(), equalTo("simple"));
 
-        assertThat(docMapper.mappers().fullName("object1.multi1").mapper(), notNullValue());
-        assertThat(docMapper.mappers().fullName("object1.multi1").mapper(), instanceOf(DateFieldMapper.class));
-        assertThat(docMapper.mappers().fullName("object1.multi1.string").mapper(), notNullValue());
-        assertThat(docMapper.mappers().fullName("object1.multi1.string").mapper(), instanceOf(StringFieldMapper.class));
-        assertNotSame(IndexOptions.NONE, docMapper.mappers().fullName("object1.multi1.string").mapper().fieldType().indexOptions());
-        assertThat(docMapper.mappers().fullName("object1.multi1.string").mapper().fieldType().tokenized(), equalTo(false));
+        assertThat(docMapper.mappers().getMapper("object1.multi1"), notNullValue());
+        assertThat(docMapper.mappers().getMapper("object1.multi1"), instanceOf(DateFieldMapper.class));
+        assertThat(docMapper.mappers().getMapper("object1.multi1.string"), notNullValue());
+        assertThat(docMapper.mappers().getMapper("object1.multi1.string"), instanceOf(StringFieldMapper.class));
+        assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("object1.multi1.string").fieldType().indexOptions());
+        assertThat(docMapper.mappers().getMapper("object1.multi1.string").fieldType().tokenized(), equalTo(false));
     }
 
     @Test
@@ -198,23 +198,23 @@ public class MultiFieldTests extends ElasticsearchSingleNodeTest {
         assertThat(f.fieldType().stored(), equalTo(true));
         assertEquals(IndexOptions.NONE, f.fieldType().indexOptions());
 
-        assertThat(docMapper.mappers().fullName("name").mapper(), notNullValue());
-        assertThat(docMapper.mappers().fullName("name").mapper(), instanceOf(StringFieldMapper.class));
-        assertEquals(IndexOptions.NONE, docMapper.mappers().fullName("name").mapper().fieldType().indexOptions());
-        assertThat(docMapper.mappers().fullName("name").mapper().fieldType().stored(), equalTo(false));
-        assertThat(docMapper.mappers().fullName("name").mapper().fieldType().tokenized(), equalTo(true));
+        assertThat(docMapper.mappers().getMapper("name"), notNullValue());
+        assertThat(docMapper.mappers().getMapper("name"), instanceOf(StringFieldMapper.class));
+        assertEquals(IndexOptions.NONE, docMapper.mappers().getMapper("name").fieldType().indexOptions());
+        assertThat(docMapper.mappers().getMapper("name").fieldType().stored(), equalTo(false));
+        assertThat(docMapper.mappers().getMapper("name").fieldType().tokenized(), equalTo(true));
 
-        assertThat(docMapper.mappers().fullName("name.indexed").mapper(), notNullValue());
-        assertThat(docMapper.mappers().fullName("name.indexed").mapper(), instanceOf(StringFieldMapper.class));
-        assertNotNull(docMapper.mappers().fullName("name.indexed").mapper().fieldType().indexOptions());
-        assertThat(docMapper.mappers().fullName("name.indexed").mapper().fieldType().stored(), equalTo(false));
-        assertThat(docMapper.mappers().fullName("name.indexed").mapper().fieldType().tokenized(), equalTo(true));
+        assertThat(docMapper.mappers().getMapper("name.indexed"), notNullValue());
+        assertThat(docMapper.mappers().getMapper("name.indexed"), instanceOf(StringFieldMapper.class));
+        assertNotNull(docMapper.mappers().getMapper("name.indexed").fieldType().indexOptions());
+        assertThat(docMapper.mappers().getMapper("name.indexed").fieldType().stored(), equalTo(false));
+        assertThat(docMapper.mappers().getMapper("name.indexed").fieldType().tokenized(), equalTo(true));
 
-        assertThat(docMapper.mappers().fullName("name.not_indexed").mapper(), notNullValue());
-        assertThat(docMapper.mappers().fullName("name.not_indexed").mapper(), instanceOf(StringFieldMapper.class));
-        assertEquals(IndexOptions.NONE, docMapper.mappers().fullName("name.not_indexed").mapper().fieldType().indexOptions());
-        assertThat(docMapper.mappers().fullName("name.not_indexed").mapper().fieldType().stored(), equalTo(true));
-        assertThat(docMapper.mappers().fullName("name.not_indexed").mapper().fieldType().tokenized(), equalTo(true));
+        assertThat(docMapper.mappers().getMapper("name.not_indexed"), notNullValue());
+        assertThat(docMapper.mappers().getMapper("name.not_indexed"), instanceOf(StringFieldMapper.class));
+        assertEquals(IndexOptions.NONE, docMapper.mappers().getMapper("name.not_indexed").fieldType().indexOptions());
+        assertThat(docMapper.mappers().getMapper("name.not_indexed").fieldType().stored(), equalTo(true));
+        assertThat(docMapper.mappers().getMapper("name.not_indexed").fieldType().tokenized(), equalTo(true));
 
         assertNull(doc.getField("age"));
         f = doc.getField("age.not_stored");
@@ -229,23 +229,23 @@ public class MultiFieldTests extends ElasticsearchSingleNodeTest {
         assertThat(f.fieldType().stored(), equalTo(true));
         assertNotSame(IndexOptions.NONE, f.fieldType().indexOptions());
 
-        assertThat(docMapper.mappers().fullName("age").mapper(), notNullValue());
-        assertThat(docMapper.mappers().fullName("age").mapper(), instanceOf(LongFieldMapper.class));
-        assertEquals(IndexOptions.NONE, docMapper.mappers().fullName("age").mapper().fieldType().indexOptions());
-        assertThat(docMapper.mappers().fullName("age").mapper().fieldType().stored(), equalTo(false));
-        assertThat(docMapper.mappers().fullName("age").mapper().fieldType().tokenized(), equalTo(false));
+        assertThat(docMapper.mappers().getMapper("age"), notNullValue());
+        assertThat(docMapper.mappers().getMapper("age"), instanceOf(LongFieldMapper.class));
+        assertEquals(IndexOptions.NONE, docMapper.mappers().getMapper("age").fieldType().indexOptions());
+        assertThat(docMapper.mappers().getMapper("age").fieldType().stored(), equalTo(false));
+        assertThat(docMapper.mappers().getMapper("age").fieldType().tokenized(), equalTo(false));
 
-        assertThat(docMapper.mappers().fullName("age.not_stored").mapper(), notNullValue());
-        assertThat(docMapper.mappers().fullName("age.not_stored").mapper(), instanceOf(LongFieldMapper.class));
-        assertNotSame(IndexOptions.NONE, docMapper.mappers().fullName("age.not_stored").mapper().fieldType().indexOptions());
-        assertThat(docMapper.mappers().fullName("age.not_stored").mapper().fieldType().stored(), equalTo(false));
-        assertThat(docMapper.mappers().fullName("age.not_stored").mapper().fieldType().tokenized(), equalTo(false));
+        assertThat(docMapper.mappers().getMapper("age.not_stored"), notNullValue());
+        assertThat(docMapper.mappers().getMapper("age.not_stored"), instanceOf(LongFieldMapper.class));
+        assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("age.not_stored").fieldType().indexOptions());
+        assertThat(docMapper.mappers().getMapper("age.not_stored").fieldType().stored(), equalTo(false));
+        assertThat(docMapper.mappers().getMapper("age.not_stored").fieldType().tokenized(), equalTo(false));
 
-        assertThat(docMapper.mappers().fullName("age.stored").mapper(), notNullValue());
-        assertThat(docMapper.mappers().fullName("age.stored").mapper(), instanceOf(LongFieldMapper.class));
-        assertNotSame(IndexOptions.NONE, docMapper.mappers().fullName("age.stored").mapper().fieldType().indexOptions());
-        assertThat(docMapper.mappers().fullName("age.stored").mapper().fieldType().stored(), equalTo(true));
-        assertThat(docMapper.mappers().fullName("age.stored").mapper().fieldType().tokenized(), equalTo(false));
+        assertThat(docMapper.mappers().getMapper("age.stored"), notNullValue());
+        assertThat(docMapper.mappers().getMapper("age.stored"), instanceOf(LongFieldMapper.class));
+        assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("age.stored").fieldType().indexOptions());
+        assertThat(docMapper.mappers().getMapper("age.stored").fieldType().stored(), equalTo(true));
+        assertThat(docMapper.mappers().getMapper("age.stored").fieldType().tokenized(), equalTo(false));
     }
 
     @Test
@@ -253,17 +253,17 @@ public class MultiFieldTests extends ElasticsearchSingleNodeTest {
         String mapping = copyToStringFromClasspath("/org/elasticsearch/index/mapper/multifield/test-multi-field-type-geo_point.json");
         DocumentMapper docMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
 
-        assertThat(docMapper.mappers().fullName("a").mapper(), notNullValue());
-        assertThat(docMapper.mappers().fullName("a").mapper(), instanceOf(StringFieldMapper.class));
-        assertNotSame(IndexOptions.NONE, docMapper.mappers().fullName("a").mapper().fieldType().indexOptions());
-        assertThat(docMapper.mappers().fullName("a").mapper().fieldType().stored(), equalTo(false));
-        assertThat(docMapper.mappers().fullName("a").mapper().fieldType().tokenized(), equalTo(false));
+        assertThat(docMapper.mappers().getMapper("a"), notNullValue());
+        assertThat(docMapper.mappers().getMapper("a"), instanceOf(StringFieldMapper.class));
+        assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("a").fieldType().indexOptions());
+        assertThat(docMapper.mappers().getMapper("a").fieldType().stored(), equalTo(false));
+        assertThat(docMapper.mappers().getMapper("a").fieldType().tokenized(), equalTo(false));
 
-        assertThat(docMapper.mappers().fullName("a.b").mapper(), notNullValue());
-        assertThat(docMapper.mappers().fullName("a.b").mapper(), instanceOf(GeoPointFieldMapper.class));
-        assertNotSame(IndexOptions.NONE, docMapper.mappers().fullName("a.b").mapper().fieldType().indexOptions());
-        assertThat(docMapper.mappers().fullName("a.b").mapper().fieldType().stored(), equalTo(false));
-        assertThat(docMapper.mappers().fullName("a.b").mapper().fieldType().tokenized(), equalTo(false));
+        assertThat(docMapper.mappers().getMapper("a.b"), notNullValue());
+        assertThat(docMapper.mappers().getMapper("a.b"), instanceOf(GeoPointFieldMapper.class));
+        assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("a.b").fieldType().indexOptions());
+        assertThat(docMapper.mappers().getMapper("a.b").fieldType().stored(), equalTo(false));
+        assertThat(docMapper.mappers().getMapper("a.b").fieldType().tokenized(), equalTo(false));
 
         BytesReference json = jsonBuilder().startObject()
                 .field("_id", "1")
@@ -285,17 +285,17 @@ public class MultiFieldTests extends ElasticsearchSingleNodeTest {
         assertThat(f.fieldType().stored(), equalTo(false));
         assertNotSame(IndexOptions.NONE, f.fieldType().indexOptions());
 
-        assertThat(docMapper.mappers().fullName("b").mapper(), notNullValue());
-        assertThat(docMapper.mappers().fullName("b").mapper(), instanceOf(GeoPointFieldMapper.class));
-        assertNotSame(IndexOptions.NONE, docMapper.mappers().fullName("b").mapper().fieldType().indexOptions());
-        assertThat(docMapper.mappers().fullName("b").mapper().fieldType().stored(), equalTo(false));
-        assertThat(docMapper.mappers().fullName("b").mapper().fieldType().tokenized(), equalTo(false));
+        assertThat(docMapper.mappers().getMapper("b"), notNullValue());
+        assertThat(docMapper.mappers().getMapper("b"), instanceOf(GeoPointFieldMapper.class));
+        assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("b").fieldType().indexOptions());
+        assertThat(docMapper.mappers().getMapper("b").fieldType().stored(), equalTo(false));
+        assertThat(docMapper.mappers().getMapper("b").fieldType().tokenized(), equalTo(false));
 
-        assertThat(docMapper.mappers().fullName("b.a").mapper(), notNullValue());
-        assertThat(docMapper.mappers().fullName("b.a").mapper(), instanceOf(StringFieldMapper.class));
-        assertNotSame(IndexOptions.NONE, docMapper.mappers().fullName("b.a").mapper().fieldType().indexOptions());
-        assertThat(docMapper.mappers().fullName("b.a").mapper().fieldType().stored(), equalTo(false));
-        assertThat(docMapper.mappers().fullName("b.a").mapper().fieldType().tokenized(), equalTo(false));
+        assertThat(docMapper.mappers().getMapper("b.a"), notNullValue());
+        assertThat(docMapper.mappers().getMapper("b.a"), instanceOf(StringFieldMapper.class));
+        assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("b.a").fieldType().indexOptions());
+        assertThat(docMapper.mappers().getMapper("b.a").fieldType().stored(), equalTo(false));
+        assertThat(docMapper.mappers().getMapper("b.a").fieldType().tokenized(), equalTo(false));
 
         json = jsonBuilder().startObject()
                 .field("_id", "1")
@@ -353,17 +353,17 @@ public class MultiFieldTests extends ElasticsearchSingleNodeTest {
         String mapping = copyToStringFromClasspath("/org/elasticsearch/index/mapper/multifield/test-multi-field-type-completion.json");
         DocumentMapper docMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
 
-        assertThat(docMapper.mappers().fullName("a").mapper(), notNullValue());
-        assertThat(docMapper.mappers().fullName("a").mapper(), instanceOf(StringFieldMapper.class));
-        assertNotSame(IndexOptions.NONE, docMapper.mappers().fullName("a").mapper().fieldType().indexOptions());
-        assertThat(docMapper.mappers().fullName("a").mapper().fieldType().stored(), equalTo(false));
-        assertThat(docMapper.mappers().fullName("a").mapper().fieldType().tokenized(), equalTo(false));
+        assertThat(docMapper.mappers().getMapper("a"), notNullValue());
+        assertThat(docMapper.mappers().getMapper("a"), instanceOf(StringFieldMapper.class));
+        assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("a").fieldType().indexOptions());
+        assertThat(docMapper.mappers().getMapper("a").fieldType().stored(), equalTo(false));
+        assertThat(docMapper.mappers().getMapper("a").fieldType().tokenized(), equalTo(false));
 
-        assertThat(docMapper.mappers().fullName("a.b").mapper(), notNullValue());
-        assertThat(docMapper.mappers().fullName("a.b").mapper(), instanceOf(CompletionFieldMapper.class));
-        assertNotSame(IndexOptions.NONE, docMapper.mappers().fullName("a.b").mapper().fieldType().indexOptions());
-        assertThat(docMapper.mappers().fullName("a.b").mapper().fieldType().stored(), equalTo(false));
-        assertThat(docMapper.mappers().fullName("a.b").mapper().fieldType().tokenized(), equalTo(true));
+        assertThat(docMapper.mappers().getMapper("a.b"), notNullValue());
+        assertThat(docMapper.mappers().getMapper("a.b"), instanceOf(CompletionFieldMapper.class));
+        assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("a.b").fieldType().indexOptions());
+        assertThat(docMapper.mappers().getMapper("a.b").fieldType().stored(), equalTo(false));
+        assertThat(docMapper.mappers().getMapper("a.b").fieldType().tokenized(), equalTo(true));
 
         BytesReference json = jsonBuilder().startObject()
                 .field("_id", "1")
@@ -385,17 +385,17 @@ public class MultiFieldTests extends ElasticsearchSingleNodeTest {
         assertThat(f.fieldType().stored(), equalTo(false));
         assertNotSame(IndexOptions.NONE, f.fieldType().indexOptions());
 
-        assertThat(docMapper.mappers().fullName("b").mapper(), notNullValue());
-        assertThat(docMapper.mappers().fullName("b").mapper(), instanceOf(CompletionFieldMapper.class));
-        assertNotSame(IndexOptions.NONE, docMapper.mappers().fullName("b").mapper().fieldType().indexOptions());
-        assertThat(docMapper.mappers().fullName("b").mapper().fieldType().stored(), equalTo(false));
-        assertThat(docMapper.mappers().fullName("b").mapper().fieldType().tokenized(), equalTo(true));
+        assertThat(docMapper.mappers().getMapper("b"), notNullValue());
+        assertThat(docMapper.mappers().getMapper("b"), instanceOf(CompletionFieldMapper.class));
+        assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("b").fieldType().indexOptions());
+        assertThat(docMapper.mappers().getMapper("b").fieldType().stored(), equalTo(false));
+        assertThat(docMapper.mappers().getMapper("b").fieldType().tokenized(), equalTo(true));
 
-        assertThat(docMapper.mappers().fullName("b.a").mapper(), notNullValue());
-        assertThat(docMapper.mappers().fullName("b.a").mapper(), instanceOf(StringFieldMapper.class));
-        assertNotSame(IndexOptions.NONE, docMapper.mappers().fullName("b.a").mapper().fieldType().indexOptions());
-        assertThat(docMapper.mappers().fullName("b.a").mapper().fieldType().stored(), equalTo(false));
-        assertThat(docMapper.mappers().fullName("b.a").mapper().fieldType().tokenized(), equalTo(false));
+        assertThat(docMapper.mappers().getMapper("b.a"), notNullValue());
+        assertThat(docMapper.mappers().getMapper("b.a"), instanceOf(StringFieldMapper.class));
+        assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("b.a").fieldType().indexOptions());
+        assertThat(docMapper.mappers().getMapper("b.a").fieldType().stored(), equalTo(false));
+        assertThat(docMapper.mappers().getMapper("b.a").fieldType().tokenized(), equalTo(false));
 
         json = jsonBuilder().startObject()
                 .field("_id", "1")

--- a/src/test/java/org/elasticsearch/index/mapper/multifield/merge/JavaMultiFieldMergeTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/multifield/merge/JavaMultiFieldMergeTests.java
@@ -48,8 +48,8 @@ public class JavaMultiFieldMergeTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper docMapper = parser.parse(mapping);
 
-        assertNotSame(IndexOptions.NONE, docMapper.mappers().fullName("name").mapper().fieldType().indexOptions());
-        assertThat(docMapper.mappers().fullName("name.indexed"), nullValue());
+        assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("name").fieldType().indexOptions());
+        assertThat(docMapper.mappers().getMapper("name.indexed"), nullValue());
 
         BytesReference json = new BytesArray(copyToBytesFromClasspath("/org/elasticsearch/index/mapper/multifield/merge/test-data.json"));
         Document doc = docMapper.parse(json).rootDoc();
@@ -67,13 +67,13 @@ public class JavaMultiFieldMergeTests extends ElasticsearchSingleNodeTest {
 
         docMapper.merge(docMapper2.mapping(), mergeFlags().simulate(false));
 
-        assertNotSame(IndexOptions.NONE, docMapper.mappers().name("name").mapper().fieldType().indexOptions());
+        assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("name").fieldType().indexOptions());
 
-        assertNotSame(IndexOptions.NONE, docMapper.mappers().fullName("name").mapper().fieldType().indexOptions());
-        assertThat(docMapper.mappers().fullName("name.indexed").mapper(), notNullValue());
-        assertThat(docMapper.mappers().fullName("name.not_indexed").mapper(), notNullValue());
-        assertThat(docMapper.mappers().fullName("name.not_indexed2"), nullValue());
-        assertThat(docMapper.mappers().fullName("name.not_indexed3"), nullValue());
+        assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("name").fieldType().indexOptions());
+        assertThat(docMapper.mappers().getMapper("name.indexed"), notNullValue());
+        assertThat(docMapper.mappers().getMapper("name.not_indexed"), notNullValue());
+        assertThat(docMapper.mappers().getMapper("name.not_indexed2"), nullValue());
+        assertThat(docMapper.mappers().getMapper("name.not_indexed3"), nullValue());
 
         json = new BytesArray(copyToBytesFromClasspath("/org/elasticsearch/index/mapper/multifield/merge/test-data.json"));
         doc = docMapper.parse(json).rootDoc();
@@ -90,13 +90,13 @@ public class JavaMultiFieldMergeTests extends ElasticsearchSingleNodeTest {
 
         docMapper.merge(docMapper3.mapping(), mergeFlags().simulate(false));
 
-        assertNotSame(IndexOptions.NONE, docMapper.mappers().name("name").mapper().fieldType().indexOptions());
+        assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("name").fieldType().indexOptions());
 
-        assertNotSame(IndexOptions.NONE, docMapper.mappers().fullName("name").mapper().fieldType().indexOptions());
-        assertThat(docMapper.mappers().fullName("name.indexed").mapper(), notNullValue());
-        assertThat(docMapper.mappers().fullName("name.not_indexed").mapper(), notNullValue());
-        assertThat(docMapper.mappers().fullName("name.not_indexed2").mapper(), notNullValue());
-        assertThat(docMapper.mappers().fullName("name.not_indexed3"), nullValue());
+        assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("name").fieldType().indexOptions());
+        assertThat(docMapper.mappers().getMapper("name.indexed"), notNullValue());
+        assertThat(docMapper.mappers().getMapper("name.not_indexed"), notNullValue());
+        assertThat(docMapper.mappers().getMapper("name.not_indexed2"), notNullValue());
+        assertThat(docMapper.mappers().getMapper("name.not_indexed3"), nullValue());
 
 
         mapping = copyToStringFromClasspath("/org/elasticsearch/index/mapper/multifield/merge/test-mapping4.json");
@@ -108,13 +108,13 @@ public class JavaMultiFieldMergeTests extends ElasticsearchSingleNodeTest {
 
         docMapper.merge(docMapper4.mapping(), mergeFlags().simulate(false));
 
-        assertNotSame(IndexOptions.NONE, docMapper.mappers().name("name").mapper().fieldType().indexOptions());
+        assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("name").fieldType().indexOptions());
 
-        assertNotSame(IndexOptions.NONE, docMapper.mappers().fullName("name").mapper().fieldType().indexOptions());
-        assertThat(docMapper.mappers().fullName("name.indexed").mapper(), notNullValue());
-        assertThat(docMapper.mappers().fullName("name.not_indexed").mapper(), notNullValue());
-        assertThat(docMapper.mappers().fullName("name.not_indexed2").mapper(), notNullValue());
-        assertThat(docMapper.mappers().fullName("name.not_indexed3").mapper(), notNullValue());
+        assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("name").fieldType().indexOptions());
+        assertThat(docMapper.mappers().getMapper("name.indexed"), notNullValue());
+        assertThat(docMapper.mappers().getMapper("name.not_indexed"), notNullValue());
+        assertThat(docMapper.mappers().getMapper("name.not_indexed2"), notNullValue());
+        assertThat(docMapper.mappers().getMapper("name.not_indexed3"), notNullValue());
     }
 
     @Test
@@ -124,8 +124,8 @@ public class JavaMultiFieldMergeTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper docMapper = parser.parse(mapping);
 
-        assertNotSame(IndexOptions.NONE, docMapper.mappers().fullName("name").mapper().fieldType().indexOptions());
-        assertThat(docMapper.mappers().fullName("name.indexed"), nullValue());
+        assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("name").fieldType().indexOptions());
+        assertThat(docMapper.mappers().getMapper("name.indexed"), nullValue());
 
         BytesReference json = new BytesArray(copyToBytesFromClasspath("/org/elasticsearch/index/mapper/multifield/merge/test-data.json"));
         Document doc = docMapper.parse(json).rootDoc();
@@ -143,13 +143,13 @@ public class JavaMultiFieldMergeTests extends ElasticsearchSingleNodeTest {
 
         docMapper.merge(docMapper2.mapping(), mergeFlags().simulate(false));
 
-        assertNotSame(IndexOptions.NONE, docMapper.mappers().name("name").mapper().fieldType().indexOptions());
+        assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("name").fieldType().indexOptions());
 
-        assertNotSame(IndexOptions.NONE, docMapper.mappers().fullName("name").mapper().fieldType().indexOptions());
-        assertThat(docMapper.mappers().fullName("name.indexed").mapper(), notNullValue());
-        assertThat(docMapper.mappers().fullName("name.not_indexed").mapper(), notNullValue());
-        assertThat(docMapper.mappers().fullName("name.not_indexed2"), nullValue());
-        assertThat(docMapper.mappers().fullName("name.not_indexed3"), nullValue());
+        assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("name").fieldType().indexOptions());
+        assertThat(docMapper.mappers().getMapper("name.indexed"), notNullValue());
+        assertThat(docMapper.mappers().getMapper("name.not_indexed"), notNullValue());
+        assertThat(docMapper.mappers().getMapper("name.not_indexed2"), nullValue());
+        assertThat(docMapper.mappers().getMapper("name.not_indexed3"), nullValue());
 
         json = new BytesArray(copyToBytesFromClasspath("/org/elasticsearch/index/mapper/multifield/merge/test-data.json"));
         doc = docMapper.parse(json).rootDoc();
@@ -166,13 +166,13 @@ public class JavaMultiFieldMergeTests extends ElasticsearchSingleNodeTest {
 
         docMapper.merge(docMapper3.mapping(), mergeFlags().simulate(false));
 
-        assertNotSame(IndexOptions.NONE, docMapper.mappers().name("name").mapper().fieldType().indexOptions());
+        assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("name").fieldType().indexOptions());
 
-        assertNotSame(IndexOptions.NONE, docMapper.mappers().fullName("name").mapper().fieldType().indexOptions());
-        assertThat(docMapper.mappers().fullName("name.indexed").mapper(), notNullValue());
-        assertThat(docMapper.mappers().fullName("name.not_indexed").mapper(), notNullValue());
-        assertThat(docMapper.mappers().fullName("name.not_indexed2").mapper(), notNullValue());
-        assertThat(docMapper.mappers().fullName("name.not_indexed3"), nullValue());
+        assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("name").fieldType().indexOptions());
+        assertThat(docMapper.mappers().getMapper("name.indexed"), notNullValue());
+        assertThat(docMapper.mappers().getMapper("name.not_indexed"), notNullValue());
+        assertThat(docMapper.mappers().getMapper("name.not_indexed2"), notNullValue());
+        assertThat(docMapper.mappers().getMapper("name.not_indexed3"), nullValue());
 
 
         mapping = copyToStringFromClasspath("/org/elasticsearch/index/mapper/multifield/merge/upgrade3.json");
@@ -185,15 +185,15 @@ public class JavaMultiFieldMergeTests extends ElasticsearchSingleNodeTest {
         mergeResult = docMapper.merge(docMapper4.mapping(), mergeFlags().simulate(false));
         assertThat(Arrays.toString(mergeResult.conflicts()), mergeResult.hasConflicts(), equalTo(true));
 
-        assertNotSame(IndexOptions.NONE, docMapper.mappers().name("name").mapper().fieldType().indexOptions());
+        assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("name").fieldType().indexOptions());
         assertThat(mergeResult.conflicts()[0], equalTo("mapper [name] has different index values"));
         assertThat(mergeResult.conflicts()[1], equalTo("mapper [name] has different store values"));
 
         // There are conflicts, but the `name.not_indexed3` has been added, b/c that field has no conflicts
-        assertNotSame(IndexOptions.NONE, docMapper.mappers().fullName("name").mapper().fieldType().indexOptions());
-        assertThat(docMapper.mappers().fullName("name.indexed").mapper(), notNullValue());
-        assertThat(docMapper.mappers().fullName("name.not_indexed").mapper(), notNullValue());
-        assertThat(docMapper.mappers().fullName("name.not_indexed2").mapper(), notNullValue());
-        assertThat(docMapper.mappers().fullName("name.not_indexed3").mapper(), notNullValue());
+        assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("name").fieldType().indexOptions());
+        assertThat(docMapper.mappers().getMapper("name.indexed"), notNullValue());
+        assertThat(docMapper.mappers().getMapper("name.not_indexed"), notNullValue());
+        assertThat(docMapper.mappers().getMapper("name.not_indexed2"), notNullValue());
+        assertThat(docMapper.mappers().getMapper("name.not_indexed3"), notNullValue());
     }
 }

--- a/src/test/java/org/elasticsearch/index/mapper/path/PathMapperTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/path/PathMapperTests.java
@@ -40,18 +40,18 @@ public class PathMapperTests extends ElasticsearchSingleNodeTest {
         DocumentMapper docMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
 
         // test full name
-        assertThat(docMapper.mappers().fullName("first1"), nullValue());
-        assertThat(docMapper.mappers().fullName("name1.first1"), notNullValue());
-        assertThat(docMapper.mappers().fullName("last1"), nullValue());
-        assertThat(docMapper.mappers().fullName("i_last_1"), nullValue());
-        assertThat(docMapper.mappers().fullName("name1.last1"), notNullValue());
-        assertThat(docMapper.mappers().fullName("name1.i_last_1"), nullValue());
+        assertThat(docMapper.mappers().getMapper("first1"), nullValue());
+        assertThat(docMapper.mappers().getMapper("name1.first1"), notNullValue());
+        assertThat(docMapper.mappers().getMapper("last1"), nullValue());
+        assertThat(docMapper.mappers().getMapper("i_last_1"), nullValue());
+        assertThat(docMapper.mappers().getMapper("name1.last1"), notNullValue());
+        assertThat(docMapper.mappers().getMapper("name1.i_last_1"), nullValue());
 
-        assertThat(docMapper.mappers().fullName("first2"), nullValue());
-        assertThat(docMapper.mappers().fullName("name2.first2"), notNullValue());
-        assertThat(docMapper.mappers().fullName("last2"), nullValue());
-        assertThat(docMapper.mappers().fullName("i_last_2"), nullValue());
-        assertThat(docMapper.mappers().fullName("name2.i_last_2"), nullValue());
-        assertThat(docMapper.mappers().fullName("name2.last2"), notNullValue());
+        assertThat(docMapper.mappers().getMapper("first2"), nullValue());
+        assertThat(docMapper.mappers().getMapper("name2.first2"), notNullValue());
+        assertThat(docMapper.mappers().getMapper("last2"), nullValue());
+        assertThat(docMapper.mappers().getMapper("i_last_2"), nullValue());
+        assertThat(docMapper.mappers().getMapper("name2.i_last_2"), nullValue());
+        assertThat(docMapper.mappers().getMapper("name2.last2"), notNullValue());
     }
 }

--- a/src/test/java/org/elasticsearch/index/mapper/simple/SimpleMapperTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/simple/SimpleMapperTests.java
@@ -53,7 +53,7 @@ public class SimpleMapperTests extends ElasticsearchSingleNodeTest {
         BytesReference json = new BytesArray(copyToBytesFromClasspath("/org/elasticsearch/index/mapper/simple/test1.json"));
         Document doc = docMapper.parse("person", "1", json).rootDoc();
 
-        assertThat(doc.get(docMapper.mappers().name("name.first").mapper().names().indexName()), equalTo("shay"));
+        assertThat(doc.get(docMapper.mappers().getMapper("name.first").names().indexName()), equalTo("shay"));
 //        System.out.println("Document: " + doc);
 //        System.out.println("Json: " + docMapper.sourceMapper().value(doc));
         doc = docMapper.parse(json).rootDoc();
@@ -73,7 +73,7 @@ public class SimpleMapperTests extends ElasticsearchSingleNodeTest {
         BytesReference json = new BytesArray(copyToBytesFromClasspath("/org/elasticsearch/index/mapper/simple/test1.json"));
         Document doc = builtDocMapper.parse(json).rootDoc();
         assertThat(doc.get(docMapper.uidMapper().names().indexName()), equalTo(Uid.createUid("person", "1")));
-        assertThat(doc.get(docMapper.mappers().name("name.first").mapper().names().indexName()), equalTo("shay"));
+        assertThat(doc.get(docMapper.mappers().getMapper("name.first").names().indexName()), equalTo("shay"));
 //        System.out.println("Document: " + doc);
 //        System.out.println("Json: " + docMapper.sourceMapper().value(doc));
     }
@@ -88,7 +88,7 @@ public class SimpleMapperTests extends ElasticsearchSingleNodeTest {
         BytesReference json = new BytesArray(copyToBytesFromClasspath("/org/elasticsearch/index/mapper/simple/test1.json"));
         Document doc = docMapper.parse(json).rootDoc();
         assertThat(doc.get(docMapper.uidMapper().names().indexName()), equalTo(Uid.createUid("person", "1")));
-        assertThat(doc.get(docMapper.mappers().name("name.first").mapper().names().indexName()), equalTo("shay"));
+        assertThat(doc.get(docMapper.mappers().getMapper("name.first").names().indexName()), equalTo("shay"));
 //        System.out.println("Document: " + doc);
 //        System.out.println("Json: " + docMapper.sourceMapper().value(doc));
     }
@@ -100,7 +100,7 @@ public class SimpleMapperTests extends ElasticsearchSingleNodeTest {
         BytesReference json = new BytesArray(copyToBytesFromClasspath("/org/elasticsearch/index/mapper/simple/test1-notype-noid.json"));
         Document doc = docMapper.parse("person", "1", json).rootDoc();
         assertThat(doc.get(docMapper.uidMapper().names().indexName()), equalTo(Uid.createUid("person", "1")));
-        assertThat(doc.get(docMapper.mappers().name("name.first").mapper().names().indexName()), equalTo("shay"));
+        assertThat(doc.get(docMapper.mappers().getMapper("name.first").names().indexName()), equalTo("shay"));
 //        System.out.println("Document: " + doc);
 //        System.out.println("Json: " + docMapper.sourceMapper().value(doc));
     }

--- a/src/test/java/org/elasticsearch/index/mapper/string/SimpleStringMappingTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/string/SimpleStringMappingTests.java
@@ -527,7 +527,7 @@ public class SimpleStringMappingTests extends ElasticsearchSingleNodeTest {
                 .endObject().endObject().string();
 
         DocumentMapper defaultMapper = parser.parse(mapping);
-        FieldMapper<?> mapper = defaultMapper.mappers().fullName("field").mapper();
+        FieldMapper<?> mapper = defaultMapper.mappers().getMapper("field");
         assertNotNull(mapper);
         assertTrue(mapper instanceof StringFieldMapper);
         assertEquals(Queries.newMatchNoDocsFilter(), mapper.termsFilter(Collections.emptyList(), null));

--- a/src/test/java/org/elasticsearch/index/similarity/SimilarityTests.java
+++ b/src/test/java/org/elasticsearch/index/similarity/SimilarityTests.java
@@ -57,9 +57,9 @@ public class SimilarityTests extends ElasticsearchSingleNodeTest {
                 .build();
         SimilarityService similarityService = createIndex("foo", indexSettings).similarityService();
         DocumentMapper documentMapper = similarityService.mapperService().documentMapperParser().parse(mapping);
-        assertThat(documentMapper.mappers().name("field1").mapper().similarity(), instanceOf(DefaultSimilarityProvider.class));
+        assertThat(documentMapper.mappers().getMapper("field1").similarity(), instanceOf(DefaultSimilarityProvider.class));
 
-        DefaultSimilarity similarity = (DefaultSimilarity) documentMapper.mappers().name("field1").mapper().similarity().get();
+        DefaultSimilarity similarity = (DefaultSimilarity) documentMapper.mappers().getMapper("field1").similarity().get();
         assertThat(similarity.getDiscountOverlaps(), equalTo(false));
     }
 
@@ -79,9 +79,9 @@ public class SimilarityTests extends ElasticsearchSingleNodeTest {
                 .build();
         SimilarityService similarityService = createIndex("foo", indexSettings).similarityService();
         DocumentMapper documentMapper = similarityService.mapperService().documentMapperParser().parse(mapping);
-        assertThat(documentMapper.mappers().name("field1").mapper().similarity(), instanceOf(BM25SimilarityProvider.class));
+        assertThat(documentMapper.mappers().getMapper("field1").similarity(), instanceOf(BM25SimilarityProvider.class));
 
-        BM25Similarity similarity = (BM25Similarity) documentMapper.mappers().name("field1").mapper().similarity().get();
+        BM25Similarity similarity = (BM25Similarity) documentMapper.mappers().getMapper("field1").similarity().get();
         assertThat(similarity.getK1(), equalTo(2.0f));
         assertThat(similarity.getB(), equalTo(1.5f));
         assertThat(similarity.getDiscountOverlaps(), equalTo(false));
@@ -104,9 +104,9 @@ public class SimilarityTests extends ElasticsearchSingleNodeTest {
                 .build();
         SimilarityService similarityService = createIndex("foo", indexSettings).similarityService();
         DocumentMapper documentMapper = similarityService.mapperService().documentMapperParser().parse(mapping);
-        assertThat(documentMapper.mappers().name("field1").mapper().similarity(), instanceOf(DFRSimilarityProvider.class));
+        assertThat(documentMapper.mappers().getMapper("field1").similarity(), instanceOf(DFRSimilarityProvider.class));
 
-        DFRSimilarity similarity = (DFRSimilarity) documentMapper.mappers().name("field1").mapper().similarity().get();
+        DFRSimilarity similarity = (DFRSimilarity) documentMapper.mappers().getMapper("field1").similarity().get();
         assertThat(similarity.getBasicModel(), instanceOf(BasicModelG.class));
         assertThat(similarity.getAfterEffect(), instanceOf(AfterEffectL.class));
         assertThat(similarity.getNormalization(), instanceOf(NormalizationH2.class));
@@ -130,9 +130,9 @@ public class SimilarityTests extends ElasticsearchSingleNodeTest {
                 .build();
         SimilarityService similarityService = createIndex("foo", indexSettings).similarityService();
         DocumentMapper documentMapper = similarityService.mapperService().documentMapperParser().parse(mapping);
-        assertThat(documentMapper.mappers().name("field1").mapper().similarity(), instanceOf(IBSimilarityProvider.class));
+        assertThat(documentMapper.mappers().getMapper("field1").similarity(), instanceOf(IBSimilarityProvider.class));
 
-        IBSimilarity similarity = (IBSimilarity) documentMapper.mappers().name("field1").mapper().similarity().get();
+        IBSimilarity similarity = (IBSimilarity) documentMapper.mappers().getMapper("field1").similarity().get();
         assertThat(similarity.getDistribution(), instanceOf(DistributionSPL.class));
         assertThat(similarity.getLambda(), instanceOf(LambdaTTF.class));
         assertThat(similarity.getNormalization(), instanceOf(NormalizationH2.class));
@@ -153,9 +153,9 @@ public class SimilarityTests extends ElasticsearchSingleNodeTest {
                 .build();
         SimilarityService similarityService = createIndex("foo", indexSettings).similarityService();
         DocumentMapper documentMapper = similarityService.mapperService().documentMapperParser().parse(mapping);
-        assertThat(documentMapper.mappers().name("field1").mapper().similarity(), instanceOf(LMDirichletSimilarityProvider.class));
+        assertThat(documentMapper.mappers().getMapper("field1").similarity(), instanceOf(LMDirichletSimilarityProvider.class));
 
-        LMDirichletSimilarity similarity = (LMDirichletSimilarity) documentMapper.mappers().name("field1").mapper().similarity().get();
+        LMDirichletSimilarity similarity = (LMDirichletSimilarity) documentMapper.mappers().getMapper("field1").similarity().get();
         assertThat(similarity.getMu(), equalTo(3000f));
     }
 
@@ -173,9 +173,9 @@ public class SimilarityTests extends ElasticsearchSingleNodeTest {
                 .build();
         SimilarityService similarityService = createIndex("foo", indexSettings).similarityService();
         DocumentMapper documentMapper = similarityService.mapperService().documentMapperParser().parse(mapping);
-        assertThat(documentMapper.mappers().name("field1").mapper().similarity(), instanceOf(LMJelinekMercerSimilarityProvider.class));
+        assertThat(documentMapper.mappers().getMapper("field1").similarity(), instanceOf(LMJelinekMercerSimilarityProvider.class));
 
-        LMJelinekMercerSimilarity similarity = (LMJelinekMercerSimilarity) documentMapper.mappers().name("field1").mapper().similarity().get();
+        LMJelinekMercerSimilarity similarity = (LMJelinekMercerSimilarity) documentMapper.mappers().getMapper("field1").similarity().get();
         assertThat(similarity.getLambda(), equalTo(0.7f));
     }
 }


### PR DESCRIPTION
We no longer support overriding field index names, but the lookup
data structures still optimize for this use case. This complicates
the work for #8871.  Instead, we can use a lookup structure
by making the legacy case slower.

This change simplifies the field mappers lookup to only
store a single map, keyed by the field's full name. It also
changes a lot of tests to decrease the uses of the older api
(looking up by index name where the index name is different
than the field name).
