### PR TITLE
Query Refactoring: Increase coverage of BaseQueryTestCase

### DIFF
--- a/src/test/java/org/elasticsearch/index/query/BaseQueryTestCase.java
+++ b/src/test/java/org/elasticsearch/index/query/BaseQueryTestCase.java
@@ -145,7 +145,7 @@ public abstract class BaseQueryTestCase<QB extends BaseQueryBuilder & Streamable
             String contentString = testQuery.toString();
             XContentParser parser = XContentFactory.xContent(contentString).createParser(contentString);
             context.reset(parser);
-            assertQueryHeader(parser);
+            assertQueryHeader(parser, testQuery.parserName());
 
             QueryBuilder newQuery = queryParserService.queryParser(testQuery.parserName()).fromXContent(context);
             assertNotSame(newQuery, testQuery);
@@ -193,10 +193,10 @@ public abstract class BaseQueryTestCase<QB extends BaseQueryBuilder & Streamable
         return new QueryParseContext(index, queryParserService);
     }
 
-    private void assertQueryHeader(XContentParser parser) throws IOException {
+    private static void assertQueryHeader(XContentParser parser, String expectedParserName) throws IOException {
         assertThat(parser.nextToken(), is(XContentParser.Token.START_OBJECT));
         assertThat(parser.nextToken(), is(XContentParser.Token.FIELD_NAME));
-        assertThat(parser.currentName(), is(testQuery.parserName()));
+        assertThat(parser.currentName(), is(expectedParserName));
         assertThat(parser.nextToken(), is(XContentParser.Token.START_OBJECT));
     }
 }


### PR DESCRIPTION
We are creating random queries for testing purposes in BaseQueryTestCase and discussed using more repetitions of the basic test cases (e.g. serialization, fromXContent parsing) for better coverage if the query has more options. Instead of using @Repeat annotation this change uses outer loop in each individual test method to recreate new test queries to archive this.
