### PR TITLE
Read configuration file with .yaml suffix

### DIFF
--- a/src/main/java/org/elasticsearch/node/internal/InternalSettingsPreparer.java
+++ b/src/main/java/org/elasticsearch/node/internal/InternalSettingsPreparer.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.node.internal;
 
+import com.google.common.collect.ImmutableList;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.common.Names;
 import org.elasticsearch.common.Strings;
@@ -28,6 +29,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.FailedToResolveConfigException;
 
+import java.util.List;
 import java.util.Map;
 
 import static org.elasticsearch.common.Strings.cleanPath;
@@ -37,6 +39,8 @@ import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilde
  *
  */
 public class InternalSettingsPreparer {
+
+    static final List<String> ALLOWED_SUFFIXES = ImmutableList.of(".yml", ".yaml", ".json", ".properties");
 
     public static Tuple<Settings, Environment> prepareSettings(Settings pSettings, boolean loadConfigSettings) {
         // ignore this prefixes when getting properties from es. and elasticsearch.
@@ -73,22 +77,12 @@ public class InternalSettingsPreparer {
                 }
             }
             if (loadFromEnv) {
-                try {
-                    settingsBuilder.loadFromUrl(environment.resolveConfig("elasticsearch.yml"));
-                } catch (FailedToResolveConfigException e) {
-                    // ignore
-                } catch (NoClassDefFoundError e) {
-                    // ignore, no yaml
-                }
-                try {
-                    settingsBuilder.loadFromUrl(environment.resolveConfig("elasticsearch.json"));
-                } catch (FailedToResolveConfigException e) {
-                    // ignore
-                }
-                try {
-                    settingsBuilder.loadFromUrl(environment.resolveConfig("elasticsearch.properties"));
-                } catch (FailedToResolveConfigException e) {
-                    // ignore
+                for (String allowedSuffix : ALLOWED_SUFFIXES) {
+                    try {
+                        settingsBuilder.loadFromUrl(environment.resolveConfig("elasticsearch" + allowedSuffix));
+                    } catch (FailedToResolveConfigException e) {
+                        // ignore
+                    }
                 }
             }
         }

--- a/src/test/java/org/elasticsearch/node/internal/InternalSettingsPreparerTests.java
+++ b/src/test/java/org/elasticsearch/node/internal/InternalSettingsPreparerTests.java
@@ -52,4 +52,16 @@ public class InternalSettingsPreparerTests extends ElasticsearchTestCase {
         // Should use setting from the system property
         assertThat(tuple.v1().get("node.zone"), equalTo("bar"));
     }
+
+    @Test
+    public void testAlternateConfigFileSuffixes() {
+        // test that we can read config files with .yaml, .json, and .properties suffixes
+        Tuple<Settings, Environment> tuple = InternalSettingsPreparer.prepareSettings(settingsBuilder()
+                .put("config.ignore_system_properties", true)
+                .build(), true);
+
+        assertThat(tuple.v1().get("yaml.config.exists"), equalTo("true"));
+        assertThat(tuple.v1().get("json.config.exists"), equalTo("true"));
+        assertThat(tuple.v1().get("properties.config.exists"), equalTo("true"));
+    }
 }

--- a/src/test/resources/config/elasticsearch.json
+++ b/src/test/resources/config/elasticsearch.json
@@ -1,0 +1,3 @@
+{
+  "json.config.exists" : "true"
+}

--- a/src/test/resources/config/elasticsearch.properties
+++ b/src/test/resources/config/elasticsearch.properties
@@ -1,0 +1,2 @@
+
+properties.config.exists: true

--- a/src/test/resources/config/elasticsearch.yaml
+++ b/src/test/resources/config/elasticsearch.yaml
@@ -1,0 +1,3 @@
+
+yaml.config.exists: true
+


### PR DESCRIPTION
Fixes a bug whereby we failed to read an elasticsearch config file with
the .yaml extension. This commit allows elasticsearch config files to
be suffixed with: .yml, .yaml, .json, .properties.

Closes #9706
