### PR TITLE
Phrase Suggester Collate Enhancements

### DIFF
--- a/docs/reference/search/suggesters/phrase-suggest.asciidoc
+++ b/docs/reference/search/suggesters/phrase-suggest.asciidoc
@@ -171,12 +171,19 @@ can contain misspellings (See parameter descriptions below).
     template `params` -- the `suggestion` value will be added to the
     variables you specify. You can specify a `preference` to control
     on which shards the query is executed (see <<search-request-preference>>).
-    The default value is `_only_local`. Additionally, you can specify
+    The default value is `_only_local`. You can specify a `routing` to control
+    on which shards the collate `query` or `filter` should route to
+    (see <<search.html#search-routing>>). Specifying a `routing` value will
+    ignore the `preference` option. Additionally, you can specify
     a `prune` to control if all phrase suggestions will be
     returned, when set to `true` the suggestions will have an additional
     option `collate_match`, which will be `true` if matching documents
     for the phrase was found, `false` otherwise. The default value for
     `prune` is `false`.
+
+IMPORTANT: When using `collate` option, `preference` or `routing` has to be
+explicitly set for `collate`. The `preference` or `routing` value specified
+in the top level search will not be respected.
 
 [source,js]
 --------------------------------------------------

--- a/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestParser.java
+++ b/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestParser.java
@@ -161,6 +161,8 @@ public final class PhraseSuggestParser implements SuggestContextParser {
                             }
                         } else if ("preference".equals(fieldName)) {
                             suggestion.setPreference(parser.text());
+                        } else if ("routing".equals(fieldName)) {
+                            suggestion.setRouting(parser.text());
                         } else if ("params".equals(fieldName)) {
                             suggestion.setCollateScriptParams(parser.map());
                         } else if ("prune".equals(fieldName)) {

--- a/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilder.java
+++ b/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilder.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.search.suggest.phrase;
 
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.suggest.SuggestBuilder.SuggestionBuilder;
@@ -45,6 +46,7 @@ public final class PhraseSuggestionBuilder extends SuggestionBuilder<PhraseSugge
     private String collateQuery;
     private String collateFilter;
     private String collatePreference;
+    private String collateRouting;
     private Map<String, Object> collateParams;
     private Boolean collatePrune;
 
@@ -196,6 +198,21 @@ public final class PhraseSuggestionBuilder extends SuggestionBuilder<PhraseSugge
     }
 
     /**
+     * A comma separated list of routing values to control the shards the collate search will be executed on.
+     */
+    public PhraseSuggestionBuilder collateRouting(String routing) {
+        this.collateRouting = routing;
+        return this;
+    }
+
+    /**
+     * The routing values to control the shards that the collate search will be executed on.
+     */
+    public PhraseSuggestionBuilder collateRouting(String... routing) {
+        this.collateRouting = Strings.arrayToCommaDelimitedString(routing);
+        return this;
+    }
+    /**
      * Sets additional params for collate script
      */
     public PhraseSuggestionBuilder collateParams(Map<String, Object> collateParams) {
@@ -265,6 +282,9 @@ public final class PhraseSuggestionBuilder extends SuggestionBuilder<PhraseSugge
             }
             if (collatePreference != null) {
                 builder.field("preference", collatePreference);
+            }
+            if (collateRouting != null) {
+                builder.field("routing", collateRouting);
             }
             if (collateParams != null) {
                 builder.field("params", collateParams);

--- a/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionContext.java
+++ b/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionContext.java
@@ -27,6 +27,7 @@ import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.cluster.routing.Preference;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.script.CompiledScript;
 import org.elasticsearch.search.suggest.DirectSpellcheckerSettings;
 import org.elasticsearch.search.suggest.Suggester;
@@ -47,6 +48,7 @@ class PhraseSuggestionContext extends SuggestionContext {
     private CompiledScript collateQueryScript;
     private CompiledScript collateFilterScript;
     private String preference = Preference.ONLY_LOCAL.type();
+    private String routing;
     private Map<String, Object> collateScriptParams = new HashMap<>(1);
 
     private WordScorer.WordScorerFactory scorer;
@@ -212,6 +214,14 @@ class PhraseSuggestionContext extends SuggestionContext {
 
     void setPreference(String preference) {
         this.preference = preference;
+    }
+
+    String getRouting() {
+        return routing;
+    }
+
+    void setRouting(String routing) {
+        this.routing = routing;
     }
 
     Map<String, Object> getCollateScriptParams() {


### PR DESCRIPTION
Enhancements:
- Adds support for `routing` param in `collate` option to control which shards should execute `collate` requests.
- Ensures `collate` option works with concurrent client requests. (fixes #9377)
- doc clarification regarding use of `preference` or `routing` params.

closes #9377
