### PR TITLE
use sync id when recovering

### DIFF
--- a/src/main/java/org/elasticsearch/gateway/GatewayAllocator.java
+++ b/src/main/java/org/elasticsearch/gateway/GatewayAllocator.java
@@ -330,8 +330,9 @@ public class GatewayAllocator extends AbstractComponent {
                             if (primaryNodeStore != null && primaryNodeStore.allocated()) {
                                 long sizeMatched = 0;
 
-                                // see if we have a sync id we cna make use of
+                                // see if we have a sync id we can make use of
                                 if (storeFilesMetaData.syncId() != null && storeFilesMetaData.syncId().equals(primaryNodeStore.syncId())) {
+                                    logger.trace("{}: node [{}] has same sync id {} as primary", shard, discoNode.name(), storeFilesMetaData.syncId());
                                     lastNodeMatched = node;
                                     lastSizeMatched = Long.MAX_VALUE;
                                     lastDiscoNodeMatched = discoNode;
@@ -429,7 +430,7 @@ public class GatewayAllocator extends AbstractComponent {
                 continue;
             }
             // we log warn here. debug logs with full stack traces will be logged if debug logging is turned on for TransportNodeListGatewayStartedShards
-            logger.warn("{}: failed to list shard {} on node [{}]", cause, failure, shard.shardId(), actionType, failure.nodeId());
+            logger.warn("{}: failed to list shard {} on node [{}]", failure, shard.shardId(), actionType, failure.nodeId());
         }
     }
 

--- a/src/main/java/org/elasticsearch/gateway/GatewayAllocator.java
+++ b/src/main/java/org/elasticsearch/gateway/GatewayAllocator.java
@@ -330,17 +330,26 @@ public class GatewayAllocator extends AbstractComponent {
                             if (primaryNodeStore != null && primaryNodeStore.allocated()) {
                                 long sizeMatched = 0;
 
-                                for (StoreFileMetaData storeFileMetaData : storeFilesMetaData) {
-                                    if (primaryNodeStore.fileExists(storeFileMetaData.name()) && primaryNodeStore.file(storeFileMetaData.name()).isSame(storeFileMetaData)) {
-                                        sizeMatched += storeFileMetaData.length();
-                                    }
-                                }
-                                logger.trace("{}: node [{}] has [{}/{}] bytes of re-usable data",
-                                        shard, discoNode.name(), new ByteSizeValue(sizeMatched), sizeMatched);
-                                if (sizeMatched > lastSizeMatched) {
-                                    lastSizeMatched = sizeMatched;
-                                    lastDiscoNodeMatched = discoNode;
+                                // see if we have a sync id we cna make use of
+                                if (storeFilesMetaData.syncId() != null && storeFilesMetaData.syncId().equals(primaryNodeStore.syncId())) {
                                     lastNodeMatched = node;
+                                    lastSizeMatched = Long.MAX_VALUE;
+                                    lastDiscoNodeMatched = discoNode;
+                                } else {
+                                    for (StoreFileMetaData storeFileMetaData : storeFilesMetaData) {
+                                        logger.trace("{}: node [{}] has file {}",
+                                                shard, discoNode.name(), storeFileMetaData.name());
+                                        if (primaryNodeStore.fileExists(storeFileMetaData.name()) && primaryNodeStore.file(storeFileMetaData.name()).isSame(storeFileMetaData)) {
+                                            sizeMatched += storeFileMetaData.length();
+                                        }
+                                    }
+                                    logger.trace("{}: node [{}] has [{}/{}] bytes of re-usable data",
+                                            shard, discoNode.name(), new ByteSizeValue(sizeMatched), sizeMatched);
+                                    if (sizeMatched > lastSizeMatched) {
+                                        lastSizeMatched = sizeMatched;
+                                        lastDiscoNodeMatched = discoNode;
+                                        lastNodeMatched = node;
+                                    }
                                 }
                             }
                         }
@@ -420,7 +429,7 @@ public class GatewayAllocator extends AbstractComponent {
                 continue;
             }
             // we log warn here. debug logs with full stack traces will be logged if debug logging is turned on for TransportNodeListGatewayStartedShards
-            logger.warn("{}: failed to list shard {} on node [{}]", failure, shard.shardId(), actionType, failure.nodeId());
+            logger.warn("{}: failed to list shard {} on node [{}]", cause, failure, shard.shardId(), actionType, failure.nodeId());
         }
     }
 

--- a/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -1283,6 +1283,11 @@ public class InternalEngine extends Engine {
             throw new EngineException(shardId, "failed to recover from translog", e);
         }
 
