### PR TITLE
Exclude jackson-databind dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -267,6 +267,12 @@
             <artifactId>jackson-dataformat-yaml</artifactId>
             <version>2.5.1</version>
             <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
the jackson yaml data format pulls in the databind dependency, its important that we exclude it so we won't use any of its classes by mistake
