### PR TITLE
[TEST] don't check shard counter if there are still write operations …

### DIFF
--- a/src/test/java/org/elasticsearch/percolator/TTLPercolatorTests.java
+++ b/src/test/java/org/elasticsearch/percolator/TTLPercolatorTests.java
@@ -52,6 +52,10 @@ public class TTLPercolatorTests extends ElasticsearchIntegrationTest {
     private static final long PURGE_INTERVAL = 200;
 
     @Override
+    protected void beforeIndexDeletion() {
+    }
+
+    @Override
     protected Settings nodeSettings(int nodeOrdinal) {
         return settingsBuilder()
                 .put(super.nodeSettings(nodeOrdinal))

--- a/src/test/java/org/elasticsearch/river/RiverTests.java
+++ b/src/test/java/org/elasticsearch/river/RiverTests.java
@@ -43,6 +43,10 @@ import static org.hamcrest.Matchers.equalTo;
 @AwaitsFix(bugUrl="occasionally fails apparently due to synchronous mappings updates")
 public class RiverTests extends ElasticsearchIntegrationTest {
 
+    @Override
+    protected void beforeIndexDeletion() {
+    }
+
     @Test
     public void testRiverStart() throws Exception {
         startAndCheckRiverIsStarted("dummy-river-test");

--- a/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
@@ -642,7 +642,7 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
                     }
                     ensureClusterSizeConsistency();
                     ensureClusterStateConsistency();
-                    cluster().beforeIndexDeletion();
+                    beforeIndexDeletion();
                     cluster().wipe(); // wipe after to make sure we fail in the test that didn't ack the delete
                     if (afterClass || currentClusterScope == Scope.TEST) {
                         cluster().close();
@@ -663,6 +663,10 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
                 // afterTestRule.forceFailure();
             }
         }
+    }
+
+    protected void beforeIndexDeletion() {
+        cluster().beforeIndexDeletion();
     }
 
     public static TestCluster cluster() {

--- a/src/test/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/src/test/java/org/elasticsearch/test/InternalTestCluster.java
@@ -971,6 +971,11 @@ public final class InternalTestCluster extends TestCluster {
 
     @Override
     public void beforeIndexDeletion() {
+        // Check that the operations counter on index shard has reached 1.
+        // The assumption here is that after a test there are no ongoing write operations.
+        // test that have ongoing write operations after the test (for example because ttl is used
+        // and not all docs have been purged after the test) and inherit from
+        // ElasticsearchIntegrationTest must override beforeIndexDeletion() to avoid failures.
         assertShardIndexCounter();
     }
 


### PR DESCRIPTION
…ongoing after test

We added a check to see if the counter for write operations on IndexShard always reaches 0 after a test.
The assumption here is that after a test there are no ongoing write operations. 
However, tests that use ttl or rivers might trigger write operations after the test also.
Test that have ongoing write operations after the test and inherit from
ElasticsearchIntegrationTest should override beforeIndexDeletion() to avoid failures.
