### PR TITLE
Ensure JNA is fully loaded when its available, but don't fail its not

### DIFF
--- a/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
+++ b/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
@@ -107,7 +107,13 @@ public class Bootstrap {
                 }
             });
         }
-        Kernel32Library.getInstance();
+
+        // force remainder of JNA to be loaded (if available).
+        try {
+            Kernel32Library.getInstance();
+        } catch (Throwable ignored) {
+            // we've already logged this.
+        }
  
         // initialize sigar explicitly
         try {


### PR DESCRIPTION
Note: core tests will still fail if JNA/sigar is e.g. misconfigured today. This is intentional.

But we don't need to make plugins tests fail, or even fail at all at runtime if stuff is not available.
