### PR TITLE
Remove workdir, thats unused

### DIFF
--- a/bin/service.bat
+++ b/bin/service.bat
@@ -137,13 +137,11 @@ set JVM_SS=256
 
 if "%DATA_DIR%" == "" set DATA_DIR=%ES_HOME%\data
 
-if "%WORK_DIR%" == "" set WORK_DIR=%ES_HOME%
-
 if "%CONF_DIR%" == "" set CONF_DIR=%ES_HOME%\config
 
 if "%CONF_FILE%" == "" set CONF_FILE=%ES_HOME%\config\elasticsearch.yml
 
-set ES_PARAMS=-Delasticsearch;-Des.path.home="%ES_HOME%";-Des.default.config="%CONF_FILE%";-Des.default.path.home="%ES_HOME%";-Des.default.path.logs="%LOG_DIR%";-Des.default.path.data="%DATA_DIR%";-Des.default.path.work="%WORK_DIR%";-Des.default.path.conf="%CONF_DIR%"
+set ES_PARAMS=-Delasticsearch;-Des.path.home="%ES_HOME%";-Des.default.config="%CONF_FILE%";-Des.default.path.home="%ES_HOME%";-Des.default.path.logs="%LOG_DIR%";-Des.default.path.data="%DATA_DIR%";-Des.default.path.conf="%CONF_DIR%"
 
 set JVM_OPTS=%JAVA_OPTS: =;%
 

--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -154,10 +154,6 @@
 #
 #path.data: /path/to/data1,/path/to/data2
 
-# Path to temporary files:
-#
-#path.work: /path/to/work
-
 # Path to log files:
 #
 #path.logs: /path/to/logs

--- a/docs/reference/setup/as-a-service.asciidoc
+++ b/docs/reference/setup/as-a-service.asciidoc
@@ -21,7 +21,6 @@ Each package features a configuration file, which allows you to set the followin
 `MAX_MAP_COUNT`::         Maximum number of memory map areas a process may have. If you use `mmapfs` as index store type, make sure this is set to a high value. For more information, check the https://github.com/torvalds/linux/blob/master/Documentation/sysctl/vm.txt[linux kernel documentation] about `max_map_count`. This is set via `sysctl` before starting elasticsearch. Defaults to `65535`
 `LOG_DIR`::               Log directory, defaults to `/var/log/elasticsearch`
 `DATA_DIR`::              Data directory, defaults to `/var/lib/elasticsearch`
-`WORK_DIR`::              Work directory, defaults to `/tmp/elasticsearch`
 `CONF_DIR`::              Configuration file directory (which needs to include `elasticsearch.yml` and `logging.yml` files), defaults to `/etc/elasticsearch`
 `CONF_FILE`::             Path to configuration file, defaults to `/etc/elasticsearch/elasticsearch.yml`
 `ES_JAVA_OPTS`::          Any additional java options you may want to apply. This may be useful, if you need to set the `node.name` property, but do not want to change the `elasticsearch.yml` configuration file, because it is distributed via a provisioning system like puppet or chef. Example: `ES_JAVA_OPTS="-Des.node.name=search-01"`

