### PR TITLE
Transport: read/write support for list of strings

### DIFF
--- a/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -335,6 +335,21 @@ public abstract class StreamInput extends InputStream {
         return ret;
     }
 
+    /**
+     * Read in a list of strings. List can be empty but not {@code null}.
+     */
+    public List<String> readStringList() throws IOException {
+        int size = readVInt();
+        if (size == 0) {
+            return Collections.emptyList();
+        }
+        List<String> ret = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            ret.add(readString());
+        }
+        return ret;
+    }
+
     @Nullable
     public Map<String, Object> readMap() throws IOException {
         return (Map<String, Object>) readGenericValue();
@@ -427,7 +442,7 @@ public abstract class StreamInput extends InputStream {
         }
         return values;
     }
-    
+
     public long[] readLongArray() throws IOException {
         int length = readVInt();
         long[] values = new long[length];
@@ -436,7 +451,7 @@ public abstract class StreamInput extends InputStream {
         }
         return values;
     }
-    
+
     public float[] readFloatArray() throws IOException {
         int length = readVInt();
         float[] values = new float[length];
@@ -445,7 +460,7 @@ public abstract class StreamInput extends InputStream {
         }
         return values;
     }
-    
+
     public double[] readDoubleArray() throws IOException {
         int length = readVInt();
         double[] values = new double[length];

--- a/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -284,6 +284,16 @@ public abstract class StreamOutput extends OutputStream {
     }
 
     /**
+     * Write a list of strings. List can be empty but not {@code null}.
+     */
+    public void writeStringList(List<String> stringList) throws IOException {
+        writeVInt(stringList.size());
+        for (String s : stringList) {
+            writeString(s);
+        }
+    }
+
+    /**
      * Writes a string array, for nullable string, writes it as 0 (empty string).
      */
     public void writeStringArrayNullable(@Nullable String[] array) throws IOException {
@@ -399,21 +409,21 @@ public abstract class StreamOutput extends OutputStream {
             writeInt(value[i]);
         }
     }
-    
+
     public void writeLongArray(long[] value) throws IOException {
         writeVInt(value.length);
         for (int i=0; i<value.length; i++) {
             writeLong(value[i]);
         }
     }
-    
+
     public void writeFloatArray(float[] value) throws IOException {
         writeVInt(value.length);
         for (int i=0; i<value.length; i++) {
             writeFloat(value[i]);
         }
     }
-    
+
     public void writeDoubleArray(double[] value) throws IOException {
         writeVInt(value.length);
         for (int i=0; i<value.length; i++) {

--- a/src/test/java/org/elasticsearch/common/io/streams/BytesStreamsTests.java
+++ b/src/test/java/org/elasticsearch/common/io/streams/BytesStreamsTests.java
@@ -28,6 +28,8 @@ import org.elasticsearch.test.ElasticsearchTestCase;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import java.util.Arrays;
+
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -282,6 +284,7 @@ public class BytesStreamsTests extends ElasticsearchTestCase {
         out.writeGenericValue(doubleArray);
         out.writeString("hello");
         out.writeString("goodbye");
+        out.writeStringList(Arrays.asList(new String[]{"Hello", "Again"}));
         out.writeGenericValue(BytesRefs.toBytesRef("bytesref"));
         BytesStreamInput in = new BytesStreamInput(out.bytes().toBytes());
         assertThat(in.readBoolean(), equalTo(false));
@@ -299,6 +302,7 @@ public class BytesStreamsTests extends ElasticsearchTestCase {
         assertThat(in.readGenericValue(), equalTo((Object)doubleArray));
         assertThat(in.readString(), equalTo("hello"));
         assertThat(in.readString(), equalTo("goodbye"));
+        assertThat(in.readStringList(), equalTo(Arrays.asList(new String[]{"Hello", "Again"})));
         assertThat(in.readGenericValue(), equalTo((Object)BytesRefs.toBytesRef("bytesref")));
         in.close();
         out.close();


### PR DESCRIPTION
Add support for reading and writng string lists to existing StreamInput and StreamOutput class.
We will need this often when adding streaming support to queries, so it makes sense to add this to main branch also.
