### PR TITLE
Fix `_field_names` to not have doc values

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/internal/FieldNamesFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/FieldNamesFieldMapper.java
@@ -139,7 +139,7 @@ public class FieldNamesFieldMapper extends AbstractFieldMapper<String> implement
     }
 
     public FieldNamesFieldMapper(String name, String indexName, float boost, FieldType fieldType, EnabledAttributeMapper enabledState, @Nullable Settings fieldDataSettings, Settings indexSettings) {
-        super(new Names(name, indexName, indexName, name), boost, fieldType, null, Lucene.KEYWORD_ANALYZER,
+        super(new Names(name, indexName, indexName, name), boost, fieldType, false, Lucene.KEYWORD_ANALYZER,
                 Lucene.KEYWORD_ANALYZER, null, null, fieldDataSettings, indexSettings);
         this.defaultFieldType = Defaults.FIELD_TYPE;
         this.pre13Index = Version.indexCreated(indexSettings).before(Version.V_1_3_0);
@@ -239,9 +239,6 @@ public class FieldNamesFieldMapper extends AbstractFieldMapper<String> implement
                 for (String fieldName : extractFieldNames(path)) {
                     if (fieldType.indexOptions() != IndexOptions.NONE || fieldType.stored()) {
                         document.add(new Field(names().indexName(), fieldName, fieldType));
-                    }
-                    if (hasDocValues()) {
-                        document.add(new SortedSetDocValuesField(names().indexName(), new BytesRef(fieldName)));
                     }
                 }
             }

--- a/src/test/java/org/elasticsearch/index/mapper/internal/FieldNamesFieldMapperTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/internal/FieldNamesFieldMapperTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.mapper.internal;
 
+import org.apache.lucene.index.IndexOptions;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.settings.ImmutableSettings;
@@ -60,6 +61,20 @@ public class FieldNamesFieldMapperTests extends ElasticsearchSingleNodeTest {
         assertEquals(set("", ".a"), extract(".a"));
         assertEquals(set("a", "a."), extract("a."));
         assertEquals(set("", ".", ".."), extract(".."));
+    }
+
+    public void testFieldType() throws Exception {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+            .startObject("_field_names").field("store", "yes").endObject()
+            .endObject().endObject().string();
+
+        DocumentMapper docMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
+        FieldNamesFieldMapper fieldNamesMapper = docMapper.rootMapper(FieldNamesFieldMapper.class);
+        assertFalse(fieldNamesMapper.hasDocValues());
+        assertEquals(IndexOptions.DOCS, fieldNamesMapper.fieldType().indexOptions());
+        assertFalse(fieldNamesMapper.fieldType().tokenized());
+        assertFalse(fieldNamesMapper.fieldType().stored());
+        assertTrue(fieldNamesMapper.fieldType().omitNorms());
     }
 
     public void testInjectIntoDocDuringParsing() throws Exception {


### PR DESCRIPTION
When doc values were turned on a by default, most meta fields
had it explicitly disabled.  However, _field_names was missed.
This change forces doc values to be off always for _field_names
and removes the unnecessary support when creating index fields.

closes #10892
