### PR TITLE
Return positions of parse errors found in JSON

### DIFF
--- a/src/main/java/org/elasticsearch/common/xcontent/XContentLocation.java
+++ b/src/main/java/org/elasticsearch/common/xcontent/XContentLocation.java
@@ -19,21 +19,19 @@
 
 package org.elasticsearch.common.xcontent;
 
+/**
+ * Simple data structure representing the line and column number of a position
+ * in some XContent e.g. JSON. Locations are typically used to communicate the
+ * position of a parsing error to end users and consequently have line and
+ * column numbers starting from 1.
+ */
 public class XContentLocation {
-    private int lineNumber;
-    private int columnNumber;
+    public final int lineNumber;
+    public final int columnNumber;
 
     public XContentLocation(int lineNumber, int columnNumber) {
         super();
         this.lineNumber = lineNumber;
         this.columnNumber = columnNumber;
-    }
-
-    public int getLineNumber() {
-        return lineNumber;
-    }
-
-    public int getColumnNumber() {
-        return columnNumber;
     }
 }

--- a/src/main/java/org/elasticsearch/common/xcontent/XContentLocation.java
+++ b/src/main/java/org/elasticsearch/common/xcontent/XContentLocation.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.xcontent;
+
+public class XContentLocation {
+    private int lineNumber;
+    private int columnNumber;
+
+    public XContentLocation(int lineNumber, int columnNumber) {
+        super();
+        this.lineNumber = lineNumber;
+        this.columnNumber = columnNumber;
+    }
+
+    public int getLineNumber() {
+        return lineNumber;
+    }
+
+    public int getColumnNumber() {
+        return columnNumber;
+    }
+}

--- a/src/main/java/org/elasticsearch/common/xcontent/XContentParser.java
+++ b/src/main/java/org/elasticsearch/common/xcontent/XContentParser.java
@@ -241,4 +241,12 @@ public interface XContentParser extends Releasable {
      *
      */
     byte[] binaryValue() throws IOException;
+
+    /**
+     * Used for error reporting to highlight where syntax errors occur in
+     * content being parsed.
+     * 
+     * @return last token's location or null if cannot be determined
+     */
+    XContentLocation getTokenLocation();
 }

--- a/src/main/java/org/elasticsearch/common/xcontent/json/JsonXContentParser.java
+++ b/src/main/java/org/elasticsearch/common/xcontent/json/JsonXContentParser.java
@@ -19,11 +19,14 @@
 
 package org.elasticsearch.common.xcontent.json;
 
+import com.fasterxml.jackson.core.JsonLocation;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
+
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.ElasticsearchIllegalStateException;
+import org.elasticsearch.common.xcontent.XContentLocation;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.support.AbstractXContentParser;
 
@@ -186,6 +189,16 @@ public class JsonXContentParser extends AbstractXContentParser {
     @Override
     public byte[] binaryValue() throws IOException {
         return parser.getBinaryValue();
+    }
+
+    @Override
+    public XContentLocation getTokenLocation() {
+        XContentLocation result = null;
+        JsonLocation loc = parser.getTokenLocation();
+        if (loc != null) {
+            result = new XContentLocation(loc.getLineNr(), loc.getColumnNr());
+        }
+        return result;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/common/xcontent/json/JsonXContentParser.java
+++ b/src/main/java/org/elasticsearch/common/xcontent/json/JsonXContentParser.java
@@ -193,12 +193,11 @@ public class JsonXContentParser extends AbstractXContentParser {
 
     @Override
     public XContentLocation getTokenLocation() {
-        XContentLocation result = null;
         JsonLocation loc = parser.getTokenLocation();
-        if (loc != null) {
-            result = new XContentLocation(loc.getLineNr(), loc.getColumnNr());
+        if (loc == null) {
+            return null;
         }
-        return result;
+        return new XContentLocation(loc.getLineNr(), loc.getColumnNr());
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/percolator/PercolatorQueriesRegistry.java
+++ b/src/main/java/org/elasticsearch/index/percolator/PercolatorQueriesRegistry.java
@@ -223,7 +223,7 @@ public class PercolatorQueriesRegistry extends AbstractIndexShardComponent imple
             context.setMapUnmappedFieldAsString(mapUnmappedFieldsAsString ? true : false);
             return queryParserService.parseInnerQuery(context);
         } catch (IOException e) {
-            throw new QueryParsingException(queryParserService.index(), "Failed to parse", parser.getTokenLocation(), e);
+            throw new QueryParsingException(context, "Failed to parse", e);
         } finally {
             if (type != null) {
                 QueryParseContext.setTypes(previousTypes);

--- a/src/main/java/org/elasticsearch/index/percolator/PercolatorQueriesRegistry.java
+++ b/src/main/java/org/elasticsearch/index/percolator/PercolatorQueriesRegistry.java
@@ -223,7 +223,7 @@ public class PercolatorQueriesRegistry extends AbstractIndexShardComponent imple
             context.setMapUnmappedFieldAsString(mapUnmappedFieldsAsString ? true : false);
             return queryParserService.parseInnerQuery(context);
         } catch (IOException e) {
-            throw new QueryParsingException(queryParserService.index(), "Failed to parse", e);
+            throw new QueryParsingException(queryParserService.index(), "Failed to parse", parser.getTokenLocation(), e);
         } finally {
             if (type != null) {
                 QueryParseContext.setTypes(previousTypes);

--- a/src/main/java/org/elasticsearch/index/query/AndFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/AndFilterParser.java
@@ -100,16 +100,14 @@ public class AndFilterParser implements FilterParser {
                     } else if ("_cache_key".equals(currentFieldName) || "_cacheKey".equals(currentFieldName)) {
                         cacheKey = new HashedBytesRef(parser.text());
                     } else {
-                        throw new QueryParsingException(parseContext.index(), "[and] filter does not support [" + currentFieldName + "]",
-                                parser.getTokenLocation());
+                        throw new QueryParsingException(parseContext, "[and] filter does not support [" + currentFieldName + "]");
                     }
                 }
             }
         }
 
         if (!filtersFound) {
-            throw new QueryParsingException(parseContext.index(), "[and] filter requires 'filters' to be set on it'",
-                    parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "[and] filter requires 'filters' to be set on it'");
         }
 
         if (filters.isEmpty()) {

--- a/src/main/java/org/elasticsearch/index/query/AndFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/AndFilterParser.java
@@ -100,14 +100,16 @@ public class AndFilterParser implements FilterParser {
                     } else if ("_cache_key".equals(currentFieldName) || "_cacheKey".equals(currentFieldName)) {
                         cacheKey = new HashedBytesRef(parser.text());
                     } else {
-                        throw new QueryParsingException(parseContext.index(), "[and] filter does not support [" + currentFieldName + "]");
+                        throw new QueryParsingException(parseContext.index(), "[and] filter does not support [" + currentFieldName + "]",
+                                parser.getTokenLocation());
                     }
                 }
             }
         }
 
         if (!filtersFound) {
-            throw new QueryParsingException(parseContext.index(), "[and] filter requires 'filters' to be set on it'");
+            throw new QueryParsingException(parseContext.index(), "[and] filter requires 'filters' to be set on it'",
+                    parser.getTokenLocation());
         }
 
         if (filters.isEmpty()) {

--- a/src/main/java/org/elasticsearch/index/query/BoolFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/BoolFilterParser.java
@@ -85,7 +85,8 @@ public class BoolFilterParser implements FilterParser {
                         boolFilter.add(new BooleanClause(filter, BooleanClause.Occur.SHOULD));
                     }
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[bool] filter does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[bool] filter does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.START_ARRAY) {
                 if ("must".equals(currentFieldName)) {
@@ -114,7 +115,8 @@ public class BoolFilterParser implements FilterParser {
                         }
                     }
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[bool] filter does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[bool] filter does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             } else if (token.isValue()) {
                 if ("_cache".equals(currentFieldName)) {
@@ -124,13 +126,15 @@ public class BoolFilterParser implements FilterParser {
                 } else if ("_cache_key".equals(currentFieldName) || "_cacheKey".equals(currentFieldName)) {
                     cacheKey = new HashedBytesRef(parser.text());
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[bool] filter does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[bool] filter does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             }
         }
 
         if (!hasAnyFilter) {
-            throw new QueryParsingException(parseContext.index(), "[bool] filter has no inner should/must/must_not elements");
+            throw new QueryParsingException(parseContext.index(), "[bool] filter has no inner should/must/must_not elements",
+                    parser.getTokenLocation());
         }
 
         if (boolFilter.clauses().isEmpty()) {

--- a/src/main/java/org/elasticsearch/index/query/BoolFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/BoolFilterParser.java
@@ -85,8 +85,7 @@ public class BoolFilterParser implements FilterParser {
                         boolFilter.add(new BooleanClause(filter, BooleanClause.Occur.SHOULD));
                     }
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[bool] filter does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[bool] filter does not support [" + currentFieldName + "]");
                 }
             } else if (token == XContentParser.Token.START_ARRAY) {
                 if ("must".equals(currentFieldName)) {
@@ -115,8 +114,7 @@ public class BoolFilterParser implements FilterParser {
                         }
                     }
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[bool] filter does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[bool] filter does not support [" + currentFieldName + "]");
                 }
             } else if (token.isValue()) {
                 if ("_cache".equals(currentFieldName)) {
@@ -126,15 +124,13 @@ public class BoolFilterParser implements FilterParser {
                 } else if ("_cache_key".equals(currentFieldName) || "_cacheKey".equals(currentFieldName)) {
                     cacheKey = new HashedBytesRef(parser.text());
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[bool] filter does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[bool] filter does not support [" + currentFieldName + "]");
                 }
             }
         }
 
         if (!hasAnyFilter) {
-            throw new QueryParsingException(parseContext.index(), "[bool] filter has no inner should/must/must_not elements",
-                    parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "[bool] filter has no inner should/must/must_not elements");
         }
 
         if (boolFilter.clauses().isEmpty()) {

--- a/src/main/java/org/elasticsearch/index/query/BoolQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/BoolQueryParser.java
@@ -85,7 +85,8 @@ public class BoolQueryParser implements QueryParser {
                         clauses.add(new BooleanClause(query, BooleanClause.Occur.SHOULD));
                     }
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[bool] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[bool] query does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.START_ARRAY) {
                 if ("must".equals(currentFieldName)) {
@@ -110,7 +111,8 @@ public class BoolQueryParser implements QueryParser {
                         }
                     }
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "bool query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "bool query does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             } else if (token.isValue()) {
                 if ("disable_coord".equals(currentFieldName) || "disableCoord".equals(currentFieldName)) {
@@ -126,7 +128,8 @@ public class BoolQueryParser implements QueryParser {
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[bool] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[bool] query does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             }
         }

--- a/src/main/java/org/elasticsearch/index/query/BoolQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/BoolQueryParser.java
@@ -85,8 +85,7 @@ public class BoolQueryParser implements QueryParser {
                         clauses.add(new BooleanClause(query, BooleanClause.Occur.SHOULD));
                     }
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[bool] query does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[bool] query does not support [" + currentFieldName + "]");
                 }
             } else if (token == XContentParser.Token.START_ARRAY) {
                 if ("must".equals(currentFieldName)) {
@@ -111,8 +110,7 @@ public class BoolQueryParser implements QueryParser {
                         }
                     }
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "bool query does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "bool query does not support [" + currentFieldName + "]");
                 }
             } else if (token.isValue()) {
                 if ("disable_coord".equals(currentFieldName) || "disableCoord".equals(currentFieldName)) {
@@ -128,8 +126,7 @@ public class BoolQueryParser implements QueryParser {
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[bool] query does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[bool] query does not support [" + currentFieldName + "]");
                 }
             }
         }

--- a/src/main/java/org/elasticsearch/index/query/BoostingQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/BoostingQueryParser.java
@@ -66,8 +66,7 @@ public class BoostingQueryParser implements QueryParser {
                     negativeQuery = parseContext.parseInnerQuery();
                     negativeQueryFound = true;
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[boosting] query does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[boosting] query does not support [" + currentFieldName + "]");
                 }
             } else if (token.isValue()) {
                 if ("negative_boost".equals(currentFieldName) || "negativeBoost".equals(currentFieldName)) {
@@ -75,23 +74,19 @@ public class BoostingQueryParser implements QueryParser {
                 } else if ("boost".equals(currentFieldName)) {
                     boost = parser.floatValue();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[boosting] query does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[boosting] query does not support [" + currentFieldName + "]");
                 }
             }
         }
 
         if (positiveQuery == null && !positiveQueryFound) {
-            throw new QueryParsingException(parseContext.index(), "[boosting] query requires 'positive' query to be set'",
-                    parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "[boosting] query requires 'positive' query to be set'");
         }
         if (negativeQuery == null && !negativeQueryFound) {
-            throw new QueryParsingException(parseContext.index(), "[boosting] query requires 'negative' query to be set'",
-                    parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "[boosting] query requires 'negative' query to be set'");
         }
         if (negativeBoost == -1) {
-            throw new QueryParsingException(parseContext.index(), "[boosting] query requires 'negative_boost' to be set'",
-                    parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "[boosting] query requires 'negative_boost' to be set'");
         }
 
         // parsers returned null

--- a/src/main/java/org/elasticsearch/index/query/BoostingQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/BoostingQueryParser.java
@@ -66,7 +66,8 @@ public class BoostingQueryParser implements QueryParser {
                     negativeQuery = parseContext.parseInnerQuery();
                     negativeQueryFound = true;
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[boosting] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[boosting] query does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             } else if (token.isValue()) {
                 if ("negative_boost".equals(currentFieldName) || "negativeBoost".equals(currentFieldName)) {
@@ -74,19 +75,23 @@ public class BoostingQueryParser implements QueryParser {
                 } else if ("boost".equals(currentFieldName)) {
                     boost = parser.floatValue();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[boosting] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[boosting] query does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             }
         }
 
         if (positiveQuery == null && !positiveQueryFound) {
-            throw new QueryParsingException(parseContext.index(), "[boosting] query requires 'positive' query to be set'");
+            throw new QueryParsingException(parseContext.index(), "[boosting] query requires 'positive' query to be set'",
+                    parser.getTokenLocation());
         }
         if (negativeQuery == null && !negativeQueryFound) {
-            throw new QueryParsingException(parseContext.index(), "[boosting] query requires 'negative' query to be set'");
+            throw new QueryParsingException(parseContext.index(), "[boosting] query requires 'negative' query to be set'",
+                    parser.getTokenLocation());
         }
         if (negativeBoost == -1) {
-            throw new QueryParsingException(parseContext.index(), "[boosting] query requires 'negative_boost' to be set'");
+            throw new QueryParsingException(parseContext.index(), "[boosting] query requires 'negative_boost' to be set'",
+                    parser.getTokenLocation());
         }
 
         // parsers returned null

--- a/src/main/java/org/elasticsearch/index/query/CommonTermsQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/CommonTermsQueryParser.java
@@ -66,7 +66,7 @@ public class CommonTermsQueryParser implements QueryParser {
         XContentParser parser = parseContext.parser();
         XContentParser.Token token = parser.nextToken();
         if (token != XContentParser.Token.FIELD_NAME) {
-            throw new QueryParsingException(parseContext.index(), "[common] query malformed, no field");
+            throw new QueryParsingException(parseContext.index(), "[common] query malformed, no field", parser.getTokenLocation());
         }
         String fieldName = parser.currentName();
         Object value = null;
@@ -97,12 +97,14 @@ public class CommonTermsQueryParser implements QueryParser {
                                 } else if ("high_freq".equals(innerFieldName) || "highFreq".equals(innerFieldName)) {
                                     highFreqMinimumShouldMatch = parser.text();
                                 } else {
-                                    throw new QueryParsingException(parseContext.index(), "[common] query does not support [" + innerFieldName + "] for [" + currentFieldName + "]");
+                                    throw new QueryParsingException(parseContext.index(), "[common] query does not support ["
+                                            + innerFieldName + "] for [" + currentFieldName + "]", parser.getTokenLocation());
                                 }
                             }
                         }
                     } else {
-                        throw new QueryParsingException(parseContext.index(), "[common] query does not support [" + currentFieldName + "]");
+                        throw new QueryParsingException(parseContext.index(), "[common] query does not support [" + currentFieldName + "]",
+                                parser.getTokenLocation());
                     }
                 } else if (token.isValue()) {
                     if ("query".equals(currentFieldName)) {
@@ -110,7 +112,8 @@ public class CommonTermsQueryParser implements QueryParser {
                     } else if ("analyzer".equals(currentFieldName)) {
                         String analyzer = parser.text();
                         if (parseContext.analysisService().analyzer(analyzer) == null) {
-                            throw new QueryParsingException(parseContext.index(), "[common] analyzer [" + parser.text() + "] not found");
+                            throw new QueryParsingException(parseContext.index(), "[common] analyzer [" + parser.text() + "] not found",
+                                    parser.getTokenLocation());
                         }
                         queryAnalyzer = analyzer;
                     } else if ("disable_coord".equals(currentFieldName) || "disableCoord".equals(currentFieldName)) {
@@ -125,7 +128,8 @@ public class CommonTermsQueryParser implements QueryParser {
                             highFreqOccur = BooleanClause.Occur.MUST;
                         } else {
                             throw new QueryParsingException(parseContext.index(),
-                                    "[common] query requires operator to be either 'and' or 'or', not [" + op + "]");
+                                    "[common] query requires operator to be either 'and' or 'or', not [" + op + "]",
+                                    parser.getTokenLocation());
                         }
                     } else if ("low_freq_operator".equals(currentFieldName) || "lowFreqOperator".equals(currentFieldName)) {
                         String op = parser.text();
@@ -135,7 +139,8 @@ public class CommonTermsQueryParser implements QueryParser {
                             lowFreqOccur = BooleanClause.Occur.MUST;
                         } else {
                             throw new QueryParsingException(parseContext.index(),
-                                    "[common] query requires operator to be either 'and' or 'or', not [" + op + "]");
+                                    "[common] query requires operator to be either 'and' or 'or', not [" + op + "]",
+                                    parser.getTokenLocation());
                         }
                     } else if ("minimum_should_match".equals(currentFieldName) || "minimumShouldMatch".equals(currentFieldName)) {
                         lowFreqMinimumShouldMatch = parser.text();
@@ -144,7 +149,8 @@ public class CommonTermsQueryParser implements QueryParser {
                     } else if ("_name".equals(currentFieldName)) {
                         queryName = parser.text();
                     } else {
-                        throw new QueryParsingException(parseContext.index(), "[common] query does not support [" + currentFieldName + "]");
+                        throw new QueryParsingException(parseContext.index(), "[common] query does not support [" + currentFieldName + "]",
+                                parser.getTokenLocation());
                     }
                 }
             }
@@ -156,12 +162,13 @@ public class CommonTermsQueryParser implements QueryParser {
             if (token != XContentParser.Token.END_OBJECT) {
                 throw new QueryParsingException(
                         parseContext.index(),
-                        "[common] query parsed in simplified form, with direct field name, but included more options than just the field name, possibly use its 'options' form, with 'query' element?");
+                        "[common] query parsed in simplified form, with direct field name, but included more options than just the field name, possibly use its 'options' form, with 'query' element?",
+                        parser.getTokenLocation());
             }
         }
 
         if (value == null) {
-            throw new QueryParsingException(parseContext.index(), "No text specified for text query");
+            throw new QueryParsingException(parseContext.index(), "No text specified for text query", parser.getTokenLocation());
         }
         FieldMapper<?> mapper = null;
         String field;

--- a/src/main/java/org/elasticsearch/index/query/CommonTermsQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/CommonTermsQueryParser.java
@@ -66,7 +66,7 @@ public class CommonTermsQueryParser implements QueryParser {
         XContentParser parser = parseContext.parser();
         XContentParser.Token token = parser.nextToken();
         if (token != XContentParser.Token.FIELD_NAME) {
-            throw new QueryParsingException(parseContext.index(), "[common] query malformed, no field", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "[common] query malformed, no field");
         }
         String fieldName = parser.currentName();
         Object value = null;
@@ -97,14 +97,13 @@ public class CommonTermsQueryParser implements QueryParser {
                                 } else if ("high_freq".equals(innerFieldName) || "highFreq".equals(innerFieldName)) {
                                     highFreqMinimumShouldMatch = parser.text();
                                 } else {
-                                    throw new QueryParsingException(parseContext.index(), "[common] query does not support ["
-                                            + innerFieldName + "] for [" + currentFieldName + "]", parser.getTokenLocation());
+                                    throw new QueryParsingException(parseContext, "[common] query does not support [" + innerFieldName
+                                            + "] for [" + currentFieldName + "]");
                                 }
                             }
                         }
                     } else {
-                        throw new QueryParsingException(parseContext.index(), "[common] query does not support [" + currentFieldName + "]",
-                                parser.getTokenLocation());
+                        throw new QueryParsingException(parseContext, "[common] query does not support [" + currentFieldName + "]");
                     }
                 } else if (token.isValue()) {
                     if ("query".equals(currentFieldName)) {
@@ -112,8 +111,7 @@ public class CommonTermsQueryParser implements QueryParser {
                     } else if ("analyzer".equals(currentFieldName)) {
                         String analyzer = parser.text();
                         if (parseContext.analysisService().analyzer(analyzer) == null) {
-                            throw new QueryParsingException(parseContext.index(), "[common] analyzer [" + parser.text() + "] not found",
-                                    parser.getTokenLocation());
+                            throw new QueryParsingException(parseContext, "[common] analyzer [" + parser.text() + "] not found");
                         }
                         queryAnalyzer = analyzer;
                     } else if ("disable_coord".equals(currentFieldName) || "disableCoord".equals(currentFieldName)) {
@@ -127,9 +125,8 @@ public class CommonTermsQueryParser implements QueryParser {
                         } else if ("and".equalsIgnoreCase(op)) {
                             highFreqOccur = BooleanClause.Occur.MUST;
                         } else {
-                            throw new QueryParsingException(parseContext.index(),
-                                    "[common] query requires operator to be either 'and' or 'or', not [" + op + "]",
-                                    parser.getTokenLocation());
+                            throw new QueryParsingException(parseContext,
+                                    "[common] query requires operator to be either 'and' or 'or', not [" + op + "]");
                         }
                     } else if ("low_freq_operator".equals(currentFieldName) || "lowFreqOperator".equals(currentFieldName)) {
                         String op = parser.text();
@@ -138,9 +135,8 @@ public class CommonTermsQueryParser implements QueryParser {
                         } else if ("and".equalsIgnoreCase(op)) {
                             lowFreqOccur = BooleanClause.Occur.MUST;
                         } else {
-                            throw new QueryParsingException(parseContext.index(),
-                                    "[common] query requires operator to be either 'and' or 'or', not [" + op + "]",
-                                    parser.getTokenLocation());
+                            throw new QueryParsingException(parseContext,
+                                    "[common] query requires operator to be either 'and' or 'or', not [" + op + "]");
                         }
                     } else if ("minimum_should_match".equals(currentFieldName) || "minimumShouldMatch".equals(currentFieldName)) {
                         lowFreqMinimumShouldMatch = parser.text();
@@ -149,8 +145,7 @@ public class CommonTermsQueryParser implements QueryParser {
                     } else if ("_name".equals(currentFieldName)) {
                         queryName = parser.text();
                     } else {
-                        throw new QueryParsingException(parseContext.index(), "[common] query does not support [" + currentFieldName + "]",
-                                parser.getTokenLocation());
+                        throw new QueryParsingException(parseContext, "[common] query does not support [" + currentFieldName + "]");
                     }
                 }
             }
@@ -161,14 +156,13 @@ public class CommonTermsQueryParser implements QueryParser {
             token = parser.nextToken();
             if (token != XContentParser.Token.END_OBJECT) {
                 throw new QueryParsingException(
-                        parseContext.index(),
-                        "[common] query parsed in simplified form, with direct field name, but included more options than just the field name, possibly use its 'options' form, with 'query' element?",
-                        parser.getTokenLocation());
+                        parseContext,
+                        "[common] query parsed in simplified form, with direct field name, but included more options than just the field name, possibly use its 'options' form, with 'query' element?");
             }
         }
 
         if (value == null) {
-            throw new QueryParsingException(parseContext.index(), "No text specified for text query", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "No text specified for text query");
         }
         FieldMapper<?> mapper = null;
         String field;

--- a/src/main/java/org/elasticsearch/index/query/ConstantScoreQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/ConstantScoreQueryParser.java
@@ -71,8 +71,7 @@ public class ConstantScoreQueryParser implements QueryParser {
                     query = parseContext.parseInnerQuery();
                     queryFound = true;
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[constant_score] query does not support [" + currentFieldName
-                            + "]", parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[constant_score] query does not support [" + currentFieldName + "]");
                 }
             } else if (token.isValue()) {
                 if ("boost".equals(currentFieldName)) {
@@ -82,14 +81,12 @@ public class ConstantScoreQueryParser implements QueryParser {
                 } else if ("_cache_key".equals(currentFieldName) || "_cacheKey".equals(currentFieldName)) {
                     cacheKey = new HashedBytesRef(parser.text());
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[constant_score] query does not support [" + currentFieldName
-                            + "]", parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[constant_score] query does not support [" + currentFieldName + "]");
                 }
             }
         }
         if (!filterFound && !queryFound) {
-            throw new QueryParsingException(parseContext.index(), "[constant_score] requires either 'filter' or 'query' element",
-                    parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "[constant_score] requires either 'filter' or 'query' element");
         }
 
         if (query == null && filter == null) {

--- a/src/main/java/org/elasticsearch/index/query/ConstantScoreQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/ConstantScoreQueryParser.java
@@ -71,7 +71,8 @@ public class ConstantScoreQueryParser implements QueryParser {
                     query = parseContext.parseInnerQuery();
                     queryFound = true;
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[constant_score] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[constant_score] query does not support [" + currentFieldName
+                            + "]", parser.getTokenLocation());
                 }
             } else if (token.isValue()) {
                 if ("boost".equals(currentFieldName)) {
@@ -81,12 +82,14 @@ public class ConstantScoreQueryParser implements QueryParser {
                 } else if ("_cache_key".equals(currentFieldName) || "_cacheKey".equals(currentFieldName)) {
                     cacheKey = new HashedBytesRef(parser.text());
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[constant_score] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[constant_score] query does not support [" + currentFieldName
+                            + "]", parser.getTokenLocation());
                 }
             }
         }
         if (!filterFound && !queryFound) {
-            throw new QueryParsingException(parseContext.index(), "[constant_score] requires either 'filter' or 'query' element");
+            throw new QueryParsingException(parseContext.index(), "[constant_score] requires either 'filter' or 'query' element",
+                    parser.getTokenLocation());
         }
 
         if (query == null && filter == null) {

--- a/src/main/java/org/elasticsearch/index/query/DisMaxQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/DisMaxQueryParser.java
@@ -70,7 +70,8 @@ public class DisMaxQueryParser implements QueryParser {
                         queries.add(query);
                     }
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[dis_max] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[dis_max] query does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.START_ARRAY) {
                 if ("queries".equals(currentFieldName)) {
@@ -83,7 +84,8 @@ public class DisMaxQueryParser implements QueryParser {
                         token = parser.nextToken();
                     }
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[dis_max] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[dis_max] query does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             } else {
                 if ("boost".equals(currentFieldName)) {
@@ -93,13 +95,14 @@ public class DisMaxQueryParser implements QueryParser {
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[dis_max] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[dis_max] query does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             }
         }
 
         if (!queriesFound) {
-            throw new QueryParsingException(parseContext.index(), "[dis_max] requires 'queries' field");
+            throw new QueryParsingException(parseContext.index(), "[dis_max] requires 'queries' field", parser.getTokenLocation());
         }
 
         if (queries.isEmpty()) {

--- a/src/main/java/org/elasticsearch/index/query/DisMaxQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/DisMaxQueryParser.java
@@ -70,8 +70,7 @@ public class DisMaxQueryParser implements QueryParser {
                         queries.add(query);
                     }
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[dis_max] query does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[dis_max] query does not support [" + currentFieldName + "]");
                 }
             } else if (token == XContentParser.Token.START_ARRAY) {
                 if ("queries".equals(currentFieldName)) {
@@ -84,8 +83,7 @@ public class DisMaxQueryParser implements QueryParser {
                         token = parser.nextToken();
                     }
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[dis_max] query does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[dis_max] query does not support [" + currentFieldName + "]");
                 }
             } else {
                 if ("boost".equals(currentFieldName)) {
@@ -95,14 +93,13 @@ public class DisMaxQueryParser implements QueryParser {
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[dis_max] query does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[dis_max] query does not support [" + currentFieldName + "]");
                 }
             }
         }
 
         if (!queriesFound) {
-            throw new QueryParsingException(parseContext.index(), "[dis_max] requires 'queries' field", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "[dis_max] requires 'queries' field");
         }
 
         if (queries.isEmpty()) {

--- a/src/main/java/org/elasticsearch/index/query/ExistsFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/ExistsFilterParser.java
@@ -23,8 +23,6 @@ import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Filter;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.search.QueryWrapperFilter;
-import org.apache.lucene.search.TermRangeFilter;
 import org.apache.lucene.search.TermRangeQuery;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.lucene.HashedBytesRef;
@@ -71,13 +69,14 @@ public class ExistsFilterParser implements FilterParser {
                 } else if ("_name".equals(currentFieldName)) {
                     filterName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[exists] filter does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[exists] filter does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             }
         }
 
         if (fieldPattern == null) {
-            throw new QueryParsingException(parseContext.index(), "exists must be provided with a [field]");
+            throw new QueryParsingException(parseContext.index(), "exists must be provided with a [field]", parser.getTokenLocation());
         }
 
         return newFilter(parseContext, fieldPattern, filterName);

--- a/src/main/java/org/elasticsearch/index/query/ExistsFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/ExistsFilterParser.java
@@ -69,14 +69,13 @@ public class ExistsFilterParser implements FilterParser {
                 } else if ("_name".equals(currentFieldName)) {
                     filterName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[exists] filter does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[exists] filter does not support [" + currentFieldName + "]");
                 }
             }
         }
 
         if (fieldPattern == null) {
-            throw new QueryParsingException(parseContext.index(), "exists must be provided with a [field]", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "exists must be provided with a [field]");
         }
 
         return newFilter(parseContext, fieldPattern, filterName);

