### PR TITLE
Add ability to prompt for selected settings on startup

### DIFF
--- a/docs/reference/setup/configuration.asciidoc
+++ b/docs/reference/setup/configuration.asciidoc
@@ -264,6 +264,29 @@ file which will resolve to an environment setting, for example:
 }
 --------------------------------------------------
 
+Additionally, for settings that you do not wish to store in the configuration
+file, you can use the value `${prompt::text}` or `${prompt::secret}` and start
+Elasticsearch in the foreground. `${prompt::secret}` has echoing disabled so
+that the value entered will not be shown in your terminal; `${prompt::text}`
+will allow you to see the value as you type it in. For example:
+
+[source,yaml]
+--------------------------------------------------
+node:
+  name: ${prompt::text}
+--------------------------------------------------
+
+On execution of the `elasticsearch` command, you will be prompted to enter
+the actual value like so:
+
+[source,sh]
+--------------------------------------------------
+Enter value for [node.name]:
+--------------------------------------------------
+
+NOTE: Elasticsearch will not start if `${prompt::text}` or `${prompt::secret}`
+is used in the settings and the process is run as a service or in the background.
+
 The location of the configuration file can be set externally using a
 system property:
 

--- a/src/main/java/org/elasticsearch/common/cli/CliTool.java
+++ b/src/main/java/org/elasticsearch/common/cli/CliTool.java
@@ -93,7 +93,7 @@ public abstract class CliTool {
         Preconditions.checkArgument(config.cmds().size() != 0, "At least one command must be configured");
         this.config = config;
         this.terminal = terminal;
-        Tuple<Settings, Environment> tuple = InternalSettingsPreparer.prepareSettings(EMPTY_SETTINGS, true);
+        Tuple<Settings, Environment> tuple = InternalSettingsPreparer.prepareSettings(EMPTY_SETTINGS, true, terminal);
         settings = tuple.v1();
         env = tuple.v2();
     }

