### PR TITLE
CommitStats doesn't need to allow for null values in commit user data

### DIFF
--- a/src/main/java/org/elasticsearch/index/engine/CommitStats.java
+++ b/src/main/java/org/elasticsearch/index/engine/CommitStats.java
@@ -78,7 +78,7 @@ public final class CommitStats implements Streamable, ToXContent {
     public void readFrom(StreamInput in) throws IOException {
         MapBuilder<String, String> builder = MapBuilder.newMapBuilder();
         for (int i = in.readVInt(); i > 0; i--) {
-            builder.put(in.readString(), in.readOptionalString());
+            builder.put(in.readString(), in.readString());
         }
         userData = builder.immutableMap();
         generation = in.readLong();
@@ -90,7 +90,7 @@ public final class CommitStats implements Streamable, ToXContent {
         out.writeVInt(userData.size());
         for (Map.Entry<String, String> entry : userData.entrySet()) {
             out.writeString(entry.getKey());
-            out.writeOptionalString(entry.getValue());
+            out.writeString(entry.getValue());
         }
         out.writeLong(generation);
         out.writeString(id);


### PR DESCRIPTION
Lucene forbids writing those and MapBuilder.immutableMap doesn't like them either, as discovered by @brwe 

see #10687 
