### PR TITLE
Remove `percent_terms_to_match`

### DIFF
--- a/docs/reference/migration/migrate_2_0.asciidoc
+++ b/docs/reference/migration/migrate_2_0.asciidoc
@@ -29,6 +29,9 @@ Partial fields were deprecated since 1.0.0beta1 in favor of <<search-request-sou
 The More Like This API and the More Like This Field query have been removed in
 favor of the <<query-dsl-mlt-query, More Like This Query>>.
 
+The parameter `percent_terms_to_match` has been removed in favor of
+`minimum_should_match`.
+
 === Routing
 
 The default hash function that is used for routing has been changed from djb2 to

--- a/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilder.java
@@ -259,14 +259,6 @@ public class MoreLikeThisQueryBuilder extends BaseQueryBuilder implements Boosta
     }
 
     /**
-     * The percentage of terms to match. Defaults to <tt>0.3</tt>.
-     */
-    @Deprecated
-    public MoreLikeThisQueryBuilder percentTermsToMatch(float percentTermsToMatch) {
-        return minimumShouldMatch(Math.round(percentTermsToMatch * 100) + "%");
-    }
-
-    /**
      * The frequency below which terms will be ignored in the source doc. The default
      * frequency is <tt>2</tt>.
      */

--- a/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryParser.java
@@ -67,7 +67,6 @@ public class MoreLikeThisQueryParser implements QueryParser {
         public static final ParseField MAX_DOC_FREQ = new ParseField("max_doc_freq");
         public static final ParseField BOOST_TERMS = new ParseField("boost_terms");
         public static final ParseField MINIMUM_SHOULD_MATCH = new ParseField("minimum_should_match");
-        public static final ParseField PERCENT_TERMS_TO_MATCH = new ParseField("percent_terms_to_match").withAllDeprecated("minimum_should_match");
         public static final ParseField FAIL_ON_UNSUPPORTED_FIELD = new ParseField("fail_on_unsupported_field");
         public static final ParseField STOP_WORDS = new ParseField("stop_words");
         public static final ParseField DOCUMENT_IDS = new ParseField("ids").withAllDeprecated("like");
@@ -142,8 +141,6 @@ public class MoreLikeThisQueryParser implements QueryParser {
                     }
                 } else if (Fields.MINIMUM_SHOULD_MATCH.match(currentFieldName, parseContext.parseFlags())) {
                     mltQuery.setMinimumShouldMatch(parser.text());
-                } else if (Fields.PERCENT_TERMS_TO_MATCH.match(currentFieldName, parseContext.parseFlags())) {
-                    mltQuery.setMinimumShouldMatch(Math.round(parser.floatValue() * 100) + "%");
                 } else if ("analyzer".equals(currentFieldName)) {
                     analyzer = parseContext.analysisService().analyzer(parser.text());
                 } else if ("boost".equals(currentFieldName)) {

--- a/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
+++ b/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
@@ -1751,7 +1751,7 @@ public class SimpleIndexQueryParserTests extends ElasticsearchSingleNodeTest {
     }
 
     @Test
-    public void testMLTPercentTermsToMatch() throws Exception {
+    public void testMLTMinimumShouldMatch() throws Exception {
         // setup for mocking fetching items
         MoreLikeThisQueryParser parser = (MoreLikeThisQueryParser) queryParser.queryParser("more_like_this");
         parser.setFetchService(new MockMoreLikeThisFetchService());

--- a/src/test/java/org/elasticsearch/search/morelikethis/MoreLikeThisTests.java
+++ b/src/test/java/org/elasticsearch/search/morelikethis/MoreLikeThisTests.java
@@ -299,16 +299,16 @@ public class MoreLikeThisTests extends ElasticsearchIntegrationTest {
 
         logger.info("Running More Like This with include true");
         SearchResponse response = client().prepareSearch().setQuery(
-                new MoreLikeThisQueryBuilder().addItem(new Item("test", "type1", "1")).minTermFreq(1).minDocFreq(1).include(true).percentTermsToMatch(0)).get();
+                new MoreLikeThisQueryBuilder().addItem(new Item("test", "type1", "1")).minTermFreq(1).minDocFreq(1).include(true).minimumShouldMatch("0%")).get();
         assertOrderedSearchHits(response, "1", "2");
 
         response = client().prepareSearch().setQuery(
-                new MoreLikeThisQueryBuilder().addItem(new Item("test", "type1", "2")).minTermFreq(1).minDocFreq(1).include(true).percentTermsToMatch(0)).get();
+                new MoreLikeThisQueryBuilder().addItem(new Item("test", "type1", "2")).minTermFreq(1).minDocFreq(1).include(true).minimumShouldMatch("0%")).get();
         assertOrderedSearchHits(response, "2", "1");
 
         logger.info("Running More Like This with include false");
         response = client().prepareSearch().setQuery(
-                new MoreLikeThisQueryBuilder().addItem(new Item("test", "type1", "1")).minTermFreq(1).minDocFreq(1).percentTermsToMatch(0)).get();
+                new MoreLikeThisQueryBuilder().addItem(new Item("test", "type1", "1")).minTermFreq(1).minDocFreq(1).minimumShouldMatch("0%")).get();
         assertSearchHits(response, "2");
     }
 
