### PR TITLE
Infra for deprecation logging

### DIFF
--- a/config/logging.yml
+++ b/config/logging.yml
@@ -4,6 +4,10 @@ rootLogger: ${es.logger.level}, console, file
 logger:
   # log action execution errors for easier debugging
   action: DEBUG
+
+  # deprecation logging, turn to DEBUG to see them
+  deprecation: INFO, deprecation_log_file
+
   # reduce the logging for aws, too much is logged under the default INFO
   com.amazonaws: WARN
   org.apache.http: INFO
@@ -24,6 +28,7 @@ logger:
 additivity:
   index.search.slowlog: false
   index.indexing.slowlog: false
+  deprecation: false
 
 appender:
   console:
@@ -50,6 +55,14 @@ appender:
     #layout:
       #type: pattern
       #conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"
+
+  deprecation_log_file:
+    type: dailyRollingFile
+    file: ${path.logs}/${cluster.name}_deprecation.log
+    datePattern: "'.'yyyy-MM-dd"
+    layout:
+      type: pattern
+      conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"
 
   index_search_slow_log_file:
     type: dailyRollingFile

--- a/src/main/java/org/elasticsearch/common/component/AbstractComponent.java
+++ b/src/main/java/org/elasticsearch/common/component/AbstractComponent.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.common.component;
 
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
@@ -29,16 +30,18 @@ import org.elasticsearch.common.settings.Settings;
 public abstract class AbstractComponent {
 
     protected final ESLogger logger;
-
+    protected final DeprecationLogger deprecationLogger;
     protected final Settings settings;
 
     public AbstractComponent(Settings settings) {
         this.logger = Loggers.getLogger(getClass(), settings);
+        this.deprecationLogger = new DeprecationLogger(logger);
         this.settings = settings;
     }
 
     public AbstractComponent(Settings settings, Class customClass) {
         this.logger = Loggers.getLogger(customClass, settings);
+        this.deprecationLogger = new DeprecationLogger(logger);
         this.settings = settings;
     }
 

--- a/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
+++ b/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.logging;
+
+/**
+ * A logger that logs deprecation notices.
+ */
+public class DeprecationLogger {
+
+    private final ESLogger logger;
+
+    /**
+     * Creates a new deprecation logger based on the parent logger. Automatically
+     * prefixes the logger name with "deprecation", if it starts with "org.elasticsearch.",
+     * it replaces "org.elasticsearch" with "org.elasticsearch.deprecation" to maintain
+     * the "org.elasticsearch" namespace.
+     */
+    public DeprecationLogger(ESLogger parentLogger) {
+        String name = parentLogger.getName();
+        if (name.startsWith("org.elasticsearch")) {
+            name = name.replace("org.elasticsearch.", "org.elasticsearch.deprecation.");
+        } else {
+            name = "deprecation." + name;
+        }
+        this.logger = ESLoggerFactory.getLogger(parentLogger.getPrefix(), name);
+    }
+
+    /**
+     * Logs a deprecated message.
+     */
+    public void deprecated(String msg, Object... params) {
+        logger.debug(msg, params);
+    }
+}

--- a/src/main/java/org/elasticsearch/index/AbstractIndexComponent.java
+++ b/src/main/java/org/elasticsearch/index/AbstractIndexComponent.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index;
 
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
@@ -30,9 +31,8 @@ import org.elasticsearch.index.settings.IndexSettings;
 public abstract class AbstractIndexComponent implements IndexComponent {
 
     protected final ESLogger logger;
-
+    protected final DeprecationLogger deprecationLogger;
     protected final Index index;
-
     protected final Settings indexSettings;
 
     /**
@@ -45,6 +45,7 @@ public abstract class AbstractIndexComponent implements IndexComponent {
         this.index = index;
         this.indexSettings = indexSettings;
         this.logger = Loggers.getLogger(getClass(), indexSettings, index);
+        this.deprecationLogger = new DeprecationLogger(logger);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/shard/AbstractIndexShardComponent.java
+++ b/src/main/java/org/elasticsearch/index/shard/AbstractIndexShardComponent.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.shard;
 
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
@@ -30,15 +31,15 @@ import org.elasticsearch.index.settings.IndexSettings;
 public abstract class AbstractIndexShardComponent implements IndexShardComponent {
 
     protected final ESLogger logger;
-
+    protected final DeprecationLogger deprecationLogger;
     protected final ShardId shardId;
-
     protected final Settings indexSettings;
 
     protected AbstractIndexShardComponent(ShardId shardId, @IndexSettings Settings indexSettings) {
         this.shardId = shardId;
         this.indexSettings = indexSettings;
         this.logger = Loggers.getLogger(getClass(), indexSettings, shardId);
+        this.deprecationLogger = new DeprecationLogger(logger);
     }
 
     @Override


### PR DESCRIPTION
Add support for a specific deprecation logging that can be used to turn on in order to notify users of a specific feature, flag, setting, parameter, ... being deprecated.

 The deprecation logger logs with a "deprecation." prefix logger (or "org.elasticsearch.deprecation." if full name is used), and outputs the logging to a dedicated deprecation log file.

Deprecation logging are logged under the DEBUG category. The idea is not to enabled them by default (under WARN or ERROR) when running embedded in another application.

By default they are turned off (INFO), in order to turn it on, the "deprecation" category need to be set to DEBUG. This can be set in the logging file or using the cluster update settings API.
