### PR TITLE
Use http for lucene snapshot downloads

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <repository>
             <id>lucene-snapshots</id>
             <name>Lucene Snapshots</name>
-            <url>https://download.elastic.co/lucenesnapshots/${lucene.snapshot.revision}</url>
+            <url>http://download.elastic.co/lucenesnapshots/${lucene.snapshot.revision}</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
This is much faster. The https gives me unpredictable read perf/timeouts
