### PR TITLE
Mustache tags syntax

### DIFF
--- a/docs/reference/query-dsl/queries/template-query.asciidoc
+++ b/docs/reference/query-dsl/queries/template-query.asciidoc
@@ -12,7 +12,7 @@ GET /_search
 {
     "query": {
         "template": {
-            "query": { "match": { "text": "{query_string}" }}},
+            "query": { "match": { "text": "{{query_string}}" }}},
             "params" : {
                 "query_string" : "all about search"
             }
@@ -45,7 +45,7 @@ GET /_search
 {
     "query": {
         "template": {
-            "query": "{ \"match\": { \"text\": \"{query_string}\" }}}", <1>
+            "query": "{ \"match\": { \"text\": \"{{query_string}}\" }}}", <1>
             "params" : {
                 "query_string" : "all about search"
             }
@@ -85,7 +85,7 @@ Alternatively, you can register a query template in the special `.scripts` index
 ------------------------------------------
 PUT /_search/template/my_template
 {
-    "template": { "match": { "text": "{query_string}" }}},
+    "template": { "match": { "text": "{{query_string}}" }}},
 }
 ------------------------------------------
 


### PR DESCRIPTION
Hi there. I've been experimenting with the search templates recently and I'm a bit confused. Shouldn't the Mustache tags be written like `{{tagname}}` instead of `{tagname}`? Your using `{{...}}` [here](http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html) BTW.

Using the first example in that page  seems to indicate that something's wrong, or am I missing something?

```
$ curl 'localhost:9200/test/_search' -d '{"query":{"template":{"query":{"match":{"text":"{keywords}"}},"params":{"keywords":"value1_foo"}}}}'
{"took":1,"timed_out":false,"_shards":{"total":1,"successful":1,"failed":0},"hits":{"total":0,"max_score":null,"hits":[]}}

$ curl 'localhost:9200/test/_search' -d '{"query":{"template":{"query":{"match":{"text":"{{keywords}}"}},"params":{"keywords":"value1_foo"}}}}'
{"took":1,"timed_out":false,"_shards":{"total":1,"successful":1,"failed":0},"hits":{"total":1,"max_score":1.0,"hits":[{"_index":"test","_type":"testtype","_id":"1","_score":1.0,"_source":{"text":"value1_foo"}}]}}
```
