### PR TITLE
Add multi-valued text support to the analyzer API

### DIFF
--- a/docs/reference/indices/analyze.asciidoc
+++ b/docs/reference/indices/analyze.asciidoc
@@ -18,6 +18,19 @@ curl -XGET 'localhost:9200/_analyze' -d '
 
 coming[2.0.0, body based parameters were added in 2.0.0]
 
+If text parameter is provided as array of string, it analyze as a multi-valued.
+
+[source,js]
+--------------------------------------------------
+curl -XGET 'localhost:9200/_analyze' -d '
+{
+  "analyzer" : "standard",
+  "text" : ["this is a test", "the second text"]
+}'
+--------------------------------------------------
+
+coming[2.0.0, body based parameters were added in 2.0.0]
+
 Or by building a custom transient analyzer out of tokenizers,
 token filters and char filters. Token filters can use the shorter 'filters'
 parameter name:

--- a/docs/reference/indices/analyze.asciidoc
+++ b/docs/reference/indices/analyze.asciidoc
@@ -18,7 +18,7 @@ curl -XGET 'localhost:9200/_analyze' -d '
 
 coming[2.0.0, body based parameters were added in 2.0.0]
 
-If text parameter is provided as array of string, it analyze as a multi-valued.
+If text parameter is provided as array of strings, it is analyzed as a multi-valued field.
 
 [source,js]
 --------------------------------------------------

