### PR TITLE
Remove includes and excludes from _source

### DIFF
--- a/docs/reference/mapping/fields/source-field.asciidoc
+++ b/docs/reference/mapping/fields/source-field.asciidoc
@@ -20,22 +20,3 @@ example:
     }
 }
 --------------------------------------------------
-
-[float]
-[[include-exclude]]
-==== Includes / Excludes
-
-Allow to specify paths in the source that would be included / excluded
-when it's stored, supporting `*` as wildcard annotation. For example:
-
-[source,js]
---------------------------------------------------
-{
-    "my_type" : {
-        "_source" : {
-            "includes" : ["path1.*", "path2.*"],
-            "excludes" : ["path3.*"]
-        }
-    }
-}
---------------------------------------------------

--- a/docs/reference/migration/migrate_2_0.asciidoc
+++ b/docs/reference/migration/migrate_2_0.asciidoc
@@ -270,7 +270,7 @@ to provide special features.  They now have limited configuration options.
 * `_field_names` configuration is limited to disabling the field.
 * `_size` configuration is limited to enabling the field.
 
-=== Boolean fields
+==== Boolean fields
 
 Boolean fields used to have a string fielddata with `F` meaning `false` and `T`
 meaning `true`. They have been refactored to use numeric fielddata, with `0`
@@ -302,9 +302,13 @@ the user-friendly representation of boolean fields: `false`/`true`:
 ]
 ---------------
 
-=== Murmur3 Fields
+==== Murmur3 Fields
 Fields of type `murmur3` can no longer change `doc_values` or `index` setting.
 They are always stored with doc values, and not indexed.
+
+==== Source field configuration
+The `_source` field no longer supports `includes` and `excludes` paramters. When
+`_source` is enabled, the entire original source will be stored.
 
 === Codecs
 

--- a/src/main/java/org/elasticsearch/index/mapper/internal/SourceFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/SourceFieldMapper.java
@@ -26,6 +26,7 @@ import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.Version;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -166,7 +167,7 @@ public class SourceFieldMapper extends AbstractFieldMapper<byte[]> implements In
                 } else if ("format".equals(fieldName)) {
                     builder.format(nodeStringValue(fieldNode, null));
                     iterator.remove();
-                } else if (fieldName.equals("includes")) {
+                } else if (fieldName.equals("includes") && parserContext.indexVersionCreated().before(Version.V_2_0_0)) {
                     List<Object> values = (List<Object>) fieldNode;
                     String[] includes = new String[values.size()];
                     for (int i = 0; i < includes.length; i++) {
@@ -174,7 +175,7 @@ public class SourceFieldMapper extends AbstractFieldMapper<byte[]> implements In
                     }
                     builder.includes(includes);
                     iterator.remove();
-                } else if (fieldName.equals("excludes")) {
+                } else if (fieldName.equals("excludes") && parserContext.indexVersionCreated().before(Version.V_2_0_0)) {
                     List<Object> values = (List<Object>) fieldNode;
                     String[] excludes = new String[values.size()];
                     for (int i = 0; i < excludes.length; i++) {

--- a/src/test/java/org/elasticsearch/get/GetActionTests.java
+++ b/src/test/java/org/elasticsearch/get/GetActionTests.java
@@ -21,11 +21,13 @@ package org.elasticsearch.get;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ShardOperationFailedException;
 import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.action.admin.indices.flush.FlushResponse;
 import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.get.*;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.Base64;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
@@ -412,7 +414,7 @@ public class GetActionTests extends ElasticsearchIntegrationTest {
 
         assertAcked(prepareCreate(index)
                 .addMapping(type, mapping)
-                .setSettings(ImmutableSettings.settingsBuilder().put("index.refresh_interval", -1)));
+                .setSettings("index.refresh_interval", -1, IndexMetaData.SETTING_VERSION_CREATED, Version.V_1_4_2.id));
 
         client().prepareIndex(index, type, "1")
                 .setSource(jsonBuilder().startObject().field("field", "1", "2").field("excluded", "should not be seen").endObject())
@@ -446,7 +448,7 @@ public class GetActionTests extends ElasticsearchIntegrationTest {
 
         assertAcked(prepareCreate(index)
                 .addMapping(type, mapping)
-                .setSettings(ImmutableSettings.settingsBuilder().put("index.refresh_interval", -1)));
+                .setSettings("index.refresh_interval", -1, IndexMetaData.SETTING_VERSION_CREATED, Version.V_1_4_2.id));
 
         client().prepareIndex(index, type, "1")
                 .setSource(jsonBuilder().startObject().field("field", "1", "2").field("included", "should be seen").endObject())
@@ -482,7 +484,7 @@ public class GetActionTests extends ElasticsearchIntegrationTest {
 
         assertAcked(prepareCreate(index)
                 .addMapping(type, mapping)
-                .setSettings(ImmutableSettings.settingsBuilder().put("index.refresh_interval", -1)));
+                .setSettings("index.refresh_interval", -1, IndexMetaData.SETTING_VERSION_CREATED, Version.V_1_4_2.id));
 
         client().prepareIndex(index, type, "1")
                 .setSource(jsonBuilder().startObject()

--- a/src/test/java/org/elasticsearch/search/innerhits/InnerHitsTests.java
+++ b/src/test/java/org/elasticsearch/search/innerhits/InnerHitsTests.java
@@ -19,9 +19,11 @@
 
 package org.elasticsearch.search.innerhits;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.support.QueryInnerHitBuilder;
@@ -772,7 +774,7 @@ public class InnerHitsTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testNestedInnerHitsWithExcludeSource() throws Exception {
-        assertAcked(prepareCreate("articles")
+        assertAcked(prepareCreate("articles").setSettings(IndexMetaData.SETTING_VERSION_CREATED, Version.V_1_4_2.id)
                         .addMapping("article", jsonBuilder().startObject()
                                         .startObject("_source").field("excludes", new String[]{"comments"}).endObject()
                                         .startObject("properties")
@@ -810,7 +812,7 @@ public class InnerHitsTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testNestedInnerHitsHiglightWithExcludeSource() throws Exception {
-        assertAcked(prepareCreate("articles")
+        assertAcked(prepareCreate("articles").setSettings(IndexMetaData.SETTING_VERSION_CREATED, Version.V_1_4_2.id)
                         .addMapping("article", jsonBuilder().startObject()
                                         .startObject("_source").field("excludes", new String[]{"comments"}).endObject()
                                         .startObject("properties")


### PR DESCRIPTION
Regardless of the outcome of #8142, we should at least enforce that
when _source is enabled, it is sufficient to reindex. This change
removes the excludes and includes settings, since these modify
the source, causing us to lose the ability to reindex some fields.

Note: I also renamed one of the UpdateMappingTests so the class names are unique.
