### PR TITLE
Use buffered translog type also when sync is set to 0

### DIFF
--- a/src/main/java/org/elasticsearch/index/translog/Translog.java
+++ b/src/main/java/org/elasticsearch/index/translog/Translog.java
@@ -152,10 +152,10 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
 
         syncInterval = indexSettings.getAsTime(INDEX_TRANSLOG_SYNC_INTERVAL, TimeValue.timeValueSeconds(5));
         if (syncInterval.millis() > 0 && threadPool != null) {
-            syncOnEachOperation(false);
+            this.syncOnEachOperation = false;
             syncScheduler = threadPool.schedule(syncInterval, ThreadPool.Names.SAME, new Sync());
         } else if (syncInterval.millis() == 0) {
-            syncOnEachOperation(true);
+            this.syncOnEachOperation = true;
         }
 
         if (indexSettingsService != null) {
@@ -504,15 +504,6 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
     public boolean syncNeeded() {
         try (ReleasableLock lock = readLock.acquire()) {
             return current.syncNeeded();
-        }
-    }
-
-    public void syncOnEachOperation(boolean syncOnEachOperation) {
-        this.syncOnEachOperation = syncOnEachOperation;
-        if (syncOnEachOperation) {
-            type = TranslogFile.Type.SIMPLE;
-        } else {
-            type = TranslogFile.Type.BUFFERED;
         }
     }
 


### PR DESCRIPTION
When settings sync to 0, we benefit from using the buffered type, no need to change to simple, since we get a chance to fsync multiple operations (for that single operation) and not have to sync for the other ones before returning each one