--- a/src/main/java/org/elasticsearch/index/query/FQueryFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/FQueryFilterParser.java
@@ -66,8 +66,7 @@ public class FQueryFilterParser implements FilterParser {
                     queryFound = true;
                     query = parseContext.parseInnerQuery();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[fquery] filter does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[fquery] filter does not support [" + currentFieldName + "]");
                 }
             } else if (token.isValue()) {
                 if ("_name".equals(currentFieldName)) {
@@ -77,13 +76,12 @@ public class FQueryFilterParser implements FilterParser {
                 } else if ("_cache_key".equals(currentFieldName) || "_cacheKey".equals(currentFieldName)) {
                     cacheKey = new HashedBytesRef(parser.text());
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[fquery] filter does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[fquery] filter does not support [" + currentFieldName + "]");
                 }
             }
         }
         if (!queryFound) {
-            throw new QueryParsingException(parseContext.index(), "[fquery] requires 'query' element", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "[fquery] requires 'query' element");
         }
         if (query == null) {
             return null;

--- a/src/main/java/org/elasticsearch/index/query/FQueryFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/FQueryFilterParser.java
@@ -66,7 +66,8 @@ public class FQueryFilterParser implements FilterParser {
                     queryFound = true;
                     query = parseContext.parseInnerQuery();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[fquery] filter does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[fquery] filter does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             } else if (token.isValue()) {
                 if ("_name".equals(currentFieldName)) {
@@ -76,12 +77,13 @@ public class FQueryFilterParser implements FilterParser {
                 } else if ("_cache_key".equals(currentFieldName) || "_cacheKey".equals(currentFieldName)) {
                     cacheKey = new HashedBytesRef(parser.text());
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[fquery] filter does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[fquery] filter does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             }
         }
         if (!queryFound) {
-            throw new QueryParsingException(parseContext.index(), "[fquery] requires 'query' element");
+            throw new QueryParsingException(parseContext.index(), "[fquery] requires 'query' element", parser.getTokenLocation());
         }
         if (query == null) {
             return null;

--- a/src/main/java/org/elasticsearch/index/query/FieldMaskingSpanQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/FieldMaskingSpanQueryParser.java
@@ -64,13 +64,12 @@ public class FieldMaskingSpanQueryParser implements QueryParser {
                 if ("query".equals(currentFieldName)) {
                     Query query = parseContext.parseInnerQuery();
                     if (!(query instanceof SpanQuery)) {
-                        throw new QueryParsingException(parseContext.index(), "[field_masking_span] query] must be of type span query",
-                                parser.getTokenLocation());
+                        throw new QueryParsingException(parseContext, "[field_masking_span] query] must be of type span query");
                     }
                     inner = (SpanQuery) query;
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[field_masking_span] query does not support ["
-                            + currentFieldName + "]", parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[field_masking_span] query does not support ["
+                            + currentFieldName + "]");
                 }
             } else {
                 if ("boost".equals(currentFieldName)) {
@@ -80,18 +79,15 @@ public class FieldMaskingSpanQueryParser implements QueryParser {
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[field_masking_span] query does not support ["
-                            + currentFieldName + "]", parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[field_masking_span] query does not support [" + currentFieldName + "]");
                 }
             }
         }
         if (inner == null) {
-            throw new QueryParsingException(parseContext.index(), "field_masking_span must have [query] span query clause",
-                    parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "field_masking_span must have [query] span query clause");
         }
         if (field == null) {
-            throw new QueryParsingException(parseContext.index(), "field_masking_span must have [field] set for it",
-                    parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "field_masking_span must have [field] set for it");
         }
 
         FieldMapper mapper = parseContext.fieldMapper(field);

--- a/src/main/java/org/elasticsearch/index/query/FieldMaskingSpanQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/FieldMaskingSpanQueryParser.java
@@ -64,11 +64,13 @@ public class FieldMaskingSpanQueryParser implements QueryParser {
                 if ("query".equals(currentFieldName)) {
                     Query query = parseContext.parseInnerQuery();
                     if (!(query instanceof SpanQuery)) {
-                        throw new QueryParsingException(parseContext.index(), "[field_masking_span] query] must be of type span query");
+                        throw new QueryParsingException(parseContext.index(), "[field_masking_span] query] must be of type span query",
+                                parser.getTokenLocation());
                     }
                     inner = (SpanQuery) query;
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[field_masking_span] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[field_masking_span] query does not support ["
+                            + currentFieldName + "]", parser.getTokenLocation());
                 }
             } else {
                 if ("boost".equals(currentFieldName)) {
@@ -78,15 +80,18 @@ public class FieldMaskingSpanQueryParser implements QueryParser {
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[field_masking_span] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[field_masking_span] query does not support ["
+                            + currentFieldName + "]", parser.getTokenLocation());
                 }
             }
         }
         if (inner == null) {
-            throw new QueryParsingException(parseContext.index(), "field_masking_span must have [query] span query clause");
+            throw new QueryParsingException(parseContext.index(), "field_masking_span must have [query] span query clause",
+                    parser.getTokenLocation());
         }
         if (field == null) {
-            throw new QueryParsingException(parseContext.index(), "field_masking_span must have [field] set for it");
+            throw new QueryParsingException(parseContext.index(), "field_masking_span must have [field] set for it",
+                    parser.getTokenLocation());
         }
 
         FieldMapper mapper = parseContext.fieldMapper(field);

--- a/src/main/java/org/elasticsearch/index/query/FilteredQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/FilteredQueryParser.java
@@ -73,8 +73,7 @@ public class FilteredQueryParser implements QueryParser {
                     filterFound = true;
                     filter = parseContext.parseInnerFilter();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[filtered] query does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[filtered] query does not support [" + currentFieldName + "]");
                 }
             } else if (token.isValue()) {
                 if ("strategy".equals(currentFieldName)) {
@@ -94,8 +93,7 @@ public class FilteredQueryParser implements QueryParser {
                     } else if ("leap_frog_filter_first".equals(value) || "leapFrogFilterFirst".equals(value)) {
                         filterStrategy = FilteredQuery.LEAP_FROG_FILTER_FIRST_STRATEGY;
                     } else {
-                        throw new QueryParsingException(parseContext.index(), "[filtered] strategy value not supported [" + value + "]",
-                                parser.getTokenLocation());
+                        throw new QueryParsingException(parseContext, "[filtered] strategy value not supported [" + value + "]");
                     }
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
@@ -106,8 +104,7 @@ public class FilteredQueryParser implements QueryParser {
                 } else if ("_cache_key".equals(currentFieldName) || "_cacheKey".equals(currentFieldName)) {
                     cacheKey = new HashedBytesRef(parser.text());
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[filtered] query does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[filtered] query does not support [" + currentFieldName + "]");
                 }
             }
         }

--- a/src/main/java/org/elasticsearch/index/query/FilteredQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/FilteredQueryParser.java
@@ -73,7 +73,8 @@ public class FilteredQueryParser implements QueryParser {
                     filterFound = true;
                     filter = parseContext.parseInnerFilter();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[filtered] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[filtered] query does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             } else if (token.isValue()) {
                 if ("strategy".equals(currentFieldName)) {
@@ -93,7 +94,8 @@ public class FilteredQueryParser implements QueryParser {
                     } else if ("leap_frog_filter_first".equals(value) || "leapFrogFilterFirst".equals(value)) {
                         filterStrategy = FilteredQuery.LEAP_FROG_FILTER_FIRST_STRATEGY;
                     } else {
-                        throw new QueryParsingException(parseContext.index(), "[filtered] strategy value not supported [" + value + "]");
+                        throw new QueryParsingException(parseContext.index(), "[filtered] strategy value not supported [" + value + "]",
+                                parser.getTokenLocation());
                     }
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
@@ -104,7 +106,8 @@ public class FilteredQueryParser implements QueryParser {
                 } else if ("_cache_key".equals(currentFieldName) || "_cacheKey".equals(currentFieldName)) {
                     cacheKey = new HashedBytesRef(parser.text());
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[filtered] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[filtered] query does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             }
         }

--- a/src/main/java/org/elasticsearch/index/query/FuzzyQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/FuzzyQueryParser.java
@@ -57,7 +57,7 @@ public class FuzzyQueryParser implements QueryParser {
 
         XContentParser.Token token = parser.nextToken();
         if (token != XContentParser.Token.FIELD_NAME) {
-            throw new QueryParsingException(parseContext.index(), "[fuzzy] query malformed, no field");
+            throw new QueryParsingException(parseContext.index(), "[fuzzy] query malformed, no field", parser.getTokenLocation());
         }
         String fieldName = parser.currentName();
 
@@ -95,7 +95,8 @@ public class FuzzyQueryParser implements QueryParser {
                     } else if ("_name".equals(currentFieldName)) {
                         queryName = parser.text();
                     } else {
-                        throw new QueryParsingException(parseContext.index(), "[fuzzy] query does not support [" + currentFieldName + "]");
+                        throw new QueryParsingException(parseContext.index(), "[fuzzy] query does not support [" + currentFieldName + "]",
+                                parser.getTokenLocation());
                     }
                 }
             }
@@ -107,7 +108,7 @@ public class FuzzyQueryParser implements QueryParser {
         }
 
         if (value == null) {
-            throw new QueryParsingException(parseContext.index(), "No value specified for fuzzy query");
+            throw new QueryParsingException(parseContext.index(), "No value specified for fuzzy query", parser.getTokenLocation());
         }
 
         Query query = null;

--- a/src/main/java/org/elasticsearch/index/query/FuzzyQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/FuzzyQueryParser.java
@@ -57,7 +57,7 @@ public class FuzzyQueryParser implements QueryParser {
 
         XContentParser.Token token = parser.nextToken();
         if (token != XContentParser.Token.FIELD_NAME) {
-            throw new QueryParsingException(parseContext.index(), "[fuzzy] query malformed, no field", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "[fuzzy] query malformed, no field");
         }
         String fieldName = parser.currentName();
 
@@ -95,8 +95,7 @@ public class FuzzyQueryParser implements QueryParser {
                     } else if ("_name".equals(currentFieldName)) {
                         queryName = parser.text();
                     } else {
-                        throw new QueryParsingException(parseContext.index(), "[fuzzy] query does not support [" + currentFieldName + "]",
-                                parser.getTokenLocation());
+                        throw new QueryParsingException(parseContext, "[fuzzy] query does not support [" + currentFieldName + "]");
                     }
                 }
             }
@@ -108,7 +107,7 @@ public class FuzzyQueryParser implements QueryParser {
         }
 
         if (value == null) {
-            throw new QueryParsingException(parseContext.index(), "No value specified for fuzzy query", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "No value specified for fuzzy query");
         }
 
         Query query = null;

--- a/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxFilterParser.java
@@ -147,7 +147,8 @@ public class GeoBoundingBoxFilterParser implements FilterParser {
                 } else if ("type".equals(currentFieldName)) {
                     type = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[geo_bbox] filter does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[geo_bbox] filter does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             }
         }
@@ -169,11 +170,13 @@ public class GeoBoundingBoxFilterParser implements FilterParser {
 
         MapperService.SmartNameFieldMappers smartMappers = parseContext.smartFieldMappers(fieldName);
         if (smartMappers == null || !smartMappers.hasMapper()) {
-            throw new QueryParsingException(parseContext.index(), "failed to find geo_point field [" + fieldName + "]");
+            throw new QueryParsingException(parseContext.index(), "failed to find geo_point field [" + fieldName + "]",
+                    parser.getTokenLocation());
         }
         FieldMapper<?> mapper = smartMappers.mapper();
         if (!(mapper instanceof GeoPointFieldMapper)) {
-            throw new QueryParsingException(parseContext.index(), "field [" + fieldName + "] is not a geo_point field");
+            throw new QueryParsingException(parseContext.index(), "field [" + fieldName + "] is not a geo_point field",
+                    parser.getTokenLocation());
         }
         GeoPointFieldMapper geoMapper = ((GeoPointFieldMapper) mapper);
 
@@ -184,7 +187,8 @@ public class GeoBoundingBoxFilterParser implements FilterParser {
             IndexGeoPointFieldData indexFieldData = parseContext.getForField(mapper);
             filter = new InMemoryGeoBoundingBoxFilter(topLeft, bottomRight, indexFieldData);
         } else {
-            throw new QueryParsingException(parseContext.index(), "geo bounding box type [" + type + "] not supported, either 'indexed' or 'memory' are allowed");
+            throw new QueryParsingException(parseContext.index(), "geo bounding box type [" + type
+                    + "] not supported, either 'indexed' or 'memory' are allowed", parser.getTokenLocation());
         }
 
         if (cache != null) {

--- a/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxFilterParser.java
@@ -147,8 +147,7 @@ public class GeoBoundingBoxFilterParser implements FilterParser {
                 } else if ("type".equals(currentFieldName)) {
                     type = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[geo_bbox] filter does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[geo_bbox] filter does not support [" + currentFieldName + "]");
                 }
             }
         }
@@ -170,13 +169,11 @@ public class GeoBoundingBoxFilterParser implements FilterParser {
 
         MapperService.SmartNameFieldMappers smartMappers = parseContext.smartFieldMappers(fieldName);
         if (smartMappers == null || !smartMappers.hasMapper()) {
-            throw new QueryParsingException(parseContext.index(), "failed to find geo_point field [" + fieldName + "]",
-                    parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "failed to find geo_point field [" + fieldName + "]");
         }
         FieldMapper<?> mapper = smartMappers.mapper();
         if (!(mapper instanceof GeoPointFieldMapper)) {
-            throw new QueryParsingException(parseContext.index(), "field [" + fieldName + "] is not a geo_point field",
-                    parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "field [" + fieldName + "] is not a geo_point field");
         }
         GeoPointFieldMapper geoMapper = ((GeoPointFieldMapper) mapper);
 
@@ -187,8 +184,8 @@ public class GeoBoundingBoxFilterParser implements FilterParser {
             IndexGeoPointFieldData indexFieldData = parseContext.getForField(mapper);
             filter = new InMemoryGeoBoundingBoxFilter(topLeft, bottomRight, indexFieldData);
         } else {
-            throw new QueryParsingException(parseContext.index(), "geo bounding box type [" + type
-                    + "] not supported, either 'indexed' or 'memory' are allowed", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "geo bounding box type [" + type
+                    + "] not supported, either 'indexed' or 'memory' are allowed");
         }
 
         if (cache != null) {

--- a/src/main/java/org/elasticsearch/index/query/GeoDistanceFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoDistanceFilterParser.java
@@ -98,7 +98,8 @@ public class GeoDistanceFilterParser implements FilterParser {
                         } else if (currentName.equals(GeoPointFieldMapper.Names.GEOHASH)) {
                             GeoHashUtils.decode(parser.text(), point);
                         } else {
-                            throw new QueryParsingException(parseContext.index(), "[geo_distance] filter does not support [" + currentFieldName + "]");
+                            throw new QueryParsingException(parseContext.index(), "[geo_distance] filter does not support ["
+                                    + currentFieldName + "]", parser.getTokenLocation());
                         }
                     }
                 }
@@ -141,7 +142,8 @@ public class GeoDistanceFilterParser implements FilterParser {
         }
 
         if (vDistance == null) {
-            throw new QueryParsingException(parseContext.index(), "geo_distance requires 'distance' to be specified");
+            throw new QueryParsingException(parseContext.index(), "geo_distance requires 'distance' to be specified",
+                    parser.getTokenLocation());
         } else if (vDistance instanceof Number) {
             distance = DistanceUnit.DEFAULT.convert(((Number) vDistance).doubleValue(), unit);
         } else {
@@ -155,11 +157,13 @@ public class GeoDistanceFilterParser implements FilterParser {
 
         MapperService.SmartNameFieldMappers smartMappers = parseContext.smartFieldMappers(fieldName);
         if (smartMappers == null || !smartMappers.hasMapper()) {
-            throw new QueryParsingException(parseContext.index(), "failed to find geo_point field [" + fieldName + "]");
+            throw new QueryParsingException(parseContext.index(), "failed to find geo_point field [" + fieldName + "]",
+                    parser.getTokenLocation());
         }
         FieldMapper<?> mapper = smartMappers.mapper();
         if (!(mapper instanceof GeoPointFieldMapper)) {
-            throw new QueryParsingException(parseContext.index(), "field [" + fieldName + "] is not a geo_point field");
+            throw new QueryParsingException(parseContext.index(), "field [" + fieldName + "] is not a geo_point field",
+                    parser.getTokenLocation());
         }
         GeoPointFieldMapper geoMapper = ((GeoPointFieldMapper) mapper);
 

--- a/src/main/java/org/elasticsearch/index/query/GeoDistanceFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoDistanceFilterParser.java
@@ -98,8 +98,8 @@ public class GeoDistanceFilterParser implements FilterParser {
                         } else if (currentName.equals(GeoPointFieldMapper.Names.GEOHASH)) {
                             GeoHashUtils.decode(parser.text(), point);
                         } else {
-                            throw new QueryParsingException(parseContext.index(), "[geo_distance] filter does not support ["
-                                    + currentFieldName + "]", parser.getTokenLocation());
+                            throw new QueryParsingException(parseContext, "[geo_distance] filter does not support [" + currentFieldName
+                                    + "]");
                         }
                     }
                 }
@@ -142,8 +142,7 @@ public class GeoDistanceFilterParser implements FilterParser {
         }
 
         if (vDistance == null) {
-            throw new QueryParsingException(parseContext.index(), "geo_distance requires 'distance' to be specified",
-                    parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "geo_distance requires 'distance' to be specified");
         } else if (vDistance instanceof Number) {
             distance = DistanceUnit.DEFAULT.convert(((Number) vDistance).doubleValue(), unit);
         } else {
@@ -157,13 +156,11 @@ public class GeoDistanceFilterParser implements FilterParser {
 
         MapperService.SmartNameFieldMappers smartMappers = parseContext.smartFieldMappers(fieldName);
         if (smartMappers == null || !smartMappers.hasMapper()) {
-            throw new QueryParsingException(parseContext.index(), "failed to find geo_point field [" + fieldName + "]",
-                    parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "failed to find geo_point field [" + fieldName + "]");
         }
         FieldMapper<?> mapper = smartMappers.mapper();
         if (!(mapper instanceof GeoPointFieldMapper)) {
-            throw new QueryParsingException(parseContext.index(), "field [" + fieldName + "] is not a geo_point field",
-                    parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "field [" + fieldName + "] is not a geo_point field");
         }
         GeoPointFieldMapper geoMapper = ((GeoPointFieldMapper) mapper);
 

--- a/src/main/java/org/elasticsearch/index/query/GeoDistanceRangeFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoDistanceRangeFilterParser.java
@@ -196,13 +196,11 @@ public class GeoDistanceRangeFilterParser implements FilterParser {
 
         MapperService.SmartNameFieldMappers smartMappers = parseContext.smartFieldMappers(fieldName);
         if (smartMappers == null || !smartMappers.hasMapper()) {
-            throw new QueryParsingException(parseContext.index(), "failed to find geo_point field [" + fieldName + "]",
-                    parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "failed to find geo_point field [" + fieldName + "]");
         }
         FieldMapper<?> mapper = smartMappers.mapper();
         if (!(mapper instanceof GeoPointFieldMapper)) {
-            throw new QueryParsingException(parseContext.index(), "field [" + fieldName + "] is not a geo_point field",
-                    parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "field [" + fieldName + "] is not a geo_point field");
         }
         GeoPointFieldMapper geoMapper = ((GeoPointFieldMapper) mapper);
 

--- a/src/main/java/org/elasticsearch/index/query/GeoDistanceRangeFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoDistanceRangeFilterParser.java
@@ -196,11 +196,13 @@ public class GeoDistanceRangeFilterParser implements FilterParser {
 
         MapperService.SmartNameFieldMappers smartMappers = parseContext.smartFieldMappers(fieldName);
         if (smartMappers == null || !smartMappers.hasMapper()) {
-            throw new QueryParsingException(parseContext.index(), "failed to find geo_point field [" + fieldName + "]");
+            throw new QueryParsingException(parseContext.index(), "failed to find geo_point field [" + fieldName + "]",
+                    parser.getTokenLocation());
         }
         FieldMapper<?> mapper = smartMappers.mapper();
         if (!(mapper instanceof GeoPointFieldMapper)) {
-            throw new QueryParsingException(parseContext.index(), "field [" + fieldName + "] is not a geo_point field");
+            throw new QueryParsingException(parseContext.index(), "field [" + fieldName + "] is not a geo_point field",
+                    parser.getTokenLocation());
         }
         GeoPointFieldMapper geoMapper = ((GeoPointFieldMapper) mapper);
 

--- a/src/main/java/org/elasticsearch/index/query/GeoPolygonFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoPolygonFilterParser.java
@@ -96,10 +96,12 @@ public class GeoPolygonFilterParser implements FilterParser {
                                 shell.add(GeoUtils.parseGeoPoint(parser));
                             }
                         } else {
-                            throw new QueryParsingException(parseContext.index(), "[geo_polygon] filter does not support [" + currentFieldName + "]");
+                            throw new QueryParsingException(parseContext.index(), "[geo_polygon] filter does not support ["
+                                    + currentFieldName + "]", parser.getTokenLocation());
                         }
                     } else {
-                        throw new QueryParsingException(parseContext.index(), "[geo_polygon] filter does not support token type [" + token.name() + "] under [" + currentFieldName + "]");
+                        throw new QueryParsingException(parseContext.index(), "[geo_polygon] filter does not support token type ["
+                                + token.name() + "] under [" + currentFieldName + "]", parser.getTokenLocation());
                     }
                 }
             } else if (token.isValue()) {
@@ -113,25 +115,29 @@ public class GeoPolygonFilterParser implements FilterParser {
                     normalizeLat = parser.booleanValue();
                     normalizeLon = parser.booleanValue();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[geo_polygon] filter does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[geo_polygon] filter does not support [" + currentFieldName
+                            + "]", parser.getTokenLocation());
                 }
             } else {
-                throw new QueryParsingException(parseContext.index(), "[geo_polygon] unexpected token type [" + token.name() + "]");
+                throw new QueryParsingException(parseContext.index(), "[geo_polygon] unexpected token type [" + token.name() + "]",
+                        parser.getTokenLocation());
             }
         }
 
         if (shell.isEmpty()) {
-            throw new QueryParsingException(parseContext.index(), "no points defined for geo_polygon filter");
+            throw new QueryParsingException(parseContext.index(), "no points defined for geo_polygon filter", parser.getTokenLocation());
         } else {
             if (shell.size() < 3) {
-                throw new QueryParsingException(parseContext.index(), "too few points defined for geo_polygon filter");
+                throw new QueryParsingException(parseContext.index(), "too few points defined for geo_polygon filter",
+                        parser.getTokenLocation());
             }
             GeoPoint start = shell.get(0);
             if (!start.equals(shell.get(shell.size() - 1))) {
                 shell.add(start);
             }
             if (shell.size() < 4) {
-                throw new QueryParsingException(parseContext.index(), "too few points defined for geo_polygon filter");
+                throw new QueryParsingException(parseContext.index(), "too few points defined for geo_polygon filter",
+                        parser.getTokenLocation());
             }
         }
 
@@ -143,11 +149,13 @@ public class GeoPolygonFilterParser implements FilterParser {
 
         MapperService.SmartNameFieldMappers smartMappers = parseContext.smartFieldMappers(fieldName);
         if (smartMappers == null || !smartMappers.hasMapper()) {
-            throw new QueryParsingException(parseContext.index(), "failed to find geo_point field [" + fieldName + "]");
+            throw new QueryParsingException(parseContext.index(), "failed to find geo_point field [" + fieldName + "]",
+                    parser.getTokenLocation());
         }
         FieldMapper<?> mapper = smartMappers.mapper();
         if (!(mapper instanceof GeoPointFieldMapper)) {
-            throw new QueryParsingException(parseContext.index(), "field [" + fieldName + "] is not a geo_point field");
+            throw new QueryParsingException(parseContext.index(), "field [" + fieldName + "] is not a geo_point field",
+                    parser.getTokenLocation());
         }
 
         IndexGeoPointFieldData indexFieldData = parseContext.getForField(mapper);

--- a/src/main/java/org/elasticsearch/index/query/GeoPolygonFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoPolygonFilterParser.java
@@ -96,12 +96,12 @@ public class GeoPolygonFilterParser implements FilterParser {
                                 shell.add(GeoUtils.parseGeoPoint(parser));
                             }
                         } else {
-                            throw new QueryParsingException(parseContext.index(), "[geo_polygon] filter does not support ["
-                                    + currentFieldName + "]", parser.getTokenLocation());
+                            throw new QueryParsingException(parseContext, "[geo_polygon] filter does not support [" + currentFieldName
+                                    + "]");
                         }
                     } else {
-                        throw new QueryParsingException(parseContext.index(), "[geo_polygon] filter does not support token type ["
-                                + token.name() + "] under [" + currentFieldName + "]", parser.getTokenLocation());
+                        throw new QueryParsingException(parseContext, "[geo_polygon] filter does not support token type [" + token.name()
+                                + "] under [" + currentFieldName + "]");
                     }
                 }
             } else if (token.isValue()) {
@@ -115,29 +115,25 @@ public class GeoPolygonFilterParser implements FilterParser {
                     normalizeLat = parser.booleanValue();
                     normalizeLon = parser.booleanValue();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[geo_polygon] filter does not support [" + currentFieldName
-                            + "]", parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[geo_polygon] filter does not support [" + currentFieldName + "]");
                 }
             } else {
-                throw new QueryParsingException(parseContext.index(), "[geo_polygon] unexpected token type [" + token.name() + "]",
-                        parser.getTokenLocation());
+                throw new QueryParsingException(parseContext, "[geo_polygon] unexpected token type [" + token.name() + "]");
             }
         }
 
         if (shell.isEmpty()) {
-            throw new QueryParsingException(parseContext.index(), "no points defined for geo_polygon filter", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "no points defined for geo_polygon filter");
         } else {
             if (shell.size() < 3) {
-                throw new QueryParsingException(parseContext.index(), "too few points defined for geo_polygon filter",
-                        parser.getTokenLocation());
+                throw new QueryParsingException(parseContext, "too few points defined for geo_polygon filter");
             }
             GeoPoint start = shell.get(0);
             if (!start.equals(shell.get(shell.size() - 1))) {
                 shell.add(start);
             }
             if (shell.size() < 4) {
-                throw new QueryParsingException(parseContext.index(), "too few points defined for geo_polygon filter",
-                        parser.getTokenLocation());
+                throw new QueryParsingException(parseContext, "too few points defined for geo_polygon filter");
             }
         }
 
@@ -149,13 +145,11 @@ public class GeoPolygonFilterParser implements FilterParser {
 
         MapperService.SmartNameFieldMappers smartMappers = parseContext.smartFieldMappers(fieldName);
         if (smartMappers == null || !smartMappers.hasMapper()) {
-            throw new QueryParsingException(parseContext.index(), "failed to find geo_point field [" + fieldName + "]",
-                    parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "failed to find geo_point field [" + fieldName + "]");
         }
         FieldMapper<?> mapper = smartMappers.mapper();
         if (!(mapper instanceof GeoPointFieldMapper)) {
-            throw new QueryParsingException(parseContext.index(), "field [" + fieldName + "] is not a geo_point field",
-                    parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "field [" + fieldName + "] is not a geo_point field");
         }
 
         IndexGeoPointFieldData indexFieldData = parseContext.getForField(mapper);

--- a/src/main/java/org/elasticsearch/index/query/GeoShapeFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoShapeFilterParser.java
@@ -113,8 +113,7 @@ public class GeoShapeFilterParser implements FilterParser {
                         } else if ("relation".equals(currentFieldName)) {
                             shapeRelation = ShapeRelation.getRelationByName(parser.text());
                             if (shapeRelation == null) {
-                                throw new QueryParsingException(parseContext.index(), "Unknown shape operation [" + parser.text() + "]",
-                                        parser.getTokenLocation());
+                                throw new QueryParsingException(parseContext, "Unknown shape operation [" + parser.text() + "]");
                             }
                         } else if ("strategy".equals(currentFieldName)) {
                             strategyName = parser.text();
@@ -135,16 +134,13 @@ public class GeoShapeFilterParser implements FilterParser {
                                 }
                             }
                             if (id == null) {
-                                throw new QueryParsingException(parseContext.index(), "ID for indexed shape not provided",
-                                        parser.getTokenLocation());
+                                throw new QueryParsingException(parseContext, "ID for indexed shape not provided");
                             } else if (type == null) {
-                                throw new QueryParsingException(parseContext.index(), "Type for indexed shape not provided",
-                                        parser.getTokenLocation());
+                                throw new QueryParsingException(parseContext, "Type for indexed shape not provided");
                             }
                             shape = fetchService.fetch(id, type, index, shapePath);
                         }  else {
-                            throw new QueryParsingException(parseContext.index(), "[geo_shape] filter does not support ["
-                                    + currentFieldName + "]", parser.getTokenLocation());
+                            throw new QueryParsingException(parseContext, "[geo_shape] filter does not support [" + currentFieldName + "]");
                         }
                     }
                 }
@@ -156,28 +152,26 @@ public class GeoShapeFilterParser implements FilterParser {
                 } else if ("_cache_key".equals(currentFieldName)) {
                     cacheKey = new HashedBytesRef(parser.text());
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[geo_shape] filter does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[geo_shape] filter does not support [" + currentFieldName + "]");
                 }
             }
         }
 
         if (shape == null) {
-            throw new QueryParsingException(parseContext.index(), "No Shape defined", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "No Shape defined");
         } else if (shapeRelation == null) {
-            throw new QueryParsingException(parseContext.index(), "No Shape Relation defined", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "No Shape Relation defined");
         }
 
         MapperService.SmartNameFieldMappers smartNameFieldMappers = parseContext.smartFieldMappers(fieldName);
         if (smartNameFieldMappers == null || !smartNameFieldMappers.hasMapper()) {
-            throw new QueryParsingException(parseContext.index(), "Failed to find geo_shape field [" + fieldName + "]",
-                    parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "Failed to find geo_shape field [" + fieldName + "]");
         }
 
         FieldMapper fieldMapper = smartNameFieldMappers.mapper();
         // TODO: This isn't the nicest way to check this
         if (!(fieldMapper instanceof GeoShapeFieldMapper)) {
-            throw new QueryParsingException(parseContext.index(), "Field [" + fieldName + "] is not a geo_shape", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "Field [" + fieldName + "] is not a geo_shape");
         }
 
         GeoShapeFieldMapper shapeFieldMapper = (GeoShapeFieldMapper) fieldMapper;

--- a/src/main/java/org/elasticsearch/index/query/GeoShapeFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoShapeFilterParser.java
@@ -113,7 +113,8 @@ public class GeoShapeFilterParser implements FilterParser {
                         } else if ("relation".equals(currentFieldName)) {
                             shapeRelation = ShapeRelation.getRelationByName(parser.text());
                             if (shapeRelation == null) {
-                                throw new QueryParsingException(parseContext.index(), "Unknown shape operation [" + parser.text() + "]");
+                                throw new QueryParsingException(parseContext.index(), "Unknown shape operation [" + parser.text() + "]",
+                                        parser.getTokenLocation());
                             }
                         } else if ("strategy".equals(currentFieldName)) {
                             strategyName = parser.text();
@@ -134,13 +135,16 @@ public class GeoShapeFilterParser implements FilterParser {
                                 }
                             }
                             if (id == null) {
-                                throw new QueryParsingException(parseContext.index(), "ID for indexed shape not provided");
+                                throw new QueryParsingException(parseContext.index(), "ID for indexed shape not provided",
+                                        parser.getTokenLocation());
                             } else if (type == null) {
-                                throw new QueryParsingException(parseContext.index(), "Type for indexed shape not provided");
+                                throw new QueryParsingException(parseContext.index(), "Type for indexed shape not provided",
+                                        parser.getTokenLocation());
                             }
                             shape = fetchService.fetch(id, type, index, shapePath);
                         }  else {
-                            throw new QueryParsingException(parseContext.index(), "[geo_shape] filter does not support [" + currentFieldName + "]");
+                            throw new QueryParsingException(parseContext.index(), "[geo_shape] filter does not support ["
+                                    + currentFieldName + "]", parser.getTokenLocation());
                         }
                     }
                 }
@@ -152,26 +156,28 @@ public class GeoShapeFilterParser implements FilterParser {
                 } else if ("_cache_key".equals(currentFieldName)) {
                     cacheKey = new HashedBytesRef(parser.text());
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[geo_shape] filter does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[geo_shape] filter does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             }
         }
 
         if (shape == null) {
-            throw new QueryParsingException(parseContext.index(), "No Shape defined");
+            throw new QueryParsingException(parseContext.index(), "No Shape defined", parser.getTokenLocation());
         } else if (shapeRelation == null) {
-            throw new QueryParsingException(parseContext.index(), "No Shape Relation defined");
+            throw new QueryParsingException(parseContext.index(), "No Shape Relation defined", parser.getTokenLocation());
         }
 
         MapperService.SmartNameFieldMappers smartNameFieldMappers = parseContext.smartFieldMappers(fieldName);
         if (smartNameFieldMappers == null || !smartNameFieldMappers.hasMapper()) {
-            throw new QueryParsingException(parseContext.index(), "Failed to find geo_shape field [" + fieldName + "]");
+            throw new QueryParsingException(parseContext.index(), "Failed to find geo_shape field [" + fieldName + "]",
+                    parser.getTokenLocation());
         }
 
         FieldMapper fieldMapper = smartNameFieldMappers.mapper();
         // TODO: This isn't the nicest way to check this
         if (!(fieldMapper instanceof GeoShapeFieldMapper)) {
-            throw new QueryParsingException(parseContext.index(), "Field [" + fieldName + "] is not a geo_shape");
+            throw new QueryParsingException(parseContext.index(), "Field [" + fieldName + "] is not a geo_shape", parser.getTokenLocation());
         }
 
         GeoShapeFieldMapper shapeFieldMapper = (GeoShapeFieldMapper) fieldMapper;

--- a/src/main/java/org/elasticsearch/index/query/GeoShapeQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoShapeQueryParser.java
@@ -94,8 +94,7 @@ public class GeoShapeQueryParser implements QueryParser {
                         } else if ("relation".equals(currentFieldName)) {
                             shapeRelation = ShapeRelation.getRelationByName(parser.text());
                             if (shapeRelation == null) {
-                                throw new QueryParsingException(parseContext.index(), "Unknown shape operation [" + parser.text() + " ]",
-                                        parser.getTokenLocation());
+                                throw new QueryParsingException(parseContext, "Unknown shape operation [" + parser.text() + " ]");
                             }
                         } else if ("indexed_shape".equals(currentFieldName) || "indexedShape".equals(currentFieldName)) {
                             while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
@@ -114,16 +113,13 @@ public class GeoShapeQueryParser implements QueryParser {
                                 }
                             }
                             if (id == null) {
-                                throw new QueryParsingException(parseContext.index(), "ID for indexed shape not provided",
-                                        parser.getTokenLocation());
+                                throw new QueryParsingException(parseContext, "ID for indexed shape not provided");
                             } else if (type == null) {
-                                throw new QueryParsingException(parseContext.index(), "Type for indexed shape not provided",
-                                        parser.getTokenLocation());
+                                throw new QueryParsingException(parseContext, "Type for indexed shape not provided");
                             }
                             shape = fetchService.fetch(id, type, index, shapePath);
                         } else {
-                            throw new QueryParsingException(parseContext.index(), "[geo_shape] query does not support [" + currentFieldName
-                                    + "]", parser.getTokenLocation());
+                            throw new QueryParsingException(parseContext, "[geo_shape] query does not support [" + currentFieldName + "]");
                         }
                     }
                 }
@@ -133,28 +129,26 @@ public class GeoShapeQueryParser implements QueryParser {
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[geo_shape] query does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[geo_shape] query does not support [" + currentFieldName + "]");
                 }
             }
         }
 
         if (shape == null) {
-            throw new QueryParsingException(parseContext.index(), "No Shape defined", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "No Shape defined");
         } else if (shapeRelation == null) {
-            throw new QueryParsingException(parseContext.index(), "No Shape Relation defined", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "No Shape Relation defined");
         }
 
         MapperService.SmartNameFieldMappers smartNameFieldMappers = parseContext.smartFieldMappers(fieldName);
         if (smartNameFieldMappers == null || !smartNameFieldMappers.hasMapper()) {
-            throw new QueryParsingException(parseContext.index(), "Failed to find geo_shape field [" + fieldName + "]",
-                    parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "Failed to find geo_shape field [" + fieldName + "]");
         }
 
         FieldMapper fieldMapper = smartNameFieldMappers.mapper();
         // TODO: This isn't the nicest way to check this
         if (!(fieldMapper instanceof GeoShapeFieldMapper)) {
-            throw new QueryParsingException(parseContext.index(), "Field [" + fieldName + "] is not a geo_shape", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "Field [" + fieldName + "] is not a geo_shape");
         }
 
         GeoShapeFieldMapper shapeFieldMapper = (GeoShapeFieldMapper) fieldMapper;

--- a/src/main/java/org/elasticsearch/index/query/GeoShapeQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoShapeQueryParser.java
@@ -94,7 +94,8 @@ public class GeoShapeQueryParser implements QueryParser {
                         } else if ("relation".equals(currentFieldName)) {
                             shapeRelation = ShapeRelation.getRelationByName(parser.text());
                             if (shapeRelation == null) {
-                                throw new QueryParsingException(parseContext.index(), "Unknown shape operation [" + parser.text() + " ]");
+                                throw new QueryParsingException(parseContext.index(), "Unknown shape operation [" + parser.text() + " ]",
+                                        parser.getTokenLocation());
                             }
                         } else if ("indexed_shape".equals(currentFieldName) || "indexedShape".equals(currentFieldName)) {
                             while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
@@ -113,13 +114,16 @@ public class GeoShapeQueryParser implements QueryParser {
                                 }
                             }
                             if (id == null) {
-                                throw new QueryParsingException(parseContext.index(), "ID for indexed shape not provided");
+                                throw new QueryParsingException(parseContext.index(), "ID for indexed shape not provided",
+                                        parser.getTokenLocation());
                             } else if (type == null) {
-                                throw new QueryParsingException(parseContext.index(), "Type for indexed shape not provided");
+                                throw new QueryParsingException(parseContext.index(), "Type for indexed shape not provided",
+                                        parser.getTokenLocation());
                             }
                             shape = fetchService.fetch(id, type, index, shapePath);
                         } else {
-                            throw new QueryParsingException(parseContext.index(), "[geo_shape] query does not support [" + currentFieldName + "]");
+                            throw new QueryParsingException(parseContext.index(), "[geo_shape] query does not support [" + currentFieldName
+                                    + "]", parser.getTokenLocation());
                         }
                     }
                 }
@@ -129,26 +133,28 @@ public class GeoShapeQueryParser implements QueryParser {
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[geo_shape] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[geo_shape] query does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             }
         }
 
         if (shape == null) {
-            throw new QueryParsingException(parseContext.index(), "No Shape defined");
+            throw new QueryParsingException(parseContext.index(), "No Shape defined", parser.getTokenLocation());
         } else if (shapeRelation == null) {
-            throw new QueryParsingException(parseContext.index(), "No Shape Relation defined");
+            throw new QueryParsingException(parseContext.index(), "No Shape Relation defined", parser.getTokenLocation());
         }
 
         MapperService.SmartNameFieldMappers smartNameFieldMappers = parseContext.smartFieldMappers(fieldName);
         if (smartNameFieldMappers == null || !smartNameFieldMappers.hasMapper()) {
-            throw new QueryParsingException(parseContext.index(), "Failed to find geo_shape field [" + fieldName + "]");
+            throw new QueryParsingException(parseContext.index(), "Failed to find geo_shape field [" + fieldName + "]",
+                    parser.getTokenLocation());
         }
 
         FieldMapper fieldMapper = smartNameFieldMappers.mapper();
         // TODO: This isn't the nicest way to check this
         if (!(fieldMapper instanceof GeoShapeFieldMapper)) {
-            throw new QueryParsingException(parseContext.index(), "Field [" + fieldName + "] is not a geo_shape");
+            throw new QueryParsingException(parseContext.index(), "Field [" + fieldName + "] is not a geo_shape", parser.getTokenLocation());
         }
 
         GeoShapeFieldMapper shapeFieldMapper = (GeoShapeFieldMapper) fieldMapper;

