### PR TITLE
Remove deprecated METADATA cluster block level

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/block/ClusterBlock.java
+++ b/src/main/java/org/elasticsearch/cluster/block/ClusterBlock.java
@@ -131,7 +131,7 @@ public class ClusterBlock implements Serializable, Streamable, ToXContent {
         final int len = in.readVInt();
         ArrayList<ClusterBlockLevel> levels = new ArrayList<>();
         for (int i = 0; i < len; i++) {
-            levels.addAll(ClusterBlockLevel.fromId(in.readVInt()));
+            levels.add(ClusterBlockLevel.fromId(in.readVInt()));
         }
         this.levels = EnumSet.copyOf(levels);
         retryable = in.readBoolean();
@@ -145,7 +145,7 @@ public class ClusterBlock implements Serializable, Streamable, ToXContent {
         out.writeString(description);
         out.writeVInt(levels.size());
         for (ClusterBlockLevel level : levels) {
-            out.writeVInt(level.toId(out.getVersion()));
+            out.writeVInt(level.id());
         }
         out.writeBoolean(retryable);
         out.writeBoolean(disableStatePersistence);

--- a/src/main/java/org/elasticsearch/cluster/block/ClusterBlockLevel.java
+++ b/src/main/java/org/elasticsearch/cluster/block/ClusterBlockLevel.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.cluster.block;
 
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
-import org.elasticsearch.Version;
 
 import java.util.EnumSet;
 
@@ -30,16 +29,8 @@ import java.util.EnumSet;
 public enum ClusterBlockLevel {
     READ(0),
     WRITE(1),
-
-    /**
-     * Since 1.6.0, METADATA has been split into two distincts cluster block levels
-     * @deprecated Use METADATA_READ or METADATA_WRITE instead.
-     */
-    @Deprecated
-    METADATA(2),
-
-    METADATA_READ(3),
-    METADATA_WRITE(4);
+    METADATA_READ(2),
+    METADATA_WRITE(3);
 
     public static final EnumSet<ClusterBlockLevel> ALL = EnumSet.of(READ, WRITE, METADATA_READ, METADATA_WRITE);
     public static final EnumSet<ClusterBlockLevel> READ_WRITE = EnumSet.of(READ, WRITE);
@@ -54,35 +45,15 @@ public enum ClusterBlockLevel {
         return this.id;
     }
 
-    /**
-     * Returns the ClusterBlockLevel's id according to a given version, this to ensure backward compatibility.
-     *
-     * @param version the version
-     * @return the ClusterBlockLevel's id
-     */
-    public int toId(Version version) {
-        assert version != null : "Version shouldn't be null";
-        // Since 1.6.0, METADATA has been split into two distincts cluster block levels
-        if (version.before(Version.V_1_6_0)) {
-            if (this == ClusterBlockLevel.METADATA_READ || this == ClusterBlockLevel.METADATA_WRITE) {
-                return ClusterBlockLevel.METADATA.id();
-            }
-        }
-        return id();
-    }
-
-    static EnumSet<ClusterBlockLevel> fromId(int id) {
+    static ClusterBlockLevel fromId(int id) {
         if (id == 0) {
-            return EnumSet.of(READ);
+            return READ;
         } else if (id == 1) {
-            return EnumSet.of(WRITE);
+            return WRITE;
         } else if (id == 2) {
-            // Since 1.6.0, METADATA has been split into two distincts cluster block levels
-            return EnumSet.of(METADATA_READ, METADATA_WRITE);
+            return METADATA_READ;
         } else if (id == 3) {
-            return EnumSet.of(METADATA_READ);
-        } else if (id == 4) {
-            return EnumSet.of(METADATA_WRITE);
+            return METADATA_WRITE;
         }
         throw new ElasticsearchIllegalArgumentException("No cluster block level matching [" + id + "]");
     }

--- a/src/test/java/org/elasticsearch/cluster/block/ClusterBlockTests.java
+++ b/src/test/java/org/elasticsearch/cluster/block/ClusterBlockTests.java
@@ -28,7 +28,6 @@ import org.junit.Test;
 
 import java.util.EnumSet;
 
-import static org.elasticsearch.cluster.block.ClusterBlockLevel.*;
 import static org.elasticsearch.test.VersionUtils.randomVersion;
 import static org.hamcrest.CoreMatchers.equalTo;
 
@@ -64,21 +63,7 @@ public class ClusterBlockTests extends ElasticsearchTestCase {
             assertThat(result.description(), equalTo(clusterBlock.description()));
             assertThat(result.retryable(), equalTo(clusterBlock.retryable()));
             assertThat(result.disableStatePersistence(), equalTo(clusterBlock.disableStatePersistence()));
-
-            // This enum set is used to count the expected serialized/deserialized number of blocks
-            EnumSet<ClusterBlockLevel> expected = EnumSet.noneOf(ClusterBlockLevel.class);
-
-            for (ClusterBlockLevel level : clusterBlock.levels()) {
-                if (level == METADATA) {
-                    assertTrue(result.levels().contains(METADATA_READ));
-                    assertTrue(result.levels().contains(METADATA_WRITE));
-                } else {
-                    assertTrue(result.levels().contains(level));
-                }
-
-                expected.addAll(ClusterBlockLevel.fromId(level.toId(version)));
-            }
-            assertThat(result.levels().size(), equalTo(expected.size()));
+            assertArrayEquals(result.levels().toArray(), clusterBlock.levels().toArray());
         }
     }
 }


### PR DESCRIPTION
This commit removes the deprecated ClusterBlockLevel.METADATA, replaced in #9203 with METADATA_READ and METADATA_WRITE.
