### PR TITLE
Return term vectors as part of the search response

### DIFF
--- a/docs/reference/search/request-body.asciidoc
+++ b/docs/reference/search/request-body.asciidoc
@@ -107,6 +107,8 @@ include::request/script-fields.asciidoc[]
 
 include::request/fielddata-fields.asciidoc[]
 
+include::request/termvectors.asciidoc[]
+
 include::request/post-filter.asciidoc[]
 
 include::request/highlighting.asciidoc[]

--- a/docs/reference/search/request/termvectors.asciidoc
+++ b/docs/reference/search/request/termvectors.asciidoc
@@ -1,0 +1,30 @@
+[[search-request-termvectors]]
+=== Term Vectors
+
+Allows to return the term vectors for each hit, for example:
+
+[source,js]
+--------------------------------------------------
+{
+    "query" : {
+        ...
+    },
+    "term_vectors" : {
+        "fields" : ["text"],
+        "offsets" : true,
+        "payloads" : true,
+        "positions" : true,
+        "term_statistics" : true,
+        "field_statistics" : true
+    }
+}
+--------------------------------------------------
+
+The parameters are the same as for the <<docs-termvectors,Term Vectors API>>.
+Use `"term_vectors": true` with no parameters, to only return the term vectors
+stored for each document hit. This will ensure that if the term vectors are
+not stored, they will not be computed on the fly.
+
+[NOTE]
+Parameters such as `_index`, `_type`, `_id`, `doc`, `_routing`,
+`_version` and `_version_type` are not allowed.

--- a/rest-api-spec/test/search/60_term_vectors.yaml
+++ b/rest-api-spec/test/search/60_term_vectors.yaml
@@ -1,0 +1,35 @@
+---
+"Term Vectors":
+
+  - do:
+      indices.create:
+          index: test
+          body:
+            mappings:
+              type:
+                "properties":
+                  "text":
+                     "type" : "string"
+                     "term_vector" : "with_positions_offsets"
+  - do:
+      index:
+        index: test
+        type:  type
+        id:    1
+        body:
+            "text" : "The quick brown fox is brown."
+  - do:
+      indices.refresh: {}
+
+  - do:
+      search:
+        index: test
+        type: type
+        body:
+          term_vectors: { term_statistics: true }
+          query: { match_all: {} }
+
+  - match: { hits.total: 1 }
+  - match: { hits.hits.0.term_vectors.text.field_statistics.sum_doc_freq: 5 }
+  - match: { hits.hits.0.term_vectors.text.terms.brown.doc_freq: 1 }
+  - match: { hits.hits.0.term_vectors.text.terms.brown.tokens.0.start_offset: 10 }

--- a/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
@@ -35,6 +35,7 @@ import org.elasticsearch.search.Scroll;
 import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.fetch.innerhits.InnerHitsBuilder;
+import org.elasticsearch.search.fetch.termvectors.TermVectorsBuilder;
 import org.elasticsearch.search.highlight.HighlightBuilder;
 import org.elasticsearch.search.rescore.RescoreBuilder;
 import org.elasticsearch.search.sort.SortBuilder;
@@ -967,6 +968,22 @@ public class SearchRequestBuilder extends ActionRequestBuilder<SearchRequest, Se
      */
     public SearchRequestBuilder setQueryCache(Boolean queryCache) {
         request.queryCache(queryCache);
+        return this;
+    }
+
+    /**
+     * Specifies whether to return the stored term vectors for each hit, disregarding any previous parameters.
+     */
+    public SearchRequestBuilder setTermVectors(boolean fetch) {
+        sourceBuilder().termVectors(fetch);
+        return this;
+    }
+
+    /**
+     * Specifies how term vectors should be fetched for each hit.
+     */
+    public SearchRequestBuilder setTermVectors(TermVectorsBuilder termVectorsBuilder) {
+        sourceBuilder().termVectors(termVectorsBuilder);
         return this;
     }
 

--- a/src/main/java/org/elasticsearch/action/termvectors/TermVectorsResponse.java
+++ b/src/main/java/org/elasticsearch/action/termvectors/TermVectorsResponse.java
@@ -102,7 +102,7 @@ public class TermVectorsResponse extends ActionResponse implements ToXContent {
         this.id = id;
     }
 
