### PR TITLE
Security manager cleanups

### DIFF
--- a/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
+++ b/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
@@ -59,7 +59,6 @@ public class Bootstrap {
     private static Bootstrap bootstrap;
 
     private void setup(boolean addShutdownHook, Settings settings, Environment environment) throws Exception {
-        setupSecurity(settings, environment);
         if (settings.getAsBoolean("bootstrap.mlockall", false)) {
             Natives.tryMlockall();
         }
@@ -90,6 +89,8 @@ public class Bootstrap {
                 }
             });
         }
+        // install SM after natives, JNA can require strange permissions
+        setupSecurity(settings, environment);
     }
     
     /** 

--- a/src/main/resources/org/elasticsearch/bootstrap/security.policy
+++ b/src/main/resources/org/elasticsearch/bootstrap/security.policy
@@ -37,9 +37,6 @@ grant {
   permission java.io.FilePermission "${project.basedir}${/}lib/sigar{/}-", "read";
   // mvn custom ./m2/repository for dependency jars
   permission java.io.FilePermission "${m2.repository}${/}-", "read";
-  // per-jvm directory
-  permission java.io.FilePermission "${junit4.childvm.cwd}${/}temp", "read,write";
-  permission java.io.FilePermission "${junit4.childvm.cwd}${/}temp${/}-", "read,write,delete";
 
   permission java.nio.file.LinkPermission "symbolic";
   permission groovy.security.GroovyCodeSourcePermission "/groovy/script";
@@ -86,7 +83,10 @@ grant {
 
   // needed for natives calls
   permission java.lang.RuntimePermission "loadLibrary.*";
+
+  // needed for testing access rules etc
   permission java.lang.RuntimePermission "createSecurityManager";
+  permission java.security.SecurityPermission "createPolicy.JavaPolicy";
 
   // reflection hacks:
   // needed for Striped64 (what is this doing), also enables unmap hack


### PR DESCRIPTION
1. initialize SM after things like mlockall. Their tests currently
   don't run with securitymanager enabled, and its simpler to just
   run mlockall etc first.
2. remove redundant test permissions (junit4.childvm.cwd/temp). This
   is already added as java.io.tmpdir.
3. improve tests to load the generated policy with some various
   settings and assert things about the permissions on configured
   directories.
4. refactor logic to make it easier to fine-grain the permissions later.
   for example we currently allow write access to conf/. In the future
   I think we can improve testing so we are able to make improvements here.
