### PR TITLE
Fix to let eclipse ignore the antigun plugin in it's maven integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1626,7 +1626,7 @@
                                         </goals>
                                     </pluginExecutionFilter>
                                     <action>
-                                        <execute/>
+                                        <ignore/>
                                     </action>
                                 </pluginExecution>
                                 <pluginExecution>


### PR DESCRIPTION
This plugin should be ignored as it will make the internal eclipse build fail when there are NOCOMMIT comments in files, which are expected during feature development. This change only affects eclipse users and only when they are using the m2e eclipse integration
