### PR TITLE
[TEST] Run tests with [1..3] nodes by default

### DIFF
--- a/src/test/java/org/elasticsearch/action/IndicesRequestTests.java
+++ b/src/test/java/org/elasticsearch/action/IndicesRequestTests.java
@@ -117,7 +117,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcke
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.*;
 
-@ClusterScope(scope = Scope.SUITE, numClientNodes = 1)
+@ClusterScope(scope = Scope.SUITE, numClientNodes = 1, minNumDataNodes = 2)
 @Slow
 public class IndicesRequestTests extends ElasticsearchIntegrationTest {
 

--- a/src/test/java/org/elasticsearch/bwcompat/OldIndexBackwardsCompatibilityTests.java
+++ b/src/test/java/org/elasticsearch/bwcompat/OldIndexBackwardsCompatibilityTests.java
@@ -72,6 +72,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcke
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
+// needs at least 2 nodes since it bumps replicas to 1
 @ElasticsearchIntegrationTest.ClusterScope(scope = ElasticsearchIntegrationTest.Scope.TEST, numDataNodes = 0)
 @LuceneTestCase.SuppressFileSystems("ExtrasFS")
 @LuceneTestCase.Slow

--- a/src/test/java/org/elasticsearch/cluster/ack/AckClusterUpdateSettingsTests.java
+++ b/src/test/java/org/elasticsearch/cluster/ack/AckClusterUpdateSettingsTests.java
@@ -42,7 +42,7 @@ import static org.elasticsearch.test.ElasticsearchIntegrationTest.Scope.TEST;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.equalTo;
 
-@ClusterScope(scope = TEST)
+@ClusterScope(scope = TEST, minNumDataNodes = 2)
 public class AckClusterUpdateSettingsTests extends ElasticsearchIntegrationTest {
 
     @Override

--- a/src/test/java/org/elasticsearch/cluster/ack/AckTests.java
+++ b/src/test/java/org/elasticsearch/cluster/ack/AckTests.java
@@ -27,7 +27,6 @@ import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesResponse;
 import org.elasticsearch.action.admin.indices.close.CloseIndexResponse;
 import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
-import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsResponse;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingResponse;
 import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsResponse;
 import org.elasticsearch.action.admin.indices.warmer.delete.DeleteWarmerResponse;
@@ -52,11 +51,10 @@ import org.junit.Test;
 import static org.elasticsearch.cluster.metadata.IndexMetaData.*;
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 import static org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
-import static org.elasticsearch.test.ElasticsearchIntegrationTest.Scope.SUITE;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.*;
 
-@ClusterScope(scope = SUITE)
+@ClusterScope(minNumDataNodes = 2)
 public class AckTests extends ElasticsearchIntegrationTest {
 
     @Override

--- a/src/test/java/org/elasticsearch/cluster/allocation/AwarenessAllocationTests.java
+++ b/src/test/java/org/elasticsearch/cluster/allocation/AwarenessAllocationTests.java
@@ -47,7 +47,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 /**
  */
-@ClusterScope(scope= ElasticsearchIntegrationTest.Scope.TEST, numDataNodes =0)
+@ClusterScope(scope= ElasticsearchIntegrationTest.Scope.TEST, numDataNodes =0, minNumDataNodes = 2)
 public class AwarenessAllocationTests extends ElasticsearchIntegrationTest {
 
     private final ESLogger logger = Loggers.getLogger(AwarenessAllocationTests.class);

--- a/src/test/java/org/elasticsearch/cluster/shards/ClusterSearchShardsTests.java
+++ b/src/test/java/org/elasticsearch/cluster/shards/ClusterSearchShardsTests.java
@@ -37,7 +37,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 /**
  */
-@ClusterScope(scope= Scope.SUITE, numDataNodes =2)
+@ClusterScope(scope= Scope.SUITE, numDataNodes = 2)
 public class ClusterSearchShardsTests extends ElasticsearchIntegrationTest {
     
     @Override

--- a/src/test/java/org/elasticsearch/index/suggest/stats/SuggestStatsTests.java
+++ b/src/test/java/org/elasticsearch/index/suggest/stats/SuggestStatsTests.java
@@ -39,12 +39,14 @@ import java.util.Set;
 
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_REPLICAS;
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.Scope.SUITE;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAllSuccessful;
 import static org.hamcrest.Matchers.*;
 
 /**
  */
+@ElasticsearchIntegrationTest.ClusterScope(minNumDataNodes = 2)
 public class SuggestStatsTests extends ElasticsearchIntegrationTest {
 
     @Override

--- a/src/test/java/org/elasticsearch/indices/settings/UpdateNumberOfReplicasTests.java
+++ b/src/test/java/org/elasticsearch/indices/settings/UpdateNumberOfReplicasTests.java
@@ -38,6 +38,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcke
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.hamcrest.Matchers.equalTo;
 
+@ElasticsearchIntegrationTest.ClusterScope(minNumDataNodes = 2)
 public class UpdateNumberOfReplicasTests extends ElasticsearchIntegrationTest {
 
     @Override

--- a/src/test/java/org/elasticsearch/indices/state/SimpleIndexStateTests.java
+++ b/src/test/java/org/elasticsearch/indices/state/SimpleIndexStateTests.java
@@ -44,6 +44,7 @@ import static org.hamcrest.Matchers.nullValue;
 /**
  *
  */
+@ElasticsearchIntegrationTest.ClusterScope(minNumDataNodes = 2)
 public class SimpleIndexStateTests extends ElasticsearchIntegrationTest {
 
     private final ESLogger logger = Loggers.getLogger(SimpleIndexStateTests.class);

--- a/src/test/java/org/elasticsearch/indices/template/SimpleIndexTemplateTests.java
+++ b/src/test/java/org/elasticsearch/indices/template/SimpleIndexTemplateTests.java
@@ -70,6 +70,7 @@ public class SimpleIndexTemplateTests extends ElasticsearchIntegrationTest {
 
         client().admin().indices().preparePutTemplate("template_1")
                 .setTemplate("te*")
+                .setSettings(indexSettings())
                 .setOrder(0)
                 .addMapping("type1", XContentFactory.jsonBuilder().startObject().startObject("type1").startObject("properties")
                         .startObject("field1").field("type", "string").field("store", "yes").endObject()
@@ -79,6 +80,7 @@ public class SimpleIndexTemplateTests extends ElasticsearchIntegrationTest {
 
         client().admin().indices().preparePutTemplate("template_2")
                 .setTemplate("test*")
+                .setSettings(indexSettings())
                 .setOrder(1)
                 .addMapping("type1", XContentFactory.jsonBuilder().startObject().startObject("type1").startObject("properties")
                         .startObject("field2").field("type", "string").field("store", "no").endObject()
@@ -88,6 +90,7 @@ public class SimpleIndexTemplateTests extends ElasticsearchIntegrationTest {
         // test create param
         assertThrows(client().admin().indices().preparePutTemplate("template_2")
                 .setTemplate("test*")
+                .setSettings(indexSettings())
                 .setCreate(true)
                 .setOrder(1)
                 .addMapping("type1", XContentFactory.jsonBuilder().startObject().startObject("type1").startObject("properties")
@@ -103,8 +106,7 @@ public class SimpleIndexTemplateTests extends ElasticsearchIntegrationTest {
         // index something into test_index, will match on both templates
         client().prepareIndex("test_index", "type1", "1").setSource("field1", "value1", "field2", "value 2").setRefresh(true).execute().actionGet();
 
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
-
+        ensureGreen();
         SearchResponse searchResponse = client().prepareSearch("test_index")
                 .setQuery(termQuery("field1", "value1"))
                 .addField("field1").addField("field2")
@@ -116,8 +118,7 @@ public class SimpleIndexTemplateTests extends ElasticsearchIntegrationTest {
 
         client().prepareIndex("text_index", "type1", "1").setSource("field1", "value1", "field2", "value 2").setRefresh(true).execute().actionGet();
 
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
-
+        ensureGreen();
         // now only match on one template (template_1)
         searchResponse = client().prepareSearch("text_index")
                 .setQuery(termQuery("field1", "value1"))

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/SignificantTermsTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/SignificantTermsTests.java
@@ -65,8 +65,8 @@ public class SignificantTermsTests extends ElasticsearchIntegrationTest {
     @Override
     public Settings indexSettings() {
         return ImmutableSettings.builder()
-                .put("index.number_of_shards", between(1, 5))
-                .put("index.number_of_replicas", between(0, 1))
+                .put("index.number_of_shards", numberOfShards())
+                .put("index.number_of_replicas", numberOfReplicas())
                 .build();
     }
 

--- a/src/test/java/org/elasticsearch/search/aggregations/metrics/CardinalityTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/metrics/CardinalityTests.java
@@ -46,8 +46,8 @@ public class CardinalityTests extends ElasticsearchIntegrationTest {
     @Override
     public Settings indexSettings() {
         return ImmutableSettings.builder()
-                .put("index.number_of_shards", between(1, 5))
-                .put("index.number_of_replicas", between(0, 1))
+                .put("index.number_of_shards", numberOfShards())
+                .put("index.number_of_replicas", numberOfReplicas())
                 .build();
     }
 

--- a/src/test/java/org/elasticsearch/search/basic/SearchWhileRelocatingTests.java
+++ b/src/test/java/org/elasticsearch/search/basic/SearchWhileRelocatingTests.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.search.basic;
 
-import com.carrotsearch.randomizedtesting.annotations.Nightly;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
@@ -43,6 +42,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoTi
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
+@ElasticsearchIntegrationTest.ClusterScope(minNumDataNodes = 2)
 public class SearchWhileRelocatingTests extends ElasticsearchIntegrationTest {
 
 // @LuceneTestCase.AwaitsFix(bugUrl = "problem with search searching on 1 shard (no replica), " +

--- a/src/test/java/org/elasticsearch/search/basic/SearchWithRandomExceptionsTests.java
+++ b/src/test/java/org/elasticsearch/search/basic/SearchWithRandomExceptionsTests.java
@@ -94,7 +94,7 @@ public class SearchWithRandomExceptionsTests extends ElasticsearchIntegrationTes
 
         if (createIndexWithoutErrors) {
             Builder settings = settingsBuilder()
-                    .put("index.number_of_replicas", randomIntBetween(0, 1));
+                    .put("index.number_of_replicas", numberOfReplicas());
             logger.info("creating index: [test] using settings: [{}]", settings.build().getAsMap());
             client().admin().indices().prepareCreate("test")
                     .setSettings(settings)

--- a/src/test/java/org/elasticsearch/search/preference/SearchPreferenceTests.java
+++ b/src/test/java/org/elasticsearch/search/preference/SearchPreferenceTests.java
@@ -36,6 +36,7 @@ import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.*;
 
+@ElasticsearchIntegrationTest.ClusterScope(minNumDataNodes = 2)
 public class SearchPreferenceTests extends ElasticsearchIntegrationTest {
 
     @Test // see #2896

--- a/src/test/java/org/elasticsearch/search/stats/SearchStatsTests.java
+++ b/src/test/java/org/elasticsearch/search/stats/SearchStatsTests.java
@@ -46,6 +46,7 @@ import static org.hamcrest.Matchers.*;
 
 /**
  */
+@ElasticsearchIntegrationTest.ClusterScope(minNumDataNodes = 2)
 public class SearchStatsTests extends ElasticsearchIntegrationTest {
 
     @Override

--- a/src/test/java/org/elasticsearch/snapshots/RepositoriesTests.java
+++ b/src/test/java/org/elasticsearch/snapshots/RepositoriesTests.java
@@ -36,6 +36,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.repositories.RepositoryException;
 import org.elasticsearch.repositories.RepositoryVerificationException;
 import org.elasticsearch.snapshots.mockstore.MockRepositoryModule;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.junit.Test;
 
 import java.nio.file.Path;
@@ -48,6 +49,7 @@ import static org.hamcrest.Matchers.notNullValue;
 
 /**
  */
+@ElasticsearchIntegrationTest.ClusterScope(minNumDataNodes = 2)
 public class RepositoriesTests extends AbstractSnapshotTests {
 
     @Test

--- a/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
@@ -1503,16 +1503,16 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
         int numDataNodes() default -1;
 
         /**
-         * Returns the minimum number of nodes in the cluster. Default is {@link InternalTestCluster#DEFAULT_MIN_NUM_DATA_NODES}.
+         * Returns the minimum number of nodes in the cluster. Default is <tt>-1</tt>.
          * Ignored when {@link ClusterScope#numDataNodes()} is set.
          */
-        int minNumDataNodes() default InternalTestCluster.DEFAULT_MIN_NUM_DATA_NODES;
+        int minNumDataNodes() default -1;
 
         /**
-         * Returns the maximum number of nodes in the cluster.  Default is {@link InternalTestCluster#DEFAULT_MAX_NUM_DATA_NODES}.
+         * Returns the maximum number of nodes in the cluster.  Default is <tt>-1</tt>.
          * Ignored when {@link ClusterScope#numDataNodes()} is set.
          */
-        int maxNumDataNodes() default InternalTestCluster.DEFAULT_MAX_NUM_DATA_NODES;
+        int maxNumDataNodes() default -1;
 
         /**
          * Returns the number of client nodes in the cluster. Default is {@link InternalTestCluster#DEFAULT_NUM_CLIENT_NODES}, a
@@ -1613,12 +1613,12 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
 
     private int getMinNumDataNodes() {
         ClusterScope annotation = getAnnotation(this.getClass());
-        return annotation == null ? InternalTestCluster.DEFAULT_MIN_NUM_DATA_NODES : annotation.minNumDataNodes();
+        return annotation == null || annotation.minNumDataNodes() == -1 ? InternalTestCluster.DEFAULT_MIN_NUM_DATA_NODES  : annotation.minNumDataNodes();
     }
 
     private int getMaxNumDataNodes() {
         ClusterScope annotation = getAnnotation(this.getClass());
-        return annotation == null ? InternalTestCluster.DEFAULT_MAX_NUM_DATA_NODES : annotation.maxNumDataNodes();
+        return annotation == null || annotation.maxNumDataNodes() == -1 ? InternalTestCluster.DEFAULT_MAX_NUM_DATA_NODES : annotation.maxNumDataNodes();
     }
 
     private int getNumClientNodes() {

--- a/src/test/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/src/test/java/org/elasticsearch/test/InternalTestCluster.java
@@ -181,8 +181,8 @@ public final class InternalTestCluster extends TestCluster {
 
     private static final boolean ENABLE_MOCK_MODULES = RandomizedTest.systemPropertyAsBoolean(TESTS_ENABLE_MOCK_MODULES, true);
 
-    static final int DEFAULT_MIN_NUM_DATA_NODES = 2;
-    static final int DEFAULT_MAX_NUM_DATA_NODES = 6;
+    static final int DEFAULT_MIN_NUM_DATA_NODES = 1;
+    static final int DEFAULT_MAX_NUM_DATA_NODES = TEST_NIGHTLY ? 6 : 3;
 
     static final int DEFAULT_NUM_CLIENT_NODES = -1;
     static final int DEFAULT_MIN_NUM_CLIENT_NODES = 0;
@@ -237,7 +237,6 @@ public final class InternalTestCluster extends TestCluster {
         super(clusterSeed);
         this.baseDir = baseDir;
         this.clusterName = clusterName;
-
         if (minNumDataNodes < 0 || maxNumDataNodes < 0) {
             throw new IllegalArgumentException("minimum and maximum number of data nodes must be >= 0");
         }

--- a/src/test/java/org/elasticsearch/test/rest/ElasticsearchRestTestCase.java
+++ b/src/test/java/org/elasticsearch/test/rest/ElasticsearchRestTestCase.java
@@ -247,7 +247,10 @@ public abstract class ElasticsearchRestTestCase extends ElasticsearchIntegration
 
     @Override
     protected int maximumNumberOfReplicas() {
-        return 1; // never go crazy in the REST tests
+        // hardcoded 1 since this is what clients also do and our tests must expect that we have only node
+        // with replicas set to 1 ie. the cluster won't be green
+        return 1;
+
     }
 
     /**


### PR DESCRIPTION
This commit adds support for running with only one node and sets the
maximum number of nodes to 3 by default. if run with test.nighly=true
at most 6 nodes are used. This gave a 20% speed improvement compared to
the previoulys minimum number of nodes of 3.
