### PR TITLE
Change BigArrays to not extend AbstractComponent

### DIFF
--- a/src/main/java/org/elasticsearch/common/util/BigArrays.java
+++ b/src/main/java/org/elasticsearch/common/util/BigArrays.java
@@ -39,9 +39,9 @@ import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import java.util.Arrays;
 
 /** Utility class to work with arrays. */
-public class BigArrays extends AbstractComponent {
+public class BigArrays {
 
-    public static final BigArrays NON_RECYCLING_INSTANCE = new BigArrays(ImmutableSettings.EMPTY, null, null);
+    public static final BigArrays NON_RECYCLING_INSTANCE = new BigArrays(null, null);
 
     /** Page size in bytes: 16KB */
     public static final int PAGE_SIZE_IN_BYTES = 1 << 14;
@@ -366,13 +366,12 @@ public class BigArrays extends AbstractComponent {
     final boolean checkBreaker;
 
     @Inject
-    public BigArrays(Settings settings, PageCacheRecycler recycler, @Nullable final CircuitBreakerService breakerService) {
+    public BigArrays(PageCacheRecycler recycler, @Nullable final CircuitBreakerService breakerService) {
         // Checking the breaker is disabled if not specified
-        this(settings, recycler, breakerService, false);
+        this(recycler, breakerService, false);
     }
 
-    public BigArrays(Settings settings, PageCacheRecycler recycler, @Nullable final CircuitBreakerService breakerService, boolean checkBreaker) {
-        super(settings);
+    public BigArrays(PageCacheRecycler recycler, @Nullable final CircuitBreakerService breakerService, boolean checkBreaker) {
         this.checkBreaker = checkBreaker;
         this.recycler = recycler;
         this.breakerService = breakerService;
@@ -415,7 +414,7 @@ public class BigArrays extends AbstractComponent {
      * explicitly enabled, instead of only accounting enabled
      */
     public BigArrays withCircuitBreaking() {
-        return new BigArrays(this.settings, this.recycler, this.breakerService, true);
+        return new BigArrays(this.recycler, this.breakerService, true);
     }
 
     private <T extends AbstractBigArray> T resizeInPlace(T array, long newSize) {

--- a/src/test/java/org/elasticsearch/common/bytes/PagedBytesReferenceTest.java
+++ b/src/test/java/org/elasticsearch/common/bytes/PagedBytesReferenceTest.java
@@ -54,7 +54,7 @@ public class PagedBytesReferenceTest extends ElasticsearchTestCase {
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        bigarrays = new BigArrays(ImmutableSettings.EMPTY, null, new NoneCircuitBreakerService());
+        bigarrays = new BigArrays(null, new NoneCircuitBreakerService());
     }
 
     @Override

--- a/src/test/java/org/elasticsearch/common/util/BigArraysTests.java
+++ b/src/test/java/org/elasticsearch/common/util/BigArraysTests.java
@@ -39,7 +39,7 @@ public class BigArraysTests extends ElasticsearchSingleNodeTest {
 
     public static BigArrays randombigArrays() {
         final PageCacheRecycler recycler = randomBoolean() ? null : ElasticsearchSingleNodeTest.getInstanceFromNode(PageCacheRecycler.class);
-        return new MockBigArrays(ImmutableSettings.EMPTY, recycler, new NoneCircuitBreakerService());
+        return new MockBigArrays(recycler, new NoneCircuitBreakerService());
     }
 
     private BigArrays bigArrays;
@@ -339,7 +339,7 @@ public class BigArraysTests extends ElasticsearchSingleNodeTest {
                             .put(HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_LIMIT_SETTING, size - 1)
                             .build(),
                     new NodeSettingsService(ImmutableSettings.EMPTY));
-            BigArrays bigArrays = new BigArrays(ImmutableSettings.EMPTY, null, hcbs).withCircuitBreaking();
+            BigArrays bigArrays = new BigArrays(null, hcbs).withCircuitBreaking();
             Method create = BigArrays.class.getMethod("new" + type + "Array", long.class);
             try {
                 create.invoke(bigArrays, size);
@@ -359,7 +359,7 @@ public class BigArraysTests extends ElasticsearchSingleNodeTest {
                             .put(HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_LIMIT_SETTING, maxSize)
                             .build(),
                     new NodeSettingsService(ImmutableSettings.EMPTY));
-            BigArrays bigArrays = new BigArrays(ImmutableSettings.EMPTY, null, hcbs).withCircuitBreaking();
+            BigArrays bigArrays = new BigArrays(null, hcbs).withCircuitBreaking();
             Method create = BigArrays.class.getMethod("new" + type + "Array", long.class);
             final int size = scaledRandomIntBetween(1, 20);
             BigArray array = (BigArray) create.invoke(bigArrays, size);

--- a/src/test/java/org/elasticsearch/http/netty/NettyHttpServerPipeliningTest.java
+++ b/src/test/java/org/elasticsearch/http/netty/NettyHttpServerPipeliningTest.java
@@ -76,7 +76,7 @@ public class NettyHttpServerPipeliningTest extends ElasticsearchTestCase {
         networkService = new NetworkService(ImmutableSettings.EMPTY);
         threadPool = new ThreadPool("test");
         mockPageCacheRecycler = new MockPageCacheRecycler(ImmutableSettings.EMPTY, threadPool);
-        bigArrays = new MockBigArrays(ImmutableSettings.EMPTY, mockPageCacheRecycler, new NoneCircuitBreakerService());
+        bigArrays = new MockBigArrays(mockPageCacheRecycler, new NoneCircuitBreakerService());
     }
 
     @After

--- a/src/test/java/org/elasticsearch/test/cache/recycler/MockBigArrays.java
+++ b/src/test/java/org/elasticsearch/test/cache/recycler/MockBigArrays.java
@@ -30,7 +30,6 @@ import org.apache.lucene.util.Accountables;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.cache.recycler.PageCacheRecycler;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArray;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.ByteArray;
@@ -87,18 +86,16 @@ public class MockBigArrays extends BigArrays {
     }
 
     private final Random random;
-    private final Settings settings;
     private final PageCacheRecycler recycler;
     private final CircuitBreakerService breakerService;
 
     @Inject
-    public MockBigArrays(Settings settings, PageCacheRecycler recycler, CircuitBreakerService breakerService) {
-        this(settings, recycler, breakerService, false);
+    public MockBigArrays(PageCacheRecycler recycler, CircuitBreakerService breakerService) {
+        this(recycler, breakerService, false);
     }
 
-    public MockBigArrays(Settings settings, PageCacheRecycler recycler, CircuitBreakerService breakerService, boolean checkBreaker) {
-        super(settings, recycler, breakerService, checkBreaker);
-        this.settings = settings;
+    public MockBigArrays(PageCacheRecycler recycler, CircuitBreakerService breakerService, boolean checkBreaker) {
+        super(recycler, breakerService, checkBreaker);
         this.recycler = recycler;
         this.breakerService = breakerService;
         long seed;
@@ -114,7 +111,7 @@ public class MockBigArrays extends BigArrays {
 
     @Override
     public BigArrays withCircuitBreaking() {
-        return new MockBigArrays(this.settings, this.recycler, this.breakerService, true);
+        return new MockBigArrays(this.recycler, this.breakerService, true);
     }
 
     @Override

--- a/src/test/java/org/elasticsearch/transport/NettySizeHeaderFrameDecoderTests.java
+++ b/src/test/java/org/elasticsearch/transport/NettySizeHeaderFrameDecoderTests.java
@@ -61,7 +61,7 @@ public class NettySizeHeaderFrameDecoderTests extends ElasticsearchTestCase {
         threadPool = new ThreadPool(settings, new NodeSettingsService(settings));
 
         NetworkService networkService = new NetworkService(settings);
-        BigArrays bigArrays = new MockBigArrays(settings, new MockPageCacheRecycler(settings, threadPool), new NoneCircuitBreakerService());
+        BigArrays bigArrays = new MockBigArrays(new MockPageCacheRecycler(settings, threadPool), new NoneCircuitBreakerService());
         nettyTransport = new NettyTransport(settings, threadPool, networkService, bigArrays, Version.CURRENT);
         nettyTransport.start();
         TransportService transportService = new TransportService(nettyTransport, threadPool);

--- a/src/test/java/org/elasticsearch/transport/netty/NettyTransportMultiPortTests.java
+++ b/src/test/java/org/elasticsearch/transport/netty/NettyTransportMultiPortTests.java
@@ -170,7 +170,7 @@ public class NettyTransportMultiPortTests extends ElasticsearchTestCase {
     }
 
     private NettyTransport startNettyTransport(Settings settings, ThreadPool threadPool) {
-        BigArrays bigArrays = new MockBigArrays(settings, new PageCacheRecycler(settings, threadPool), new NoneCircuitBreakerService());
+        BigArrays bigArrays = new MockBigArrays(new PageCacheRecycler(settings, threadPool), new NoneCircuitBreakerService());
 
         NettyTransport nettyTransport = new NettyTransport(settings, threadPool, new NetworkService(settings), bigArrays, Version.CURRENT);
         nettyTransport.start();


### PR DESCRIPTION
In order to avoid the `getLogger(getClass())` calls in the
AbstractComponent constructor.

Seems like BigArrays used to be a Singleton but it actually
no longer is one. Every time a SearchContext is created a
new BigArrays instance is created via the
`withCircuitBreaking` call.
