### PR TITLE
Remove (dfs_)query_and_fetch from the REST API

### DIFF
--- a/docs/java-api/search.asciidoc
+++ b/docs/java-api/search.asciidoc
@@ -38,6 +38,10 @@ you can write:
 SearchResponse response = client.prepareSearch().execute().actionGet();
 --------------------------------------------------
 
+NOTE:   Although the Java API defines the additional search types QUERY_AND_FETCH and
+        DFS_QUERY_AND_FETCH, these modes are internal optimizations and should not
+        be specified explicitly by users of the API.
+
 For more information on the search operation, check out the REST
 {ref}/search.html[search] docs.
 

--- a/docs/reference/search/request-body.asciidoc
+++ b/docs/reference/search/request-body.asciidoc
@@ -64,9 +64,9 @@ And here is a sample response:
 `search_type`::
 
     The type of the search operation to perform. Can be
-    `dfs_query_then_fetch`, `query_then_fetch`, 'count',
-    or 'scan'. Defaults to `query_then_fetch`. See
-    <<search-request-search-type,_Search Type_>> for more.
+    `dfs_query_then_fetch`, `query_then_fetch`, or 'scan'.
+    Defaults to `query_then_fetch`.
+    See <<search-request-search-type,_Search Type_>> for more.
 
 `query_cache`::
 

--- a/docs/reference/search/request-body.asciidoc
+++ b/docs/reference/search/request-body.asciidoc
@@ -64,8 +64,8 @@ And here is a sample response:
 `search_type`::
 
     The type of the search operation to perform. Can be
-    `dfs_query_then_fetch`, `dfs_query_and_fetch`, `query_then_fetch`,
-    `query_and_fetch`. Defaults to `query_then_fetch`. See
+    `dfs_query_then_fetch`, `query_then_fetch`, 'count',
+    or 'scan'. Defaults to `query_then_fetch`. See
     <<search-request-search-type,_Search Type_>> for more.
 
 `query_cache`::

--- a/docs/reference/search/request/search-type.asciidoc
+++ b/docs/reference/search/request/search-type.asciidoc
@@ -82,23 +82,4 @@ Parameter value: *scan*.
 The `scan` search type disables sorting in order to allow very efficient
 scrolling through large result sets.  See <<scroll-scan>> for more.
 
-[[query-and-fetch]]
-==== Query And Fetch
-
-Parameter value: *query_and_fetch*.
-
-The `query_and_fetch` mode is an *internal* optimization which
-is chosen automatically when a `query_then_fetch` request
-targets a single shard only.  Both phases of `query_then_fetch`
-are executed in a single pass.  This mode should not be
-explicitly specified by the user.
-
-[[dfs-query-and-fetch]]
-==== Dfs, Query And Fetch
-
-Parameter value: *dfs_query_and_fetch*.
-
-Same as `query_and_fetch`, except for an initial scatter phase which
-goes and computes the distributed term frequencies for more accurate
-scoring. This mode should not be explicitly specified by the user.
 

--- a/docs/reference/search/uri-request.asciidoc
+++ b/docs/reference/search/uri-request.asciidoc
@@ -94,8 +94,8 @@ Defaults to no terminate_after.
 |`size` |The number of hits to return. Defaults to `10`.
 
 |`search_type` |The type of the search operation to perform. Can be
-`dfs_query_then_fetch`, `dfs_query_and_fetch`, `query_then_fetch`,
-`query_and_fetch`, `scan` or `count` deprecated[2.0,Replaced by `size: 0`]. Defaults to `query_then_fetch`. See
+`dfs_query_then_fetch`, `query_then_fetch`, `scan` or `count`
+deprecated[2.0,Replaced by `size: 0`]. Defaults to `query_then_fetch`. See
 <<search-request-search-type,_Search Type_>> for
 more details on the different types of search that can be performed.
 

--- a/rest-api-spec/api/search.json
+++ b/rest-api-spec/api/search.json
@@ -90,7 +90,7 @@
         },
         "search_type": {
           "type" : "enum",
-          "options" : ["query_then_fetch", "query_and_fetch", "dfs_query_then_fetch", "dfs_query_and_fetch", "count", "scan"],
+          "options" : ["query_then_fetch", "dfs_query_then_fetch", "count", "scan"],
           "description" : "Search operation type"
         },
         "size": {

--- a/rest-api-spec/test/search/issue9606.yaml
+++ b/rest-api-spec/test/search/issue9606.yaml
@@ -1,0 +1,44 @@
+---
+setup:
+  - do:
+      indices.create:
+          index: test
+
+  - do:
+      index:
+          index:  test
+          type:   test
+          id:     1
+          body:   { foo: bar }
+
+  - do:
+      indices.refresh:
+        index: [test]
+
+---
+"Test search_type=query_and_fetch not supported from REST layer":
+
+  - do:
+      catch: request
+      search:
+          index: test
+          type:  test
+          search_type: query_and_fetch
+          body:
+              query:
+                match:
+                  foo: bar
+
+---
+"Test search_type=dfs_query_and_fetch not supported from REST layer":
+
+  - do:
+      catch: request
+      search:
+          index: test
+          type:  test
+          search_type: dfs_query_and_fetch
+          body:
+              query:
+                match:
+                  foo: bar

--- a/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
@@ -22,6 +22,7 @@ package org.elasticsearch.rest.action.search;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Strings;
@@ -96,8 +97,18 @@ public class RestSearchAction extends BaseRestHandler {
             }
         }
 
+        // do not allow 'query_and_fetch' or 'dfs_query_and_fetch' search types
+        // from the REST layer. these modes are an internal optimization and should
+        // not be specified explicitly by the user.
+        String searchType = request.param("search_type");
+        if (SearchType.fromString(searchType).equals(SearchType.QUERY_AND_FETCH) ||
+                SearchType.fromString(searchType).equals(SearchType.DFS_QUERY_AND_FETCH)) {
+            throw new ElasticsearchIllegalArgumentException("Unsupported search type [" + searchType + "]");
+        } else {
+            searchRequest.searchType(searchType);
+        }
+
         searchRequest.extraSource(parseSearchSource(request));
-        searchRequest.searchType(request.param("search_type"));
         searchRequest.queryCache(request.paramAsBoolean("query_cache", null));
 
         String scroll = request.param("scroll");


### PR DESCRIPTION
Remove the ability to specify search type ‘query_and_fetch’ and ‘dfs_query_and_fetch’ from the REST API.
- Adds REST tests
- Updates REST API spec to remove ‘query_and_fetch’ and ‘dfs_query_and_fetch’ as options
- Removes documentation for these options

Closes #9606