--- a/src/main/java/org/elasticsearch/bootstrap/Security.java
+++ b/src/main/java/org/elasticsearch/bootstrap/Security.java
@@ -83,8 +83,6 @@ class Security {
             paths.add(environment.configFile());
             paths.add(environment.logsFile());
             paths.add(environment.pluginsFile());
-            paths.add(environment.workFile());
-            paths.add(environment.workWithClusterFile());
             for (Path path : environment.dataFiles()) {
                 paths.add(path);
             }

--- a/src/main/java/org/elasticsearch/env/Environment.java
+++ b/src/main/java/org/elasticsearch/env/Environment.java
@@ -43,10 +43,6 @@ public class Environment {
 
     private final Path homeFile;
 
-    private final Path workFile;
-
-    private final Path workWithClusterFile;
-
     private final Path[] dataFiles;
 
     private final Path[] dataWithClusterFiles;
@@ -97,13 +93,6 @@ public class Environment {
             pluginsFile = homeFile.resolve("plugins");
         }
 
-        if (settings.get("path.work") != null) {
-            workFile = PathUtils.get(cleanPath(settings.get("path.work")));
-        } else {
-            workFile = homeFile.resolve("work");
-        }
-        workWithClusterFile = workFile.resolve(ClusterName.clusterNameFromSettings(settings).value());
-
         String[] dataPaths = settings.getAsArray("path.data");
         if (dataPaths.length > 0) {
             dataFiles = new Path[dataPaths.length];
@@ -136,26 +125,6 @@ public class Environment {
      */
     public Path homeFile() {
         return homeFile;
-    }
-
-    /**
-     * The work location, path to temp files.
-     *
-     * Note, currently, we don't use it in ES at all, we should strive to see if we can keep it like that,
-     * but if we do, we have the infra for it.
-     */
-    public Path workFile() {
-        return workFile;
-    }
-
-    /**
-     * The work location with the cluster name as a sub directory.
-     *
-     * Note, currently, we don't use it in ES at all, we should strive to see if we can keep it like that,
-     * but if we do, we have the infra for it.
-     */
-    public Path workWithClusterFile() {
-        return workWithClusterFile;
     }
 
     /**

--- a/src/main/java/org/elasticsearch/node/Node.java
+++ b/src/main/java/org/elasticsearch/node/Node.java
@@ -143,9 +143,9 @@ public class Node implements Releasable {
 
         if (logger.isDebugEnabled()) {
             Environment env = tuple.v2();
-            logger.debug("using home [{}], config [{}], data [{}], logs [{}], work [{}], plugins [{}]",
+            logger.debug("using home [{}], config [{}], data [{}], logs [{}], plugins [{}]",
                     env.homeFile(), env.configFile(), Arrays.toString(env.dataFiles()), env.logsFile(),
-                    env.workFile(), env.pluginsFile());
+                    env.pluginsFile());
         }
 
         this.pluginsService = new PluginsService(tuple.v1(), tuple.v2());

--- a/src/packaging/common/env/elasticsearch
+++ b/src/packaging/common/env/elasticsearch
@@ -17,9 +17,6 @@
 # Elasticsearch logs directory
 #LOG_DIR=${packaging.elasticsearch.log.dir}
 
-# Elasticsearch work directory
-#WORK_DIR=${packaging.elasticsearch.work.dir}
-
 # Elasticsearch PID directory
 #PID_DIR=${packaging.elasticsearch.pid.dir}
 

--- a/src/packaging/common/scripts/postrm
+++ b/src/packaging/common/scripts/postrm
@@ -54,7 +54,6 @@ esac
 ES_USER="${packaging.elasticsearch.user}"
 ES_GROUP="${packaging.elasticsearch.group}"
 LOG_DIR="${packaging.elasticsearch.log.dir}"
-WORK_DIR="${packaging.elasticsearch.work.dir}"
 PLUGINS_DIR="${packaging.elasticsearch.plugins.dir}"
 PID_DIR="${packaging.elasticsearch.pid.dir}"
 DATA_DIR="${packaging.elasticsearch.data.dir}"
@@ -86,12 +85,6 @@ if [ "$REMOVE_DIRS" = "true" ]; then
     if [ -d "$LOG_DIR" ]; then
         echo -n "Deleting log directory..."
         rm -rf "$LOG_DIR"
-        echo " OK"
-    fi
-
-    if [ -d "$WORK_DIR" ]; then
-        echo -n "Deleting work directory..."
-        rm -rf "$WORK_DIR"
         echo " OK"
     fi
 

--- a/src/packaging/deb/init.d/elasticsearch
+++ b/src/packaging/deb/init.d/elasticsearch
@@ -82,9 +82,6 @@ LOG_DIR=/var/log/$NAME
 # Elasticsearch data directory
 DATA_DIR=/var/lib/$NAME
 
-# Elasticsearch work directory
-WORK_DIR=/tmp/$NAME
-
 # Elasticsearch configuration directory
 CONF_DIR=/etc/$NAME
 
@@ -107,7 +104,7 @@ fi
 # Define other required variables
 PID_FILE=/var/run/$NAME.pid
 DAEMON=$ES_HOME/bin/elasticsearch
-DAEMON_OPTS="-d -p $PID_FILE --default.config=$CONF_FILE --default.path.home=$ES_HOME --default.path.logs=$LOG_DIR --default.path.data=$DATA_DIR --default.path.work=$WORK_DIR --default.path.conf=$CONF_DIR"
+DAEMON_OPTS="-d -p $PID_FILE --default.config=$CONF_FILE --default.path.home=$ES_HOME --default.path.logs=$LOG_DIR --default.path.data=$DATA_DIR --default.path.conf=$CONF_DIR"
 
 export ES_HEAP_SIZE
 export ES_HEAP_NEWSIZE
@@ -150,7 +147,7 @@ case "$1" in
 	fi
 
 	# Prepare environment
-	mkdir -p "$LOG_DIR" "$DATA_DIR" "$WORK_DIR" && chown "$ES_USER":"$ES_GROUP" "$LOG_DIR" "$DATA_DIR" "$WORK_DIR"
+	mkdir -p "$LOG_DIR" "$DATA_DIR" && chown "$ES_USER":"$ES_GROUP" "$LOG_DIR" "$DATA_DIR"
 	touch "$PID_FILE" && chown "$ES_USER":"$ES_GROUP" "$PID_FILE"
 
 	if [ -n "$MAX_OPEN_FILES" ]; then

--- a/src/packaging/deb/systemd/elasticsearch.service
+++ b/src/packaging/deb/systemd/elasticsearch.service
@@ -9,7 +9,6 @@ Environment=CONF_FILE=${packaging.elasticsearch.conf.dir}/elasticsearch.yml
 Environment=ES_HOME=${packaging.elasticsearch.home.dir}
 Environment=LOG_DIR=${packaging.elasticsearch.log.dir}
 Environment=DATA_DIR=${packaging.elasticsearch.data.dir}
-Environment=WORK_DIR=${packaging.elasticsearch.work.dir}
 Environment=CONF_DIR=${packaging.elasticsearch.conf.dir}
 EnvironmentFile=-${packaging.env.file}
 User=elasticsearch
@@ -19,7 +18,6 @@ ExecStart=/usr/share/elasticsearch/bin/elasticsearch            \
                             -Des.default.path.home=$ES_HOME     \
                             -Des.default.path.logs=$LOG_DIR     \
                             -Des.default.path.data=$DATA_DIR    \
-                            -Des.default.path.work=$WORK_DIR    \
                             -Des.default.path.conf=$CONF_DIR
 # See MAX_OPEN_FILES in sysconfig
 LimitNOFILE=65535

--- a/src/packaging/rpm/init.d/elasticsearch
+++ b/src/packaging/rpm/init.d/elasticsearch
@@ -39,7 +39,6 @@ MAX_OPEN_FILES=${packaging.os.max.open.files}
 MAX_MAP_COUNT=${packaging.os.max.map.count}
 LOG_DIR="${packaging.elasticsearch.log.dir}"
 DATA_DIR="${packaging.elasticsearch.data.dir}"
-WORK_DIR="${packaging.elasticsearch.work.dir}"
 CONF_DIR="${packaging.elasticsearch.conf.dir}"
 CONF_FILE="${packaging.elasticsearch.conf.dir}/elasticsearch.yml"
 
@@ -97,15 +96,11 @@ start() {
     if [ -n "$MAX_MAP_COUNT" -a -f /proc/sys/vm/max_map_count ]; then
         sysctl -q -w vm.max_map_count=$MAX_MAP_COUNT
     fi
-    if [ -n "$WORK_DIR" ]; then
-        mkdir -p "$WORK_DIR"
-        chown "$ES_USER":"$ES_GROUP" "$WORK_DIR"
-    fi
     export ES_GC_LOG_FILE
 
     echo -n $"Starting $prog: "
     # if not running, start it up here, usually something like "daemon $exec"
-    daemon --user $ES_USER --pidfile $pidfile $exec -p $pidfile -d -Des.default.path.home=$ES_HOME -Des.default.path.logs=$LOG_DIR -Des.default.path.data=$DATA_DIR -Des.default.path.work=$WORK_DIR -Des.default.path.conf=$CONF_DIR
+    daemon --user $ES_USER --pidfile $pidfile $exec -p $pidfile -d -Des.default.path.home=$ES_HOME -Des.default.path.logs=$LOG_DIR -Des.default.path.data=$DATA_DIR -Des.default.path.conf=$CONF_DIR
     retval=$?
     echo
     [ $retval -eq 0 ] && touch $lockfile

--- a/src/packaging/rpm/systemd/elasticsearch.service
+++ b/src/packaging/rpm/systemd/elasticsearch.service
@@ -8,13 +8,12 @@ Environment=CONF_FILE=${packaging.elasticsearch.conf.dir}/elasticsearch.yml
 Environment=ES_HOME=${packaging.elasticsearch.home.dir}
 Environment=LOG_DIR=${packaging.elasticsearch.log.dir}
 Environment=DATA_DIR=${packaging.elasticsearch.data.dir}
-Environment=WORK_DIR=${packaging.elasticsearch.work.dir}
 Environment=CONF_DIR=${packaging.elasticsearch.conf.dir}
 EnvironmentFile=-${packaging.env.file}
 User=elasticsearch
 Group=elasticsearch
 PIDFile=/var/run/elasticsearch/elasticsearch.pid
-ExecStart=/usr/share/elasticsearch/bin/elasticsearch -d -p /var/run/elasticsearch/elasticsearch.pid -Des.default.config=$CONF_FILE -Des.default.path.home=$ES_HOME -Des.default.path.logs=$LOG_DIR -Des.default.path.data=$DATA_DIR -Des.default.path.work=$WORK_DIR -Des.default.path.conf=$CONF_DIR
+ExecStart=/usr/share/elasticsearch/bin/elasticsearch -d -p /var/run/elasticsearch/elasticsearch.pid -Des.default.config=$CONF_FILE -Des.default.path.home=$ES_HOME -Des.default.path.logs=$LOG_DIR -Des.default.path.data=$DATA_DIR -Des.default.path.conf=$CONF_DIR
 # See MAX_OPEN_FILES in sysconfig
 LimitNOFILE=65535
 # See MAX_LOCKED_MEMORY in sysconfig, use "infinity" when MAX_LOCKED_MEMORY=unlimited and using bootstrap.mlockall: true


### PR DESCRIPTION
We don't need to keep around code for something we are not using.

If we ever need it, we can just revert this commit instead of maintaining dead code.
