### PR TITLE
Let HTTPS work correctly

### DIFF
--- a/src/main/java/org/elasticsearch/plugins/PluginManager.java
+++ b/src/main/java/org/elasticsearch/plugins/PluginManager.java
@@ -33,10 +33,6 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.node.internal.InternalSettingsPreparer;
 
-import javax.net.ssl.HttpsURLConnection;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.X509TrustManager;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.net.MalformedURLException;
@@ -87,34 +83,6 @@ public class PluginManager {
         this.url = url;
         this.outputMode = outputMode;
         this.timeout = timeout;
-
-        TrustManager[] trustAllCerts = new TrustManager[]{
-                new X509TrustManager() {
-                    @Override
-                    public java.security.cert.X509Certificate[] getAcceptedIssuers() {
-                        return null;
-                    }
-
-                    @Override
-                    public void checkClientTrusted(
-                            java.security.cert.X509Certificate[] certs, String authType) {
-                    }
-
-                    @Override
-                    public void checkServerTrusted(
-                            java.security.cert.X509Certificate[] certs, String authType) {
-                    }
-                }
-        };
-
-        // Install the all-trusting trust manager
-        try {
-            SSLContext sc = SSLContext.getInstance("SSL");
-            sc.init(null, trustAllCerts, new java.security.SecureRandom());
-            HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory());
-        } catch (Exception e) {
-            throw new ElasticsearchException("Failed to install all-trusting trust manager", e);
-        }
     }
 
     public void downloadAndExtract(String name) throws IOException {

--- a/src/main/resources/org/elasticsearch/bootstrap/security.policy
+++ b/src/main/resources/org/elasticsearch/bootstrap/security.policy
@@ -68,9 +68,6 @@ grant {
   // needed by ImmutableSettings
   permission java.lang.RuntimePermission "getenv.*";
 
-  // needed by PluginManager
-  permission java.lang.RuntimePermission "setFactory";
-
   // needed by LuceneTestCase/TestRuleLimitSysouts
   permission java.lang.RuntimePermission "setIO";
 


### PR DESCRIPTION
Currently pluginmanager init disables https verification _jvm-wide_ for any HttpsURLConnections. This is seriously screwed-up, and makes https completely useless here. It does this without any comment or justification as to why.

If you don't want the cert check, just use http. or configure this trust stuff in your jvm differently. But we should let HTTPS just work correctly by default.

cc: @jaymode 