@@ -394,7 +394,7 @@ public class MoreLikeThisTests extends ElasticsearchIntegrationTest {
             int max_query_terms = randomIntBetween(1, values.length);
             logger.info("Running More Like This with max_query_terms = %s", max_query_terms);
             MoreLikeThisQueryBuilder mltQuery = moreLikeThisQuery("text").ids("0").minTermFreq(1).minDocFreq(1)
-                    .maxQueryTerms(max_query_terms).percentTermsToMatch(0);
+                    .maxQueryTerms(max_query_terms).minimumShouldMatch("0%");
             SearchResponse response = client().prepareSearch("test").setTypes("type1")
                     .setQuery(mltQuery).execute().actionGet();
             assertSearchResponse(response);
@@ -493,7 +493,7 @@ public class MoreLikeThisTests extends ElasticsearchIntegrationTest {
                 .docs((Item) new Item().doc(malformedFieldDoc).index("test").type("type1"))
                 .minTermFreq(0)
                 .minDocFreq(0)
-                .percentTermsToMatch(0);
+                .minimumShouldMatch("0%");
         SearchResponse response = client().prepareSearch("test").setTypes("type1")
                 .setQuery(mltQuery).get();
         assertSearchResponse(response);
@@ -505,7 +505,7 @@ public class MoreLikeThisTests extends ElasticsearchIntegrationTest {
                 .docs((Item) new Item().doc(emptyDoc).index("test").type("type1"))
                 .minTermFreq(0)
                 .minDocFreq(0)
-                .percentTermsToMatch(0);
+                .minimumShouldMatch("0%");
         response = client().prepareSearch("test").setTypes("type1")
                 .setQuery(mltQuery).get();
         assertSearchResponse(response);
@@ -517,7 +517,7 @@ public class MoreLikeThisTests extends ElasticsearchIntegrationTest {
                 .docs((Item) new Item().doc(malformedDoc).index("test").type("type1"))
                 .minTermFreq(0)
                 .minDocFreq(0)
-                .percentTermsToMatch(0);
+                .minimumShouldMatch("0%");
         response = client().prepareSearch("test").setTypes("type1")
                 .setQuery(mltQuery).get();
         assertSearchResponse(response);
@@ -533,7 +533,7 @@ public class MoreLikeThisTests extends ElasticsearchIntegrationTest {
                 .docs((Item) new Item().doc(normalDoc).index("test").type("type1"))
                 .minTermFreq(0)
                 .minDocFreq(0)
-                .percentTermsToMatch(1);  // strict all terms must match but date is ignored
+                .minimumShouldMatch("100%");  // strict all terms must match but date is ignored
         response = client().prepareSearch("test").setTypes("type1")
                 .setQuery(mltQuery).get();
         assertSearchResponse(response);


### PR DESCRIPTION
Users should use `minimum_should_match` instead.
