### PR TITLE
Remove Codehaus repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,11 +67,6 @@
 
     <repositories>
         <repository>
-            <id>codehaus-snapshots</id>
-            <name>Codehaus Snapshots</name>
-            <url>http://repository.codehaus.org/</url>
-        </repository>
-        <repository>
             <id>lucene-snapshots</id>
             <name>Lucene Snapshots</name>
             <url>http://download.elastic.co/lucenesnapshots/${lucene.snapshot.revision}</url>


### PR DESCRIPTION
Codehaus announced they are shutting down their services: https://www.codehaus.org/

We should remove their repository from our pom as it could cause some errors an useless HTTP calls.

Related to #10939 

I think this should go to at least 1.5, 1.x and master.
