### PR TITLE
Remove obsolete `expand_wildcards_open` and  `expand_wildcards_close` options

### DIFF
--- a/docs/reference/migration/migrate_2_0.asciidoc
+++ b/docs/reference/migration/migrate_2_0.asciidoc
@@ -389,3 +389,10 @@ favour or `bool`.
 
 The `execution` option of the `terms` filter is now deprecated and ignored if
 provided.
+
+=== Snapshot and Restore
+
+The obsolete parameters `expand_wildcards_open` and `expand_wildcards_close` are no longer
+supported by the snapshot and restore operations. These parameters have been replaced by
+a single `expand_wildcards` parameter. See <<multi-index,the multi-index docs>> for more.
+

--- a/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotRequest.java
@@ -371,10 +371,6 @@ public class CreateSnapshotRequest extends MasterNodeOperationRequest<CreateSnap
      * @return this request
      */
     public CreateSnapshotRequest source(Map source) {
-        boolean ignoreUnavailable = IndicesOptions.lenientExpandOpen().ignoreUnavailable();
-        boolean allowNoIndices = IndicesOptions.lenientExpandOpen().allowNoIndices();
-        boolean expandWildcardsOpen = IndicesOptions.lenientExpandOpen().expandWildcardsOpen();
-        boolean expandWildcardsClosed = IndicesOptions.lenientExpandOpen().expandWildcardsClosed();
         for (Map.Entry<String, Object> entry : ((Map<String, Object>) source).entrySet()) {
             String name = entry.getKey();
             if (name.equals("indices")) {
@@ -385,10 +381,6 @@ public class CreateSnapshotRequest extends MasterNodeOperationRequest<CreateSnap
                 } else {
                     throw new ElasticsearchIllegalArgumentException("malformed indices section, should be an array of strings");
                 }
-            } else if (name.equals("expand_wildcards_open") || name.equals("expandWildcardsOpen")) {
-                expandWildcardsOpen = nodeBooleanValue(entry.getValue());
-            } else if (name.equals("expand_wildcards_closed") || name.equals("expandWildcardsClosed")) {
-                expandWildcardsClosed = nodeBooleanValue(entry.getValue());
             } else if (name.equals("partial")) {
                 partial(nodeBooleanValue(entry.getValue()));
             } else if (name.equals("settings")) {
@@ -400,7 +392,7 @@ public class CreateSnapshotRequest extends MasterNodeOperationRequest<CreateSnap
                 includeGlobalState = nodeBooleanValue(entry.getValue());
             }
         }
-        indicesOptions(IndicesOptions.fromMap((Map<String, Object>) source, IndicesOptions.fromOptions(ignoreUnavailable, allowNoIndices, expandWildcardsOpen, expandWildcardsClosed)));
+        indicesOptions(IndicesOptions.fromMap((Map<String, Object>) source, IndicesOptions.lenientExpandOpen()));
         return this;
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
@@ -504,11 +504,6 @@ public class RestoreSnapshotRequest extends MasterNodeOperationRequest<RestoreSn
      * @return this request
      */
     public RestoreSnapshotRequest source(Map source) {
-        boolean ignoreUnavailable = IndicesOptions.lenientExpandOpen().ignoreUnavailable();
-        boolean allowNoIndices = IndicesOptions.lenientExpandOpen().allowNoIndices();
-        boolean expandWildcardsOpen = IndicesOptions.lenientExpandOpen().expandWildcardsOpen();
-        boolean expandWildcardsClosed = IndicesOptions.lenientExpandOpen().expandWildcardsClosed();
-
         for (Map.Entry<String, Object> entry : ((Map<String, Object>) source).entrySet()) {
             String name = entry.getKey();
             if (name.equals("indices")) {
@@ -519,10 +514,6 @@ public class RestoreSnapshotRequest extends MasterNodeOperationRequest<RestoreSn
                 } else {
                     throw new ElasticsearchIllegalArgumentException("malformed indices section, should be an array of strings");
                 }
-            } else if (name.equals("expand_wildcards_open") || name.equals("expandWildcardsOpen")) {
-                expandWildcardsOpen = nodeBooleanValue(entry.getValue());
-            } else if (name.equals("expand_wildcards_closed") || name.equals("expandWildcardsClosed")) {
-                expandWildcardsClosed = nodeBooleanValue(entry.getValue());
             } else if (name.equals("partial")) {
                 partial(nodeBooleanValue(entry.getValue()));
             } else if (name.equals("settings")) {
@@ -563,7 +554,7 @@ public class RestoreSnapshotRequest extends MasterNodeOperationRequest<RestoreSn
                 throw new ElasticsearchIllegalArgumentException("Unknown parameter " + name);
             }
         }
-        indicesOptions(IndicesOptions.fromMap((Map<String, Object>) source, IndicesOptions.fromOptions(ignoreUnavailable, allowNoIndices, expandWildcardsOpen, expandWildcardsClosed)));
+        indicesOptions(IndicesOptions.fromMap((Map<String, Object>) source, IndicesOptions.lenientExpandOpen()));
         return this;
     }
 


### PR DESCRIPTION
In #6097 we made snapshot/restore index option consistent with other API. Now we can remove old style options from master.

Closes #10743
