### PR TITLE
Backcompat: Add test for missing filter

### DIFF
--- a/src/test/java/org/elasticsearch/bwcompat/OldIndexBackwardsCompatibilityTests.java
+++ b/src/test/java/org/elasticsearch/bwcompat/OldIndexBackwardsCompatibilityTests.java
@@ -204,6 +204,7 @@ public class OldIndexBackwardsCompatibilityTests extends ElasticsearchIntegratio
                 }
                 return FileVisitResult.CONTINUE;
             }
+
             @Override
             public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
                 if (file.getFileName().toString().equals(IndexWriter.WRITE_LOCK_NAME)) {
@@ -285,7 +286,6 @@ public class OldIndexBackwardsCompatibilityTests extends ElasticsearchIntegratio
                 version.luceneVersion.minor == Version.CURRENT.luceneVersion.minor;
     }
 
-
     void assertIndexSanity(String indexName) {
         GetIndexResponse getIndexResponse = client().admin().indices().prepareGetIndex().addIndices(indexName).get();
         assertEquals(1, getIndexResponse.indices().length);
@@ -311,7 +311,14 @@ public class OldIndexBackwardsCompatibilityTests extends ElasticsearchIntegratio
         searchReq = client().prepareSearch(indexName).setQuery(QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(), FilterBuilders.existsFilter("string")));
         searchRsp = searchReq.get();
         ElasticsearchAssertions.assertNoFailures(searchRsp);
-        assertThat(numDocs, equalTo(searchRsp.getHits().getTotalHits()));
+        assertEquals(numDocs, searchRsp.getHits().getTotalHits());
+
+        logger.info("--> testing missing filter");
+        // the field for the missing filter here needs to be different than the exists filter above, to avoid being found in the cache
+        searchReq = client().prepareSearch(indexName).setQuery(QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(), FilterBuilders.missingFilter("long_sort")));
+        searchRsp = searchReq.get();
+        ElasticsearchAssertions.assertNoFailures(searchRsp);
+        assertEquals(0, searchRsp.getHits().getTotalHits());
     }
 
     void assertBasicAggregationWorks(String indexName) {


### PR DESCRIPTION
The _field_names field was fixed in 1.5.1 (#10268) to correctly be
disabled for indexes before 1.3.0.  However, only the exists filter
was updated to check this enabled flag on 1.x/1.5. The missing
filter on those branches still checks the field type to see if it
is indexed, which causes the filter to always try and use
the _field_names field for those old indexes.

This change adds a test to the old index tests for missing filter.

Note: Something alarming about this test is it does not always fail.
If I narrow down to run just on say 1.1.0, it fails most of the time,
but not always. @jpountz Maybe you have an idea on why this might be?
