### PR TITLE
Logging: add the ability to specify an alternate logging configuration location

### DIFF
--- a/docs/reference/setup/configuration.asciidoc
+++ b/docs/reference/setup/configuration.asciidoc
@@ -322,8 +322,9 @@ All of the index level configuration can be found within each
 Elasticsearch uses an internal logging abstraction and comes, out of the
 box, with http://logging.apache.org/log4j/1.2/[log4j]. It tries to simplify
 log4j configuration by using http://www.yaml.org/[YAML] to configure it,
-and the logging configuration file is `config/logging.yml`. The
-http://en.wikipedia.org/wiki/JSON[JSON] and
+and the logging configuration file is `config/logging.yml`. The location
+of the configuration file can be customized through the `path.conf.logging`
+configuration parameter. The http://en.wikipedia.org/wiki/JSON[JSON] and
 http://en.wikipedia.org/wiki/.properties[properties] formats are also
 supported. Multiple configuration files can be loaded, in which case they will
 get merged, as long as they start with the `logging.` prefix and end with one
@@ -337,20 +338,6 @@ the http://logging.apache.org/log4j/1.2/manual.html[log4j documentation].
 Additional Appenders and other logging classes provided by 
 http://logging.apache.org/log4j/extras/[log4j-extras] are also available, 
 out of the box.
-
-Optionally, the location of the configuration file can be set externally using
-a system property, for example:
-
-[source,sh]
---------------------------------------------------
-$ elasticsearch -Des.logging=/abs/path/to/logging/file.yml
---------------------------------------------------
-
-or
-
-[source,sh]
---------------------------------------------------
-$ elasticsearch -Des.logging=log_config_file_in_classpath.yml
 
 [float]
 [[deprecation-logging]]

--- a/docs/reference/setup/configuration.asciidoc
+++ b/docs/reference/setup/configuration.asciidoc
@@ -338,6 +338,20 @@ Additional Appenders and other logging classes provided by
 http://logging.apache.org/log4j/extras/[log4j-extras] are also available, 
 out of the box.
 
+Optionally, the location of the configuration file can be set externally using
+a system property, for example:
+
+[source,sh]
+--------------------------------------------------
+$ elasticsearch -Des.logging=/abs/path/to/logging/file.yml
+--------------------------------------------------
+
+or
+
+[source,sh]
+--------------------------------------------------
+$ elasticsearch -Des.logging=log_config_file_in_classpath.yml
+
 [float]
 [[deprecation-logging]]
 ==== Deprecation logging

