### PR TITLE
Remove reflection permission for sun.management.

### DIFF
--- a/src/main/resources/org/elasticsearch/bootstrap/security.policy
+++ b/src/main/resources/org/elasticsearch/bootstrap/security.policy
@@ -95,8 +95,6 @@ grant {
   permission java.lang.RuntimePermission "accessClassInPackage.sun.nio.ch";
   // needed by groovy engine
   permission java.lang.RuntimePermission "accessClassInPackage.sun.reflect";
-  // needed to get file descriptor statistics
-  permission java.lang.RuntimePermission "accessClassInPackage.sun.management";
 
   permission java.lang.RuntimePermission "accessDeclaredMembers";
   permission java.lang.RuntimePermission "getStackTrace";


### PR DESCRIPTION
This is no longer needed after #10553
