### PR TITLE
Unify query_string parameters parsing

### DIFF
--- a/rest-api-spec/api/count.json
+++ b/rest-api-spec/api/count.json
@@ -41,6 +41,36 @@
         "routing": {
           "type" : "string",
           "description" : "Specific routing value"
+        },
+        "q": {
+          "type" : "string",
+          "description" : "Query in the Lucene query string syntax"
+        },
+        "analyzer": {
+          "type" : "string",
+          "description" : "The analyzer to use for the query string"
+        },
+        "analyze_wildcard": {
+          "type" : "boolean",
+          "description" : "Specify whether wildcard and prefix queries should be analyzed (default: false)"
+        },
+        "default_operator": {
+          "type" : "enum",
+          "options" : ["AND","OR"],
+          "default" : "OR",
+          "description" : "The default operator for query string query (AND or OR)"
+        },
+        "df": {
+          "type" : "string",
+          "description" : "The field to use as default where no field prefix is given in the query string"
+        },
+        "lenient": {
+          "type" : "boolean",
+          "description" : "Specify whether format-based query failures (such as providing text to a numeric field) should be ignored"
+        },
+        "lowercase_expanded_terms": {
+          "type" : "boolean",
+          "description" : "Specify whether query terms should be lowercased"
         }
       }
     },

--- a/rest-api-spec/api/indices.validate_query.json
+++ b/rest-api-spec/api/indices.validate_query.json
@@ -40,6 +40,32 @@
         "q": {
           "type" : "string",
           "description" : "Query in the Lucene query string syntax"
+        },
+        "analyzer": {
+          "type" : "string",
+          "description" : "The analyzer to use for the query string"
+        },
+        "analyze_wildcard": {
+          "type" : "boolean",
+          "description" : "Specify whether wildcard and prefix queries should be analyzed (default: false)"
+        },
+        "default_operator": {
+          "type" : "enum",
+          "options" : ["AND","OR"],
+          "default" : "OR",
+          "description" : "The default operator for query string query (AND or OR)"
+        },
+        "df": {
+          "type" : "string",
+          "description" : "The field to use as default where no field prefix is given in the query string"
+        },
+        "lenient": {
+          "type" : "boolean",
+          "description" : "Specify whether format-based query failures (such as providing text to a numeric field) should be ignored"
+        },
+        "lowercase_expanded_terms": {
+          "type" : "boolean",
+          "description" : "Specify whether query terms should be lowercased"
         }
       }
     },

--- a/rest-api-spec/api/search_exists.json
+++ b/rest-api-spec/api/search_exists.json
@@ -41,6 +41,36 @@
         "routing": {
           "type" : "string",
           "description" : "Specific routing value"
+        },
+        "q": {
+          "type" : "string",
+          "description" : "Query in the Lucene query string syntax"
+        },
+        "analyzer": {
+          "type" : "string",
+          "description" : "The analyzer to use for the query string"
+        },
+        "analyze_wildcard": {
+          "type" : "boolean",
+          "description" : "Specify whether wildcard and prefix queries should be analyzed (default: false)"
+        },
+        "default_operator": {
+          "type" : "enum",
+          "options" : ["AND","OR"],
+          "default" : "OR",
+          "description" : "The default operator for query string query (AND or OR)"
+        },
+        "df": {
+          "type" : "string",
+          "description" : "The field to use as default where no field prefix is given in the query string"
+        },
+        "lenient": {
+          "type" : "boolean",
+          "description" : "Specify whether format-based query failures (such as providing text to a numeric field) should be ignored"
+        },
+        "lowercase_expanded_terms": {
+          "type" : "boolean",
+          "description" : "Specify whether query terms should be lowercased"
         }
       }
     },

--- a/rest-api-spec/test/count/10_basic.yaml
+++ b/rest-api-spec/test/count/10_basic.yaml
@@ -1,0 +1,37 @@
+---
+"count with body":
+  - do:
+      indices.create:
+          index:  test
+  - do:
+      index:
+          index:  test
+          type:   test
+          id:     1
+          body:   { foo: bar }
+
+  - do:
+      indices.refresh:
+        index: [test]
+
+  - do:
+      count:
+        index: test
+        type: test
+        body:
+          query:
+            match:
+              foo: bar
+
+  - match: {count : 1}
+
+  - do:
+      count:
+        index: test
+        type: test
+        body:
+          query:
+            match:
+              foo: test
+
+  - match: {count : 0}

