### PR TITLE
Filter refactoring: Introduce toFilter() and fromXContent() in FilterBuilders and FilterParsers

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/AndFilterBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/AndFilterBuilder.java
@@ -93,4 +93,9 @@ public class AndFilterBuilder extends BaseFilterBuilder {
         }
         builder.endObject();
     }
+
+    @Override
+    protected String parserName() {
+        return AndFilterParser.NAME;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/AndFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/AndFilterParser.java
@@ -36,7 +36,7 @@ import static com.google.common.collect.Lists.newArrayList;
 /**
  *
  */
-public class AndFilterParser implements FilterParser {
+public class AndFilterParser extends BaseFilterParserTemp {
 
     public static final String NAME = "and";
 

--- a/src/main/java/org/elasticsearch/index/query/BaseFilterBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/BaseFilterBuilder.java
@@ -70,8 +70,8 @@ public abstract class BaseFilterBuilder implements FilterBuilder {
 
     /**
      * Temporary default implementation for toFilter that parses the filter using its filter parser
-     * Will be removed once all filters override toFilter with their own specific implementation.
      */
+    //norelease to be removed once all filter builders override toFilter providing their own specific implementation.
     @Override
     public Filter toFilter(QueryParseContext parseContext) throws IOException {
         return parseContext.indexQueryParserService().filterParser(parserName()).parse(parseContext);
@@ -79,8 +79,8 @@ public abstract class BaseFilterBuilder implements FilterBuilder {
 
     /**
      * Temporary method that allows to retrieve the parser for each filter.
-     * Won't be needed anymore once all filter builders properly implement {@link #toFilter(QueryParseContext)}
      * @return the name of the parser class the default {@link #toFilter(QueryParseContext)} method delegates to
      */
+    //norelease to be removed once all filter builders override toFilter providing their own specific implementation.
     protected abstract String parserName();
 }

--- a/src/main/java/org/elasticsearch/index/query/BaseFilterBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/BaseFilterBuilder.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.search.Filter;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -27,9 +28,6 @@ import org.elasticsearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 
-/**
- *
- */
 public abstract class BaseFilterBuilder implements FilterBuilder {
 
     @Override
@@ -69,4 +67,20 @@ public abstract class BaseFilterBuilder implements FilterBuilder {
     }
 
     protected abstract void doXContent(XContentBuilder builder, Params params) throws IOException;
+
+    /**
+     * Temporary default implementation for toFilter that parses the filter using its filter parser
+     * Will be removed once all filters override toFilter with their own specific implementation.
+     */
+    @Override
+    public Filter toFilter(QueryParseContext parseContext) throws IOException {
+        return parseContext.indexQueryParserService().filterParser(parserName()).parse(parseContext);
+    }
+
+    /**
+     * Temporary method that allows to retrieve the parser for each filter.
+     * Won't be needed anymore once all filter builders properly implement {@link #toFilter(QueryParseContext)}
+     * @return the name of the parser class the default {@link #toFilter(QueryParseContext)} method delegates to
+     */
+    protected abstract String parserName();
 }

--- a/src/main/java/org/elasticsearch/index/query/BaseFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/BaseFilterParser.java
@@ -19,30 +19,20 @@
 
 package org.elasticsearch.index.query;
 
-import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.apache.lucene.search.Filter;
 
 import java.io.IOException;
 
 /**
- * A filter that simply wraps a query.
- *
- *
+ * Class used during the filter parsers refactoring.
+ * All filter parsers that have a refactored "fromXContent" method can be changed to extend this instead of {@link BaseFilterParserTemp}.
+ * Keeps old {@link FilterParser#parse(QueryParseContext)} method as a stub delegating to
+ * {@link FilterParser#fromXContent(QueryParseContext)} and {@link FilterBuilder#toFilter(QueryParseContext)}}
  */
-public class MatchAllFilterBuilder extends BaseFilterBuilder {
-
-    /**
-     * A filter that simply matches all docs.
-     */
-    public MatchAllFilterBuilder() {
-    }
+public abstract class BaseFilterParser implements FilterParser {
 
     @Override
-    protected void doXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(MatchAllFilterParser.NAME).endObject();
-    }
-
-    @Override
-    protected String parserName() {
-        return MatchAllFilterParser.NAME;
+    public final Filter parse(QueryParseContext parseContext) throws IOException, QueryParsingException {
+        return fromXContent(parseContext).toFilter(parseContext);
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/BaseFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/BaseFilterParser.java
@@ -24,11 +24,12 @@ import org.apache.lucene.search.Filter;
 import java.io.IOException;
 
 /**
- * Class used during the filter parsers refactoring.
+ * Class used during the filter parsers refactoring. Will be removed once we can parse search requests on the coordinating node.
  * All filter parsers that have a refactored "fromXContent" method can be changed to extend this instead of {@link BaseFilterParserTemp}.
  * Keeps old {@link FilterParser#parse(QueryParseContext)} method as a stub delegating to
  * {@link FilterParser#fromXContent(QueryParseContext)} and {@link FilterBuilder#toFilter(QueryParseContext)}}
  */
+//norelease needs to be removed once we parse search requests on the coordinating node, as the parse method is not needed anymore at that point.
 public abstract class BaseFilterParser implements FilterParser {
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/BaseFilterParserTemp.java
+++ b/src/main/java/org/elasticsearch/index/query/BaseFilterParserTemp.java
@@ -19,30 +19,21 @@
 
 package org.elasticsearch.index.query;
 
-import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.apache.lucene.search.Filter;
 
 import java.io.IOException;
 
 /**
- * A filter that simply wraps a query.
- *
- *
+ * This class with method impl is an intermediate step in the filter parsers refactoring.
+ * Provides a fromXContent default implementation for filter parsers that don't have yet a
+ * specific fromXContent implementation that returns a FilterBuilder.
+ * To be removed once all filters are moved over to extend {@link BaseFilterParser}.
  */
-public class MatchAllFilterBuilder extends BaseFilterBuilder {
-
-    /**
-     * A filter that simply matches all docs.
-     */
-    public MatchAllFilterBuilder() {
-    }
+public abstract class BaseFilterParserTemp implements FilterParser {
 
     @Override
-    protected void doXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(MatchAllFilterParser.NAME).endObject();
-    }
-
-    @Override
-    protected String parserName() {
-        return MatchAllFilterParser.NAME;
+    public FilterBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
+        Filter filter = parse(parseContext);
+        return new FilterWrappingFilterBuilder(filter);
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/BaseFilterParserTemp.java
+++ b/src/main/java/org/elasticsearch/index/query/BaseFilterParserTemp.java
@@ -27,8 +27,8 @@ import java.io.IOException;
  * This class with method impl is an intermediate step in the filter parsers refactoring.
  * Provides a fromXContent default implementation for filter parsers that don't have yet a
  * specific fromXContent implementation that returns a FilterBuilder.
- * To be removed once all filters are moved over to extend {@link BaseFilterParser}.
  */
+//norelease to be removed once all filters are moved over to extend BaseFilterParser
 public abstract class BaseFilterParserTemp implements FilterParser {
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/BaseQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/BaseQueryBuilder.java
@@ -71,17 +71,17 @@ public abstract class BaseQueryBuilder implements QueryBuilder {
 
     /**
      * Temporary default implementation for toQuery that parses the query using its query parser
-     * Will be removed once all queries override toQuery with their own specific implementation.
      */
+    //norelease to be removed once all query builders override toQuery providing their own specific implementation.
     public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
         return parseContext.indexQueryParserService().queryParser(parserName()).parse(parseContext);
     }
 
     /**
      * Temporary method that allows to retrieve the parser for each query.
-     * Won't be needed anymore once all query builders properly implement {@link #toQuery(QueryParseContext)}
      * @return the name of the parser class the default {@link #toQuery(QueryParseContext)} method delegates to
      */
+    //norelease to be removed once all query builders override toQuery providing their own specific implementation.
     protected abstract String parserName();
 
     protected abstract void doXContent(XContentBuilder builder, Params params) throws IOException;

--- a/src/main/java/org/elasticsearch/index/query/BaseQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/BaseQueryParser.java
@@ -24,11 +24,12 @@ import org.apache.lucene.search.Query;
 import java.io.IOException;
 
 /**
- * Class used during the query parsers refactoring.
+ * Class used during the query parsers refactoring. Will be removed once we can parse search requests on the coordinating node.
  * All query parsers that have a refactored "fromXContent" method can be changed to extend this instead of {@link BaseQueryParserTemp}.
  * Keeps old {@link QueryParser#parse(QueryParseContext)} method as a stub delegating to
  * {@link QueryParser#fromXContent(QueryParseContext)} and {@link QueryBuilder#toQuery(QueryParseContext)}}
  */
+//norelease needs to be removed once we parse search requests on the coordinating node, as the parse method is not needed anymore at that point.
 public abstract class BaseQueryParser implements QueryParser {
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/BaseQueryParserTemp.java
+++ b/src/main/java/org/elasticsearch/index/query/BaseQueryParserTemp.java
@@ -27,8 +27,8 @@ import java.io.IOException;
  * This class with method impl is an intermediate step in the query parsers refactoring.
  * Provides a fromXContent default implementation for query parsers that don't have yet a
  * specific fromXContent implementation that returns a QueryBuilder.
- * To be removed once all filters are moved over to extend {@link BaseQueryParser}.
  */
+//norelease to be removed once all queries are moved over to extend BaseQueryParser
 public abstract class BaseQueryParserTemp implements QueryParser {
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/BoolFilterBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/BoolFilterBuilder.java
@@ -161,4 +161,9 @@ public class BoolFilterBuilder extends BaseFilterBuilder {
             builder.endArray();
         }
     }
+
+    @Override
+    protected String parserName() {
+        return BoolFilterParser.NAME;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/BoolFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/BoolFilterParser.java
@@ -33,7 +33,7 @@ import java.io.IOException;
 /**
  *
  */
-public class BoolFilterParser implements FilterParser {
+public class BoolFilterParser extends BaseFilterParserTemp {
 
     public static final String NAME = "bool";
 

--- a/src/main/java/org/elasticsearch/index/query/ExistsFilterBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/ExistsFilterBuilder.java
@@ -56,4 +56,9 @@ public class ExistsFilterBuilder extends BaseFilterBuilder {
         }
         builder.endObject();
     }
+
+    @Override
+    protected String parserName() {
+        return ExistsFilterParser.NAME;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/ExistsFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/ExistsFilterParser.java
@@ -38,7 +38,7 @@ import java.util.List;
 /**
  *
  */
-public class ExistsFilterParser implements FilterParser {
+public class ExistsFilterParser extends BaseFilterParserTemp {
 
     public static final String NAME = "exists";
 

--- a/src/main/java/org/elasticsearch/index/query/FQueryFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/FQueryFilterParser.java
@@ -33,7 +33,7 @@ import java.io.IOException;
  * The "fquery" filter is the same as the {@link QueryFilterParser} except that it allows also to
  * associate a name with the query filter.
  */
-public class FQueryFilterParser implements FilterParser {
+public class FQueryFilterParser extends BaseFilterParserTemp {
 
     public static final String NAME = "fquery";
 

--- a/src/main/java/org/elasticsearch/index/query/FilterBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/FilterBuilder.java
@@ -19,18 +19,24 @@
 
 package org.elasticsearch.index.query;
 
-import org.elasticsearch.ElasticsearchException;
+import org.apache.lucene.search.Filter;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentType;
 
-/**
- *
- */
+import java.io.IOException;
+
 public interface FilterBuilder extends ToXContent {
 
     BytesReference buildAsBytes();
 
     BytesReference buildAsBytes(XContentType contentType);
 
+    /**
+     * Converts this FilterBuilder to a lucene {@link Filter}
+     * @param parseContext additional information needed to construct the filter
+     * @return the {@link Filter}
+     * @throws IOException
+     */
+    Filter toFilter(QueryParseContext parseContext) throws IOException;
 }

--- a/src/main/java/org/elasticsearch/index/query/FilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/FilterParser.java
@@ -24,9 +24,6 @@ import org.elasticsearch.common.Nullable;
 
 import java.io.IOException;
 
-/**
- *
- */
 public interface FilterParser {
 
     /**
@@ -43,6 +40,7 @@ public interface FilterParser {
      * it exists within a must clause or a must_not bool clause (that is why returning MATCH_ALL will
      * not be good, since it will not match anything when returned within a must_not clause).
      */
+    //norelease can be removed in favour of fromXContent once search requests can be parsed on the coordinating node
     @Nullable
     Filter parse(QueryParseContext parseContext) throws IOException, QueryParsingException;
 

--- a/src/main/java/org/elasticsearch/index/query/FilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/FilterParser.java
@@ -45,4 +45,18 @@ public interface FilterParser {
      */
     @Nullable
     Filter parse(QueryParseContext parseContext) throws IOException, QueryParsingException;
+
+    /**
+     * Creates a new {@link FilterBuilder} from the filter held by the {@link QueryParseContext}
+     * in {@link org.elasticsearch.common.xcontent.XContent} format
+     *
+     * @param parseContext
+     *            the input parse context. The state on the parser contained in
+     *            this context will be changed as a side effect of this method
+     *            call
+     * @return the new FilterBuilder
+     * @throws IOException
+     * @throws QueryParsingException
+     */
+    FilterBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException;
 }

--- a/src/main/java/org/elasticsearch/index/query/FilterWrappingFilterBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/FilterWrappingFilterBuilder.java
@@ -27,8 +27,8 @@ import java.io.IOException;
 /**
  * FilterBuilder implementation that  holds a lucene filter, which can be returned by {@link #toFilter(QueryParseContext)}.
  * Doesn't support conversion to {@link org.elasticsearch.common.xcontent.XContent} via {@link #doXContent(XContentBuilder, Params)}.
- * Will be removed once all filters support separate fromXContent and toFilter methods.
  */
+//norelease to be removed once all queries support separate fromXContent and toQuery methods
 public class FilterWrappingFilterBuilder extends BaseFilterBuilder {
 
     private final Filter filter;

--- a/src/main/java/org/elasticsearch/index/query/FilterWrappingFilterBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/FilterWrappingFilterBuilder.java
@@ -19,37 +19,37 @@
 
 package org.elasticsearch.index.query;
 
-import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.xcontent.*;
+import org.apache.lucene.search.Filter;
+import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 
 /**
- * FilterBuilder that constructs filters from {@link org.elasticsearch.common.bytes.BytesReference}
- * source
+ * FilterBuilder implementation that  holds a lucene filter, which can be returned by {@link #toFilter(QueryParseContext)}.
+ * Doesn't support conversion to {@link org.elasticsearch.common.xcontent.XContent} via {@link #doXContent(XContentBuilder, Params)}.
+ * Will be removed once all filters support separate fromXContent and toFilter methods.
  */
-public class BytesFilterBuilder extends BaseFilterBuilder {
+public class FilterWrappingFilterBuilder extends BaseFilterBuilder {
 
-    private final BytesReference source;
+    private final Filter filter;
 
-    public BytesFilterBuilder(BytesReference source) {
-        this.source = source;
-
+    public FilterWrappingFilterBuilder(Filter filter) {
+        this.filter = filter;
     }
 
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
-        try (XContentParser parser = XContentFactory.xContent(source).createParser(source)) {
-            // unwrap the first layer of json dictionary
-            parser.nextToken();
-            parser.nextToken();
-            builder.copyCurrentStructure(parser);
-        }
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Filter toFilter(QueryParseContext parseContext) throws IOException {
+        return this.filter;
     }
 
     @Override
     protected String parserName() {
-        //TODO this class is going to be removed, will disappear once we get #10919 in
+        // this should not be called since we overwrite BaseFilterBuilder#toFilter() in this class
         throw new UnsupportedOperationException();
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxFilterBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxFilterBuilder.java
@@ -197,4 +197,9 @@ public class GeoBoundingBoxFilterBuilder extends BaseFilterBuilder {
 
         builder.endObject();
     }
+
+    @Override
+    protected String parserName() {
+        return GeoBoundingBoxFilterParser.NAME;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxFilterParser.java
@@ -39,7 +39,7 @@ import java.io.IOException;
 /**
  *
  */
-public class GeoBoundingBoxFilterParser implements FilterParser {
+public class GeoBoundingBoxFilterParser extends BaseFilterParserTemp {
 
     public static final String TOP = "top";
     public static final String LEFT = "left";

--- a/src/main/java/org/elasticsearch/index/query/GeoDistanceFilterBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoDistanceFilterBuilder.java
@@ -142,4 +142,9 @@ public class GeoDistanceFilterBuilder extends BaseFilterBuilder {
         }
         builder.endObject();
     }
+
+    @Override
+    protected String parserName() {
+        return GeoDistanceFilterParser.NAME;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/GeoDistanceFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoDistanceFilterParser.java
@@ -45,7 +45,7 @@ import java.io.IOException;
  * }
  * </pre>
  */
-public class GeoDistanceFilterParser implements FilterParser {
+public class GeoDistanceFilterParser extends BaseFilterParserTemp {
 
     public static final String NAME = "geo_distance";
 

--- a/src/main/java/org/elasticsearch/index/query/GeoDistanceRangeFilterBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoDistanceRangeFilterBuilder.java
@@ -181,4 +181,9 @@ public class GeoDistanceRangeFilterBuilder extends BaseFilterBuilder {
         }
         builder.endObject();
     }
+
+    @Override
+    protected String parserName() {
+        return GeoDistanceRangeFilterParser.NAME;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/GeoDistanceRangeFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoDistanceRangeFilterParser.java
@@ -45,7 +45,7 @@ import java.io.IOException;
  * }
  * </pre>
  */
-public class GeoDistanceRangeFilterParser implements FilterParser {
+public class GeoDistanceRangeFilterParser extends BaseFilterParserTemp {
 
     public static final String NAME = "geo_distance_range";
 

--- a/src/main/java/org/elasticsearch/index/query/GeoPolygonFilterBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoPolygonFilterBuilder.java
@@ -112,4 +112,9 @@ public class GeoPolygonFilterBuilder extends BaseFilterBuilder {
 
         builder.endObject();
     }
+
+    @Override
+    protected String parserName() {
+        return GeoPolygonFilterParser.NAME;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/GeoPolygonFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoPolygonFilterParser.java
@@ -50,7 +50,7 @@ import java.util.List;
  * }
  * </pre>
  */
-public class GeoPolygonFilterParser implements FilterParser {
+public class GeoPolygonFilterParser extends BaseFilterParserTemp {
 
     public static final String NAME = "geo_polygon";
     public static final String POINTS = "points";

--- a/src/main/java/org/elasticsearch/index/query/GeoShapeFilterBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoShapeFilterBuilder.java
@@ -214,4 +214,9 @@ public class GeoShapeFilterBuilder extends BaseFilterBuilder {
 
         builder.endObject();
     }
+
+    @Override
+    protected String parserName() {
+        return GeoShapeFilterParser.NAME;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/GeoShapeFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoShapeFilterParser.java
@@ -61,7 +61,7 @@ import java.io.IOException;
  * }
  * </pre>
  */
-public class GeoShapeFilterParser implements FilterParser {
+public class GeoShapeFilterParser extends BaseFilterParserTemp {
 
     public static final String NAME = "geo_shape";
 

--- a/src/main/java/org/elasticsearch/index/query/GeohashCellFilter.java
+++ b/src/main/java/org/elasticsearch/index/query/GeohashCellFilter.java
@@ -193,9 +193,14 @@ public class GeohashCellFilter {
 
             builder.endObject();
         }
+
+        @Override
+        protected String parserName() {
+            return NAME;
+        }
     }
 
-    public static class Parser implements FilterParser {
+    public static class Parser extends BaseFilterParserTemp {
 
         @Inject
         public Parser() {

--- a/src/main/java/org/elasticsearch/index/query/HasChildFilterBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/HasChildFilterBuilder.java
@@ -135,5 +135,10 @@ public class HasChildFilterBuilder extends BaseFilterBuilder {
         }
         builder.endObject();
     }
+
+    @Override
+    protected String parserName() {
+        return HasChildFilterParser.NAME;
+    }
 }
 

--- a/src/main/java/org/elasticsearch/index/query/HasChildFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/HasChildFilterParser.java
@@ -44,7 +44,7 @@ import java.io.IOException;
 /**
  *
  */
-public class HasChildFilterParser implements FilterParser {
+public class HasChildFilterParser extends BaseFilterParserTemp {
 
     public static final String NAME = "has_child";
 

--- a/src/main/java/org/elasticsearch/index/query/HasParentFilterBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/HasParentFilterBuilder.java
@@ -105,5 +105,10 @@ public class HasParentFilterBuilder extends BaseFilterBuilder {
         }
         builder.endObject();
     }
+
+    @Override
+    protected String parserName() {
+        return HasParentFilterParser.NAME;
+    }
 }
 

--- a/src/main/java/org/elasticsearch/index/query/HasParentFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/HasParentFilterParser.java
@@ -36,7 +36,7 @@ import static org.elasticsearch.index.query.HasParentQueryParser.createParentQue
 /**
  *
  */
-public class HasParentFilterParser implements FilterParser {
+public class HasParentFilterParser extends BaseFilterParserTemp {
 
     public static final String NAME = "has_parent";
 

--- a/src/main/java/org/elasticsearch/index/query/IdsFilterBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/IdsFilterBuilder.java
@@ -93,4 +93,9 @@ public class IdsFilterBuilder extends BaseFilterBuilder {
 
         builder.endObject();
     }
+
+    @Override
+    protected String parserName() {
+        return IdsFilterParser.NAME;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/IdsFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/IdsFilterParser.java
@@ -36,7 +36,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-public class IdsFilterParser implements FilterParser {
+public class IdsFilterParser extends BaseFilterParserTemp {
 
     public static final String NAME = "ids";
 

--- a/src/main/java/org/elasticsearch/index/query/IndicesFilterBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/IndicesFilterBuilder.java
@@ -86,4 +86,9 @@ public class IndicesFilterBuilder extends BaseFilterBuilder {
 
         builder.endObject();
     }
+
+    @Override
+    protected String parserName() {
+        return IndicesFilterParser.NAME;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/IndicesFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/IndicesFilterParser.java
@@ -34,7 +34,7 @@ import java.util.Collection;
 
 /**
  */
-public class IndicesFilterParser implements FilterParser {
+public class IndicesFilterParser extends BaseFilterParserTemp {
 
     public static final String NAME = "indices";
 

--- a/src/main/java/org/elasticsearch/index/query/LimitFilterBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/LimitFilterBuilder.java
@@ -42,4 +42,9 @@ public class LimitFilterBuilder extends BaseFilterBuilder {
         builder.field("value", limit);
         builder.endObject();
     }
+
+    @Override
+    protected String parserName() {
+        return LimitFilterParser.NAME;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/LimitFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/LimitFilterParser.java
@@ -26,7 +26,7 @@ import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
 
-public class LimitFilterParser implements FilterParser {
+public class LimitFilterParser extends BaseFilterParserTemp {
 
     public static final String NAME = "limit";
 

--- a/src/main/java/org/elasticsearch/index/query/MatchAllFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MatchAllFilterParser.java
@@ -30,7 +30,7 @@ import java.io.IOException;
 /**
  *
  */
-public class MatchAllFilterParser implements FilterParser {
+public class MatchAllFilterParser extends BaseFilterParserTemp {
 
     public static final String NAME = "match_all";
 

--- a/src/main/java/org/elasticsearch/index/query/MissingFilterBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/MissingFilterBuilder.java
@@ -81,4 +81,9 @@ public class MissingFilterBuilder extends BaseFilterBuilder {
         }
         builder.endObject();
     }
+
+    @Override
+    protected String parserName() {
+        return MissingFilterParser.NAME;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/MissingFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MissingFilterParser.java
@@ -38,7 +38,7 @@ import java.util.List;
 /**
  *
  */
-public class MissingFilterParser implements FilterParser {
+public class MissingFilterParser extends BaseFilterParserTemp {
 
     public static final String NAME = "missing";
     public static final boolean DEFAULT_NULL_VALUE = false;

--- a/src/main/java/org/elasticsearch/index/query/NestedFilterBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/NestedFilterBuilder.java
@@ -114,4 +114,9 @@ public class NestedFilterBuilder extends BaseFilterBuilder {
         }
         builder.endObject();
     }
+
+    @Override
+    protected String parserName() {
+        return NestedFilterParser.NAME;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/NestedFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/NestedFilterParser.java
@@ -31,7 +31,7 @@ import org.elasticsearch.index.query.support.InnerHitsQueryParserHelper;
 
 import java.io.IOException;
 
-public class NestedFilterParser implements FilterParser {
+public class NestedFilterParser extends BaseFilterParserTemp {
 
     public static final String NAME = "nested";
 

--- a/src/main/java/org/elasticsearch/index/query/NotFilterBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/NotFilterBuilder.java
@@ -66,4 +66,9 @@ public class NotFilterBuilder extends BaseFilterBuilder {
         }
         builder.endObject();
     }
+
+    @Override
+    protected String parserName() {
+        return NotFilterParser.NAME;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/NotFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/NotFilterParser.java
@@ -30,7 +30,7 @@ import java.io.IOException;
 /**
  *
  */
-public class NotFilterParser implements FilterParser {
+public class NotFilterParser extends BaseFilterParserTemp {
 
     public static final String NAME = "not";
 

--- a/src/main/java/org/elasticsearch/index/query/OrFilterBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/OrFilterBuilder.java
@@ -90,4 +90,9 @@ public class OrFilterBuilder extends BaseFilterBuilder {
         }
         builder.endObject();
     }
+
+    @Override
+    protected String parserName() {
+        return OrFilterParser.NAME;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/OrFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/OrFilterParser.java
@@ -36,7 +36,7 @@ import static com.google.common.collect.Lists.newArrayList;
 /**
  *
  */
-public class OrFilterParser implements FilterParser {
+public class OrFilterParser extends BaseFilterParserTemp {
 
     public static final String NAME = "or";
 

--- a/src/main/java/org/elasticsearch/index/query/PrefixFilterBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/PrefixFilterBuilder.java
@@ -88,4 +88,9 @@ public class PrefixFilterBuilder extends BaseFilterBuilder {
         }
         builder.endObject();
     }
+
+    @Override
+    protected String parserName() {
+        return PrefixFilterParser.NAME;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/PrefixFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/PrefixFilterParser.java
@@ -35,7 +35,7 @@ import java.io.IOException;
 /**
  *
  */
-public class PrefixFilterParser implements FilterParser {
+public class PrefixFilterParser extends BaseFilterParserTemp {
 
     public static final String NAME = "prefix";
 

--- a/src/main/java/org/elasticsearch/index/query/QueryFilterBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryFilterBuilder.java
@@ -79,4 +79,9 @@ public class QueryFilterBuilder extends BaseFilterBuilder {
             builder.endObject();
         }
     }
+
+    @Override
+    protected String parserName() {
+        return QueryFilterParser.NAME;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/QueryFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryFilterParser.java
@@ -29,7 +29,7 @@ import java.io.IOException;
 /**
  *
  */
-public class QueryFilterParser implements FilterParser {
+public class QueryFilterParser extends BaseFilterParserTemp {
 
     public static final String NAME = "query";
 

--- a/src/main/java/org/elasticsearch/index/query/QueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryParser.java
@@ -42,6 +42,7 @@ public interface QueryParser {
      * Returns <tt>null</tt> if this query should be ignored in the context of
      * the DSL.
      */
+    //norelease can be removed in favour of fromXContent once search requests can be parsed on the coordinating node
     @Nullable
     Query parse(QueryParseContext parseContext) throws IOException, QueryParsingException;
 

--- a/src/main/java/org/elasticsearch/index/query/QueryWrappingQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryWrappingQueryBuilder.java
@@ -27,8 +27,8 @@ import java.io.IOException;
 /**
  * QueryBuilder implementation that  holds a lucene query, which can be returned by {@link #toQuery(QueryParseContext)}.
  * Doesn't support conversion to {@link org.elasticsearch.common.xcontent.XContent} via {@link #doXContent(XContentBuilder, Params)}.
- * Will be removed once all queries support separate fromXContent and toQuery methods.
  */
+//norelease to be removed once all queries support separate fromXContent and toQuery methods
 public class QueryWrappingQueryBuilder extends BaseQueryBuilder {
 
     private Query query;

--- a/src/main/java/org/elasticsearch/index/query/RangeFilterBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/RangeFilterBuilder.java
@@ -409,4 +409,9 @@ public class RangeFilterBuilder extends BaseFilterBuilder {
 
         builder.endObject();
     }
+
+    @Override
+    protected String parserName() {
+        return RangeFilterParser.NAME;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/RangeFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/RangeFilterParser.java
@@ -40,7 +40,7 @@ import java.io.IOException;
 /**
  *
  */
-public class RangeFilterParser implements FilterParser {
+public class RangeFilterParser extends BaseFilterParserTemp {
 
     public static final String NAME = "range";
 

--- a/src/main/java/org/elasticsearch/index/query/RegexpFilterBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/RegexpFilterBuilder.java
@@ -126,4 +126,9 @@ public class RegexpFilterBuilder extends BaseFilterBuilder {
         }
         builder.endObject();
     }
+
+    @Override
+    protected String parserName() {
+        return RegexpFilterParser.NAME;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/RegexpFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/RegexpFilterParser.java
@@ -36,7 +36,7 @@ import java.io.IOException;
 /**
  *
  */
-public class RegexpFilterParser implements FilterParser {
+public class RegexpFilterParser extends BaseFilterParserTemp {
 
     public static final String NAME = "regexp";
 

--- a/src/main/java/org/elasticsearch/index/query/ScriptFilterBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/ScriptFilterBuilder.java
@@ -113,4 +113,9 @@ public class ScriptFilterBuilder extends BaseFilterBuilder {
         }
         builder.endObject();
     }
+
+    @Override
+    protected String parserName() {
+        return ScriptFilterParser.NAME;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/ScriptFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/ScriptFilterParser.java
@@ -47,7 +47,7 @@ import static com.google.common.collect.Maps.newHashMap;
 /**
  *
  */
-public class ScriptFilterParser implements FilterParser {
+public class ScriptFilterParser extends BaseFilterParserTemp {
 
     public static final String NAME = "script";
 

--- a/src/main/java/org/elasticsearch/index/query/TermFilterBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/TermFilterBuilder.java
@@ -136,4 +136,9 @@ public class TermFilterBuilder extends BaseFilterBuilder {
         }
         builder.endObject();
     }
+
+    @Override
+    protected String parserName() {
+        return TermFilterParser.NAME;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/TermFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TermFilterParser.java
@@ -35,7 +35,7 @@ import java.io.IOException;
 /**
  *
  */
-public class TermFilterParser implements FilterParser {
+public class TermFilterParser extends BaseFilterParserTemp {
 
     public static final String NAME = "term";
 

--- a/src/main/java/org/elasticsearch/index/query/TermsFilterBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/TermsFilterBuilder.java
@@ -168,4 +168,9 @@ public class TermsFilterBuilder extends BaseFilterBuilder {
 
         builder.endObject();
     }
+
+    @Override
+    protected String parserName() {
+        return TermsFilterParser.NAME;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/TermsFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TermsFilterParser.java
@@ -44,7 +44,7 @@ import java.util.List;
 /**
  *
  */
-public class TermsFilterParser implements FilterParser {
+public class TermsFilterParser extends BaseFilterParserTemp {
 
     public static final String NAME = "terms";
     private Client client;

--- a/src/main/java/org/elasticsearch/index/query/TermsLookupFilterBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/TermsLookupFilterBuilder.java
@@ -24,7 +24,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import java.io.IOException;
 
 /**
- * A filer for a field based on several terms matching on any of them.
+ * A filter for a field based on several terms matching on any of them.
  */
 public class TermsLookupFilterBuilder extends BaseFilterBuilder {
 
@@ -134,5 +134,10 @@ public class TermsLookupFilterBuilder extends BaseFilterBuilder {
         }
 
         builder.endObject();
+    }
+
+    @Override
+    protected String parserName() {
+        return TermsFilterParser.NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/TypeFilterBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/TypeFilterBuilder.java
@@ -37,4 +37,9 @@ public class TypeFilterBuilder extends BaseFilterBuilder {
         builder.field("value", type);
         builder.endObject();
     }
+
+    @Override
+    protected String parserName() {
+        return TypeFilterParser.NAME;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/TypeFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TypeFilterParser.java
@@ -31,7 +31,7 @@ import org.elasticsearch.index.mapper.internal.TypeFieldMapper;
 
 import java.io.IOException;
 
-public class TypeFilterParser implements FilterParser {
+public class TypeFilterParser extends BaseFilterParserTemp {
 
     public static final String NAME = "type";
 

--- a/src/main/java/org/elasticsearch/index/query/WrapperFilterBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/WrapperFilterBuilder.java
@@ -59,4 +59,9 @@ public class WrapperFilterBuilder extends BaseFilterBuilder {
         builder.field("filter", source, offset, length);
         builder.endObject();
     }
+
+    @Override
+    protected String parserName() {
+        return WrapperFilterParser.NAME;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/WrapperFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/WrapperFilterParser.java
@@ -29,7 +29,7 @@ import java.io.IOException;
 /**
  * Filter parser for embedded filter.
  */
-public class WrapperFilterParser implements FilterParser {
+public class WrapperFilterParser extends BaseFilterParserTemp {
 
     public static final String NAME = "wrapper";
 

--- a/src/test/java/org/elasticsearch/index/query/guice/MyJsonFilterParser.java
+++ b/src/test/java/org/elasticsearch/index/query/guice/MyJsonFilterParser.java
@@ -25,9 +25,7 @@ import org.elasticsearch.common.inject.assistedinject.Assisted;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.AbstractIndexComponent;
 import org.elasticsearch.index.Index;
-import org.elasticsearch.index.query.FilterParser;
-import org.elasticsearch.index.query.QueryParseContext;
-import org.elasticsearch.index.query.QueryParsingException;
+import org.elasticsearch.index.query.*;
 import org.elasticsearch.index.settings.IndexSettings;
 
 import java.io.IOException;
@@ -56,6 +54,12 @@ public class MyJsonFilterParser extends AbstractIndexComponent implements Filter
     @Override
     public Filter parse(QueryParseContext parseContext) throws IOException, QueryParsingException {
         return null;
+    }
+
+    @Override
+    public FilterBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
+        Filter filter = parse(parseContext);
+        return new FilterWrappingFilterBuilder(filter);
     }
 
     public Settings settings() {

--- a/src/test/java/org/elasticsearch/index/query/plugin/PluginJsonFilterParser.java
+++ b/src/test/java/org/elasticsearch/index/query/plugin/PluginJsonFilterParser.java
@@ -25,9 +25,7 @@ import org.elasticsearch.common.inject.assistedinject.Assisted;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.AbstractIndexComponent;
 import org.elasticsearch.index.Index;
-import org.elasticsearch.index.query.FilterParser;
-import org.elasticsearch.index.query.QueryParseContext;
-import org.elasticsearch.index.query.QueryParsingException;
+import org.elasticsearch.index.query.*;
 import org.elasticsearch.index.settings.IndexSettings;
 
 import java.io.IOException;
@@ -56,6 +54,12 @@ public class PluginJsonFilterParser extends AbstractIndexComponent implements Fi
     @Override
     public Filter parse(QueryParseContext parseContext) throws IOException, QueryParsingException {
         return null;
+    }
+
+    @Override
+    public FilterBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
+        Filter filter = parse(parseContext);
+        return new FilterWrappingFilterBuilder(filter);
     }
 
     public Settings settings() {


### PR DESCRIPTION
This PR is against the feature/query-refactoring branch.

Similar to #10580 but applied to all filters.

The planned refactoring of search queries requires to split the "parse()" method in FilterParsers into two methods, first a "fromXContent(...)" method that allows parsing to an intermediate filter representation (currently called FooFilterBuilder) and second a "Filter toFilter(...)" method on these intermediate representations that create the actual lucene filters.
This PR is a first step in that direction as it introduces the interface changes necessary for the further refactoring. It introduces the new interface methods while for now keeping the old Builder/Parsers still in place by delegating the new "toFilter()" implementations to the existing "parse()" methods, and by introducing a "catch-all" "fromXContent()" implementation in a BaseFilterParser that returns a temporary FilterBuilder wrapper implementation. This allows us to refactor the existing FilterBuilders step by step while already being able to start refactoring queries and filters with inner queries/filters.
