### PR TITLE
Remove double exception handling that causes false replica failures

### DIFF
--- a/src/main/java/org/elasticsearch/action/support/replication/TransportShardReplicationOperationAction.java
+++ b/src/main/java/org/elasticsearch/action/support/replication/TransportShardReplicationOperationAction.java
@@ -278,9 +278,6 @@ public abstract class TransportShardReplicationOperationAction<Request extends S
         protected void doRun() throws Exception {
             try (Releasable shardReference = getIndexShardOperationsCounter(request.internalShardId)) {
                 shardOperationOnReplica(request.internalShardId, request);
-            } catch (Throwable t) {
-                failReplicaIfNeeded(request.internalShardId.index().name(), request.internalShardId.id(), t);
-                throw t;
             }
             channel.sendResponse(TransportResponse.Empty.INSTANCE);
         }


### PR DESCRIPTION
we already fail the shard in the `onFailure` method if the replica
operation barfs. This additional check has been added lately that
bypasses the clusterstate observer which causes replicas to fail
if the mappings are not yet present.