--- a/src/main/java/org/elasticsearch/index/query/GeohashCellFilter.java
+++ b/src/main/java/org/elasticsearch/index/query/GeohashCellFilter.java
@@ -266,22 +266,26 @@ public class GeohashCellFilter {
             }
 
             if (geohash == null) {
-                throw new QueryParsingException(parseContext.index(), "no geohash value provided to geohash_cell filter");
+                throw new QueryParsingException(parseContext.index(), "no geohash value provided to geohash_cell filter",
+                        parser.getTokenLocation());
             }
 
             MapperService.SmartNameFieldMappers smartMappers = parseContext.smartFieldMappers(fieldName);
             if (smartMappers == null || !smartMappers.hasMapper()) {
-                throw new QueryParsingException(parseContext.index(), "failed to find geo_point field [" + fieldName + "]");
+                throw new QueryParsingException(parseContext.index(), "failed to find geo_point field [" + fieldName + "]",
+                        parser.getTokenLocation());
             }
 
             FieldMapper<?> mapper = smartMappers.mapper();
             if (!(mapper instanceof GeoPointFieldMapper)) {
-                throw new QueryParsingException(parseContext.index(), "field [" + fieldName + "] is not a geo_point field");
+                throw new QueryParsingException(parseContext.index(), "field [" + fieldName + "] is not a geo_point field",
+                        parser.getTokenLocation());
             }
 
             GeoPointFieldMapper geoMapper = ((GeoPointFieldMapper) mapper);
             if (!geoMapper.isEnableGeohashPrefix()) {
-                throw new QueryParsingException(parseContext.index(), "can't execute geohash_cell on field [" + fieldName + "], geohash_prefix is not enabled");
+                throw new QueryParsingException(parseContext.index(), "can't execute geohash_cell on field [" + fieldName
+                        + "], geohash_prefix is not enabled", parser.getTokenLocation());
             }
 
             if(levels > 0) {

--- a/src/main/java/org/elasticsearch/index/query/GeohashCellFilter.java
+++ b/src/main/java/org/elasticsearch/index/query/GeohashCellFilter.java
@@ -266,26 +266,23 @@ public class GeohashCellFilter {
             }
 
             if (geohash == null) {
-                throw new QueryParsingException(parseContext.index(), "no geohash value provided to geohash_cell filter",
-                        parser.getTokenLocation());
+                throw new QueryParsingException(parseContext, "no geohash value provided to geohash_cell filter");
             }
 
             MapperService.SmartNameFieldMappers smartMappers = parseContext.smartFieldMappers(fieldName);
             if (smartMappers == null || !smartMappers.hasMapper()) {
-                throw new QueryParsingException(parseContext.index(), "failed to find geo_point field [" + fieldName + "]",
-                        parser.getTokenLocation());
+                throw new QueryParsingException(parseContext, "failed to find geo_point field [" + fieldName + "]");
             }
 
             FieldMapper<?> mapper = smartMappers.mapper();
             if (!(mapper instanceof GeoPointFieldMapper)) {
-                throw new QueryParsingException(parseContext.index(), "field [" + fieldName + "] is not a geo_point field",
-                        parser.getTokenLocation());
+                throw new QueryParsingException(parseContext, "field [" + fieldName + "] is not a geo_point field");
             }
 
             GeoPointFieldMapper geoMapper = ((GeoPointFieldMapper) mapper);
             if (!geoMapper.isEnableGeohashPrefix()) {
-                throw new QueryParsingException(parseContext.index(), "can't execute geohash_cell on field [" + fieldName
-                        + "], geohash_prefix is not enabled", parser.getTokenLocation());
+                throw new QueryParsingException(parseContext, "can't execute geohash_cell on field [" + fieldName
+                        + "], geohash_prefix is not enabled");
             }
 
             if(levels > 0) {

--- a/src/main/java/org/elasticsearch/index/query/HasChildFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/HasChildFilterParser.java
@@ -97,8 +97,7 @@ public class HasChildFilterParser implements FilterParser {
                 } else if ("inner_hits".equals(currentFieldName)) {
                     innerHits = innerHitsQueryParserHelper.parse(parseContext);
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[has_child] filter does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[has_child] filter does not support [" + currentFieldName + "]");
                 }
             } else if (token.isValue()) {
                 if ("type".equals(currentFieldName) || "child_type".equals(currentFieldName) || "childType".equals(currentFieldName)) {
@@ -116,17 +115,15 @@ public class HasChildFilterParser implements FilterParser {
                 } else if ("max_children".equals(currentFieldName) || "maxChildren".equals(currentFieldName)) {
                     maxChildren = parser.intValue(true);
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[has_child] filter does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[has_child] filter does not support [" + currentFieldName + "]");
                 }
             }
         }
         if (!queryFound && !filterFound) {
-            throw new QueryParsingException(parseContext.index(), "[has_child] filter requires 'query' or 'filter' field",
-                    parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "[has_child] filter requires 'query' or 'filter' field");
         }
         if (childType == null) {
-            throw new QueryParsingException(parseContext.index(), "[has_child] filter requires 'type' field", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "[has_child] filter requires 'type' field");
         }
 
         Query query;
@@ -142,7 +139,7 @@ public class HasChildFilterParser implements FilterParser {
 
         DocumentMapper childDocMapper = parseContext.mapperService().documentMapper(childType);
         if (childDocMapper == null) {
-            throw new QueryParsingException(parseContext.index(), "No mapping for for type [" + childType + "]", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "No mapping for for type [" + childType + "]");
         }
         if (innerHits != null) {
             InnerHitsContext.ParentChildInnerHits parentChildInnerHits = new InnerHitsContext.ParentChildInnerHits(innerHits.v2(), query, null, childDocMapper);
@@ -151,8 +148,7 @@ public class HasChildFilterParser implements FilterParser {
         }
         ParentFieldMapper parentFieldMapper = childDocMapper.parentFieldMapper();
         if (!parentFieldMapper.active()) {
-            throw new QueryParsingException(parseContext.index(), "Type [" + childType + "] does not have parent mapping",
-                    parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "Type [" + childType + "] does not have parent mapping");
         }
         String parentType = parentFieldMapper.type();
 
@@ -161,13 +157,12 @@ public class HasChildFilterParser implements FilterParser {
 
         DocumentMapper parentDocMapper = parseContext.mapperService().documentMapper(parentType);
         if (parentDocMapper == null) {
-            throw new QueryParsingException(parseContext.index(), "[has_child]  Type [" + childType
-                    + "] points to a non existent parent type [" + parentType + "]", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "[has_child]  Type [" + childType + "] points to a non existent parent type ["
+                    + parentType + "]");
         }
 
         if (maxChildren > 0 && maxChildren < minChildren) {
-            throw new QueryParsingException(parseContext.index(), "[has_child] 'max_children' is less than 'min_children'",
-                    parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "[has_child] 'max_children' is less than 'min_children'");
         }
 
         BitDocIdSetFilter nonNestedDocsFilter = null;

--- a/src/main/java/org/elasticsearch/index/query/HasChildFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/HasChildFilterParser.java
@@ -97,7 +97,8 @@ public class HasChildFilterParser implements FilterParser {
                 } else if ("inner_hits".equals(currentFieldName)) {
                     innerHits = innerHitsQueryParserHelper.parse(parseContext);
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[has_child] filter does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[has_child] filter does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             } else if (token.isValue()) {
                 if ("type".equals(currentFieldName) || "child_type".equals(currentFieldName) || "childType".equals(currentFieldName)) {
@@ -115,15 +116,17 @@ public class HasChildFilterParser implements FilterParser {
                 } else if ("max_children".equals(currentFieldName) || "maxChildren".equals(currentFieldName)) {
                     maxChildren = parser.intValue(true);
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[has_child] filter does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[has_child] filter does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             }
         }
         if (!queryFound && !filterFound) {
-            throw new QueryParsingException(parseContext.index(), "[has_child] filter requires 'query' or 'filter' field");
+            throw new QueryParsingException(parseContext.index(), "[has_child] filter requires 'query' or 'filter' field",
+                    parser.getTokenLocation());
         }
         if (childType == null) {
-            throw new QueryParsingException(parseContext.index(), "[has_child] filter requires 'type' field");
+            throw new QueryParsingException(parseContext.index(), "[has_child] filter requires 'type' field", parser.getTokenLocation());
         }
 
         Query query;
@@ -139,7 +142,7 @@ public class HasChildFilterParser implements FilterParser {
 
         DocumentMapper childDocMapper = parseContext.mapperService().documentMapper(childType);
         if (childDocMapper == null) {
-            throw new QueryParsingException(parseContext.index(), "No mapping for for type [" + childType + "]");
+            throw new QueryParsingException(parseContext.index(), "No mapping for for type [" + childType + "]", parser.getTokenLocation());
         }
         if (innerHits != null) {
             InnerHitsContext.ParentChildInnerHits parentChildInnerHits = new InnerHitsContext.ParentChildInnerHits(innerHits.v2(), query, null, childDocMapper);
@@ -148,7 +151,8 @@ public class HasChildFilterParser implements FilterParser {
         }
         ParentFieldMapper parentFieldMapper = childDocMapper.parentFieldMapper();
         if (!parentFieldMapper.active()) {
-            throw new QueryParsingException(parseContext.index(), "Type [" + childType + "] does not have parent mapping");
+            throw new QueryParsingException(parseContext.index(), "Type [" + childType + "] does not have parent mapping",
+                    parser.getTokenLocation());
         }
         String parentType = parentFieldMapper.type();
 
@@ -157,11 +161,13 @@ public class HasChildFilterParser implements FilterParser {
 
         DocumentMapper parentDocMapper = parseContext.mapperService().documentMapper(parentType);
         if (parentDocMapper == null) {
-            throw new QueryParsingException(parseContext.index(), "[has_child]  Type [" + childType + "] points to a non existent parent type [" + parentType + "]");
+            throw new QueryParsingException(parseContext.index(), "[has_child]  Type [" + childType
+                    + "] points to a non existent parent type [" + parentType + "]", parser.getTokenLocation());
         }
 
         if (maxChildren > 0 && maxChildren < minChildren) {
-            throw new QueryParsingException(parseContext.index(), "[has_child] 'max_children' is less than 'min_children'");
+            throw new QueryParsingException(parseContext.index(), "[has_child] 'max_children' is less than 'min_children'",
+                    parser.getTokenLocation());
         }
 
         BitDocIdSetFilter nonNestedDocsFilter = null;

--- a/src/main/java/org/elasticsearch/index/query/HasChildQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/HasChildQueryParser.java
@@ -95,7 +95,8 @@ public class HasChildQueryParser implements QueryParser {
                 } else if ("inner_hits".equals(currentFieldName)) {
                     innerHits = innerHitsQueryParserHelper.parse(parseContext);
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[has_child] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[has_child] query does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             } else if (token.isValue()) {
                 if ("type".equals(currentFieldName) || "child_type".equals(currentFieldName) || "childType".equals(currentFieldName)) {
@@ -115,15 +116,16 @@ public class HasChildQueryParser implements QueryParser {
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[has_child] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[has_child] query does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             }
         }
         if (!queryFound) {
-            throw new QueryParsingException(parseContext.index(), "[has_child] requires 'query' field");
+            throw new QueryParsingException(parseContext.index(), "[has_child] requires 'query' field", parser.getTokenLocation());
         }
         if (childType == null) {
-            throw new QueryParsingException(parseContext.index(), "[has_child] requires 'type' field");
+            throw new QueryParsingException(parseContext.index(), "[has_child] requires 'type' field", parser.getTokenLocation());
         }
 
         Query innerQuery = iq.asQuery(childType);
@@ -135,10 +137,12 @@ public class HasChildQueryParser implements QueryParser {
 
         DocumentMapper childDocMapper = parseContext.mapperService().documentMapper(childType);
         if (childDocMapper == null) {
-            throw new QueryParsingException(parseContext.index(), "[has_child] No mapping for for type [" + childType + "]");
+            throw new QueryParsingException(parseContext.index(), "[has_child] No mapping for for type [" + childType + "]",
+                    parser.getTokenLocation());
         }
         if (!childDocMapper.parentFieldMapper().active()) {
-            throw new QueryParsingException(parseContext.index(), "[has_child]  Type [" + childType + "] does not have parent mapping");
+            throw new QueryParsingException(parseContext.index(), "[has_child]  Type [" + childType + "] does not have parent mapping",
+                    parser.getTokenLocation());
         }
 
         if (innerHits != null) {
@@ -149,18 +153,19 @@ public class HasChildQueryParser implements QueryParser {
 
         ParentFieldMapper parentFieldMapper = childDocMapper.parentFieldMapper();
         if (!parentFieldMapper.active()) {
-            throw new QueryParsingException(parseContext.index(), "[has_child] _parent field not configured");
+            throw new QueryParsingException(parseContext.index(), "[has_child] _parent field not configured", parser.getTokenLocation());
         }
 
         String parentType = parentFieldMapper.type();
         DocumentMapper parentDocMapper = parseContext.mapperService().documentMapper(parentType);
         if (parentDocMapper == null) {
             throw new QueryParsingException(parseContext.index(), "[has_child]  Type [" + childType
-                    + "] points to a non existent parent type [" + parentType + "]");
+                    + "] points to a non existent parent type [" + parentType + "]", parser.getTokenLocation());
         }
 
         if (maxChildren > 0 && maxChildren < minChildren) {
-            throw new QueryParsingException(parseContext.index(), "[has_child] 'max_children' is less than 'min_children'");
+            throw new QueryParsingException(parseContext.index(), "[has_child] 'max_children' is less than 'min_children'",
+                    parser.getTokenLocation());
         }
 
         BitDocIdSetFilter nonNestedDocsFilter = null;

--- a/src/main/java/org/elasticsearch/index/query/HasChildQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/HasChildQueryParser.java
@@ -95,8 +95,7 @@ public class HasChildQueryParser implements QueryParser {
                 } else if ("inner_hits".equals(currentFieldName)) {
                     innerHits = innerHitsQueryParserHelper.parse(parseContext);
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[has_child] query does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[has_child] query does not support [" + currentFieldName + "]");
                 }
             } else if (token.isValue()) {
                 if ("type".equals(currentFieldName) || "child_type".equals(currentFieldName) || "childType".equals(currentFieldName)) {
@@ -116,16 +115,15 @@ public class HasChildQueryParser implements QueryParser {
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[has_child] query does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[has_child] query does not support [" + currentFieldName + "]");
                 }
             }
         }
         if (!queryFound) {
-            throw new QueryParsingException(parseContext.index(), "[has_child] requires 'query' field", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "[has_child] requires 'query' field");
         }
         if (childType == null) {
-            throw new QueryParsingException(parseContext.index(), "[has_child] requires 'type' field", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "[has_child] requires 'type' field");
         }
 
         Query innerQuery = iq.asQuery(childType);
@@ -137,12 +135,10 @@ public class HasChildQueryParser implements QueryParser {
 
         DocumentMapper childDocMapper = parseContext.mapperService().documentMapper(childType);
         if (childDocMapper == null) {
-            throw new QueryParsingException(parseContext.index(), "[has_child] No mapping for for type [" + childType + "]",
-                    parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "[has_child] No mapping for for type [" + childType + "]");
         }
         if (!childDocMapper.parentFieldMapper().active()) {
-            throw new QueryParsingException(parseContext.index(), "[has_child]  Type [" + childType + "] does not have parent mapping",
-                    parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "[has_child]  Type [" + childType + "] does not have parent mapping");
         }
 
         if (innerHits != null) {
@@ -153,19 +149,18 @@ public class HasChildQueryParser implements QueryParser {
 
         ParentFieldMapper parentFieldMapper = childDocMapper.parentFieldMapper();
         if (!parentFieldMapper.active()) {
-            throw new QueryParsingException(parseContext.index(), "[has_child] _parent field not configured", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "[has_child] _parent field not configured");
         }
 
         String parentType = parentFieldMapper.type();
         DocumentMapper parentDocMapper = parseContext.mapperService().documentMapper(parentType);
         if (parentDocMapper == null) {
-            throw new QueryParsingException(parseContext.index(), "[has_child]  Type [" + childType
-                    + "] points to a non existent parent type [" + parentType + "]", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "[has_child]  Type [" + childType + "] points to a non existent parent type ["
+                    + parentType + "]");
         }
 
         if (maxChildren > 0 && maxChildren < minChildren) {
-            throw new QueryParsingException(parseContext.index(), "[has_child] 'max_children' is less than 'min_children'",
-                    parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "[has_child] 'max_children' is less than 'min_children'");
         }
 
         BitDocIdSetFilter nonNestedDocsFilter = null;

--- a/src/main/java/org/elasticsearch/index/query/HasParentFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/HasParentFilterParser.java
@@ -85,7 +85,8 @@ public class HasParentFilterParser implements FilterParser {
                 } else if ("inner_hits".equals(currentFieldName)) {
                     innerHits = innerHitsQueryParserHelper.parse(parseContext);
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[has_parent] filter does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(),
+                            "[has_parent] filter does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             } else if (token.isValue()) {
                 if ("type".equals(currentFieldName) || "parent_type".equals(currentFieldName) || "parentType".equals(currentFieldName)) {
@@ -97,15 +98,18 @@ public class HasParentFilterParser implements FilterParser {
                 } else if ("_cache_key".equals(currentFieldName) || "_cacheKey".equals(currentFieldName)) {
                     // noop to be backwards compatible
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[has_parent] filter does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(),
+                            "[has_parent] filter does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             }
         }
         if (!queryFound && !filterFound) {
-            throw new QueryParsingException(parseContext.index(), "[has_parent] filter requires 'query' or 'filter' field");
+            throw new QueryParsingException(parseContext.index(), "[has_parent] filter requires 'query' or 'filter' field",
+                    parser.getTokenLocation());
         }
         if (parentType == null) {
-            throw new QueryParsingException(parseContext.index(), "[has_parent] filter requires 'parent_type' field");
+            throw new QueryParsingException(parseContext.index(), "[has_parent] filter requires 'parent_type' field",
+                    parser.getTokenLocation());
         }
 
         Query innerQuery;

--- a/src/main/java/org/elasticsearch/index/query/HasParentFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/HasParentFilterParser.java
@@ -85,8 +85,7 @@ public class HasParentFilterParser implements FilterParser {
                 } else if ("inner_hits".equals(currentFieldName)) {
                     innerHits = innerHitsQueryParserHelper.parse(parseContext);
                 } else {
-                    throw new QueryParsingException(parseContext.index(),
-                            "[has_parent] filter does not support [" + currentFieldName + "]", parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[has_parent] filter does not support [" + currentFieldName + "]");
                 }
             } else if (token.isValue()) {
                 if ("type".equals(currentFieldName) || "parent_type".equals(currentFieldName) || "parentType".equals(currentFieldName)) {
@@ -98,18 +97,15 @@ public class HasParentFilterParser implements FilterParser {
                 } else if ("_cache_key".equals(currentFieldName) || "_cacheKey".equals(currentFieldName)) {
                     // noop to be backwards compatible
                 } else {
-                    throw new QueryParsingException(parseContext.index(),
-                            "[has_parent] filter does not support [" + currentFieldName + "]", parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[has_parent] filter does not support [" + currentFieldName + "]");
                 }
             }
         }
         if (!queryFound && !filterFound) {
-            throw new QueryParsingException(parseContext.index(), "[has_parent] filter requires 'query' or 'filter' field",
-                    parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "[has_parent] filter requires 'query' or 'filter' field");
         }
         if (parentType == null) {
-            throw new QueryParsingException(parseContext.index(), "[has_parent] filter requires 'parent_type' field",
-                    parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "[has_parent] filter requires 'parent_type' field");
         }
 
         Query innerQuery;

--- a/src/main/java/org/elasticsearch/index/query/HasParentQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/HasParentQueryParser.java
@@ -23,7 +23,6 @@ import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Filter;
 import org.apache.lucene.search.FilteredQuery;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.search.QueryWrapperFilter;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.inject.Inject;
@@ -91,7 +90,8 @@ public class HasParentQueryParser implements QueryParser {
                 } else if ("inner_hits".equals(currentFieldName)) {
                     innerHits = innerHitsQueryParserHelper.parse(parseContext);
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[has_parent] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[has_parent] query does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             } else if (token.isValue()) {
                 if ("type".equals(currentFieldName) || "parent_type".equals(currentFieldName) || "parentType".equals(currentFieldName)) {
@@ -115,15 +115,17 @@ public class HasParentQueryParser implements QueryParser {
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[has_parent] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[has_parent] query does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             }
         }
         if (!queryFound) {
-            throw new QueryParsingException(parseContext.index(), "[has_parent] query requires 'query' field");
+            throw new QueryParsingException(parseContext.index(), "[has_parent] query requires 'query' field", parser.getTokenLocation());
         }
         if (parentType == null) {
-            throw new QueryParsingException(parseContext.index(), "[has_parent] query requires 'parent_type' field");
+            throw new QueryParsingException(parseContext.index(), "[has_parent] query requires 'parent_type' field",
+                    parser.getTokenLocation());
         }
 
         Query innerQuery = iq.asQuery(parentType);
@@ -148,7 +150,8 @@ public class HasParentQueryParser implements QueryParser {
     static Query createParentQuery(Query innerQuery, String parentType, boolean score, QueryParseContext parseContext, Tuple<String, SubSearchContext> innerHits) {
         DocumentMapper parentDocMapper = parseContext.mapperService().documentMapper(parentType);
         if (parentDocMapper == null) {
-            throw new QueryParsingException(parseContext.index(), "[has_parent] query configured 'parent_type' [" + parentType + "] is not a valid type");
+            throw new QueryParsingException(parseContext.index(), "[has_parent] query configured 'parent_type' [" + parentType
+                    + "] is not a valid type", null);
         }
 
         if (innerHits != null) {
@@ -172,7 +175,7 @@ public class HasParentQueryParser implements QueryParser {
             }
         }
         if (parentChildIndexFieldData == null) {
-            throw new QueryParsingException(parseContext.index(), "[has_parent] no _parent field configured");
+            throw new QueryParsingException(parseContext.index(), "[has_parent] no _parent field configured", null);
         }
 
         Filter parentFilter = null;

--- a/src/main/java/org/elasticsearch/index/query/HasParentQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/HasParentQueryParser.java
@@ -90,8 +90,7 @@ public class HasParentQueryParser implements QueryParser {
                 } else if ("inner_hits".equals(currentFieldName)) {
                     innerHits = innerHitsQueryParserHelper.parse(parseContext);
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[has_parent] query does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[has_parent] query does not support [" + currentFieldName + "]");
                 }
             } else if (token.isValue()) {
                 if ("type".equals(currentFieldName) || "parent_type".equals(currentFieldName) || "parentType".equals(currentFieldName)) {
@@ -115,17 +114,15 @@ public class HasParentQueryParser implements QueryParser {
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[has_parent] query does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[has_parent] query does not support [" + currentFieldName + "]");
                 }
             }
         }
         if (!queryFound) {
-            throw new QueryParsingException(parseContext.index(), "[has_parent] query requires 'query' field", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "[has_parent] query requires 'query' field");
         }
         if (parentType == null) {
-            throw new QueryParsingException(parseContext.index(), "[has_parent] query requires 'parent_type' field",
-                    parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "[has_parent] query requires 'parent_type' field");
         }
 
         Query innerQuery = iq.asQuery(parentType);
@@ -150,8 +147,8 @@ public class HasParentQueryParser implements QueryParser {
     static Query createParentQuery(Query innerQuery, String parentType, boolean score, QueryParseContext parseContext, Tuple<String, SubSearchContext> innerHits) {
         DocumentMapper parentDocMapper = parseContext.mapperService().documentMapper(parentType);
         if (parentDocMapper == null) {
-            throw new QueryParsingException(parseContext.index(), "[has_parent] query configured 'parent_type' [" + parentType
-                    + "] is not a valid type", null);
+            throw new QueryParsingException(parseContext, "[has_parent] query configured 'parent_type' [" + parentType
+                    + "] is not a valid type");
         }
 
         if (innerHits != null) {
@@ -175,7 +172,7 @@ public class HasParentQueryParser implements QueryParser {
             }
         }
         if (parentChildIndexFieldData == null) {
-            throw new QueryParsingException(parseContext.index(), "[has_parent] no _parent field configured", null);
+            throw new QueryParsingException(parseContext, "[has_parent] no _parent field configured");
         }
 
         Filter parentFilter = null;

--- a/src/main/java/org/elasticsearch/index/query/IdsFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/IdsFilterParser.java
@@ -68,7 +68,8 @@ public class IdsFilterParser implements FilterParser {
                     while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                         BytesRef value = parser.utf8BytesOrNull();
                         if (value == null) {
-                            throw new QueryParsingException(parseContext.index(), "No value specified for term filter");
+                            throw new QueryParsingException(parseContext.index(), "No value specified for term filter",
+                                    parser.getTokenLocation());
                         }
                         ids.add(value);
                     }
@@ -77,12 +78,14 @@ public class IdsFilterParser implements FilterParser {
                     while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                         String value = parser.textOrNull();
                         if (value == null) {
-                            throw new QueryParsingException(parseContext.index(), "No type specified for term filter");
+                            throw new QueryParsingException(parseContext.index(), "No type specified for term filter",
+                                    parser.getTokenLocation());
                         }
                         types.add(value);
                     }
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[ids] filter does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[ids] filter does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             } else if (token.isValue()) {
                 if ("type".equals(currentFieldName) || "_type".equals(currentFieldName)) {
@@ -90,13 +93,15 @@ public class IdsFilterParser implements FilterParser {
                 } else if ("_name".equals(currentFieldName)) {
                     filterName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[ids] filter does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[ids] filter does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             }
         }
 
         if (!idsProvided) {
-            throw new QueryParsingException(parseContext.index(), "[ids] filter requires providing a values element");
+            throw new QueryParsingException(parseContext.index(), "[ids] filter requires providing a values element",
+                    parser.getTokenLocation());
         }
 
         if (ids.isEmpty()) {

--- a/src/main/java/org/elasticsearch/index/query/IdsFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/IdsFilterParser.java
@@ -68,8 +68,7 @@ public class IdsFilterParser implements FilterParser {
                     while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                         BytesRef value = parser.utf8BytesOrNull();
                         if (value == null) {
-                            throw new QueryParsingException(parseContext.index(), "No value specified for term filter",
-                                    parser.getTokenLocation());
+                            throw new QueryParsingException(parseContext, "No value specified for term filter");
                         }
                         ids.add(value);
                     }
@@ -78,14 +77,12 @@ public class IdsFilterParser implements FilterParser {
                     while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                         String value = parser.textOrNull();
                         if (value == null) {
-                            throw new QueryParsingException(parseContext.index(), "No type specified for term filter",
-                                    parser.getTokenLocation());
+                            throw new QueryParsingException(parseContext, "No type specified for term filter");
                         }
                         types.add(value);
                     }
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[ids] filter does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[ids] filter does not support [" + currentFieldName + "]");
                 }
             } else if (token.isValue()) {
                 if ("type".equals(currentFieldName) || "_type".equals(currentFieldName)) {
@@ -93,15 +90,13 @@ public class IdsFilterParser implements FilterParser {
                 } else if ("_name".equals(currentFieldName)) {
                     filterName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[ids] filter does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[ids] filter does not support [" + currentFieldName + "]");
                 }
             }
         }
 
         if (!idsProvided) {
-            throw new QueryParsingException(parseContext.index(), "[ids] filter requires providing a values element",
-                    parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "[ids] filter requires providing a values element");
         }
 
         if (ids.isEmpty()) {

--- a/src/main/java/org/elasticsearch/index/query/IdsQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/IdsQueryParser.java
@@ -74,13 +74,12 @@ public class IdsQueryParser implements QueryParser {
                                 (token == XContentParser.Token.VALUE_NUMBER)) {
                             BytesRef value = parser.utf8BytesOrNull();
                             if (value == null) {
-                                throw new QueryParsingException(parseContext.index(), "No value specified for term filter",
-                                        parser.getTokenLocation());
+                                throw new QueryParsingException(parseContext, "No value specified for term filter");
                             }
                             ids.add(value);
                         } else {
-                            throw new QueryParsingException(parseContext.index(),
-                                    "Illegal value for id, expecting a string or number, got: " + token, parser.getTokenLocation());
+                            throw new QueryParsingException(parseContext, "Illegal value for id, expecting a string or number, got: "
+                                    + token);
                         }
                     }
                 } else if ("types".equals(currentFieldName) || "type".equals(currentFieldName)) {
@@ -88,14 +87,12 @@ public class IdsQueryParser implements QueryParser {
                     while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                         String value = parser.textOrNull();
                         if (value == null) {
-                            throw new QueryParsingException(parseContext.index(), "No type specified for term filter",
-                                    parser.getTokenLocation());
+                            throw new QueryParsingException(parseContext, "No type specified for term filter");
                         }
                         types.add(value);
                     }
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[ids] query does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[ids] query does not support [" + currentFieldName + "]");
                 }
             } else if (token.isValue()) {
                 if ("type".equals(currentFieldName) || "_type".equals(currentFieldName)) {
@@ -105,14 +102,13 @@ public class IdsQueryParser implements QueryParser {
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[ids] query does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[ids] query does not support [" + currentFieldName + "]");
                 }
             }
         }
 
         if (!idsProvided) {
-            throw new QueryParsingException(parseContext.index(), "[ids] query, no ids values provided", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "[ids] query, no ids values provided");
         }
 
         if (ids.isEmpty()) {

--- a/src/main/java/org/elasticsearch/index/query/IdsQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/IdsQueryParser.java
@@ -74,12 +74,13 @@ public class IdsQueryParser implements QueryParser {
                                 (token == XContentParser.Token.VALUE_NUMBER)) {
                             BytesRef value = parser.utf8BytesOrNull();
                             if (value == null) {
-                                throw new QueryParsingException(parseContext.index(), "No value specified for term filter");
+                                throw new QueryParsingException(parseContext.index(), "No value specified for term filter",
+                                        parser.getTokenLocation());
                             }
                             ids.add(value);
                         } else {
                             throw new QueryParsingException(parseContext.index(),
-                                    "Illegal value for id, expecting a string or number, got: " + token);
+                                    "Illegal value for id, expecting a string or number, got: " + token, parser.getTokenLocation());
                         }
                     }
                 } else if ("types".equals(currentFieldName) || "type".equals(currentFieldName)) {
@@ -87,12 +88,14 @@ public class IdsQueryParser implements QueryParser {
                     while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                         String value = parser.textOrNull();
                         if (value == null) {
-                            throw new QueryParsingException(parseContext.index(), "No type specified for term filter");
+                            throw new QueryParsingException(parseContext.index(), "No type specified for term filter",
+                                    parser.getTokenLocation());
                         }
                         types.add(value);
                     }
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[ids] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[ids] query does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             } else if (token.isValue()) {
                 if ("type".equals(currentFieldName) || "_type".equals(currentFieldName)) {
@@ -102,13 +105,14 @@ public class IdsQueryParser implements QueryParser {
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[ids] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[ids] query does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             }
         }
 
         if (!idsProvided) {
-            throw new QueryParsingException(parseContext.index(), "[ids] query, no ids values provided");
+            throw new QueryParsingException(parseContext.index(), "[ids] query, no ids values provided", parser.getTokenLocation());
         }
 
         if (ids.isEmpty()) {

--- a/src/main/java/org/elasticsearch/index/query/IndexQueryParserService.java
+++ b/src/main/java/org/elasticsearch/index/query/IndexQueryParserService.java
@@ -210,7 +210,7 @@ public class IndexQueryParserService extends AbstractIndexComponent {
         } catch (QueryParsingException e) {
             throw e;
         } catch (Exception e) {
-            throw new QueryParsingException(index, "Failed to parse", null, e);
+            throw new QueryParsingException(getParseContext(), "Failed to parse", e);
         } finally {
             if (parser != null) {
                 parser.close();
@@ -230,7 +230,7 @@ public class IndexQueryParserService extends AbstractIndexComponent {
         } catch (QueryParsingException e) {
             throw e;
         } catch (Exception e) {
-            throw new QueryParsingException(index, "Failed to parse", null, e);
+            throw new QueryParsingException(getParseContext(), "Failed to parse", e);
         } finally {
             if (parser != null) {
                 parser.close();
@@ -250,7 +250,7 @@ public class IndexQueryParserService extends AbstractIndexComponent {
         } catch (QueryParsingException e) {
             throw e;
         } catch (Exception e) {
-            throw new QueryParsingException(index, "Failed to parse", null, e);
+            throw new QueryParsingException(context, "Failed to parse", e);
         } finally {
             if (parser != null) {
                 parser.close();
@@ -266,7 +266,7 @@ public class IndexQueryParserService extends AbstractIndexComponent {
         } catch (QueryParsingException e) {
             throw e;
         } catch (Exception e) {
-            throw new QueryParsingException(index, "Failed to parse [" + source + "]", null, e);
+            throw new QueryParsingException(getParseContext(), "Failed to parse [" + source + "]", e);
         } finally {
             if (parser != null) {
                 parser.close();
@@ -282,7 +282,7 @@ public class IndexQueryParserService extends AbstractIndexComponent {
         try {
             return innerParse(context, parser);
         } catch (IOException e) {
-            throw new QueryParsingException(index, "Failed to parse", null, e);
+            throw new QueryParsingException(context, "Failed to parse", e);
         }
     }
 
@@ -359,7 +359,7 @@ public class IndexQueryParserService extends AbstractIndexComponent {
                         XContentParser qSourceParser = XContentFactory.xContent(querySource).createParser(querySource);
                         parsedQuery = parse(qSourceParser);
                     } else {
-                        throw new QueryParsingException(index(), "request does not support [" + fieldName + "]", parser.getTokenLocation());
+                        throw new QueryParsingException(getParseContext(), "request does not support [" + fieldName + "]");
                     }
                 }
             }
@@ -369,10 +369,10 @@ public class IndexQueryParserService extends AbstractIndexComponent {
         } catch (QueryParsingException e) {
             throw e;
         } catch (Throwable e) {
-            throw new QueryParsingException(index, "Failed to parse", null, e);
+            throw new QueryParsingException(getParseContext(), "Failed to parse", e);
         }
 
-        throw new QueryParsingException(index(), "Required query is missing", null);
+        throw new QueryParsingException(getParseContext(), "Required query is missing");
     }
 
     private ParsedQuery innerParse(QueryParseContext parseContext, XContentParser parser) throws IOException, QueryParsingException {

--- a/src/main/java/org/elasticsearch/index/query/IndexQueryParserService.java
+++ b/src/main/java/org/elasticsearch/index/query/IndexQueryParserService.java
@@ -210,7 +210,7 @@ public class IndexQueryParserService extends AbstractIndexComponent {
         } catch (QueryParsingException e) {
             throw e;
         } catch (Exception e) {
-            throw new QueryParsingException(index, "Failed to parse", e);
+            throw new QueryParsingException(index, "Failed to parse", null, e);
         } finally {
             if (parser != null) {
                 parser.close();
@@ -230,7 +230,7 @@ public class IndexQueryParserService extends AbstractIndexComponent {
         } catch (QueryParsingException e) {
             throw e;
         } catch (Exception e) {
-            throw new QueryParsingException(index, "Failed to parse", e);
+            throw new QueryParsingException(index, "Failed to parse", null, e);
         } finally {
             if (parser != null) {
                 parser.close();
@@ -250,7 +250,7 @@ public class IndexQueryParserService extends AbstractIndexComponent {
         } catch (QueryParsingException e) {
             throw e;
         } catch (Exception e) {
-            throw new QueryParsingException(index, "Failed to parse", e);
+            throw new QueryParsingException(index, "Failed to parse", null, e);
         } finally {
             if (parser != null) {
                 parser.close();
@@ -266,7 +266,7 @@ public class IndexQueryParserService extends AbstractIndexComponent {
         } catch (QueryParsingException e) {
             throw e;
         } catch (Exception e) {
-            throw new QueryParsingException(index, "Failed to parse [" + source + "]", e);
+            throw new QueryParsingException(index, "Failed to parse [" + source + "]", null, e);
         } finally {
             if (parser != null) {
                 parser.close();
@@ -282,7 +282,7 @@ public class IndexQueryParserService extends AbstractIndexComponent {
         try {
             return innerParse(context, parser);
         } catch (IOException e) {
-            throw new QueryParsingException(index, "Failed to parse", e);
+            throw new QueryParsingException(index, "Failed to parse", null, e);
         }
     }
 
@@ -359,7 +359,7 @@ public class IndexQueryParserService extends AbstractIndexComponent {
                         XContentParser qSourceParser = XContentFactory.xContent(querySource).createParser(querySource);
                         parsedQuery = parse(qSourceParser);
                     } else {
-                        throw new QueryParsingException(index(), "request does not support [" + fieldName + "]");
+                        throw new QueryParsingException(index(), "request does not support [" + fieldName + "]", parser.getTokenLocation());
                     }
                 }
             }
@@ -369,10 +369,10 @@ public class IndexQueryParserService extends AbstractIndexComponent {
         } catch (QueryParsingException e) {
             throw e;
         } catch (Throwable e) {
-            throw new QueryParsingException(index, "Failed to parse", e);
+            throw new QueryParsingException(index, "Failed to parse", null, e);
         }
 
-        throw new QueryParsingException(index(), "Required query is missing");
+        throw new QueryParsingException(index(), "Required query is missing", null);
     }
 
     private ParsedQuery innerParse(QueryParseContext parseContext, XContentParser parser) throws IOException, QueryParsingException {

--- a/src/main/java/org/elasticsearch/index/query/IndicesFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/IndicesFilterParser.java
@@ -83,30 +83,35 @@ public class IndicesFilterParser implements FilterParser {
                         noMatchFilter = parseContext.parseInnerFilter();
                     }
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[indices] filter does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[indices] filter does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.START_ARRAY) {
                 if ("indices".equals(currentFieldName)) {
                     if (indicesFound) {
-                        throw  new QueryParsingException(parseContext.index(), "[indices] indices or index already specified");
+                        throw new QueryParsingException(parseContext.index(), "[indices] indices or index already specified",
+                                parser.getTokenLocation());
                     }
                     indicesFound = true;
                     Collection<String> indices = new ArrayList<>();
                     while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
                         String value = parser.textOrNull();
                         if (value == null) {
-                            throw new QueryParsingException(parseContext.index(), "[indices] no value specified for 'indices' entry");
+                            throw new QueryParsingException(parseContext.index(), "[indices] no value specified for 'indices' entry",
+                                    parser.getTokenLocation());
                         }
                         indices.add(value);
                     }
                     currentIndexMatchesIndices = matchesIndices(parseContext.index().name(), indices.toArray(new String[indices.size()]));
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[indices] filter does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[indices] filter does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             } else if (token.isValue()) {
                 if ("index".equals(currentFieldName)) {
                     if (indicesFound) {
-                        throw  new QueryParsingException(parseContext.index(), "[indices] indices or index already specified");
+                        throw new QueryParsingException(parseContext.index(), "[indices] indices or index already specified",
+                                parser.getTokenLocation());
                     }
                     indicesFound = true;
                     currentIndexMatchesIndices = matchesIndices(parseContext.index().name(), parser.text());
@@ -120,15 +125,17 @@ public class IndicesFilterParser implements FilterParser {
                 } else if ("_name".equals(currentFieldName)) {
                     filterName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[indices] filter does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[indices] filter does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             }
         }
         if (!filterFound) {
-            throw new QueryParsingException(parseContext.index(), "[indices] requires 'filter' element");
+            throw new QueryParsingException(parseContext.index(), "[indices] requires 'filter' element", parser.getTokenLocation());
         }
         if (!indicesFound) {
-            throw new QueryParsingException(parseContext.index(), "[indices] requires 'indices' or 'index' element");
+            throw new QueryParsingException(parseContext.index(), "[indices] requires 'indices' or 'index' element",
+                    parser.getTokenLocation());
         }
 
         Filter chosenFilter;

--- a/src/main/java/org/elasticsearch/index/query/IndicesFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/IndicesFilterParser.java
@@ -83,35 +83,30 @@ public class IndicesFilterParser implements FilterParser {
                         noMatchFilter = parseContext.parseInnerFilter();
                     }
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[indices] filter does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[indices] filter does not support [" + currentFieldName + "]");
                 }
             } else if (token == XContentParser.Token.START_ARRAY) {
                 if ("indices".equals(currentFieldName)) {
                     if (indicesFound) {
-                        throw new QueryParsingException(parseContext.index(), "[indices] indices or index already specified",
-                                parser.getTokenLocation());
+                        throw new QueryParsingException(parseContext, "[indices] indices or index already specified");
                     }
                     indicesFound = true;
                     Collection<String> indices = new ArrayList<>();
                     while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
                         String value = parser.textOrNull();
                         if (value == null) {
-                            throw new QueryParsingException(parseContext.index(), "[indices] no value specified for 'indices' entry",
-                                    parser.getTokenLocation());
+                            throw new QueryParsingException(parseContext, "[indices] no value specified for 'indices' entry");
                         }
                         indices.add(value);
                     }
                     currentIndexMatchesIndices = matchesIndices(parseContext.index().name(), indices.toArray(new String[indices.size()]));
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[indices] filter does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[indices] filter does not support [" + currentFieldName + "]");
                 }
             } else if (token.isValue()) {
                 if ("index".equals(currentFieldName)) {
                     if (indicesFound) {
-                        throw new QueryParsingException(parseContext.index(), "[indices] indices or index already specified",
-                                parser.getTokenLocation());
+                        throw new QueryParsingException(parseContext, "[indices] indices or index already specified");
                     }
                     indicesFound = true;
                     currentIndexMatchesIndices = matchesIndices(parseContext.index().name(), parser.text());
@@ -125,17 +120,15 @@ public class IndicesFilterParser implements FilterParser {
                 } else if ("_name".equals(currentFieldName)) {
                     filterName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[indices] filter does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[indices] filter does not support [" + currentFieldName + "]");
                 }
             }
         }
         if (!filterFound) {
-            throw new QueryParsingException(parseContext.index(), "[indices] requires 'filter' element", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "[indices] requires 'filter' element");
         }
         if (!indicesFound) {
-            throw new QueryParsingException(parseContext.index(), "[indices] requires 'indices' or 'index' element",
-                    parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "[indices] requires 'indices' or 'index' element");
         }
 
         Filter chosenFilter;

--- a/src/main/java/org/elasticsearch/index/query/IndicesQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/IndicesQueryParser.java
@@ -76,30 +76,35 @@ public class IndicesQueryParser implements QueryParser {
                 } else if ("no_match_query".equals(currentFieldName)) {
                     innerNoMatchQuery = new XContentStructure.InnerQuery(parseContext, null);
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[indices] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[indices] query does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.START_ARRAY) {
                 if ("indices".equals(currentFieldName)) {
                     if (indicesFound) {
-                        throw  new QueryParsingException(parseContext.index(), "[indices] indices or index already specified");
+                        throw new QueryParsingException(parseContext.index(), "[indices] indices or index already specified",
+                                parser.getTokenLocation());
                     }
                     indicesFound = true;
                     Collection<String> indices = new ArrayList<>();
                     while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
                         String value = parser.textOrNull();
                         if (value == null) {
-                            throw new QueryParsingException(parseContext.index(), "[indices] no value specified for 'indices' entry");
+                            throw new QueryParsingException(parseContext.index(), "[indices] no value specified for 'indices' entry",
+                                    parser.getTokenLocation());
                         }
                         indices.add(value);
                     }
                     currentIndexMatchesIndices = matchesIndices(parseContext.index().name(), indices.toArray(new String[indices.size()]));
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[indices] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[indices] query does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             } else if (token.isValue()) {
                 if ("index".equals(currentFieldName)) {
                     if (indicesFound) {
-                        throw  new QueryParsingException(parseContext.index(), "[indices] indices or index already specified");
+                        throw new QueryParsingException(parseContext.index(), "[indices] indices or index already specified",
+                                parser.getTokenLocation());
                     }
                     indicesFound = true;
                     currentIndexMatchesIndices = matchesIndices(parseContext.index().name(), parser.text());
@@ -113,15 +118,17 @@ public class IndicesQueryParser implements QueryParser {
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[indices] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[indices] query does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             }
         }
         if (!queryFound) {
-            throw new QueryParsingException(parseContext.index(), "[indices] requires 'query' element");
+            throw new QueryParsingException(parseContext.index(), "[indices] requires 'query' element", parser.getTokenLocation());
         }
         if (!indicesFound) {
-            throw new QueryParsingException(parseContext.index(), "[indices] requires 'indices' or 'index' element");
+            throw new QueryParsingException(parseContext.index(), "[indices] requires 'indices' or 'index' element",
+                    parser.getTokenLocation());
         }
 
         Query chosenQuery;

--- a/src/main/java/org/elasticsearch/index/query/IndicesQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/IndicesQueryParser.java
@@ -76,35 +76,30 @@ public class IndicesQueryParser implements QueryParser {
                 } else if ("no_match_query".equals(currentFieldName)) {
                     innerNoMatchQuery = new XContentStructure.InnerQuery(parseContext, null);
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[indices] query does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[indices] query does not support [" + currentFieldName + "]");
                 }
             } else if (token == XContentParser.Token.START_ARRAY) {
                 if ("indices".equals(currentFieldName)) {
                     if (indicesFound) {
-                        throw new QueryParsingException(parseContext.index(), "[indices] indices or index already specified",
-                                parser.getTokenLocation());
+                        throw new QueryParsingException(parseContext, "[indices] indices or index already specified");
                     }
                     indicesFound = true;
                     Collection<String> indices = new ArrayList<>();
                     while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
                         String value = parser.textOrNull();
                         if (value == null) {
-                            throw new QueryParsingException(parseContext.index(), "[indices] no value specified for 'indices' entry",
-                                    parser.getTokenLocation());
+                            throw new QueryParsingException(parseContext, "[indices] no value specified for 'indices' entry");
                         }
                         indices.add(value);
                     }
                     currentIndexMatchesIndices = matchesIndices(parseContext.index().name(), indices.toArray(new String[indices.size()]));
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[indices] query does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[indices] query does not support [" + currentFieldName + "]");
                 }
             } else if (token.isValue()) {
                 if ("index".equals(currentFieldName)) {
                     if (indicesFound) {
-                        throw new QueryParsingException(parseContext.index(), "[indices] indices or index already specified",
-                                parser.getTokenLocation());
+                        throw new QueryParsingException(parseContext, "[indices] indices or index already specified");
                     }
                     indicesFound = true;
                     currentIndexMatchesIndices = matchesIndices(parseContext.index().name(), parser.text());
@@ -118,17 +113,15 @@ public class IndicesQueryParser implements QueryParser {
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[indices] query does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[indices] query does not support [" + currentFieldName + "]");
                 }
             }
         }
         if (!queryFound) {
-            throw new QueryParsingException(parseContext.index(), "[indices] requires 'query' element", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "[indices] requires 'query' element");
         }
         if (!indicesFound) {
-            throw new QueryParsingException(parseContext.index(), "[indices] requires 'indices' or 'index' element",
-                    parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "[indices] requires 'indices' or 'index' element");
         }
 
         Query chosenQuery;

--- a/src/main/java/org/elasticsearch/index/query/LimitFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/LimitFilterParser.java
@@ -53,14 +53,13 @@ public class LimitFilterParser implements FilterParser {
                 if ("value".equals(currentFieldName)) {
                     limit = parser.intValue();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[limit] filter does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[limit] filter does not support [" + currentFieldName + "]");
                 }
             }
         }
 
         if (limit == -1) {
-            throw new QueryParsingException(parseContext.index(), "No value specified for limit filter", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "No value specified for limit filter");
         }
 
         // this filter is deprecated and parses to a filter that matches everything

--- a/src/main/java/org/elasticsearch/index/query/LimitFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/LimitFilterParser.java
@@ -53,13 +53,14 @@ public class LimitFilterParser implements FilterParser {
                 if ("value".equals(currentFieldName)) {
                     limit = parser.intValue();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[limit] filter does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[limit] filter does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             }
         }
 
         if (limit == -1) {
-            throw new QueryParsingException(parseContext.index(), "No value specified for limit filter");
+            throw new QueryParsingException(parseContext.index(), "No value specified for limit filter", parser.getTokenLocation());
         }
 
         // this filter is deprecated and parses to a filter that matches everything

--- a/src/main/java/org/elasticsearch/index/query/MatchAllQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MatchAllQueryParser.java
@@ -59,8 +59,7 @@ public class MatchAllQueryParser implements QueryParser {
                 if ("boost".equals(currentFieldName)) {
                     boost = parser.floatValue();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[match_all] query does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[match_all] query does not support [" + currentFieldName + "]");
                 }
             }
         }

--- a/src/main/java/org/elasticsearch/index/query/MatchAllQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MatchAllQueryParser.java
@@ -59,7 +59,8 @@ public class MatchAllQueryParser implements QueryParser {
                 if ("boost".equals(currentFieldName)) {
                     boost = parser.floatValue();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[match_all] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[match_all] query does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             }
         }

--- a/src/main/java/org/elasticsearch/index/query/MatchQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MatchQueryParser.java
@@ -65,7 +65,7 @@ public class MatchQueryParser implements QueryParser {
 
         XContentParser.Token token = parser.nextToken();
         if (token != XContentParser.Token.FIELD_NAME) {
-            throw new QueryParsingException(parseContext.index(), "[match] query malformed, no field");
+            throw new QueryParsingException(parseContext.index(), "[match] query malformed, no field", parser.getTokenLocation());
         }
         String fieldName = parser.currentName();
 
@@ -93,12 +93,14 @@ public class MatchQueryParser implements QueryParser {
                         } else if ("phrase_prefix".equals(tStr) || "phrasePrefix".equals(currentFieldName)) {
                             type = MatchQuery.Type.PHRASE_PREFIX;
                         } else {
-                            throw new QueryParsingException(parseContext.index(), "[match] query does not support type " + tStr);
+                            throw new QueryParsingException(parseContext.index(), "[match] query does not support type " + tStr,
+                                    parser.getTokenLocation());
                         }
                     } else if ("analyzer".equals(currentFieldName)) {
                         String analyzer = parser.text();
                         if (parseContext.analysisService().analyzer(analyzer) == null) {
-                            throw new QueryParsingException(parseContext.index(), "[match] analyzer [" + parser.text() + "] not found");
+                            throw new QueryParsingException(parseContext.index(), "[match] analyzer [" + parser.text() + "] not found",
+                                    parser.getTokenLocation());
                         }
                         matchQuery.setAnalyzer(analyzer);
                     } else if ("boost".equals(currentFieldName)) {
@@ -118,7 +120,8 @@ public class MatchQueryParser implements QueryParser {
                         } else if ("and".equalsIgnoreCase(op)) {
                             matchQuery.setOccur(BooleanClause.Occur.MUST);
                         } else {
-                            throw new QueryParsingException(parseContext.index(), "text query requires operator to be either 'and' or 'or', not [" + op + "]");
+                            throw new QueryParsingException(parseContext.index(),
+                                    "text query requires operator to be either 'and' or 'or', not [" + op + "]", parser.getTokenLocation());
                         }
                     } else if ("minimum_should_match".equals(currentFieldName) || "minimumShouldMatch".equals(currentFieldName)) {
                         minimumShouldMatch = parser.textOrNull();
@@ -139,12 +142,14 @@ public class MatchQueryParser implements QueryParser {
                         } else if ("all".equalsIgnoreCase(zeroTermsDocs)) {
                             matchQuery.setZeroTermsQuery(MatchQuery.ZeroTermsQuery.ALL);
                         } else {
-                            throw new QueryParsingException(parseContext.index(), "Unsupported zero_terms_docs value [" + zeroTermsDocs + "]");
+                            throw new QueryParsingException(parseContext.index(), "Unsupported zero_terms_docs value [" + zeroTermsDocs
+                                    + "]", parser.getTokenLocation());
                         }
                     } else if ("_name".equals(currentFieldName)) {
                         queryName = parser.text();
                     } else {
-                        throw new QueryParsingException(parseContext.index(), "[match] query does not support [" + currentFieldName + "]");
+                        throw new QueryParsingException(parseContext.index(), "[match] query does not support [" + currentFieldName + "]",
+                                parser.getTokenLocation());
                     }
                 }
             }
@@ -154,12 +159,15 @@ public class MatchQueryParser implements QueryParser {
             // move to the next token
             token = parser.nextToken();
             if (token != XContentParser.Token.END_OBJECT) {
-                throw new QueryParsingException(parseContext.index(), "[match] query parsed in simplified form, with direct field name, but included more options than just the field name, possibly use its 'options' form, with 'query' element?");
+                throw new QueryParsingException(
+                        parseContext.index(),
+                        "[match] query parsed in simplified form, with direct field name, but included more options than just the field name, possibly use its 'options' form, with 'query' element?",
+                        parser.getTokenLocation());
             }
         }
 
         if (value == null) {
-            throw new QueryParsingException(parseContext.index(), "No text specified for text query");
+            throw new QueryParsingException(parseContext.index(), "No text specified for text query", parser.getTokenLocation());
         }
 
         Query query = matchQuery.parse(type, fieldName, value);

--- a/src/main/java/org/elasticsearch/index/query/MatchQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MatchQueryParser.java
@@ -65,7 +65,7 @@ public class MatchQueryParser implements QueryParser {
 
         XContentParser.Token token = parser.nextToken();
         if (token != XContentParser.Token.FIELD_NAME) {
-            throw new QueryParsingException(parseContext.index(), "[match] query malformed, no field", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "[match] query malformed, no field");
         }
         String fieldName = parser.currentName();
 
@@ -93,14 +93,12 @@ public class MatchQueryParser implements QueryParser {
                         } else if ("phrase_prefix".equals(tStr) || "phrasePrefix".equals(currentFieldName)) {
                             type = MatchQuery.Type.PHRASE_PREFIX;
                         } else {
-                            throw new QueryParsingException(parseContext.index(), "[match] query does not support type " + tStr,
-                                    parser.getTokenLocation());
+                            throw new QueryParsingException(parseContext, "[match] query does not support type " + tStr);
                         }
                     } else if ("analyzer".equals(currentFieldName)) {
                         String analyzer = parser.text();
                         if (parseContext.analysisService().analyzer(analyzer) == null) {
-                            throw new QueryParsingException(parseContext.index(), "[match] analyzer [" + parser.text() + "] not found",
-                                    parser.getTokenLocation());
+                            throw new QueryParsingException(parseContext, "[match] analyzer [" + parser.text() + "] not found");
                         }
                         matchQuery.setAnalyzer(analyzer);
                     } else if ("boost".equals(currentFieldName)) {
@@ -120,8 +118,8 @@ public class MatchQueryParser implements QueryParser {
                         } else if ("and".equalsIgnoreCase(op)) {
                             matchQuery.setOccur(BooleanClause.Occur.MUST);
                         } else {
-                            throw new QueryParsingException(parseContext.index(),
-                                    "text query requires operator to be either 'and' or 'or', not [" + op + "]", parser.getTokenLocation());
+                            throw new QueryParsingException(parseContext, "text query requires operator to be either 'and' or 'or', not ["
+                                    + op + "]");
                         }
                     } else if ("minimum_should_match".equals(currentFieldName) || "minimumShouldMatch".equals(currentFieldName)) {
                         minimumShouldMatch = parser.textOrNull();
@@ -142,14 +140,12 @@ public class MatchQueryParser implements QueryParser {
                         } else if ("all".equalsIgnoreCase(zeroTermsDocs)) {
                             matchQuery.setZeroTermsQuery(MatchQuery.ZeroTermsQuery.ALL);
                         } else {
-                            throw new QueryParsingException(parseContext.index(), "Unsupported zero_terms_docs value [" + zeroTermsDocs
-                                    + "]", parser.getTokenLocation());
+                            throw new QueryParsingException(parseContext, "Unsupported zero_terms_docs value [" + zeroTermsDocs + "]");
                         }
                     } else if ("_name".equals(currentFieldName)) {
                         queryName = parser.text();
                     } else {
-                        throw new QueryParsingException(parseContext.index(), "[match] query does not support [" + currentFieldName + "]",
-                                parser.getTokenLocation());
+                        throw new QueryParsingException(parseContext, "[match] query does not support [" + currentFieldName + "]");
                     }
                 }
             }
@@ -159,15 +155,13 @@ public class MatchQueryParser implements QueryParser {
             // move to the next token
             token = parser.nextToken();
             if (token != XContentParser.Token.END_OBJECT) {
-                throw new QueryParsingException(
-                        parseContext.index(),
-                        "[match] query parsed in simplified form, with direct field name, but included more options than just the field name, possibly use its 'options' form, with 'query' element?",
-                        parser.getTokenLocation());
+                throw new QueryParsingException(parseContext,
+                        "[match] query parsed in simplified form, with direct field name, but included more options than just the field name, possibly use its 'options' form, with 'query' element?");
             }
         }
 
         if (value == null) {
-            throw new QueryParsingException(parseContext.index(), "No text specified for text query", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "No text specified for text query");
         }
 
         Query query = matchQuery.parse(type, fieldName, value);

--- a/src/main/java/org/elasticsearch/index/query/MissingFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MissingFilterParser.java
@@ -23,7 +23,6 @@ import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Filter;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.search.QueryWrapperFilter;
 import org.apache.lucene.search.TermRangeQuery;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.lucene.HashedBytesRef;
@@ -78,13 +77,13 @@ public class MissingFilterParser implements FilterParser {
                 } else if ("_name".equals(currentFieldName)) {
                     filterName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[missing] filter does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[missing] filter does not support [" + currentFieldName + "]", parser.getTokenLocation());
                 }
             }
         }
 
         if (fieldPattern == null) {
-            throw new QueryParsingException(parseContext.index(), "missing must be provided with a [field]");
+            throw new QueryParsingException(parseContext.index(), "missing must be provided with a [field]", parser.getTokenLocation());
         }
 
         return newFilter(parseContext, fieldPattern, existence, nullValue, filterName);
@@ -92,7 +91,8 @@ public class MissingFilterParser implements FilterParser {
 
     public static Filter newFilter(QueryParseContext parseContext, String fieldPattern, boolean existence, boolean nullValue, String filterName) {
         if (!existence && !nullValue) {
-            throw new QueryParsingException(parseContext.index(), "missing must have either existence, or null_value, or both set to true");
+            throw new QueryParsingException(parseContext.index(), "missing must have either existence, or null_value, or both set to true",
+                    null);
         }
 
         final FieldMappers fieldNamesMappers = parseContext.mapperService().fullName(FieldNamesFieldMapper.NAME);

--- a/src/main/java/org/elasticsearch/index/query/MissingFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MissingFilterParser.java
@@ -77,13 +77,13 @@ public class MissingFilterParser implements FilterParser {
                 } else if ("_name".equals(currentFieldName)) {
                     filterName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[missing] filter does not support [" + currentFieldName + "]", parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[missing] filter does not support [" + currentFieldName + "]");
                 }
             }
         }
 
         if (fieldPattern == null) {
-            throw new QueryParsingException(parseContext.index(), "missing must be provided with a [field]", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "missing must be provided with a [field]");
         }
 
         return newFilter(parseContext, fieldPattern, existence, nullValue, filterName);
@@ -91,8 +91,7 @@ public class MissingFilterParser implements FilterParser {
 
     public static Filter newFilter(QueryParseContext parseContext, String fieldPattern, boolean existence, boolean nullValue, String filterName) {
         if (!existence && !nullValue) {
-            throw new QueryParsingException(parseContext.index(), "missing must have either existence, or null_value, or both set to true",
-                    null);
+            throw new QueryParsingException(parseContext, "missing must have either existence, or null_value, or both set to true");
         }
 
         final FieldMappers fieldNamesMappers = parseContext.mapperService().fullName(FieldNamesFieldMapper.NAME);

--- a/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryParser.java
@@ -156,8 +156,7 @@ public class MoreLikeThisQueryParser implements QueryParser {
                 } else if (Fields.INCLUDE.match(currentFieldName, parseContext.parseFlags())) {
                     include = parser.booleanValue();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[mlt] query does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[mlt] query does not support [" + currentFieldName + "]");
                 }
             } else if (token == XContentParser.Token.START_ARRAY) {
                 if (Fields.STOP_WORDS.match(currentFieldName, parseContext.parseFlags())) {
@@ -194,8 +193,7 @@ public class MoreLikeThisQueryParser implements QueryParser {
                         parseLikeField(parser, ignoreTexts, ignoreItems);
                     }
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[mlt] query does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[mlt] query does not support [" + currentFieldName + "]");
                 }
             } else if (token == XContentParser.Token.START_OBJECT) {
                 if (Fields.LIKE.match(currentFieldName, parseContext.parseFlags())) {
@@ -204,19 +202,16 @@ public class MoreLikeThisQueryParser implements QueryParser {
                 else if (Fields.IGNORE_LIKE.match(currentFieldName, parseContext.parseFlags())) {
                     parseLikeField(parser, ignoreTexts, ignoreItems);
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[mlt] query does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[mlt] query does not support [" + currentFieldName + "]");
                 }
             }
         }
 
         if (likeTexts.isEmpty() && likeItems.isEmpty()) {
-            throw new QueryParsingException(parseContext.index(), "more_like_this requires 'like' to be specified",
-                    parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "more_like_this requires 'like' to be specified");
         }
         if (moreLikeFields != null && moreLikeFields.isEmpty()) {
-            throw new QueryParsingException(parseContext.index(), "more_like_this requires 'fields' to be non-empty",
-                    parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "more_like_this requires 'fields' to be non-empty");
         }
 
         // set analyzer
@@ -264,9 +259,9 @@ public class MoreLikeThisQueryParser implements QueryParser {
                 }
                 if (item.type() == null) {
                     if (parseContext.queryTypes().size() > 1) {
-                        throw new QueryParsingException(parseContext.index(),
+                        throw new QueryParsingException(parseContext,
                                     "ambiguous type for item with id: " + item.id()
-                                + " and index: " + item.index(), parser.getTokenLocation());
+                                + " and index: " + item.index());
                     } else {
                         item.type(parseContext.queryTypes().iterator().next());
                     }

--- a/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryParser.java
@@ -156,7 +156,8 @@ public class MoreLikeThisQueryParser implements QueryParser {
                 } else if (Fields.INCLUDE.match(currentFieldName, parseContext.parseFlags())) {
                     include = parser.booleanValue();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[mlt] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[mlt] query does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.START_ARRAY) {
                 if (Fields.STOP_WORDS.match(currentFieldName, parseContext.parseFlags())) {
@@ -193,7 +194,8 @@ public class MoreLikeThisQueryParser implements QueryParser {
                         parseLikeField(parser, ignoreTexts, ignoreItems);
                     }
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[mlt] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[mlt] query does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.START_OBJECT) {
                 if (Fields.LIKE.match(currentFieldName, parseContext.parseFlags())) {
@@ -202,16 +204,19 @@ public class MoreLikeThisQueryParser implements QueryParser {
                 else if (Fields.IGNORE_LIKE.match(currentFieldName, parseContext.parseFlags())) {
                     parseLikeField(parser, ignoreTexts, ignoreItems);
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[mlt] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[mlt] query does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             }
         }
 
         if (likeTexts.isEmpty() && likeItems.isEmpty()) {
-            throw new QueryParsingException(parseContext.index(), "more_like_this requires 'like' to be specified");
+            throw new QueryParsingException(parseContext.index(), "more_like_this requires 'like' to be specified",
+                    parser.getTokenLocation());
         }
         if (moreLikeFields != null && moreLikeFields.isEmpty()) {
-            throw new QueryParsingException(parseContext.index(), "more_like_this requires 'fields' to be non-empty");
+            throw new QueryParsingException(parseContext.index(), "more_like_this requires 'fields' to be non-empty",
+                    parser.getTokenLocation());
         }
 
         // set analyzer
@@ -260,7 +265,8 @@ public class MoreLikeThisQueryParser implements QueryParser {
                 if (item.type() == null) {
                     if (parseContext.queryTypes().size() > 1) {
                         throw new QueryParsingException(parseContext.index(),
-                                "ambiguous type for item with id: " + item.id() + " and index: " + item.index());
+                                    "ambiguous type for item with id: " + item.id()
+                                + " and index: " + item.index(), parser.getTokenLocation());
                     } else {
                         item.type(parseContext.queryTypes().iterator().next());
                     }

--- a/src/main/java/org/elasticsearch/index/query/MultiMatchQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MultiMatchQueryParser.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.query;
 
 import com.google.common.collect.Maps;
+
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.inject.Inject;
@@ -78,7 +79,7 @@ public class MultiMatchQueryParser implements QueryParser {
                     extractFieldAndBoost(parseContext, parser, fieldNameWithBoosts);
                 } else {
                     throw new QueryParsingException(parseContext.index(), "[" + NAME + "] query does not support [" + currentFieldName
-                            + "]");
+                            + "]", parser.getTokenLocation());
                 }
             } else if (token.isValue()) {
                 if ("query".equals(currentFieldName)) {
@@ -88,7 +89,8 @@ public class MultiMatchQueryParser implements QueryParser {
                 } else if ("analyzer".equals(currentFieldName)) {
                     String analyzer = parser.text();
                     if (parseContext.analysisService().analyzer(analyzer) == null) {
-                        throw new QueryParsingException(parseContext.index(), "["+ NAME +"] analyzer [" + parser.text() + "] not found");
+                        throw new QueryParsingException(parseContext.index(), "[" + NAME + "] analyzer [" + parser.text() + "] not found",
+                                parser.getTokenLocation());
                     }
                     multiMatchQuery.setAnalyzer(analyzer);
                 } else if ("boost".equals(currentFieldName)) {
@@ -108,7 +110,8 @@ public class MultiMatchQueryParser implements QueryParser {
                     } else if ("and".equalsIgnoreCase(op)) {
                         multiMatchQuery.setOccur(BooleanClause.Occur.MUST);
                     } else {
-                        throw new QueryParsingException(parseContext.index(), "text query requires operator to be either 'and' or 'or', not [" + op + "]");
+                        throw new QueryParsingException(parseContext.index(),
+                                "text query requires operator to be either 'and' or 'or', not [" + op + "]", parser.getTokenLocation());
                     }
                 } else if ("minimum_should_match".equals(currentFieldName) || "minimumShouldMatch".equals(currentFieldName)) {
                     minimumShouldMatch = parser.textOrNull();
@@ -131,22 +134,23 @@ public class MultiMatchQueryParser implements QueryParser {
                     } else if ("all".equalsIgnoreCase(zeroTermsDocs)) {
                         multiMatchQuery.setZeroTermsQuery(MatchQuery.ZeroTermsQuery.ALL);
                     } else {
-                        throw new QueryParsingException(parseContext.index(), "Unsupported zero_terms_docs value [" + zeroTermsDocs + "]");
+                        throw new QueryParsingException(parseContext.index(), "Unsupported zero_terms_docs value [" + zeroTermsDocs + "]", parser.getTokenLocation());
                     }
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[match] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[match] query does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             }
         }
 
         if (value == null) {
-            throw new QueryParsingException(parseContext.index(), "No text specified for multi_match query");
+            throw new QueryParsingException(parseContext.index(), "No text specified for multi_match query", parser.getTokenLocation());
         }
 
         if (fieldNameWithBoosts.isEmpty()) {
-            throw new QueryParsingException(parseContext.index(), "No fields specified for multi_match query");
+            throw new QueryParsingException(parseContext.index(), "No fields specified for multi_match query", parser.getTokenLocation());
         }
         if (type == null) {
             type = MultiMatchQueryBuilder.Type.BEST_FIELDS;

--- a/src/main/java/org/elasticsearch/index/query/MultiMatchQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MultiMatchQueryParser.java
@@ -78,8 +78,7 @@ public class MultiMatchQueryParser implements QueryParser {
                 } else if (token.isValue()) {
                     extractFieldAndBoost(parseContext, parser, fieldNameWithBoosts);
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[" + NAME + "] query does not support [" + currentFieldName
-                            + "]", parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[" + NAME + "] query does not support [" + currentFieldName + "]");
                 }
             } else if (token.isValue()) {
                 if ("query".equals(currentFieldName)) {
@@ -89,8 +88,7 @@ public class MultiMatchQueryParser implements QueryParser {
                 } else if ("analyzer".equals(currentFieldName)) {
                     String analyzer = parser.text();
                     if (parseContext.analysisService().analyzer(analyzer) == null) {
-                        throw new QueryParsingException(parseContext.index(), "[" + NAME + "] analyzer [" + parser.text() + "] not found",
-                                parser.getTokenLocation());
+                        throw new QueryParsingException(parseContext, "[" + NAME + "] analyzer [" + parser.text() + "] not found");
                     }
                     multiMatchQuery.setAnalyzer(analyzer);
                 } else if ("boost".equals(currentFieldName)) {
@@ -110,8 +108,8 @@ public class MultiMatchQueryParser implements QueryParser {
                     } else if ("and".equalsIgnoreCase(op)) {
                         multiMatchQuery.setOccur(BooleanClause.Occur.MUST);
                     } else {
-                        throw new QueryParsingException(parseContext.index(),
-                                "text query requires operator to be either 'and' or 'or', not [" + op + "]", parser.getTokenLocation());
+                        throw new QueryParsingException(parseContext, "text query requires operator to be either 'and' or 'or', not [" + op
+                                + "]");
                     }
                 } else if ("minimum_should_match".equals(currentFieldName) || "minimumShouldMatch".equals(currentFieldName)) {
                     minimumShouldMatch = parser.textOrNull();
@@ -134,23 +132,22 @@ public class MultiMatchQueryParser implements QueryParser {
                     } else if ("all".equalsIgnoreCase(zeroTermsDocs)) {
                         multiMatchQuery.setZeroTermsQuery(MatchQuery.ZeroTermsQuery.ALL);
                     } else {
-                        throw new QueryParsingException(parseContext.index(), "Unsupported zero_terms_docs value [" + zeroTermsDocs + "]", parser.getTokenLocation());
+                        throw new QueryParsingException(parseContext, "Unsupported zero_terms_docs value [" + zeroTermsDocs + "]");
                     }
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[match] query does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[match] query does not support [" + currentFieldName + "]");
                 }
             }
         }
 
         if (value == null) {
-            throw new QueryParsingException(parseContext.index(), "No text specified for multi_match query", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "No text specified for multi_match query");
         }
 
         if (fieldNameWithBoosts.isEmpty()) {
-            throw new QueryParsingException(parseContext.index(), "No fields specified for multi_match query", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "No fields specified for multi_match query");
         }
         if (type == null) {
             type = MultiMatchQueryBuilder.Type.BEST_FIELDS;

--- a/src/main/java/org/elasticsearch/index/query/NestedFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/NestedFilterParser.java
@@ -70,7 +70,8 @@ public class NestedFilterParser implements FilterParser {
                 } else if ("inner_hits".equals(currentFieldName)) {
                     builder.setInnerHits(innerHitsQueryParserHelper.parse(parseContext));
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[nested] filter does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[nested] filter does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             } else if (token.isValue()) {
                 if ("path".equals(currentFieldName)) {
@@ -84,7 +85,8 @@ public class NestedFilterParser implements FilterParser {
                 } else if ("_cache_key".equals(currentFieldName) || "_cacheKey".equals(currentFieldName)) {
                     cacheKey = new HashedBytesRef(parser.text());
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[nested] filter does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[nested] filter does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             }
         }

--- a/src/main/java/org/elasticsearch/index/query/NestedFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/NestedFilterParser.java
@@ -70,8 +70,7 @@ public class NestedFilterParser implements FilterParser {
                 } else if ("inner_hits".equals(currentFieldName)) {
                     builder.setInnerHits(innerHitsQueryParserHelper.parse(parseContext));
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[nested] filter does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[nested] filter does not support [" + currentFieldName + "]");
                 }
             } else if (token.isValue()) {
                 if ("path".equals(currentFieldName)) {
@@ -85,8 +84,7 @@ public class NestedFilterParser implements FilterParser {
                 } else if ("_cache_key".equals(currentFieldName) || "_cacheKey".equals(currentFieldName)) {
                     cacheKey = new HashedBytesRef(parser.text());
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[nested] filter does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[nested] filter does not support [" + currentFieldName + "]");
                 }
             }
         }

--- a/src/main/java/org/elasticsearch/index/query/NestedQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/NestedQueryParser.java
@@ -75,8 +75,7 @@ public class NestedQueryParser implements QueryParser {
                 } else if ("inner_hits".equals(currentFieldName)) {
                     builder.setInnerHits(innerHitsQueryParserHelper.parse(parseContext));
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[nested] query does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[nested] query does not support [" + currentFieldName + "]");
                 }
             } else if (token.isValue()) {
                 if ("path".equals(currentFieldName)) {
@@ -94,14 +93,12 @@ public class NestedQueryParser implements QueryParser {
                     } else if ("none".equals(sScoreMode)) {
                         scoreMode = ScoreMode.None;
                     } else {
-                        throw new QueryParsingException(parseContext.index(), "illegal score_mode for nested query [" + sScoreMode + "]",
-                                parser.getTokenLocation());
+                        throw new QueryParsingException(parseContext, "illegal score_mode for nested query [" + sScoreMode + "]");
                     }
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[nested] query does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[nested] query does not support [" + currentFieldName + "]");
                 }
             }
         }
@@ -147,7 +144,7 @@ public class NestedQueryParser implements QueryParser {
                     innerQuery = null;
                 }
             } else {
-                throw new QueryParsingException(parseContext.index(), "[nested] requires either 'query' or 'filter' field", null);
+                throw new QueryParsingException(parseContext, "[nested] requires either 'query' or 'filter' field");
             }
 
             if (innerHits != null) {

--- a/src/main/java/org/elasticsearch/index/query/NestedQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/NestedQueryParser.java
@@ -75,7 +75,8 @@ public class NestedQueryParser implements QueryParser {
                 } else if ("inner_hits".equals(currentFieldName)) {
                     builder.setInnerHits(innerHitsQueryParserHelper.parse(parseContext));
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[nested] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[nested] query does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             } else if (token.isValue()) {
                 if ("path".equals(currentFieldName)) {
@@ -93,12 +94,14 @@ public class NestedQueryParser implements QueryParser {
                     } else if ("none".equals(sScoreMode)) {
                         scoreMode = ScoreMode.None;
                     } else {
-                        throw new QueryParsingException(parseContext.index(), "illegal score_mode for nested query [" + sScoreMode + "]");
+                        throw new QueryParsingException(parseContext.index(), "illegal score_mode for nested query [" + sScoreMode + "]",
+                                parser.getTokenLocation());
                     }
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[nested] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[nested] query does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             }
         }
@@ -144,7 +147,7 @@ public class NestedQueryParser implements QueryParser {
                     innerQuery = null;
                 }
             } else {
-                throw new QueryParsingException(parseContext.index(), "[nested] requires either 'query' or 'filter' field");
+                throw new QueryParsingException(parseContext.index(), "[nested] requires either 'query' or 'filter' field", null);
             }
 
             if (innerHits != null) {

--- a/src/main/java/org/elasticsearch/index/query/NotFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/NotFilterParser.java
@@ -79,14 +79,13 @@ public class NotFilterParser implements FilterParser {
                 } else if ("_cache_key".equals(currentFieldName) || "_cacheKey".equals(currentFieldName)) {
                     cacheKey = new HashedBytesRef(parser.text());
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[not] filter does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[not] filter does not support [" + currentFieldName + "]");
                 }
             }
         }
 
         if (!filterFound) {
-            throw new QueryParsingException(parseContext.index(), "filter is required when using `not` filter", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "filter is required when using `not` filter");
         }
 
         if (filter == null) {

--- a/src/main/java/org/elasticsearch/index/query/NotFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/NotFilterParser.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.index.query;
 
 import org.apache.lucene.search.Filter;
-import org.apache.lucene.search.QueryWrapperFilter;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.lucene.HashedBytesRef;
 import org.elasticsearch.common.lucene.search.Queries;
@@ -80,13 +79,14 @@ public class NotFilterParser implements FilterParser {
                 } else if ("_cache_key".equals(currentFieldName) || "_cacheKey".equals(currentFieldName)) {
                     cacheKey = new HashedBytesRef(parser.text());
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[not] filter does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[not] filter does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             }
         }
 
         if (!filterFound) {
-            throw new QueryParsingException(parseContext.index(), "filter is required when using `not` filter");
+            throw new QueryParsingException(parseContext.index(), "filter is required when using `not` filter", parser.getTokenLocation());
         }
 
         if (filter == null) {

--- a/src/main/java/org/elasticsearch/index/query/OrFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/OrFilterParser.java
@@ -100,14 +100,16 @@ public class OrFilterParser implements FilterParser {
                     } else if ("_cache_key".equals(currentFieldName) || "_cacheKey".equals(currentFieldName)) {
                         cacheKey = new HashedBytesRef(parser.text());
                     } else {
-                        throw new QueryParsingException(parseContext.index(), "[or] filter does not support [" + currentFieldName + "]");
+                        throw new QueryParsingException(parseContext.index(), "[or] filter does not support [" + currentFieldName + "]",
+                                parser.getTokenLocation());
                     }
                 }
             }
         }
 
         if (!filtersFound) {
-            throw new QueryParsingException(parseContext.index(), "[or] filter requires 'filters' to be set on it'");
+            throw new QueryParsingException(parseContext.index(), "[or] filter requires 'filters' to be set on it'",
+                    parser.getTokenLocation());
         }
 
         if (filters.isEmpty()) {

--- a/src/main/java/org/elasticsearch/index/query/OrFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/OrFilterParser.java
@@ -100,16 +100,14 @@ public class OrFilterParser implements FilterParser {
                     } else if ("_cache_key".equals(currentFieldName) || "_cacheKey".equals(currentFieldName)) {
                         cacheKey = new HashedBytesRef(parser.text());
                     } else {
-                        throw new QueryParsingException(parseContext.index(), "[or] filter does not support [" + currentFieldName + "]",
-                                parser.getTokenLocation());
+                        throw new QueryParsingException(parseContext, "[or] filter does not support [" + currentFieldName + "]");
                     }
                 }
             }
         }
 
         if (!filtersFound) {
-            throw new QueryParsingException(parseContext.index(), "[or] filter requires 'filters' to be set on it'",
-                    parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "[or] filter requires 'filters' to be set on it'");
         }
 
         if (filters.isEmpty()) {

--- a/src/main/java/org/elasticsearch/index/query/PrefixFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/PrefixFilterParser.java
@@ -78,7 +78,7 @@ public class PrefixFilterParser implements FilterParser {
         }
 
         if (value == null) {
-            throw new QueryParsingException(parseContext.index(), "No value specified for prefix filter");
+            throw new QueryParsingException(parseContext.index(), "No value specified for prefix filter", parser.getTokenLocation());
         }
 
         Filter filter = null;

--- a/src/main/java/org/elasticsearch/index/query/PrefixFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/PrefixFilterParser.java
@@ -78,7 +78,7 @@ public class PrefixFilterParser implements FilterParser {
         }
 
         if (value == null) {
-            throw new QueryParsingException(parseContext.index(), "No value specified for prefix filter", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "No value specified for prefix filter");
         }
 
         Filter filter = null;

--- a/src/main/java/org/elasticsearch/index/query/PrefixQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/PrefixQueryParser.java
@@ -53,7 +53,7 @@ public class PrefixQueryParser implements QueryParser {
 
         XContentParser.Token token = parser.nextToken();
         if (token != XContentParser.Token.FIELD_NAME) {
-            throw new QueryParsingException(parseContext.index(), "[prefix] query malformed, no field", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "[prefix] query malformed, no field");
         }
         String fieldName = parser.currentName();
         String rewriteMethod = null;
@@ -80,8 +80,7 @@ public class PrefixQueryParser implements QueryParser {
                         queryName = parser.text();
                     }
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[prefix] query does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[prefix] query does not support [" + currentFieldName + "]");
                 }
             }
             parser.nextToken();
@@ -91,7 +90,7 @@ public class PrefixQueryParser implements QueryParser {
         }
 
         if (value == null) {
-            throw new QueryParsingException(parseContext.index(), "No value specified for prefix query", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "No value specified for prefix query");
         }
 
         MultiTermQuery.RewriteMethod method = QueryParsers.parseRewriteMethod(rewriteMethod, null);

--- a/src/main/java/org/elasticsearch/index/query/PrefixQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/PrefixQueryParser.java
@@ -53,7 +53,7 @@ public class PrefixQueryParser implements QueryParser {
 
         XContentParser.Token token = parser.nextToken();
         if (token != XContentParser.Token.FIELD_NAME) {
-            throw new QueryParsingException(parseContext.index(), "[prefix] query malformed, no field");
+            throw new QueryParsingException(parseContext.index(), "[prefix] query malformed, no field", parser.getTokenLocation());
         }
         String fieldName = parser.currentName();
         String rewriteMethod = null;
@@ -80,7 +80,8 @@ public class PrefixQueryParser implements QueryParser {
                         queryName = parser.text();
                     }
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[prefix] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[prefix] query does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             }
             parser.nextToken();
@@ -90,7 +91,7 @@ public class PrefixQueryParser implements QueryParser {
         }
 
         if (value == null) {
-            throw new QueryParsingException(parseContext.index(), "No value specified for prefix query");
+            throw new QueryParsingException(parseContext.index(), "No value specified for prefix query", parser.getTokenLocation());
         }
 
         MultiTermQuery.RewriteMethod method = QueryParsers.parseRewriteMethod(rewriteMethod, null);

--- a/src/main/java/org/elasticsearch/index/query/QueryParseContext.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryParseContext.java
@@ -48,12 +48,12 @@ import org.elasticsearch.index.Index;
 import org.elasticsearch.index.analysis.AnalysisService;
 import org.elasticsearch.index.cache.query.parser.QueryParserCache;
 import org.elasticsearch.index.fielddata.IndexFieldData;
+import org.elasticsearch.index.mapper.ContentPath;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.FieldMappers;
 import org.elasticsearch.index.mapper.Mapper;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.MapperBuilders;
-import org.elasticsearch.index.mapper.ContentPath;
+import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.core.StringFieldMapper;
 import org.elasticsearch.index.query.support.NestedScope;
 import org.elasticsearch.index.search.child.CustomQueryWrappingFilter;
@@ -64,7 +64,12 @@ import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.lookup.SearchLookup;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  *
@@ -292,23 +297,23 @@ public class QueryParseContext {
         if (parser.currentToken() != XContentParser.Token.START_OBJECT) {
             token = parser.nextToken();
             if (token != XContentParser.Token.START_OBJECT) {
-                throw new QueryParsingException(index, "[_na] query malformed, must start with start_object");
+                throw new QueryParsingException(index, "[_na] query malformed, must start with start_object", parser.getTokenLocation());
             }
         }
         token = parser.nextToken();
         if (token != XContentParser.Token.FIELD_NAME) {
-            throw new QueryParsingException(index, "[_na] query malformed, no field after start_object");
+            throw new QueryParsingException(index, "[_na] query malformed, no field after start_object", parser.getTokenLocation());
         }
         String queryName = parser.currentName();
         // move to the next START_OBJECT
         token = parser.nextToken();
         if (token != XContentParser.Token.START_OBJECT && token != XContentParser.Token.START_ARRAY) {
-            throw new QueryParsingException(index, "[_na] query malformed, no field after start_object");
+            throw new QueryParsingException(index, "[_na] query malformed, no field after start_object", parser.getTokenLocation());
         }
 
         QueryParser queryParser = indexQueryParser.queryParser(queryName);
         if (queryParser == null) {
-            throw new QueryParsingException(index, "No query registered for [" + queryName + "]");
+            throw new QueryParsingException(index, "No query registered for [" + queryName + "]", parser.getTokenLocation());
         }
         Query result = queryParser.parse(this);
         if (parser.currentToken() == XContentParser.Token.END_OBJECT || parser.currentToken() == XContentParser.Token.END_ARRAY) {
@@ -335,7 +340,7 @@ public class QueryParseContext {
         if (parser.currentToken() != XContentParser.Token.START_OBJECT) {
             token = parser.nextToken();
             if (token != XContentParser.Token.START_OBJECT) {
-                throw new QueryParsingException(index, "[_na] filter malformed, must start with start_object");
+                throw new QueryParsingException(index, "[_na] filter malformed, must start with start_object", parser.getTokenLocation());
             }
         }
         token = parser.nextToken();
@@ -344,18 +349,18 @@ public class QueryParseContext {
             if (token == XContentParser.Token.END_OBJECT || token == XContentParser.Token.VALUE_NULL) {
                 return null;
             }
-            throw new QueryParsingException(index, "[_na] filter malformed, no field after start_object");
+            throw new QueryParsingException(index, "[_na] filter malformed, no field after start_object", parser.getTokenLocation());
         }
         String filterName = parser.currentName();
         // move to the next START_OBJECT or START_ARRAY
         token = parser.nextToken();
         if (token != XContentParser.Token.START_OBJECT && token != XContentParser.Token.START_ARRAY) {
-            throw new QueryParsingException(index, "[_na] filter malformed, no field after start_object");
+            throw new QueryParsingException(index, "[_na] filter malformed, no field after start_object", parser.getTokenLocation());
         }
 
         FilterParser filterParser = indexQueryParser.filterParser(filterName);
         if (filterParser == null) {
-            throw new QueryParsingException(index, "No filter registered for [" + filterName + "]");
+            throw new QueryParsingException(index, "No filter registered for [" + filterName + "]", parser.getTokenLocation());
         }
         Filter result = executeFilterParser(filterParser);
         if (parser.currentToken() == XContentParser.Token.END_OBJECT || parser.currentToken() == XContentParser.Token.END_ARRAY) {
@@ -368,7 +373,7 @@ public class QueryParseContext {
     public Filter parseInnerFilter(String filterName) throws IOException, QueryParsingException {
         FilterParser filterParser = indexQueryParser.filterParser(filterName);
         if (filterParser == null) {
-            throw new QueryParsingException(index, "No filter registered for [" + filterName + "]");
+            throw new QueryParsingException(index, "No filter registered for [" + filterName + "]", parser.getTokenLocation());
         }
         return executeFilterParser(filterParser);
     }
@@ -432,7 +437,9 @@ public class QueryParseContext {
         } else {
             Version indexCreatedVersion = indexQueryParser.getIndexCreatedVersion();
             if (fieldMapping == null && indexCreatedVersion.onOrAfter(Version.V_1_4_0_Beta1)) {
-                throw new QueryParsingException(index, "Strict field resolution and no field mapping can be found for the field with name [" + name + "]");
+                throw new QueryParsingException(index,
+                        "Strict field resolution and no field mapping can be found for the field with name [" + name + "]",
+                        parser.getTokenLocation());
             } else {
                 return fieldMapping;
             }

--- a/src/main/java/org/elasticsearch/index/query/QueryParseContext.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryParseContext.java
@@ -297,23 +297,23 @@ public class QueryParseContext {
         if (parser.currentToken() != XContentParser.Token.START_OBJECT) {
             token = parser.nextToken();
             if (token != XContentParser.Token.START_OBJECT) {
-                throw new QueryParsingException(index, "[_na] query malformed, must start with start_object", parser.getTokenLocation());
+                throw new QueryParsingException(this, "[_na] query malformed, must start with start_object");
             }
         }
         token = parser.nextToken();
         if (token != XContentParser.Token.FIELD_NAME) {
-            throw new QueryParsingException(index, "[_na] query malformed, no field after start_object", parser.getTokenLocation());
+            throw new QueryParsingException(this, "[_na] query malformed, no field after start_object");
         }
         String queryName = parser.currentName();
         // move to the next START_OBJECT
         token = parser.nextToken();
         if (token != XContentParser.Token.START_OBJECT && token != XContentParser.Token.START_ARRAY) {
-            throw new QueryParsingException(index, "[_na] query malformed, no field after start_object", parser.getTokenLocation());
+            throw new QueryParsingException(this, "[_na] query malformed, no field after start_object");
         }
 
         QueryParser queryParser = indexQueryParser.queryParser(queryName);
         if (queryParser == null) {
-            throw new QueryParsingException(index, "No query registered for [" + queryName + "]", parser.getTokenLocation());
+            throw new QueryParsingException(this, "No query registered for [" + queryName + "]");
         }
         Query result = queryParser.parse(this);
         if (parser.currentToken() == XContentParser.Token.END_OBJECT || parser.currentToken() == XContentParser.Token.END_ARRAY) {
@@ -340,7 +340,7 @@ public class QueryParseContext {
         if (parser.currentToken() != XContentParser.Token.START_OBJECT) {
             token = parser.nextToken();
             if (token != XContentParser.Token.START_OBJECT) {
-                throw new QueryParsingException(index, "[_na] filter malformed, must start with start_object", parser.getTokenLocation());
+                throw new QueryParsingException(this, "[_na] filter malformed, must start with start_object");
             }
         }
         token = parser.nextToken();
@@ -349,18 +349,18 @@ public class QueryParseContext {
             if (token == XContentParser.Token.END_OBJECT || token == XContentParser.Token.VALUE_NULL) {
                 return null;
             }
-            throw new QueryParsingException(index, "[_na] filter malformed, no field after start_object", parser.getTokenLocation());
+            throw new QueryParsingException(this, "[_na] filter malformed, no field after start_object");
         }
         String filterName = parser.currentName();
         // move to the next START_OBJECT or START_ARRAY
         token = parser.nextToken();
         if (token != XContentParser.Token.START_OBJECT && token != XContentParser.Token.START_ARRAY) {
-            throw new QueryParsingException(index, "[_na] filter malformed, no field after start_object", parser.getTokenLocation());
+            throw new QueryParsingException(this, "[_na] filter malformed, no field after start_object");
         }
 
         FilterParser filterParser = indexQueryParser.filterParser(filterName);
         if (filterParser == null) {
-            throw new QueryParsingException(index, "No filter registered for [" + filterName + "]", parser.getTokenLocation());
+            throw new QueryParsingException(this, "No filter registered for [" + filterName + "]");
         }
         Filter result = executeFilterParser(filterParser);
         if (parser.currentToken() == XContentParser.Token.END_OBJECT || parser.currentToken() == XContentParser.Token.END_ARRAY) {
@@ -373,7 +373,7 @@ public class QueryParseContext {
     public Filter parseInnerFilter(String filterName) throws IOException, QueryParsingException {
         FilterParser filterParser = indexQueryParser.filterParser(filterName);
         if (filterParser == null) {
-            throw new QueryParsingException(index, "No filter registered for [" + filterName + "]", parser.getTokenLocation());
+            throw new QueryParsingException(this, "No filter registered for [" + filterName + "]");
         }
         return executeFilterParser(filterParser);
     }
@@ -437,9 +437,8 @@ public class QueryParseContext {
         } else {
             Version indexCreatedVersion = indexQueryParser.getIndexCreatedVersion();
             if (fieldMapping == null && indexCreatedVersion.onOrAfter(Version.V_1_4_0_Beta1)) {
-                throw new QueryParsingException(index,
-                        "Strict field resolution and no field mapping can be found for the field with name [" + name + "]",
-                        parser.getTokenLocation());
+                throw new QueryParsingException(this, "Strict field resolution and no field mapping can be found for the field with name ["
+                        + name + "]");
             } else {
                 return fieldMapping;
             }

--- a/src/main/java/org/elasticsearch/index/query/QueryParserUtils.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryParserUtils.java
@@ -41,8 +41,7 @@ public final class QueryParserUtils {
         }
 
         if (TransportShardDeleteByQueryAction.DELETE_BY_QUERY_API.equals(context.source())) {
-            throw new QueryParsingException(parseContext.index(), "[" + name + "] query and filter unsupported in delete_by_query api",
-                    null);
+            throw new QueryParsingException(parseContext, "[" + name + "] query and filter unsupported in delete_by_query api");
         }
     }
 

--- a/src/main/java/org/elasticsearch/index/query/QueryParserUtils.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryParserUtils.java
@@ -41,7 +41,8 @@ public final class QueryParserUtils {
         }
 
         if (TransportShardDeleteByQueryAction.DELETE_BY_QUERY_API.equals(context.source())) {
-            throw new QueryParsingException(parseContext.index(), "[" + name + "] query and filter unsupported in delete_by_query api");
+            throw new QueryParsingException(parseContext.index(), "[" + name + "] query and filter unsupported in delete_by_query api",
+                    null);
         }
     }
 

--- a/src/main/java/org/elasticsearch/index/query/QueryParsingException.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryParsingException.java
@@ -34,8 +34,8 @@ import java.io.IOException;
 public class QueryParsingException extends IndexException {
 
     public static final int UNKNOWN_POSITION = -1;
-    int lineNumber = UNKNOWN_POSITION;
-    int columnNumber = UNKNOWN_POSITION;
+    private int lineNumber = UNKNOWN_POSITION;
+    private int columnNumber = UNKNOWN_POSITION;
 
     public QueryParsingException(Index index, String msg, @Nullable XContentLocation location) {
         this(index, msg, location, null);

--- a/src/main/java/org/elasticsearch/index/query/QueryParsingException.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryParsingException.java
@@ -19,26 +19,51 @@
 
 package org.elasticsearch.index.query;
 
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentLocation;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexException;
 import org.elasticsearch.rest.RestStatus;
+
+import java.io.IOException;
 
 /**
  *
  */
 public class QueryParsingException extends IndexException {
 
+    XContentLocation location;
+
     public QueryParsingException(Index index, String msg) {
-        super(index, msg);
+        this(index, msg, null, null);
+    }
+
+    public QueryParsingException(Index index, String msg, @Nullable XContentLocation location) {
+        this(index, msg, location, null);
     }
 
     public QueryParsingException(Index index, String msg, Throwable cause) {
+        this(index, msg, null, cause);
+    }
+
+    public QueryParsingException(Index index, String msg, @Nullable XContentLocation location, Throwable cause) {
         super(index, msg, cause);
+        this.location = location;
     }
 
     @Override
     public RestStatus status() {
         return RestStatus.BAD_REQUEST;
+    }
+
+    @Override
+    protected void innerToXContent(XContentBuilder builder, Params params) throws IOException {
+        if (location != null) {
+            builder.field("line", location.getLineNumber());
+            builder.field("col", location.getColumnNumber());
+        }
+        super.innerToXContent(builder, params);
     }
 
 }

--- a/src/main/java/org/elasticsearch/index/query/QueryParsingException.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryParsingException.java
@@ -44,8 +44,8 @@ public class QueryParsingException extends IndexException {
     public QueryParsingException(Index index, String msg, @Nullable XContentLocation location, Throwable cause) {
         super(index, msg, cause);
         if (location != null) {
-            lineNumber = location.getLineNumber();
-            columnNumber = location.getColumnNumber();
+            lineNumber = location.lineNumber;
+            columnNumber = location.columnNumber;
         }
     }
 

--- a/src/main/java/org/elasticsearch/index/query/QueryParsingException.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryParsingException.java
@@ -33,7 +33,7 @@ import java.io.IOException;
  */
 public class QueryParsingException extends IndexException {
 
-    public static final int UNKNOWN_POSITION = -1;
+    static final int UNKNOWN_POSITION = -1;
     private int lineNumber = UNKNOWN_POSITION;
     private int columnNumber = UNKNOWN_POSITION;
 
@@ -58,7 +58,7 @@ public class QueryParsingException extends IndexException {
      * This constructor is provided for use in unit tests where a
      * {@link QueryParseContext} may not be available
      */
-    protected QueryParsingException(Index index, int line, int col, String msg, Throwable cause) {
+    QueryParsingException(Index index, int line, int col, String msg, Throwable cause) {
         super(index, msg, cause);
         this.lineNumber = line;
         this.columnNumber = col;

--- a/src/main/java/org/elasticsearch/index/query/QueryParsingException.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryParsingException.java
@@ -33,23 +33,38 @@ import java.io.IOException;
  */
 public class QueryParsingException extends IndexException {
 
-    XContentLocation location;
-
-    public QueryParsingException(Index index, String msg) {
-        this(index, msg, null, null);
-    }
+    public static final int UNKNOWN_POSITION = -1;
+    int lineNumber = UNKNOWN_POSITION;
+    int columnNumber = UNKNOWN_POSITION;
 
     public QueryParsingException(Index index, String msg, @Nullable XContentLocation location) {
         this(index, msg, location, null);
     }
 
-    public QueryParsingException(Index index, String msg, Throwable cause) {
-        this(index, msg, null, cause);
-    }
-
     public QueryParsingException(Index index, String msg, @Nullable XContentLocation location, Throwable cause) {
         super(index, msg, cause);
-        this.location = location;
+        if (location != null) {
+            lineNumber = location.getLineNumber();
+            columnNumber = location.getColumnNumber();
+        }
+    }
+
+    /**
+     * Line number of the location of the error
+     * 
+     * @return the line number or -1 if unknown
+     */
+    public int getLineNumber() {
+        return lineNumber;
+    }
+
+    /**
+     * Column number of the location of the error
+     * 
+     * @return the column number or -1 if unknown
+     */
+    public int getColumnNumber() {
+        return columnNumber;
     }
 
     @Override
@@ -59,9 +74,9 @@ public class QueryParsingException extends IndexException {
 
     @Override
     protected void innerToXContent(XContentBuilder builder, Params params) throws IOException {
-        if (location != null) {
-            builder.field("line", location.getLineNumber());
-            builder.field("col", location.getColumnNumber());
+        if (lineNumber != UNKNOWN_POSITION) {
+            builder.field("line", lineNumber);
+            builder.field("col", columnNumber);
         }
         super.innerToXContent(builder, params);
     }

--- a/src/main/java/org/elasticsearch/index/query/QueryStringQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryStringQueryParser.java
@@ -126,8 +126,8 @@ public class QueryStringQueryParser implements QueryParser {
                         }
                     }
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[query_string] query does not support [" + currentFieldName
-                            + "]", parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[query_string] query does not support [" + currentFieldName
+                            + "]");
                 }
             } else if (token.isValue()) {
                 if ("query".equals(currentFieldName)) {
@@ -141,21 +141,19 @@ public class QueryStringQueryParser implements QueryParser {
                     } else if ("and".equalsIgnoreCase(op)) {
                         qpSettings.defaultOperator(org.apache.lucene.queryparser.classic.QueryParser.Operator.AND);
                     } else {
-                        throw new QueryParsingException(parseContext.index(), "Query default operator [" + op + "] is not allowed",
-                                parser.getTokenLocation());
+                        throw new QueryParsingException(parseContext, "Query default operator [" + op + "] is not allowed");
                     }
                 } else if ("analyzer".equals(currentFieldName)) {
                     NamedAnalyzer analyzer = parseContext.analysisService().analyzer(parser.text());
                     if (analyzer == null) {
-                        throw new QueryParsingException(parseContext.index(), "[query_string] analyzer [" + parser.text() + "] not found",
-                                parser.getTokenLocation());
+                        throw new QueryParsingException(parseContext, "[query_string] analyzer [" + parser.text() + "] not found");
                     }
                     qpSettings.forcedAnalyzer(analyzer);
                 } else if ("quote_analyzer".equals(currentFieldName) || "quoteAnalyzer".equals(currentFieldName)) {
                     NamedAnalyzer analyzer = parseContext.analysisService().analyzer(parser.text());
                     if (analyzer == null) {
-                        throw new QueryParsingException(parseContext.index(), "[query_string] quote_analyzer [" + parser.text()
-                                + "] not found", parser.getTokenLocation());
+                        throw new QueryParsingException(parseContext, "[query_string] quote_analyzer [" + parser.text()
+                                + "] not found");
                     }
                     qpSettings.forcedQuoteAnalyzer(analyzer);
                 } else if ("allow_leading_wildcard".equals(currentFieldName) || "allowLeadingWildcard".equals(currentFieldName)) {
@@ -203,19 +201,19 @@ public class QueryStringQueryParser implements QueryParser {
                     try {
                         qpSettings.timeZone(DateTimeZone.forID(parser.text()));
                     } catch (IllegalArgumentException e) {
-                        throw new QueryParsingException(parseContext.index(),
-                                "[query_string] time_zone [" + parser.text() + "] is unknown", parser.getTokenLocation());
+                        throw new QueryParsingException(parseContext,
+                                "[query_string] time_zone [" + parser.text() + "] is unknown");
                     }
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[query_string] query does not support [" + currentFieldName
-                            + "]", parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[query_string] query does not support [" + currentFieldName
+ + "]");
                 }
             }
         }
         if (qpSettings.queryString() == null) {
-            throw new QueryParsingException(parseContext.index(), "query_string must be provided with a [query]", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "query_string must be provided with a [query]");
         }
         qpSettings.defaultAnalyzer(parseContext.mapperService().searchAnalyzer());
         qpSettings.defaultQuoteAnalyzer(parseContext.mapperService().searchQuoteAnalyzer());
@@ -253,8 +251,7 @@ public class QueryStringQueryParser implements QueryParser {
             }
             return query;
         } catch (org.apache.lucene.queryparser.classic.ParseException e) {
-            throw new QueryParsingException(parseContext.index(), "Failed to parse query [" + qpSettings.queryString() + "]",
-                    parser.getTokenLocation(), e);
+            throw new QueryParsingException(parseContext, "Failed to parse query [" + qpSettings.queryString() + "]", e);
         }
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/QueryStringQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryStringQueryParser.java
@@ -126,7 +126,8 @@ public class QueryStringQueryParser implements QueryParser {
                         }
                     }
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[query_string] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[query_string] query does not support [" + currentFieldName
+                            + "]", parser.getTokenLocation());
                 }
             } else if (token.isValue()) {
                 if ("query".equals(currentFieldName)) {
@@ -140,18 +141,21 @@ public class QueryStringQueryParser implements QueryParser {
                     } else if ("and".equalsIgnoreCase(op)) {
                         qpSettings.defaultOperator(org.apache.lucene.queryparser.classic.QueryParser.Operator.AND);
                     } else {
-                        throw new QueryParsingException(parseContext.index(), "Query default operator [" + op + "] is not allowed");
+                        throw new QueryParsingException(parseContext.index(), "Query default operator [" + op + "] is not allowed",
+                                parser.getTokenLocation());
                     }
                 } else if ("analyzer".equals(currentFieldName)) {
                     NamedAnalyzer analyzer = parseContext.analysisService().analyzer(parser.text());
                     if (analyzer == null) {
-                        throw new QueryParsingException(parseContext.index(), "[query_string] analyzer [" + parser.text() + "] not found");
+                        throw new QueryParsingException(parseContext.index(), "[query_string] analyzer [" + parser.text() + "] not found",
+                                parser.getTokenLocation());
                     }
                     qpSettings.forcedAnalyzer(analyzer);
                 } else if ("quote_analyzer".equals(currentFieldName) || "quoteAnalyzer".equals(currentFieldName)) {
                     NamedAnalyzer analyzer = parseContext.analysisService().analyzer(parser.text());
                     if (analyzer == null) {
-                        throw new QueryParsingException(parseContext.index(), "[query_string] quote_analyzer [" + parser.text() + "] not found");
+                        throw new QueryParsingException(parseContext.index(), "[query_string] quote_analyzer [" + parser.text()
+                                + "] not found", parser.getTokenLocation());
                     }
                     qpSettings.forcedQuoteAnalyzer(analyzer);
                 } else if ("allow_leading_wildcard".equals(currentFieldName) || "allowLeadingWildcard".equals(currentFieldName)) {
@@ -199,17 +203,19 @@ public class QueryStringQueryParser implements QueryParser {
                     try {
                         qpSettings.timeZone(DateTimeZone.forID(parser.text()));
                     } catch (IllegalArgumentException e) {
-                        throw new QueryParsingException(parseContext.index(), "[query_string] time_zone [" + parser.text() + "] is unknown");
+                        throw new QueryParsingException(parseContext.index(),
+                                "[query_string] time_zone [" + parser.text() + "] is unknown", parser.getTokenLocation());
                     }
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[query_string] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[query_string] query does not support [" + currentFieldName
+                            + "]", parser.getTokenLocation());
                 }
             }
         }
         if (qpSettings.queryString() == null) {
-            throw new QueryParsingException(parseContext.index(), "query_string must be provided with a [query]");
+            throw new QueryParsingException(parseContext.index(), "query_string must be provided with a [query]", parser.getTokenLocation());
         }
         qpSettings.defaultAnalyzer(parseContext.mapperService().searchAnalyzer());
         qpSettings.defaultQuoteAnalyzer(parseContext.mapperService().searchQuoteAnalyzer());
@@ -247,7 +253,8 @@ public class QueryStringQueryParser implements QueryParser {
             }
             return query;
         } catch (org.apache.lucene.queryparser.classic.ParseException e) {
-            throw new QueryParsingException(parseContext.index(), "Failed to parse query [" + qpSettings.queryString() + "]", e);
+            throw new QueryParsingException(parseContext.index(), "Failed to parse query [" + qpSettings.queryString() + "]",
+                    parser.getTokenLocation(), e);
         }
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/RangeFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/RangeFilterParser.java
@@ -105,8 +105,7 @@ public class RangeFilterParser implements FilterParser {
                         } else if ("format".equals(currentFieldName)) {
                             forcedDateParser = new DateMathParser(Joda.forPattern(parser.text()), DateFieldMapper.Defaults.TIME_UNIT);
                         } else {
-                            throw new QueryParsingException(parseContext.index(), "[range] filter does not support [" + currentFieldName
-                                    + "]", parser.getTokenLocation());
+                            throw new QueryParsingException(parseContext, "[range] filter does not support [" + currentFieldName + "]");
                         }
                     }
                 }
@@ -120,15 +119,13 @@ public class RangeFilterParser implements FilterParser {
                 } else if ("execution".equals(currentFieldName)) {
                     execution = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[range] filter does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[range] filter does not support [" + currentFieldName + "]");
                 }
             }
         }
 
         if (fieldName == null) {
-            throw new QueryParsingException(parseContext.index(), "[range] filter no field specified for range filter",
-                    parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "[range] filter no field specified for range filter");
         }
 
         Filter filter = null;
@@ -139,41 +136,39 @@ public class RangeFilterParser implements FilterParser {
                     FieldMapper mapper = smartNameFieldMappers.mapper();
                     if (mapper instanceof DateFieldMapper) {
                         if ((from instanceof Number || to instanceof Number) && timeZone != null) {
-                            throw new QueryParsingException(parseContext.index(),
+                            throw new QueryParsingException(parseContext,
                                     "[range] time_zone when using ms since epoch format as it's UTC based can not be applied to ["
-                                            + fieldName + "]", parser.getTokenLocation());
+                                            + fieldName + "]");
                         }
                         filter = ((DateFieldMapper) mapper).rangeFilter(from, to, includeLower, includeUpper, timeZone, forcedDateParser, parseContext);
                     } else  {
                         if (timeZone != null) {
-                            throw new QueryParsingException(parseContext.index(),
-                                    "[range] time_zone can not be applied to non date field [" + fieldName + "]", parser.getTokenLocation());
+                            throw new QueryParsingException(parseContext, "[range] time_zone can not be applied to non date field ["
+                                    + fieldName + "]");
                         }
                         filter = mapper.rangeFilter(from, to, includeLower, includeUpper, parseContext);
                     }
                 } else if ("fielddata".equals(execution)) {
                     FieldMapper mapper = smartNameFieldMappers.mapper();
                     if (!(mapper instanceof NumberFieldMapper)) {
-                        throw new QueryParsingException(parseContext.index(), "[range] filter field [" + fieldName
-                                + "] is not a numeric type", parser.getTokenLocation());
+                        throw new QueryParsingException(parseContext, "[range] filter field [" + fieldName + "] is not a numeric type");
                     }
                     if (mapper instanceof DateFieldMapper) {
                         if ((from instanceof Number || to instanceof Number) && timeZone != null) {
-                            throw new QueryParsingException(parseContext.index(),
+                            throw new QueryParsingException(parseContext,
                                     "[range] time_zone when using ms since epoch format as it's UTC based can not be applied to ["
-                                            + fieldName + "]", parser.getTokenLocation());
+                                            + fieldName + "]");
                         }
                         filter = ((DateFieldMapper) mapper).rangeFilter(parseContext, from, to, includeLower, includeUpper, timeZone, forcedDateParser, parseContext);
                     } else {
                         if (timeZone != null) {
-                            throw new QueryParsingException(parseContext.index(),
-                                    "[range] time_zone can not be applied to non date field [" + fieldName + "]", parser.getTokenLocation());
+                            throw new QueryParsingException(parseContext, "[range] time_zone can not be applied to non date field ["
+                                    + fieldName + "]");
                         }
                         filter = ((NumberFieldMapper) mapper).rangeFilter(parseContext, from, to, includeLower, includeUpper, parseContext);
                     }
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[range] filter doesn't support [" + execution + "] execution",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[range] filter doesn't support [" + execution + "] execution");
                 }
             }
         }

--- a/src/main/java/org/elasticsearch/index/query/RangeFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/RangeFilterParser.java
@@ -105,7 +105,8 @@ public class RangeFilterParser implements FilterParser {
                         } else if ("format".equals(currentFieldName)) {
                             forcedDateParser = new DateMathParser(Joda.forPattern(parser.text()), DateFieldMapper.Defaults.TIME_UNIT);
                         } else {
-                            throw new QueryParsingException(parseContext.index(), "[range] filter does not support [" + currentFieldName + "]");
+                            throw new QueryParsingException(parseContext.index(), "[range] filter does not support [" + currentFieldName
+                                    + "]", parser.getTokenLocation());
                         }
                     }
                 }
@@ -119,13 +120,15 @@ public class RangeFilterParser implements FilterParser {
                 } else if ("execution".equals(currentFieldName)) {
                     execution = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[range] filter does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[range] filter does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             }
         }
 
         if (fieldName == null) {
-            throw new QueryParsingException(parseContext.index(), "[range] filter no field specified for range filter");
+            throw new QueryParsingException(parseContext.index(), "[range] filter no field specified for range filter",
+                    parser.getTokenLocation());
         }
 
         Filter filter = null;
@@ -136,33 +139,41 @@ public class RangeFilterParser implements FilterParser {
                     FieldMapper mapper = smartNameFieldMappers.mapper();
                     if (mapper instanceof DateFieldMapper) {
                         if ((from instanceof Number || to instanceof Number) && timeZone != null) {
-                            throw new QueryParsingException(parseContext.index(), "[range] time_zone when using ms since epoch format as it's UTC based can not be applied to [" + fieldName + "]");
+                            throw new QueryParsingException(parseContext.index(),
+                                    "[range] time_zone when using ms since epoch format as it's UTC based can not be applied to ["
+                                            + fieldName + "]", parser.getTokenLocation());
                         }
                         filter = ((DateFieldMapper) mapper).rangeFilter(from, to, includeLower, includeUpper, timeZone, forcedDateParser, parseContext);
                     } else  {
                         if (timeZone != null) {
-                            throw new QueryParsingException(parseContext.index(), "[range] time_zone can not be applied to non date field [" + fieldName + "]");
+                            throw new QueryParsingException(parseContext.index(),
+                                    "[range] time_zone can not be applied to non date field [" + fieldName + "]", parser.getTokenLocation());
                         }
                         filter = mapper.rangeFilter(from, to, includeLower, includeUpper, parseContext);
                     }
                 } else if ("fielddata".equals(execution)) {
                     FieldMapper mapper = smartNameFieldMappers.mapper();
                     if (!(mapper instanceof NumberFieldMapper)) {
-                        throw new QueryParsingException(parseContext.index(), "[range] filter field [" + fieldName + "] is not a numeric type");
+                        throw new QueryParsingException(parseContext.index(), "[range] filter field [" + fieldName
+                                + "] is not a numeric type", parser.getTokenLocation());
                     }
                     if (mapper instanceof DateFieldMapper) {
                         if ((from instanceof Number || to instanceof Number) && timeZone != null) {
-                            throw new QueryParsingException(parseContext.index(), "[range] time_zone when using ms since epoch format as it's UTC based can not be applied to [" + fieldName + "]");
+                            throw new QueryParsingException(parseContext.index(),
+                                    "[range] time_zone when using ms since epoch format as it's UTC based can not be applied to ["
+                                            + fieldName + "]", parser.getTokenLocation());
                         }
                         filter = ((DateFieldMapper) mapper).rangeFilter(parseContext, from, to, includeLower, includeUpper, timeZone, forcedDateParser, parseContext);
                     } else {
                         if (timeZone != null) {
-                            throw new QueryParsingException(parseContext.index(), "[range] time_zone can not be applied to non date field [" + fieldName + "]");
+                            throw new QueryParsingException(parseContext.index(),
+                                    "[range] time_zone can not be applied to non date field [" + fieldName + "]", parser.getTokenLocation());
                         }
                         filter = ((NumberFieldMapper) mapper).rangeFilter(parseContext, from, to, includeLower, includeUpper, parseContext);
                     }
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[range] filter doesn't support [" + execution + "] execution");
+                    throw new QueryParsingException(parseContext.index(), "[range] filter doesn't support [" + execution + "] execution",
+                            parser.getTokenLocation());
                 }
             }
         }

--- a/src/main/java/org/elasticsearch/index/query/RangeQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/RangeQueryParser.java
@@ -55,12 +55,14 @@ public class RangeQueryParser implements QueryParser {
 
         XContentParser.Token token = parser.nextToken();
         if (token != XContentParser.Token.FIELD_NAME) {
-            throw new QueryParsingException(parseContext.index(), "[range] query malformed, no field to indicate field name");
+            throw new QueryParsingException(parseContext.index(), "[range] query malformed, no field to indicate field name",
+                    parser.getTokenLocation());
         }
         String fieldName = parser.currentName();
         token = parser.nextToken();
         if (token != XContentParser.Token.START_OBJECT) {
-            throw new QueryParsingException(parseContext.index(), "[range] query malformed, after field missing start object");
+            throw new QueryParsingException(parseContext.index(), "[range] query malformed, after field missing start object",
+                    parser.getTokenLocation());
         }
 
         Object from = null;
@@ -106,7 +108,8 @@ public class RangeQueryParser implements QueryParser {
                 } else if ("format".equals(currentFieldName)) {
                     forcedDateParser = new DateMathParser(Joda.forPattern(parser.text()), DateFieldMapper.Defaults.TIME_UNIT);
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[range] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[range] query does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             }
         }
@@ -114,7 +117,8 @@ public class RangeQueryParser implements QueryParser {
         // move to the next end object, to close the field name
         token = parser.nextToken();
         if (token != XContentParser.Token.END_OBJECT) {
-            throw new QueryParsingException(parseContext.index(), "[range] query malformed, does not end with an object");
+            throw new QueryParsingException(parseContext.index(), "[range] query malformed, does not end with an object",
+                    parser.getTokenLocation());
         }
 
         Query query = null;
@@ -124,12 +128,15 @@ public class RangeQueryParser implements QueryParser {
                 FieldMapper mapper = smartNameFieldMappers.mapper();
                 if (mapper instanceof DateFieldMapper) {
                     if ((from instanceof Number || to instanceof Number) && timeZone != null) {
-                        throw new QueryParsingException(parseContext.index(), "[range] time_zone when using ms since epoch format as it's UTC based can not be applied to [" + fieldName + "]");
+                        throw new QueryParsingException(parseContext.index(),
+                                "[range] time_zone when using ms since epoch format as it's UTC based can not be applied to [" + fieldName
+                                        + "]", parser.getTokenLocation());
                     }
                     query = ((DateFieldMapper) mapper).rangeQuery(from, to, includeLower, includeUpper, timeZone, forcedDateParser, parseContext);
                 } else  {
                     if (timeZone != null) {
-                        throw new QueryParsingException(parseContext.index(), "[range] time_zone can not be applied to non date field [" + fieldName + "]");
+                        throw new QueryParsingException(parseContext.index(), "[range] time_zone can not be applied to non date field ["
+                                + fieldName + "]", parser.getTokenLocation());
                     }
                     //LUCENE 4 UPGRADE Mapper#rangeQuery should use bytesref as well?
                     query = mapper.rangeQuery(from, to, includeLower, includeUpper, parseContext);

--- a/src/main/java/org/elasticsearch/index/query/RangeQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/RangeQueryParser.java
@@ -55,14 +55,12 @@ public class RangeQueryParser implements QueryParser {
 
         XContentParser.Token token = parser.nextToken();
         if (token != XContentParser.Token.FIELD_NAME) {
-            throw new QueryParsingException(parseContext.index(), "[range] query malformed, no field to indicate field name",
-                    parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "[range] query malformed, no field to indicate field name");
         }
         String fieldName = parser.currentName();
         token = parser.nextToken();
         if (token != XContentParser.Token.START_OBJECT) {
-            throw new QueryParsingException(parseContext.index(), "[range] query malformed, after field missing start object",
-                    parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "[range] query malformed, after field missing start object");
         }
 
         Object from = null;
@@ -108,8 +106,7 @@ public class RangeQueryParser implements QueryParser {
                 } else if ("format".equals(currentFieldName)) {
                     forcedDateParser = new DateMathParser(Joda.forPattern(parser.text()), DateFieldMapper.Defaults.TIME_UNIT);
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[range] query does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[range] query does not support [" + currentFieldName + "]");
                 }
             }
         }
@@ -117,8 +114,7 @@ public class RangeQueryParser implements QueryParser {
         // move to the next end object, to close the field name
         token = parser.nextToken();
         if (token != XContentParser.Token.END_OBJECT) {
-            throw new QueryParsingException(parseContext.index(), "[range] query malformed, does not end with an object",
-                    parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "[range] query malformed, does not end with an object");
         }
 
         Query query = null;
@@ -128,15 +124,15 @@ public class RangeQueryParser implements QueryParser {
                 FieldMapper mapper = smartNameFieldMappers.mapper();
                 if (mapper instanceof DateFieldMapper) {
                     if ((from instanceof Number || to instanceof Number) && timeZone != null) {
-                        throw new QueryParsingException(parseContext.index(),
+                        throw new QueryParsingException(parseContext,
                                 "[range] time_zone when using ms since epoch format as it's UTC based can not be applied to [" + fieldName
-                                        + "]", parser.getTokenLocation());
+                                        + "]");
                     }
                     query = ((DateFieldMapper) mapper).rangeQuery(from, to, includeLower, includeUpper, timeZone, forcedDateParser, parseContext);
                 } else  {
                     if (timeZone != null) {
-                        throw new QueryParsingException(parseContext.index(), "[range] time_zone can not be applied to non date field ["
-                                + fieldName + "]", parser.getTokenLocation());
+                        throw new QueryParsingException(parseContext, "[range] time_zone can not be applied to non date field ["
+                                + fieldName + "]");
                     }
                     //LUCENE 4 UPGRADE Mapper#rangeQuery should use bytesref as well?
                     query = mapper.rangeQuery(from, to, includeLower, includeUpper, parseContext);

--- a/src/main/java/org/elasticsearch/index/query/RegexpFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/RegexpFilterParser.java
@@ -84,7 +84,8 @@ public class RegexpFilterParser implements FilterParser {
                         } else if ("flags_value".equals(currentFieldName)) {
                             flagsValue = parser.intValue();
                         } else {
-                            throw new QueryParsingException(parseContext.index(), "[regexp] filter does not support [" + currentFieldName + "]");
+                            throw new QueryParsingException(parseContext.index(), "[regexp] filter does not support [" + currentFieldName
+                                    + "]", parser.getTokenLocation());
                         }
                     }
                 }
@@ -108,7 +109,7 @@ public class RegexpFilterParser implements FilterParser {
         }
 
         if (value == null) {
-            throw new QueryParsingException(parseContext.index(), "No value specified for regexp filter");
+            throw new QueryParsingException(parseContext.index(), "No value specified for regexp filter", parser.getTokenLocation());
         }
 
         Filter filter = null;

--- a/src/main/java/org/elasticsearch/index/query/RegexpFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/RegexpFilterParser.java
@@ -84,8 +84,7 @@ public class RegexpFilterParser implements FilterParser {
                         } else if ("flags_value".equals(currentFieldName)) {
                             flagsValue = parser.intValue();
                         } else {
-                            throw new QueryParsingException(parseContext.index(), "[regexp] filter does not support [" + currentFieldName
-                                    + "]", parser.getTokenLocation());
+                            throw new QueryParsingException(parseContext, "[regexp] filter does not support [" + currentFieldName + "]");
                         }
                     }
                 }
@@ -109,7 +108,7 @@ public class RegexpFilterParser implements FilterParser {
         }
 
         if (value == null) {
-            throw new QueryParsingException(parseContext.index(), "No value specified for regexp filter", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "No value specified for regexp filter");
         }
 
         Filter filter = null;

--- a/src/main/java/org/elasticsearch/index/query/RegexpQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/RegexpQueryParser.java
@@ -55,7 +55,7 @@ public class RegexpQueryParser implements QueryParser {
 
         XContentParser.Token token = parser.nextToken();
         if (token != XContentParser.Token.FIELD_NAME) {
-            throw new QueryParsingException(parseContext.index(), "[regexp] query malformed, no field");
+            throw new QueryParsingException(parseContext.index(), "[regexp] query malformed, no field", parser.getTokenLocation());
         }
         String fieldName = parser.currentName();
         String rewriteMethod = null;
@@ -92,7 +92,8 @@ public class RegexpQueryParser implements QueryParser {
                         queryName = parser.text();
                     }
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[regexp] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[regexp] query does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             }
             parser.nextToken();
@@ -102,7 +103,7 @@ public class RegexpQueryParser implements QueryParser {
         }
 
         if (value == null) {
-            throw new QueryParsingException(parseContext.index(), "No value specified for regexp query");
+            throw new QueryParsingException(parseContext.index(), "No value specified for regexp query", parser.getTokenLocation());
         }
 
         MultiTermQuery.RewriteMethod method = QueryParsers.parseRewriteMethod(rewriteMethod, null);

--- a/src/main/java/org/elasticsearch/index/query/RegexpQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/RegexpQueryParser.java
@@ -55,7 +55,7 @@ public class RegexpQueryParser implements QueryParser {
 
         XContentParser.Token token = parser.nextToken();
         if (token != XContentParser.Token.FIELD_NAME) {
-            throw new QueryParsingException(parseContext.index(), "[regexp] query malformed, no field", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "[regexp] query malformed, no field");
         }
         String fieldName = parser.currentName();
         String rewriteMethod = null;
@@ -92,8 +92,7 @@ public class RegexpQueryParser implements QueryParser {
                         queryName = parser.text();
                     }
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[regexp] query does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[regexp] query does not support [" + currentFieldName + "]");
                 }
             }
             parser.nextToken();
@@ -103,7 +102,7 @@ public class RegexpQueryParser implements QueryParser {
         }
 
         if (value == null) {
-            throw new QueryParsingException(parseContext.index(), "No value specified for regexp query", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "No value specified for regexp query");
         }
 
         MultiTermQuery.RewriteMethod method = QueryParsers.parseRewriteMethod(rewriteMethod, null);

--- a/src/main/java/org/elasticsearch/index/query/ScriptFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/ScriptFilterParser.java
@@ -86,7 +86,8 @@ public class ScriptFilterParser implements FilterParser {
                 if ("params".equals(currentFieldName)) {
                     params = parser.map();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[script] filter does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[script] filter does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             } else if (token.isValue()) {
                 if ("_name".equals(currentFieldName)) {
@@ -96,7 +97,8 @@ public class ScriptFilterParser implements FilterParser {
                 } else if ("_cache_key".equals(currentFieldName) || "_cacheKey".equals(currentFieldName)) {
                     cacheKey = new HashedBytesRef(parser.text());
                 } else if (!scriptParameterParser.token(currentFieldName, token, parser)){
-                    throw new QueryParsingException(parseContext.index(), "[script] filter does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[script] filter does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             }
         }
@@ -109,7 +111,8 @@ public class ScriptFilterParser implements FilterParser {
         scriptLang = scriptParameterParser.lang();
 
         if (script == null) {
-            throw new QueryParsingException(parseContext.index(), "script must be provided with a [script] filter");
+            throw new QueryParsingException(parseContext.index(), "script must be provided with a [script] filter",
+                    parser.getTokenLocation());
         }
         if (params == null) {
             params = newHashMap();

--- a/src/main/java/org/elasticsearch/index/query/ScriptFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/ScriptFilterParser.java
@@ -86,8 +86,7 @@ public class ScriptFilterParser implements FilterParser {
                 if ("params".equals(currentFieldName)) {
                     params = parser.map();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[script] filter does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[script] filter does not support [" + currentFieldName + "]");
                 }
             } else if (token.isValue()) {
                 if ("_name".equals(currentFieldName)) {
@@ -97,8 +96,7 @@ public class ScriptFilterParser implements FilterParser {
                 } else if ("_cache_key".equals(currentFieldName) || "_cacheKey".equals(currentFieldName)) {
                     cacheKey = new HashedBytesRef(parser.text());
                 } else if (!scriptParameterParser.token(currentFieldName, token, parser)){
-                    throw new QueryParsingException(parseContext.index(), "[script] filter does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[script] filter does not support [" + currentFieldName + "]");
                 }
             }
         }
@@ -111,8 +109,7 @@ public class ScriptFilterParser implements FilterParser {
         scriptLang = scriptParameterParser.lang();
 
         if (script == null) {
-            throw new QueryParsingException(parseContext.index(), "script must be provided with a [script] filter",
-                    parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "script must be provided with a [script] filter");
         }
         if (params == null) {
             params = newHashMap();

--- a/src/main/java/org/elasticsearch/index/query/SimpleQueryStringParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SimpleQueryStringParser.java
@@ -140,7 +140,8 @@ public class SimpleQueryStringParser implements QueryParser {
                     }
                 } else {
                     throw new QueryParsingException(parseContext.index(),
-                            "[" + NAME + "] query does not support [" + currentFieldName + "]");
+ "[" + NAME + "] query does not support [" + currentFieldName
+                            + "]", parser.getTokenLocation());
                 }
             } else if (token.isValue()) {
                 if ("query".equals(currentFieldName)) {
@@ -148,7 +149,8 @@ public class SimpleQueryStringParser implements QueryParser {
                 } else if ("analyzer".equals(currentFieldName)) {
                     analyzer = parseContext.analysisService().analyzer(parser.text());
                     if (analyzer == null) {
-                        throw new QueryParsingException(parseContext.index(), "[" + NAME + "] analyzer [" + parser.text() + "] not found");
+                        throw new QueryParsingException(parseContext.index(), "[" + NAME + "] analyzer [" + parser.text() + "] not found",
+                                parser.getTokenLocation());
                     }
                 } else if ("field".equals(currentFieldName)) {
                     field = parser.text();
@@ -160,7 +162,7 @@ public class SimpleQueryStringParser implements QueryParser {
                         defaultOperator = BooleanClause.Occur.MUST;
                     } else {
                         throw new QueryParsingException(parseContext.index(),
-                                "[" + NAME + "] default operator [" + op + "] is not allowed");
+                                "[" + NAME + "] default operator [" + op + "] is not allowed", parser.getTokenLocation());
                     }
                 } else if ("flags".equals(currentFieldName)) {
                     if (parser.currentToken() != XContentParser.Token.VALUE_NUMBER) {
@@ -188,14 +190,15 @@ public class SimpleQueryStringParser implements QueryParser {
                 } else if ("minimum_should_match".equals(currentFieldName)) {
                     minimumShouldMatch = parser.textOrNull();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[" + NAME + "] unsupported field [" + parser.currentName() + "]");
+                    throw new QueryParsingException(parseContext.index(),
+                            "[" + NAME + "] unsupported field [" + parser.currentName() + "]", parser.getTokenLocation());
                 }
             }
         }
 
         // Query text is required
         if (queryBody == null) {
-            throw new QueryParsingException(parseContext.index(), "[" + NAME + "] query text missing");
+            throw new QueryParsingException(parseContext.index(), "[" + NAME + "] query text missing", parser.getTokenLocation());
         }
 
         // Support specifying only a field instead of a map

--- a/src/main/java/org/elasticsearch/index/query/SimpleQueryStringParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SimpleQueryStringParser.java
@@ -139,9 +139,9 @@ public class SimpleQueryStringParser implements QueryParser {
                         }
                     }
                 } else {
-                    throw new QueryParsingException(parseContext.index(),
+                    throw new QueryParsingException(parseContext,
  "[" + NAME + "] query does not support [" + currentFieldName
-                            + "]", parser.getTokenLocation());
+ + "]");
                 }
             } else if (token.isValue()) {
                 if ("query".equals(currentFieldName)) {
@@ -149,8 +149,7 @@ public class SimpleQueryStringParser implements QueryParser {
                 } else if ("analyzer".equals(currentFieldName)) {
                     analyzer = parseContext.analysisService().analyzer(parser.text());
                     if (analyzer == null) {
-                        throw new QueryParsingException(parseContext.index(), "[" + NAME + "] analyzer [" + parser.text() + "] not found",
-                                parser.getTokenLocation());
+                        throw new QueryParsingException(parseContext, "[" + NAME + "] analyzer [" + parser.text() + "] not found");
                     }
                 } else if ("field".equals(currentFieldName)) {
                     field = parser.text();
@@ -161,8 +160,7 @@ public class SimpleQueryStringParser implements QueryParser {
                     } else if ("and".equalsIgnoreCase(op)) {
                         defaultOperator = BooleanClause.Occur.MUST;
                     } else {
-                        throw new QueryParsingException(parseContext.index(),
-                                "[" + NAME + "] default operator [" + op + "] is not allowed", parser.getTokenLocation());
+                        throw new QueryParsingException(parseContext, "[" + NAME + "] default operator [" + op + "] is not allowed");
                     }
                 } else if ("flags".equals(currentFieldName)) {
                     if (parser.currentToken() != XContentParser.Token.VALUE_NUMBER) {
@@ -190,15 +188,14 @@ public class SimpleQueryStringParser implements QueryParser {
                 } else if ("minimum_should_match".equals(currentFieldName)) {
                     minimumShouldMatch = parser.textOrNull();
                 } else {
-                    throw new QueryParsingException(parseContext.index(),
-                            "[" + NAME + "] unsupported field [" + parser.currentName() + "]", parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[" + NAME + "] unsupported field [" + parser.currentName() + "]");
                 }
             }
         }
 
         // Query text is required
         if (queryBody == null) {
-            throw new QueryParsingException(parseContext.index(), "[" + NAME + "] query text missing", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "[" + NAME + "] query text missing");
         }
 
         // Support specifying only a field instead of a map

--- a/src/main/java/org/elasticsearch/index/query/SpanFirstQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanFirstQueryParser.java
@@ -63,11 +63,13 @@ public class SpanFirstQueryParser implements QueryParser {
                 if ("match".equals(currentFieldName)) {
                     Query query = parseContext.parseInnerQuery();
                     if (!(query instanceof SpanQuery)) {
-                        throw new QueryParsingException(parseContext.index(), "spanFirst [match] must be of type span query");
+                        throw new QueryParsingException(parseContext.index(), "spanFirst [match] must be of type span query",
+                                parser.getTokenLocation());
                     }
                     match = (SpanQuery) query;
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[span_first] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[span_first] query does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             } else {
                 if ("boost".equals(currentFieldName)) {
@@ -77,15 +79,17 @@ public class SpanFirstQueryParser implements QueryParser {
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[span_first] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[span_first] query does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             }
         }
         if (match == null) {
-            throw new QueryParsingException(parseContext.index(), "spanFirst must have [match] span query clause");
+            throw new QueryParsingException(parseContext.index(), "spanFirst must have [match] span query clause",
+                    parser.getTokenLocation());
         }
         if (end == -1) {
-            throw new QueryParsingException(parseContext.index(), "spanFirst must have [end] set for it");
+            throw new QueryParsingException(parseContext.index(), "spanFirst must have [end] set for it", parser.getTokenLocation());
         }
 
         SpanFirstQuery query = new SpanFirstQuery(match, end);

--- a/src/main/java/org/elasticsearch/index/query/SpanFirstQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanFirstQueryParser.java
@@ -63,13 +63,11 @@ public class SpanFirstQueryParser implements QueryParser {
                 if ("match".equals(currentFieldName)) {
                     Query query = parseContext.parseInnerQuery();
                     if (!(query instanceof SpanQuery)) {
-                        throw new QueryParsingException(parseContext.index(), "spanFirst [match] must be of type span query",
-                                parser.getTokenLocation());
+                        throw new QueryParsingException(parseContext, "spanFirst [match] must be of type span query");
                     }
                     match = (SpanQuery) query;
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[span_first] query does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[span_first] query does not support [" + currentFieldName + "]");
                 }
             } else {
                 if ("boost".equals(currentFieldName)) {
@@ -79,17 +77,15 @@ public class SpanFirstQueryParser implements QueryParser {
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[span_first] query does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[span_first] query does not support [" + currentFieldName + "]");
                 }
             }
         }
         if (match == null) {
-            throw new QueryParsingException(parseContext.index(), "spanFirst must have [match] span query clause",
-                    parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "spanFirst must have [match] span query clause");
         }
         if (end == -1) {
-            throw new QueryParsingException(parseContext.index(), "spanFirst must have [end] set for it", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "spanFirst must have [end] set for it");
         }
 
         SpanFirstQuery query = new SpanFirstQuery(match, end);

--- a/src/main/java/org/elasticsearch/index/query/SpanMultiTermQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanMultiTermQueryParser.java
@@ -51,18 +51,17 @@ public class SpanMultiTermQueryParser implements QueryParser {
 
         Token token = parser.nextToken();
         if (!MATCH_NAME.equals(parser.currentName()) || token != XContentParser.Token.FIELD_NAME) {
-            throw new QueryParsingException(parseContext.index(), "spanMultiTerm must have [" + MATCH_NAME + "] multi term query clause", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "spanMultiTerm must have [" + MATCH_NAME + "] multi term query clause");
         }
 
         token = parser.nextToken();
         if (token != XContentParser.Token.START_OBJECT) {
-            throw new QueryParsingException(parseContext.index(), "spanMultiTerm must have [" + MATCH_NAME + "] multi term query clause",
-                    parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "spanMultiTerm must have [" + MATCH_NAME + "] multi term query clause");
         }
 
         Query subQuery = parseContext.parseInnerQuery();
         if (!(subQuery instanceof MultiTermQuery)) {
-            throw new QueryParsingException(parseContext.index(), "spanMultiTerm [" + MATCH_NAME + "] must be of type multi term query", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "spanMultiTerm [" + MATCH_NAME + "] must be of type multi term query");
         }
 
         parser.nextToken();

--- a/src/main/java/org/elasticsearch/index/query/SpanMultiTermQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanMultiTermQueryParser.java
@@ -51,17 +51,18 @@ public class SpanMultiTermQueryParser implements QueryParser {
 
         Token token = parser.nextToken();
         if (!MATCH_NAME.equals(parser.currentName()) || token != XContentParser.Token.FIELD_NAME) {
-            throw new QueryParsingException(parseContext.index(), "spanMultiTerm must have [" + MATCH_NAME + "] multi term query clause");
+            throw new QueryParsingException(parseContext.index(), "spanMultiTerm must have [" + MATCH_NAME + "] multi term query clause", parser.getTokenLocation());
         }
 
         token = parser.nextToken();
         if (token != XContentParser.Token.START_OBJECT) {
-            throw new QueryParsingException(parseContext.index(), "spanMultiTerm must have [" + MATCH_NAME + "] multi term query clause");
+            throw new QueryParsingException(parseContext.index(), "spanMultiTerm must have [" + MATCH_NAME + "] multi term query clause",
+                    parser.getTokenLocation());
         }
 
         Query subQuery = parseContext.parseInnerQuery();
         if (!(subQuery instanceof MultiTermQuery)) {
-            throw new QueryParsingException(parseContext.index(), "spanMultiTerm [" + MATCH_NAME + "] must be of type multi term query");
+            throw new QueryParsingException(parseContext.index(), "spanMultiTerm [" + MATCH_NAME + "] must be of type multi term query", parser.getTokenLocation());
         }
 
         parser.nextToken();

--- a/src/main/java/org/elasticsearch/index/query/SpanNearQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanNearQueryParser.java
@@ -69,14 +69,12 @@ public class SpanNearQueryParser implements QueryParser {
                     while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                         Query query = parseContext.parseInnerQuery();
                         if (!(query instanceof SpanQuery)) {
-                            throw new QueryParsingException(parseContext.index(), "spanNear [clauses] must be of type span query",
-                                    parser.getTokenLocation());
+                            throw new QueryParsingException(parseContext, "spanNear [clauses] must be of type span query");
                         }
                         clauses.add((SpanQuery) query);
                     }
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[span_near] query does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[span_near] query does not support [" + currentFieldName + "]");
                 }
             } else if (token.isValue()) {
                 if ("in_order".equals(currentFieldName) || "inOrder".equals(currentFieldName)) {
@@ -90,19 +88,17 @@ public class SpanNearQueryParser implements QueryParser {
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[span_near] query does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[span_near] query does not support [" + currentFieldName + "]");
                 }
             } else {
-                throw new QueryParsingException(parseContext.index(), "[span_near] query does not support [" + currentFieldName + "]",
-                        parser.getTokenLocation());
+                throw new QueryParsingException(parseContext, "[span_near] query does not support [" + currentFieldName + "]");
             }
         }
         if (clauses.isEmpty()) {
-            throw new QueryParsingException(parseContext.index(), "span_near must include [clauses]", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "span_near must include [clauses]");
         }
         if (slop == null) {
-            throw new QueryParsingException(parseContext.index(), "span_near must include [slop]", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "span_near must include [slop]");
         }
 
         SpanNearQuery query = new SpanNearQuery(clauses.toArray(new SpanQuery[clauses.size()]), slop.intValue(), inOrder, collectPayloads);

--- a/src/main/java/org/elasticsearch/index/query/SpanNearQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanNearQueryParser.java
@@ -69,12 +69,14 @@ public class SpanNearQueryParser implements QueryParser {
                     while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                         Query query = parseContext.parseInnerQuery();
                         if (!(query instanceof SpanQuery)) {
-                            throw new QueryParsingException(parseContext.index(), "spanNear [clauses] must be of type span query");
+                            throw new QueryParsingException(parseContext.index(), "spanNear [clauses] must be of type span query",
+                                    parser.getTokenLocation());
                         }
                         clauses.add((SpanQuery) query);
                     }
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[span_near] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[span_near] query does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             } else if (token.isValue()) {
                 if ("in_order".equals(currentFieldName) || "inOrder".equals(currentFieldName)) {
@@ -88,17 +90,19 @@ public class SpanNearQueryParser implements QueryParser {
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[span_near] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[span_near] query does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             } else {
-                throw new QueryParsingException(parseContext.index(), "[span_near] query does not support [" + currentFieldName + "]");
+                throw new QueryParsingException(parseContext.index(), "[span_near] query does not support [" + currentFieldName + "]",
+                        parser.getTokenLocation());
             }
         }
         if (clauses.isEmpty()) {
-            throw new QueryParsingException(parseContext.index(), "span_near must include [clauses]");
+            throw new QueryParsingException(parseContext.index(), "span_near must include [clauses]", parser.getTokenLocation());
         }
         if (slop == null) {
-            throw new QueryParsingException(parseContext.index(), "span_near must include [slop]");
+            throw new QueryParsingException(parseContext.index(), "span_near must include [slop]", parser.getTokenLocation());
         }
 
         SpanNearQuery query = new SpanNearQuery(clauses.toArray(new SpanQuery[clauses.size()]), slop.intValue(), inOrder, collectPayloads);

--- a/src/main/java/org/elasticsearch/index/query/SpanNotQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanNotQueryParser.java
@@ -68,20 +68,17 @@ public class SpanNotQueryParser implements QueryParser {
                 if ("include".equals(currentFieldName)) {
                     Query query = parseContext.parseInnerQuery();
                     if (!(query instanceof SpanQuery)) {
-                        throw new QueryParsingException(parseContext.index(), "spanNot [include] must be of type span query",
-                                parser.getTokenLocation());
+                        throw new QueryParsingException(parseContext, "spanNot [include] must be of type span query");
                     }
                     include = (SpanQuery) query;
                 } else if ("exclude".equals(currentFieldName)) {
                     Query query = parseContext.parseInnerQuery();
                     if (!(query instanceof SpanQuery)) {
-                        throw new QueryParsingException(parseContext.index(), "spanNot [exclude] must be of type span query",
-                                parser.getTokenLocation());
+                        throw new QueryParsingException(parseContext, "spanNot [exclude] must be of type span query");
                     }
                     exclude = (SpanQuery) query;
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[span_not] query does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[span_not] query does not support [" + currentFieldName + "]");
                 }
             } else {
                 if ("dist".equals(currentFieldName)) {
@@ -95,22 +92,18 @@ public class SpanNotQueryParser implements QueryParser {
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[span_not] query does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[span_not] query does not support [" + currentFieldName + "]");
                 }
             }
         }
         if (include == null) {
-            throw new QueryParsingException(parseContext.index(), "spanNot must have [include] span query clause",
-                    parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "spanNot must have [include] span query clause");
         }
         if (exclude == null) {
-            throw new QueryParsingException(parseContext.index(), "spanNot must have [exclude] span query clause",
-                    parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "spanNot must have [exclude] span query clause");
         }
         if (dist != null && (pre != null || post != null)) {
-            throw new QueryParsingException(parseContext.index(), "spanNot can either use [dist] or [pre] & [post] (or none)",
-                    parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "spanNot can either use [dist] or [pre] & [post] (or none)");
         }
 
         // set appropriate defaults

--- a/src/main/java/org/elasticsearch/index/query/SpanNotQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanNotQueryParser.java
@@ -68,17 +68,20 @@ public class SpanNotQueryParser implements QueryParser {
                 if ("include".equals(currentFieldName)) {
                     Query query = parseContext.parseInnerQuery();
                     if (!(query instanceof SpanQuery)) {
-                        throw new QueryParsingException(parseContext.index(), "spanNot [include] must be of type span query");
+                        throw new QueryParsingException(parseContext.index(), "spanNot [include] must be of type span query",
+                                parser.getTokenLocation());
                     }
                     include = (SpanQuery) query;
                 } else if ("exclude".equals(currentFieldName)) {
                     Query query = parseContext.parseInnerQuery();
                     if (!(query instanceof SpanQuery)) {
-                        throw new QueryParsingException(parseContext.index(), "spanNot [exclude] must be of type span query");
+                        throw new QueryParsingException(parseContext.index(), "spanNot [exclude] must be of type span query",
+                                parser.getTokenLocation());
                     }
                     exclude = (SpanQuery) query;
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[span_not] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[span_not] query does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             } else {
                 if ("dist".equals(currentFieldName)) {
@@ -92,18 +95,22 @@ public class SpanNotQueryParser implements QueryParser {
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[span_not] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[span_not] query does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             }
         }
         if (include == null) {
-            throw new QueryParsingException(parseContext.index(), "spanNot must have [include] span query clause");
+            throw new QueryParsingException(parseContext.index(), "spanNot must have [include] span query clause",
+                    parser.getTokenLocation());
         }
         if (exclude == null) {
-            throw new QueryParsingException(parseContext.index(), "spanNot must have [exclude] span query clause");
+            throw new QueryParsingException(parseContext.index(), "spanNot must have [exclude] span query clause",
+                    parser.getTokenLocation());
         }
         if (dist != null && (pre != null || post != null)) {
-            throw new QueryParsingException(parseContext.index(), "spanNot can either use [dist] or [pre] & [post] (or none)");
+            throw new QueryParsingException(parseContext.index(), "spanNot can either use [dist] or [pre] & [post] (or none)",
+                    parser.getTokenLocation());
         }
 
         // set appropriate defaults

--- a/src/main/java/org/elasticsearch/index/query/SpanOrQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanOrQueryParser.java
@@ -66,12 +66,14 @@ public class SpanOrQueryParser implements QueryParser {
                     while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                         Query query = parseContext.parseInnerQuery();
                         if (!(query instanceof SpanQuery)) {
-                            throw new QueryParsingException(parseContext.index(), "spanOr [clauses] must be of type span query");
+                            throw new QueryParsingException(parseContext.index(), "spanOr [clauses] must be of type span query",
+                                    parser.getTokenLocation());
                         }
                         clauses.add((SpanQuery) query);
                     }
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[span_or] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[span_or] query does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             } else {
                 if ("boost".equals(currentFieldName)) {
@@ -79,12 +81,13 @@ public class SpanOrQueryParser implements QueryParser {
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[span_or] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[span_or] query does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             }
         }
         if (clauses.isEmpty()) {
-            throw new QueryParsingException(parseContext.index(), "spanOr must include [clauses]");
+            throw new QueryParsingException(parseContext.index(), "spanOr must include [clauses]", parser.getTokenLocation());
         }
 
         SpanOrQuery query = new SpanOrQuery(clauses.toArray(new SpanQuery[clauses.size()]));

--- a/src/main/java/org/elasticsearch/index/query/SpanOrQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanOrQueryParser.java
@@ -66,14 +66,12 @@ public class SpanOrQueryParser implements QueryParser {
                     while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                         Query query = parseContext.parseInnerQuery();
                         if (!(query instanceof SpanQuery)) {
-                            throw new QueryParsingException(parseContext.index(), "spanOr [clauses] must be of type span query",
-                                    parser.getTokenLocation());
+                            throw new QueryParsingException(parseContext, "spanOr [clauses] must be of type span query");
                         }
                         clauses.add((SpanQuery) query);
                     }
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[span_or] query does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[span_or] query does not support [" + currentFieldName + "]");
                 }
             } else {
                 if ("boost".equals(currentFieldName)) {
@@ -81,13 +79,12 @@ public class SpanOrQueryParser implements QueryParser {
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[span_or] query does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[span_or] query does not support [" + currentFieldName + "]");
                 }
             }
         }
         if (clauses.isEmpty()) {
-            throw new QueryParsingException(parseContext.index(), "spanOr must include [clauses]", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "spanOr must include [clauses]");
         }
 
         SpanOrQuery query = new SpanOrQuery(clauses.toArray(new SpanQuery[clauses.size()]));

--- a/src/main/java/org/elasticsearch/index/query/SpanTermQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanTermQueryParser.java
@@ -77,8 +77,7 @@ public class SpanTermQueryParser implements QueryParser {
                     } else if ("_name".equals(currentFieldName)) {
                         queryName = parser.text();
                     } else {
-                        throw new QueryParsingException(parseContext.index(), "[span_term] query does not support [" + currentFieldName
-                                + "]", parser.getTokenLocation());
+                        throw new QueryParsingException(parseContext, "[span_term] query does not support [" + currentFieldName + "]");
                     }
                 }
             }
@@ -90,7 +89,7 @@ public class SpanTermQueryParser implements QueryParser {
         }
 
         if (value == null) {
-            throw new QueryParsingException(parseContext.index(), "No value specified for term query", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "No value specified for term query");
         }
 
         BytesRef valueBytes = null;

--- a/src/main/java/org/elasticsearch/index/query/SpanTermQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanTermQueryParser.java
@@ -77,7 +77,8 @@ public class SpanTermQueryParser implements QueryParser {
                     } else if ("_name".equals(currentFieldName)) {
                         queryName = parser.text();
                     } else {
-                        throw new QueryParsingException(parseContext.index(), "[span_term] query does not support [" + currentFieldName + "]");
+                        throw new QueryParsingException(parseContext.index(), "[span_term] query does not support [" + currentFieldName
+                                + "]", parser.getTokenLocation());
                     }
                 }
             }
@@ -89,7 +90,7 @@ public class SpanTermQueryParser implements QueryParser {
         }
 
         if (value == null) {
-            throw new QueryParsingException(parseContext.index(), "No value specified for term query");
+            throw new QueryParsingException(parseContext.index(), "No value specified for term query", parser.getTokenLocation());
         }
 
         BytesRef valueBytes = null;

--- a/src/main/java/org/elasticsearch/index/query/TermFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TermFilterParser.java
@@ -81,8 +81,7 @@ public class TermFilterParser implements FilterParser {
                         } else if ("_cache_key".equals(currentFieldName) || "_cacheKey".equals(currentFieldName)) {
                             cacheKey = new HashedBytesRef(parser.text());
                         } else {
-                            throw new QueryParsingException(parseContext.index(), "[term] filter does not support [" + currentFieldName
-                                    + "]", parser.getTokenLocation());
+                            throw new QueryParsingException(parseContext, "[term] filter does not support [" + currentFieldName + "]");
                         }
                     }
                 }
@@ -101,11 +100,11 @@ public class TermFilterParser implements FilterParser {
         }
 
         if (fieldName == null) {
-            throw new QueryParsingException(parseContext.index(), "No field specified for term filter", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "No field specified for term filter");
         }
 
         if (value == null) {
-            throw new QueryParsingException(parseContext.index(), "No value specified for term filter", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "No value specified for term filter");
         }
 
         Filter filter = null;

--- a/src/main/java/org/elasticsearch/index/query/TermFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TermFilterParser.java
@@ -81,7 +81,8 @@ public class TermFilterParser implements FilterParser {
                         } else if ("_cache_key".equals(currentFieldName) || "_cacheKey".equals(currentFieldName)) {
                             cacheKey = new HashedBytesRef(parser.text());
                         } else {
-                            throw new QueryParsingException(parseContext.index(), "[term] filter does not support [" + currentFieldName + "]");
+                            throw new QueryParsingException(parseContext.index(), "[term] filter does not support [" + currentFieldName
+                                    + "]", parser.getTokenLocation());
                         }
                     }
                 }
@@ -100,11 +101,11 @@ public class TermFilterParser implements FilterParser {
         }
 
         if (fieldName == null) {
-            throw new QueryParsingException(parseContext.index(), "No field specified for term filter");
+            throw new QueryParsingException(parseContext.index(), "No field specified for term filter", parser.getTokenLocation());
         }
 
         if (value == null) {
-            throw new QueryParsingException(parseContext.index(), "No value specified for term filter");
+            throw new QueryParsingException(parseContext.index(), "No value specified for term filter", parser.getTokenLocation());
         }
 
         Filter filter = null;

--- a/src/main/java/org/elasticsearch/index/query/TermQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TermQueryParser.java
@@ -51,7 +51,7 @@ public class TermQueryParser implements QueryParser {
 
         XContentParser.Token token = parser.nextToken();
         if (token != XContentParser.Token.FIELD_NAME) {
-            throw new QueryParsingException(parseContext.index(), "[term] query malformed, no field", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "[term] query malformed, no field");
         }
         String fieldName = parser.currentName();
 
@@ -74,8 +74,7 @@ public class TermQueryParser implements QueryParser {
                     } else if ("_name".equals(currentFieldName)) {
                         queryName = parser.text();
                     } else {
-                        throw new QueryParsingException(parseContext.index(), "[term] query does not support [" + currentFieldName + "]",
-                                parser.getTokenLocation());
+                        throw new QueryParsingException(parseContext, "[term] query does not support [" + currentFieldName + "]");
                     }
                 }
             }
@@ -87,7 +86,7 @@ public class TermQueryParser implements QueryParser {
         }
 
         if (value == null) {
-            throw new QueryParsingException(parseContext.index(), "No value specified for term query", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "No value specified for term query");
         }
 
         Query query = null;

--- a/src/main/java/org/elasticsearch/index/query/TermQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TermQueryParser.java
@@ -51,7 +51,7 @@ public class TermQueryParser implements QueryParser {
 
         XContentParser.Token token = parser.nextToken();
         if (token != XContentParser.Token.FIELD_NAME) {
-            throw new QueryParsingException(parseContext.index(), "[term] query malformed, no field");
+            throw new QueryParsingException(parseContext.index(), "[term] query malformed, no field", parser.getTokenLocation());
         }
         String fieldName = parser.currentName();
 
@@ -74,7 +74,8 @@ public class TermQueryParser implements QueryParser {
                     } else if ("_name".equals(currentFieldName)) {
                         queryName = parser.text();
                     } else {
-                        throw new QueryParsingException(parseContext.index(), "[term] query does not support [" + currentFieldName + "]");
+                        throw new QueryParsingException(parseContext.index(), "[term] query does not support [" + currentFieldName + "]",
+                                parser.getTokenLocation());
                     }
                 }
             }
@@ -86,7 +87,7 @@ public class TermQueryParser implements QueryParser {
         }
 
         if (value == null) {
-            throw new QueryParsingException(parseContext.index(), "No value specified for term query");
+            throw new QueryParsingException(parseContext.index(), "No value specified for term query", parser.getTokenLocation());
         }
 
         Query query = null;

--- a/src/main/java/org/elasticsearch/index/query/TermsFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TermsFilterParser.java
@@ -90,14 +90,16 @@ public class TermsFilterParser implements FilterParser {
                 currentFieldName = parser.currentName();
             } else if (token == XContentParser.Token.START_ARRAY) {
                 if  (fieldName != null) {
-                    throw new QueryParsingException(parseContext.index(), "[terms] filter does not support multiple fields");
+                    throw new QueryParsingException(parseContext.index(), "[terms] filter does not support multiple fields",
+                            parser.getTokenLocation());
                 }
                 fieldName = currentFieldName;
 
                 while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                     Object value = parser.objectBytes();
                     if (value == null) {
-                        throw new QueryParsingException(parseContext.index(), "No value specified for terms filter");
+                        throw new QueryParsingException(parseContext.index(), "No value specified for terms filter",
+                                parser.getTokenLocation());
                     }
                     terms.add(value);
                 }
@@ -118,18 +120,22 @@ public class TermsFilterParser implements FilterParser {
                         } else if ("routing".equals(currentFieldName)) {
                             lookupRouting = parser.textOrNull();
                         } else {
-                            throw new QueryParsingException(parseContext.index(), "[terms] filter does not support [" + currentFieldName + "] within lookup element");
+                            throw new QueryParsingException(parseContext.index(), "[terms] filter does not support [" + currentFieldName
+                                    + "] within lookup element", parser.getTokenLocation());
                         }
                     }
                 }
                 if (lookupType == null) {
-                    throw new QueryParsingException(parseContext.index(), "[terms] filter lookup element requires specifying the type");
+                    throw new QueryParsingException(parseContext.index(), "[terms] filter lookup element requires specifying the type",
+                            parser.getTokenLocation());
                 }
                 if (lookupId == null) {
-                    throw new QueryParsingException(parseContext.index(), "[terms] filter lookup element requires specifying the id");
+                    throw new QueryParsingException(parseContext.index(), "[terms] filter lookup element requires specifying the id",
+                            parser.getTokenLocation());
                 }
                 if (lookupPath == null) {
-                    throw new QueryParsingException(parseContext.index(), "[terms] filter lookup element requires specifying the path");
+                    throw new QueryParsingException(parseContext.index(), "[terms] filter lookup element requires specifying the path",
+                            parser.getTokenLocation());
                 }
             } else if (token.isValue()) {
                 if (EXECUTION_KEY.equals(currentFieldName)) {
@@ -141,13 +147,15 @@ public class TermsFilterParser implements FilterParser {
                 } else if ("_cache_key".equals(currentFieldName) || "_cacheKey".equals(currentFieldName)) {
                     cacheKey = new HashedBytesRef(parser.text());
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[terms] filter does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[terms] filter does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             }
         }
 
         if (fieldName == null) {
-            throw new QueryParsingException(parseContext.index(), "terms filter requires a field name, followed by array of terms");
+            throw new QueryParsingException(parseContext.index(), "terms filter requires a field name, followed by array of terms",
+                    parser.getTokenLocation());
         }
 
         FieldMapper<?> fieldMapper = null;

--- a/src/main/java/org/elasticsearch/index/query/TermsFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TermsFilterParser.java
@@ -90,16 +90,14 @@ public class TermsFilterParser implements FilterParser {
                 currentFieldName = parser.currentName();
             } else if (token == XContentParser.Token.START_ARRAY) {
                 if  (fieldName != null) {
-                    throw new QueryParsingException(parseContext.index(), "[terms] filter does not support multiple fields",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[terms] filter does not support multiple fields");
                 }
                 fieldName = currentFieldName;
 
                 while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                     Object value = parser.objectBytes();
                     if (value == null) {
-                        throw new QueryParsingException(parseContext.index(), "No value specified for terms filter",
-                                parser.getTokenLocation());
+                        throw new QueryParsingException(parseContext, "No value specified for terms filter");
                     }
                     terms.add(value);
                 }
@@ -120,22 +118,19 @@ public class TermsFilterParser implements FilterParser {
                         } else if ("routing".equals(currentFieldName)) {
                             lookupRouting = parser.textOrNull();
                         } else {
-                            throw new QueryParsingException(parseContext.index(), "[terms] filter does not support [" + currentFieldName
-                                    + "] within lookup element", parser.getTokenLocation());
+                            throw new QueryParsingException(parseContext, "[terms] filter does not support [" + currentFieldName
+                                    + "] within lookup element");
                         }
                     }
                 }
                 if (lookupType == null) {
-                    throw new QueryParsingException(parseContext.index(), "[terms] filter lookup element requires specifying the type",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[terms] filter lookup element requires specifying the type");
                 }
                 if (lookupId == null) {
-                    throw new QueryParsingException(parseContext.index(), "[terms] filter lookup element requires specifying the id",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[terms] filter lookup element requires specifying the id");
                 }
                 if (lookupPath == null) {
-                    throw new QueryParsingException(parseContext.index(), "[terms] filter lookup element requires specifying the path",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[terms] filter lookup element requires specifying the path");
                 }
             } else if (token.isValue()) {
                 if (EXECUTION_KEY.equals(currentFieldName)) {
@@ -147,15 +142,13 @@ public class TermsFilterParser implements FilterParser {
                 } else if ("_cache_key".equals(currentFieldName) || "_cacheKey".equals(currentFieldName)) {
                     cacheKey = new HashedBytesRef(parser.text());
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[terms] filter does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[terms] filter does not support [" + currentFieldName + "]");
                 }
             }
         }
 
         if (fieldName == null) {
-            throw new QueryParsingException(parseContext.index(), "terms filter requires a field name, followed by array of terms",
-                    parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "terms filter requires a field name, followed by array of terms");
         }
 
         FieldMapper<?> fieldMapper = null;

--- a/src/main/java/org/elasticsearch/index/query/TermsQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TermsQueryParser.java
@@ -75,15 +75,13 @@ public class TermsQueryParser implements QueryParser {
                 currentFieldName = parser.currentName();
             } else if (token == XContentParser.Token.START_ARRAY) {
                 if  (fieldName != null) {
-                    throw new QueryParsingException(parseContext.index(), "[terms] query does not support multiple fields",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[terms] query does not support multiple fields");
                 }
                 fieldName = currentFieldName;
                 while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                     Object value = parser.objectBytes();
                     if (value == null) {
-                        throw new QueryParsingException(parseContext.index(), "No value specified for terms query",
-                                parser.getTokenLocation());
+                        throw new QueryParsingException(parseContext, "No value specified for terms query");
                     }
                     values.add(value);
                 }
@@ -99,17 +97,15 @@ public class TermsQueryParser implements QueryParser {
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[terms] query does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[terms] query does not support [" + currentFieldName + "]");
                 }
             } else {
-                throw new QueryParsingException(parseContext.index(), "[terms] query does not support [" + currentFieldName + "]",
-                        parser.getTokenLocation());
+                throw new QueryParsingException(parseContext, "[terms] query does not support [" + currentFieldName + "]");
             }
         }
 
         if (fieldName == null) {
-            throw new QueryParsingException(parseContext.index(), "No field specified for terms query", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "No field specified for terms query");
         }
 
         FieldMapper mapper = null;

--- a/src/main/java/org/elasticsearch/index/query/TermsQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TermsQueryParser.java
@@ -75,13 +75,15 @@ public class TermsQueryParser implements QueryParser {
                 currentFieldName = parser.currentName();
             } else if (token == XContentParser.Token.START_ARRAY) {
                 if  (fieldName != null) {
-                    throw new QueryParsingException(parseContext.index(), "[terms] query does not support multiple fields");
+                    throw new QueryParsingException(parseContext.index(), "[terms] query does not support multiple fields",
+                            parser.getTokenLocation());
                 }
                 fieldName = currentFieldName;
                 while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                     Object value = parser.objectBytes();
                     if (value == null) {
-                        throw new QueryParsingException(parseContext.index(), "No value specified for terms query");
+                        throw new QueryParsingException(parseContext.index(), "No value specified for terms query",
+                                parser.getTokenLocation());
                     }
                     values.add(value);
                 }
@@ -97,15 +99,17 @@ public class TermsQueryParser implements QueryParser {
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[terms] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[terms] query does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             } else {
-                throw new QueryParsingException(parseContext.index(), "[terms] query does not support [" + currentFieldName + "]");
+                throw new QueryParsingException(parseContext.index(), "[terms] query does not support [" + currentFieldName + "]",
+                        parser.getTokenLocation());
             }
         }
 
         if (fieldName == null) {
-            throw new QueryParsingException(parseContext.index(), "No field specified for terms query");
+            throw new QueryParsingException(parseContext.index(), "No field specified for terms query", parser.getTokenLocation());
         }
 
         FieldMapper mapper = null;

--- a/src/main/java/org/elasticsearch/index/query/TopChildrenQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TopChildrenQueryParser.java
@@ -81,8 +81,7 @@ public class TopChildrenQueryParser implements QueryParser {
                     iq = new XContentStructure.InnerQuery(parseContext, childType == null ? null : new String[] {childType});
                     queryFound = true;
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[top_children] query does not support [" + currentFieldName
-                            + "]", parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[top_children] query does not support [" + currentFieldName + "]");
                 }
             } else if (token.isValue()) {
                 if ("type".equals(currentFieldName)) {
@@ -100,16 +99,15 @@ public class TopChildrenQueryParser implements QueryParser {
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[top_children] query does not support [" + currentFieldName
-                            + "]", parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, "[top_children] query does not support [" + currentFieldName + "]");
                 }
             }
         }
         if (!queryFound) {
-            throw new QueryParsingException(parseContext.index(), "[top_children] requires 'query' field", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "[top_children] requires 'query' field");
         }
         if (childType == null) {
-            throw new QueryParsingException(parseContext.index(), "[top_children] requires 'type' field", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "[top_children] requires 'type' field");
         }
 
         Query innerQuery = iq.asQuery(childType);
@@ -120,12 +118,11 @@ public class TopChildrenQueryParser implements QueryParser {
 
         DocumentMapper childDocMapper = parseContext.mapperService().documentMapper(childType);
         if (childDocMapper == null) {
-            throw new QueryParsingException(parseContext.index(), "No mapping for for type [" + childType + "]", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "No mapping for for type [" + childType + "]");
         }
         ParentFieldMapper parentFieldMapper = childDocMapper.parentFieldMapper();
         if (!parentFieldMapper.active()) {
-            throw new QueryParsingException(parseContext.index(), "Type [" + childType + "] does not have parent mapping",
-                    parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "Type [" + childType + "] does not have parent mapping");
         }
         String parentType = childDocMapper.parentFieldMapper().type();
 

--- a/src/main/java/org/elasticsearch/index/query/TopChildrenQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TopChildrenQueryParser.java
@@ -81,7 +81,8 @@ public class TopChildrenQueryParser implements QueryParser {
                     iq = new XContentStructure.InnerQuery(parseContext, childType == null ? null : new String[] {childType});
                     queryFound = true;
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[top_children] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[top_children] query does not support [" + currentFieldName
+                            + "]", parser.getTokenLocation());
                 }
             } else if (token.isValue()) {
                 if ("type".equals(currentFieldName)) {
@@ -99,15 +100,16 @@ public class TopChildrenQueryParser implements QueryParser {
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), "[top_children] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), "[top_children] query does not support [" + currentFieldName
+                            + "]", parser.getTokenLocation());
                 }
             }
         }
         if (!queryFound) {
-            throw new QueryParsingException(parseContext.index(), "[top_children] requires 'query' field");
+            throw new QueryParsingException(parseContext.index(), "[top_children] requires 'query' field", parser.getTokenLocation());
         }
         if (childType == null) {
-            throw new QueryParsingException(parseContext.index(), "[top_children] requires 'type' field");
+            throw new QueryParsingException(parseContext.index(), "[top_children] requires 'type' field", parser.getTokenLocation());
         }
 
         Query innerQuery = iq.asQuery(childType);
@@ -118,11 +120,12 @@ public class TopChildrenQueryParser implements QueryParser {
 
         DocumentMapper childDocMapper = parseContext.mapperService().documentMapper(childType);
         if (childDocMapper == null) {
-            throw new QueryParsingException(parseContext.index(), "No mapping for for type [" + childType + "]");
+            throw new QueryParsingException(parseContext.index(), "No mapping for for type [" + childType + "]", parser.getTokenLocation());
         }
         ParentFieldMapper parentFieldMapper = childDocMapper.parentFieldMapper();
         if (!parentFieldMapper.active()) {
-            throw new QueryParsingException(parseContext.index(), "Type [" + childType + "] does not have parent mapping");
+            throw new QueryParsingException(parseContext.index(), "Type [" + childType + "] does not have parent mapping",
+                    parser.getTokenLocation());
         }
         String parentType = childDocMapper.parentFieldMapper().type();
 

--- a/src/main/java/org/elasticsearch/index/query/TypeFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TypeFilterParser.java
@@ -50,18 +50,15 @@ public class TypeFilterParser implements FilterParser {
 
         XContentParser.Token token = parser.nextToken();
         if (token != XContentParser.Token.FIELD_NAME) {
-            throw new QueryParsingException(parseContext.index(), "[type] filter should have a value field, and the type name",
-                    parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "[type] filter should have a value field, and the type name");
         }
         String fieldName = parser.currentName();
         if (!fieldName.equals("value")) {
-            throw new QueryParsingException(parseContext.index(), "[type] filter should have a value field, and the type name",
-                    parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "[type] filter should have a value field, and the type name");
         }
         token = parser.nextToken();
         if (token != XContentParser.Token.VALUE_STRING) {
-            throw new QueryParsingException(parseContext.index(), "[type] filter should have a value field, and the type name",
-                    parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "[type] filter should have a value field, and the type name");
         }
         BytesRef type = parser.utf8Bytes();
         // move to the next token

--- a/src/main/java/org/elasticsearch/index/query/TypeFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TypeFilterParser.java
@@ -50,15 +50,18 @@ public class TypeFilterParser implements FilterParser {
 
         XContentParser.Token token = parser.nextToken();
         if (token != XContentParser.Token.FIELD_NAME) {
-            throw new QueryParsingException(parseContext.index(), "[type] filter should have a value field, and the type name");
+            throw new QueryParsingException(parseContext.index(), "[type] filter should have a value field, and the type name",
+                    parser.getTokenLocation());
         }
         String fieldName = parser.currentName();
         if (!fieldName.equals("value")) {
-            throw new QueryParsingException(parseContext.index(), "[type] filter should have a value field, and the type name");
+            throw new QueryParsingException(parseContext.index(), "[type] filter should have a value field, and the type name",
+                    parser.getTokenLocation());
         }
         token = parser.nextToken();
         if (token != XContentParser.Token.VALUE_STRING) {
-            throw new QueryParsingException(parseContext.index(), "[type] filter should have a value field, and the type name");
+            throw new QueryParsingException(parseContext.index(), "[type] filter should have a value field, and the type name",
+                    parser.getTokenLocation());
         }
         BytesRef type = parser.utf8Bytes();
         // move to the next token

--- a/src/main/java/org/elasticsearch/index/query/WildcardQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/WildcardQueryParser.java
@@ -52,7 +52,7 @@ public class WildcardQueryParser implements QueryParser {
 
         XContentParser.Token token = parser.nextToken();
         if (token != XContentParser.Token.FIELD_NAME) {
-            throw new QueryParsingException(parseContext.index(), "[wildcard] query malformed, no field", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "[wildcard] query malformed, no field");
         }
         String fieldName = parser.currentName();
         String rewriteMethod = null;
@@ -78,8 +78,7 @@ public class WildcardQueryParser implements QueryParser {
                     } else if ("_name".equals(currentFieldName)) {
                         queryName = parser.text();
                     } else {
-                        throw new QueryParsingException(parseContext.index(), "[wildcard] query does not support [" + currentFieldName
-                                + "]", parser.getTokenLocation());
+                        throw new QueryParsingException(parseContext, "[wildcard] query does not support [" + currentFieldName + "]");
                     }
                 }
             }
@@ -90,7 +89,7 @@ public class WildcardQueryParser implements QueryParser {
         }
 
         if (value == null) {
-            throw new QueryParsingException(parseContext.index(), "No value specified for prefix query", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "No value specified for prefix query");
         }
 
         BytesRef valueBytes;

--- a/src/main/java/org/elasticsearch/index/query/WildcardQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/WildcardQueryParser.java
@@ -52,7 +52,7 @@ public class WildcardQueryParser implements QueryParser {
 
         XContentParser.Token token = parser.nextToken();
         if (token != XContentParser.Token.FIELD_NAME) {
-            throw new QueryParsingException(parseContext.index(), "[wildcard] query malformed, no field");
+            throw new QueryParsingException(parseContext.index(), "[wildcard] query malformed, no field", parser.getTokenLocation());
         }
         String fieldName = parser.currentName();
         String rewriteMethod = null;
@@ -78,7 +78,8 @@ public class WildcardQueryParser implements QueryParser {
                     } else if ("_name".equals(currentFieldName)) {
                         queryName = parser.text();
                     } else {
-                        throw new QueryParsingException(parseContext.index(), "[wildcard] query does not support [" + currentFieldName + "]");
+                        throw new QueryParsingException(parseContext.index(), "[wildcard] query does not support [" + currentFieldName
+                                + "]", parser.getTokenLocation());
                     }
                 }
             }
@@ -89,7 +90,7 @@ public class WildcardQueryParser implements QueryParser {
         }
 
         if (value == null) {
-            throw new QueryParsingException(parseContext.index(), "No value specified for prefix query");
+            throw new QueryParsingException(parseContext.index(), "No value specified for prefix query", parser.getTokenLocation());
         }
 
         BytesRef valueBytes;

--- a/src/main/java/org/elasticsearch/index/query/WrapperFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/WrapperFilterParser.java
@@ -48,11 +48,11 @@ public class WrapperFilterParser implements FilterParser {
 
         XContentParser.Token token = parser.nextToken();
         if (token != XContentParser.Token.FIELD_NAME) {
-            throw new QueryParsingException(parseContext.index(), "[wrapper] filter malformed");
+            throw new QueryParsingException(parseContext.index(), "[wrapper] filter malformed", parser.getTokenLocation());
         }
         String fieldName = parser.currentName();
         if (!fieldName.equals("filter")) {
-            throw new QueryParsingException(parseContext.index(), "[wrapper] filter malformed");
+            throw new QueryParsingException(parseContext.index(), "[wrapper] filter malformed", parser.getTokenLocation());
         }
         parser.nextToken();
 

--- a/src/main/java/org/elasticsearch/index/query/WrapperFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/WrapperFilterParser.java
@@ -48,11 +48,11 @@ public class WrapperFilterParser implements FilterParser {
 
         XContentParser.Token token = parser.nextToken();
         if (token != XContentParser.Token.FIELD_NAME) {
-            throw new QueryParsingException(parseContext.index(), "[wrapper] filter malformed", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "[wrapper] filter malformed");
         }
         String fieldName = parser.currentName();
         if (!fieldName.equals("filter")) {
-            throw new QueryParsingException(parseContext.index(), "[wrapper] filter malformed", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "[wrapper] filter malformed");
         }
         parser.nextToken();
 

--- a/src/main/java/org/elasticsearch/index/query/WrapperQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/WrapperQueryParser.java
@@ -48,11 +48,11 @@ public class WrapperQueryParser implements QueryParser {
 
         XContentParser.Token token = parser.nextToken();
         if (token != XContentParser.Token.FIELD_NAME) {
-            throw new QueryParsingException(parseContext.index(), "[wrapper] query malformed");
+            throw new QueryParsingException(parseContext.index(), "[wrapper] query malformed", parser.getTokenLocation());
         }
         String fieldName = parser.currentName();
         if (!fieldName.equals("query")) {
-            throw new QueryParsingException(parseContext.index(), "[wrapper] query malformed");
+            throw new QueryParsingException(parseContext.index(), "[wrapper] query malformed", parser.getTokenLocation());
         }
         parser.nextToken();
 

--- a/src/main/java/org/elasticsearch/index/query/WrapperQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/WrapperQueryParser.java
@@ -48,11 +48,11 @@ public class WrapperQueryParser implements QueryParser {
 
         XContentParser.Token token = parser.nextToken();
         if (token != XContentParser.Token.FIELD_NAME) {
-            throw new QueryParsingException(parseContext.index(), "[wrapper] query malformed", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "[wrapper] query malformed");
         }
         String fieldName = parser.currentName();
         if (!fieldName.equals("query")) {
-            throw new QueryParsingException(parseContext.index(), "[wrapper] query malformed", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "[wrapper] query malformed");
         }
         parser.nextToken();
 

--- a/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionParser.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionParser.java
@@ -155,7 +155,7 @@ public abstract class DecayFunctionParser implements ScoreFunctionParser {
         // the doc later
         MapperService.SmartNameFieldMappers smartMappers = parseContext.smartFieldMappers(fieldName);
         if (smartMappers == null || !smartMappers.hasMapper()) {
-            throw new QueryParsingException(parseContext.index(), "Unknown field [" + fieldName + "]");
+            throw new QueryParsingException(parseContext.index(), "Unknown field [" + fieldName + "]", parser.getTokenLocation());
         }
 
         FieldMapper<?> mapper = smartMappers.fieldMappers().mapper();
@@ -169,7 +169,7 @@ public abstract class DecayFunctionParser implements ScoreFunctionParser {
             return parseNumberVariable(fieldName, parser, parseContext, (NumberFieldMapper<?>) mapper, mode);
         } else {
             throw new QueryParsingException(parseContext.index(), "Field " + fieldName + " is of type " + mapper.fieldType()
-                    + ", but only numeric types are supported.");
+                    + ", but only numeric types are supported.", parser.getTokenLocation());
         }
     }
 

--- a/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionParser.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionParser.java
@@ -155,7 +155,7 @@ public abstract class DecayFunctionParser implements ScoreFunctionParser {
         // the doc later
         MapperService.SmartNameFieldMappers smartMappers = parseContext.smartFieldMappers(fieldName);
         if (smartMappers == null || !smartMappers.hasMapper()) {
-            throw new QueryParsingException(parseContext.index(), "Unknown field [" + fieldName + "]", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "Unknown field [" + fieldName + "]");
         }
 
         FieldMapper<?> mapper = smartMappers.fieldMappers().mapper();
@@ -168,8 +168,8 @@ public abstract class DecayFunctionParser implements ScoreFunctionParser {
         } else if (mapper instanceof NumberFieldMapper<?>) {
             return parseNumberVariable(fieldName, parser, parseContext, (NumberFieldMapper<?>) mapper, mode);
         } else {
-            throw new QueryParsingException(parseContext.index(), "Field " + fieldName + " is of type " + mapper.fieldType()
-                    + ", but only numeric types are supported.", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "Field " + fieldName + " is of type " + mapper.fieldType()
+                    + ", but only numeric types are supported.");
         }
     }
 

--- a/src/main/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryParser.java
@@ -203,7 +203,7 @@ public class FunctionScoreQueryParser implements QueryParser {
             Float functionWeight = null;
             if (token != XContentParser.Token.START_OBJECT) {
                 throw new QueryParsingException(parseContext.index(), NAME + ": malformed query, expected a "
-                        + XContentParser.Token.START_OBJECT + " while parsing functions but got a " + token);
+                        + XContentParser.Token.START_OBJECT + " while parsing functions but got a " + token, parser.getTokenLocation());
             } else {
                 while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
                     if (token == XContentParser.Token.FIELD_NAME) {
@@ -253,7 +253,8 @@ public class FunctionScoreQueryParser implements QueryParser {
         } else if ("first".equals(scoreMode)) {
             return FiltersFunctionScoreQuery.ScoreMode.First;
         } else {
-            throw new QueryParsingException(parseContext.index(), NAME + " illegal score_mode [" + scoreMode + "]");
+            throw new QueryParsingException(parseContext.index(), NAME + " illegal score_mode [" + scoreMode + "]",
+                    parser.getTokenLocation());
         }
     }
 
@@ -261,7 +262,8 @@ public class FunctionScoreQueryParser implements QueryParser {
         String boostMode = parser.text();
         CombineFunction cf = combineFunctionsMap.get(boostMode);
         if (cf == null) {
-            throw new QueryParsingException(parseContext.index(), NAME + " illegal boost_mode [" + boostMode + "]");
+            throw new QueryParsingException(parseContext.index(), NAME + " illegal boost_mode [" + boostMode + "]",
+                    parser.getTokenLocation());
         }
         return cf;
     }

--- a/src/main/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryParser.java
@@ -134,7 +134,7 @@ public class FunctionScoreQueryParser implements QueryParser {
                     // we try to parse a score function. If there is no score
                     // function for the current field name,
                     // functionParserMapper.get() will throw an Exception.
-                    scoreFunction = functionParserMapper.get(parseContext.index(), currentFieldName).parse(parseContext, parser);
+                    scoreFunction = functionParserMapper.get(parseContext, currentFieldName).parse(parseContext, parser);
                 }
                 if (functionArrayFound) {
                     String errorString = "Found \"functions\": [...] already, now encountering \"" + currentFieldName + "\".";
@@ -202,8 +202,8 @@ public class FunctionScoreQueryParser implements QueryParser {
             ScoreFunction scoreFunction = null;
             Float functionWeight = null;
             if (token != XContentParser.Token.START_OBJECT) {
-                throw new QueryParsingException(parseContext.index(), NAME + ": malformed query, expected a "
-                        + XContentParser.Token.START_OBJECT + " while parsing functions but got a " + token, parser.getTokenLocation());
+                throw new QueryParsingException(parseContext, NAME + ": malformed query, expected a " + XContentParser.Token.START_OBJECT
+                        + " while parsing functions but got a " + token);
             } else {
                 while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
                     if (token == XContentParser.Token.FIELD_NAME) {
@@ -217,7 +217,7 @@ public class FunctionScoreQueryParser implements QueryParser {
                             // do not need to check null here,
                             // functionParserMapper throws exception if parser
                             // non-existent
-                            ScoreFunctionParser functionParser = functionParserMapper.get(parseContext.index(), currentFieldName);
+                            ScoreFunctionParser functionParser = functionParserMapper.get(parseContext, currentFieldName);
                             scoreFunction = functionParser.parse(parseContext, parser);
                         }
                     }
@@ -253,8 +253,7 @@ public class FunctionScoreQueryParser implements QueryParser {
         } else if ("first".equals(scoreMode)) {
             return FiltersFunctionScoreQuery.ScoreMode.First;
         } else {
-            throw new QueryParsingException(parseContext.index(), NAME + " illegal score_mode [" + scoreMode + "]",
-                    parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, NAME + " illegal score_mode [" + scoreMode + "]");
         }
     }
 
@@ -262,8 +261,7 @@ public class FunctionScoreQueryParser implements QueryParser {
         String boostMode = parser.text();
         CombineFunction cf = combineFunctionsMap.get(boostMode);
         if (cf == null) {
-            throw new QueryParsingException(parseContext.index(), NAME + " illegal boost_mode [" + boostMode + "]",
-                    parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, NAME + " illegal boost_mode [" + boostMode + "]");
         }
         return cf;
     }

--- a/src/main/java/org/elasticsearch/index/query/functionscore/ScoreFunctionParserMapper.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/ScoreFunctionParserMapper.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.query.functionscore;
 
 import com.google.common.collect.ImmutableMap;
+
 import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.index.Index;
@@ -45,7 +46,7 @@ public class ScoreFunctionParserMapper {
     public ScoreFunctionParser get(Index index, String parserName) {
         ScoreFunctionParser functionParser = get(parserName);
         if (functionParser == null) {
-            throw new QueryParsingException(index, "No function with the name [" + parserName + "] is registered.");
+            throw new QueryParsingException(index, "No function with the name [" + parserName + "] is registered.", null);
         }
         return functionParser;
     }

--- a/src/main/java/org/elasticsearch/index/query/functionscore/ScoreFunctionParserMapper.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/ScoreFunctionParserMapper.java
@@ -23,7 +23,7 @@ import com.google.common.collect.ImmutableMap;
 
 import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.index.Index;
+import org.elasticsearch.index.query.QueryParseContext;
 import org.elasticsearch.index.query.QueryParsingException;
 
 import java.util.Set;
@@ -43,10 +43,10 @@ public class ScoreFunctionParserMapper {
         this.functionParsers = builder.immutableMap();
     }
 
-    public ScoreFunctionParser get(Index index, String parserName) {
+    public ScoreFunctionParser get(QueryParseContext parseContext, String parserName) {
         ScoreFunctionParser functionParser = get(parserName);
         if (functionParser == null) {
-            throw new QueryParsingException(index, "No function with the name [" + parserName + "] is registered.", null);
+            throw new QueryParsingException(parseContext, "No function with the name [" + parserName + "] is registered.", null);
         }
         return functionParser;
     }

--- a/src/main/java/org/elasticsearch/index/query/functionscore/fieldvaluefactor/FieldValueFactorFunctionParser.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/fieldvaluefactor/FieldValueFactorFunctionParser.java
@@ -68,15 +68,18 @@ public class FieldValueFactorFunctionParser implements ScoreFunctionParser {
                 } else if ("modifier".equals(currentFieldName)) {
                     modifier = FieldValueFactorFunction.Modifier.valueOf(parser.text().toUpperCase(Locale.ROOT));
                 } else {
-                    throw new QueryParsingException(parseContext.index(), NAMES[0] + " query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), NAMES[0] + " query does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             } else if("factor".equals(currentFieldName) && (token == XContentParser.Token.START_ARRAY || token == XContentParser.Token.START_OBJECT)) {
-                throw new QueryParsingException(parseContext.index(), "[" + NAMES[0] + "] field 'factor' does not support lists or objects");
+                throw new QueryParsingException(parseContext.index(),
+                        "[" + NAMES[0] + "] field 'factor' does not support lists or objects", parser.getTokenLocation());
             }
         }
 
         if (field == null) {
-            throw new QueryParsingException(parseContext.index(), "[" + NAMES[0] + "] required field 'field' missing");
+            throw new QueryParsingException(parseContext.index(), "[" + NAMES[0] + "] required field 'field' missing",
+                    parser.getTokenLocation());
         }
 
         SearchContext searchContext = SearchContext.current();

--- a/src/main/java/org/elasticsearch/index/query/functionscore/fieldvaluefactor/FieldValueFactorFunctionParser.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/fieldvaluefactor/FieldValueFactorFunctionParser.java
@@ -68,18 +68,15 @@ public class FieldValueFactorFunctionParser implements ScoreFunctionParser {
                 } else if ("modifier".equals(currentFieldName)) {
                     modifier = FieldValueFactorFunction.Modifier.valueOf(parser.text().toUpperCase(Locale.ROOT));
                 } else {
-                    throw new QueryParsingException(parseContext.index(), NAMES[0] + " query does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, NAMES[0] + " query does not support [" + currentFieldName + "]");
                 }
             } else if("factor".equals(currentFieldName) && (token == XContentParser.Token.START_ARRAY || token == XContentParser.Token.START_OBJECT)) {
-                throw new QueryParsingException(parseContext.index(),
-                        "[" + NAMES[0] + "] field 'factor' does not support lists or objects", parser.getTokenLocation());
+                throw new QueryParsingException(parseContext, "[" + NAMES[0] + "] field 'factor' does not support lists or objects");
             }
         }
 
         if (field == null) {
-            throw new QueryParsingException(parseContext.index(), "[" + NAMES[0] + "] required field 'field' missing",
-                    parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, "[" + NAMES[0] + "] required field 'field' missing");
         }
 
         SearchContext searchContext = SearchContext.current();

--- a/src/main/java/org/elasticsearch/index/query/functionscore/random/RandomScoreFunctionParser.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/random/RandomScoreFunctionParser.java
@@ -21,6 +21,7 @@
 package org.elasticsearch.index.query.functionscore.random;
 
 import com.google.common.primitives.Longs;
+
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.lucene.search.function.RandomScoreFunction;
 import org.elasticsearch.common.lucene.search.function.ScoreFunction;
@@ -66,15 +67,18 @@ public class RandomScoreFunctionParser implements ScoreFunctionParser {
                         } else if (parser.numberType() == XContentParser.NumberType.LONG) {
                             seed = Longs.hashCode(parser.longValue());
                         } else {
-                            throw new QueryParsingException(parseContext.index(), "random_score seed must be an int, long or string, not '" + token.toString() + "'");
+                            throw new QueryParsingException(parseContext.index(), "random_score seed must be an int, long or string, not '"
+                                    + token.toString() + "'", parser.getTokenLocation());
                         }
                     } else if (token == XContentParser.Token.VALUE_STRING) {
                         seed = parser.text().hashCode();
                     } else {
-                        throw new QueryParsingException(parseContext.index(), "random_score seed must be an int/long or string, not '" + token.toString() + "'");
+                        throw new QueryParsingException(parseContext.index(), "random_score seed must be an int/long or string, not '"
+                                + token.toString() + "'", parser.getTokenLocation());
                     }
                 } else {
-                    throw new QueryParsingException(parseContext.index(), NAMES[0] + " query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), NAMES[0] + " query does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             }
         }

--- a/src/main/java/org/elasticsearch/index/query/functionscore/random/RandomScoreFunctionParser.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/random/RandomScoreFunctionParser.java
@@ -67,18 +67,17 @@ public class RandomScoreFunctionParser implements ScoreFunctionParser {
                         } else if (parser.numberType() == XContentParser.NumberType.LONG) {
                             seed = Longs.hashCode(parser.longValue());
                         } else {
-                            throw new QueryParsingException(parseContext.index(), "random_score seed must be an int, long or string, not '"
-                                    + token.toString() + "'", parser.getTokenLocation());
+                            throw new QueryParsingException(parseContext, "random_score seed must be an int, long or string, not '"
+                                    + token.toString() + "'");
                         }
                     } else if (token == XContentParser.Token.VALUE_STRING) {
                         seed = parser.text().hashCode();
                     } else {
-                        throw new QueryParsingException(parseContext.index(), "random_score seed must be an int/long or string, not '"
-                                + token.toString() + "'", parser.getTokenLocation());
+                        throw new QueryParsingException(parseContext, "random_score seed must be an int/long or string, not '"
+                                + token.toString() + "'");
                     }
                 } else {
-                    throw new QueryParsingException(parseContext.index(), NAMES[0] + " query does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, NAMES[0] + " query does not support [" + currentFieldName + "]");
                 }
             }
         }

--- a/src/main/java/org/elasticsearch/index/query/functionscore/script/ScriptScoreFunctionParser.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/script/ScriptScoreFunctionParser.java
@@ -28,7 +28,9 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.query.QueryParseContext;
 import org.elasticsearch.index.query.QueryParsingException;
 import org.elasticsearch.index.query.functionscore.ScoreFunctionParser;
-import org.elasticsearch.script.*;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.script.ScriptContext;
+import org.elasticsearch.script.ScriptParameterParser;
 import org.elasticsearch.script.ScriptParameterParser.ScriptParameterValue;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.script.SearchScript;
@@ -67,11 +69,13 @@ public class ScriptScoreFunctionParser implements ScoreFunctionParser {
                 if ("params".equals(currentFieldName)) {
                     vars = parser.map();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), NAMES[0] + " query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), NAMES[0] + " query does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             } else if (token.isValue()) {
                 if (!scriptParameterParser.token(currentFieldName, token, parser)) {
-                    throw new QueryParsingException(parseContext.index(), NAMES[0] + " query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext.index(), NAMES[0] + " query does not support [" + currentFieldName + "]",
+                            parser.getTokenLocation());
                 }
             }
         }
@@ -82,7 +86,7 @@ public class ScriptScoreFunctionParser implements ScoreFunctionParser {
             scriptType = scriptValue.scriptType();
         }
         if (script == null) {
-            throw new QueryParsingException(parseContext.index(), NAMES[0] + " requires 'script' field");
+            throw new QueryParsingException(parseContext.index(), NAMES[0] + " requires 'script' field", parser.getTokenLocation());
         }
 
         SearchScript searchScript;
@@ -90,7 +94,8 @@ public class ScriptScoreFunctionParser implements ScoreFunctionParser {
             searchScript = parseContext.scriptService().search(parseContext.lookup(), new Script(scriptParameterParser.lang(), script, scriptType, vars), ScriptContext.Standard.SEARCH);
             return new ScriptScoreFunction(script, vars, searchScript);
         } catch (Exception e) {
-            throw new QueryParsingException(parseContext.index(), NAMES[0] + " the script could not be loaded", e);
+            throw new QueryParsingException(parseContext.index(), NAMES[0] + " the script could not be loaded", parser.getTokenLocation(),
+                    e);
         }
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/functionscore/script/ScriptScoreFunctionParser.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/script/ScriptScoreFunctionParser.java
@@ -69,13 +69,11 @@ public class ScriptScoreFunctionParser implements ScoreFunctionParser {
                 if ("params".equals(currentFieldName)) {
                     vars = parser.map();
                 } else {
-                    throw new QueryParsingException(parseContext.index(), NAMES[0] + " query does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, NAMES[0] + " query does not support [" + currentFieldName + "]");
                 }
             } else if (token.isValue()) {
                 if (!scriptParameterParser.token(currentFieldName, token, parser)) {
-                    throw new QueryParsingException(parseContext.index(), NAMES[0] + " query does not support [" + currentFieldName + "]",
-                            parser.getTokenLocation());
+                    throw new QueryParsingException(parseContext, NAMES[0] + " query does not support [" + currentFieldName + "]");
                 }
             }
         }
@@ -86,7 +84,7 @@ public class ScriptScoreFunctionParser implements ScoreFunctionParser {
             scriptType = scriptValue.scriptType();
         }
         if (script == null) {
-            throw new QueryParsingException(parseContext.index(), NAMES[0] + " requires 'script' field", parser.getTokenLocation());
+            throw new QueryParsingException(parseContext, NAMES[0] + " requires 'script' field");
         }
 
         SearchScript searchScript;
@@ -94,8 +92,7 @@ public class ScriptScoreFunctionParser implements ScoreFunctionParser {
             searchScript = parseContext.scriptService().search(parseContext.lookup(), new Script(scriptParameterParser.lang(), script, scriptType, vars), ScriptContext.Standard.SEARCH);
             return new ScriptScoreFunction(script, vars, searchScript);
         } catch (Exception e) {
-            throw new QueryParsingException(parseContext.index(), NAMES[0] + " the script could not be loaded", parser.getTokenLocation(),
-                    e);
+            throw new QueryParsingException(parseContext, NAMES[0] + " the script could not be loaded", e);
         }
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/support/InnerHitsQueryParserHelper.java
+++ b/src/main/java/org/elasticsearch/index/query/support/InnerHitsQueryParserHelper.java
@@ -73,7 +73,7 @@ public class InnerHitsQueryParserHelper {
                 }
             }
         } catch (Exception e) {
-            throw new QueryParsingException(parserContext.index(), "Failed to parse [_inner_hits]", null, e);
+            throw new QueryParsingException(parserContext, "Failed to parse [_inner_hits]", e);
         }
         return new Tuple<>(innerHitName, subSearchContext);
     }

--- a/src/main/java/org/elasticsearch/index/query/support/InnerHitsQueryParserHelper.java
+++ b/src/main/java/org/elasticsearch/index/query/support/InnerHitsQueryParserHelper.java
@@ -73,7 +73,7 @@ public class InnerHitsQueryParserHelper {
                 }
             }
         } catch (Exception e) {
-            throw new QueryParsingException(parserContext.index(), "Failed to parse [_inner_hits]", e);
+            throw new QueryParsingException(parserContext.index(), "Failed to parse [_inner_hits]", null, e);
         }
         return new Tuple<>(innerHitName, subSearchContext);
     }

--- a/src/main/java/org/elasticsearch/index/query/support/NestedInnerQueryParseSupport.java
+++ b/src/main/java/org/elasticsearch/index/query/support/NestedInnerQueryParseSupport.java
@@ -106,10 +106,10 @@ public class NestedInnerQueryParseSupport {
             return innerQuery;
         } else {
             if (path == null) {
-                throw new QueryParsingException(parseContext.index(), "[nested] requires 'path' field", null);
+                throw new QueryParsingException(parseContext, "[nested] requires 'path' field");
             }
             if (!queryFound) {
-                throw new QueryParsingException(parseContext.index(), "[nested] requires either 'query' or 'filter' field", null);
+                throw new QueryParsingException(parseContext, "[nested] requires either 'query' or 'filter' field");
             }
 
             XContentParser old = parseContext.parser();
@@ -135,10 +135,10 @@ public class NestedInnerQueryParseSupport {
             return innerFilter;
         } else {
             if (path == null) {
-                throw new QueryParsingException(parseContext.index(), "[nested] requires 'path' field", null);
+                throw new QueryParsingException(parseContext, "[nested] requires 'path' field");
             }
             if (!filterFound) {
-                throw new QueryParsingException(parseContext.index(), "[nested] requires either 'query' or 'filter' field", null);
+                throw new QueryParsingException(parseContext, "[nested] requires either 'query' or 'filter' field");
             }
 
             setPathLevel();
@@ -160,16 +160,15 @@ public class NestedInnerQueryParseSupport {
         this.path = path;
         MapperService.SmartNameObjectMapper smart = parseContext.smartObjectMapper(path);
         if (smart == null) {
-            throw new QueryParsingException(parseContext.index(), "[nested] failed to find nested object under path [" + path + "]", null);
+            throw new QueryParsingException(parseContext, "[nested] failed to find nested object under path [" + path + "]");
         }
         childDocumentMapper = smart.docMapper();
         nestedObjectMapper = smart.mapper();
         if (nestedObjectMapper == null) {
-            throw new QueryParsingException(parseContext.index(), "[nested] failed to find nested object under path [" + path + "]", null);
+            throw new QueryParsingException(parseContext, "[nested] failed to find nested object under path [" + path + "]");
         }
         if (!nestedObjectMapper.nested().isNested()) {
-            throw new QueryParsingException(parseContext.index(), "[nested] nested object under path [" + path + "] is not of nested type",
-                    null);
+            throw new QueryParsingException(parseContext, "[nested] nested object under path [" + path + "] is not of nested type");
         }
     }
 

--- a/src/main/java/org/elasticsearch/index/query/support/NestedInnerQueryParseSupport.java
+++ b/src/main/java/org/elasticsearch/index/query/support/NestedInnerQueryParseSupport.java
@@ -106,10 +106,10 @@ public class NestedInnerQueryParseSupport {
             return innerQuery;
         } else {
             if (path == null) {
-                throw new QueryParsingException(parseContext.index(), "[nested] requires 'path' field");
+                throw new QueryParsingException(parseContext.index(), "[nested] requires 'path' field", null);
             }
             if (!queryFound) {
-                throw new QueryParsingException(parseContext.index(), "[nested] requires either 'query' or 'filter' field");
+                throw new QueryParsingException(parseContext.index(), "[nested] requires either 'query' or 'filter' field", null);
             }
 
             XContentParser old = parseContext.parser();
@@ -135,10 +135,10 @@ public class NestedInnerQueryParseSupport {
             return innerFilter;
         } else {
             if (path == null) {
-                throw new QueryParsingException(parseContext.index(), "[nested] requires 'path' field");
+                throw new QueryParsingException(parseContext.index(), "[nested] requires 'path' field", null);
             }
             if (!filterFound) {
-                throw new QueryParsingException(parseContext.index(), "[nested] requires either 'query' or 'filter' field");
+                throw new QueryParsingException(parseContext.index(), "[nested] requires either 'query' or 'filter' field", null);
             }
 
             setPathLevel();
@@ -160,15 +160,16 @@ public class NestedInnerQueryParseSupport {
         this.path = path;
         MapperService.SmartNameObjectMapper smart = parseContext.smartObjectMapper(path);
         if (smart == null) {
-            throw new QueryParsingException(parseContext.index(), "[nested] failed to find nested object under path [" + path + "]");
+            throw new QueryParsingException(parseContext.index(), "[nested] failed to find nested object under path [" + path + "]", null);
         }
         childDocumentMapper = smart.docMapper();
         nestedObjectMapper = smart.mapper();
         if (nestedObjectMapper == null) {
-            throw new QueryParsingException(parseContext.index(), "[nested] failed to find nested object under path [" + path + "]");
+            throw new QueryParsingException(parseContext.index(), "[nested] failed to find nested object under path [" + path + "]", null);
         }
         if (!nestedObjectMapper.nested().isNested()) {
-            throw new QueryParsingException(parseContext.index(), "[nested] nested object under path [" + path + "] is not of nested type");
+            throw new QueryParsingException(parseContext.index(), "[nested] nested object under path [" + path + "] is not of nested type",
+                    null);
         }
     }
 

--- a/src/main/java/org/elasticsearch/search/SearchParseException.java
+++ b/src/main/java/org/elasticsearch/search/SearchParseException.java
@@ -43,8 +43,8 @@ public class SearchParseException extends SearchContextException {
     public SearchParseException(SearchContext context, String msg, @Nullable XContentLocation location, Throwable cause) {
         super(context, msg, cause);
         if (location != null) {
-            lineNumber = location.getLineNumber();
-            columnNumber = location.getColumnNumber();
+            lineNumber = location.lineNumber;
+            columnNumber = location.columnNumber;
         }
     }
 

--- a/src/main/java/org/elasticsearch/search/SearchParseException.java
+++ b/src/main/java/org/elasticsearch/search/SearchParseException.java
@@ -19,24 +19,64 @@
 
 package org.elasticsearch.search;
 
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentLocation;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.internal.SearchContext;
+
+import java.io.IOException;
 
 /**
  *
  */
 public class SearchParseException extends SearchContextException {
 
-    public SearchParseException(SearchContext context, String msg) {
-        super(context, msg);
+    public static final int UNKNOWN_POSITION = -1;
+    private int lineNumber = UNKNOWN_POSITION;
+    private int columnNumber = UNKNOWN_POSITION;
+
+    public SearchParseException(SearchContext context, String msg, @Nullable XContentLocation location) {
+        this(context, msg, location, null);
     }
 
-    public SearchParseException(SearchContext context, String msg, Throwable cause) {
+    public SearchParseException(SearchContext context, String msg, @Nullable XContentLocation location, Throwable cause) {
         super(context, msg, cause);
+        if (location != null) {
+            lineNumber = location.getLineNumber();
+            columnNumber = location.getColumnNumber();
+        }
     }
 
     @Override
     public RestStatus status() {
         return RestStatus.BAD_REQUEST;
+    }
+
+    @Override
+    protected void innerToXContent(XContentBuilder builder, Params params) throws IOException {
+        if (lineNumber != UNKNOWN_POSITION) {
+            builder.field("line", lineNumber);
+            builder.field("col", columnNumber);
+        }
+        super.innerToXContent(builder, params);
+    }
+
+    /**
+     * Line number of the location of the error
+     * 
+     * @return the line number or -1 if unknown
+     */
+    public int getLineNumber() {
+        return lineNumber;
+    }
+
+    /**
+     * Column number of the location of the error
+     * 
+     * @return the column number or -1 if unknown
+     */
+    public int getColumnNumber() {
+        return columnNumber;
     }
 }

--- a/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/src/main/java/org/elasticsearch/search/SearchService.java
@@ -24,6 +24,7 @@ import com.carrotsearch.hppc.ObjectSet;
 import com.carrotsearch.hppc.cursors.ObjectCursor;
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
+
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.NumericDocValues;
@@ -78,10 +79,23 @@ import org.elasticsearch.script.mustache.MustacheScriptEngineService;
 import org.elasticsearch.search.dfs.CachedDfSource;
 import org.elasticsearch.search.dfs.DfsPhase;
 import org.elasticsearch.search.dfs.DfsSearchResult;
-import org.elasticsearch.search.fetch.*;
-import org.elasticsearch.search.internal.*;
+import org.elasticsearch.search.fetch.FetchPhase;
+import org.elasticsearch.search.fetch.FetchSearchResult;
+import org.elasticsearch.search.fetch.QueryFetchSearchResult;
+import org.elasticsearch.search.fetch.ScrollQueryFetchSearchResult;
+import org.elasticsearch.search.fetch.ShardFetchRequest;
+import org.elasticsearch.search.internal.DefaultSearchContext;
+import org.elasticsearch.search.internal.InternalScrollSearchRequest;
+import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.internal.SearchContext.Lifetime;
-import org.elasticsearch.search.query.*;
+import org.elasticsearch.search.internal.ShardSearchLocalRequest;
+import org.elasticsearch.search.internal.ShardSearchRequest;
+import org.elasticsearch.search.query.QueryPhase;
+import org.elasticsearch.search.query.QueryPhaseExecutionException;
+import org.elasticsearch.search.query.QuerySearchRequest;
+import org.elasticsearch.search.query.QuerySearchResult;
+import org.elasticsearch.search.query.QuerySearchResultProvider;
+import org.elasticsearch.search.query.ScrollQuerySearchResult;
 import org.elasticsearch.search.warmer.IndexWarmersMetaData;
 import org.elasticsearch.threadpool.ThreadPool;
 
@@ -719,7 +733,7 @@ public class SearchService extends AbstractLifecycleComponent<SearchService> {
                     parser.nextToken();
                     SearchParseElement element = elementParsers.get(fieldName);
                     if (element == null) {
-                        throw new SearchParseException(context, "No parser for element [" + fieldName + "]");
+                        throw new SearchParseException(context, "No parser for element [" + fieldName + "]", parser.getTokenLocation());
                     }
                     element.parse(parser, context);
                 } else {
@@ -737,7 +751,7 @@ public class SearchService extends AbstractLifecycleComponent<SearchService> {
             } catch (Throwable e1) {
                 // ignore
             }
-            throw new SearchParseException(context, "Failed to parse source [" + sSource + "]", e);
+            throw new SearchParseException(context, "Failed to parse source [" + sSource + "]", parser.getTokenLocation(), e);
         } finally {
             if (parser != null) {
                 parser.close();

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/children/ChildrenParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/children/ChildrenParser.java
@@ -56,15 +56,18 @@ public class ChildrenParser implements Aggregator.Parser {
                 if ("type".equals(currentFieldName)) {
                     childType = parser.text();
                 } else {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: ["
+                            + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else {
-                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].");
+                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].",
+                        parser.getTokenLocation());
             }
         }
 
         if (childType == null) {
-            throw new SearchParseException(context, "Missing [child_type] field for children aggregation [" + aggregationName + "]");
+            throw new SearchParseException(context, "Missing [child_type] field for children aggregation [" + aggregationName + "]",
+                    parser.getTokenLocation());
         }
 
         ValuesSourceConfig<ValuesSource.Bytes.WithOrdinals.ParentChild> config = new ValuesSourceConfig<>(ValuesSource.Bytes.WithOrdinals.ParentChild.class);
@@ -76,7 +79,7 @@ public class ChildrenParser implements Aggregator.Parser {
         if (childDocMapper != null) {
             ParentFieldMapper parentFieldMapper = childDocMapper.parentFieldMapper();
             if (!parentFieldMapper.active()) {
-                throw new SearchParseException(context, "[children] _parent field not configured");
+                throw new SearchParseException(context, "[children] _parent field not configured", parser.getTokenLocation());
             }
             parentType = parentFieldMapper.type();
             DocumentMapper parentDocMapper = context.mapperService().documentMapper(parentType);

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/filters/FiltersParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/filters/FiltersParser.java
@@ -65,7 +65,8 @@ public class FiltersParser implements Aggregator.Parser {
                         }
                     }
                 } else {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: ["
+                            + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.START_ARRAY) {
                 if ("filters".equals(currentFieldName)) {
@@ -78,10 +79,12 @@ public class FiltersParser implements Aggregator.Parser {
                         idx++;
                     }
                 } else {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: ["
+                            + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else {
-                throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: ["
+                        + currentFieldName + "].", parser.getTokenLocation());
             }
         }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramParser.java
@@ -108,13 +108,15 @@ public class DateHistogramParser implements Aggregator.Parser {
                 } else if (INTERVAL.match(currentFieldName)) {
                     interval = parser.text();
                 } else {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: ["
+                            + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.VALUE_BOOLEAN) {
                 if ("keyed".equals(currentFieldName)) {
                     keyed = parser.booleanValue();
                 } else {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: ["
+                            + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.VALUE_NUMBER) {
                 if ("min_doc_count".equals(currentFieldName) || "minDocCount".equals(currentFieldName)) {
@@ -122,7 +124,8 @@ public class DateHistogramParser implements Aggregator.Parser {
                 } else if ("time_zone".equals(currentFieldName) || "timeZone".equals(currentFieldName)) {
                     timeZone = DateTimeZone.forOffsetHours(parser.intValue());
                 } else {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: ["
+                            + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.START_OBJECT) {
                 if ("order".equals(currentFieldName)) {
@@ -147,7 +150,8 @@ public class DateHistogramParser implements Aggregator.Parser {
                             } else if ("max".equals(currentFieldName)) {
                                 extendedBounds.maxAsStr = parser.text();
                             } else {
-                                throw new SearchParseException(context, "Unknown extended_bounds key for a " + token + " in aggregation [" + aggregationName + "]: [" + currentFieldName + "].");
+                                throw new SearchParseException(context, "Unknown extended_bounds key for a " + token + " in aggregation ["
+                                        + aggregationName + "]: [" + currentFieldName + "].", parser.getTokenLocation());
                             }
                         } else if (token == XContentParser.Token.VALUE_NUMBER) {
                             if ("min".equals(currentFieldName)) {
@@ -155,23 +159,28 @@ public class DateHistogramParser implements Aggregator.Parser {
                             } else if ("max".equals(currentFieldName)) {
                                 extendedBounds.max = parser.longValue();
                             } else {
-                                throw new SearchParseException(context, "Unknown extended_bounds key for a " + token + " in aggregation [" + aggregationName + "]: [" + currentFieldName + "].");
+                                throw new SearchParseException(context, "Unknown extended_bounds key for a " + token + " in aggregation ["
+                                        + aggregationName + "]: [" + currentFieldName + "].", parser.getTokenLocation());
                             }
                         } else {
-                            throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                            throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: ["
+                                    + currentFieldName + "].", parser.getTokenLocation());
                         }
                     }
 
                 } else {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: ["
+                            + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else {
-                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].");
+                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].",
+                        parser.getTokenLocation());
             }
         }
 
         if (interval == null) {
-            throw new SearchParseException(context, "Missing required field [interval] for histogram aggregation [" + aggregationName + "]");
+            throw new SearchParseException(context,
+                    "Missing required field [interval] for histogram aggregation [" + aggregationName + "]", parser.getTokenLocation());
         }
 
         TimeZoneRounding.Builder tzRoundingBuilder;

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/ExtendedBounds.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/ExtendedBounds.java
@@ -56,7 +56,7 @@ public class ExtendedBounds {
         }
         if (min != null && max != null && min.compareTo(max) > 0) {
             throw new SearchParseException(context, "[extended_bounds.min][" + min + "] cannot be greater than " +
-                    "[extended_bounds.max][" + max + "] for histogram aggregation [" + aggName + "]");
+                    "[extended_bounds.max][" + max + "] for histogram aggregation [" + aggName + "]", null);
         }
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/HistogramParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/HistogramParser.java
@@ -75,7 +75,8 @@ public class HistogramParser implements Aggregator.Parser {
                 } else if ("offset".equals(currentFieldName)) {
                     offset = parser.longValue();
                 } else {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in aggregation [" + aggregationName + "]: [" + currentFieldName + "].");
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in aggregation [" + aggregationName + "]: ["
+                            + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.START_OBJECT) {
                 if ("order".equals(currentFieldName)) {
@@ -86,7 +87,8 @@ public class HistogramParser implements Aggregator.Parser {
                             String dir = parser.text();
                             boolean asc = "asc".equals(dir);
                             if (!asc && !"desc".equals(dir)) {
-                                throw new SearchParseException(context, "Unknown order direction [" + dir + "] in aggregation [" + aggregationName + "]. Should be either [asc] or [desc]");
+                                throw new SearchParseException(context, "Unknown order direction [" + dir + "] in aggregation ["
+                                        + aggregationName + "]. Should be either [asc] or [desc]", parser.getTokenLocation());
                             }
                             order = resolveOrder(currentFieldName, asc);
                         }
@@ -102,21 +104,25 @@ public class HistogramParser implements Aggregator.Parser {
                             } else if ("max".equals(currentFieldName)) {
                                 extendedBounds.max = parser.longValue(true);
                             } else {
-                                throw new SearchParseException(context, "Unknown extended_bounds key for a " + token + " in aggregation [" + aggregationName + "]: [" + currentFieldName + "].");
+                                throw new SearchParseException(context, "Unknown extended_bounds key for a " + token + " in aggregation ["
+                                        + aggregationName + "]: [" + currentFieldName + "].", parser.getTokenLocation());
                             }
                         }
                     }
 
                 } else {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in aggregation [" + aggregationName + "]: [" + currentFieldName + "].");
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in aggregation [" + aggregationName + "]: ["
+                            + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else {
-                throw new SearchParseException(context, "Unexpected token " + token + " in aggregation [" + aggregationName + "].");
+                throw new SearchParseException(context, "Unexpected token " + token + " in aggregation [" + aggregationName + "].",
+                        parser.getTokenLocation());
             }
         }
 
         if (interval < 1) {
-            throw new SearchParseException(context, "Missing required field [interval] for histogram aggregation [" + aggregationName + "]");
+            throw new SearchParseException(context,
+                    "Missing required field [interval] for histogram aggregation [" + aggregationName + "]", parser.getTokenLocation());
         }
 
         Rounding rounding = new Rounding.Interval(interval);

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/missing/MissingParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/missing/MissingParser.java
@@ -52,7 +52,8 @@ public class MissingParser implements Aggregator.Parser {
             } else if (vsParser.token(currentFieldName, token, parser)) {
                 continue;
             } else {
-                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].");
+                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].",
+                        parser.getTokenLocation());
             }
         }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/NestedParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/NestedParser.java
@@ -49,16 +49,19 @@ public class NestedParser implements Aggregator.Parser {
                 if ("path".equals(currentFieldName)) {
                     path = parser.text();
                 } else {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: ["
+                            + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else {
-                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].");
+                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].",
+                        parser.getTokenLocation());
             }
         }
 
         if (path == null) {
             // "field" doesn't exist, so we fall back to the context of the ancestors
-            throw new SearchParseException(context, "Missing [path] field for nested aggregation [" + aggregationName + "]");
+            throw new SearchParseException(context, "Missing [path] field for nested aggregation [" + aggregationName + "]",
+                    parser.getTokenLocation());
         }
 
         return new NestedAggregator.Factory(aggregationName, path, context.queryParserService().autoFilterCachePolicy());

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/ReverseNestedAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/ReverseNestedAggregator.java
@@ -131,7 +131,8 @@ public class ReverseNestedAggregator extends SingleBucketAggregator {
             // Early validation
             NestedAggregator closestNestedAggregator = findClosestNestedAggregator(parent);
             if (closestNestedAggregator == null) {
-                throw new SearchParseException(context.searchContext(), "Reverse nested aggregation [" + name + "] can only be used inside a [nested] aggregation");
+                throw new SearchParseException(context.searchContext(), "Reverse nested aggregation [" + name
+                        + "] can only be used inside a [nested] aggregation", null);
             }
 
             final ObjectMapper objectMapper;

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/ReverseNestedParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/ReverseNestedParser.java
@@ -49,10 +49,12 @@ public class ReverseNestedParser implements Aggregator.Parser {
                 if ("path".equals(currentFieldName)) {
                     path = parser.text();
                 } else {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: ["
+                            + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else {
-                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].");
+                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].",
+                        parser.getTokenLocation());
             }
         }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/range/RangeParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/range/RangeParser.java
@@ -89,21 +89,25 @@ public class RangeParser implements Aggregator.Parser {
                         ranges.add(new RangeAggregator.Range(key, from, fromAsStr, to, toAsStr));
                     }
                 } else {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: ["
+                            + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.VALUE_BOOLEAN) {
                 if ("keyed".equals(currentFieldName)) {
                     keyed = parser.booleanValue();
                 } else {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: ["
+                            + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else {
-                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].");
+                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].",
+                        parser.getTokenLocation());
             }
         }
 
         if (ranges == null) {
-            throw new SearchParseException(context, "Missing [ranges] in ranges aggregator [" + aggregationName + "]");
+            throw new SearchParseException(context, "Missing [ranges] in ranges aggregator [" + aggregationName + "]",
+                    parser.getTokenLocation());
         }
 
         return new RangeAggregator.Factory(aggregationName, vsParser.config(), InternalRange.FACTORY, ranges, keyed);

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/range/date/DateRangeParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/range/date/DateRangeParser.java
@@ -79,7 +79,8 @@ public class DateRangeParser implements Aggregator.Parser {
                                 } else if ("to".equals(toOrFromOrKey)) {
                                     to = parser.doubleValue();
                                 } else {
-                                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName
+                                            + "]: [" + currentFieldName + "].", parser.getTokenLocation());
                                 }
                             } else if (token == XContentParser.Token.VALUE_STRING) {
                                 if ("from".equals(toOrFromOrKey)) {
@@ -89,7 +90,7 @@ public class DateRangeParser implements Aggregator.Parser {
                                 } else if ("key".equals(toOrFromOrKey)) {
                                     key = parser.text();
                                 } else {
-                                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].", parser.getTokenLocation());
                                 }
                             }
                         }
@@ -100,15 +101,18 @@ public class DateRangeParser implements Aggregator.Parser {
                 if ("keyed".equals(currentFieldName)) {
                     keyed = parser.booleanValue();
                 } else {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: ["
+                            + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else {
-                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].");
+                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].",
+                        parser.getTokenLocation());
             }
         }
 
         if (ranges == null) {
-            throw new SearchParseException(context, "Missing [ranges] in ranges aggregator [" + aggregationName + "]");
+            throw new SearchParseException(context, "Missing [ranges] in ranges aggregator [" + aggregationName + "]",
+                    parser.getTokenLocation());
         }
 
         return new RangeAggregator.Factory(aggregationName, vsParser.config(), InternalDateRange.FACTORY, ranges, keyed);

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/range/geodistance/GeoDistanceParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/range/geodistance/GeoDistanceParser.java
@@ -98,13 +98,15 @@ public class GeoDistanceParser implements Aggregator.Parser {
                 } else if ("distance_type".equals(currentFieldName) || "distanceType".equals(currentFieldName)) {
                     distanceType = GeoDistance.fromString(parser.text());
                 } else {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: ["
+                            + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.VALUE_BOOLEAN) {
                 if ("keyed".equals(currentFieldName)) {
                     keyed = parser.booleanValue();
                 } else {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: ["
+                            + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.START_ARRAY) {
                 if ("ranges".equals(currentFieldName)) {
@@ -138,20 +140,24 @@ public class GeoDistanceParser implements Aggregator.Parser {
                         ranges.add(new RangeAggregator.Range(key(key, from, to), from, fromAsStr, to, toAsStr));
                     }
                 } else  {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: ["
+                            + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else {
-                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].");
+                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].",
+                        parser.getTokenLocation());
             }
         }
 
         if (ranges == null) {
-            throw new SearchParseException(context, "Missing [ranges] in geo_distance aggregator [" + aggregationName + "]");
+            throw new SearchParseException(context, "Missing [ranges] in geo_distance aggregator [" + aggregationName + "]",
+                    parser.getTokenLocation());
         }
 
         GeoPoint origin = geoPointParser.geoPoint();
         if (origin == null) {
-            throw new SearchParseException(context, "Missing [origin] in geo_distance aggregator [" + aggregationName + "]");
+            throw new SearchParseException(context, "Missing [origin] in geo_distance aggregator [" + aggregationName + "]",
+                    parser.getTokenLocation());
         }
 
         return new GeoDistanceFactory(aggregationName, vsParser.config(), InternalGeoDistance.FACTORY, origin, unit, distanceType, ranges, keyed);

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ipv4/IpRangeParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ipv4/IpRangeParser.java
@@ -99,21 +99,25 @@ public class IpRangeParser implements Aggregator.Parser {
                         ranges.add(range);
                     }
                 } else {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: ["
+                            + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.VALUE_BOOLEAN) {
                 if ("keyed".equals(currentFieldName)) {
                     keyed = parser.booleanValue();
                 } else {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: ["
+                            + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else {
-                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].");
+                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].",
+                        parser.getTokenLocation());
             }
         }
 
         if (ranges == null) {
-            throw new SearchParseException(context, "Missing [ranges] in ranges aggregator [" + aggregationName + "]");
+            throw new SearchParseException(context, "Missing [ranges] in ranges aggregator [" + aggregationName + "]",
+                    parser.getTokenLocation());
         }
 
         return new RangeAggregator.Factory(aggregationName, vsParser.config(), InternalIPv4Range.FACTORY, ranges, keyed);
@@ -122,7 +126,8 @@ public class IpRangeParser implements Aggregator.Parser {
     private static void parseMaskRange(String cidr, RangeAggregator.Range range, String aggregationName, SearchContext ctx) {
         long[] fromTo = IPv4RangeBuilder.cidrMaskToMinMax(cidr);
         if (fromTo == null) {
-            throw new SearchParseException(ctx, "invalid CIDR mask [" + cidr + "] in aggregation [" + aggregationName + "]");
+            throw new SearchParseException(ctx, "invalid CIDR mask [" + cidr + "] in aggregation [" + aggregationName + "]",
+                    null);
         }
         range.from = fromTo[0] < 0 ? Double.NEGATIVE_INFINITY : fromTo[0];
         range.to = fromTo[1] < 0 ? Double.POSITIVE_INFINITY : fromTo[1];

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/SamplerParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/SamplerParser.java
@@ -73,17 +73,18 @@ public class SamplerParser implements Aggregator.Parser {
                     maxDocsPerValue = parser.intValue();
                 } else {
                     throw new SearchParseException(context, "Unsupported property \"" + currentFieldName + "\" for aggregation \""
-                            + aggregationName);
+                            + aggregationName, parser.getTokenLocation());
                 }
             } else if (!vsParser.token(currentFieldName, token, parser)) {
                 if (EXECUTION_HINT_FIELD.match(currentFieldName)) {
                     executionHint = parser.text();
                 } else {
-                    throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].");
+                    throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].",
+                            parser.getTokenLocation());
                 }
             } else {
                 throw new SearchParseException(context, "Unsupported property \"" + currentFieldName + "\" for aggregation \""
-                        + aggregationName);
+                        + aggregationName, parser.getTokenLocation());
             }
         }
 
@@ -93,7 +94,8 @@ public class SamplerParser implements Aggregator.Parser {
         } else {
             if (diversityChoiceMade) {
                 throw new SearchParseException(context, "Sampler aggregation has " + MAX_DOCS_PER_VALUE_FIELD.getPreferredName()
-                        + " setting but no \"field\" or \"script\" setting to provide values for aggregation \"" + aggregationName + "\"");
+                        + " setting but no \"field\" or \"script\" setting to provide values for aggregation \"" + aggregationName + "\"",
+                        parser.getTokenLocation());
 
             }
             return new SamplerAggregator.Factory(aggregationName, shardSize);

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsParametersParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsParametersParser.java
@@ -68,10 +68,12 @@ public class SignificantTermsParametersParser extends AbstractTermsParametersPar
             } else if (BACKGROUND_FILTER.match(currentFieldName)) {
                 filter = context.queryParserService().parseInnerFilter(parser).filter();
             } else {
-                throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: ["
+                        + currentFieldName + "].", parser.getTokenLocation());
             }
         } else {
-            throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+            throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName
+                    + "].", parser.getTokenLocation());
         }
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsParametersParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsParametersParser.java
@@ -56,7 +56,8 @@ public class TermsParametersParser extends AbstractTermsParametersParser {
             if ("order".equals(currentFieldName)) {
                 this.orderElements = Collections.singletonList(parseOrderParam(aggregationName, parser, context));
             } else {
-                throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: ["
+                        + currentFieldName + "].", parser.getTokenLocation());
             }
         } else if (token == XContentParser.Token.START_ARRAY) {
             if ("order".equals(currentFieldName)) {
@@ -66,18 +67,21 @@ public class TermsParametersParser extends AbstractTermsParametersParser {
                         OrderElement orderParam = parseOrderParam(aggregationName, parser, context);
                         orderElements.add(orderParam);
                     } else {
-                        throw new SearchParseException(context, "Order elements must be of type object in [" + aggregationName + "].");
+                        throw new SearchParseException(context, "Order elements must be of type object in [" + aggregationName + "].",
+                                parser.getTokenLocation());
                     }
                 }
             } else {
-                throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: ["
+                        + currentFieldName + "].", parser.getTokenLocation());
             }
         } else if (token == XContentParser.Token.VALUE_BOOLEAN) {
             if (SHOW_TERM_DOC_COUNT_ERROR.match(currentFieldName)) {
                 showTermDocCountError = parser.booleanValue();
             }
         } else {
-            throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+            throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName
+                    + "].", parser.getTokenLocation());
         }
     }
 
@@ -96,14 +100,17 @@ public class TermsParametersParser extends AbstractTermsParametersParser {
                 } else if ("desc".equalsIgnoreCase(dir)) {
                     orderAsc = false;
                 } else {
-                    throw new SearchParseException(context, "Unknown terms order direction [" + dir + "] in terms aggregation [" + aggregationName + "]");
+                    throw new SearchParseException(context, "Unknown terms order direction [" + dir + "] in terms aggregation ["
+                            + aggregationName + "]", parser.getTokenLocation());
                 }
             } else {
-                throw new SearchParseException(context, "Unexpected token " + token + " for [order] in [" + aggregationName + "].");
+                throw new SearchParseException(context, "Unexpected token " + token + " for [order] in [" + aggregationName + "].",
+                        parser.getTokenLocation());
             }
         }
         if (orderKey == null) {
-            throw new SearchParseException(context, "Must specify at least one field for [order] in [" + aggregationName + "].");
+            throw new SearchParseException(context, "Must specify at least one field for [order] in [" + aggregationName + "].",
+                    parser.getTokenLocation());
         } else {
             orderParam = new OrderElement(orderKey, orderAsc);
         }

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/NumericValuesSourceMetricsAggregatorParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/NumericValuesSourceMetricsAggregatorParser.java
@@ -58,7 +58,8 @@ public abstract class NumericValuesSourceMetricsAggregatorParser<S extends Inter
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
             } else if (!vsParser.token(currentFieldName, token, parser)) {
-                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].");
+                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].",
+                        parser.getTokenLocation());
             }
         }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/CardinalityParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/CardinalityParser.java