--- a/rest-api-spec/test/count/20_query_string.yaml
+++ b/rest-api-spec/test/count/20_query_string.yaml
@@ -1,0 +1,79 @@
+---
+"count with query_string parameters":
+  - do:
+      indices.create:
+          index:  test
+          body:
+            mappings:
+              test:
+                _all:
+                  enabled: false
+                properties:
+                  number:
+                    type: integer
+
+  - do:
+      index:
+          index:  test
+          type:   test
+          id:     1
+          body:   { field: foo bar}
+
+  - do:
+      indices.refresh:
+        index: [test]
+
+  - do:
+      count:
+        index: test
+        q: bar
+        df: field
+
+  - match: {count : 1}
+
+  - do:
+      count:
+        index: test
+        q: field:foo field:xyz
+
+  - match: {count : 1}
+
+  - do:
+      count:
+        index: test
+        q: field:foo field:xyz
+        default_operator: AND
+
+  - match: {count : 0}
+
+  - do:
+      count:
+        index: test
+        q: field:bars
+        analyzer: snowball
+
+  - match: {count : 1}
+
+  - do:
+      count:
+        index: test
+        q: field:BA*
+        lowercase_expanded_terms: false
+
+  - match: {count : 0}
+
+  - do:
+      count:
+        index: test
+        q: field:BA*
+        analyze_wildcard: true
+
+  - match: {count : 1}
+
+  - do:
+      count:
+        index: test
+        q: number:foo
+        lenient: true
+
+  - match: {count : 0}

--- a/rest-api-spec/test/explain/30_query_string.yaml
+++ b/rest-api-spec/test/explain/30_query_string.yaml
@@ -1,0 +1,93 @@
+---
+"explain with query_string parameters":
+  - do:
+      indices.create:
+          index:  test
+          body:
+            mappings:
+              test:
+                _all:
+                  enabled: false
+                properties:
+                  number:
+                    type: integer
+
+  - do:
+      index:
+          index:  test
+          type:   test
+          id:     1
+          body:   { field: foo bar}
+
+  - do:
+      indices.refresh:
+        index: [test]
+
+  - do:
+      explain:
+        index:  test
+        type:   test
+        id:     1
+        q: bar
+        df: field
+
+  - is_true: matched
+
+  - do:
+      explain:
+        index:  test
+        type:   test
+        id:     1
+        q: field:foo field:xyz
+
+  - is_true: matched
+
+  - do:
+      explain:
+        index:  test
+        type:   test
+        id:     1
+        q: field:foo field:xyz
+        default_operator: AND
+
+  - is_false: matched
+
+  - do:
+      explain:
+        index:  test
+        type:   test
+        id:     1
+        q: field:bars
+        analyzer: snowball
+
+  - is_true: matched
+
+  - do:
+      explain:
+        index:  test
+        type:   test
+        id:     1
+        q: field:BA*
+        lowercase_expanded_terms: false
+
+  - is_false: matched
+
+  - do:
+      explain:
+        index:  test
+        type:   test
+        id:     1
+        q: field:BA*
+        analyze_wildcard: true
+
+  - is_true: matched
+
+  - do:
+      explain:
+        index:  test
+        type:   test
+        id:     1
+        q: number:foo
+        lenient: true
+
+  - is_false: matched

--- a/rest-api-spec/test/indices.validate_query/20_query_string.yaml
+++ b/rest-api-spec/test/indices.validate_query/20_query_string.yaml
@@ -1,0 +1,70 @@
+---
+"validate_query with query_string parameters":
+  - do:
+      indices.create:
+          index:  test
+          body:
+            mappings:
+              test:
+                _all:
+                  enabled: false
+                properties:
+                  field:
+                    type: string
+                  number:
+                    type: integer
+
+  - do:
+      indices.validate_query:
+        index: test
+        q: bar
+        df: field
+
+  - is_true: valid
+
+  - do:
+      indices.validate_query:
+        index: test
+        q: field:foo field:xyz
+
+  - is_true: valid
+
+  - do:
+      indices.validate_query:
+        index: test
+        q: field:foo field:xyz
+        default_operator: AND
+
+  - is_true: valid
+
+  - do:
+      indices.validate_query:
+        index: test
+        q: field:bars
+        analyzer: snowball
+
+  - is_true: valid
+
+  - do:
+      indices.validate_query:
+        index: test
+        q: field:BA*
+        lowercase_expanded_terms: false
+
+  - is_true: valid
+
+  - do:
+      indices.validate_query:
+        index: test
+        q: field:BA*
+        analyze_wildcard: true
+
+  - is_true: valid
+
+  - do:
+      indices.validate_query:
+        index: test
+        q: number:foo
+        lenient: true
+
+  - is_true: valid

--- a/rest-api-spec/test/search/60_query_string.yaml
+++ b/rest-api-spec/test/search/60_query_string.yaml
@@ -1,0 +1,79 @@
+---
+"search with query_string parameters":
+  - do:
+      indices.create:
+          index:  test
+          body:
+            mappings:
+              test:
+                _all:
+                  enabled: false
+                properties:
+                  number:
+                    type: integer
+
+  - do:
+      index:
+          index:  test
+          type:   test
+          id:     1
+          body:   { field: foo bar}
+
+  - do:
+      indices.refresh:
+        index: [test]
+
+  - do:
+      search:
+        index: test
+        q: bar
+        df: field
+
+  - match: {hits.total: 1}
+
+  - do:
+      search:
+        index: test
+        q: field:foo field:xyz
+
+  - match: {hits.total: 1}
+
+  - do:
+      search:
+        index: test
+        q: field:foo field:xyz
+        default_operator: AND
+
+  - match: {hits.total: 0}
+
+  - do:
+      search:
+        index: test
+        q: field:bars
+        analyzer: snowball
+
+  - match: {hits.total: 1}
+
+  - do:
+      search:
+        index: test
+        q: field:BA*
+        lowercase_expanded_terms: false
+
+  - match: {hits.total: 0}
+
+  - do:
+      search:
+        index: test
+        q: field:BA*
+        analyze_wildcard: true
+
+  - match: {hits.total: 1}
+
+  - do:
+      search:
+        index: test
+        q: number:foo
+        lenient: true
+
+  - match: {hits.total: 0}

