### PR TITLE
analysis: add sentence tokenizer

### DIFF
--- a/docs/reference/analysis/tokenizers.asciidoc
+++ b/docs/reference/analysis/tokenizers.asciidoc
@@ -32,3 +32,5 @@ include::tokenizers/classic-tokenizer.asciidoc[]
 
 include::tokenizers/thai-tokenizer.asciidoc[]
 
+include::tokenizers/sentence-tokenizer.asciidoc[]
+

--- a/docs/reference/analysis/tokenizers/sentence-tokenizer.asciidoc
+++ b/docs/reference/analysis/tokenizers/sentence-tokenizer.asciidoc
@@ -15,10 +15,10 @@ sentence breaks, like 1.23.
 
 the output will be six tokens:
 
-* `Hello world!`
-* `How are you?`
-* `I am fine.`
-* `This is a difficult sentence because I use I.D.`
-* `Newlines should also be accepted.`
+* `Hello world! `
+* `How are you? `
+* `I am fine.\n`
+* `This is a difficult sentence because I use I.D.\n\n`
+* `Newlines should also be accepted. `
 * `Numbers should not cause \nsentence breaks, like 1.23.`
 

--- a/docs/reference/analysis/tokenizers/sentence-tokenizer.asciidoc
+++ b/docs/reference/analysis/tokenizers/sentence-tokenizer.asciidoc
@@ -1,0 +1,24 @@
+[[analysis-sentence-tokenizer]]
+=== Sentence Tokenizer
+
+A tokenizer of type `sentence` providing breaks a text into sentences.
+
+For example, if you have:
+
+------------------------
+Hello world! How are you? I am fine.
+This is a difficult sentence because I use I.D.
+
+Newlines should also be accepted. Numbers should not cause
+sentence breaks, like 1.23.
+------------------------
+
+the output will be six tokens:
+
+* `Hello world!`
+* `How are you?`
+* `I am fine.`
+* `This is a difficult sentence because I use I.D.`
+* `Newlines should also be accepted.`
+* `Numbers should not cause \nsentence breaks, like 1.23.`
+