--- a/rest-api-spec/api/indices.analyze.json
+++ b/rest-api-spec/api/indices.analyze.json
@@ -41,7 +41,7 @@
           "description" : "With `true`, specify that a local shard should be used if available, with `false`, use a random shard (default: true)"
         },
         "text": {
-          "type" : "string",
+          "type" : "list",
           "description" : "The text on which the analysis should be performed (when request body is not used)"
         },
         "tokenizer": {

--- a/rest-api-spec/test/indices.analyze/10_analyze.yaml
+++ b/rest-api-spec/test/indices.analyze/10_analyze.yaml
@@ -63,3 +63,11 @@ setup:
           body: { "text": "Bar Foo", "filters": ["lowercase"], "tokenizer": keyword }
     - length: {tokens: 1 }
     - match:     { tokens.0.token: bar foo }
+---
+"Array text":
+    - do:
+        indices.analyze:
+          body: { "text": ["Foo Bar", "Baz"], "filters": ["lowercase"], "tokenizer": keyword }
+    - length: {tokens: 2 }
+    - match:     { tokens.0.token: foo bar }
+    - match:     { tokens.1.token: baz }

--- a/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeRequest.java
@@ -36,7 +36,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
  */
 public class AnalyzeRequest extends SingleCustomOperationRequest<AnalyzeRequest> {
 
-    private String text;
+    private String[] text;
 
     private String analyzer;
 
@@ -61,11 +61,11 @@ public class AnalyzeRequest extends SingleCustomOperationRequest<AnalyzeRequest>
         this.index(index);
     }
 
-    public String text() {
+    public String[] text() {
         return this.text;
     }
 
-    public AnalyzeRequest text(String text) {
+    public AnalyzeRequest text(String... text) {
         this.text = text;
         return this;
     }
@@ -118,7 +118,7 @@ public class AnalyzeRequest extends SingleCustomOperationRequest<AnalyzeRequest>
     @Override
     public ActionRequestValidationException validate() {
         ActionRequestValidationException validationException = super.validate();
-        if (text == null) {
+        if (text == null || text.length == 0) {
             validationException = addValidationError("text is missing", validationException);
         }
         if (tokenFilters == null) {
@@ -133,7 +133,7 @@ public class AnalyzeRequest extends SingleCustomOperationRequest<AnalyzeRequest>
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        text = in.readString();
+        text = in.readStringArray();
         analyzer = in.readOptionalString();
         tokenizer = in.readOptionalString();
         tokenFilters = in.readStringArray();
@@ -144,7 +144,7 @@ public class AnalyzeRequest extends SingleCustomOperationRequest<AnalyzeRequest>
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeString(text);
+        out.writeStringArray(text);
         out.writeOptionalString(analyzer);
         out.writeOptionalString(tokenizer);
         out.writeStringArray(tokenFilters);

--- a/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeRequestBuilder.java
@@ -31,7 +31,7 @@ public class AnalyzeRequestBuilder extends SingleCustomOperationRequestBuilder<A
         super(indicesClient, new AnalyzeRequest());
     }
 
-    public AnalyzeRequestBuilder(IndicesAdminClient indicesClient, String index, String text) {
+    public AnalyzeRequestBuilder(IndicesAdminClient indicesClient, String index, String... text) {
         super(indicesClient, new AnalyzeRequest(index).text(text));
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeRequestBuilder.java
@@ -88,6 +88,14 @@ public class AnalyzeRequestBuilder extends SingleCustomOperationRequestBuilder<A
         return this;
     }
 
+    /**
+     * Sets texts to analyze
+     */
+    public AnalyzeRequestBuilder setText(String... texts) {
+        request.text(texts);
+        return this;
+    }
+
     @Override
     protected void doExecute(ActionListener<AnalyzeResponse> listener) {
         client.analyze(request, listener);

--- a/src/main/java/org/elasticsearch/action/admin/indices/analyze/TransportAnalyzeAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/analyze/TransportAnalyzeAction.java
@@ -25,6 +25,7 @@ import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.analysis.tokenattributes.OffsetAttribute;
 import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
 import org.apache.lucene.analysis.tokenattributes.TypeAttribute;
+import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.Version;
@@ -240,13 +241,7 @@ public class TransportAnalyzeAction extends TransportSingleCustomOperationAction
             } catch (IOException e) {
                 throw new ElasticsearchException("failed to analyze", e);
             } finally {
-                if (stream != null) {
-                    try {
-                        stream.close();
-                    } catch (IOException e) {
-                        // ignore
-                    }
-                }
+                IOUtils.closeWhileHandlingException(stream);
             }
         }
 

--- a/src/main/java/org/elasticsearch/client/IndicesAdminClient.java
+++ b/src/main/java/org/elasticsearch/client/IndicesAdminClient.java
@@ -581,26 +581,26 @@ public interface IndicesAdminClient extends ElasticsearchClient<IndicesAdminClie
     AnalyzeRequestBuilder prepareAnalyze(@Nullable String index, String text);
 
     /**
+     * Analyze text.
+     *
+     * @param text The text to analyze
+     */
+    AnalyzeRequestBuilder prepareAnalyze(String text);
+
+    /**
      * Analyze texts under the provided index.
      *
      * @param index The index name
      * @param text  The array of text to analyze
      */
-    AnalyzeRequestBuilder prepareAnalyze(@Nullable String index, String... text);
+    AnalyzeRequestBuilder prepareAnalyzeWithIndexAndMultiValued(@Nullable String index, String... text);
 
     /**
      * Analyze texts.
      *
      * @param text The array of text to analyze
      */
-    AnalyzeRequestBuilder prepareAnalyze(String... text);
-
-    /**
-     * Analyze text.
-     *
-     * @param text The text to analyze
-     */
-    AnalyzeRequestBuilder prepareAnalyze(String text);
+    AnalyzeRequestBuilder prepareAnalyzeWithMultiValued(String... text);
 
     /**
      * Puts an index template.

--- a/src/main/java/org/elasticsearch/client/IndicesAdminClient.java
+++ b/src/main/java/org/elasticsearch/client/IndicesAdminClient.java
@@ -581,6 +581,21 @@ public interface IndicesAdminClient extends ElasticsearchClient<IndicesAdminClie
     AnalyzeRequestBuilder prepareAnalyze(@Nullable String index, String text);
 
     /**
+     * Analyze texts under the provided index.
+     *
+     * @param index The index name
+     * @param text  The array of text to analyze
+     */
+    AnalyzeRequestBuilder prepareAnalyze(@Nullable String index, String... text);
+
+    /**
+     * Analyze texts.
+     *
+     * @param text The array of text to analyze
+     */
+    AnalyzeRequestBuilder prepareAnalyze(String... text);
+
+    /**
      * Analyze text.
      *
      * @param text The text to analyze

--- a/src/main/java/org/elasticsearch/client/IndicesAdminClient.java
+++ b/src/main/java/org/elasticsearch/client/IndicesAdminClient.java
@@ -588,19 +588,10 @@ public interface IndicesAdminClient extends ElasticsearchClient<IndicesAdminClie
     AnalyzeRequestBuilder prepareAnalyze(String text);
 
     /**
-     * Analyze texts under the provided index.
+     * Analyze text/texts.
      *
-     * @param index The index name
-     * @param text  The array of text to analyze
      */
-    AnalyzeRequestBuilder prepareAnalyzeWithIndexAndMultiValued(@Nullable String index, String... text);
-
-    /**
-     * Analyze texts.
-     *
-     * @param text The array of text to analyze
-     */
-    AnalyzeRequestBuilder prepareAnalyzeWithMultiValued(String... text);
+    AnalyzeRequestBuilder prepareAnalyze();
 
     /**
      * Puts an index template.

--- a/src/main/java/org/elasticsearch/client/support/AbstractIndicesAdminClient.java
+++ b/src/main/java/org/elasticsearch/client/support/AbstractIndicesAdminClient.java
@@ -481,13 +481,8 @@ public abstract class AbstractIndicesAdminClient implements IndicesAdminClient {
     }
 
     @Override
-    public AnalyzeRequestBuilder prepareAnalyzeWithIndexAndMultiValued(@Nullable String index, String... text) {
-        return new AnalyzeRequestBuilder(this, index, text);
-    }
-
-    @Override
-    public AnalyzeRequestBuilder prepareAnalyzeWithMultiValued(String... text) {
-        return new AnalyzeRequestBuilder(this, null, text);
+    public AnalyzeRequestBuilder prepareAnalyze() {
+        return new AnalyzeRequestBuilder(this);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/client/support/AbstractIndicesAdminClient.java
+++ b/src/main/java/org/elasticsearch/client/support/AbstractIndicesAdminClient.java
@@ -471,12 +471,22 @@ public abstract class AbstractIndicesAdminClient implements IndicesAdminClient {
     }
 
     @Override
+    public AnalyzeRequestBuilder prepareAnalyze(@Nullable String index, String... text) {
+        return new AnalyzeRequestBuilder(this, index, text);
+    }
+
+    @Override
     public AnalyzeRequestBuilder prepareAnalyze(@Nullable String index, String text) {
         return new AnalyzeRequestBuilder(this, index, text);
     }
 
     @Override
     public AnalyzeRequestBuilder prepareAnalyze(String text) {
+        return new AnalyzeRequestBuilder(this, null, text);
+    }
+
+    @Override
+    public AnalyzeRequestBuilder prepareAnalyze(String... text) {
         return new AnalyzeRequestBuilder(this, null, text);
     }
 

--- a/src/main/java/org/elasticsearch/client/support/AbstractIndicesAdminClient.java
+++ b/src/main/java/org/elasticsearch/client/support/AbstractIndicesAdminClient.java
@@ -471,11 +471,6 @@ public abstract class AbstractIndicesAdminClient implements IndicesAdminClient {
     }
 
     @Override
-    public AnalyzeRequestBuilder prepareAnalyze(@Nullable String index, String... text) {
-        return new AnalyzeRequestBuilder(this, index, text);
-    }
-
-    @Override
     public AnalyzeRequestBuilder prepareAnalyze(@Nullable String index, String text) {
         return new AnalyzeRequestBuilder(this, index, text);
     }
@@ -486,7 +481,12 @@ public abstract class AbstractIndicesAdminClient implements IndicesAdminClient {
     }
 
     @Override
-    public AnalyzeRequestBuilder prepareAnalyze(String... text) {
+    public AnalyzeRequestBuilder prepareAnalyzeWithIndexAndMultiValued(@Nullable String index, String... text) {
+        return new AnalyzeRequestBuilder(this, index, text);
+    }
+
+    @Override
+    public AnalyzeRequestBuilder prepareAnalyzeWithMultiValued(String... text) {
         return new AnalyzeRequestBuilder(this, null, text);
     }
 

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/analyze/RestAnalyzeAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/analyze/RestAnalyzeAction.java
@@ -23,11 +23,10 @@ import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.action.admin.indices.analyze.AnalyzeRequest;
 import org.elasticsearch.action.admin.indices.analyze.AnalyzeResponse;
 import org.elasticsearch.client.Client;
-import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
@@ -108,7 +107,7 @@ public class RestAnalyzeAction extends BaseRestHandler {
                             }
                             texts.add(parser.text());
                         }
-                        analyzeRequest.text(texts.toArray(new String[0]));
+                        analyzeRequest.text(texts.toArray(Strings.EMPTY_ARRAY));
                     } else if ("analyzer".equals(currentFieldName) && token == XContentParser.Token.VALUE_STRING) {
                         analyzeRequest.analyzer(parser.text());
                     } else if ("field".equals(currentFieldName) && token == XContentParser.Token.VALUE_STRING) {
@@ -123,7 +122,7 @@ public class RestAnalyzeAction extends BaseRestHandler {
                             }
                             filters.add(parser.text());
                         }
-                        analyzeRequest.tokenFilters(filters.toArray(new String[0]));
+                        analyzeRequest.tokenFilters(filters.toArray(Strings.EMPTY_ARRAY));
                     } else if ("char_filters".equals(currentFieldName) && token == XContentParser.Token.START_ARRAY) {
                         List<String> charFilters = Lists.newArrayList();
                         while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
@@ -132,7 +131,7 @@ public class RestAnalyzeAction extends BaseRestHandler {
                             }
                             charFilters.add(parser.text());
                         }
-                        analyzeRequest.tokenFilters(charFilters.toArray(new String[0]));
+                        analyzeRequest.tokenFilters(charFilters.toArray(Strings.EMPTY_ARRAY));
                     } else {
                         throw new ElasticsearchIllegalArgumentException("Unknown parameter [" + currentFieldName + "] in request body or parameter is of the wrong type[" + token + "] ");
                     }

--- a/src/test/java/org/elasticsearch/indices/analyze/AnalyzeActionTests.java
+++ b/src/test/java/org/elasticsearch/indices/analyze/AnalyzeActionTests.java
@@ -282,7 +282,7 @@ public class AnalyzeActionTests extends ElasticsearchIntegrationTest {
 
         String[] texts = new String[]{"THIS IS A TEST", "THE SECOND TEXT"};
 
-        final AnalyzeRequestBuilder requestBuilder = client().admin().indices().prepareAnalyze(texts);
+        final AnalyzeRequestBuilder requestBuilder = client().admin().indices().prepareAnalyzeWithMultiValued(texts);
         requestBuilder.setIndex(indexOrAlias());
         requestBuilder.setField("simple");
         AnalyzeResponse analyzeResponse = requestBuilder.get();

--- a/src/test/java/org/elasticsearch/indices/analyze/AnalyzeActionTests.java
+++ b/src/test/java/org/elasticsearch/indices/analyze/AnalyzeActionTests.java
@@ -282,7 +282,8 @@ public class AnalyzeActionTests extends ElasticsearchIntegrationTest {
 
         String[] texts = new String[]{"THIS IS A TEST", "THE SECOND TEXT"};
 
-        final AnalyzeRequestBuilder requestBuilder = client().admin().indices().prepareAnalyzeWithMultiValued(texts);
+        final AnalyzeRequestBuilder requestBuilder = client().admin().indices().prepareAnalyze();
+        requestBuilder.setText(texts);
         requestBuilder.setIndex(indexOrAlias());
         requestBuilder.setField("simple");
         AnalyzeResponse analyzeResponse = requestBuilder.get();

--- a/src/test/java/org/elasticsearch/indices/analyze/AnalyzeActionTests.java
+++ b/src/test/java/org/elasticsearch/indices/analyze/AnalyzeActionTests.java
@@ -159,18 +159,7 @@ public class AnalyzeActionTests extends ElasticsearchIntegrationTest {
         ensureGreen();
 
         client().admin().indices().preparePutMapping("test")
-                .setType("document").setSource(
-                "{\n" +
-                        "    \"document\":{\n" +
-                        "        \"properties\":{\n" +
-                        "            \"simple\":{\n" +
-                        "                \"type\":\"string\",\n" +
-                        "                \"analyzer\": \"simple\"\n" +
-                        "            }\n" +
-                        "        }\n" +
-                        "    }\n" +
-                        "}"
-        ).get();
+                .setType("document").setSource("simple", "type=string,analyzer=simple").get();
 
         for (int i = 0; i < 10; i++) {
             final AnalyzeRequestBuilder requestBuilder = client().admin().indices().prepareAnalyze("THIS IS A TEST");
@@ -266,19 +255,7 @@ public class AnalyzeActionTests extends ElasticsearchIntegrationTest {
         ensureGreen();
 
         client().admin().indices().preparePutMapping("test")
-            .setType("document").setSource(
-            "{\n" +
-                "    \"document\":{\n" +
-                "        \"properties\":{\n" +
-                "            \"simple\":{\n" +
-                "                \"type\":\"string\",\n" +
-                "                \"analyzer\": \"simple\",\n" +
-                "                \"position_offset_gap\": 100\n" +
-                "            }\n" +
-                "        }\n" +
-                "    }\n" +
-                "}"
-        ).get();
+            .setType("document").setSource("simple", "type=string,analyzer=simple,position_offset_gap=100").get();
 
         String[] texts = new String[]{"THIS IS A TEST", "THE SECOND TEXT"};
 


### PR DESCRIPTION
Add support array text as a multi-valued for AnalyzeRequestBuilder and REST API

Closes #3023
