### PR TITLE
Documentation: Mention RPM repo does not work with older distributions

### DIFF
--- a/docs/reference/setup/repositories.asciidoc
+++ b/docs/reference/setup/repositories.asciidoc
@@ -91,6 +91,9 @@ yum install elasticsearch
 Configure Elasticsearch to automatically start during bootup. If your
 distribution is using SysV init, then you will need to run:
 
+WARNING: The repositories do not work with older rpm based distributions
+         that still use RPM v3, like CentOS5.
+
 [source,sh]
 --------------------------------------------------
 chkconfig --add elasticsearch


### PR DESCRIPTION
Getting this to work would be a lot of work (creating two different
repositories, having another GPG key, integrating this into our build).

Closes #6498
