### PR TITLE
Remove exitVM permissions

### DIFF
--- a/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
+++ b/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
@@ -177,7 +177,9 @@ public class Bootstrap {
 
     private void stop() {
         try {
-            node.close();
+            if (node != null) {
+                node.close();
+            }
         } finally {
             keepAliveLatch.countDown();
         }

--- a/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
+++ b/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
@@ -55,11 +55,33 @@ import static org.elasticsearch.common.settings.ImmutableSettings.Builder.EMPTY_
  */
 public class Bootstrap {
 
-    private Node node;
+    private static volatile Bootstrap INSTANCE;
 
-    private static volatile Thread keepAliveThread;
-    private static volatile CountDownLatch keepAliveLatch;
-    private static Bootstrap bootstrap;
+    private Node node;
+    private final CountDownLatch keepAliveLatch = new CountDownLatch(1);
+    private final Thread keepAliveThread;
+
+    /** creates a new instance */
+    Bootstrap() {
+        keepAliveThread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    keepAliveLatch.await();
+                } catch (InterruptedException e) {
+                    // bail out
+                }
+            }
+        }, "elasticsearch[keepAlive/" + Version.CURRENT + "]");
+        keepAliveThread.setDaemon(false);
+        // keep this thread alive (non daemon thread) until we shutdown
+        Runtime.getRuntime().addShutdownHook(new Thread() {
+            @Override
+            public void run() {
+                keepAliveLatch.countDown();
+            }
+        });
+    }
     
     /** initialize native resources */
     public static void initializeNatives(boolean mlockAll, boolean ctrlHandler) {
@@ -77,7 +99,7 @@ public class Bootstrap {
                         ESLogger logger = Loggers.getLogger(Bootstrap.class);
                         logger.info("running graceful exit on windows");
 
-                        System.exit(0);
+                        Bootstrap.INSTANCE.stop();
                         return true;
                     }
                     return false;
@@ -148,47 +170,22 @@ public class Bootstrap {
         return InternalSettingsPreparer.prepareSettings(EMPTY_SETTINGS, true);
     }
 
-    /**
-     * hook for JSVC
-     */
-    public void init(String[] args) throws Exception {
-        Tuple<Settings, Environment> tuple = initialSettings();
-        Settings settings = tuple.v1();
-        Environment environment = tuple.v2();
-        setupLogging(settings, environment);
-        setup(true, settings, environment);
-    }
-
-    /**
-     * hook for JSVC
-     */
-    public void start() {
+    private void start() {
         node.start();
+        keepAliveThread.start();
     }
 
-    /**
-     * hook for JSVC
-     */
-    public void stop() {
-       destroy();
-    }
-
-
-    /**
-     * hook for JSVC
-     */
-    public void destroy() {
-        node.close();
-    }
-
-    public static void close(String[] args) {
-        bootstrap.destroy();
-        keepAliveLatch.countDown();
+    private void stop() {
+        try {
+            node.close();
+        } finally {
+            keepAliveLatch.countDown();
+        }
     }
 
     public static void main(String[] args) {
         System.setProperty("es.logger.prefix", "");
-        bootstrap = new Bootstrap();
+        INSTANCE = new Bootstrap();
         final String pidFile = System.getProperty("es.pidfile", System.getProperty("es-pidfile"));
 
         if (pidFile != null) {
@@ -240,40 +237,18 @@ public class Bootstrap {
             // fail if using broken version
             JVMCheck.check();
 
-            keepAliveLatch = new CountDownLatch(1);
-            // keep this thread alive (non daemon thread) until we shutdown
-            Runtime.getRuntime().addShutdownHook(new Thread() {
-                @Override
-                public void run() {
-                    keepAliveLatch.countDown();
-                }
-            });
-
-            bootstrap.setup(true, settings, environment);
+            INSTANCE.setup(true, settings, environment);
 
             stage = "Startup";
-            bootstrap.start();
+            INSTANCE.start();
 
             if (!foreground) {
                 closeSysError();
             }
-
-            keepAliveThread = new Thread(new Runnable() {
-                @Override
-                public void run() {
-                    try {
-                        keepAliveLatch.await();
-                    } catch (InterruptedException e) {
-                        // bail out
-                    }
-                }
-            }, "elasticsearch[keepAlive/" + Version.CURRENT + "]");
-            keepAliveThread.setDaemon(false);
-            keepAliveThread.start();
         } catch (Throwable e) {
             ESLogger logger = Loggers.getLogger(Bootstrap.class);
-            if (bootstrap.node != null) {
-                logger = Loggers.getLogger(Bootstrap.class, bootstrap.node.settings().get("name"));
+            if (INSTANCE.node != null) {
+                logger = Loggers.getLogger(Bootstrap.class, INSTANCE.node.settings().get("name"));
             }
             String errorMessage = buildErrorMessage(stage, e);
             if (foreground) {

--- a/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
+++ b/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
@@ -30,6 +30,7 @@ import org.elasticsearch.common.inject.spi.Message;
 import org.elasticsearch.common.io.PathUtils;
 import org.elasticsearch.common.jna.Kernel32Library;
 import org.elasticsearch.common.jna.Natives;
+import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.logging.log4j.LogConfigurator;
@@ -177,9 +178,7 @@ public class Bootstrap {
 
     private void stop() {
         try {
-            if (node != null) {
-                node.close();
-            }
+            Releasables.close(node);
         } finally {
             keepAliveLatch.countDown();
         }

--- a/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
+++ b/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
@@ -24,10 +24,6 @@ package org.elasticsearch.bootstrap;
  */
 public class Elasticsearch extends Bootstrap {
 
-    public static void close(String[] args) {
-        Bootstrap.close(args);
-    }
-
     public static void main(String[] args) {
         Bootstrap.main(args);
     }

--- a/src/main/java/org/elasticsearch/bootstrap/ElasticsearchF.java
+++ b/src/main/java/org/elasticsearch/bootstrap/ElasticsearchF.java
@@ -25,10 +25,6 @@ package org.elasticsearch.bootstrap;
  */
 public class ElasticsearchF {
 
-    public static void close(String[] args) {
-        Bootstrap.close(args);
-    }
-
     public static void main(String[] args) {
         System.setProperty("es.foreground", "yes");
         Bootstrap.main(args);

--- a/src/main/resources/org/elasticsearch/bootstrap/security.policy
+++ b/src/main/resources/org/elasticsearch/bootstrap/security.policy
@@ -63,9 +63,6 @@ grant {
   // needed by ImmutableSettings
   permission java.lang.RuntimePermission "getenv.*";
 
-  // needed by BootStrap, etc
-  permission java.lang.RuntimePermission "exitVM.*";
-
   // needed by PluginManager
   permission java.lang.RuntimePermission "setFactory";
 


### PR DESCRIPTION
The tricky part here is just the windows handler for closing the console.

But its not so bad if we just have that handler properly shut down the instance instead of doing System.exit. 

There is also some general refactoring to Bootstrap. I'm sorry to mix this in, but it was too hard to reason about otherwise for me :)

Tested on linux, mac, and windows. also tested closing windows console worked.
