### PR TITLE
Don't create a new BigArrays instance for every call of `withCircuitBreaking`

### DIFF
--- a/src/main/java/org/elasticsearch/common/util/BigArrays.java
+++ b/src/main/java/org/elasticsearch/common/util/BigArrays.java
@@ -364,6 +364,7 @@ public class BigArrays {
     final PageCacheRecycler recycler;
     final CircuitBreakerService breakerService;
     final boolean checkBreaker;
+    private final BigArrays circuitBreakingInstance;
 
     @Inject
     public BigArrays(PageCacheRecycler recycler, @Nullable final CircuitBreakerService breakerService) {
@@ -375,6 +376,11 @@ public class BigArrays {
         this.checkBreaker = checkBreaker;
         this.recycler = recycler;
         this.breakerService = breakerService;
+        if (checkBreaker) {
+            this.circuitBreakingInstance = this;
+        } else {
+            this.circuitBreakingInstance = new BigArrays(recycler, breakerService, true);
+        }
     }
 
     /**
@@ -410,11 +416,11 @@ public class BigArrays {
     }
 
     /**
-     * Return a new instance of this BigArrays class with circuit breaking
+     * Return an instance of this BigArrays class with circuit breaking
      * explicitly enabled, instead of only accounting enabled
      */
     public BigArrays withCircuitBreaking() {
-        return new BigArrays(this.recycler, this.breakerService, true);
+        return this.circuitBreakingInstance;
     }
 
     private <T extends AbstractBigArray> T resizeInPlace(T array, long newSize) {


### PR DESCRIPTION
Since the circuit breaking service doesn't actually change for
BigArrays, we can lazily create a new instance only once and use that for all
further invocations of `withCircuitBreaking`.

This is a follow-up to #10798