-    TermVectorsResponse() {
+    public TermVectorsResponse() {
     }
 
     @Override
@@ -184,9 +184,13 @@ public class TermVectorsResponse extends ActionResponse implements ToXContent {
         builder.field(FieldStrings._VERSION, docVersion);
         builder.field(FieldStrings.FOUND, isExists());
         builder.field(FieldStrings.TOOK, tookInMillis);
-        if (!isExists()) {
-            return builder;
+        if (isExists()) {
+            buildTermVectors(builder);
         }
+        return builder;
+    }
+    
+    public void buildTermVectors(XContentBuilder builder) throws IOException {
         builder.startObject(FieldStrings.TERM_VECTORS);
         final CharsRefBuilder spare = new CharsRefBuilder();
         Fields theFields = getFields();
@@ -195,7 +199,6 @@ public class TermVectorsResponse extends ActionResponse implements ToXContent {
             buildField(builder, spare, theFields, fieldIter);
         }
         builder.endObject();
-        return builder;
     }
 
     private void buildField(XContentBuilder builder, final CharsRefBuilder spare, Fields theFields, Iterator<String> fieldIter) throws IOException {

--- a/src/main/java/org/elasticsearch/search/SearchHit.java
+++ b/src/main/java/org/elasticsearch/search/SearchHit.java
@@ -21,6 +21,7 @@ package org.elasticsearch.search;
 
 import org.apache.lucene.search.Explanation;
 import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.action.termvectors.TermVectorsResponse;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.text.Text;
@@ -226,4 +227,9 @@ public interface SearchHit extends Streamable, ToXContent, Iterable<SearchHitFie
          */
         public NestedIdentity getChild();
     }
+
+    /**
+     * The possibly fetched term vectors of the hit.
+     */
+    TermVectorsResponse getTermVectorsResponse();
 }

--- a/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
+++ b/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
@@ -40,6 +40,7 @@ import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
 import org.elasticsearch.search.fetch.innerhits.InnerHitsBuilder;
 import org.elasticsearch.search.fetch.source.FetchSourceContext;
+import org.elasticsearch.search.fetch.termvectors.TermVectorsBuilder;
 import org.elasticsearch.search.highlight.HighlightBuilder;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.rescore.RescoreBuilder;
@@ -123,7 +124,7 @@ public class SearchSourceBuilder implements ToXContent {
 
     private String[] stats;
 
-
+    private TermVectorsBuilder termVectorsBuilder;
     /**
      * Constructs a new search source builder.
      */
@@ -623,6 +624,25 @@ public class SearchSourceBuilder implements ToXContent {
         return this;
     }
 
+    /**
+     * Specifies whether to return the stored term vectors for each hit, disregarding any previous parameters.
+     */
+    public SearchSourceBuilder termVectors(boolean fetch) {
+        if (this.termVectorsBuilder == null) {
+            this.termVectorsBuilder = new TermVectorsBuilder();
+        }
+        this.termVectorsBuilder.setFetchOnly(fetch);
+        return this;
+    }
+
+    /**
+     * Specifies how term vectors should be fetched for each hit.
+     */
+    public SearchSourceBuilder termVectors(TermVectorsBuilder termVectorsBuilder) {
+        this.termVectorsBuilder = termVectorsBuilder;
+        return this;
+    }
+
     @Override
     public String toString() {
         try {
@@ -853,6 +873,10 @@ public class SearchSourceBuilder implements ToXContent {
                 builder.value(stat);
             }
             builder.endArray();
+        }
+
+        if (termVectorsBuilder != null) {
+            termVectorsBuilder.toXContent(builder, params);
         }
     }
 

--- a/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
+++ b/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
@@ -21,7 +21,6 @@ package org.elasticsearch.search.fetch;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.ReaderUtil;
 import org.apache.lucene.search.DocIdSetIterator;
@@ -56,22 +55,17 @@ import org.elasticsearch.search.fetch.matchedqueries.MatchedQueriesFetchSubPhase
 import org.elasticsearch.search.fetch.script.ScriptFieldsFetchSubPhase;
 import org.elasticsearch.search.fetch.source.FetchSourceContext;
 import org.elasticsearch.search.fetch.source.FetchSourceSubPhase;
+import org.elasticsearch.search.fetch.termvectors.TermVectorsFetchSubPhase;
 import org.elasticsearch.search.fetch.version.VersionFetchSubPhase;
 import org.elasticsearch.search.highlight.HighlightPhase;
 import org.elasticsearch.search.internal.InternalSearchHit;
 import org.elasticsearch.search.internal.InternalSearchHitField;
 import org.elasticsearch.search.internal.InternalSearchHits;
 import org.elasticsearch.search.internal.SearchContext;
-import org.elasticsearch.search.lookup.LeafSearchLookup;
 import org.elasticsearch.search.lookup.SourceLookup;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static org.elasticsearch.common.xcontent.XContentFactory.contentBuilder;
@@ -87,10 +81,10 @@ public class FetchPhase implements SearchPhase {
     public FetchPhase(HighlightPhase highlightPhase, ScriptFieldsFetchSubPhase scriptFieldsPhase,
                       MatchedQueriesFetchSubPhase matchedQueriesPhase, ExplainFetchSubPhase explainPhase, VersionFetchSubPhase versionPhase,
                       FetchSourceSubPhase fetchSourceSubPhase, FieldDataFieldsFetchSubPhase fieldDataFieldsFetchSubPhase, 
-                      InnerHitsFetchSubPhase innerHitsFetchSubPhase) {
+                      InnerHitsFetchSubPhase innerHitsFetchSubPhase, TermVectorsFetchSubPhase termVectorsFetchSubPhase) {
         innerHitsFetchSubPhase.setFetchPhase(this);
         this.fetchSubPhases = new FetchSubPhase[]{scriptFieldsPhase, matchedQueriesPhase, explainPhase, highlightPhase,
-                fetchSourceSubPhase, versionPhase, fieldDataFieldsFetchSubPhase, innerHitsFetchSubPhase};
+                fetchSourceSubPhase, versionPhase, fieldDataFieldsFetchSubPhase, innerHitsFetchSubPhase, termVectorsFetchSubPhase};
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/fetch/FetchSubPhase.java
+++ b/src/main/java/org/elasticsearch/search/fetch/FetchSubPhase.java
@@ -19,9 +19,9 @@
 package org.elasticsearch.search.fetch;
 
 import com.google.common.collect.Maps;
+import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.search.IndexSearcher;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.search.SearchHit;

--- a/src/main/java/org/elasticsearch/search/fetch/source/FetchSourceContext.java
+++ b/src/main/java/org/elasticsearch/search/fetch/source/FetchSourceContext.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.search.fetch.source;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.Booleans;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;

--- a/src/main/java/org/elasticsearch/search/fetch/termvectors/TermVectorsBuilder.java
+++ b/src/main/java/org/elasticsearch/search/fetch/termvectors/TermVectorsBuilder.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.fetch.termvectors;
+
+import org.elasticsearch.action.termvectors.TermVectorsRequest;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ */
+public class TermVectorsBuilder implements ToXContent {
+
+    private Boolean fetchOnly;
+    private String[] selectedFields;
+    private Boolean realtime;
+    private Map<String, String> perFieldAnalyzer;
+    private Boolean positions;
+    private Boolean offsets;
+    private Boolean payloads;
+    private Boolean fieldStatistics;
+    private Boolean termStatistics;
+    private Boolean dfs;
+    private TermVectorsRequest.FilterSettings filterSettings;
+
+    /**
+     * Specifies whether to return the stored term vectors, disregarding any previous parameters.
+     */
+    public TermVectorsBuilder setFetchOnly(Boolean fetchOnly) {
+        this.fetchOnly = fetchOnly;
+        return this;
+    }
+
+    /**
+     * Sets whether to return only term vectors for special selected fields. Returns the term
+     * vectors for all fields if selectedFields == null
+     */
+    public TermVectorsBuilder setSelectedFields(String... fields) {
+        this.selectedFields = fields;
+        return this;
+    }
+
+    /**
+     * Sets whether term vectors are generated real-time.
+     */
+    public TermVectorsBuilder setRealtime(Boolean realtime) {
+        this.realtime = realtime;
+        return this;
+    }
+
+    /**
+     * Sets the analyzer used at each field when generating term vectors.
+     */
+    public TermVectorsBuilder setPerFieldAnalyzer(Map<String, String> perFieldAnalyzer) {
+        this.perFieldAnalyzer = perFieldAnalyzer;
+        return this;
+    }
+
+    /**
+     * Sets the settings for filtering out terms.
+     */
+    public TermVectorsBuilder setFilterSettings(TermVectorsRequest.FilterSettings filterSettings) {
+        this.filterSettings = filterSettings;
+        return this;
+    }
+
+    /**
+     * Sets whether to return the positions for each term if stored or skip.
+     */
+    public TermVectorsBuilder setPositions(boolean positions) {
+        this.positions = positions;
+        return this;
+    }
+
+    /**
+     * Sets whether to return the start and stop offsets for each term if they were stored or
+     * skip offsets.
+     */
+    public TermVectorsBuilder setOffsets(boolean offsets) {
+        this.offsets = offsets;
+        return this;
+    }
+
+    /**
+     * Sets whether to return the payloads for each term or skip.
+     */
+    public TermVectorsBuilder setPayloads(boolean payloads) {
+        this.payloads = payloads;
+        return this;
+    }
+
+    /**
+     * Sets whether to return the field statistics for each term in the shard or skip.
+     */
+    public TermVectorsBuilder setFieldStatistics(boolean fieldStatistics) {
+        this.fieldStatistics = fieldStatistics;
+        return this;
+    }
+
+    /**
+     * Sets whether to return the term statistics for each term in the shard or skip.
+     */
+    public TermVectorsBuilder setTermStatistics(boolean termStatistics) {
+        this.termStatistics = termStatistics;
+        return this;
+    }
+
+    /**
+     * Sets whether to use distributed frequencies instead of shard statistics.
+     */
+    public TermVectorsBuilder setDfs(boolean dfs) {
+        this.dfs = dfs;
+        return this;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        if (fetchOnly != null) {
+            return builder.field("term_vectors", fetchOnly);
+        }
+        builder.startObject("term_vectors");
+        if (selectedFields != null) {
+            builder.startArray("fields");
+            for (String field : selectedFields) {
+                builder.value(field);
+            }
+            builder.endArray();
+        }
+        if (realtime != null) {
+            builder.field("realtime", realtime);
+        }
+        if (perFieldAnalyzer != null) {
+            builder.startObject("per_field_analyzer");
+            for (Map.Entry<String, String> entry : perFieldAnalyzer.entrySet()) {
+                builder.field(entry.getKey(), entry.getValue());
+            }
+            builder.endObject();
+        }
+        if (positions != null) {
+            builder.field("positions", positions);
+        }
+        if (offsets != null) {
+            builder.field("offsets", offsets);
+        }
+        if (realtime != null) {
+            builder.field("realtime", realtime);
+        }
+        if (payloads != null) {
+            builder.field("payloads", payloads);
+        }
+        if (fieldStatistics != null) {
+            builder.field("field_statistics", fieldStatistics);
+        }
+        if (termStatistics != null) {
+            builder.field("term_statistics", termStatistics);
+        }
+        if (dfs != null) {
+            builder.field("dfs", dfs);
+        }
+        if (filterSettings != null) {
+            filterSettings.toXContent(builder, params);
+        }
+        return builder.endObject();
+    }
+}

--- a/src/main/java/org/elasticsearch/search/fetch/termvectors/TermVectorsContext.java
+++ b/src/main/java/org/elasticsearch/search/fetch/termvectors/TermVectorsContext.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.fetch.termvectors;
+
+import org.elasticsearch.action.termvectors.TermVectorsRequest;
+import org.elasticsearch.action.termvectors.TermVectorsResponse;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.termvectors.ShardTermVectorsService;
+import org.elasticsearch.search.fetch.FetchSubPhase;
+import org.elasticsearch.search.internal.SearchContext;
+
+/**
+ *
+ */
+public class TermVectorsContext {
+    
+    private TermVectorsRequest termVectorsRequest;
+
+    public TermVectorsContext() {
+        this.termVectorsRequest = new TermVectorsRequest();
+    }
+
+    public TermVectorsContext(TermVectorsRequest termVectorsRequest) {
+        this.termVectorsRequest = termVectorsRequest;
+    }
+    
+    public TermVectorsResponse getResponse(SearchContext context, FetchSubPhase.HitContext hitContext) {
+        ShardTermVectorsService termVectorsService = context.termVectorsService();
+        TermVectorsRequest request = termVectorsRequest.index(
+                context.shardTarget().index()).type(hitContext.hit().type()).id(hitContext.hit().getId());
+        return termVectorsService.getTermVectors(request, context.shardTarget().index());
+    }
+}

--- a/src/main/java/org/elasticsearch/search/fetch/termvectors/TermVectorsFetchSubPhase.java
+++ b/src/main/java/org/elasticsearch/search/fetch/termvectors/TermVectorsFetchSubPhase.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.search.fetch.termvectors;
+
+import com.google.common.collect.ImmutableMap;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.termvectors.TermVectorsResponse;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.search.SearchParseElement;
+import org.elasticsearch.search.fetch.FetchSubPhase;
+import org.elasticsearch.search.internal.InternalSearchHit;
+import org.elasticsearch.search.internal.SearchContext;
+
+import java.util.Map;
+
+/**
+ * Query sub phase which returns term vectors as part of the search response.
+ *
+ * Specifying {@code "term_vectors": true|false|{term vectors parameters}}
+ */
+public class TermVectorsFetchSubPhase implements FetchSubPhase {
+
+    @Inject
+    public TermVectorsFetchSubPhase() {
+    }
+
+    @Override
+    public Map<String, ? extends SearchParseElement> parseElements() {
+        ImmutableMap.Builder<String, SearchParseElement> parseElements = ImmutableMap.builder();
+        parseElements.put("term_vectors", new TermVectorsParseElement())
+                .put("termVectors", new TermVectorsParseElement());
+        return parseElements.build();
+    }
+
+    @Override
+    public boolean hitsExecutionNeeded(SearchContext context) {
+        return false;
+    }
+
+    @Override
+    public void hitsExecute(SearchContext context, InternalSearchHit[] hits) throws ElasticsearchException {
+    }
+
+    @Override
+    public boolean hitExecutionNeeded(SearchContext context) {
+        return context.hasTermVectorsContext();
+    }
+
+    @Override
+    public void hitExecute(SearchContext context, HitContext hitContext) throws ElasticsearchException {
+        assert context.hasTermVectorsContext();
+        TermVectorsResponse response = context.termVectorsContext().getResponse(context, hitContext);
+        if (response.isExists()) {
+            hitContext.hit().setTermVectorsResponse(response);
+        }
+    }
+}

--- a/src/main/java/org/elasticsearch/search/fetch/termvectors/TermVectorsParseElement.java
+++ b/src/main/java/org/elasticsearch/search/fetch/termvectors/TermVectorsParseElement.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.search.fetch.termvectors;
+
+import com.google.common.collect.Sets;
+import org.elasticsearch.ElasticsearchIllegalStateException;
+import org.elasticsearch.action.termvectors.TermVectorsRequest;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.search.SearchParseElement;
+import org.elasticsearch.search.internal.SearchContext;
+
+import java.util.Set;
+
+/**
+ * Parses the {@code term_vectors} parameters in a search request.
+ *
+ * <pre>
+ * {
+ *   "query": {...},
+ *   "term_vectors" : true|false|{term vectors parameters}
+ * }
+ * </pre>
+ */public class TermVectorsParseElement implements SearchParseElement {
+
+    private final static Set<String> disallowedParameters = Sets.newHashSet("_index", "_type", "_id", "doc", "_routing", "routing", 
+            "_version", "version", "_version_type", "version_type", "_versionType", "versionType");
+
+    @Override
+    public void parse(XContentParser parser, SearchContext context) throws Exception {
+        XContentParser.Token token = parser.currentToken();
+        if (token == XContentParser.Token.VALUE_BOOLEAN) {
+            if (parser.booleanValue()) {
+                context.termVectorsContext(new TermVectorsContext());
+            }
+        } else if (token == XContentParser.Token.START_OBJECT) {
+            TermVectorsRequest template = new TermVectorsRequest();
+            TermVectorsRequest.parseRequest(template, parser, disallowedParameters);
+            context.termVectorsContext(new TermVectorsContext(template));
+        } else {
+            throw new ElasticsearchIllegalStateException("Expected either a VALUE_BOOLEAN or a START_OBJECT but got " + token);
+        }
+    }
+}

--- a/src/main/java/org/elasticsearch/search/internal/InternalSearchHit.java
+++ b/src/main/java/org/elasticsearch/search/internal/InternalSearchHit.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableMap;
 import org.apache.lucene.search.Explanation;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.action.termvectors.TermVectorsResponse;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
@@ -75,6 +76,8 @@ public class InternalSearchHit implements SearchHit {
 
     private long version = -1;
 
+    private TermVectorsResponse termVectorsResponse;
+
     private BytesReference source;
 
     private Map<String, SearchHitField> fields = ImmutableMap.of();
@@ -94,7 +97,7 @@ public class InternalSearchHit implements SearchHit {
     private byte[] sourceAsBytes;
 
     private Map<String, InternalSearchHits> innerHits;
-
+    
     private InternalSearchHit() {
 
     }
@@ -411,6 +414,15 @@ public class InternalSearchHit implements SearchHit {
         this.innerHits = innerHits;
     }
 
+    @Override
+    public TermVectorsResponse getTermVectorsResponse() {
+        return this.termVectorsResponse;
+    }
+
+    public void setTermVectorsResponse(TermVectorsResponse termVectors) {
+        this.termVectorsResponse = termVectors;
+    }
+
     public static class Fields {
         static final XContentBuilderString _INDEX = new XContentBuilderString("_index");
         static final XContentBuilderString _TYPE = new XContentBuilderString("_type");
@@ -523,6 +535,9 @@ public class InternalSearchHit implements SearchHit {
                 builder.endObject();
             }
             builder.endObject();
+        }
+        if (termVectorsResponse != null) {
+            termVectorsResponse.buildTermVectors(builder);
         }
         builder.endObject();
         return builder;
@@ -693,6 +708,11 @@ public class InternalSearchHit implements SearchHit {
                 innerHits.put(key, value);
             }
         }
+        
+        if (in.readBoolean()) {
+            termVectorsResponse = new TermVectorsResponse();
+            termVectorsResponse.readFrom(in);
+        }
     }
 
     @Override
@@ -805,6 +825,13 @@ public class InternalSearchHit implements SearchHit {
                 out.writeString(entry.getKey());
                 entry.getValue().writeTo(out, InternalSearchHits.streamContext().streamShardTarget(InternalSearchHits.StreamContext.ShardTargetType.NO_STREAM));
             }
+        }
+        
+        if (termVectorsResponse == null) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            termVectorsResponse.writeTo(out);
         }
     }
 

