### PR TITLE
Deprecate the More-Like-This API in favour of the MLT query

### DIFF
--- a/docs/reference/migration/index.asciidoc
+++ b/docs/reference/migration/index.asciidoc
@@ -17,9 +17,10 @@ As a general rule:
 See <<setup-upgrade>> for more info.
 --
 
+include::migrate_1_6.asciidoc[]
+
+include::migrate_1_5.asciidoc[]
+
 include::migrate_1_4.asciidoc[]
 
 include::migrate_1_0.asciidoc[]
-
-
-

--- a/docs/reference/migration/migrate_1_6.asciidoc
+++ b/docs/reference/migration/migrate_1_6.asciidoc
@@ -1,0 +1,10 @@
+[[breaking-changes-1.6]]
+== Breaking changes in 1.6
+
+This section discusses the changes that you need to be aware of when migrating
+your application from Elasticsearch 1.x to Elasticsearch 1.6.
+
+[float]
+=== More Like This API
+
+The More Like This API query has been deprecated and will be removed in 2.0. Instead use the <<query-dsl-mlt-query, More Like This Query>>.

--- a/docs/reference/search/more-like-this.asciidoc
+++ b/docs/reference/search/more-like-this.asciidoc
@@ -1,6 +1,8 @@
 [[search-more-like-this]]
 == More Like This API
 
+deprecated[1.6, The More Like This API will be removed in 2.0, instead use the <<query-dsl-mlt-query, More Like This Query>>]
+
 The more like this (mlt) API allows to get documents that are "like" a
 specified document. Here is an example:
 

--- a/src/main/java/org/elasticsearch/action/mlt/MoreLikeThisAction.java
+++ b/src/main/java/org/elasticsearch/action/mlt/MoreLikeThisAction.java
@@ -24,7 +24,9 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.Client;
 
 /**
+ * @deprecated The More Like This API will be removed in 2.0.  Instead, use the More Like This Query.
  */
+@Deprecated
 public class MoreLikeThisAction extends ClientAction<MoreLikeThisRequest, SearchResponse, MoreLikeThisRequestBuilder> {
 
     public static final MoreLikeThisAction INSTANCE = new MoreLikeThisAction();

--- a/src/main/java/org/elasticsearch/action/mlt/MoreLikeThisRequest.java
+++ b/src/main/java/org/elasticsearch/action/mlt/MoreLikeThisRequest.java
@@ -53,7 +53,10 @@ import static org.elasticsearch.search.Scroll.readScroll;
  * @see org.elasticsearch.client.Client#moreLikeThis(MoreLikeThisRequest)
  * @see org.elasticsearch.client.Requests#moreLikeThisRequest(String)
  * @see org.elasticsearch.action.search.SearchResponse
+ * 
+ * @deprecated The More Like This API will be removed in 2.0.  Instead, use the More Like This Query.
  */
+@Deprecated
 public class MoreLikeThisRequest extends ActionRequest<MoreLikeThisRequest> implements CompositeIndicesRequest {
 
     private String index;

--- a/src/main/java/org/elasticsearch/action/mlt/MoreLikeThisRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/mlt/MoreLikeThisRequestBuilder.java
@@ -32,7 +32,9 @@ import org.elasticsearch.search.builder.SearchSourceBuilder;
 import java.util.Map;
 
 /**
+ * @deprecated The More Like This API will be removed in 2.0.  Instead, use the More Like This Query.
  */
+@Deprecated
 public class MoreLikeThisRequestBuilder extends ActionRequestBuilder<MoreLikeThisRequest, SearchResponse, MoreLikeThisRequestBuilder, Client> {
 
     public MoreLikeThisRequestBuilder(Client client) {

--- a/src/main/java/org/elasticsearch/action/mlt/TransportMoreLikeThisAction.java
+++ b/src/main/java/org/elasticsearch/action/mlt/TransportMoreLikeThisAction.java
@@ -64,7 +64,10 @@ import static org.elasticsearch.search.builder.SearchSourceBuilder.searchSource;
 
 /**
  * The more like this action.
+ *
+ * @deprecated The More Like This API will be removed in 2.0.  Instead, use the More Like This Query.
  */
+@Deprecated
 public class TransportMoreLikeThisAction extends HandledTransportAction<MoreLikeThisRequest, SearchResponse> {
 
     private final TransportSearchAction searchAction;

--- a/src/main/java/org/elasticsearch/client/Client.java
+++ b/src/main/java/org/elasticsearch/client/Client.java
@@ -529,7 +529,10 @@ public interface Client extends ElasticsearchClient<Client>, Releasable {
      *
      * @param request The more like this request
      * @return The response future
+     * 
+     * @deprecated The More Like This API will be removed in 2.0.  Instead, use the More Like This Query.
      */
+    @Deprecated
     ActionFuture<SearchResponse> moreLikeThis(MoreLikeThisRequest request);
 
     /**
@@ -537,7 +540,10 @@ public interface Client extends ElasticsearchClient<Client>, Releasable {
      *
      * @param request  The more like this request
      * @param listener A listener to be notified of the result
+     *
+     * @deprecated The More Like This API will be removed in 2.0.  Instead, use the More Like This Query.
      */
+    @Deprecated
     void moreLikeThis(MoreLikeThisRequest request, ActionListener<SearchResponse> listener);
 
     /**
@@ -546,7 +552,10 @@ public interface Client extends ElasticsearchClient<Client>, Releasable {
      * @param index The index to load the document from
      * @param type  The type of the document
      * @param id    The id of the document
+     *
+     * @deprecated The More Like This API will be removed in 2.0.  Instead, use the More Like This Query.
      */
+    @Deprecated
     MoreLikeThisRequestBuilder prepareMoreLikeThis(String index, String type, String id);
 
     /**

--- a/src/main/java/org/elasticsearch/client/Requests.java
+++ b/src/main/java/org/elasticsearch/client/Requests.java
@@ -181,7 +181,10 @@ public class Requests {
      * @param index The index to load the document from
      * @return The more like this request
      * @see org.elasticsearch.client.Client#moreLikeThis(org.elasticsearch.action.mlt.MoreLikeThisRequest)
+     *
+     * @deprecated The More Like This API will be removed in 2.0.  Instead, use the More Like This Query.
      */
+    @Deprecated
     public static MoreLikeThisRequest moreLikeThisRequest(String index) {
         return new MoreLikeThisRequest(index);
     }

--- a/src/main/java/org/elasticsearch/rest/action/mlt/RestMoreLikeThisAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/mlt/RestMoreLikeThisAction.java
@@ -35,8 +35,9 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 
 /**
- *
+ * @deprecated The More Like This API will be removed in 2.0.  Instead, use the More Like This Query.
  */
+@Deprecated
 public class RestMoreLikeThisAction extends BaseRestHandler {
 
     @Inject


### PR DESCRIPTION
Deprecates the More Like This API until it gets removed in 2.0. Users are
encouraged to use the More Like This query.

Relates #10736 
