### PR TITLE
Prevent injection of unannotated dynamic settings

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/settings/ClusterDynamicSettingsModule.java
+++ b/src/main/java/org/elasticsearch/cluster/settings/ClusterDynamicSettingsModule.java
@@ -27,6 +27,7 @@ import org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllo
 import org.elasticsearch.cluster.routing.allocation.decider.*;
 import org.elasticsearch.cluster.service.InternalClusterService;
 import org.elasticsearch.common.inject.AbstractModule;
+import org.elasticsearch.common.inject.util.Providers;
 import org.elasticsearch.discovery.DiscoverySettings;
 import org.elasticsearch.discovery.zen.ZenDiscovery;
 import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
@@ -109,9 +110,13 @@ public class ClusterDynamicSettingsModule extends AbstractModule {
         clusterDynamicSettings.addDynamicSetting(setting, validator);
     }
 
-
     @Override
     protected void configure() {
         bind(DynamicSettings.class).annotatedWith(ClusterDynamicSettings.class).toInstance(clusterDynamicSettings);
+
+        // Bind to null provider just in case somebody will forget to supply @ClusterDynamicSetting or @IndexDynamicSetting annotations
+        // This will cause any attempt to inject a unannotated DynamicSettings to fail with Guice error, instead of silently
+        // injecting an empty copy of dynamic settings
+        bind(DynamicSettings.class).toProvider(Providers.<DynamicSettings>of(null));
     }
 }


### PR DESCRIPTION
Dynamic settings has to be injected into constructor with either @ClusterDynamicSettings or @IndexDynamicSettings. If annotations are not specified an empty instance of Dynamic Settings is injected that can lead to difficult to discover errors such as #10614. This commit will make any attempt to inject unannotated dynamic settings to generate a giuce error.

Alternatively, we could bind unannotated DynamicSettings to cluster dynamic settings by default, this will prevent the issue as well but in more quiet manner. Any other ideas?