@@ -62,10 +62,11 @@ public class CardinalityParser implements Aggregator.Parser {
                 } else if (PRECISION_THRESHOLD.match(currentFieldName)) {
                     precisionThreshold = parser.longValue();
                 } else {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + name + "]: [" + currentFieldName + "].");
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + name + "]: [" + currentFieldName
+                            + "].", parser.getTokenLocation());
                 }
             } else {
-                throw new SearchParseException(context, "Unexpected token " + token + " in [" + name + "].");
+                throw new SearchParseException(context, "Unexpected token " + token + " in [" + name + "].", parser.getTokenLocation());
             }
         }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/geobounds/GeoBoundsParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/geobounds/GeoBoundsParser.java
@@ -56,10 +56,12 @@ public class GeoBoundsParser implements Aggregator.Parser {
                 if ("wrap_longitude".equals(currentFieldName) || "wrapLongitude".equals(currentFieldName)) {
                     wrapLongitude = parser.booleanValue();
                 } else {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in aggregation [" + aggregationName + "]: [" + currentFieldName + "].");
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in aggregation [" + aggregationName + "]: ["
+                            + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else {
-                throw new SearchParseException(context, "Unknown key for a " + token + " in aggregation [" + aggregationName + "]: [" + currentFieldName + "].");
+                throw new SearchParseException(context, "Unknown key for a " + token + " in aggregation [" + aggregationName + "]: ["
+                        + currentFieldName + "].", parser.getTokenLocation());
             }
         }
         return new GeoBoundsAggregator.Factory(aggregationName, vsParser.config(), wrapLongitude);

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/AbstractPercentilesParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/AbstractPercentilesParser.java
@@ -69,22 +69,26 @@ public abstract class AbstractPercentilesParser implements Aggregator.Parser {
                     keys = values.toArray();
                     Arrays.sort(keys);
                 } else {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: ["
+                            + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.VALUE_BOOLEAN) {
                 if ("keyed".equals(currentFieldName)) {
                     keyed = parser.booleanValue();
                 } else {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: ["
+                            + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.VALUE_NUMBER) {
                 if ("compression".equals(currentFieldName)) {
                     compression = parser.doubleValue();
                 } else {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: ["
+                            + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else {
-                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].");
+                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].",
+                        parser.getTokenLocation());
             }
         }
         return buildFactory(context, aggregationName, vsParser.config(), keys, compression, keyed);

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/PercentileRanksParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/PercentileRanksParser.java
@@ -46,7 +46,7 @@ public class PercentileRanksParser extends AbstractPercentilesParser {
     @Override
     protected AggregatorFactory buildFactory(SearchContext context, String aggregationName, ValuesSourceConfig<Numeric> valuesSourceConfig, double[] keys, double compression, boolean keyed) {
         if (keys == null) {
-            throw new SearchParseException(context, "Missing token values in [" + aggregationName + "].");
+            throw new SearchParseException(context, "Missing token values in [" + aggregationName + "].", null);
         }
         return new PercentileRanksAggregator.Factory(aggregationName, valuesSourceConfig, keys, compression, keyed);
     }

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/scripted/ScriptedMetricAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/scripted/ScriptedMetricAggregator.java
@@ -22,15 +22,17 @@ package org.elasticsearch.search.aggregations.metrics.scripted;
 import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.script.ExecutableScript;
 import org.elasticsearch.script.LeafSearchScript;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptService;
-import org.elasticsearch.script.*;
 import org.elasticsearch.script.ScriptService.ScriptType;
+import org.elasticsearch.script.SearchScript;
 import org.elasticsearch.search.SearchParseException;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
-import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
+import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
 import org.elasticsearch.search.aggregations.metrics.MetricsAggregator;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.internal.SearchContext;
@@ -190,7 +192,7 @@ public class ScriptedMetricAggregator extends MetricsAggregator {
                 clone = original;
             } else {
                 throw new SearchParseException(context, "Can only clone primitives, String, ArrayList, and HashMap. Found: "
-                        + original.getClass().getCanonicalName());
+                        + original.getClass().getCanonicalName(), null);
             }
             return clone;
         }

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/scripted/ScriptedMetricParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/scripted/ScriptedMetricParser.java
@@ -72,14 +72,17 @@ public class ScriptedMetricParser implements Aggregator.Parser {
                 } else if (REDUCE_PARAMS_FIELD.match(currentFieldName)) {
                   reduceParams = parser.map();
                 } else {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: ["
+                            + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else if (token.isValue()) {
                 if (!scriptParameterParser.token(currentFieldName, token, parser)) {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: ["
+                            + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else {
-                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].");
+                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].",
+                        parser.getTokenLocation());
             }
         }
         
@@ -114,7 +117,7 @@ public class ScriptedMetricParser implements Aggregator.Parser {
         scriptLang = scriptParameterParser.lang();
         
         if (mapScript == null) {
-            throw new SearchParseException(context, "map_script field is required in [" + aggregationName + "].");
+            throw new SearchParseException(context, "map_script field is required in [" + aggregationName + "].", parser.getTokenLocation());
         }
         return new ScriptedMetricAggregator.Factory(aggregationName, scriptLang, initScriptType, initScript, mapScriptType, mapScript,
                 combineScriptType, combineScript, reduceScriptType, reduceScript, params, reduceParams);

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/extended/ExtendedStatsParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/extended/ExtendedStatsParser.java
@@ -65,15 +65,17 @@ public class ExtendedStatsParser  implements Aggregator.Parser {
                 if (SIGMA.match(currentFieldName)) {
                     sigma = parser.doubleValue();
                 } else {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: ["
+                            + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else {
-                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].");
+                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].",
+                        parser.getTokenLocation());
             }
         }
 
         if (sigma < 0) {
-            throw new SearchParseException(context, "[sigma] must not be negative. Value provided was" + sigma );
+            throw new SearchParseException(context, "[sigma] must not be negative. Value provided was" + sigma, parser.getTokenLocation());
         }
 
         return createFactory(aggregationName, vsParser.config(), sigma);

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/TopHitsParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/TopHitsParser.java
@@ -94,7 +94,8 @@ public class TopHitsParser implements Aggregator.Parser {
                             subSearchContext.explain(parser.booleanValue());
                             break;
                         default:
-                            throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                        throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: ["
+                                + currentFieldName + "].", parser.getTokenLocation());
                     }
                 } else if (token == XContentParser.Token.START_OBJECT) {
                     switch (currentFieldName) {
@@ -106,7 +107,8 @@ public class TopHitsParser implements Aggregator.Parser {
                             scriptFieldsParseElement.parse(parser, subSearchContext);
                             break;
                         default:
-                            throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                        throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: ["
+                                + currentFieldName + "].", parser.getTokenLocation());
                     }
                 } else if (token == XContentParser.Token.START_ARRAY) {
                     switch (currentFieldName) {
@@ -115,10 +117,12 @@ public class TopHitsParser implements Aggregator.Parser {
                             fieldDataFieldsParseElement.parse(parser, subSearchContext);
                             break;
                         default:
-                            throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
+                        throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: ["
+                                + currentFieldName + "].", parser.getTokenLocation());
                     }
                 } else {
-                    throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].");
+                    throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].",
+                            parser.getTokenLocation());
                 }
             }
         } catch (Exception e) {

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/valuecount/ValueCountParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/valuecount/ValueCountParser.java
@@ -49,7 +49,8 @@ public class ValueCountParser implements Aggregator.Parser {
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
             } else if (!vsParser.token(currentFieldName, token, parser)) {
-                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].");
+                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].",
+                        parser.getTokenLocation());
             }
         }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/support/GeoPointParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/support/GeoPointParser.java
