### PR TITLE
Load fielddata on behalf of scripts.

### DIFF
--- a/src/test/java/org/elasticsearch/script/GroovySecurityTests.java
+++ b/src/test/java/org/elasticsearch/script/GroovySecurityTests.java
@@ -54,10 +54,14 @@ public class GroovySecurityTests extends ElasticsearchIntegrationTest {
         internalCluster().startNodesAsync(nodes, nodeSettings).get();
         client().admin().cluster().prepareHealth().setWaitForNodes(nodes + "").get();
 
-        client().prepareIndex("test", "doc", "1").setSource("foo", 5).setRefresh(true).get();
+        client().prepareIndex("test", "doc", "1").setSource("foo", 5, "bar", "baz").setRefresh(true).get();
 
         // Plain test
         assertSuccess("");
+        // numeric field access
+        assertSuccess("def foo = doc['foo'].value; if (foo == null) { return 5; }");
+        // string field access
+        assertSuccess("def bar = doc['bar'].value; if (foo == null) { return 5; }");
         // List
         assertSuccess("def list = [doc['foo'].value, 3, 4]; def v = list.get(1); list.add(10)");
         // Ranges


### PR DESCRIPTION
If we have to do the one-time loading of fieldata, it requires
more permissions than groovy scripts currently have (zero). This
is because of RamUsageEstimator reflection and so on in PagedBytes.

GroovySecurityTests only test a numeric field, so add a string field
to the test (so pagedbytes fielddata gets created etc).
