### PR TITLE
Only check existence for absolute paths in env.resolveConfig()

### DIFF
--- a/src/main/java/org/elasticsearch/env/Environment.java
+++ b/src/main/java/org/elasticsearch/env/Environment.java
@@ -178,7 +178,7 @@ public class Environment {
         String origPath = path;
         // first, try it as a path on the file system
         Path f1 = PathUtils.get(path);
-        if (Files.exists(f1)) {
+        if (f1.isAbsolute() && Files.exists(f1)) {
             try {
                 return f1.toUri().toURL();
             } catch (MalformedURLException e) {


### PR DESCRIPTION
When resolving a path using `env.resolveConfig(String)`, it first checks for the path existence in the current working directory. This can fails when the security manager is enabled and elasticsearch not started from the ES_HOME directory like with init.d/systemd scripts or also with ./path/to/elasticsearch/bin/elasticsearch: Files.exist() resolves against the working directory and fails with a SecurityException.

I'm not sure we always need to set "user.dir" so I add a check for absolute path. This couldn't hurt much since the following `f1.toUri().toURL()` expects an absolute path.

What do you think?
