### PR TITLE
Execute tests with $JAVA_HOME.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -445,7 +445,7 @@
               </execution>
             </executions>
             <configuration>
-              <executable>${jvm.executable></executable>
+              <executable>${jvm.executable}</executable>
               <arguments>
                 <argument>-classpath</argument>
                 <classpath/>

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
         <tests.heap.size>512m</tests.heap.size>
         <tests.heapdump.path>${basedir}/logs/</tests.heapdump.path>
         <tests.topn>5</tests.topn>
+        <jvm.executable>${java.home}${file.separator}bin${file.separator}java</jvm.executable>
         <execution.hint.file>.local-${project.version}-execution-hints.log</execution.hint.file>
 
         <!-- Properties used for building RPM & DEB packages (see common/packaging.properties) -->
@@ -444,7 +445,7 @@
               </execution>
             </executions>
             <configuration>
-              <executable>java</executable>
+              <executable>${jvm.executable></executable>
               <arguments>
                 <argument>-classpath</argument>
                 <classpath/>
@@ -516,6 +517,7 @@
                             <goal>junit4</goal>
                         </goals>
                         <configuration>
+                            <jvm>${jvm.executable}</jvm>
                             <heartbeat>10</heartbeat>
                             <jvmOutputAction>pipe,warn</jvmOutputAction>
                             <leaveTemporary>true</leaveTemporary>


### PR DESCRIPTION
Currently, crazy things happen in the build because of $PATH vs $JAVA_HOME.

Example, where some things are done with java 8, others with java 7:

```
rmuir@beast:~/workspace/elasticsearch$ export JAVA_HOME=$JAVA8_HOME
rmuir@beast:~/workspace/elasticsearch$ export PATH=$JAVA7_HOME/bin:$PATH
rmuir@beast:~/workspace/elasticsearch$ mvn clean test

main:
     [echo] Using Java(TM) SE Runtime Environment 1.8.0_45-b14 Oracle Corporation

  2> NOTE: Linux 3.13.0-49-generic amd64/Oracle Corporation 1.7.0_55 (64-bit)/cpus=8,threads=1,free=423438432,total=515375104
```

This creates confusion because there is stuff in the build scripts e.g. configuring permgen based on the jvm running maven and it will do the wrong thing in this case. 

I think we should just always use JAVA_HOME for everything.