--- a/rest-api-spec/test/search_exists/10_basic.yaml
+++ b/rest-api-spec/test/search_exists/10_basic.yaml
@@ -1,0 +1,38 @@
+---
+"search_exists with body":
+  - do:
+      indices.create:
+          index:  test
+  - do:
+      index:
+          index:  test
+          type:   test
+          id:     1
+          body:   { foo: bar }
+
+  - do:
+      indices.refresh:
+        index: [test]
+
+  - do:
+      search_exists:
+        index: test
+        type: test
+        body:
+          query:
+            match:
+              foo: bar
+
+  - is_true: exists
+
+  - do:
+      catch: missing
+      search_exists:
+        index: test
+        type: test
+        body:
+          query:
+            match:
+              foo: test
+
+  - is_false: exists

--- a/rest-api-spec/test/search_exists/20_query_string.yaml
+++ b/rest-api-spec/test/search_exists/20_query_string.yaml
@@ -1,0 +1,82 @@
+---
+"search_exists with query_string parameters":
+  - do:
+      indices.create:
+          index:  test
+          body:
+            mappings:
+              test:
+                _all:
+                  enabled: false
+                properties:
+                  number:
+                    type: integer
+
+  - do:
+      index:
+          index:  test
+          type:   test
+          id:     1
+          body:   { field: foo bar}
+
+  - do:
+      indices.refresh:
+        index: [test]
+
+  - do:
+      search_exists:
+        index: test
+        q: bar
+        df: field
+
+  - is_true: exists
+
+  - do:
+      search_exists:
+        index: test
+        q: field:foo field:xyz
+
+  - is_true: exists
+
+  - do:
+      catch: missing
+      search_exists:
+        index: test
+        q: field:foo field:xyz
+        default_operator: AND
+
+  - is_false: exists
+
+  - do:
+      search_exists:
+        index: test
+        q: field:bars
+        analyzer: snowball
+
+  - is_true: exists
+
+  - do:
+      catch: missing
+      search_exists:
+        index: test
+        q: field:BA*
+        lowercase_expanded_terms: false
+
+  - is_false: exists
+
+  - do:
+      search_exists:
+        index: test
+        q: field:BA*
+        analyze_wildcard: true
+
+  - is_true: exists
+
+  - do:
+      catch: missing
+      search_exists:
+        index: test
+        q: number:foo
+        lenient: true
+
+  - is_false: exists

--- a/src/main/java/org/elasticsearch/action/support/QuerySourceBuilder.java
+++ b/src/main/java/org/elasticsearch/action/support/QuerySourceBuilder.java
@@ -49,6 +49,12 @@ public class QuerySourceBuilder implements ToXContent {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
+        innerToXContent(builder, params);
+        builder.endObject();
+        return builder;
+    }
+
+    public void innerToXContent(XContentBuilder builder, Params params) throws IOException {
         if (queryBuilder != null) {
             builder.field("query");
             queryBuilder.toXContent(builder, params);
@@ -61,9 +67,6 @@ public class QuerySourceBuilder implements ToXContent {
                 builder.field("query_binary", queryBinary);
             }
         }
-
-        builder.endObject();
-        return builder;
     }
 
     public BytesReference buildAsBytes(XContentType contentType) throws SearchSourceBuilderException {

--- a/src/main/java/org/elasticsearch/rest/action/support/RestActions.java
+++ b/src/main/java/org/elasticsearch/rest/action/support/RestActions.java
@@ -104,6 +104,9 @@ public class RestActions {
         QueryStringQueryBuilder queryBuilder = QueryBuilders.queryStringQuery(queryString);
         queryBuilder.defaultField(request.param("df"));
         queryBuilder.analyzer(request.param("analyzer"));
+        queryBuilder.analyzeWildcard(request.paramAsBoolean("analyze_wildcard", false));
+        queryBuilder.lowercaseExpandedTerms(request.paramAsBoolean("lowercase_expanded_terms", true));
+        queryBuilder.lenient(request.paramAsBoolean("lenient", null));
         String defaultOperator = request.param("default_operator");
         if (defaultOperator != null) {
             if ("OR".equals(defaultOperator)) {


### PR DESCRIPTION
There currently are small differences between search api and count, exists, validate query, explain api when it comes to reading query_string parameters.  `analyze_wildcard`, `lowercase_expanded_terms` and `lenient` are only read by the search api and ignored by all other mentioned apis. Unified code to fix this and make sure it doesn't happen again. Also shared some code when it comes to printing out the query as part of SearchSourceBuilder conversion to ToXContent.