--- a/src/main/java/org/elasticsearch/common/settings/Settings.java
+++ b/src/main/java/org/elasticsearch/common/settings/Settings.java
@@ -1211,7 +1211,7 @@ public final class Settings implements ToXContent {
          * tries and resolve it against an environment variable ({@link System#getenv(String)}), and last, tries
          * and replace it with another setting already set on this builder.
          */
-        public Builder replacePropertyPlaceholders() {
+        public Builder replacePropertyPlaceholders(String... ignoredValues) {
             PropertyPlaceholder propertyPlaceholder = new PropertyPlaceholder("${", "}", false);
             PropertyPlaceholder.PlaceholderResolver placeholderResolver = new PropertyPlaceholder.PlaceholderResolver() {
                     @Override
@@ -1241,7 +1241,19 @@ public final class Settings implements ToXContent {
                     }
                 };
             for (Map.Entry<String, String> entry : Maps.newHashMap(map).entrySet()) {
-                String value = propertyPlaceholder.replacePlaceholders(entry.getValue(), placeholderResolver);
+                String possiblePlaceholder = entry.getValue();
+                boolean ignored = false;
+                for (String ignoredValue : ignoredValues) {
+                    if (ignoredValue.equals(possiblePlaceholder)) {
+                        ignored = true;
+                        break;
+                    }
+                }
+                if (ignored) {
+                    continue;
+                }
+
+                String value = propertyPlaceholder.replacePlaceholders(possiblePlaceholder, placeholderResolver);
                 // if the values exists and has length, we should maintain it  in the map
                 // otherwise, the replace process resolved into removing it
                 if (Strings.hasLength(value)) {

--- a/src/main/java/org/elasticsearch/plugins/PluginManager.java
+++ b/src/main/java/org/elasticsearch/plugins/PluginManager.java
@@ -25,6 +25,7 @@ import com.google.common.collect.Iterators;
 import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.*;
 import org.elasticsearch.common.SuppressForbidden;
+import org.elasticsearch.common.cli.Terminal;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.http.client.HttpDownloadHelper;
 import org.elasticsearch.common.io.FileSystemUtils;
@@ -338,7 +339,7 @@ public class PluginManager {
     private static final int EXIT_CODE_ERROR = 70;
 
     public static void main(String[] args) {
-        Tuple<Settings, Environment> initialSettings = InternalSettingsPreparer.prepareSettings(EMPTY_SETTINGS, true);
+        Tuple<Settings, Environment> initialSettings = InternalSettingsPreparer.prepareSettings(EMPTY_SETTINGS, true, Terminal.DEFAULT);
 
         try {
             Files.createDirectories(initialSettings.v2().pluginsFile());

--- a/src/main/java/org/elasticsearch/tribe/TribeService.java
+++ b/src/main/java/org/elasticsearch/tribe/TribeService.java
@@ -45,6 +45,7 @@ import org.elasticsearch.discovery.DiscoveryService;
 import org.elasticsearch.gateway.GatewayService;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.node.NodeBuilder;
+import org.elasticsearch.node.internal.InternalSettingsPreparer;
 import org.elasticsearch.rest.RestStatus;
 
 import java.util.EnumSet;
@@ -128,7 +129,7 @@ public class TribeService extends AbstractLifecycleComponent<TribeService> {
             sb.put("node.name", settings.get("name") + "/" + entry.getKey());
             sb.put("path.home", settings.get("path.home")); // pass through ES home dir
             sb.put(TRIBE_NAME, entry.getKey());
-            sb.put("config.ignore_system_properties", true);
+            sb.put(InternalSettingsPreparer.IGNORE_SYSTEM_PROPERTIES_SETTING, true);
             if (sb.get("http.enabled") == null) {
                 sb.put("http.enabled", false);
             }

--- a/src/test/java/org/elasticsearch/client/transport/TransportClientRetryTests.java
+++ b/src/test/java/org/elasticsearch/client/transport/TransportClientRetryTests.java
@@ -28,6 +28,7 @@ import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.node.internal.InternalSettingsPreparer;
 import org.elasticsearch.plugins.PluginsService;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.elasticsearch.test.InternalTestCluster;
@@ -61,7 +62,7 @@ public class TransportClientRetryTests extends ElasticsearchIntegrationTest {
                 .put("node.mode", InternalTestCluster.nodeMode())
                 .put("plugins." + PluginsService.LOAD_PLUGIN_FROM_CLASSPATH, false)
                 .put(ClusterName.SETTING, internalCluster().getClusterName())
-                .put("config.ignore_system_properties", true)
+                .put(InternalSettingsPreparer.IGNORE_SYSTEM_PROPERTIES_SETTING, true)
                 .put("path.home", createTempDir());
 
         try (TransportClient transportClient = TransportClient.builder().settings(builder.build()).build()) {

--- a/src/test/java/org/elasticsearch/client/transport/TransportClientTests.java
+++ b/src/test/java/org/elasticsearch/client/transport/TransportClientTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.node.Node;
+import org.elasticsearch.node.internal.InternalSettingsPreparer;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
 import org.elasticsearch.transport.TransportService;
@@ -59,7 +60,7 @@ public class TransportClientTests extends ElasticsearchIntegrationTest {
                 .put("path.home", createTempDir())
                 .put("node.name", "testNodeVersionIsUpdated")
                 .put("http.enabled", false)
-                .put("config.ignore_system_properties", true) // make sure we get what we set :)
+                .put(InternalSettingsPreparer.IGNORE_SYSTEM_PROPERTIES_SETTING, true) // make sure we get what we set :)
                 .build()).clusterName("foobar").build();
         node.start();
         try {

--- a/src/test/java/org/elasticsearch/common/settings/SettingsTests.java
+++ b/src/test/java/org/elasticsearch/common/settings/SettingsTests.java
@@ -138,6 +138,17 @@ public class SettingsTests extends ElasticsearchTestCase {
     }
 
     @Test
+    public void testReplacePropertiesPlaceholderIgnores() {
+        Settings settings = settingsBuilder()
+                .put("setting1", "${foo.bar}")
+                .put("setting2", "${foo.bar1}")
+                .replacePropertyPlaceholders("${foo.bar}", "${foo.bar1}")
+                .build();
+        assertThat(settings.get("setting1"), is("${foo.bar}"));
+        assertThat(settings.get("setting2"), is("${foo.bar1}"));
+    }
+
+    @Test
     public void testUnFlattenedSettings() {
         Settings settings = settingsBuilder()
                 .put("foo", "abc")

--- a/src/test/java/org/elasticsearch/indices/memory/IndexingMemoryControllerTests.java
+++ b/src/test/java/org/elasticsearch/indices/memory/IndexingMemoryControllerTests.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.index.engine.EngineConfig;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.node.internal.InternalSettingsPreparer;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.junit.Test;
 
@@ -143,7 +144,7 @@ public class IndexingMemoryControllerTests extends ElasticsearchIntegrationTest 
                         .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
                         .put(EsExecutors.PROCESSORS, 1) // limit the number of threads created
                         .put("http.enabled", false)
-                        .put("config.ignore_system_properties", true) // make sure we get what we set :)
+                        .put(InternalSettingsPreparer.IGNORE_SYSTEM_PROPERTIES_SETTING, true) // make sure we get what we set :)
                         .put("indices.memory.interval", "100ms")
                         .put(settings)
         );

--- a/src/test/java/org/elasticsearch/node/internal/InternalSettingsPreparerTests.java
+++ b/src/test/java/org/elasticsearch/node/internal/InternalSettingsPreparerTests.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.node.internal;
 
+import org.elasticsearch.common.cli.CliToolTestCase;
+import org.elasticsearch.common.cli.Terminal;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
@@ -27,11 +29,16 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.elasticsearch.common.settings.Settings.settingsBuilder;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 public class InternalSettingsPreparerTests extends ElasticsearchTestCase {
+
     @Before
     public void setupSystemProperties() {
         System.setProperty("es.node.zone", "foo");
@@ -53,7 +60,7 @@ public class InternalSettingsPreparerTests extends ElasticsearchTestCase {
         assertThat(tuple.v1().get("node.zone"), equalTo("foo"));
 
         settings = settingsBuilder()
-                .put("config.ignore_system_properties", true)
+                .put(InternalSettingsPreparer.IGNORE_SYSTEM_PROPERTIES_SETTING, true)
                 .put("node.zone", "bar")
                 .put("path.home", createTempDir().toString())
                 .build();
@@ -73,5 +80,75 @@ public class InternalSettingsPreparerTests extends ElasticsearchTestCase {
         assertThat(tuple.v1().get("yaml.config.exists"), equalTo("true"));
         assertThat(tuple.v1().get("json.config.exists"), equalTo("true"));
         assertThat(tuple.v1().get("properties.config.exists"), equalTo("true"));
+    }
+
+    @Test
+    public void testReplacePromptPlaceholders() {
+        final List<String> replacedSecretProperties = new ArrayList<>();
+        final List<String> replacedTextProperties = new ArrayList<>();
+        final Terminal terminal = new CliToolTestCase.MockTerminal() {
+            @Override
+            public char[] readSecret(String message, Object... args) {
+                for (Object arg : args) {
+                    replacedSecretProperties.add((String) arg);
+                }
+                return "replaced".toCharArray();
+            }
+
+            @Override
+            public String readText(String message, Object... args) {
+                for (Object arg : args) {
+                    replacedTextProperties.add((String) arg);
+                }
+                return "text";
+            }
+        };
+
+        Settings.Builder builder = settingsBuilder()
+                .put("password.replace", InternalSettingsPreparer.SECRET_PROMPT_VALUE)
+                .put("dont.replace", "prompt:secret")
+                .put("dont.replace2", "_prompt:secret_")
+                .put("dont.replace3", "_prompt:text__")
+                .put("dont.replace4", "__prompt:text_")
+                .put("dont.replace5", "prompt:secret__")
+                .put("replace_me", InternalSettingsPreparer.TEXT_PROMPT_VALUE);
+        Settings settings = builder.build();
+        settings = InternalSettingsPreparer.replacePromptPlaceholders(settings, terminal);
+
+        assertThat(replacedSecretProperties.size(), is(1));
+        assertThat(replacedTextProperties.size(), is(1));
+        assertThat(settings.get("password.replace"), equalTo("replaced"));
+        assertThat(settings.get("replace_me"), equalTo("text"));
+
+        // verify other values unchanged
+        assertThat(settings.get("dont.replace"), equalTo("prompt:secret"));
+        assertThat(settings.get("dont.replace2"), equalTo("_prompt:secret_"));
+        assertThat(settings.get("dont.replace3"), equalTo("_prompt:text__"));
+        assertThat(settings.get("dont.replace4"), equalTo("__prompt:text_"));
+        assertThat(settings.get("dont.replace5"), equalTo("prompt:secret__"));
+    }
+
+    @Test
+    public void testReplaceSecretPromptPlaceholderWithNullTerminal() {
+        Settings.Builder builder = settingsBuilder()
+                .put("replace_me1", InternalSettingsPreparer.SECRET_PROMPT_VALUE);
+        try {
+            InternalSettingsPreparer.replacePromptPlaceholders(builder.build(), null);
+            fail("an exception should have been thrown since no terminal was provided!");
+        } catch (UnsupportedOperationException e) {
+            assertThat(e.getMessage(), containsString("with value [" + InternalSettingsPreparer.SECRET_PROMPT_VALUE + "]"));
+        }
+    }
+
+    @Test
+    public void testReplaceTextPromptPlaceholderWithNullTerminal() {
+        Settings.Builder builder = settingsBuilder()
+                .put("replace_me1", InternalSettingsPreparer.TEXT_PROMPT_VALUE);
+        try {
+            InternalSettingsPreparer.replacePromptPlaceholders(builder.build(), null);
+            fail("an exception should have been thrown since no terminal was provided!");
+        } catch (UnsupportedOperationException e) {
+            assertThat(e.getMessage(), containsString("with value [" + InternalSettingsPreparer.TEXT_PROMPT_VALUE + "]"));
+        }
     }
 }

--- a/src/test/java/org/elasticsearch/test/ElasticsearchSingleNodeTest.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchSingleNodeTest.java
@@ -39,6 +39,7 @@ import org.elasticsearch.index.IndexService;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.node.NodeBuilder;
+import org.elasticsearch.node.internal.InternalSettingsPreparer;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.After;
@@ -127,7 +128,7 @@ public abstract class ElasticsearchSingleNodeTest extends ElasticsearchTestCase 
             .put("script.indexed", "on")
             .put(EsExecutors.PROCESSORS, 1) // limit the number of threads created
             .put("http.enabled", false)
-            .put("config.ignore_system_properties", true) // make sure we get what we set :)
+            .put(InternalSettingsPreparer.IGNORE_SYSTEM_PROPERTIES_SETTING, true) // make sure we get what we set :)
         ).build();
         build.start();
         assertThat(DiscoveryNode.localNode(build.settings()), is(true));

--- a/src/test/java/org/elasticsearch/test/ExternalNode.java
+++ b/src/test/java/org/elasticsearch/test/ExternalNode.java
@@ -33,6 +33,7 @@ import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.discovery.DiscoveryModule;
+import org.elasticsearch.node.internal.InternalSettingsPreparer;
 import org.elasticsearch.transport.TransportModule;
 
 import java.io.Closeable;
@@ -53,7 +54,7 @@ import static org.elasticsearch.common.settings.Settings.settingsBuilder;
 final class ExternalNode implements Closeable {
 
     public static final Settings REQUIRED_SETTINGS = Settings.builder()
-            .put("config.ignore_system_properties", true)
+            .put(InternalSettingsPreparer.IGNORE_SYSTEM_PROPERTIES_SETTING, true)
             .put(DiscoveryModule.DISCOVERY_TYPE_KEY, "zen")
             .put("node.mode", "network").build(); // we need network mode for this
 
@@ -115,7 +116,7 @@ final class ExternalNode implements Closeable {
                 case TransportModule.TRANSPORT_TYPE_KEY:
                 case DiscoveryModule.DISCOVERY_TYPE_KEY:
                 case TransportModule.TRANSPORT_SERVICE_TYPE_KEY:
-                case "config.ignore_system_properties":
+                case InternalSettingsPreparer.IGNORE_SYSTEM_PROPERTIES_SETTING:
                     continue;
                 default:
                     externaNodeSettingsBuilder.put(entry.getKey(), entry.getValue());

--- a/src/test/java/org/elasticsearch/test/ExternalTestCluster.java
+++ b/src/test/java/org/elasticsearch/test/ExternalTestCluster.java
@@ -33,6 +33,7 @@ import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
 import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.node.internal.InternalSettingsPreparer;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -67,7 +68,7 @@ public final class ExternalTestCluster extends TestCluster {
         super(0);
         Settings clientSettings = Settings.settingsBuilder()
                 .put("name", InternalTestCluster.TRANSPORT_CLIENT_PREFIX + EXTERNAL_CLUSTER_PREFIX + counter.getAndIncrement())
-                .put("config.ignore_system_properties", true) // prevents any settings to be replaced by system properties.
+                .put(InternalSettingsPreparer.IGNORE_SYSTEM_PROPERTIES_SETTING, true) // prevents any settings to be replaced by system properties.
                 .put("client.transport.ignore_cluster_name", true)
                 .put("node.mode", "network").build(); // we require network here!
 

--- a/src/test/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/src/test/java/org/elasticsearch/test/InternalTestCluster.java
@@ -88,6 +88,7 @@ import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
 import org.elasticsearch.indices.fielddata.cache.IndicesFieldDataCache;
 import org.elasticsearch.indices.recovery.RecoverySettings;
 import org.elasticsearch.node.Node;
+import org.elasticsearch.node.internal.InternalSettingsPreparer;
 import org.elasticsearch.node.service.NodeService;
 import org.elasticsearch.plugins.PluginsService;
 import org.elasticsearch.search.SearchService;
@@ -279,7 +280,7 @@ public final class InternalTestCluster extends TestCluster {
         builder.put("path.repo", baseDir.resolve("repos"));
         builder.put("transport.tcp.port", BASE_PORT + "-" + (BASE_PORT+100));
         builder.put("http.port", BASE_PORT+101 + "-" + (BASE_PORT+200));
-        builder.put("config.ignore_system_properties", true);
+        builder.put(InternalSettingsPreparer.IGNORE_SYSTEM_PROPERTIES_SETTING, true);
         builder.put("node.mode", NODE_MODE);
         builder.put("http.pipelining", enableHttpPipelining);
         builder.put("plugins." + PluginsService.LOAD_PLUGIN_FROM_CLASSPATH, false);
@@ -874,7 +875,7 @@ public final class InternalTestCluster extends TestCluster {
                     .put("node.local", nodeSettings.get("node.local", ""))
                     .put("logger.prefix", nodeSettings.get("logger.prefix", ""))
                     .put("logger.level", nodeSettings.get("logger.level", "INFO"))
-                    .put("config.ignore_system_properties", true)
+                    .put(InternalSettingsPreparer.IGNORE_SYSTEM_PROPERTIES_SETTING, true)
                     .put(settings);
 
             TransportClient client = TransportClient.builder().settings(builder.build()).build();

--- a/src/test/java/org/elasticsearch/tribe/TribeUnitTests.java
+++ b/src/test/java/org/elasticsearch/tribe/TribeUnitTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.node.NodeBuilder;
+import org.elasticsearch.node.internal.InternalSettingsPreparer;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.elasticsearch.test.InternalTestCluster;
 import org.junit.AfterClass;
@@ -51,7 +52,7 @@ public class TribeUnitTests extends ElasticsearchTestCase {
     @BeforeClass
     public static void createTribes() {
         Settings baseSettings = Settings.builder()
-            .put("config.ignore_system_properties", true)
+            .put(InternalSettingsPreparer.IGNORE_SYSTEM_PROPERTIES_SETTING, true)
             .put("http.enabled", false)
             .put("node.mode", NODE_MODE)
             .put("path.home", createTempDir()).build();
@@ -86,7 +87,7 @@ public class TribeUnitTests extends ElasticsearchTestCase {
     @Test
     public void testThatTribeClientsIgnoreGlobalConfig() throws Exception {
         Path pathConf = getDataPath("elasticsearch.yml").getParent();
-        Settings settings = Settings.builder().put("config.ignore_system_properties", true).put("path.conf", pathConf).build();
+        Settings settings = Settings.builder().put(InternalSettingsPreparer.IGNORE_SYSTEM_PROPERTIES_SETTING, true).put("path.conf", pathConf).build();
         assertTribeNodeSuccesfullyCreated(settings);
     }
 


### PR DESCRIPTION
Some settings may be considered sensitive, such as passwords, and storing them
in the configuration file on disk is not good from a security perspective. This change
allows settings to have a special value, `__prompt__`, that indicates elasticsearch
should prompt the user for the actual value on startup. This only works when
started in the foreground. In cases where elasticsearch is started as a service or
in the background, an exception will be thrown.

Closes #10838
