### PR TITLE
Refactor TransportShardReplicationOperationAction

### DIFF
--- a/src/main/java/org/elasticsearch/action/support/replication/TransportShardReplicationOperationAction.java
+++ b/src/main/java/org/elasticsearch/action/support/replication/TransportShardReplicationOperationAction.java
@@ -475,7 +475,7 @@ public abstract class TransportShardReplicationOperationAction<Request extends S
 
                 @Override
                 public void onClusterServiceClose() {
-                    listener.onFailure(new NodeClosedException(clusterService.localNode()));
+                    finishAsFailed(new NodeClosedException(clusterService.localNode()));
                 }
 
                 @Override
@@ -695,7 +695,7 @@ public abstract class TransportShardReplicationOperationAction<Request extends S
                         numberOfUnassignedReplicas++;
                     } else if (shard.primary()) {
                         if (shard.relocating()) {
-                            // we have to repplicate to the other copy
+                            // we have to replicate to the other copy
                             numberOfPendingShardInstances += 1;
                         }
                     } else if (shard.relocating()) {

--- a/src/main/java/org/elasticsearch/action/support/replication/TransportShardReplicationOperationAction.java
+++ b/src/main/java/org/elasticsearch/action/support/replication/TransportShardReplicationOperationAction.java
@@ -619,7 +619,7 @@ public abstract class TransportShardReplicationOperationAction<Request extends S
 
     private void failReplicaIfNeeded(String index, int shardId, Throwable t) {
         logger.trace("failure on replica [{}][{}]", t, index, shardId);
-        if (!ignoreReplicaException(t)) {
+        if (ignoreReplicaException(t) == false) {
             IndexService indexService = indicesService.indexService(index);
             if (indexService == null) {
                 logger.debug("ignoring failed replica [{}][{}] because index was already removed.", index, shardId);
@@ -825,7 +825,7 @@ public abstract class TransportShardReplicationOperationAction<Request extends S
                             public void handleException(TransportException exp) {
                                 onReplicaFailure(nodeId, exp);
                                 logger.trace("[{}] transport failure during replica request [{}] ", exp, node, replicaRequest);
-                                if (!ignoreReplicaException(exp)) {
+                                if (ignoreReplicaException(exp) == false) {
                                     logger.warn("failed to perform " + actionName + " on remote replica " + node + shardIt.shardId(), exp);
                                     shardStateAction.shardFailed(shard, indexMetaData.getUUID(),
                                             "Failed to perform [" + actionName + "] on replica, message [" + ExceptionsHelper.detailedMessage(exp) + "]");
@@ -878,7 +878,7 @@ public abstract class TransportShardReplicationOperationAction<Request extends S
 
         void onReplicaFailure(String nodeId, @Nullable Throwable e) {
             // Only version conflict should be ignored from being put into the _shards header?
-            if (e != null && !ignoreReplicaException(e)) {
+            if (e != null && ignoreReplicaException(e) == false) {
                 shardReplicaFailures.put(nodeId, e);
             }
             decPendingAndFinishIfNeeded();

--- a/src/main/java/org/elasticsearch/common/transport/DummyTransportAddress.java
+++ b/src/main/java/org/elasticsearch/common/transport/DummyTransportAddress.java
@@ -51,4 +51,9 @@ public class DummyTransportAddress implements TransportAddress {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
     }
+
+    @Override
+    public String toString() {
+        return "_dummy_addr_";
+    }
 }

--- a/src/test/java/org/elasticsearch/action/support/replication/ShardReplicationOperationTests.java
+++ b/src/test/java/org/elasticsearch/action/support/replication/ShardReplicationOperationTests.java
@@ -101,6 +101,7 @@ public class ShardReplicationOperationTests extends ElasticsearchTestCase {
     @AfterClass
     public static void afterClass() {
         ThreadPool.terminate(threadPool, 30, TimeUnit.SECONDS);
+        threadPool = null;
     }
 
 

--- a/src/test/java/org/elasticsearch/action/support/replication/ShardReplicationOperationTests.java
+++ b/src/test/java/org/elasticsearch/action/support/replication/ShardReplicationOperationTests.java
@@ -307,7 +307,6 @@ public class ShardReplicationOperationTests extends ElasticsearchTestCase {
             assertThat("listener is done, but there are outstanding replicas", listener.isDone(), equalTo(false));
         }
         int pending = replicationPhase.pending();
-        int failures = 0;
         int criticalFailures = 0; // failures that should fail the shard
         int successfull = 1;
         for (CapturingTransport.CapturedRequest capturedRequest : capturedRequests) {
@@ -319,7 +318,6 @@ public class ShardReplicationOperationTests extends ElasticsearchTestCase {
                 } else {
                     t = new IndexShardNotStartedException(shardId, IndexShardState.RECOVERING);
                 }
-                failures++;
                 logger.debug("--> simulating failure on {} with [{}]", capturedRequest.node, t.getClass().getSimpleName());
                 transport.handleResponse(capturedRequest.requestId, t);
             } else {

--- a/src/test/java/org/elasticsearch/action/support/replication/ShardReplicationOperationTests.java
+++ b/src/test/java/org/elasticsearch/action/support/replication/ShardReplicationOperationTests.java
@@ -328,7 +328,7 @@ public class ShardReplicationOperationTests extends ElasticsearchTestCase {
             }
             pending--;
             assertThat(replicationPhase.pending(), equalTo(pending));
-            assertThat(replicationPhase.succesful(), equalTo(successfull));
+            assertThat(replicationPhase.successful(), equalTo(successfull));
         }
         assertThat(listener.isDone(), equalTo(true));
         Response response = listener.get();

--- a/src/test/java/org/elasticsearch/action/support/replication/ShardReplicationOperationTests.java
+++ b/src/test/java/org/elasticsearch/action/support/replication/ShardReplicationOperationTests.java
@@ -1,0 +1,306 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.action.support.replication;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.ActionWriteResponse;
+import org.elasticsearch.action.support.ActionFilter;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.action.shard.ShardStateAction;
+import org.elasticsearch.cluster.block.ClusterBlock;
+import org.elasticsearch.cluster.block.ClusterBlockException;
+import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.block.ClusterBlocks;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.routing.ShardIterator;
+import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.common.component.Lifecycle;
+import org.elasticsearch.common.component.LifecycleListener;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.BoundTransportAddress;
+import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.test.cluster.TestClusterService;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.*;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.Matchers.instanceOf;
+
+public class ShardReplicationOperationTests extends ElasticsearchTestCase {
+
+    static class Request extends ShardReplicationOperationRequest<Request> {
+        ShardId shardId;
+    }
+
+    static class Response extends ActionWriteResponse {
+
+    }
+
+    static class CapturingTransport implements Transport {
+        private TransportServiceAdapter adapter;
+
+        static public class CapturedRequest {
+            final public DiscoveryNode node;
+            final public long requestId;
+            final public String action;
+            final public TransportRequest request;
+
+            public CapturedRequest(DiscoveryNode node, long requestId, String action, TransportRequest request) {
+                this.node = node;
+                this.requestId = requestId;
+                this.action = action;
+                this.request = request;
+            }
+        }
+
+        private BlockingQueue<CapturedRequest> capturedRequests = ConcurrentCollections.newBlockingQueue();
+
+        public CapturedRequest[] capturedRequests() {
+            return capturedRequests.toArray(new CapturedRequest[0]);
+        }
+
+        public void clear() {
+            capturedRequests.clear();
+        }
+
+        public void handleResponse(final long requestId, final TransportResponse response) {
+            adapter.onResponseReceived(requestId).handleResponse(response);
+        }
+
+
+        @Override
+        public void sendRequest(DiscoveryNode node, long requestId, String action, TransportRequest request, TransportRequestOptions options) throws IOException, TransportException {
+            capturedRequests.add(new CapturedRequest(node, requestId, action, request));
+        }
+
+
+        @Override
+        public void transportServiceAdapter(TransportServiceAdapter adapter) {
+            this.adapter = adapter;
+        }
+
+        @Override
+        public BoundTransportAddress boundAddress() {
+            return null;
+        }
+
+        @Override
+        public Map<String, BoundTransportAddress> profileBoundAddresses() {
+            return null;
+        }
+
+        @Override
+        public TransportAddress[] addressesFromString(String address) throws Exception {
+            return new TransportAddress[0];
+        }
+
+        @Override
+        public boolean addressSupported(Class<? extends TransportAddress> address) {
+            return false;
+        }
+
+        @Override
+        public boolean nodeConnected(DiscoveryNode node) {
+            return true;
+        }
+
+        @Override
+        public void connectToNode(DiscoveryNode node) throws ConnectTransportException {
+
+        }
+
+        @Override
+        public void connectToNodeLight(DiscoveryNode node) throws ConnectTransportException {
+
+        }
+
+        @Override
+        public void disconnectFromNode(DiscoveryNode node) {
+
+        }
+
+        @Override
+        public long serverOpen() {
+            return 0;
+        }
+
+        @Override
+        public Lifecycle.State lifecycleState() {
+            return null;
+        }
+
+        @Override
+        public void addLifecycleListener(LifecycleListener listener) {
+
+        }
+
+        @Override
+        public void removeLifecycleListener(LifecycleListener listener) {
+
+        }
+
+        @Override
+        public Transport start() throws ElasticsearchException {
+            return null;
+        }
+
+        @Override
+        public Transport stop() throws ElasticsearchException {
+            return null;
+        }
+
+        @Override
+        public void close() throws ElasticsearchException {
+
+        }
+    }
+
+    static class Action extends TransportShardReplicationOperationAction<Request, Request, Response> {
+
+        protected Action(Settings settings, String actionName, TransportService transportService,
+                         ClusterService clusterService,
+                         ThreadPool threadPool) {
+            super(settings, actionName, transportService, clusterService, null, threadPool,
+                    new ShardStateAction(settings, clusterService, transportService, null, null),
+                    new ActionFilters(new HashSet<ActionFilter>()));
+        }
+
+        @Override
+        protected Request newRequestInstance() {
+            return new Request();
+        }
+
+        @Override
+        protected Request newReplicaRequestInstance() {
+            return new Request();
+        }
+
+        @Override
+        protected Response newResponseInstance() {
+            return new Response();
+        }
+
+        @Override
+        protected String executor() {
+            return ThreadPool.Names.SAME;
+        }
+
+        @Override
+        protected Tuple<Response, Request> shardOperationOnPrimary(ClusterState clusterState, PrimaryOperationRequest shardRequest) throws Throwable {
+            return null;
+        }
+
+        @Override
+        protected void shardOperationOnReplica(ReplicaOperationRequest shardRequest) {
+
+        }
+
+        @Override
+        protected ShardIterator shards(ClusterState clusterState, InternalRequest request) throws ElasticsearchException {
+            return clusterState.getRoutingTable().index(request.concreteIndex()).shard(request.request().shardId.id()).shardsIt();
+        }
+
+        @Override
+        protected boolean checkWriteConsistency() {
+            return false;
+        }
+
+        @Override
+        protected boolean resolveIndex() {
+            return false;
+        }
+    }
+
+    static CapturingTransport transport;
+    static ThreadPool threadPool;
+
+    @BeforeClass
+    public static void beforeClass() {
+        threadPool = new ThreadPool("ShardReplicationOperationTests");
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        transport = new CapturingTransport();
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        ThreadPool.terminate(threadPool, 30, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void testBlocks() throws ExecutionException, InterruptedException {
+        TestClusterService clusterService = new TestClusterService(threadPool);
+        Action action = new Action(ImmutableSettings.EMPTY, "test",
+                new TransportService(transport, threadPool), clusterService, threadPool);
+
+        Request request = new Request();
+        PlainActionFuture<Response> listener = new PlainActionFuture<>();
+
+        ClusterBlocks.Builder block = ClusterBlocks.builder()
+                .addGlobalBlock(new ClusterBlock(1, "non retryable", false, true, RestStatus.SERVICE_UNAVAILABLE, ClusterBlockLevel.ALL));
+        clusterService.setState(ClusterState.builder(clusterService.state()).blocks(block));
+        TransportShardReplicationOperationAction<Request, Request, Response>.PrimaryPhase primaryPhase = action.new PrimaryPhase(request, listener);
+        assertFalse("primary phase should stop execution", primaryPhase.checkBlocks());
+        try {
+            listener.get();
+            fail("primary phase should fail operation");
+        } catch (ExecutionException ex) {
+            assertThat(ex.getCause(), instanceOf(ClusterBlockException.class));
+        }
+
+        block = ClusterBlocks.builder()
+                .addGlobalBlock(new ClusterBlock(1, "retryable", true, true, RestStatus.SERVICE_UNAVAILABLE, ClusterBlockLevel.ALL));
+        clusterService.setState(ClusterState.builder(clusterService.state()).blocks(block));
+        listener = new PlainActionFuture<>();
+        primaryPhase = action.new PrimaryPhase(request, listener);
+        assertFalse("primary phase should stop execution on retryable block", primaryPhase.checkBlocks());
+        assertFalse("primary phase should wait on retryable block", listener.isDone());
+
+        block = ClusterBlocks.builder()
+                .addGlobalBlock(new ClusterBlock(1, "non retryable", false, true, RestStatus.SERVICE_UNAVAILABLE, ClusterBlockLevel.ALL));
+        clusterService.setState(ClusterState.builder(clusterService.state()).blocks(block));
+        try {
+            listener.get();
+            fail("primary phase should fail operation when moving from a retryable block a non-retryable one");
+        } catch (ExecutionException ex) {
+            assertThat(ex.getCause(), instanceOf(ClusterBlockException.class));
+        }
+    }
+}

--- a/src/test/java/org/elasticsearch/test/cluster/TestClusterService.java
+++ b/src/test/java/org/elasticsearch/test/cluster/TestClusterService.java
@@ -1,0 +1,245 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.test.cluster;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.ElasticsearchIllegalStateException;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.*;
+import org.elasticsearch.cluster.block.ClusterBlock;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.routing.OperationRouting;
+import org.elasticsearch.cluster.service.PendingClusterTask;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.Priority;
+import org.elasticsearch.common.component.Lifecycle;
+import org.elasticsearch.common.component.LifecycleListener;
+import org.elasticsearch.common.transport.DummyTransportAddress;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
+import org.elasticsearch.common.util.concurrent.FutureUtils;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ScheduledFuture;
+
+public class TestClusterService implements ClusterService {
+
+    volatile ClusterState state;
+    private final Collection<ClusterStateListener> listeners = new CopyOnWriteArrayList<>();
+    private final Queue<NotifyTimeout> onGoingTimeouts = ConcurrentCollections.newQueue();
+    private final ThreadPool threadPool;
+
+    public TestClusterService() {
+        this(ClusterState.builder(new ClusterName("test")).build());
+    }
+
+    public TestClusterService(ThreadPool threadPool) {
+        this(ClusterState.builder(new ClusterName("test")).build(), threadPool);
+    }
+
+    public TestClusterService(ClusterState state) {
+        this(state, null);
+    }
+
+    public TestClusterService(ClusterState state, @Nullable ThreadPool threadPool) {
+        if (state.getNodes().size() == 0) {
+            state = ClusterState.builder(state).nodes(
+                    DiscoveryNodes.builder()
+                            .put(new DiscoveryNode("test_id", DummyTransportAddress.INSTANCE, Version.CURRENT))
+                            .localNodeId("test_id")).build();
+        }
+
+        assert state.getNodes().localNode() != null;
+        this.state = state;
+        this.threadPool = threadPool;
+
+    }
+
+
+    public void setState(ClusterState state) {
+        assert state.getNodes().localNode() != null;
+        // make sure we have a version increment
+        state = ClusterState.builder(state).version(this.state.version() + 1).build();
+        ClusterChangedEvent event = new ClusterChangedEvent("test", state, this.state);
+        this.state = state;
+        for (ClusterStateListener listener : listeners) {
+            listener.clusterChanged(event);
+        }
+    }
+
+    public void setState(ClusterState.Builder state) {
+        setState(state.build());
+    }
+
+    @Override
+    public DiscoveryNode localNode() {
+        return state.getNodes().localNode();
+    }
+
+    @Override
+    public ClusterState state() {
+        return state;
+    }
+
+    @Override
+    public void addInitialStateBlock(ClusterBlock block) throws ElasticsearchIllegalStateException {
+        throw new UnsupportedOperationException();
+
+    }
+
+    @Override
+    public void removeInitialStateBlock(ClusterBlock block) throws ElasticsearchIllegalStateException {
+        throw new UnsupportedOperationException();
+
+    }
+
+    @Override
+    public OperationRouting operationRouting() {
+        return null;
+    }
+
+    @Override
+    public void addFirst(ClusterStateListener listener) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void addLast(ClusterStateListener listener) {
+        listeners.add(listener);
+    }
+
+    @Override
+    public void add(ClusterStateListener listener) {
+        listeners.add(listener);
+    }
+
+    @Override
+    public void remove(ClusterStateListener listener) {
+        listeners.remove(listener);
+        for (Iterator<NotifyTimeout> it = onGoingTimeouts.iterator(); it.hasNext(); ) {
+            NotifyTimeout timeout = it.next();
+            if (timeout.listener.equals(listener)) {
+                timeout.cancel();
+                it.remove();
+            }
+        }
+    }
+
+    @Override
+    public void add(LocalNodeMasterListener listener) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void remove(LocalNodeMasterListener listener) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void add(final TimeValue timeout, final TimeoutClusterStateListener listener) {
+        if (threadPool == null) {
+            throw new UnsupportedOperationException("TestClusterService wasn't initialized with a thread pool");
+        }
+        NotifyTimeout notifyTimeout = new NotifyTimeout(listener, timeout);
+        notifyTimeout.future = threadPool.schedule(timeout, ThreadPool.Names.GENERIC, notifyTimeout);
+        onGoingTimeouts.add(notifyTimeout);
+        listeners.add(listener);
+        listener.postAdded();
+    }
+
+    @Override
+    public void submitStateUpdateTask(String source, Priority priority, ClusterStateUpdateTask updateTask) {
+
+    }
+
+    @Override
+    public void submitStateUpdateTask(String source, ClusterStateUpdateTask updateTask) {
+
+    }
+
+    @Override
+    public List<PendingClusterTask> pendingTasks() {
+        return null;
+    }
+
+    @Override
+    public int numberOfPendingTasks() {
+        return 0;
+    }
+
+    @Override
+    public Lifecycle.State lifecycleState() {
+        return null;
+    }
+
+    @Override
+    public void addLifecycleListener(LifecycleListener listener) {
+
+    }
+
+    @Override
+    public void removeLifecycleListener(LifecycleListener listener) {
+
+    }
+
+    @Override
+    public ClusterService start() throws ElasticsearchException {
+        return null;
+    }
+
+    @Override
+    public ClusterService stop() throws ElasticsearchException {
+        return null;
+    }
+
+    @Override
+    public void close() throws ElasticsearchException {
+        throw new UnsupportedOperationException();
+    }
+
+    class NotifyTimeout implements Runnable {
+        final TimeoutClusterStateListener listener;
+        final TimeValue timeout;
+        volatile ScheduledFuture future;
+
+        NotifyTimeout(TimeoutClusterStateListener listener, TimeValue timeout) {
+            this.listener = listener;
+            this.timeout = timeout;
+        }
+
+        public void cancel() {
+            FutureUtils.cancel(future);
+        }
+
+        @Override
+        public void run() {
+            if (future != null && future.isCancelled()) {
+                return;
+            }
+            listener.onTimeout(this.timeout);
+            // note, we rely on the listener to remove itself in case of timeout if needed
+        }
+    }
+}

--- a/src/test/java/org/elasticsearch/test/cluster/TestClusterService.java
+++ b/src/test/java/org/elasticsearch/test/cluster/TestClusterService.java
@@ -44,6 +44,7 @@ import java.util.Queue;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ScheduledFuture;
 
+/** a class that simulate simple cluster service features, like state storage and listeners */
 public class TestClusterService implements ClusterService {
 
     volatile ClusterState state;
@@ -78,6 +79,7 @@ public class TestClusterService implements ClusterService {
     }
 
 
+    /** set the current state and trigger any registered listeners about the change */
     public void setState(ClusterState state) {
         assert state.getNodes().localNode() != null;
         // make sure we have a version increment
@@ -89,6 +91,7 @@ public class TestClusterService implements ClusterService {
         }
     }
 
+    /** set the current state and trigger any registered listeners about the change */
     public void setState(ClusterState.Builder state) {
         setState(state.build());
     }
@@ -171,47 +174,48 @@ public class TestClusterService implements ClusterService {
 
     @Override
     public void submitStateUpdateTask(String source, Priority priority, ClusterStateUpdateTask updateTask) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void submitStateUpdateTask(String source, ClusterStateUpdateTask updateTask) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public List<PendingClusterTask> pendingTasks() {
-        return null;
+        throw new UnsupportedOperationException();
+
     }
 
     @Override
     public int numberOfPendingTasks() {
-        return 0;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public Lifecycle.State lifecycleState() {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void addLifecycleListener(LifecycleListener listener) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void removeLifecycleListener(LifecycleListener listener) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public ClusterService start() throws ElasticsearchException {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public ClusterService stop() throws ElasticsearchException {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/src/test/java/org/elasticsearch/test/transport/CapturingTransport.java
+++ b/src/test/java/org/elasticsearch/test/transport/CapturingTransport.java
@@ -54,10 +54,15 @@ public class CapturingTransport implements Transport {
 
     private BlockingQueue<CapturedRequest> capturedRequests = ConcurrentCollections.newBlockingQueue();
 
+    /** returns all requests captured so far. Doesn't clear the captured request list. See {@link #clear()} */
     public CapturedRequest[] capturedRequests() {
         return capturedRequests.toArray(new CapturedRequest[0]);
     }
 
+    /**
+     * returns all requests captured so far, grouped by target node.
+     * Doesn't clear the captured request list. See {@link #clear()}
+     */
     public Map<String, List<CapturedRequest>> capturedRequestsByTargetNode() {
         Map<String, List<CapturedRequest>> map = new HashMap<>();
         for (CapturedRequest request : capturedRequests) {
@@ -71,14 +76,17 @@ public class CapturingTransport implements Transport {
         return map;
     }
 
+    /** clears captured requests */
     public void clear() {
         capturedRequests.clear();
     }
 
+    /** simulate a response for the given requestId */
     public void handleResponse(final long requestId, final TransportResponse response) {
         adapter.onResponseReceived(requestId).handleResponse(response);
     }
 
+    /** simulate a remote error for the given requesTId */
     public void handleResponse(final long requestId, final Throwable t) {
         adapter.onResponseReceived(requestId).handleException(new RemoteTransportException("remote failure", t));
     }

--- a/src/test/java/org/elasticsearch/test/transport/CapturingTransport.java
+++ b/src/test/java/org/elasticsearch/test/transport/CapturingTransport.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.test.transport;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.component.Lifecycle;
+import org.elasticsearch.common.component.LifecycleListener;
+import org.elasticsearch.common.transport.BoundTransportAddress;
+import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
+import org.elasticsearch.transport.*;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+
+/** A transport class that doesn't send anything but rather captures all requests for inspection from tests */
+public class CapturingTransport implements Transport {
+    private TransportServiceAdapter adapter;
+
+    static public class CapturedRequest {
+        final public DiscoveryNode node;
+        final public long requestId;
+        final public String action;
+        final public TransportRequest request;
+
+        public CapturedRequest(DiscoveryNode node, long requestId, String action, TransportRequest request) {
+            this.node = node;
+            this.requestId = requestId;
+            this.action = action;
+            this.request = request;
+        }
+    }
+
+    private BlockingQueue<CapturedRequest> capturedRequests = ConcurrentCollections.newBlockingQueue();
+
+    public CapturedRequest[] capturedRequests() {
+        return capturedRequests.toArray(new CapturedRequest[0]);
+    }
+
+    public Map<String, List<CapturedRequest>> capturedRequestsByTargetNode() {
+        Map<String, List<CapturedRequest>> map = new HashMap<>();
+        for (CapturedRequest request : capturedRequests) {
+            List<CapturedRequest> nodeList = map.get(request.node.id());
+            if (nodeList == null) {
+                nodeList = new ArrayList<>();
+                map.put(request.node.id(), nodeList);
+            }
+            nodeList.add(request);
+        }
+        return map;
+    }
+
+    public void clear() {
+        capturedRequests.clear();
+    }
+
+    public void handleResponse(final long requestId, final TransportResponse response) {
+        adapter.onResponseReceived(requestId).handleResponse(response);
+    }
+
+
+    @Override
+    public void sendRequest(DiscoveryNode node, long requestId, String action, TransportRequest request, TransportRequestOptions options) throws IOException, TransportException {
+        capturedRequests.add(new CapturedRequest(node, requestId, action, request));
+    }
+
+
+    @Override
+    public void transportServiceAdapter(TransportServiceAdapter adapter) {
+        this.adapter = adapter;
+    }
+
+    @Override
+    public BoundTransportAddress boundAddress() {
+        return null;
+    }
+
+    @Override
+    public Map<String, BoundTransportAddress> profileBoundAddresses() {
+        return null;
+    }
+
+    @Override
+    public TransportAddress[] addressesFromString(String address) throws Exception {
+        return new TransportAddress[0];
+    }
+
+    @Override
+    public boolean addressSupported(Class<? extends TransportAddress> address) {
+        return false;
+    }
+
+    @Override
+    public boolean nodeConnected(DiscoveryNode node) {
+        return true;
+    }
+
+    @Override
+    public void connectToNode(DiscoveryNode node) throws ConnectTransportException {
+
+    }
+
+    @Override
+    public void connectToNodeLight(DiscoveryNode node) throws ConnectTransportException {
+
+    }
+
+    @Override
+    public void disconnectFromNode(DiscoveryNode node) {
+
+    }
+
+    @Override
+    public long serverOpen() {
+        return 0;
+    }
+
+    @Override
+    public Lifecycle.State lifecycleState() {
+        return null;
+    }
+
+    @Override
+    public void addLifecycleListener(LifecycleListener listener) {
+
+    }
+
+    @Override
+    public void removeLifecycleListener(LifecycleListener listener) {
+
+    }
+
+    @Override
+    public Transport start() throws ElasticsearchException {
+        return null;
+    }
+
+    @Override
+    public Transport stop() throws ElasticsearchException {
+        return null;
+    }
+
+    @Override
+    public void close() throws ElasticsearchException {
+
+    }
+}

--- a/src/test/java/org/elasticsearch/test/transport/CapturingTransport.java
+++ b/src/test/java/org/elasticsearch/test/transport/CapturingTransport.java
@@ -79,6 +79,10 @@ public class CapturingTransport implements Transport {
         adapter.onResponseReceived(requestId).handleResponse(response);
     }
 
+    public void handleResponse(final long requestId, final Throwable t) {
+        adapter.onResponseReceived(requestId).handleException(new RemoteTransportException("remote failure", t));
+    }
+
 
     @Override
     public void sendRequest(DiscoveryNode node, long requestId, String action, TransportRequest request, TransportRequestOptions options) throws IOException, TransportException {


### PR DESCRIPTION
Refactors TransportShardReplicationOperationAction state management into clear separate Primary phase and Replication phase. The primary phase is responsible for routing the request to the node  holding the primary, validating it and performing the operation on the primary. The Replication phase is responsible for sending the request to the replicas and managing their responses.

This refactoring is aimed at simplifying adding operation start and end hooks that are needed for the counter mentioned in #10032 . 

This also adds unit test infrastructure for this class, and some basic tests. We can extend later as we continue developing.

For now, this is planned to go to 2.0.0 but we make backport it to 1.6.0, depending how work goes with #10032
