### PR TITLE
Archives on github seems to have a "v" before version number

### DIFF
--- a/src/main/java/org/elasticsearch/plugins/PluginManager.java
+++ b/src/main/java/org/elasticsearch/plugins/PluginManager.java
@@ -620,7 +620,7 @@ public class PluginManager {
                 // Sonatype repository
                 addUrl(urls, "https://oss.sonatype.org/service/local/repositories/releases/content/" + user.replace('.', '/') + "/" + repo + "/" + version + "/" + repo + "-" + version + ".zip");
                 // Github repository
-                addUrl(urls, "https://github.com/" + user + "/" + repo + "/archive/" + version + ".zip");
+                addUrl(urls, "https://github.com/" + user + "/" + repo + "/archive/v" + version + ".zip");
             }
             // Github repository for master branch (assume site)
             addUrl(urls, "https://github.com/" + user + "/" + repo + "/archive/master.zip");


### PR DESCRIPTION
Normally, it's a little fix when you try to have an archive from github
