### PR TITLE
Remove traverse functions from Mapper

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/Mapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/Mapper.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.index.mapper;
 
 import com.google.common.collect.ImmutableMap;
-
 import org.elasticsearch.Version;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
@@ -29,17 +28,13 @@ import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.index.analysis.AnalysisService;
 import org.elasticsearch.index.similarity.SimilarityLookupService;
 
-import java.io.IOException;
 import java.util.Map;
 
-/**
- *
- */
-public interface Mapper extends ToXContent {
+public interface Mapper extends ToXContent, Iterable<Mapper> {
 
-    public static final Mapper[] EMPTY_ARRAY = new Mapper[0];
+    Mapper[] EMPTY_ARRAY = new Mapper[0];
 
-    public static class BuilderContext {
+    class BuilderContext {
         private final Settings indexSettings;
         private final ContentPath contentPath;
 
@@ -66,7 +61,7 @@ public interface Mapper extends ToXContent {
         }
     }
 
-    public static abstract class Builder<T extends Builder, Y extends Mapper> {
+    abstract class Builder<T extends Builder, Y extends Mapper> {
 
         public String name;
 
@@ -83,9 +78,9 @@ public interface Mapper extends ToXContent {
         public abstract Y build(BuilderContext context);
     }
 
-    public interface TypeParser {
+    interface TypeParser {
 
-        public static class ParserContext {
+        class ParserContext {
 
             private final AnalysisService analysisService;
 
@@ -126,10 +121,6 @@ public interface Mapper extends ToXContent {
     String name();
 
     void merge(Mapper mergeWith, MergeResult mergeResult) throws MergeMappingException;
-
-    void traverse(FieldMapperListener fieldMapperListener);
-
-    void traverse(ObjectMapperListener objectMapperListener);
 
     void close();
 }

--- a/src/main/java/org/elasticsearch/index/mapper/MapperUtils.java
+++ b/src/main/java/org/elasticsearch/index/mapper/MapperUtils.java
@@ -21,14 +21,13 @@ package org.elasticsearch.index.mapper;
 
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.index.mapper.object.ObjectMapper;
+import org.elasticsearch.index.mapper.object.RootObjectMapper;
 
 import java.io.IOException;
 import java.util.Collection;
 
 public enum MapperUtils {
     ;
-
-
 
     private static MergeResult newStrictMergeContext() {
         return new MergeResult(false) {
@@ -76,4 +75,17 @@ public enum MapperUtils {
         mergeInto.merge(mergeWith, newStrictMergeContext());
     }
 
+    /** Split mapper and its descendants into object and field mappers. */
+    public static void collect(Mapper mapper, Collection<ObjectMapper> objectMappers, Collection<FieldMapper<?>> fieldMappers) {
+        if (mapper instanceof RootObjectMapper) {
+            // root mapper isn't really an object mapper
+        } else if (mapper instanceof ObjectMapper) {
+            objectMappers.add((ObjectMapper)mapper);
+        } else if (mapper instanceof FieldMapper<?>) {
+            fieldMappers.add((FieldMapper<?>)mapper);
+        }
+        for (Mapper child : mapper) {
+            collect(child, objectMappers, fieldMappers);
+        }
+    }
 }

--- a/src/main/java/org/elasticsearch/index/mapper/ObjectMapperListener.java
+++ b/src/main/java/org/elasticsearch/index/mapper/ObjectMapperListener.java
@@ -22,11 +22,9 @@ package org.elasticsearch.index.mapper;
 import org.elasticsearch.index.mapper.object.ObjectMapper;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
-/**
- *
- */
 public abstract class ObjectMapperListener {
 
     public static class Aggregator extends ObjectMapperListener {
@@ -40,7 +38,7 @@ public abstract class ObjectMapperListener {
 
     public abstract void objectMapper(ObjectMapper objectMapper);
 
-    public void objectMappers(ObjectMapper... objectMappers) {
+    public void objectMappers(Collection<ObjectMapper> objectMappers) {
         for (ObjectMapper objectMapper : objectMappers) {
             objectMapper(objectMapper);
         }

--- a/src/main/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapper.java
@@ -22,7 +22,7 @@ package org.elasticsearch.index.mapper.geo;
 import com.carrotsearch.hppc.ObjectOpenHashSet;
 import com.carrotsearch.hppc.cursors.ObjectCursor;
 import com.google.common.base.Objects;
-
+import com.google.common.collect.Iterators;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.index.DocValuesType;
@@ -45,12 +45,10 @@ import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.fielddata.FieldDataType;
 import org.elasticsearch.index.mapper.ContentPath;
 import org.elasticsearch.index.mapper.FieldMapper;
-import org.elasticsearch.index.mapper.FieldMapperListener;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
-import org.elasticsearch.index.mapper.MergeResult;
 import org.elasticsearch.index.mapper.MergeMappingException;
-import org.elasticsearch.index.mapper.ObjectMapperListener;
+import org.elasticsearch.index.mapper.MergeResult;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.core.AbstractFieldMapper;
 import org.elasticsearch.index.mapper.core.DoubleFieldMapper;
@@ -61,6 +59,7 @@ import org.elasticsearch.index.mapper.object.ArrayValueMapperParser;
 import org.elasticsearch.index.similarity.SimilarityProvider;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
@@ -678,19 +677,16 @@ public class GeoPointFieldMapper extends AbstractFieldMapper<GeoPoint> implement
     }
 
     @Override
-    public void traverse(FieldMapperListener fieldMapperListener) {
-        super.traverse(fieldMapperListener);
+    public Iterator<Mapper> iterator() {
+        List<Mapper> extras = new ArrayList<>();
         if (enableGeoHash) {
-            geohashMapper.traverse(fieldMapperListener);
+            extras.add(geohashMapper);
         }
         if (enableLatLon) {
-            latMapper.traverse(fieldMapperListener);
-            lonMapper.traverse(fieldMapperListener);
+            extras.add(latMapper);
+            extras.add(lonMapper);
         }
-    }
-
-    @Override
-    public void traverse(ObjectMapperListener objectMapperListener) {
+        return Iterators.concat(super.iterator(), extras.iterator());
     }
 
     @Override

--- a/src/test/java/org/elasticsearch/index/mapper/core/BooleanFieldMapperTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/core/BooleanFieldMapperTests.java
@@ -89,17 +89,9 @@ public class BooleanFieldMapperTests extends ElasticsearchSingleNodeTest {
                 .endObject().endObject().string();
 
         DocumentMapper defaultMapper = parser.parse(mapping);
-        final FieldMapper<?>[] mapper = new BooleanFieldMapper[1];
-        defaultMapper.root().traverse(new FieldMapperListener() {
-            @Override
-            public void fieldMapper(FieldMapper<?> fieldMapper) {
-                if (fieldMapper.name().equals("field")) {
-                    mapper[0] = fieldMapper;
-                }
-            }
-        });
+        FieldMapper<?> mapper = defaultMapper.mappers().getMapper("field");
         XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
-        mapper[0].toXContent(builder, ToXContent.EMPTY_PARAMS);
+        mapper.toXContent(builder, ToXContent.EMPTY_PARAMS);
         builder.endObject();
         assertEquals("{\"field\":{\"type\":\"boolean\"}}", builder.string());
 
@@ -113,16 +105,9 @@ public class BooleanFieldMapperTests extends ElasticsearchSingleNodeTest {
                 .endObject().endObject().string();
 
         defaultMapper = parser.parse(mapping);
-        defaultMapper.root().traverse(new FieldMapperListener() {
-            @Override
-            public void fieldMapper(FieldMapper<?> fieldMapper) {
-                if (fieldMapper.name().equals("field")) {
-                    mapper[0] = fieldMapper;
-                }
-            }
-        });
+        mapper = defaultMapper.mappers().getMapper("field");
         builder = XContentFactory.jsonBuilder().startObject();
-        mapper[0].toXContent(builder, ToXContent.EMPTY_PARAMS);
+        mapper.toXContent(builder, ToXContent.EMPTY_PARAMS);
         builder.endObject();
         assertEquals("{\"field\":{\"type\":\"boolean\",\"doc_values\":false,\"null_value\":true}}", builder.string());
     }

--- a/src/test/java/org/elasticsearch/index/mapper/externalvalues/ExternalMapper.java
+++ b/src/test/java/org/elasticsearch/index/mapper/externalvalues/ExternalMapper.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.index.mapper.externalvalues;
 
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
 import com.spatial4j.core.shape.Point;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
@@ -221,16 +223,8 @@ public class ExternalMapper extends AbstractFieldMapper<Object> {
     }
 
     @Override
-    public void traverse(FieldMapperListener fieldMapperListener) {
-        binMapper.traverse(fieldMapperListener);
-        boolMapper.traverse(fieldMapperListener);
-        pointMapper.traverse(fieldMapperListener);
-        shapeMapper.traverse(fieldMapperListener);
-        stringMapper.traverse(fieldMapperListener);
-    }
-
-    @Override
-    public void traverse(ObjectMapperListener objectMapperListener) {
+    public Iterator<Mapper> iterator() {
+        return Iterators.concat(super.iterator(), Lists.newArrayList(binMapper, boolMapper, pointMapper, shapeMapper, stringMapper).iterator());
     }
 
     @Override

--- a/src/test/java/org/elasticsearch/index/mapper/externalvalues/ExternalRootMapper.java
+++ b/src/test/java/org/elasticsearch/index/mapper/externalvalues/ExternalRootMapper.java
@@ -25,6 +25,8 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.mapper.*;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.Iterator;
 import java.util.Map;
 
 public class ExternalRootMapper implements RootMapper {
@@ -46,11 +48,8 @@ public class ExternalRootMapper implements RootMapper {
     }
 
     @Override
-    public void traverse(FieldMapperListener fieldMapperListener) {
-    }
-
-    @Override
-    public void traverse(ObjectMapperListener objectMapperListener) {
+    public Iterator<Mapper> iterator() {
+        return Collections.emptyIterator();
     }
 
     @Override


### PR DESCRIPTION
The mapper listener abstractions for object and field mappers are used
to notify the mapper service of new fields, as well as collect
all object and field mappers through a set of traversal functions.

This change removes the traversal functions in favor of simple
iteration over subfields of a mapper.

Note there is a single test which fails currently, for a seemingly impossible reason.
`RecoveryWhileUnderLoadTests.recoverWhileRelocating` fails with a NPE when trying to get the thread local parse context inside DocumentParser....