--- a/src/main/java/org/elasticsearch/bootstrap/Security.java
+++ b/src/main/java/org/elasticsearch/bootstrap/Security.java
@@ -62,6 +62,7 @@ final class Security {
         addPath(policy, environment.tmpFile(), "read,readlink,write,delete");
         addPath(policy, environment.homeFile(), "read,readlink,write,delete");
         addPath(policy, environment.configFile(), "read,readlink,write,delete");
+        addPath(policy, environment.loggingFile(), "read,readlink,write,delete");
         addPath(policy, environment.logsFile(), "read,readlink,write,delete");
         addPath(policy, environment.pluginsFile(), "read,readlink,write,delete");
         for (Path path : environment.dataFiles()) {

--- a/src/main/java/org/elasticsearch/common/logging/log4j/LogConfigurator.java
+++ b/src/main/java/org/elasticsearch/common/logging/log4j/LogConfigurator.java
@@ -21,19 +21,15 @@ package org.elasticsearch.common.logging.log4j;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-
 import org.apache.log4j.PropertyConfigurator;
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.MapBuilder;
-import org.elasticsearch.common.io.PathUtils;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.FailedToResolveConfigException;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
-import java.net.URISyntaxException;
 import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.EnumSet;
@@ -49,8 +45,6 @@ import static org.elasticsearch.common.settings.Settings.settingsBuilder;
 public class LogConfigurator {
 
     static final List<String> ALLOWED_SUFFIXES = ImmutableList.of(".yml", ".yaml", ".json", ".properties");
-
-    static final String ES_LOGGING_SYSPROP = "es.logging";
 
     private static boolean loaded;
 
@@ -126,15 +120,7 @@ public class LogConfigurator {
     public static void resolveConfig(Environment env, final Settings.Builder settingsBuilder) {
 
         try {
-            Path startingPath;
-            final String esLoggingDir = System.getProperty(ES_LOGGING_SYSPROP);
-            if (Strings.hasText(esLoggingDir)) {
-                startingPath = PathUtils.get(env.resolveConfig(esLoggingDir).toURI());
-            } else {
-                startingPath = env.configFile();
-            }
-
-            Files.walkFileTree(startingPath, EnumSet.of(FileVisitOption.FOLLOW_LINKS), Integer.MAX_VALUE, new SimpleFileVisitor<Path>() {
+            Files.walkFileTree(env.loggingFile(), EnumSet.of(FileVisitOption.FOLLOW_LINKS), Integer.MAX_VALUE, new SimpleFileVisitor<Path>() {
                 @Override
                 public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
                     String fileName = file.getFileName().toString();
@@ -149,8 +135,8 @@ public class LogConfigurator {
                     return FileVisitResult.CONTINUE;
                 }
             });
-        } catch (IOException | URISyntaxException e) {
-            throw new ElasticsearchException("Failed to load logging configuration", e);
+        } catch (IOException ioe) {
+            throw new ElasticsearchException("Failed to load logging configuration", ioe);
         }
     }
 

--- a/src/main/java/org/elasticsearch/env/Environment.java
+++ b/src/main/java/org/elasticsearch/env/Environment.java
@@ -54,6 +54,8 @@ public class Environment {
 
     private final Path configFile;
 
+    private final Path loggingFile;
+
     private final Path pluginsFile;
 
     private final Path logsFile;
@@ -92,6 +94,12 @@ public class Environment {
             configFile = PathUtils.get(cleanPath(settings.get("path.conf")));
         } else {
             configFile = homeFile.resolve("config");
+        }
+
+        if (settings.get("path.conf.logging") != null) {
+            loggingFile = PathUtils.get(cleanPath(settings.get("path.conf.logging")));
+        } else {
+            loggingFile = configFile;
         }
 
         if (settings.get("path.plugins") != null) {
@@ -183,6 +191,13 @@ public class Environment {
      */
     public Path configFile() {
         return configFile;
+    }
+
+    /**
+     * The logging config location.
+     */
+    public Path loggingFile() {
+        return loggingFile;
     }
 
     public Path pluginsFile() {

--- a/src/test/java/org/elasticsearch/bootstrap/SecurityTests.java
+++ b/src/test/java/org/elasticsearch/bootstrap/SecurityTests.java
@@ -68,6 +68,7 @@ public class SecurityTests extends ElasticsearchTestCase {
         Settings.Builder settingsBuilder = Settings.builder();
         settingsBuilder.put("path.home", path.resolve("home").toString());
         settingsBuilder.put("path.conf", path.resolve("conf").toString());
+        settingsBuilder.put("path.conf.logging", path.resolve("conf/logging.yml").toString());
         settingsBuilder.put("path.plugins", path.resolve("plugins").toString());
         settingsBuilder.putArray("path.data", path.resolve("data1").toString(), path.resolve("data2").toString());
         settingsBuilder.put("path.logs", path.resolve("logs").toString());
@@ -93,6 +94,7 @@ public class SecurityTests extends ElasticsearchTestCase {
         // config file
         // TODO: make read-only
         assertTrue(permissions.implies(new FilePermission(environment.configFile().toString(), "read,readlink,write,delete")));
+        assertTrue(permissions.implies(new FilePermission(environment.loggingFile().toString(), "read,readlink,write,delete")));
         // plugins: r/w, TODO: can this be minimized?
         assertTrue(permissions.implies(new FilePermission(environment.pluginsFile().toString(), "read,readlink,write,delete")));
         // data paths: r/w


### PR DESCRIPTION
Replaces #7395 , which introduced support for a system property that allows to override the logging config location. This PR moves the logic to `Environment` from `LogConfigurator` and replaces `es.logging` with `path.logging`, which can be set from either sysprop (with `es.` prefix) or from the `elasticsearch.yml` config file. If `path.logging` is not set, behaviour is the same as before, it takes the same value as `path.config`.

Closes #2044
