### PR TITLE
Fix JVM isolation in tests.

### DIFF
--- a/dev-tools/tests.policy
+++ b/dev-tools/tests.policy
@@ -35,7 +35,6 @@ grant {
   // per-jvm directory
   permission java.io.FilePermission "${junit4.childvm.cwd}${/}temp", "read,write";
   permission java.io.FilePermission "${junit4.childvm.cwd}${/}temp${/}-", "read,write,delete";
-  //permission java.io.FilePermission "${junit4.tempDir}${/}*", "read,write,delete";
 
   permission java.nio.file.LinkPermission "symbolic";
   permission groovy.security.GroovyCodeSourcePermission "/groovy/script";

--- a/dev-tools/tests.policy
+++ b/dev-tools/tests.policy
@@ -32,9 +32,11 @@ grant {
   permission java.io.FilePermission "${m2.repository}${/}-", "read";
   // system jar resources
   permission java.io.FilePermission "${java.home}${/}-", "read";
+  // per-jvm directory
   permission java.io.FilePermission "${junit4.childvm.cwd}${/}temp", "read,write";
   permission java.io.FilePermission "${junit4.childvm.cwd}${/}temp${/}-", "read,write,delete";
-  permission java.io.FilePermission "${junit4.tempDir}${/}*", "read,write,delete";
+  //permission java.io.FilePermission "${junit4.tempDir}${/}*", "read,write,delete";
+
   permission java.nio.file.LinkPermission "symbolic";
   permission groovy.security.GroovyCodeSourcePermission "/groovy/script";
 

--- a/pom.xml
+++ b/pom.xml
@@ -627,8 +627,7 @@
                                 <tests.security.manager>${tests.security.manager}</tests.security.manager>
                                 <tests.compatibility>${tests.compatibility}</tests.compatibility>
                                 <java.awt.headless>true</java.awt.headless>
-                                <!-- everything below is for security manager / test.policy -->
-                                <junit4.tempDir>${project.build.directory}</junit4.tempDir>
+                                <!-- security manager / test.policy -->
                                 <java.security.policy>${basedir}/dev-tools/tests.policy</java.security.policy>
                             </systemProperties>
                         </configuration>


### PR DESCRIPTION
Currently security manager would allow for one JVM to muck
with the files (read, write, AND delete) of another JVM.

This is unnecessary.