+        // nocommit:  when we recover from gateway we recover ops from the translog we found and then create a new translog with new id.
+        // we flush here because we need to write a new translog id after recovery.
+        // we need to make sure here that an existing sync id is not overwritten by this flush if one exists.
+        // so, in case the old translog did not contain any ops, we should use the old sync id for flushing.
+        // nocommit because not sure if this here is the best solution for this...
         if (operationsRecovered > 0) {
             flush(true, true);
             refresh("translog recovery");

--- a/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -73,7 +73,9 @@ public class InternalEngine extends Engine {
     private final FailEngineOnMergeFailure mergeSchedulerFailureListener;
     private final MergeSchedulerListener mergeSchedulerListener;
 
-    /** When we last pruned expired tombstones from versionMap.deletes: */
+    /**
+     * When we last pruned expired tombstones from versionMap.deletes:
+     */
     private volatile long lastDeleteVersionPruneTimeMSec;
 
     private final ShardIndexingService indexingService;
@@ -153,7 +155,13 @@ public class InternalEngine extends Engine {
                 if (translogId.v1() != null && skipInitialTranslogRecovery == false) {
                     recoverFromTranslog(translogId.v1(), transformer);
                 } else {
-                    flush(true, true);
+                    if (lastCommittedSegmentInfos.getUserData().get(SYNC_COMMIT_ID) == null) {
+                        flush(true, true);
+                    } else {
+                        SyncedFlushResult syncedFlushResult = syncFlushIfNoPendingChanges(lastCommittedSegmentInfos.getUserData().get(SYNC_COMMIT_ID), lastCommittedSegmentInfos.getId());
+                        assert syncedFlushResult.equals(SyncedFlushResult.SUCCESS) : "skipped translog recovery but synced flush failed";
+                    }
+
                 }
             } catch (IOException | EngineException ex) {
                 throw new EngineCreationFailureException(shardId, "failed to recover from translog", ex);
@@ -185,7 +193,7 @@ public class InternalEngine extends Engine {
             final long currentTranslogId = Long.parseLong(commitUserData.get(Translog.TRANSLOG_ID_KEY));
             return new Tuple<>(currentTranslogId, nextTranslogId);
         }
-         // translog id is not in the metadata - fix this inconsistency some code relies on this and old indices might not have it.
+        // translog id is not in the metadata - fix this inconsistency some code relies on this and old indices might not have it.
         writer.setCommitData(Collections.singletonMap(Translog.TRANSLOG_ID_KEY, Long.toString(nextTranslogId)));
         commitIndexWriter(writer);
         logger.debug("no translog ID present in the current commit - creating one");
@@ -1058,7 +1066,8 @@ public class InternalEngine extends Engine {
             boolean verbose = false;
             try {
                 verbose = Boolean.parseBoolean(System.getProperty("tests.verbose"));
-            } catch (Throwable ignore) {}
+            } catch (Throwable ignore) {
+            }
             iwc.setInfoStream(verbose ? InfoStream.getDefault() : new LoggerInfoStream(logger));
             iwc.setMergeScheduler(mergeScheduler.newMergeScheduler());
             MergePolicy mergePolicy = mergePolicyProvider.getMergePolicy();
@@ -1109,7 +1118,9 @@ public class InternalEngine extends Engine {
         }
     }
 
-    /** Extended SearcherFactory that warms the segments if needed when acquiring a new searcher */
+    /**
+     * Extended SearcherFactory that warms the segments if needed when acquiring a new searcher
+     */
     class SearchFactory extends EngineSearcherFactory {
 
         SearchFactory(EngineConfig engineConfig) {
@@ -1271,9 +1282,15 @@ public class InternalEngine extends Engine {
             IOUtils.closeWhileHandlingException(translog);
             throw new EngineException(shardId, "failed to recover from translog", e);
         }
-        flush(true, true);
+
         if (operationsRecovered > 0) {
+            flush(true, true);
             refresh("translog recovery");
+        } else if (lastCommittedSegmentInfos.getUserData().get(SYNC_COMMIT_ID) == null) {
+            flush(true, true);
+        } else {
+            SyncedFlushResult syncedFlushResult = syncFlushIfNoPendingChanges(lastCommittedSegmentInfos.getUserData().get(SYNC_COMMIT_ID), lastCommittedSegmentInfos.getId());
+            assert syncedFlushResult.equals(SyncedFlushResult.SUCCESS) : "no operations during translog recovery but synced flush failed";
         }
         translog.clearUnreferenced();
     }

--- a/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardRepository.java
+++ b/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardRepository.java
@@ -187,7 +187,6 @@ public class BlobStoreIndexShardRepository extends AbstractComponent implements 
     @Override
     public void verify(String seed) {
         BlobContainer testBlobContainer = blobStore.blobContainer(basePath);
-        ;
         DiscoveryNode localNode = clusterService.localNode();
         if (testBlobContainer.blobExists(testBlobPrefix(seed) + "-master")) {
             try (OutputStream outputStream = testBlobContainer.createOutput(testBlobPrefix(seed) + "-" + localNode.getId())) {

--- a/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardRepository.java
+++ b/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardRepository.java
@@ -186,7 +186,8 @@ public class BlobStoreIndexShardRepository extends AbstractComponent implements 
 
     @Override
     public void verify(String seed) {
-        BlobContainer testBlobContainer = blobStore.blobContainer(basePath);;
+        BlobContainer testBlobContainer = blobStore.blobContainer(basePath);
+        ;
         DiscoveryNode localNode = clusterService.localNode();
         if (testBlobContainer.blobExists(testBlobPrefix(seed) + "-master")) {
             try (OutputStream outputStream = testBlobContainer.createOutput(testBlobPrefix(seed) + "-" + localNode.getId())) {
@@ -232,7 +233,7 @@ public class BlobStoreIndexShardRepository extends AbstractComponent implements 
      * Serializes snapshot to JSON
      *
      * @param snapshot snapshot
-     * @param stream the stream to output the snapshot JSON represetation to
+     * @param stream   the stream to output the snapshot JSON represetation to
      * @throws IOException if an IOException occurs
      */
     public static void writeSnapshot(BlobStoreIndexShardSnapshot snapshot, OutputStream stream) throws IOException {
@@ -247,7 +248,7 @@ public class BlobStoreIndexShardRepository extends AbstractComponent implements 
      * @param stream JSON
      * @return snapshot
      * @throws IOException if an IOException occurs
-     * */
+     */
     public static BlobStoreIndexShardSnapshot readSnapshot(InputStream stream) throws IOException {
         try (XContentParser parser = XContentFactory.xContent(XContentType.JSON).createParser(stream)) {
             parser.nextToken();
@@ -314,7 +315,7 @@ public class BlobStoreIndexShardRepository extends AbstractComponent implements 
         public BlobStoreIndexShardSnapshot loadSnapshot() {
             BlobStoreIndexShardSnapshot snapshot;
             try (InputStream stream = blobContainer.openInput(snapshotBlobName(snapshotId))) {
-                    snapshot = readSnapshot(stream);
+                snapshot = readSnapshot(stream);
             } catch (IOException ex) {
                 throw new IndexShardRestoreFailedException(shardId, "failed to read shard snapshot file", ex);
             }
@@ -472,7 +473,7 @@ public class BlobStoreIndexShardRepository extends AbstractComponent implements 
                         // don't have this hash we try to read that hash from the blob store
                         // in a bwc compatible way.
                         maybeRecalculateMetadataHash(blobContainer, fileInfo, metadata);
-                    }  catch (Throwable e) {
+                    } catch (Throwable e) {
                         logger.warn("{} Can't calculate hash from blob for file [{}] [{}]", e, shardId, fileInfo.physicalName(), fileInfo.metadata());
                     }
                     if (fileInfo == null || !fileInfo.isSame(md) || !snapshotFileExistsInBlobs(fileInfo, blobs)) {
@@ -550,7 +551,7 @@ public class BlobStoreIndexShardRepository extends AbstractComponent implements 
             try (IndexInput indexInput = store.openVerifyingInput(file, IOContext.READONCE, fileInfo.metadata())) {
                 for (int i = 0; i < fileInfo.numberOfParts(); i++) {
                     final InputStreamIndexInput inputStreamIndexInput = new InputStreamIndexInput(indexInput, fileInfo.partBytes());
-                    InputStream inputStream = snapshotRateLimiter == null ? inputStreamIndexInput :  new RateLimitingInputStream(inputStreamIndexInput, snapshotRateLimiter, snapshotThrottleListener);
+                    InputStream inputStream = snapshotRateLimiter == null ? inputStreamIndexInput : new RateLimitingInputStream(inputStreamIndexInput, snapshotRateLimiter, snapshotThrottleListener);
                     inputStream = new AbortableInputStream(inputStream, fileInfo.physicalName());
                     try (OutputStream output = blobContainer.createOutput(fileInfo.partName(i))) {
                         int len;
@@ -727,14 +728,14 @@ public class BlobStoreIndexShardRepository extends AbstractComponent implements 
                         // don't have this hash we try to read that hash from the blob store
                         // in a bwc compatible way.
                         maybeRecalculateMetadataHash(blobContainer, fileInfo, recoveryTargetMetadata);
-                    }  catch (Throwable e) {
+                    } catch (Throwable e) {
                         // if the index is broken we might not be able to read it
                         logger.warn("{} Can't calculate hash from blog for file [{}] [{}]", e, shardId, fileInfo.physicalName(), fileInfo.metadata());
                     }
                     snapshotMetaData.put(fileInfo.metadata().name(), fileInfo.metadata());
                     fileInfos.put(fileInfo.metadata().name(), fileInfo);
                 }
-                final Store.MetadataSnapshot sourceMetaData = new Store.MetadataSnapshot(snapshotMetaData);
+                final Store.MetadataSnapshot sourceMetaData = new Store.MetadataSnapshot(snapshotMetaData, Collections.EMPTY_MAP);
                 final Store.RecoveryDiff diff = sourceMetaData.recoveryDiff(recoveryTargetMetadata);
                 for (StoreFileMetaData md : diff.identical) {
                     FileInfo fileInfo = fileInfos.get(md.name());
@@ -804,8 +805,8 @@ public class BlobStoreIndexShardRepository extends AbstractComponent implements 
                 try (final IndexOutput indexOutput = store.createVerifyingOutput(fileInfo.physicalName(), fileInfo.metadata(), IOContext.DEFAULT)) {
                     final byte[] buffer = new byte[BUFFER_SIZE];
                     int length;
-                    while((length=stream.read(buffer))>0){
-                        indexOutput.writeBytes(buffer,0,length);
+                    while ((length = stream.read(buffer)) > 0) {
+                        indexOutput.writeBytes(buffer, 0, length);
                         recoveryState.getIndex().addRecoveredBytesToFile(fileInfo.name(), length);
                         if (restoreRateLimiter != null) {
                             rateLimiterListener.onRestorePause(restoreRateLimiter.pause(length));
@@ -838,7 +839,7 @@ public class BlobStoreIndexShardRepository extends AbstractComponent implements 
         }
 
     }
-    
+
     public interface RateLimiterListener {
         void onRestorePause(long nanos);
 

--- a/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/src/main/java/org/elasticsearch/index/store/Store.java
@@ -47,6 +47,7 @@ import org.elasticsearch.common.util.SingleObjectCache;
 import org.elasticsearch.common.util.concurrent.AbstractRefCounted;
 import org.elasticsearch.common.util.concurrent.RefCounted;
 import org.elasticsearch.env.ShardLock;
+import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.settings.IndexSettings;
 import org.elasticsearch.index.shard.AbstractIndexShardComponent;
 import org.elasticsearch.index.shard.ShardId;
@@ -1028,6 +1029,10 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
                 }
             }
             return count;
+        }
+
+        public String getSyncId() {
+            return commitUserData.get(Engine.SYNC_COMMIT_ID);
         }
     }
 

--- a/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/src/main/java/org/elasticsearch/index/store/Store.java
@@ -678,11 +678,11 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
         }
 
         MetadataSnapshot(IndexCommit commit, Directory directory, ESLogger logger) throws IOException {
-            initMetadata(commit, directory, logger);
+            loadMetadata(commit, directory, logger);
             assert metadata.isEmpty() || numSegmentFiles() == 1 : "numSegmentFiles: " + numSegmentFiles();
         }
 
-        void initMetadata(IndexCommit commit, Directory directory, ESLogger logger) throws IOException {
+        void loadMetadata(IndexCommit commit, Directory directory, ESLogger logger) throws IOException {
             ImmutableMap.Builder<String, StoreFileMetaData> builder = ImmutableMap.builder();
             Map<String, String> checksumMap = readLegacyChecksums(directory).v1();
             try {

--- a/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/src/main/java/org/elasticsearch/index/store/Store.java
@@ -981,7 +981,7 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
             commitUserData = new HashMap<>();
             int num = in.readVInt();
             for (int i = num; i > 0; i--) {
-                commitUserData.put(in.readString(), in.readOptionalString());
+                commitUserData.put(in.readString(), in.readString());
             }
         }
 
@@ -994,7 +994,7 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
             out.writeVInt(commitUserData.size());
             for (Map.Entry<String, String> entry : commitUserData.entrySet()) {
                 out.writeString(entry.getKey());
-                out.writeOptionalString(entry.getValue());
+                out.writeString(entry.getValue());
             }
         }
 

--- a/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/src/main/java/org/elasticsearch/index/store/Store.java
@@ -964,7 +964,6 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
         public static MetadataSnapshot read(StreamInput in) throws IOException {
             MetadataSnapshot storeFileMetaDatas = new MetadataSnapshot();
             storeFileMetaDatas.readFrom(in);
-
             return storeFileMetaDatas;
         }
 

--- a/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/src/main/java/org/elasticsearch/index/store/Store.java
@@ -28,6 +28,7 @@ import org.apache.lucene.store.*;
 import org.apache.lucene.util.*;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ExceptionsHelper;
+import org.apache.lucene.util.Version;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.inject.Inject;
@@ -166,10 +167,10 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
      * Returns a new MetadataSnapshot for the latest commit in this store or
      * an empty snapshot if no index exists or can not be opened.
      *
-     * @throws CorruptIndexException if the lucene index is corrupted. This can be caused by a checksum mismatch or an
-     *                               unexpected exception when opening the index reading the segments file.
-     * @throws IndexFormatTooOldException  if the lucene index is too old to be opened.
-     * @throws IndexFormatTooNewException  if the lucene index is too new to be opened.
+     * @throws CorruptIndexException      if the lucene index is corrupted. This can be caused by a checksum mismatch or an
+     *                                    unexpected exception when opening the index reading the segments file.
+     * @throws IndexFormatTooOldException if the lucene index is too old to be opened.
+     * @throws IndexFormatTooNewException if the lucene index is too new to be opened.
      */
     public MetadataSnapshot getMetadataOrEmpty() throws IOException {
         try {
@@ -185,13 +186,13 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
     /**
      * Returns a new MetadataSnapshot for the latest commit in this store.
      *
-     * @throws CorruptIndexException  if the lucene index is corrupted. This can be caused by a checksum mismatch or an
-     *                                unexpected exception when opening the index reading the segments file.
-     * @throws IndexFormatTooOldException  if the lucene index is too old to be opened.
-     * @throws IndexFormatTooNewException  if the lucene index is too new to be opened.
-     * @throws FileNotFoundException  if one or more files referenced by a commit are not present.
-     * @throws NoSuchFileException    if one or more files referenced by a commit are not present.
-     * @throws IndexNotFoundException if no index / valid commit-point can be found in this store
+     * @throws CorruptIndexException      if the lucene index is corrupted. This can be caused by a checksum mismatch or an
+     *                                    unexpected exception when opening the index reading the segments file.
+     * @throws IndexFormatTooOldException if the lucene index is too old to be opened.
+     * @throws IndexFormatTooNewException if the lucene index is too new to be opened.
+     * @throws FileNotFoundException      if one or more files referenced by a commit are not present.
+     * @throws NoSuchFileException        if one or more files referenced by a commit are not present.
+     * @throws IndexNotFoundException     if no index / valid commit-point can be found in this store
      */
     public MetadataSnapshot getMetadata() throws IOException {
         return getMetadata(null);
@@ -201,13 +202,13 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
      * Returns a new MetadataSnapshot for the given commit. If the given commit is <code>null</code>
      * the latest commit point is used.
      *
-     * @throws CorruptIndexException  if the lucene index is corrupted. This can be caused by a checksum mismatch or an
-     *                                unexpected exception when opening the index reading the segments file.
-     * @throws IndexFormatTooOldException  if the lucene index is too old to be opened.
-     * @throws IndexFormatTooNewException  if the lucene index is too new to be opened.
-     * @throws FileNotFoundException  if one or more files referenced by a commit are not present.
-     * @throws NoSuchFileException    if one or more files referenced by a commit are not present.
-     * @throws IndexNotFoundException if the commit point can't be found in this store
+     * @throws CorruptIndexException      if the lucene index is corrupted. This can be caused by a checksum mismatch or an
+     *                                    unexpected exception when opening the index reading the segments file.
+     * @throws IndexFormatTooOldException if the lucene index is too old to be opened.
+     * @throws IndexFormatTooNewException if the lucene index is too new to be opened.
+     * @throws FileNotFoundException      if one or more files referenced by a commit are not present.
+     * @throws NoSuchFileException        if one or more files referenced by a commit are not present.
+     * @throws IndexNotFoundException     if the commit point can't be found in this store
      */
     public MetadataSnapshot getMetadata(IndexCommit commit) throws IOException {
         ensureOpen();
@@ -363,7 +364,7 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
      * @throws IOException if the index we try to read is corrupted
      */
     public static MetadataSnapshot readMetadataSnapshot(Path indexLocation, ESLogger logger) throws IOException {
-        try (Directory dir = new SimpleFSDirectory(indexLocation)){
+        try (Directory dir = new SimpleFSDirectory(indexLocation)) {
             failIfCorrupted(dir, new ShardId("", 1));
             return new MetadataSnapshot(null, dir, logger);
         } catch (IndexNotFoundException ex) {
@@ -433,7 +434,7 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
     public boolean checkIntegrityNoException(StoreFileMetaData md) {
         return checkIntegrityNoException(md, directory());
     }
-    
+
     public static boolean checkIntegrityNoException(StoreFileMetaData md, Directory directory) {
         try {
             checkIntegrity(md, directory);
@@ -454,7 +455,7 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
                 // throw exception if metadata is inconsistent
                 if (!checksum.equals(md.checksum())) {
                     throw new CorruptIndexException("inconsistent metadata: lucene checksum=" + checksum +
-                                                                       ", metadata checksum=" + md.checksum(), input);
+                            ", metadata checksum=" + md.checksum(), input);
                 }
             } else if (md.hasLegacyChecksum()) {
                 // legacy checksum verification - no footer that we need to omit in the checksum!
@@ -472,7 +473,7 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
                 String adler32 = Store.digestToString(checksum.getValue());
                 if (!adler32.equals(md.checksum())) {
                     throw new CorruptIndexException("checksum failed (hardware problem?) : expected=" + md.checksum() +
-                                                                                           " actual=" + adler32, input);
+                            " actual=" + adler32, input);
                 }
             }
         }
@@ -549,7 +550,7 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
                     // FNF should not happen since we hold a write lock?
                 } catch (IOException ex) {
                     if (existingFile.startsWith(IndexFileNames.SEGMENTS)
-                        || existingFile.equals(IndexFileNames.OLD_SEGMENTS_GEN)) {
+                            || existingFile.equals(IndexFileNames.OLD_SEGMENTS_GEN)) {
                         // TODO do we need to also fail this if we can't delete the pending commit file?
                         // if one of those files can't be deleted we better fail the cleanup otherwise we might leave an old commit point around?
                         throw new IllegalStateException("Can't delete " + existingFile + " - cleanup failed", ex);
@@ -664,24 +665,30 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
 
         public static final MetadataSnapshot EMPTY = new MetadataSnapshot();
 
-        public MetadataSnapshot(Map<String, StoreFileMetaData> metadata) {
+        private Map<String, String> commitUserData;
+
+        public MetadataSnapshot(Map<String, StoreFileMetaData> metadata, Map<String, String> commitUserData) {
             this.metadata = metadata;
+            this.commitUserData = commitUserData;
         }
 
         MetadataSnapshot() {
-            this.metadata = Collections.emptyMap();
+            this.metadata = Collections.EMPTY_MAP;
+            this.commitUserData = Collections.EMPTY_MAP;
         }
 
         MetadataSnapshot(IndexCommit commit, Directory directory, ESLogger logger) throws IOException {
-            metadata = buildMetadata(commit, directory, logger);
+            final SegmentInfos segmentCommitInfos = Store.readSegmentsInfo(commit, directory);
+            commitUserData = segmentCommitInfos.getUserData();
+            metadata = buildMetadata(commit, directory, logger, segmentCommitInfos);
             assert metadata.isEmpty() || numSegmentFiles() == 1 : "numSegmentFiles: " + numSegmentFiles();
         }
 
-        ImmutableMap<String, StoreFileMetaData> buildMetadata(IndexCommit commit, Directory directory, ESLogger logger) throws IOException {
+        ImmutableMap<String, StoreFileMetaData> buildMetadata(IndexCommit commit, Directory directory, ESLogger logger, SegmentInfos segmentCommitInfos) throws IOException {
             ImmutableMap.Builder<String, StoreFileMetaData> builder = ImmutableMap.builder();
             Map<String, String> checksumMap = readLegacyChecksums(directory).v1();
             try {
-                final SegmentInfos segmentCommitInfos = Store.readSegmentsInfo(commit, directory);
+
                 Version maxVersion = Version.LUCENE_4_0; // we don't know which version was used to write so we take the max version.
                 for (SegmentCommitInfo info : segmentCommitInfos) {
                     final Version version = info.info.getVersion();
@@ -958,6 +965,7 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
         public static MetadataSnapshot read(StreamInput in) throws IOException {
             MetadataSnapshot storeFileMetaDatas = new MetadataSnapshot();
             storeFileMetaDatas.readFrom(in);
+
             return storeFileMetaDatas;
         }
 
@@ -968,9 +976,15 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
             for (int i = 0; i < size; i++) {
                 StoreFileMetaData meta = StoreFileMetaData.readStoreFileMetaData(in);
                 builder.put(meta.name(), meta);
+                logger.info("read {} {}", meta.name(), meta);
             }
             this.metadata = builder.build();
             assert metadata.isEmpty() || numSegmentFiles() == 1 : "numSegmentFiles: " + numSegmentFiles();
+            commitUserData = new HashMap<>();
+            int num = in.readVInt();
+            for (int i = num; i > 0; i--) {
+                commitUserData.put(in.readString(), in.readOptionalString());
+            }
         }
 
         @Override
@@ -979,6 +993,15 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
             for (StoreFileMetaData meta : this) {
                 meta.writeTo(out);
             }
+            out.writeVInt(commitUserData.size());
+            for (Map.Entry<String, String> entry : commitUserData.entrySet()) {
+                out.writeString(entry.getKey());
+                out.writeOptionalString(entry.getValue());
+            }
+        }
+
+        public Map<String, String> getCommitUserData() {
+            return commitUserData;
         }
 
         /**
@@ -1360,7 +1383,7 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
         }
 
         @Override
-        protected StoreStats refresh()  {
+        protected StoreStats refresh() {
             try {
                 return new StoreStats(estimateSize(directory), directoryService.throttleTimeInNanos());
             } catch (IOException ex) {

--- a/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/src/main/java/org/elasticsearch/index/store/Store.java
@@ -975,7 +975,6 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
             for (int i = 0; i < size; i++) {
                 StoreFileMetaData meta = StoreFileMetaData.readStoreFileMetaData(in);
                 builder.put(meta.name(), meta);
-                logger.info("read {} {}", meta.name(), meta);
             }
             this.metadata = builder.build();
             assert metadata.isEmpty() || numSegmentFiles() == 1 : "numSegmentFiles: " + numSegmentFiles();

--- a/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/src/main/java/org/elasticsearch/index/store/Store.java
@@ -1033,6 +1033,11 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
             return count;
         }
 
+        /**
+         * Returns the sync id of the commit point that this MetadataSnapshot represents.
+         *
+         * @return sync id if exists, else null
+         */
         public String getSyncId() {
             return commitUserData.get(Engine.SYNC_COMMIT_ID);
         }

--- a/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/src/main/java/org/elasticsearch/index/store/Store.java
@@ -678,17 +678,16 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
         }
 
         MetadataSnapshot(IndexCommit commit, Directory directory, ESLogger logger) throws IOException {
-            final SegmentInfos segmentCommitInfos = Store.readSegmentsInfo(commit, directory);
-            commitUserData = segmentCommitInfos.getUserData();
-            metadata = buildMetadata(commit, directory, logger, segmentCommitInfos);
+            initMetadata(commit, directory, logger);
             assert metadata.isEmpty() || numSegmentFiles() == 1 : "numSegmentFiles: " + numSegmentFiles();
         }
 
-        ImmutableMap<String, StoreFileMetaData> buildMetadata(IndexCommit commit, Directory directory, ESLogger logger, SegmentInfos segmentCommitInfos) throws IOException {
+        void initMetadata(IndexCommit commit, Directory directory, ESLogger logger) throws IOException {
             ImmutableMap.Builder<String, StoreFileMetaData> builder = ImmutableMap.builder();
             Map<String, String> checksumMap = readLegacyChecksums(directory).v1();
             try {
-
+                final SegmentInfos segmentCommitInfos = Store.readSegmentsInfo(commit, directory);
+                commitUserData = segmentCommitInfos.getUserData();
                 Version maxVersion = Version.LUCENE_4_0; // we don't know which version was used to write so we take the max version.
                 for (SegmentCommitInfo info : segmentCommitInfos) {
                     final Version version = info.info.getVersion();
@@ -741,7 +740,7 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
 
                 throw ex;
             }
-            return builder.build();
+            metadata = builder.build();
         }
 
         /**

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoveryCleanFilesRequest.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoveryCleanFilesRequest.java
@@ -61,7 +61,7 @@ class RecoveryCleanFilesRequest extends TransportRequest {
         super.readFrom(in);
         recoveryId = in.readLong();
         shardId = ShardId.readShardId(in);
-        snapshotFiles = Store.MetadataSnapshot.read(in);
+        snapshotFiles = new Store.MetadataSnapshot(in);
         totalTranslogOps = in.readVInt();
     }
 

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -169,8 +169,10 @@ public class RecoverySourceHandler implements Engine.RecoveryHandler {
             // Generate a "diff" of all the identical, different, and missing
             // segment files on the target node, using the existing files on
             // the source node
-            final boolean recoverWithSyncId = recoverySourceMetadata.getCommitUserData().get(Engine.SYNC_COMMIT_ID) != null &&
-                    recoverySourceMetadata.getCommitUserData().get(Engine.SYNC_COMMIT_ID).equals(request.metadataSnapshot().getCommitUserData().get(Engine.SYNC_COMMIT_ID));
+            String recoverySourceSyncId = recoverySourceMetadata.getSyncId();
+            String recoveryTargetSyncId = request.metadataSnapshot().getSyncId();
+            final boolean recoverWithSyncId = recoverySourceSyncId != null &&
+                    recoverySourceSyncId.equals(recoveryTargetSyncId);
             if (recoverWithSyncId) {
                 for (StoreFileMetaData md : request.metadataSnapshot()) {
                     response.phase1ExistingFileNames.add(md.name());

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -176,8 +176,8 @@ public class RecoverySourceHandler implements Engine.RecoveryHandler {
                     response.phase1ExistingFileNames.add(md.name());
                     response.phase1ExistingFileSizes.add(md.length());
                     existingTotalSize += md.length();
-                    if (logger.isDebugEnabled()) {
-                        logger.debug("[{}][{}] recovery [phase1] to {}: not recovering [{}], checksum [{}], size [{}], sync ids {} coincide, will skip file copy",
+                    if (logger.isTraceEnabled()) {
+                        logger.trace("[{}][{}] recovery [phase1] to {}: not recovering [{}], checksum [{}], size [{}], sync ids {} coincide, will skip file copy",
                                 indexName, shardId, request.targetNode(), md.name(), md.checksum(), md.length(), recoverySourceMetadata.getCommitUserData().get(Engine.SYNC_COMMIT_ID));
                     }
                     totalSize += md.length();
@@ -188,8 +188,8 @@ public class RecoverySourceHandler implements Engine.RecoveryHandler {
                     response.phase1ExistingFileNames.add(md.name());
                     response.phase1ExistingFileSizes.add(md.length());
                     existingTotalSize += md.length();
-                    if (logger.isDebugEnabled()) {
-                        logger.debug("[{}][{}] recovery [phase1] to {}: not recovering [{}], exists in local store and has checksum [{}], size [{}]",
+                    if (logger.isTraceEnabled()) {
+                        logger.trace("[{}][{}] recovery [phase1] to {}: not recovering [{}], exists in local store and has checksum [{}], size [{}]",
                                 indexName, shardId, request.targetNode(), md.name(), md.checksum(), md.length());
                     }
                     totalSize += md.length();

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -65,6 +65,7 @@ import org.elasticsearch.transport.TransportRequestOptions;
 import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.*;
@@ -137,11 +138,11 @@ public class RecoverySourceHandler implements Engine.RecoveryHandler {
      * Perform phase1 of the recovery operations. Once this {@link SnapshotIndexCommit}
      * snapshot has been performed no commit operations (files being fsync'd)
      * are effectively allowed on this index until all recovery phases are done
-     *
+     * <p/>
      * Phase1 examines the segment files on the target node and copies over the
      * segments that are missing. Only segments that have the same size and
      * checksum can be reused
-     *
+     * <p/>
      * {@code InternalEngine#recover} is responsible for snapshotting the index
      * and releasing the snapshot once all 3 phases of recovery are complete
      */
@@ -168,21 +169,33 @@ public class RecoverySourceHandler implements Engine.RecoveryHandler {
             // Generate a "diff" of all the identical, different, and missing
             // segment files on the target node, using the existing files on
             // the source node
-            final Store.RecoveryDiff diff = recoverySourceMetadata.recoveryDiff(new Store.MetadataSnapshot(request.existingFiles()));
+            final Store.RecoveryDiff diff;
+            boolean copyFiles = true;
+            if (recoverySourceMetadata.getCommitUserData().get(Engine.SYNC_COMMIT_ID) != null &&
+                    recoverySourceMetadata.getCommitUserData().get(Engine.SYNC_COMMIT_ID).equals(request.metadataSnapshot().getCommitUserData().get(Engine.SYNC_COMMIT_ID))) {
+                diff = request.metadataSnapshot().recoveryDiff(request.metadataSnapshot());
+                copyFiles = false;
+            } else {
+                diff = recoverySourceMetadata.recoveryDiff(request.metadataSnapshot());
+            }
             for (StoreFileMetaData md : diff.identical) {
                 response.phase1ExistingFileNames.add(md.name());
                 response.phase1ExistingFileSizes.add(md.length());
                 existingTotalSize += md.length();
-                if (logger.isTraceEnabled()) {
-                    logger.trace("[{}][{}] recovery [phase1] to {}: not recovering [{}], exists in local store and has checksum [{}], size [{}]",
-                            indexName, shardId, request.targetNode(), md.name(), md.checksum(), md.length());
+                if (logger.isDebugEnabled()) {
+                    if (copyFiles) {
+                        logger.debug("[{}][{}] recovery [phase1] to {}: not recovering [{}], exists in local store and has checksum [{}], size [{}]",
+                                indexName, shardId, request.targetNode(), md.name(), md.checksum(), md.length());
+                    } else {
+                        logger.debug("[{}][{}] recovery [phase1] to {}: not recovering [{}], checksum [{}], size [{}], sync ids {} coincide, will skip file copy", indexName, shardId, request.targetNode(), md.name(), md.checksum(), md.length(), recoverySourceMetadata.getCommitUserData().get(Engine.SYNC_COMMIT_ID));
+                    }
                 }
                 totalSize += md.length();
             }
             for (StoreFileMetaData md : Iterables.concat(diff.different, diff.missing)) {
-                if (request.existingFiles().containsKey(md.name())) {
+                if (request.metadataSnapshot().asMap().containsKey(md.name())) {
                     logger.trace("[{}][{}] recovery [phase1] to {}: recovering [{}], exists in local store, but is different: remote [{}], local [{}]",
-                            indexName, shardId, request.targetNode(), md.name(), request.existingFiles().get(md.name()), md);
+                            indexName, shardId, request.targetNode(), md.name(), request.metadataSnapshot().asMap().get(md.name()), md);
                 } else {
                     logger.trace("[{}][{}] recovery [phase1] to {}: recovering [{}], does not exists in remote",
                             indexName, shardId, request.targetNode(), md.name());
@@ -209,6 +222,9 @@ public class RecoverySourceHandler implements Engine.RecoveryHandler {
                 }
             });
 
+            if (copyFiles == false) {
+                return;
+            }
 
             // This latch will be used to wait until all files have been transferred to the target node
             final CountDownLatch latch = new CountDownLatch(response.phase1FileNames.size());
@@ -418,12 +434,12 @@ public class RecoverySourceHandler implements Engine.RecoveryHandler {
 
     /**
      * Perform phase2 of the recovery process
-     *
+     * <p/>
      * Phase2 takes a snapshot of the current translog *without* acquiring the
      * write lock (however, the translog snapshot is a point-in-time view of
      * the translog). It then sends each translog operation to the target node
      * so it can be replayed into the new shard.
-     *
+     * <p/>
      * {@code InternalEngine#recover} is responsible for taking the snapshot
      * of the translog and releasing it once all 3 phases of recovery are complete
      */
@@ -469,11 +485,11 @@ public class RecoverySourceHandler implements Engine.RecoveryHandler {
 
     /**
      * Perform phase 3 of the recovery process
-     *
+     * <p/>
      * Phase3 again takes a snapshot of the translog, however this time the
      * snapshot is acquired under a write lock. The translog operations are
      * sent to the target node where they are replayed.
-     *
+     * <p/>
      * {@code InternalEngine#recover} is responsible for taking the snapshot
      * of the translog, and after phase 3 completes the snapshots from all
      * three phases are released.
@@ -587,7 +603,7 @@ public class RecoverySourceHandler implements Engine.RecoveryHandler {
 
     /**
      * Send the given snapshot's operations to this handler's target node.
-     *
+     * <p/>
      * Operations are bulked into a single request depending on an operation
      * count limit or size-in-bytes limit
      *
@@ -600,8 +616,8 @@ public class RecoverySourceHandler implements Engine.RecoveryHandler {
         final List<Translog.Operation> operations = Lists.newArrayList();
         Translog.Operation operation;
         try {
-             operation = snapshot.next(); // this ex should bubble up
-        } catch (IOException ex){
+            operation = snapshot.next(); // this ex should bubble up
+        } catch (IOException ex) {
             throw new ElasticsearchException("failed to get next operation from translog", ex);
         }
 
@@ -659,9 +675,10 @@ public class RecoverySourceHandler implements Engine.RecoveryHandler {
             }
             try {
                 operation = snapshot.next(); // this ex should bubble up
-            } catch (IOException ex){
+            } catch (IOException ex) {
                 throw new ElasticsearchException("failed to get next operation from translog", ex);
-            }        }
+            }
+        }
         // send the leftover
         if (!operations.isEmpty()) {
             cancellableThreads.execute(new Interruptable() {

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.logging.ESLoggerFactory;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -809,15 +810,7 @@ public class RecoveryState implements ToXContent, Streamable {
             return total;
         }
 
-        public synchronized long totalReuseBytes() {
-            long total = 0;
-            for (File file : fileDetails.values()) {
-                if (file.reused()) {
-                    total += file.length();
-                }
-            }
-            return total;
-        }
+
 
         /** percent of bytes recovered out of total files bytes *to be* recovered */
         public synchronized float recoveredBytesPercent() {

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java
@@ -48,16 +48,24 @@ public class RecoveryState implements ToXContent, Streamable {
     public static enum Stage {
         INIT((byte) 0),
 
-        /** recovery of lucene files, either reusing local ones are copying new ones */
+        /**
+         * recovery of lucene files, either reusing local ones are copying new ones
+         */
         INDEX((byte) 1),
 
-        /** potentially running check index */
+        /**
+         * potentially running check index
+         */
         VERIFY_INDEX((byte) 2),
 
-        /**  starting up the engine, replaying the translog */
+        /**
+         * starting up the engine, replaying the translog
+         */
         TRANSLOG((byte) 3),
 
-        /** performing final task after all translog ops have been done */
+        /**
+         * performing final task after all translog ops have been done
+         */
         FINALIZE((byte) 4),
 
         DONE((byte) 5);
@@ -495,7 +503,9 @@ public class RecoveryState implements ToXContent, Streamable {
             assert total == UNKNOWN || total >= recovered : "total, if known, should be > recovered. total [" + total + "], recovered [" + recovered + "]";
         }
 
-        /** returns the total number of translog operations recovered so far */
+        /**
+         * returns the total number of translog operations recovered so far
+         */
         public synchronized int recoveredOperations() {
             return recovered;
         }
@@ -588,22 +598,30 @@ public class RecoveryState implements ToXContent, Streamable {
             recovered += bytes;
         }
 
-        /** file name * */
+        /**
+         * file name *
+         */
         public String name() {
             return name;
         }
 
-        /** file length * */
+        /**
+         * file length *
+         */
         public long length() {
             return length;
         }
 
-        /** number of bytes recovered for this file (so far). 0 if the file is reused * */
+        /**
+         * number of bytes recovered for this file (so far). 0 if the file is reused *
+         */
         public long recovered() {
             return recovered;
         }
 
-        /** returns true if the file is reused from a local copy */
+        /**
+         * returns true if the file is reused from a local copy
+         */
         public boolean reused() {
             return reused;
         }
@@ -730,12 +748,16 @@ public class RecoveryState implements ToXContent, Streamable {
             return TimeValue.timeValueNanos(targetThrottleTimeInNanos);
         }
 
-        /** total number of files that are part of this recovery, both re-used and recovered */
+        /**
+         * total number of files that are part of this recovery, both re-used and recovered
+         */
         public synchronized int totalFileCount() {
             return fileDetails.size();
         }
 
-        /** total number of files to be recovered (potentially not yet done) */
+        /**
+         * total number of files to be recovered (potentially not yet done)
+         */
         public synchronized int totalRecoverFiles() {
             int total = 0;
             for (File file : fileDetails.values()) {
@@ -747,7 +769,9 @@ public class RecoveryState implements ToXContent, Streamable {
         }
 
 
-        /** number of file that were recovered (excluding on ongoing files) */
+        /**
+         * number of file that were recovered (excluding on ongoing files)
+         */
         public synchronized int recoveredFileCount() {
             int count = 0;
             for (File file : fileDetails.values()) {
@@ -758,7 +782,9 @@ public class RecoveryState implements ToXContent, Streamable {
             return count;
         }
 
-        /** percent of recovered (i.e., not reused) files out of the total files to be recovered */
+        /**
+         * percent of recovered (i.e., not reused) files out of the total files to be recovered
+         */
         public synchronized float recoveredFilesPercent() {
             int total = 0;
             int recovered = 0;
@@ -781,7 +807,9 @@ public class RecoveryState implements ToXContent, Streamable {
             }
         }
 
-        /** total number of bytes in th shard */
+        /**
+         * total number of bytes in th shard
+         */
         public synchronized long totalBytes() {
             long total = 0;
             for (File file : fileDetails.values()) {
@@ -790,7 +818,9 @@ public class RecoveryState implements ToXContent, Streamable {
             return total;
         }
 
-        /** total number of bytes recovered so far, including both existing and reused */
+        /**
+         * total number of bytes recovered so far, including both existing and reused
+         */
         public synchronized long recoveredBytes() {
             long recovered = 0;
             for (File file : fileDetails.values()) {
@@ -799,7 +829,9 @@ public class RecoveryState implements ToXContent, Streamable {
             return recovered;
         }
 
-        /** total bytes of files to be recovered (potentially not yet done) */
+        /**
+         * total bytes of files to be recovered (potentially not yet done)
+         */
         public synchronized long totalRecoverBytes() {
             long total = 0;
             for (File file : fileDetails.values()) {
@@ -810,9 +842,19 @@ public class RecoveryState implements ToXContent, Streamable {
             return total;
         }
 
+        public synchronized long totalReuseBytes() {
+            long total = 0;
+            for (File file : fileDetails.values()) {
+                if (file.reused()) {
+                    total += file.length();
+                }
+            }
+            return total;
+        }
 
-
-        /** percent of bytes recovered out of total files bytes *to be* recovered */
+        /**
+         * percent of bytes recovered out of total files bytes *to be* recovered
+         */
         public synchronized float recoveredBytesPercent() {
             long total = 0;
             long recovered = 0;

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
@@ -40,6 +40,7 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.CancellableThreads;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.index.IndexShardMissingException;
+import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.engine.RecoveryEngineException;
 import org.elasticsearch.index.settings.IndexSettings;
 import org.elasticsearch.index.shard.*;
@@ -155,12 +156,12 @@ public class RecoveryTarget extends AbstractComponent {
         assert recoveryStatus.sourceNode() != null : "can't do a recovery without a source node";
 
         logger.trace("collecting local files for {}", recoveryStatus);
-        Map<String, StoreFileMetaData> existingFiles;
+        Store.MetadataSnapshot metadataSnapshot = null;
         try {
-            existingFiles = recoveryStatus.store().getMetadataOrEmpty().asMap();
+            metadataSnapshot = recoveryStatus.store().getMetadataOrEmpty();
         } catch (IOException e) {
             logger.warn("error while listing local files, recover as if there are none", e);
-            existingFiles = Store.MetadataSnapshot.EMPTY.asMap();
+            metadataSnapshot = Store.MetadataSnapshot.EMPTY;
         } catch (Exception e) {
             // this will be logged as warning later on...
             logger.trace("unexpected error while listing local files, failing recovery", e);
@@ -169,7 +170,7 @@ public class RecoveryTarget extends AbstractComponent {
             return;
         }
         final StartRecoveryRequest request = new StartRecoveryRequest(recoveryStatus.shardId(), recoveryStatus.sourceNode(), clusterService.localNode(),
-                false, existingFiles, recoveryStatus.state().getType(), recoveryStatus.recoveryId());
+                false, metadataSnapshot, recoveryStatus.state().getType(), recoveryStatus.recoveryId());
 
         final AtomicReference<RecoveryResponse> responseHolder = new AtomicReference<>();
         try {

--- a/src/main/java/org/elasticsearch/indices/recovery/StartRecoveryRequest.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/StartRecoveryRequest.java
@@ -109,7 +109,7 @@ public class StartRecoveryRequest extends TransportRequest {
         sourceNode = DiscoveryNode.readNode(in);
         targetNode = DiscoveryNode.readNode(in);
         markAsRelocated = in.readBoolean();
-        metadataSnapshot = Store.MetadataSnapshot.read(in);
+        metadataSnapshot = new Store.MetadataSnapshot(in);
         recoveryType = RecoveryState.Type.fromId(in.readByte());
 
     }

--- a/src/main/java/org/elasticsearch/indices/recovery/StartRecoveryRequest.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/StartRecoveryRequest.java
@@ -25,6 +25,7 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.store.Store;
 import org.elasticsearch.index.store.StoreFileMetaData;
 import org.elasticsearch.transport.TransportRequest;
 
@@ -46,7 +47,7 @@ public class StartRecoveryRequest extends TransportRequest {
 
     private boolean markAsRelocated;
 
-    private Map<String, StoreFileMetaData> existingFiles;
+    Store.MetadataSnapshot metadataSnapshot;
 
     private RecoveryState.Type recoveryType;
 
@@ -57,20 +58,19 @@ public class StartRecoveryRequest extends TransportRequest {
      * Start recovery request.
      *
      * @param shardId
-     * @param sourceNode      The node to recover from
-     * @param targetNode      The node to recover to
+     * @param sourceNode       The node to recover from
+     * @param targetNode       The node to recover to
      * @param markAsRelocated
-     * @param existingFiles
+     * @param metadataSnapshot
      */
-    public StartRecoveryRequest(ShardId shardId, DiscoveryNode sourceNode, DiscoveryNode targetNode, boolean markAsRelocated, Map<String,
-                                StoreFileMetaData> existingFiles, RecoveryState.Type recoveryType, long recoveryId) {
+    public StartRecoveryRequest(ShardId shardId, DiscoveryNode sourceNode, DiscoveryNode targetNode, boolean markAsRelocated, Store.MetadataSnapshot metadataSnapshot, RecoveryState.Type recoveryType, long recoveryId) {
         this.recoveryId = recoveryId;
         this.shardId = shardId;
         this.sourceNode = sourceNode;
         this.targetNode = targetNode;
         this.markAsRelocated = markAsRelocated;
-        this.existingFiles = existingFiles;
         this.recoveryType = recoveryType;
+        this.metadataSnapshot = metadataSnapshot;
     }
 
     public long recoveryId() {
@@ -93,10 +93,6 @@ public class StartRecoveryRequest extends TransportRequest {
         return markAsRelocated;
     }
 
-    public Map<String, StoreFileMetaData> existingFiles() {
-        return existingFiles;
-    }
-
     public RecoveryState.Type recoveryType() {
         return recoveryType;
     }
@@ -109,13 +105,9 @@ public class StartRecoveryRequest extends TransportRequest {
         sourceNode = DiscoveryNode.readNode(in);
         targetNode = DiscoveryNode.readNode(in);
         markAsRelocated = in.readBoolean();
-        int size = in.readVInt();
-        existingFiles = Maps.newHashMapWithExpectedSize(size);
-        for (int i = 0; i < size; i++) {
-            StoreFileMetaData md = StoreFileMetaData.readStoreFileMetaData(in);
-            existingFiles.put(md.name(), md);
-        }
+        metadataSnapshot = Store.MetadataSnapshot.read(in);
         recoveryType = RecoveryState.Type.fromId(in.readByte());
+
     }
 
     @Override
@@ -126,10 +118,11 @@ public class StartRecoveryRequest extends TransportRequest {
         sourceNode.writeTo(out);
         targetNode.writeTo(out);
         out.writeBoolean(markAsRelocated);
-        out.writeVInt(existingFiles.size());
-        for (StoreFileMetaData md : existingFiles.values()) {
-            md.writeTo(out);
-        }
+        metadataSnapshot.writeTo(out);
         out.writeByte(recoveryType.id());
+    }
+
+    public Store.MetadataSnapshot metadataSnapshot() {
+        return metadataSnapshot;
     }
 }

--- a/src/main/java/org/elasticsearch/indices/recovery/StartRecoveryRequest.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/StartRecoveryRequest.java
@@ -47,7 +47,7 @@ public class StartRecoveryRequest extends TransportRequest {
 
     private boolean markAsRelocated;
 
-    Store.MetadataSnapshot metadataSnapshot;
+    private Store.MetadataSnapshot metadataSnapshot;
 
     private RecoveryState.Type recoveryType;
 

--- a/src/main/java/org/elasticsearch/indices/recovery/StartRecoveryRequest.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/StartRecoveryRequest.java
@@ -97,6 +97,10 @@ public class StartRecoveryRequest extends TransportRequest {
         return recoveryType;
     }
 
+    public Store.MetadataSnapshot metadataSnapshot() {
+        return metadataSnapshot;
+    }
+
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
@@ -122,7 +126,4 @@ public class StartRecoveryRequest extends TransportRequest {
         out.writeByte(recoveryType.id());
     }
 
-    public Store.MetadataSnapshot metadataSnapshot() {
-        return metadataSnapshot;
-    }
 }

--- a/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetaData.java
+++ b/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetaData.java
@@ -205,7 +205,7 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesOperatio
 
         @Override
         public Iterator<StoreFileMetaData> iterator() {
-            return metadataSnapshot.asMap().values().iterator();
+            return metadataSnapshot.iterator();
         }
 
         public boolean fileExists(String name) {

--- a/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetaData.java
+++ b/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetaData.java
@@ -237,7 +237,7 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesOperatio
         }
 
         public String syncId() {
-            return metadataSnapshot.getCommitUserData().get(Engine.SYNC_COMMIT_ID);
+            return metadataSnapshot.getSyncId();
         }
     }
 

--- a/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetaData.java
+++ b/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetaData.java
@@ -40,6 +40,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.index.IndexService;
+import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.ShardPath;
@@ -144,7 +145,7 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesOperatio
                     store.incRef();
                     try {
                         exists = true;
-                        return new StoreFilesMetaData(true, shardId, store.getMetadataOrEmpty().asMap());
+                        return new StoreFilesMetaData(true, shardId, store.getMetadataOrEmpty());
                     } finally {
                         store.decRef();
                     }
@@ -153,17 +154,17 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesOperatio
             // try and see if we an list unallocated
             IndexMetaData metaData = clusterService.state().metaData().index(shardId.index().name());
             if (metaData == null) {
-                return new StoreFilesMetaData(false, shardId, ImmutableMap.<String, StoreFileMetaData>of());
+                return new StoreFilesMetaData(false, shardId, Store.MetadataSnapshot.EMPTY);
             }
             String storeType = metaData.settings().get(IndexStoreModule.STORE_TYPE, "fs");
             if (!storeType.contains("fs")) {
-                return new StoreFilesMetaData(false, shardId, ImmutableMap.<String, StoreFileMetaData>of());
+                return new StoreFilesMetaData(false, shardId, Store.MetadataSnapshot.EMPTY);
             }
             final ShardPath shardPath = ShardPath.loadShardPath(logger, nodeEnv, shardId, metaData.settings());
             if (shardPath == null) {
-                return new StoreFilesMetaData(false, shardId, ImmutableMap.<String, StoreFileMetaData>of());
+                return new StoreFilesMetaData(false, shardId, Store.MetadataSnapshot.EMPTY);
             }
-            return new StoreFilesMetaData(false, shardId, Store.readMetadataSnapshot(shardPath.resolveIndex(), logger).asMap());
+            return new StoreFilesMetaData(false, shardId, Store.readMetadataSnapshot(shardPath.resolveIndex(), logger));
         } finally {
             TimeValue took = new TimeValue(System.currentTimeMillis() - startTime);
             if (exists) {
@@ -180,17 +181,18 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesOperatio
     }
 
     public static class StoreFilesMetaData implements Iterable<StoreFileMetaData>, Streamable {
+        // here also trasmit sync id, else recovery will not use sync id because of stupid gateway allocator every now and then...
         private boolean allocated;
         private ShardId shardId;
-        private Map<String, StoreFileMetaData> files;
+        Store.MetadataSnapshot metadataSnapshot;
 
         StoreFilesMetaData() {
         }
 
-        public StoreFilesMetaData(boolean allocated, ShardId shardId, Map<String, StoreFileMetaData> files) {
+        public StoreFilesMetaData(boolean allocated, ShardId shardId, Store.MetadataSnapshot metadataSnapshot) {
             this.allocated = allocated;
             this.shardId = shardId;
-            this.files = files;
+            this.metadataSnapshot = metadataSnapshot;
         }
 
         public boolean allocated() {
@@ -203,15 +205,15 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesOperatio
 
         @Override
         public Iterator<StoreFileMetaData> iterator() {
-            return files.values().iterator();
+            return metadataSnapshot.asMap().values().iterator();
         }
 
         public boolean fileExists(String name) {
-            return files.containsKey(name);
+            return metadataSnapshot.asMap().containsKey(name);
         }
 
         public StoreFileMetaData file(String name) {
-            return files.get(name);
+            return metadataSnapshot.asMap().get(name);
         }
 
         public static StoreFilesMetaData readStoreFilesMetaData(StreamInput in) throws IOException {
@@ -224,22 +226,18 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesOperatio
         public void readFrom(StreamInput in) throws IOException {
             allocated = in.readBoolean();
             shardId = ShardId.readShardId(in);
-            int size = in.readVInt();
-            files = Maps.newHashMapWithExpectedSize(size);
-            for (int i = 0; i < size; i++) {
-                StoreFileMetaData md = StoreFileMetaData.readStoreFileMetaData(in);
-                files.put(md.name(), md);
-            }
+            this.metadataSnapshot = Store.MetadataSnapshot.read(in);
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeBoolean(allocated);
             shardId.writeTo(out);
-            out.writeVInt(files.size());
-            for (StoreFileMetaData md : files.values()) {
-                md.writeTo(out);
-            }
+            metadataSnapshot.writeTo(out);
+        }
+
+        public String syncId() {
+            return metadataSnapshot.getCommitUserData().get(Engine.SYNC_COMMIT_ID);
         }
     }
 

--- a/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetaData.java
+++ b/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetaData.java
@@ -226,7 +226,7 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesOperatio
         public void readFrom(StreamInput in) throws IOException {
             allocated = in.readBoolean();
             shardId = ShardId.readShardId(in);
-            this.metadataSnapshot = Store.MetadataSnapshot.read(in);
+            this.metadataSnapshot = new Store.MetadataSnapshot(in);
         }
 
         @Override

--- a/src/test/java/org/elasticsearch/gateway/RecoveryFromGatewayTests.java
+++ b/src/test/java/org/elasticsearch/gateway/RecoveryFromGatewayTests.java
@@ -351,6 +351,7 @@ public class RecoveryFromGatewayTests extends ElasticsearchIntegrationTest {
 
     @Test
     @Slow
+    @TestLogging("gateway:TRACE")
     public void testReusePeerRecovery() throws Exception {
         final Settings settings = settingsBuilder()
                 .put("action.admin.cluster.node.shutdown.delay", "10ms")
@@ -427,7 +428,7 @@ public class RecoveryFromGatewayTests extends ElasticsearchIntegrationTest {
                     recovered += file.length();
                 }
             }
-            if (!recoveryState.getPrimary() && useSyncIds == false) {
+            if (!recoveryState.getPrimary() && (useSyncIds == false)) {
                 logger.info("--> replica shard {} recovered from {} to {}, recovered {}, reuse {}",
                         response.getShardId(), recoveryState.getSourceNode().name(), recoveryState.getTargetNode().name(),
                         recoveryState.getIndex().recoveredBytes(), recoveryState.getIndex().reusedBytes());

--- a/src/test/java/org/elasticsearch/gateway/RecoveryFromGatewayTests.java
+++ b/src/test/java/org/elasticsearch/gateway/RecoveryFromGatewayTests.java
@@ -439,6 +439,11 @@ public class RecoveryFromGatewayTests extends ElasticsearchIntegrationTest {
                 assertThat("all files should be reused except of the segments file", recoveryState.getIndex().reusedFileCount(), equalTo(recoveryState.getIndex().totalFileCount() - 1));
                 assertThat("> 0 files should be reused", recoveryState.getIndex().reusedFileCount(), greaterThan(0));
             } else {
+                if (useSyncIds && !recoveryState.getPrimary()) {
+                    logger.info("--> replica shard {} recovered from {} to {} using sync id, recovered {}, reuse {}",
+                            response.getShardId(), recoveryState.getSourceNode().name(), recoveryState.getTargetNode().name(),
+                            recoveryState.getIndex().recoveredBytes(), recoveryState.getIndex().reusedBytes());
+                }
                 assertThat(recoveryState.getIndex().recoveredBytes(), equalTo(0l));
                 assertThat(recoveryState.getIndex().reusedBytes(), equalTo(recoveryState.getIndex().totalBytes()));
                 assertThat(recoveryState.getIndex().recoveredFileCount(), equalTo(0));

--- a/src/test/java/org/elasticsearch/gateway/RecoveryFromGatewayTests.java
+++ b/src/test/java/org/elasticsearch/gateway/RecoveryFromGatewayTests.java
@@ -407,7 +407,7 @@ public class RecoveryFromGatewayTests extends ElasticsearchIntegrationTest {
             assertSyncIdsNotNull();
         }
 
-        logger.info("--> disabling allocation while the cluster is shut down second time");
+        logger.info("--> disabling allocation while the cluster is shut down", useSyncIds ? "" : " a second time");
         // Disable allocations while we are closing nodes
         client().admin().cluster().prepareUpdateSettings()
                 .setTransientSettings(settingsBuilder()

--- a/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -2002,5 +2002,5 @@ public class InternalEngineTests extends ElasticsearchTestCase {
             recoveredOps.incrementAndGet();
         }
     }
-
+    
 }

--- a/src/test/java/org/elasticsearch/index/store/StoreTest.java
+++ b/src/test/java/org/elasticsearch/index/store/StoreTest.java
@@ -1110,7 +1110,7 @@ public class StoreTest extends ElasticsearchTestCase {
         ByteArrayInputStream inBuffer = new ByteArrayInputStream(outBuffer.toByteArray());
         InputStreamStreamInput in = new InputStreamStreamInput(inBuffer);
         in.setVersion(targetNodeVersion);
-        Store.MetadataSnapshot inMetadataSnapshot = Store.MetadataSnapshot.read(in);
+        Store.MetadataSnapshot inMetadataSnapshot = new Store.MetadataSnapshot(in);
         Map<String, StoreFileMetaData> origEntries = new HashMap<>();
         origEntries.putAll(outMetadataSnapshot.asMap());
         for (Map.Entry<String, StoreFileMetaData> entry : inMetadataSnapshot.asMap().entrySet()) {

--- a/src/test/java/org/elasticsearch/index/store/StoreTest.java
+++ b/src/test/java/org/elasticsearch/index/store/StoreTest.java
@@ -1111,7 +1111,8 @@ public class StoreTest extends ElasticsearchTestCase {
         InputStreamStreamInput in = new InputStreamStreamInput(inBuffer);
         in.setVersion(targetNodeVersion);
         Store.MetadataSnapshot inMetadataSnapshot = Store.MetadataSnapshot.read(in);
-        Map<String, StoreFileMetaData> origEntries = outMetadataSnapshot.asMap();
+        Map<String, StoreFileMetaData> origEntries = new HashMap<>();
+        origEntries.putAll(outMetadataSnapshot.asMap());
         for (Map.Entry<String, StoreFileMetaData> entry : inMetadataSnapshot.asMap().entrySet()) {
             assertThat(entry.getValue().name(), equalTo(origEntries.remove(entry.getKey()).name()));
         }

--- a/src/test/java/org/elasticsearch/index/store/StoreTest.java
+++ b/src/test/java/org/elasticsearch/index/store/StoreTest.java
@@ -713,9 +713,9 @@ public class StoreTest extends ElasticsearchTestCase {
         Map<String, StoreFileMetaData> metaDataMap = new HashMap<>();
         metaDataMap.put("segments_1", new StoreFileMetaData("segments_1", 50, null, null, new BytesRef(new byte[] {1})));
         metaDataMap.put("_0_1.del", new StoreFileMetaData("_0_1.del", 42, "foobarbaz", null, new BytesRef()));
-        Store.MetadataSnapshot first = new Store.MetadataSnapshot(metaDataMap);
+        Store.MetadataSnapshot first = new Store.MetadataSnapshot(metaDataMap, Collections.EMPTY_MAP);
 
-        Store.MetadataSnapshot second = new Store.MetadataSnapshot(metaDataMap);
+        Store.MetadataSnapshot second = new Store.MetadataSnapshot(metaDataMap, Collections.EMPTY_MAP);
         Store.RecoveryDiff recoveryDiff = first.recoveryDiff(second);
         assertEquals(recoveryDiff.toString(), recoveryDiff.different.size(), 2);
     }
@@ -985,7 +985,7 @@ public class StoreTest extends ElasticsearchTestCase {
         Map<String, StoreFileMetaData> metaDataMap = new HashMap<>();
         metaDataMap.put("segments_1", new StoreFileMetaData("segments_1", 50, null, null, new BytesRef(new byte[]{1})));
         metaDataMap.put("_0_1.del", new StoreFileMetaData("_0_1.del", 42, "foobarbaz", null, new BytesRef()));
-        Store.MetadataSnapshot snapshot = new Store.MetadataSnapshot(metaDataMap);
+        Store.MetadataSnapshot snapshot = new Store.MetadataSnapshot(metaDataMap, Collections.EMPTY_MAP);
 
         final ShardId shardId = new ShardId(new Index("index"), 1);
         DirectoryService directoryService = new LuceneManagedDirectoryService(random());

--- a/src/test/java/org/elasticsearch/indices/recovery/StartRecoveryRequestTest.java
+++ b/src/test/java/org/elasticsearch/indices/recovery/StartRecoveryRequestTest.java
@@ -89,8 +89,8 @@ public class StartRecoveryRequestTest extends ElasticsearchTestCase {
         storeFileMetaDataMap.put(storeFileMetaData1.name(), storeFileMetaData1);
         storeFileMetaDataMap.put(storeFileMetaData2.name(), storeFileMetaData2);
         Map<String, String> commitUserData = new HashMap<>();
-        commitUserData.put("userdata_1", randomBoolean() ? "test" : null);
-        commitUserData.put("userdata_2", randomBoolean() ? "test" : null);
+        commitUserData.put("userdata_1", "test");
+        commitUserData.put("userdata_2", "test");
         Store.MetadataSnapshot outMetadataSnapshot = new Store.MetadataSnapshot(storeFileMetaDataMap, commitUserData);
         Version targetNodeVersion = randomVersion(random());
 

--- a/src/test/java/org/elasticsearch/indices/recovery/StartRecoveryRequestTest.java
+++ b/src/test/java/org/elasticsearch/indices/recovery/StartRecoveryRequestTest.java
@@ -78,37 +78,4 @@ public class StartRecoveryRequestTest extends ElasticsearchTestCase {
         assertThat(outRequest.recoveryType(), equalTo(inRequest.recoveryType()));
     }
 
-
-    // TODO: where should this test be?
-    @Test
-    public void testMetadataSnapshotStreaming() throws Exception {
-
-        StoreFileMetaData storeFileMetaData1 = new StoreFileMetaData("segments", 1);
-        StoreFileMetaData storeFileMetaData2 = new StoreFileMetaData("no_segments", 1);
-        Map<String, StoreFileMetaData> storeFileMetaDataMap = new HashMap<>();
-        storeFileMetaDataMap.put(storeFileMetaData1.name(), storeFileMetaData1);
-        storeFileMetaDataMap.put(storeFileMetaData2.name(), storeFileMetaData2);
-        Map<String, String> commitUserData = new HashMap<>();
-        commitUserData.put("userdata_1", "test");
-        commitUserData.put("userdata_2", "test");
-        Store.MetadataSnapshot outMetadataSnapshot = new Store.MetadataSnapshot(storeFileMetaDataMap, commitUserData);
-        Version targetNodeVersion = randomVersion(random());
-
-        ByteArrayOutputStream outBuffer = new ByteArrayOutputStream();
-        OutputStreamStreamOutput out = new OutputStreamStreamOutput(outBuffer);
-        out.setVersion(targetNodeVersion);
-        outMetadataSnapshot.writeTo(out);
-
-        ByteArrayInputStream inBuffer = new ByteArrayInputStream(outBuffer.toByteArray());
-        InputStreamStreamInput in = new InputStreamStreamInput(inBuffer);
-        in.setVersion(targetNodeVersion);
-        Store.MetadataSnapshot inMetadataSnapshot = Store.MetadataSnapshot.read(in);
-        Map<String, StoreFileMetaData> origEntries = outMetadataSnapshot.asMap();
-        for (Map.Entry<String, StoreFileMetaData> entry : inMetadataSnapshot.asMap().entrySet()) {
-            assertThat(entry.getValue().name(), equalTo(origEntries.remove(entry.getKey()).name()));
-        }
-        assertThat(origEntries.size(), equalTo(0));
-        assertThat(inMetadataSnapshot.getCommitUserData(), equalTo(outMetadataSnapshot.getCommitUserData()));
-    }
-
 }


### PR DESCRIPTION
Skip phase 1 of recovery in case an identical sync id was found on primary and replica. Relates to #10032
