### PR TITLE
Transport: read/writeGenericValue to support BytesRef

### DIFF
--- a/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -21,7 +21,6 @@ package org.elasticsearch.common.io.stream;
 
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.CharsRefBuilder;
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
@@ -413,6 +412,8 @@ public abstract class StreamInput extends InputStream {
                 return readFloatArray();
             case 20:
                 return readDoubleArray();
+            case 21:
+                return readBytesRef();
             default:
                 throw new IOException("Can't read unknown type [" + type + "]");
         }

--- a/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -385,6 +385,9 @@ public abstract class StreamOutput extends OutputStream {
         } else if (type == double[].class) {
             writeByte((byte) 20);
             writeDoubleArray((double[]) value);
+        } else if (value instanceof BytesRef) {
+            writeByte((byte) 21);
+            writeBytesRef((BytesRef) value);
         } else {
             throw new IOException("Can't write type [" + type + "]");
         }

--- a/src/test/java/org/elasticsearch/common/io/streams/BytesStreamsTests.java
+++ b/src/test/java/org/elasticsearch/common/io/streams/BytesStreamsTests.java
@@ -22,6 +22,7 @@ package org.elasticsearch.common.io.streams;
 import org.apache.lucene.util.Constants;
 import org.elasticsearch.common.io.stream.BytesStreamInput;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.junit.Ignore;
@@ -263,8 +264,8 @@ public class BytesStreamsTests extends ElasticsearchTestCase {
         assumeTrue("requires a 64-bit JRE ... ?!", Constants.JRE_IS_64BIT);
         BytesStreamOutput out = new BytesStreamOutput();
         out.writeBoolean(false);
-        out.writeByte((byte)1);
-        out.writeShort((short)-1);
+        out.writeByte((byte) 1);
+        out.writeShort((short) -1);
         out.writeInt(-1);
         out.writeVInt(2);
         out.writeLong(-3);
@@ -281,6 +282,7 @@ public class BytesStreamsTests extends ElasticsearchTestCase {
         out.writeGenericValue(doubleArray);
         out.writeString("hello");
         out.writeString("goodbye");
+        out.writeGenericValue(BytesRefs.toBytesRef("bytesref"));
         BytesStreamInput in = new BytesStreamInput(out.bytes().toBytes());
         assertThat(in.readBoolean(), equalTo(false));
         assertThat(in.readByte(), equalTo((byte)1));
@@ -291,12 +293,13 @@ public class BytesStreamsTests extends ElasticsearchTestCase {
         assertThat(in.readVLong(), equalTo((long)4));
         assertThat((double)in.readFloat(), closeTo(1.1, 0.0001));
         assertThat(in.readDouble(), closeTo(2.2, 0.0001));
-        assertThat(in.readGenericValue(), equalTo((Object)intArray));
+        assertThat(in.readGenericValue(), equalTo((Object) intArray));
         assertThat(in.readGenericValue(), equalTo((Object)longArray));
         assertThat(in.readGenericValue(), equalTo((Object)floatArray));
         assertThat(in.readGenericValue(), equalTo((Object)doubleArray));
         assertThat(in.readString(), equalTo("hello"));
         assertThat(in.readString(), equalTo("goodbye"));
+        assertThat(in.readGenericValue(), equalTo((Object)BytesRefs.toBytesRef("bytesref")));
         in.close();
         out.close();
     }


### PR DESCRIPTION
Add support for BytesRef to existing StreamInput#readGenericValue and StreamOutput#writeGenericValue