--- a/src/main/java/org/elasticsearch/index/analysis/AnalysisModule.java
+++ b/src/main/java/org/elasticsearch/index/analysis/AnalysisModule.java
@@ -451,6 +451,7 @@ public class AnalysisModule extends AbstractModule {
             tokenizersBindings.processTokenizer("letter", LetterTokenizerFactory.class);
             tokenizersBindings.processTokenizer("lowercase", LowerCaseTokenizerFactory.class);
             tokenizersBindings.processTokenizer("whitespace", WhitespaceTokenizerFactory.class);
+            tokenizersBindings.processTokenizer("sentence", SentenceTokenizerFactory.class);
 
             tokenizersBindings.processTokenizer("nGram", NGramTokenizerFactory.class);
             tokenizersBindings.processTokenizer("ngram", NGramTokenizerFactory.class);

--- a/src/main/java/org/elasticsearch/index/analysis/SentenceTokenizerFactory.java
+++ b/src/main/java/org/elasticsearch/index/analysis/SentenceTokenizerFactory.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.analysis;
+
+import org.apache.lucene.analysis.Tokenizer;
+import org.apache.lucene.analysis.pattern.PatternTokenizer;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.assistedinject.Assisted;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.settings.IndexSettings;
+
+import java.io.Reader;
+import java.util.regex.Pattern;
+
+/**
+ * Based on http://stackoverflow.com/questions/1936388/what-is-a-regular-expression-for-parsing-out-individual-sentences
+ */
+public class SentenceTokenizerFactory extends AbstractTokenizerFactory {
+
+    private final static Pattern SENTENCE = Pattern.compile("(\\S.+?[.!?])(?=\\s+|$)", Pattern.DOTALL);
+
+    @Inject
+    public SentenceTokenizerFactory(Index index, @IndexSettings Settings indexSettings, @Assisted String name, @Assisted Settings settings) {
+        super(index, indexSettings, name, settings);
+    }
+
+    @Override
+    public Tokenizer create(Reader reader) {
+        return new PatternTokenizer(reader, SENTENCE, 0);
+    }
+}

--- a/src/main/java/org/elasticsearch/index/analysis/SentenceTokenizerFactory.java
+++ b/src/main/java/org/elasticsearch/index/analysis/SentenceTokenizerFactory.java
@@ -20,7 +20,9 @@
 package org.elasticsearch.index.analysis;
 
 import org.apache.lucene.analysis.Tokenizer;
-import org.apache.lucene.analysis.pattern.PatternTokenizer;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.apache.lucene.analysis.tokenattributes.OffsetAttribute;
+import org.apache.lucene.analysis.util.SegmentingTokenizerBase;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.assistedinject.Assisted;
 import org.elasticsearch.common.settings.Settings;
@@ -28,14 +30,13 @@ import org.elasticsearch.index.Index;
 import org.elasticsearch.index.settings.IndexSettings;
 
 import java.io.Reader;
-import java.util.regex.Pattern;
+import java.text.BreakIterator;
+import java.util.Locale;
 
 /**
- * Based on http://stackoverflow.com/questions/1936388/what-is-a-regular-expression-for-parsing-out-individual-sentences
+ * Based on http://svn.apache.org/viewvc/lucene/dev/trunk/lucene/analysis/common/src/test/org/apache/lucene/analysis/util/TestSegmentingTokenizerBase.java?revision=1664404&view=markup
  */
 public class SentenceTokenizerFactory extends AbstractTokenizerFactory {
-
-    private final static Pattern SENTENCE = Pattern.compile("(\\S.+?[.!?])(?=\\s+|$)", Pattern.DOTALL);
 
     @Inject
     public SentenceTokenizerFactory(Index index, @IndexSettings Settings indexSettings, @Assisted String name, @Assisted Settings settings) {
@@ -44,6 +45,38 @@ public class SentenceTokenizerFactory extends AbstractTokenizerFactory {
 
     @Override
     public Tokenizer create(Reader reader) {
-        return new PatternTokenizer(reader, SENTENCE, 0);
+        return new WholeSentenceTokenizer(reader);
+    }
+
+    static class WholeSentenceTokenizer extends SegmentingTokenizerBase {
+        int sentenceStart, sentenceEnd;
+        boolean hasSentence;
+
+        private CharTermAttribute termAtt = addAttribute(CharTermAttribute.class);
+        private OffsetAttribute offsetAtt = addAttribute(OffsetAttribute.class);
+
+        public WholeSentenceTokenizer(Reader reader) {
+            super(reader, BreakIterator.getSentenceInstance(Locale.ROOT));
+        }
+
+        @Override
+        protected void setNextSentence(int sentenceStart, int sentenceEnd) {
+            this.sentenceStart = sentenceStart;
+            this.sentenceEnd = sentenceEnd;
+            hasSentence = true;
+        }
+
+        @Override
+        protected boolean incrementWord() {
+            if (hasSentence) {
+                hasSentence = false;
+                clearAttributes();
+                termAtt.copyBuffer(buffer, sentenceStart, sentenceEnd-sentenceStart);
+                offsetAtt.setOffset(correctOffset(offset+sentenceStart), correctOffset(offset+sentenceEnd));
+                return true;
+            } else {
+                return false;
+            }
+        }
     }
 }

--- a/src/test/java/org/elasticsearch/index/analysis/AnalysisFactoryTests.java
+++ b/src/test/java/org/elasticsearch/index/analysis/AnalysisFactoryTests.java
@@ -52,6 +52,7 @@ public class AnalysisFactoryTests extends ElasticsearchTestCase {
         put("pathhierarchy", PathHierarchyTokenizerFactory.class);
         put("pattern",       PatternTokenizerFactory.class);
         put("standard",      StandardTokenizerFactory.class);
+        put("sentence",      SentenceTokenizerFactory.class);
         put("thai",          ThaiTokenizerFactory.class);
         put("uax29urlemail", UAX29URLEmailTokenizerFactory.class);
         put("whitespace",    WhitespaceTokenizerFactory.class);

--- a/src/test/java/org/elasticsearch/index/analysis/SentenceTokenizerFactoryTests.java
+++ b/src/test/java/org/elasticsearch/index/analysis/SentenceTokenizerFactoryTests.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.analysis;
+
+import org.apache.lucene.analysis.Tokenizer;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.test.ElasticsearchTokenStreamTestCase;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.StringReader;
+
+public class SentenceTokenizerFactoryTests extends ElasticsearchTokenStreamTestCase {
+
+    @Test
+    public void testSentenceTokenizer() throws IOException {
+        final String text = "Hello world! How are you? I am fine.\n" +
+                "This is a difficult sentence because I use I.D.\n" +
+                "\n" +
+                "Newlines should also be accepted. Numbers should not cause \n" +
+                "sentence breaks, like 1.23.";
+        final Index index = new Index("test");
+        final String name = "sent";
+        final Settings indexSettings = newAnalysisSettingsBuilder().build();
+        final Settings settings = ImmutableSettings.EMPTY;
+        Tokenizer tokenizer = new SentenceTokenizerFactory(index, indexSettings, name, settings).create(new StringReader(text));
+        assertTokenStreamContents(tokenizer, new String[]{
+                "Hello world!",
+                "How are you?",
+                "I am fine.",
+                "This is a difficult sentence because I use I.D.",
+                "Newlines should also be accepted.",
+                "Numbers should not cause \nsentence breaks, like 1.23."});
+    }
+
+    @Test
+    public void testSentenceTokenizerEmpty() throws IOException {
+        final String text = "";
+        final Index index = new Index("test");
+        final String name = "sent";
+        final Settings indexSettings = newAnalysisSettingsBuilder().build();
+        final Settings settings = ImmutableSettings.EMPTY;
+        Tokenizer tokenizer = new SentenceTokenizerFactory(index, indexSettings, name, settings).create(new StringReader(text));
+        assertTokenStreamContents(tokenizer, new String[]{});
+    }
+}

--- a/src/test/java/org/elasticsearch/index/analysis/SentenceTokenizerFactoryTests.java
+++ b/src/test/java/org/elasticsearch/index/analysis/SentenceTokenizerFactoryTests.java
@@ -44,11 +44,11 @@ public class SentenceTokenizerFactoryTests extends ElasticsearchTokenStreamTestC
         final Settings settings = ImmutableSettings.EMPTY;
         Tokenizer tokenizer = new SentenceTokenizerFactory(index, indexSettings, name, settings).create(new StringReader(text));
         assertTokenStreamContents(tokenizer, new String[]{
-                "Hello world!",
-                "How are you?",
-                "I am fine.",
-                "This is a difficult sentence because I use I.D.",
-                "Newlines should also be accepted.",
+                "Hello world! ",
+                "How are you? ",
+                "I am fine.\n",
+                "This is a difficult sentence because I use I.D.\n\n",
+                "Newlines should also be accepted. ",
                 "Numbers should not cause \nsentence breaks, like 1.23."});
     }
 


### PR DESCRIPTION
A tokenizer of type `sentence` providing breaks a text into sentences.

For example, if you have:

```
Hello world! How are you? I am fine.
This is a difficult sentence because I use I.D.

Newlines should also be accepted. Numbers should not cause
sentence breaks, like 1.23.
```

the output will be six tokens:
- `Hello world!`
- `How are you?`
- `I am fine.\n`
- `This is a difficult sentence because I use I.D.\n\n`
- `Newlines should also be accepted.`
- `Numbers should not cause \nsentence breaks, like 1.23.`