--- a/src/main/java/org/elasticsearch/search/internal/SearchContext.java
+++ b/src/main/java/org/elasticsearch/search/internal/SearchContext.java
@@ -43,9 +43,9 @@ import org.elasticsearch.index.query.IndexQueryParserService;
 import org.elasticsearch.index.query.ParsedFilter;
 import org.elasticsearch.index.query.ParsedQuery;
 import org.elasticsearch.index.query.QueryParseContext;
-import org.elasticsearch.index.query.support.NestedScope;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.similarity.SimilarityService;
+import org.elasticsearch.index.termvectors.ShardTermVectorsService;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.Scroll;
 import org.elasticsearch.search.SearchShardTarget;
@@ -56,6 +56,7 @@ import org.elasticsearch.search.fetch.fielddata.FieldDataFieldsContext;
 import org.elasticsearch.search.fetch.innerhits.InnerHitsContext;
 import org.elasticsearch.search.fetch.script.ScriptFieldsContext;
 import org.elasticsearch.search.fetch.source.FetchSourceContext;
+import org.elasticsearch.search.fetch.termvectors.TermVectorsContext;
 import org.elasticsearch.search.highlight.SearchContextHighlight;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.search.query.QuerySearchResult;
@@ -195,6 +196,18 @@ public abstract class SearchContext implements Releasable {
 
     public abstract SearchContext fetchSourceContext(FetchSourceContext fetchSourceContext);
 
+    public boolean hasTermVectorsContext() {
+        throw new UnsupportedOperationException("Returning term vectors is only supported in the search API.");
+    }
+
+    public TermVectorsContext termVectorsContext() {
+        throw new UnsupportedOperationException("Returning term vectors is only supported in the search API.");
+    }
+
+    public SearchContext termVectorsContext(TermVectorsContext termVectorsContext) {
+        throw new UnsupportedOperationException("Returning term vectors is only supported in the search API.");
+    }
+
     public abstract ContextIndexSearcher searcher();
 
     public abstract IndexShard indexShard();
@@ -208,6 +221,10 @@ public abstract class SearchContext implements Releasable {
     public abstract SimilarityService similarityService();
 
     public abstract ScriptService scriptService();
+
+    public ShardTermVectorsService termVectorsService() {
+        throw new UnsupportedOperationException("Returning term vectors is only supported in the search API.");
+    }
 
     public abstract PageCacheRecycler pageCacheRecycler();
 

--- a/src/main/java/org/elasticsearch/search/internal/SearchContext.java
+++ b/src/main/java/org/elasticsearch/search/internal/SearchContext.java
@@ -197,15 +197,15 @@ public abstract class SearchContext implements Releasable {
     public abstract SearchContext fetchSourceContext(FetchSourceContext fetchSourceContext);
 
     public boolean hasTermVectorsContext() {
-        throw new UnsupportedOperationException("Returning term vectors is only supported in the search API.");
+        return false; // only available for DefaultSearchContext
     }
 
     public TermVectorsContext termVectorsContext() {
-        throw new UnsupportedOperationException("Returning term vectors is only supported in the search API.");
+        return null; // only available for DefaultSearchContext
     }
 
     public SearchContext termVectorsContext(TermVectorsContext termVectorsContext) {
-        throw new UnsupportedOperationException("Returning term vectors is only supported in the search API.");
+        return null; // only available for DefaultSearchContext
     }
 
     public abstract ContextIndexSearcher searcher();
@@ -223,7 +223,7 @@ public abstract class SearchContext implements Releasable {
     public abstract ScriptService scriptService();
 
     public ShardTermVectorsService termVectorsService() {
-        throw new UnsupportedOperationException("Returning term vectors is only supported in the search API.");
+        return null; // only available for DefaultSearchContext
     }
 
     public abstract PageCacheRecycler pageCacheRecycler();

--- a/src/test/java/org/elasticsearch/search/termvectors/TermVectorsFetchingTests.java
+++ b/src/test/java/org/elasticsearch/search/termvectors/TermVectorsFetchingTests.java
@@ -75,7 +75,6 @@ public class TermVectorsFetchingTests extends ElasticsearchIntegrationTest {
 
         String[] disallowedParameters = new String[]{"_index", "_type", "_id", "doc", "_routing", "routing",
                 "_version", "version", "_version_type", "version_type", "_versionType", "versionType"};
-        SearchResponse resp;
         for (String param : disallowedParameters) {
             String request = 
                     "{\"" +
@@ -84,10 +83,10 @@ public class TermVectorsFetchingTests extends ElasticsearchIntegrationTest {
                         "\"term_vectors\": " + "{\"" + param + "\":\"\"}" +
                     "}";
             try {
-                resp = client().prepareSearch("test").setTypes("type").setSource(new BytesArray(new BytesRef(request))).get();
-                assertFailures(resp);
+                client().prepareSearch("test").setTypes("type").setSource(new BytesArray(new BytesRef(request))).get();
+                fail("Expected search phase execution failure.");
             } catch (SearchPhaseExecutionException e) {
-                assertThat(e.getDetailedMessage().contains("The parameter \"" + param + "\" is not allowed!"), equalTo(true));
+                assertTrue(e.getMessage().contains("The parameter \"" + param + "\" is not allowed!"));
             }
         }
     }    

--- a/src/test/java/org/elasticsearch/search/termvectors/TermVectorsFetchingTests.java
+++ b/src/test/java/org/elasticsearch/search/termvectors/TermVectorsFetchingTests.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.termvectors;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.action.search.SearchPhaseExecutionException;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.search.fetch.termvectors.TermVectorsBuilder;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertFailures;
+import static org.hamcrest.Matchers.*;
+
+public class TermVectorsFetchingTests extends ElasticsearchIntegrationTest {
+
+    @Test
+    public void testTermVectorsSimple() throws IOException {
+        assertAcked(prepareCreate("test")
+                .addMapping("type", 
+                        "with_tvs", "type=string,term_vector=yes,analyzer=whitespace", 
+                        "without_tvs", "type=string,analyzer=whitespace"));
+        ensureGreen();
+
+        String text = "the quick brown fox jumps over the lazy dog";
+        client().prepareIndex("test", "type", "1").setSource("with_tvs", text, "without_tvs", text).get();
+        refresh();
+
+        // fetch stored term vectors
+        SearchResponse response = client().prepareSearch("test").setTermVectors(true).get();
+        assertThat(response.getHits().getAt(0).getTermVectorsResponse(), notNullValue());
+        assertThat(response.getHits().getAt(0).getTermVectorsResponse().getFields().size(), Matchers.equalTo(1));
+        assertThat(response.getHits().getAt(0).getTermVectorsResponse().getFields().terms("with_tvs").size(), Matchers.equalTo(8l));
+        
+        // do not fetch term vectors
+        response = client().prepareSearch("test").get();
+        assertThat(response.getHits().getAt(0).getTermVectorsResponse(), nullValue());
+        response = client().prepareSearch("test").setTermVectors(false).get();
+        assertThat(response.getHits().getAt(0).getTermVectorsResponse(), nullValue());
+
+        // fetch stored term vectors and generate the ones not stored
+        response = client().prepareSearch("test").setTermVectors(new TermVectorsBuilder().setSelectedFields("*")).get();
+        assertThat(response.getHits().getAt(0).getTermVectorsResponse(), notNullValue());
+        assertThat(response.getHits().getAt(0).getTermVectorsResponse().getFields().size(), Matchers.equalTo(2));
+        assertThat(response.getHits().getAt(0).getTermVectorsResponse().getFields().terms("with_tvs").size(), Matchers.equalTo(8l));
+        assertThat(response.getHits().getAt(0).getTermVectorsResponse().getFields().terms("without_tvs").size(), Matchers.equalTo(8l));
+    }
+
+    @Test
+    public void testTermVectorsDisallowedParameters() throws IOException {
+        createIndex("test");
+        ensureGreen();
+
+        String[] disallowedParameters = new String[]{"_index", "_type", "_id", "doc", "_routing", "routing",
+                "_version", "version", "_version_type", "version_type", "_versionType", "versionType"};
+        SearchResponse resp;
+        for (String param : disallowedParameters) {
+            String request = 
+                    "{\"" +
+                        "query\":" +
+                            "{\"match_all\":{}}," +
+                        "\"term_vectors\": " + "{\"" + param + "\":\"\"}" +
+                    "}";
+            try {
+                resp = client().prepareSearch("test").setTypes("type").setSource(new BytesArray(new BytesRef(request))).get();
+                assertFailures(resp);
+            } catch (SearchPhaseExecutionException e) {
+                assertThat(e.getDetailedMessage().contains("The parameter \"" + param + "\" is not allowed!"), equalTo(true));
+            }
+        }
+    }    
+}


### PR DESCRIPTION
Adds a new parameter to the search API called `term_vectors` which takes as
input `true`, `false` or an `object` of parameters. The parameters are exactly
the same as the ones specified in the Term Vectors API, with the exception of
`_index`, `_type`, `_id`, `doc`, `_routing`, `_version` and `_version_type`.

Relates to #10823 
