### PR TITLE
Fixes Infinite values return from geo_bounds with non-zero bucket-ordinals

### DIFF
--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/geobounds/GeoBoundsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/geobounds/GeoBoundsAggregator.java
@@ -90,13 +90,13 @@ public final class GeoBoundsAggregator extends MetricsAggregator {
                     tops = bigArrays.grow(tops, bucket + 1);
                     tops.fill(from, tops.size(), Double.NEGATIVE_INFINITY);
                     bottoms = bigArrays.resize(bottoms, tops.size());
-                    bottoms.fill(from, bottoms.size(), Double.NEGATIVE_INFINITY);
+                    bottoms.fill(from, bottoms.size(), Double.POSITIVE_INFINITY);
                     posLefts = bigArrays.resize(posLefts, tops.size());
-                    posLefts.fill(from, posLefts.size(), Double.NEGATIVE_INFINITY);
+                    posLefts.fill(from, posLefts.size(), Double.POSITIVE_INFINITY);
                     posRights = bigArrays.resize(posRights, tops.size());
                     posRights.fill(from, posRights.size(), Double.NEGATIVE_INFINITY);
                     negLefts = bigArrays.resize(negLefts, tops.size());
-                    negLefts.fill(from, negLefts.size(), Double.NEGATIVE_INFINITY);
+                    negLefts.fill(from, negLefts.size(), Double.POSITIVE_INFINITY);
                     negRights = bigArrays.resize(negRights, tops.size());
                     negRights.fill(from, negRights.size(), Double.NEGATIVE_INFINITY);
                 }

--- a/src/test/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsTests.java
@@ -27,7 +27,6 @@ import org.elasticsearch.common.util.BigArray;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
-import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHitField;
 import org.elasticsearch.search.aggregations.bucket.global.Global;
@@ -38,7 +37,6 @@ import org.elasticsearch.search.aggregations.metrics.geobounds.GeoBoundsAggregat
 import org.elasticsearch.search.sort.SortBuilders;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
-import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -51,7 +49,10 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.global;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.sameInstance;
 
@@ -407,6 +408,10 @@ public class GeoBoundsTests extends ElasticsearchIntegrationTest {
             GeoBounds geoBounds = bucket.getAggregations().get("geoBounds");
             assertThat(geoBounds, notNullValue());
             assertThat(geoBounds.getName(), equalTo("geoBounds"));
+            assertThat(geoBounds.topLeft().getLat(), allOf(greaterThanOrEqualTo(-90.0), lessThanOrEqualTo(90.0)));
+            assertThat(geoBounds.topLeft().getLon(), allOf(greaterThanOrEqualTo(-180.0), lessThanOrEqualTo(180.0)));
+            assertThat(geoBounds.bottomRight().getLat(), allOf(greaterThanOrEqualTo(-90.0), lessThanOrEqualTo(90.0)));
+            assertThat(geoBounds.bottomRight().getLon(), allOf(greaterThanOrEqualTo(-180.0), lessThanOrEqualTo(180.0)));
         }
     }
 


### PR DESCRIPTION
If the collect method was called with a bucketOrd of > 0 the arrays holding the state for the aggregation would be grown but the initial values for the bucketOrds > 0 were all set to Double.NEGATIVE_INFINITY meaning that for the bottom, posLeft and negLeft values no collected document would change the value since NEGATIVE_INFINITY is always less than every other value.

Closes #10804
