### PR TITLE
Render non-elasticsearch exception as root cause

### DIFF
--- a/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -194,7 +194,7 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
         if (this instanceof ElasticsearchWrapperException) {
             toXContent(builder, params, this);
         } else {
-            builder.field("type", getExceptionName(this));
+            builder.field("type", getExceptionName());
             builder.field("reason", getMessage());
             innerToXContent(builder, params);
         }
@@ -261,7 +261,16 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
         if (ex instanceof ElasticsearchException) {
             return ((ElasticsearchException) ex).guessRootCauses();
         }
-        return new ElasticsearchException[0];
+        return new ElasticsearchException[] {new ElasticsearchException(t.getMessage(), t) {
+            @Override
+            protected String getExceptionName() {
+                return getExceptionName(getCause());
+            }
+        }};
+    }
+
+    protected String getExceptionName() {
+        return getExceptionName(this);
     }
 
     /**

--- a/src/test/java/org/elasticsearch/ElasticsearchExceptionTests.java
+++ b/src/test/java/org/elasticsearch/ElasticsearchExceptionTests.java
@@ -104,6 +104,15 @@ public class ElasticsearchExceptionTests extends ElasticsearchTestCase {
 
         }
 
+        {
+            final ElasticsearchException[] foobars = ElasticsearchException.guessRootCauses(new IllegalArgumentException("foobar"));
+            assertEquals(foobars.length, 1);
+            assertTrue(foobars[0] instanceof ElasticsearchException);
+            assertEquals(foobars[0].getMessage(), "foobar");
+            assertEquals(foobars[0].getCause().getClass(), IllegalArgumentException.class);
+            assertEquals(foobars[0].getExceptionName(), "illegal_argument_exception");
+        }
+
     }
 
     public void testDeduplicate() throws IOException {

--- a/src/test/java/org/elasticsearch/rest/BytesRestResponseTests.java
+++ b/src/test/java/org/elasticsearch/rest/BytesRestResponseTests.java
@@ -112,11 +112,18 @@ public class BytesRestResponseTests extends ElasticsearchTestCase {
     public void testGuessRootCause() throws IOException {
         RestRequest request = new FakeRestRequest();
         RestChannel channel = new DetailedExceptionRestChannel(request);
-
-        Throwable t = new ElasticsearchException("an error occurred reading data", new FileNotFoundException("/foo/bar"));
-        BytesRestResponse response = new BytesRestResponse(channel, t);
-        String text = response.content().toUtf8();
-        assertThat(text, containsString("{\"root_cause\":[{\"type\":\"exception\",\"reason\":\"an error occurred reading data\"}]"));
+        {
+            Throwable t = new ElasticsearchException("an error occurred reading data", new FileNotFoundException("/foo/bar"));
+            BytesRestResponse response = new BytesRestResponse(channel, t);
+            String text = response.content().toUtf8();
+            assertThat(text, containsString("{\"root_cause\":[{\"type\":\"exception\",\"reason\":\"an error occurred reading data\"}]"));
+        }
+        {
+            Throwable t = new FileNotFoundException("/foo/bar");
+            BytesRestResponse response = new BytesRestResponse(channel, t);
+            String text = response.content().toUtf8();
+            assertThat(text, containsString("{\"root_cause\":[{\"type\":\"file_not_found_exception\",\"reason\":\"/foo/bar\"}]"));
+        }
     }
 
     @Test


### PR DESCRIPTION
if we don't have an ElasticsearchException as the wrapper of the
actual cause we don't render a root cause today. This commit adds
support for 3rd party exceptions as root causes.

Closes #10836
