### PR TITLE
Fail #snapshot if translog is closed

### DIFF
--- a/src/test/java/org/elasticsearch/index/translog/AbstractSimpleTranslogTests.java
+++ b/src/test/java/org/elasticsearch/index/translog/AbstractSimpleTranslogTests.java
@@ -332,6 +332,17 @@ public abstract class AbstractSimpleTranslogTests extends ElasticsearchTestCase 
         snapshot.close();
     }
 
+    public void testSnapshotOnClosedTranslog() throws IOException {
+        assertTrue(Files.exists(translogDir.resolve("translog-1")));
+        translog.add(new Translog.Create("test", "1", new byte[]{1}));
+        translog.close();
+        try {
+            Translog.Snapshot snapshot = translog.snapshot();
+        } catch (TranslogException ex) {
+            assertEquals(ex.getMessage(), "translog is already closed");
+        }
+    }
+
     @Test
     public void deleteOnRollover() throws IOException {
         translog.add(new Translog.Create("test", "1", new byte[]{1}));


### PR DESCRIPTION
If the translog is closed while a snapshot opertion is in progress
we must fail the snapshot operation otherwise we end up in an endless
loop.

Closes #10807
