### PR TITLE
Unicast Ping should close temporary connections after returning ping results

### DIFF
--- a/src/main/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPing.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPing.java
@@ -220,11 +220,11 @@ public class UnicastZenPing extends AbstractLifecycleComponent<ZenPing> implemen
                         protected void doRun() throws Exception {
                             sendPings(timeout, TimeValue.timeValueMillis(timeout.millis() / 2), sendPingsHandler);
                             sendPingsHandler.close();
+                            listener.onPing(sendPingsHandler.pingCollection().toArray());
                             for (DiscoveryNode node : sendPingsHandler.nodeToDisconnect) {
                                 logger.trace("[{}] disconnecting from {}", sendPingsHandler.id(), node);
                                 transportService.disconnectFromNode(node);
                             }
-                            listener.onPing(sendPingsHandler.pingCollection().toArray());
                         }
 
                         @Override


### PR DESCRIPTION
During pinging we open light , temporary connections to the the unicast hosts. After the pinging is done we close those. At the moment we do so before returning the results of the pings to the caller. On the other hand, in our transport logic we acquire a lock specific to the node id while opening a connection. When disconnecting from node, we have to acquire the same lock in order to guarantee the the connection opening has finished. This can cause big delays in environments where opening a connection is very slow, as the connection closing has to wait _after_ the pinging was done.. This can be problematic as  it causes master election to use stale data.
