### PR TITLE
Minor TimeZone Fix

### DIFF
--- a/src/main/java/org/elasticsearch/script/expression/DateMethodFunctionValues.java
+++ b/src/main/java/org/elasticsearch/script/expression/DateMethodFunctionValues.java
@@ -34,7 +34,7 @@ class DateMethodFunctionValues extends FieldDataFunctionValues {
         super(parent, data);
 
         this.calendarType = calendarType;
-        calendar = Calendar.getInstance(TimeZone.getTimeZone("GMT"), Locale.ROOT);
+        calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"), Locale.ROOT);
     }
 
     @Override


### PR DESCRIPTION
Changed DateMethodFunctionValues to use UTC instead of GMT.  Should not affect what is currently there, but is correct and consistent.
