### PR TITLE
[TEST] Use a high shard delete timeout when clusterstates are delayed

### DIFF
--- a/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
+++ b/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
@@ -332,56 +332,57 @@ public class IndicesStore extends AbstractComponent implements ClusterStateListe
             // make sure shard is really there before register cluster state observer
             if (indexShard == null) {
                 channel.sendResponse(new ShardActiveResponse(false, clusterService.localNode()));
-            }
-            // create observer here. we need to register it here because we need to capture the current cluster state
-            // which will then be compared to the one that is applied when we call waitForNextChange(). if we create it
-            // later we might miss an update and wait forever in case no new cluster state comes in.
-            // in general, using a cluster state observer here is a workaround for the fact that we cannot listen on shard state changes explicitly.
-            // instead we wait for the cluster state changes because we know any shard state change will trigger or be
-            // triggered by a cluster state change.
-            ClusterStateObserver observer = new ClusterStateObserver(clusterService, request.timeout, logger);
-            // check if shard is active. if so, all is good
-            boolean shardActive = shardActive(indexShard);
-            if (shardActive) {
-                channel.sendResponse(new ShardActiveResponse(true, clusterService.localNode()));
             } else {
-                // shard is not active, might be POST_RECOVERY so check if cluster state changed inbetween or wait for next change
-                observer.waitForNextChange(new ClusterStateObserver.Listener() {
-                    @Override
-                    public void onNewClusterState(ClusterState state) {
-                        sendResult(shardActive(getShard(request)));
-                    }
-
-                    @Override
-                    public void onClusterServiceClose() {
-                        sendResult(false);
-                    }
-
-                    @Override
-                    public void onTimeout(TimeValue timeout) {
-                        sendResult(shardActive(getShard(request)));
-                    }
-
-                    public void sendResult(boolean shardActive) {
-                        try {
-                            channel.sendResponse(new ShardActiveResponse(shardActive, clusterService.localNode()));
-                        } catch (IOException e) {
-                            logger.error("failed send response for shard active while trying to delete shard {} - shard will probably not be removed", e, request.shardId);
-                        } catch (EsRejectedExecutionException e) {
-                            logger.error("failed send response for shard active while trying to delete shard {} - shard will probably not be removed", e, request.shardId);
+                // create observer here. we need to register it here because we need to capture the current cluster state
+                // which will then be compared to the one that is applied when we call waitForNextChange(). if we create it
+                // later we might miss an update and wait forever in case no new cluster state comes in.
+                // in general, using a cluster state observer here is a workaround for the fact that we cannot listen on shard state changes explicitly.
+                // instead we wait for the cluster state changes because we know any shard state change will trigger or be
+                // triggered by a cluster state change.
+                ClusterStateObserver observer = new ClusterStateObserver(clusterService, request.timeout, logger);
+                // check if shard is active. if so, all is good
+                boolean shardActive = shardActive(indexShard);
+                if (shardActive) {
+                    channel.sendResponse(new ShardActiveResponse(true, clusterService.localNode()));
+                } else {
+                    // shard is not active, might be POST_RECOVERY so check if cluster state changed inbetween or wait for next change
+                    observer.waitForNextChange(new ClusterStateObserver.Listener() {
+                        @Override
+                        public void onNewClusterState(ClusterState state) {
+                            sendResult(shardActive(getShard(request)));
                         }
-                    }
-                }, new ClusterStateObserver.ValidationPredicate() {
-                    @Override
-                    protected boolean validate(ClusterState newState) {
-                        // the shard is not there in which case we want to send back a false (shard is not active), so the cluster state listener must be notified
-                        // or the shard is active in which case we want to send back that the shard is active
-                        // here we could also evaluate the cluster state and get the information from there. we
-                        // don't do it because we would have to write another method for this that would have the same effect
-                        IndexShard indexShard = getShard(request);
-                        return indexShard == null || shardActive(indexShard);
-                    }
-                });
+
+                        @Override
+                        public void onClusterServiceClose() {
+                            sendResult(false);
+                        }
+
+                        @Override
+                        public void onTimeout(TimeValue timeout) {
+                            sendResult(shardActive(getShard(request)));
+                        }
+
+                        public void sendResult(boolean shardActive) {
+                            try {
+                                channel.sendResponse(new ShardActiveResponse(shardActive, clusterService.localNode()));
+                            } catch (IOException e) {
+                                logger.error("failed send response for shard active while trying to delete shard {} - shard will probably not be removed", e, request.shardId);
+                            } catch (EsRejectedExecutionException e) {
+                                logger.error("failed send response for shard active while trying to delete shard {} - shard will probably not be removed", e, request.shardId);
+                            }
+                        }
+                    }, new ClusterStateObserver.ValidationPredicate() {
+                        @Override
+                        protected boolean validate(ClusterState newState) {
+                            // the shard is not there in which case we want to send back a false (shard is not active), so the cluster state listener must be notified
+                            // or the shard is active in which case we want to send back that the shard is active
+                            // here we could also evaluate the cluster state and get the information from there. we
+                            // don't do it because we would have to write another method for this that would have the same effect
+                            IndexShard indexShard = getShard(request);
+                            return indexShard == null || shardActive(indexShard);
+                        }
+                    });
+                }
             }
         }
 


### PR DESCRIPTION
`IndiceStore#indexCleanup` uses a disruption scheme to delay cluster state
processing. Yet, the delay is [1..2] seconds but tests are setting the shard
deletion timeout to 1 second to speed up tests. This can cause random not
reproducible failures in this test since the timeouts and delays are bascially
overlapping. This commit adds a longer timeout for this test to prevent these
problems.

here are test failures that had this problem: 
- http://build-us-00.elastic.co/job/es_feature_cluster_state_diffs/90/console
- http://build-us-00.elastic.co/job/es_core_1x_suse/470/consoleFull
