### PR TITLE
Remove global `source` parameter from individual APIs in REST spec

### DIFF
--- a/rest-api-spec/api/count.json
+++ b/rest-api-spec/api/count.json
@@ -41,10 +41,6 @@
         "routing": {
           "type" : "string",
           "description" : "Specific routing value"
-        },
-        "source": {
-          "type" : "string",
-          "description" : "The URL-encoded query definition (instead of using the request body)"
         }
       }
     },

--- a/rest-api-spec/api/count_percolate.json
+++ b/rest-api-spec/api/count_percolate.json
@@ -23,10 +23,6 @@
         }
       },
       "params": {
-        "source": {
-          "type" : "string",
-          "description" : "The URL-encoded request definition"
-        },
         "routing": {
           "type": "list",
           "description": "A comma-separated list of specific routing values"

--- a/rest-api-spec/api/explain.json
+++ b/rest-api-spec/api/explain.json
@@ -69,10 +69,6 @@
           "type" : "string",
           "description" : "Specific routing value"
         },
-        "source": {
-          "type" : "string",
-          "description" : "The URL-encoded query definition (instead of using the request body)"
-        },
         "_source": {
           "type" : "list",
           "description" : "True or false to return the _source field or not, or a list of fields to return"

--- a/rest-api-spec/api/indices.analyze.json
+++ b/rest-api-spec/api/indices.analyze.json
@@ -12,10 +12,6 @@
         }
       },
       "params": {
-        "source": {
-          "type" : "string",
-          "description" : "The URL-encoded request definition"
-        },
         "analyzer": {
           "type" : "string",
           "description" : "The name of the analyzer to use"

--- a/rest-api-spec/api/indices.validate_query.json
+++ b/rest-api-spec/api/indices.validate_query.json
@@ -37,10 +37,6 @@
         "operation_threading": {
           "description" : "TODO: ?"
         },
-        "source": {
-          "type" : "string",
-          "description" : "The URL-encoded query definition (instead of using the request body)"
-        },
         "q": {
           "type" : "string",
           "description" : "Query in the Lucene query string syntax"

--- a/rest-api-spec/api/mget.json
+++ b/rest-api-spec/api/mget.json
@@ -16,10 +16,6 @@
         }
       },
       "params": {
-        "source": {
-          "type" : "string",
-          "description" : "The URL-encoded request definition"
-        },
         "fields": {
           "type": "list",
           "description" : "A comma-separated list of fields to return in the response"

--- a/rest-api-spec/api/mlt.json
+++ b/rest-api-spec/api/mlt.json
@@ -23,10 +23,6 @@
         }
       },
       "params": {
-        "source": {
-          "type" : "string",
-          "description" : "The URL-encoded request definition"
-        },
         "boost_terms": {
           "type" : "number",
           "description" : "The boost factor"

--- a/rest-api-spec/api/mpercolate.json
+++ b/rest-api-spec/api/mpercolate.json
@@ -16,10 +16,6 @@
         }
       },
       "params": {
-        "source": {
-          "type" : "string",
-          "description" : "The URL-encoded request definition"
-        },
         "ignore_unavailable": {
           "type": "boolean",
           "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)"

--- a/rest-api-spec/api/msearch.json
+++ b/rest-api-spec/api/msearch.json
@@ -16,10 +16,6 @@
         }
       },
       "params": {
-        "source": {
-          "type" : "string",
-          "description" : "The URL-encoded request definition"
-        },
         "search_type": {
           "type" : "enum",
           "options" : ["query_then_fetch", "query_and_fetch", "dfs_query_then_fetch", "dfs_query_and_fetch", "count", "scan"],

--- a/rest-api-spec/api/mtermvectors.json
+++ b/rest-api-spec/api/mtermvectors.json
@@ -16,10 +16,6 @@
         }
       },
       "params" : {
-        "source": {
-          "type" : "string",
-          "description" : "The URL-encoded request definition"
-        },
         "ids" : {
           "type" : "list",
           "description" : "A comma-separated list of documents ids. You must define ids as parameter or set \"ids\" or \"docs\" in the request body",

--- a/rest-api-spec/api/percolate.json
+++ b/rest-api-spec/api/percolate.json
@@ -23,10 +23,6 @@
         }
       },
       "params": {
-        "source": {
-          "type" : "string",
-          "description" : "The URL-encoded request definition"
-        },
         "routing": {
           "type" : "list",
           "description" : "A comma-separated list of specific routing values"

--- a/rest-api-spec/api/scroll.json
+++ b/rest-api-spec/api/scroll.json
@@ -12,10 +12,6 @@
         }
       },
       "params": {
-        "source": {
-          "type" : "string",
-          "description" : "The URL-encoded request definition"
-        },
         "scroll": {
           "type" : "duration",
           "description" : "Specify how long a consistent view of the index should be maintained for scrolled search"

--- a/rest-api-spec/api/search.json
+++ b/rest-api-spec/api/search.json
@@ -101,10 +101,6 @@
           "type" : "list",
           "description" : "A comma-separated list of <field>:<direction> pairs"
         },
-        "source": {
-          "type" : "string",
-          "description" : "The URL-encoded request definition using the Query DSL (instead of using request body)"
-        },
         "_source": {
           "type" : "list",
           "description" : "True or false to return the _source field or not, or a list of fields to return"

--- a/rest-api-spec/api/search_exists.json
+++ b/rest-api-spec/api/search_exists.json
@@ -41,10 +41,6 @@
         "routing": {
           "type" : "string",
           "description" : "Specific routing value"
-        },
-        "source": {
-          "type" : "string",
-          "description" : "The URL-encoded query definition (instead of using the request body)"
         }
       }
     },

--- a/rest-api-spec/api/search_template.json
+++ b/rest-api-spec/api/search_template.json
@@ -16,10 +16,6 @@
         }
       },
       "params" : {
-        "source": {
-          "type" : "string",
-          "description" : "The URL-encoded request definition"
-        },
         "ignore_unavailable": {
             "type" : "boolean",
             "description" : "Whether specified concrete indices should be ignored when unavailable (missing or closed)"

--- a/rest-api-spec/api/suggest.json
+++ b/rest-api-spec/api/suggest.json
@@ -33,10 +33,6 @@
         "routing": {
           "type" : "string",
           "description" : "Specific routing value"
-        },
-        "source": {
-          "type" : "string",
-          "description" : "The URL-encoded request definition (instead of using request body)"
         }
       }
     },

--- a/rest-api-spec/api/termvectors.json
+++ b/rest-api-spec/api/termvectors.json
@@ -22,10 +22,6 @@
          }
       },
       "params": {
-        "source": {
-          "type" : "string",
-          "description" : "The URL-encoded request definition"
-        },
         "term_statistics" : {
           "type" : "boolean",
           "description" : "Specifies if total term frequency and document frequency should be returned.",


### PR DESCRIPTION
Same way we don't define pretty anywhere, we shouldn't have source