@@ -66,7 +66,8 @@ public class GeoPointParser {
                     lat = parser.doubleValue();
                 } else {
                     throw new SearchParseException(context, "malformed [" + currentFieldName + "] geo point array in [" +
-                            aggName + "] " + aggType + " aggregation. a geo point array must be of the form [lon, lat]");
+                            aggName + "] " + aggType + " aggregation. a geo point array must be of the form [lon, lat]", 
+                            parser.getTokenLocation());
                 }
             }
             point = new GeoPoint(lat, lon);
@@ -88,7 +89,7 @@ public class GeoPointParser {
             }
             if (Double.isNaN(lat) || Double.isNaN(lon)) {
                 throw new SearchParseException(context, "malformed [" + currentFieldName + "] geo point object. either [lat] or [lon] (or both) are " +
-                        "missing in [" + aggName + "] " + aggType + " aggregation");
+                        "missing in [" + aggName + "] " + aggType + " aggregation", parser.getTokenLocation());
             }
             point = new GeoPoint(lat, lon);
             return true;

--- a/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceParser.java
@@ -101,7 +101,8 @@ public class ValuesSourceParser<VS extends ValuesSource> {
                     if (targetValueType != null && input.valueType.isNotA(targetValueType)) {
                         throw new SearchParseException(context, aggType.name() + " aggregation [" + aggName +
                                 "] was configured with an incompatible value type [" + input.valueType + "]. [" + aggType +
-                                "] aggregation can only work on value of type [" + targetValueType + "]");
+                                "] aggregation can only work on value of type [" + targetValueType + "]", 
+                                parser.getTokenLocation());
                     }
                 } else if (!scriptParameterParser.token(currentFieldName, token, parser)) {
                     return false;

--- a/src/main/java/org/elasticsearch/search/highlight/HighlighterParseElement.java
+++ b/src/main/java/org/elasticsearch/search/highlight/HighlighterParseElement.java
@@ -21,6 +21,7 @@ package org.elasticsearch.search.highlight;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+
 import org.apache.lucene.search.vectorhighlight.SimpleBoundaryScanner;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.common.collect.Tuple;
@@ -71,7 +72,7 @@ public class HighlighterParseElement implements SearchParseElement {
         try {
             context.highlight(parse(parser, context.queryParserService()));
         } catch (ElasticsearchIllegalArgumentException ex) {
-            throw new SearchParseException(context, "Error while trying to parse Highlighter element in request");
+            throw new SearchParseException(context, "Error while trying to parse Highlighter element in request", parser.getTokenLocation());
         }
     }
 

--- a/src/main/java/org/elasticsearch/search/query/FromParseElement.java
+++ b/src/main/java/org/elasticsearch/search/query/FromParseElement.java
@@ -35,7 +35,8 @@ public class FromParseElement implements SearchParseElement {
         if (token.isValue()) {
             int from = parser.intValue();
             if (from < 0) {
-                throw new SearchParseException(context, "from is set to [" + from + "] and is expected to be higher or equal to 0");
+                throw new SearchParseException(context, "from is set to [" + from + "] and is expected to be higher or equal to 0",
+                        parser.getTokenLocation());
             }
             context.from(from);
         }

--- a/src/main/java/org/elasticsearch/search/query/SizeParseElement.java
+++ b/src/main/java/org/elasticsearch/search/query/SizeParseElement.java
@@ -35,7 +35,8 @@ public class SizeParseElement implements SearchParseElement {
         if (token.isValue()) {
             int size = parser.intValue();
             if (size < 0) {
-                throw new SearchParseException(context, "size is set to [" + size + "] and is expected to be higher or equal to 0");
+                throw new SearchParseException(context, "size is set to [" + size + "] and is expected to be higher or equal to 0",
+                        parser.getTokenLocation());
             }
             context.size(size);
         }

--- a/src/main/java/org/elasticsearch/search/sort/ScriptSortParser.java
+++ b/src/main/java/org/elasticsearch/search/sort/ScriptSortParser.java
@@ -118,15 +118,15 @@ public class ScriptSortParser implements SortParser {
         }
 
         if (script == null) {
-            throw new SearchParseException(context, "_script sorting requires setting the script to sort by");
+            throw new SearchParseException(context, "_script sorting requires setting the script to sort by", parser.getTokenLocation());
         }
         if (type == null) {
-            throw new SearchParseException(context, "_script sorting requires setting the type of the script");
+            throw new SearchParseException(context, "_script sorting requires setting the type of the script", parser.getTokenLocation());
         }
         final SearchScript searchScript = context.scriptService().search(context.lookup(), new Script(scriptLang, script, scriptType, params), ScriptContext.Standard.SEARCH);
 
         if (STRING_SORT_TYPE.equals(type) && (sortMode == MultiValueMode.SUM || sortMode == MultiValueMode.AVG)) {
-            throw new SearchParseException(context, "type [string] doesn't support mode [" + sortMode + "]");
+            throw new SearchParseException(context, "type [string] doesn't support mode [" + sortMode + "]", parser.getTokenLocation());
         }
 
         if (sortMode == null) {
@@ -196,7 +196,7 @@ public class ScriptSortParser implements SortParser {
                 };
                 break;
             default:
-                throw new SearchParseException(context, "custom script sort type [" + type + "] not supported");
+            throw new SearchParseException(context, "custom script sort type [" + type + "] not supported", parser.getTokenLocation());
         }
 
         return new SortField("_script", fieldComparatorSource, reverse);

--- a/src/main/java/org/elasticsearch/search/sort/SortParseElement.java
+++ b/src/main/java/org/elasticsearch/search/sort/SortParseElement.java
@@ -213,12 +213,12 @@ public class SortParseElement implements SearchParseElement {
                 if (unmappedType != null) {
                     fieldMapper = context.mapperService().unmappedFieldMapper(unmappedType);
                 } else {
-                    throw new SearchParseException(context, "No mapping found for [" + fieldName + "] in order to sort on");
+                    throw new SearchParseException(context, "No mapping found for [" + fieldName + "] in order to sort on", null);
                 }
             }
 
             if (!fieldMapper.isSortable()) {
-                throw new SearchParseException(context, "Sorting not supported for field[" + fieldName + "]");
+                throw new SearchParseException(context, "Sorting not supported for field[" + fieldName + "]", null);
             }
 
             // Enable when we also know how to detect fields that do tokenize, but only emit one token

--- a/src/test/java/org/elasticsearch/ElasticsearchExceptionTests.java
+++ b/src/test/java/org/elasticsearch/ElasticsearchExceptionTests.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.query.QueryParsingException;
+import org.elasticsearch.index.query.TestQueryParsingException;
 import org.elasticsearch.indices.IndexMissingException;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.SearchShardTarget;
@@ -62,18 +63,6 @@ public class ElasticsearchExceptionTests extends ElasticsearchTestCase {
 
         exception = new RemoteTransportException("test", new IllegalStateException("foobar"));
         assertThat(exception.status(), equalTo(RestStatus.INTERNAL_SERVER_ERROR));
-    }
-
-    // Test class to avoid dragging QueryContext into unit testing framework
-    public static class TestQueryParsingException extends QueryParsingException {
-
-        public TestQueryParsingException(Index index, int line, int col, String msg, Throwable cause) {
-            super(index, line, col, msg, cause);
-        }
-
-        public TestQueryParsingException(Index index, String msg, Throwable cause) {
-            super(index, UNKNOWN_POSITION, UNKNOWN_POSITION, msg, cause);
-        }
     }
 
     public void testGuessRootCause() {

--- a/src/test/java/org/elasticsearch/ElasticsearchExceptionTests.java
+++ b/src/test/java/org/elasticsearch/ElasticsearchExceptionTests.java
@@ -184,6 +184,18 @@ public class ElasticsearchExceptionTests extends ElasticsearchTestCase {
             assertEquals(expected, builder.string());
         }
 
+        {
+            XContentLocation errLocation = new XContentLocation(1, 2);
+            QueryParsingException ex = new QueryParsingException(new Index("foo"), "foobar", errLocation);
+            XContentBuilder builder = XContentFactory.jsonBuilder();
+            builder.startObject();
+            ElasticsearchException.toXContent(builder, ToXContent.EMPTY_PARAMS, ex);
+            builder.endObject();
+            System.out.println(builder.string());
+            String expected = "{\"type\":\"query_parsing_exception\",\"reason\":\"foobar\",\"line\":1,\"col\":2,\"index\":\"foo\"}";
+            assertEquals(expected, builder.string());
+        }
+
         { // test equivalence
             ElasticsearchException ex =  new RemoteTransportException("foobar", new FileNotFoundException("foo not found"));
             XContentBuilder builder = XContentFactory.jsonBuilder();

--- a/src/test/java/org/elasticsearch/index/query/TestQueryParsingException.java
+++ b/src/test/java/org/elasticsearch/index/query/TestQueryParsingException.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query;
+
+import org.elasticsearch.index.Index;
+
+/**
+ * Class used to avoid dragging QueryContext into unit testing framework for
+ * basic exception handling
+ */
+public class TestQueryParsingException extends QueryParsingException {
+
+    public TestQueryParsingException(Index index, int line, int col, String msg, Throwable cause) {
+        super(index, line, col, msg, cause);
+    }
+
+    public TestQueryParsingException(Index index, String msg, Throwable cause) {
+        super(index, UNKNOWN_POSITION, UNKNOWN_POSITION, msg, cause);
+    }
+}

--- a/src/test/java/org/elasticsearch/rest/BytesRestResponseTests.java
+++ b/src/test/java/org/elasticsearch/rest/BytesRestResponseTests.java
@@ -20,10 +20,10 @@
 package org.elasticsearch.rest;
 
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.ElasticsearchExceptionTests.TestQueryParsingException;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.index.Index;
+import org.elasticsearch.index.query.TestQueryParsingException;
 import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.elasticsearch.test.rest.FakeRestRequest;

--- a/src/test/java/org/elasticsearch/rest/BytesRestResponseTests.java
+++ b/src/test/java/org/elasticsearch/rest/BytesRestResponseTests.java
@@ -134,8 +134,10 @@ public class BytesRestResponseTests extends ElasticsearchTestCase {
     public void testConvert() throws IOException {
         RestRequest request = new FakeRestRequest();
         RestChannel channel = new DetailedExceptionRestChannel(request);
-        ShardSearchFailure failure = new ShardSearchFailure(new QueryParsingException(new Index("foo"), "foobar"), new SearchShardTarget("node_1", "foo", 1));
-        ShardSearchFailure failure1 = new ShardSearchFailure(new QueryParsingException(new Index("foo"), "foobar"), new SearchShardTarget("node_1", "foo", 2));
+        ShardSearchFailure failure = new ShardSearchFailure(new QueryParsingException(new Index("foo"), "foobar", null),
+                new SearchShardTarget("node_1", "foo", 1));
+        ShardSearchFailure failure1 = new ShardSearchFailure(new QueryParsingException(new Index("foo"), "foobar", null),
+                new SearchShardTarget("node_1", "foo", 2));
         SearchPhaseExecutionException ex = new SearchPhaseExecutionException("search", "all shards failed",  new ShardSearchFailure[] {failure, failure1});
         BytesRestResponse response = new BytesRestResponse(channel, new RemoteTransportException("foo", ex));
         String text = response.content().toUtf8();

--- a/src/test/java/org/elasticsearch/rest/BytesRestResponseTests.java
+++ b/src/test/java/org/elasticsearch/rest/BytesRestResponseTests.java
@@ -20,10 +20,10 @@
 package org.elasticsearch.rest;
 
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.ElasticsearchExceptionTests.TestQueryParsingException;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.index.Index;
-import org.elasticsearch.index.query.QueryParsingException;
 import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.elasticsearch.test.rest.FakeRestRequest;
@@ -134,14 +134,14 @@ public class BytesRestResponseTests extends ElasticsearchTestCase {
     public void testConvert() throws IOException {
         RestRequest request = new FakeRestRequest();
         RestChannel channel = new DetailedExceptionRestChannel(request);
-        ShardSearchFailure failure = new ShardSearchFailure(new QueryParsingException(new Index("foo"), "foobar", null),
+        ShardSearchFailure failure = new ShardSearchFailure(new TestQueryParsingException(new Index("foo"), "foobar", null),
                 new SearchShardTarget("node_1", "foo", 1));
-        ShardSearchFailure failure1 = new ShardSearchFailure(new QueryParsingException(new Index("foo"), "foobar", null),
+        ShardSearchFailure failure1 = new ShardSearchFailure(new TestQueryParsingException(new Index("foo"), "foobar", null),
                 new SearchShardTarget("node_1", "foo", 2));
         SearchPhaseExecutionException ex = new SearchPhaseExecutionException("search", "all shards failed",  new ShardSearchFailure[] {failure, failure1});
         BytesRestResponse response = new BytesRestResponse(channel, new RemoteTransportException("foo", ex));
         String text = response.content().toUtf8();
-        String expected = "{\"error\":{\"root_cause\":[{\"type\":\"query_parsing_exception\",\"reason\":\"foobar\",\"index\":\"foo\"}],\"type\":\"search_phase_execution_exception\",\"reason\":\"all shards failed\",\"phase\":\"search\",\"grouped\":true,\"failed_shards\":[{\"shard\":1,\"index\":\"foo\",\"node\":\"node_1\",\"reason\":{\"type\":\"query_parsing_exception\",\"reason\":\"foobar\",\"index\":\"foo\"}}]},\"status\":400}";
+        String expected = "{\"error\":{\"root_cause\":[{\"type\":\"test_query_parsing_exception\",\"reason\":\"foobar\",\"index\":\"foo\"}],\"type\":\"search_phase_execution_exception\",\"reason\":\"all shards failed\",\"phase\":\"search\",\"grouped\":true,\"failed_shards\":[{\"shard\":1,\"index\":\"foo\",\"node\":\"node_1\",\"reason\":{\"type\":\"test_query_parsing_exception\",\"reason\":\"foobar\",\"index\":\"foo\"}}]},\"status\":400}";
         assertEquals(expected.trim(), text.trim());
     }
 


### PR DESCRIPTION
Extend SearchParseException and QueryParsingException to report position information in query JSON where errors were found. All query DSL parser classes that throw these exception types now pass the underlying position information (line and column number) at the point the error was found.

Closes #3303 
