### PR TITLE
Remove shutdownHooks permission

### DIFF
--- a/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
+++ b/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
@@ -216,15 +216,6 @@ public class Bootstrap {
             // fail if using broken version
             JVMCheck.check();
 
-            bootstrap.setup(true, settings, environment);
-
-            stage = "Startup";
-            bootstrap.start();
-
-            if (!foreground) {
-                closeSysError();
-            }
-
             keepAliveLatch = new CountDownLatch(1);
             // keep this thread alive (non daemon thread) until we shutdown
             Runtime.getRuntime().addShutdownHook(new Thread() {
@@ -233,6 +224,15 @@ public class Bootstrap {
                     keepAliveLatch.countDown();
                 }
             });
+
+            bootstrap.setup(true, settings, environment);
+
+            stage = "Startup";
+            bootstrap.start();
+
+            if (!foreground) {
+                closeSysError();
+            }
 
             keepAliveThread = new Thread(new Runnable() {
                 @Override

--- a/src/main/resources/org/elasticsearch/bootstrap/security.policy
+++ b/src/main/resources/org/elasticsearch/bootstrap/security.policy
@@ -66,9 +66,6 @@ grant {
   // needed by BootStrap, etc
   permission java.lang.RuntimePermission "exitVM.*";
 
-  // needed by RandomizedTest.globalTempDir()
-  permission java.lang.RuntimePermission "shutdownHooks";
-
   // needed by PluginManager
   permission java.lang.RuntimePermission "setFactory";
 


### PR DESCRIPTION
This is easy and obvious to remove. We just have to move one of our shutdown hooks before security init.
