### PR TITLE
Use System.nanoTime for elapsed time

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/cluster/health/TransportClusterHealthAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/health/TransportClusterHealthAction.java
@@ -67,7 +67,7 @@ public class TransportClusterHealthAction extends TransportMasterNodeReadOperati
     @Override
     protected void masterOperation(final ClusterHealthRequest request, final ClusterState unusedState, final ActionListener<ClusterHealthResponse> listener) {
         if (request.waitForEvents() != null) {
-            final long endTime = System.currentTimeMillis() + request.timeout().millis();
+            final long endTimeMS = TimeValue.nsecToMSec(System.nanoTime()) + request.timeout().millis();
             clusterService.submitStateUpdateTask("cluster_health (wait_for_events [" + request.waitForEvents() + "])", request.waitForEvents(), new ProcessedClusterStateUpdateTask() {
                 @Override
                 public ClusterState execute(ClusterState currentState) {
@@ -76,7 +76,7 @@ public class TransportClusterHealthAction extends TransportMasterNodeReadOperati
 
                 @Override
                 public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
-                    final long timeoutInMillis = Math.max(0, endTime - System.currentTimeMillis());
+                    final long timeoutInMillis = Math.max(0, endTimeMS - TimeValue.nsecToMSec(System.nanoTime()));
                     final TimeValue newTimeout = TimeValue.timeValueMillis(timeoutInMillis);
                     request.timeout(newTimeout);
                     executeHealth(request, listener);

--- a/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
+++ b/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
@@ -74,7 +74,7 @@ public class UpdateHelper extends AbstractComponent {
      */
     @SuppressWarnings("unchecked")
     public Result prepare(UpdateRequest request, IndexShard indexShard) {
-        long getDate = System.currentTimeMillis();
+        long getDateNS = System.nanoTime();
         final GetResult getResult = indexShard.getService().get(request.type(), request.id(),
                 new String[]{RoutingFieldMapper.NAME, ParentFieldMapper.NAME, TTLFieldMapper.NAME, TimestampFieldMapper.NAME},
                 true, request.version(), request.versionType(), FetchSourceContext.FETCH_SOURCE, false);
@@ -222,7 +222,7 @@ public class UpdateHelper extends AbstractComponent {
         if (ttl == null) {
             ttl = getResult.getFields().containsKey(TTLFieldMapper.NAME) ? (Long) getResult.field(TTLFieldMapper.NAME).getValue() : null;
             if (ttl != null) {
-                ttl = ttl - (System.currentTimeMillis() - getDate); // It is an approximation of exact TTL value, could be improved
+                ttl = ttl - TimeValue.nsecToMSec(System.nanoTime() - getDateNS); // It is an approximation of exact TTL value, could be improved
             }
         }
 

--- a/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDecider.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDecider.java
@@ -168,7 +168,7 @@ public class DiskThresholdDecider extends AllocationDecider {
                     warnAboutDiskIfNeeded(entry);
                     if (entry.getFreeBytes() < DiskThresholdDecider.this.freeBytesThresholdHigh.bytes() ||
                             entry.getFreeDiskAsPercentage() < DiskThresholdDecider.this.freeDiskThresholdHigh) {
-                        if ((TimeValue.nsecToMSec(System.nanoTime() - lastRunNS)) > DiskThresholdDecider.this.rerouteInterval.millis()) {
+                        if ((System.nanoTime() - lastRunNS) > DiskThresholdDecider.this.rerouteInterval.nanos()) {
                             lastRunNS = System.nanoTime();
                             reroute = true;
                         } else {

--- a/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDecider.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDecider.java
@@ -130,7 +130,7 @@ public class DiskThresholdDecider extends AllocationDecider {
      */
     class DiskListener implements ClusterInfoService.Listener {
         private final Client client;
-        private long lastRun;
+        private long lastRunNS;
 
         DiskListener(Client client) {
             this.client = client;
@@ -168,8 +168,8 @@ public class DiskThresholdDecider extends AllocationDecider {
                     warnAboutDiskIfNeeded(entry);
                     if (entry.getFreeBytes() < DiskThresholdDecider.this.freeBytesThresholdHigh.bytes() ||
                             entry.getFreeDiskAsPercentage() < DiskThresholdDecider.this.freeDiskThresholdHigh) {
-                        if ((System.currentTimeMillis() - lastRun) > DiskThresholdDecider.this.rerouteInterval.millis()) {
-                            lastRun = System.currentTimeMillis();
+                        if ((TimeValue.nsecToMSec(System.nanoTime() - lastRunNS)) > DiskThresholdDecider.this.rerouteInterval.millis()) {
+                            lastRunNS = System.nanoTime();
                             reroute = true;
                         } else {
                             logger.debug("high disk watermark exceeded on {} but an automatic reroute has occurred in the last [{}], skipping reroute",

--- a/src/main/java/org/elasticsearch/common/StopWatch.java
+++ b/src/main/java/org/elasticsearch/common/StopWatch.java
@@ -31,7 +31,7 @@ import java.util.concurrent.TimeUnit;
  * Simple stop watch, allowing for timing of a number of tasks,
  * exposing total running time and running time for each named task.
  * <p/>
- * <p>Conceals use of <code>System.currentTimeMillis()</code>, improving the
+ * <p>Conceals use of <code>System.nanoTime()</code>, improving the
  * readability of application code and reducing the likelihood of calculation errors.
  * <p/>
  * <p>Note that this object is not designed to be thread-safe and does not
@@ -58,7 +58,7 @@ public class StopWatch {
     /**
      * Start time of the current task
      */
-    private long startTimeMillis;
+    private long startTimeNS;
 
     /**
      * Is the stop watch currently running?
@@ -77,7 +77,7 @@ public class StopWatch {
     /**
      * Total running time
      */
-    private long totalTimeMillis;
+    private long totalTimeNS;
 
     /**
      * Construct a new stop watch. Does not start any task.
@@ -129,7 +129,7 @@ public class StopWatch {
         if (this.running) {
             throw new IllegalStateException("Can't start StopWatch: it's already running");
         }
-        this.startTimeMillis = System.currentTimeMillis();
+        this.startTimeNS = System.nanoTime();
         this.running = true;
         this.currentTaskName = taskName;
         return this;
@@ -146,9 +146,9 @@ public class StopWatch {
         if (!this.running) {
             throw new IllegalStateException("Can't stop StopWatch: it's not running");
         }
-        long lastTime = System.currentTimeMillis() - this.startTimeMillis;
-        this.totalTimeMillis += lastTime;
-        this.lastTaskInfo = new TaskInfo(this.currentTaskName, lastTime);
+        long lastTimeNS = System.nanoTime() - this.startTimeNS;
+        this.totalTimeNS += lastTimeNS;
+        this.lastTaskInfo = new TaskInfo(this.currentTaskName, TimeValue.nsecToMSec(lastTimeNS));
         if (this.keepTaskList) {
             this.taskList.add(lastTaskInfo);
         }
@@ -189,7 +189,7 @@ public class StopWatch {
      * Return the total time for all tasks.
      */
     public TimeValue totalTime() {
-        return new TimeValue(totalTimeMillis, TimeUnit.MILLISECONDS);
+        return new TimeValue(totalTimeNS, TimeUnit.NANOSECONDS);
     }
 
     /**

--- a/src/main/java/org/elasticsearch/common/inject/internal/Stopwatch.java
+++ b/src/main/java/org/elasticsearch/common/inject/internal/Stopwatch.java
@@ -16,6 +16,8 @@
 
 package org.elasticsearch.common.inject.internal;
 
+import org.elasticsearch.common.unit.TimeValue;
+
 import java.util.logging.Logger;
 
 /**
@@ -26,17 +28,17 @@ import java.util.logging.Logger;
 public class Stopwatch {
     private static final Logger logger = Logger.getLogger(Stopwatch.class.getName());
 
-    private long start = System.currentTimeMillis();
+    private long startNS = System.nanoTime();
 
     /**
      * Resets and returns elapsed time in milliseconds.
      */
     public long reset() {
-        long now = System.currentTimeMillis();
+        long nowNS = System.nanoTime();
         try {
-            return now - start;
+            return TimeValue.nsecToMSec(nowNS - startNS);
         } finally {
-            start = now;
+            startNS = nowNS;
         }
     }
 

--- a/src/main/java/org/elasticsearch/common/unit/TimeValue.java
+++ b/src/main/java/org/elasticsearch/common/unit/TimeValue.java
@@ -38,6 +38,9 @@ import java.util.concurrent.TimeUnit;
  */
 public class TimeValue implements Serializable, Streamable {
 
+    /** How many nano-seconds in one milli-second */
+    public static final long NSEC_PER_MSEC = 1000000;
+
     public static TimeValue timeValueNanos(long nanos) {
         return new TimeValue(nanos, TimeUnit.NANOSECONDS);
     }
@@ -295,5 +298,9 @@ public class TimeValue implements Serializable, Streamable {
     public int hashCode() {
         long normalized = timeUnit.toNanos(duration);
         return (int) (normalized ^ (normalized >>> 32));
+    }
+
+    public static long nsecToMSec(long ns) {
+        return ns / NSEC_PER_MSEC;
     }
 }

--- a/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.io.FileSystemUtils;
 import org.elasticsearch.common.io.PathUtils;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.settings.IndexSettings;
 import org.elasticsearch.index.shard.ShardId;
@@ -383,11 +384,11 @@ public class NodeEnvironment extends AbstractComponent implements Closeable {
         logger.trace("locking all shards for index {} - [{}]", index, numShards);
         List<ShardLock> allLocks = new ArrayList<>(numShards);
         boolean success = false;
-        long startTime = System.currentTimeMillis();
+        long startTimeNS = System.nanoTime();
         try {
             for (int i = 0; i < numShards; i++) {
-                long timeoutLeft = Math.max(0, lockTimeoutMS - (System.currentTimeMillis() - startTime));
-                allLocks.add(shardLock(new ShardId(index, i), timeoutLeft));
+                long timeoutLeftMS = Math.max(0, lockTimeoutMS - TimeValue.nsecToMSec((System.nanoTime() - startTimeNS)));
+                allLocks.add(shardLock(new ShardId(index, i), timeoutLeftMS));
             }
             success = true;
         } finally {

--- a/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
+++ b/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
@@ -82,9 +82,9 @@ public class GatewayMetaState extends AbstractComponent implements ClusterStateL
             try {
                 ensureNoPre019State();
                 pre20Upgrade();
-                long start = System.currentTimeMillis();
+                long startNS = System.nanoTime();
                 metaStateService.loadFullState();
-                logger.debug("took {} to load state", TimeValue.timeValueMillis(System.currentTimeMillis() - start));
+                logger.debug("took {} to load state", TimeValue.timeValueMillis(TimeValue.nsecToMSec(System.nanoTime() - startNS)));
             } catch (Exception e) {
                 logger.error("failed to read local state, exiting...", e);
                 throw e;

--- a/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalsBuilder.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalsBuilder.java
@@ -26,6 +26,7 @@ import org.apache.lucene.util.packed.PackedInts;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.fielddata.AtomicOrdinalsFieldData;
 import org.elasticsearch.index.fielddata.IndexOrdinalsFieldData;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
@@ -43,7 +44,7 @@ public enum GlobalOrdinalsBuilder {
      */
     public static IndexOrdinalsFieldData build(final IndexReader indexReader, IndexOrdinalsFieldData indexFieldData, Settings settings, CircuitBreakerService breakerService, ESLogger logger) throws IOException {
         assert indexReader.leaves().size() > 1;
-        long startTime = System.currentTimeMillis();
+        long startTimeNS = System.nanoTime();
 
         final AtomicOrdinalsFieldData[] atomicFD = new AtomicOrdinalsFieldData[indexReader.leaves().size()];
         final RandomAccessOrds[] subs = new RandomAccessOrds[indexReader.leaves().size()];
@@ -60,7 +61,7 @@ public enum GlobalOrdinalsBuilder {
                     "Global-ordinals[{}][{}] took {} ms",
                     indexFieldData.getFieldNames().fullName(),
                     ordinalMap.getValueCount(),
-                    (System.currentTimeMillis() - startTime)
+                    TimeValue.nsecToMSec(System.nanoTime() - startTimeNS)
             );
         }
         return new InternalGlobalOrdinalsIndexFieldData(indexFieldData.index(), settings, indexFieldData.getFieldNames(),

--- a/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -1149,7 +1149,7 @@ public class IndexShard extends AbstractIndexShardComponent {
     }
 
     private void doCheckIndex() throws IndexShardException, IOException {
-        long time = System.currentTimeMillis();
+        long timeNS = System.nanoTime();
         if (!Lucene.indexExists(store.directory())) {
             return;
         }
@@ -1208,7 +1208,7 @@ public class IndexShard extends AbstractIndexShardComponent {
             logger.debug("check index [success]\n{}", new String(os.bytes().toBytes(), Charsets.UTF_8));
         }
 
-        recoveryState.getVerifyIndex().checkIndexTime(Math.max(0, System.currentTimeMillis() - time));
+        recoveryState.getVerifyIndex().checkIndexTime(Math.max(0, TimeValue.nsecToMSec(System.nanoTime() - timeNS)));
     }
 
     public Engine engine() {

--- a/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/src/main/java/org/elasticsearch/index/store/Store.java
@@ -1079,6 +1079,7 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
 
         synchronized void writeChecksums(Directory directory, Map<String, String> checksums, long lastVersion) throws IOException {
             long nextVersion = System.currentTimeMillis();
+            // TODO: this scary ... what if time slips backwards by 1 hour?  Do we spin here for an hour?
             while (nextVersion <= lastVersion) {
                 nextVersion = System.currentTimeMillis();
             }

--- a/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/src/main/java/org/elasticsearch/index/store/Store.java
@@ -1078,11 +1078,8 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
         }
 
         synchronized void writeChecksums(Directory directory, Map<String, String> checksums, long lastVersion) throws IOException {
-            long nextVersion = System.currentTimeMillis();
-            // TODO: this scary ... what if time slips backwards by 1 hour?  Do we spin here for an hour?
-            while (nextVersion <= lastVersion) {
-                nextVersion = System.currentTimeMillis();
-            }
+            // Make sure if clock goes backwards we still move version forwards:
+            long nextVersion = Math.max(lastVersion+1, System.currentTimeMillis());
             final String checksumName = CHECKSUMS_PREFIX + nextVersion;
             try (IndexOutput output = directory.createOutput(checksumName, IOContext.DEFAULT)) {
                 output.writeInt(0); // version

--- a/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -756,7 +756,7 @@ public class IndicesService extends AbstractLifecycleComponent<IndicesService> i
                             return;
                         }
                     }
-                } while (TimeValue.nsecToMSec(System.nanoTime() - startTimeNS) < timeout.millis());
+                } while ((System.nanoTime() - startTimeNS) < timeout.nanos());
             }
         } finally {
             IOUtils.close(shardLocks);

--- a/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -697,7 +697,7 @@ public class IndicesService extends AbstractLifecycleComponent<IndicesService> i
      */
     public void processPendingDeletes(Index index, @IndexSettings Settings indexSettings, TimeValue timeout) throws IOException {
         logger.debug("{} processing pending deletes", index);
-        final long startTime = System.currentTimeMillis();
+        final long startTimeNS = System.nanoTime();
         final List<ShardLock> shardLocks = nodeEnv.lockAllForIndex(index, indexSettings, timeout.millis());
         try {
             Map<ShardId, ShardLock> locks = new HashMap<>();
@@ -756,7 +756,7 @@ public class IndicesService extends AbstractLifecycleComponent<IndicesService> i
                             return;
                         }
                     }
-                } while ((System.currentTimeMillis() - startTime) < timeout.millis());
+                } while (TimeValue.nsecToMSec(System.nanoTime() - startTimeNS) < timeout.millis());
             }
         } finally {
             IOUtils.close(shardLocks);

--- a/src/main/java/org/elasticsearch/indices/fielddata/cache/IndicesFieldDataCache.java
+++ b/src/main/java/org/elasticsearch/indices/fielddata/cache/IndicesFieldDataCache.java
@@ -312,7 +312,7 @@ public class IndicesFieldDataCache extends AbstractComponent implements RemovalL
 
         @Override
         public void run() {
-            long startTime = System.currentTimeMillis();
+            long startTimeNS = System.nanoTime();
             if (logger.isTraceEnabled()) {
                 logger.trace("running periodic field data cache cleanup");
             }
@@ -322,7 +322,7 @@ public class IndicesFieldDataCache extends AbstractComponent implements RemovalL
                 logger.warn("Exception during periodic field data cache cleanup:", e);
             }
             if (logger.isTraceEnabled()) {
-                logger.trace("periodic field data cache cleanup finished in {} milliseconds", System.currentTimeMillis() - startTime);
+                logger.trace("periodic field data cache cleanup finished in {} milliseconds", TimeValue.nsecToMSec(System.nanoTime() - startTimeNS));
             }
             // Reschedule itself to run again if not closed
             if (closed == false) {

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java
@@ -386,13 +386,15 @@ public class RecoveryState implements ToXContent, Streamable {
 
         public synchronized void start() {
             assert startTime == 0 : "already started";
-            startTime = System.currentTimeMillis();
+            startTime = TimeValue.nsecToMSec(System.nanoTime());
         }
 
+        /** Returns start time in millis */
         public synchronized long startTime() {
             return startTime;
         }
 
+        /** Returns elapsed time in millis, or 0 if timer was not started */
         public synchronized long time() {
             if (startTime == 0) {
                 return 0;
@@ -400,16 +402,18 @@ public class RecoveryState implements ToXContent, Streamable {
             if (time >= 0) {
                 return time;
             }
-            return Math.max(0, System.currentTimeMillis() - startTime);
+            long t = TimeValue.nsecToMSec(System.nanoTime());
+            return Math.max(0, t - startTime);
         }
 
+        /** Returns stop time in millis */
         public synchronized long stopTime() {
             return stopTime;
         }
 
         public synchronized void stop() {
             assert stopTime == 0 : "already stopped";
-            stopTime = Math.max(System.currentTimeMillis(), startTime);
+            stopTime = Math.max(TimeValue.nsecToMSec(System.nanoTime()), startTime);
             time = stopTime - startTime;
             assert time >= 0;
         }

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java
@@ -402,8 +402,7 @@ public class RecoveryState implements ToXContent, Streamable {
             if (time >= 0) {
                 return time;
             }
-            long t = TimeValue.nsecToMSec(System.nanoTime());
-            return Math.max(0, t - startTime);
+            return Math.max(0, TimeValue.nsecToMSec(System.nanoTime()) - startTime);
         }
 
         /** Returns stop time in millis */

--- a/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetaData.java
+++ b/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetaData.java
@@ -55,6 +55,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 
 /**
@@ -133,7 +134,7 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesOperatio
 
     private StoreFilesMetaData listStoreMetaData(ShardId shardId) throws IOException {
         logger.trace("listing store meta data for {}", shardId);
-        long startTime = System.currentTimeMillis();
+        long startTimeNS = System.nanoTime();
         boolean exists = false;
         try {
             IndexService indexService = indicesService.indexService(shardId.index().name());
@@ -165,7 +166,7 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesOperatio
             }
             return new StoreFilesMetaData(false, shardId, Store.readMetadataSnapshot(shardPath.resolveIndex(), logger).asMap());
         } finally {
-            TimeValue took = new TimeValue(System.currentTimeMillis() - startTime);
+            TimeValue took = new TimeValue(System.nanoTime() - startTimeNS, TimeUnit.NANOSECONDS);
             if (exists) {
                 logger.debug("{} loaded store meta data (took [{}])", shardId, took);
             } else {

--- a/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -313,7 +313,7 @@ public class PluginsService extends AbstractComponent {
     synchronized public PluginsInfo info() {
         if (refreshInterval.millis() != 0) {
             if (cachedPluginsInfo != null &&
-                    (refreshInterval.millis() < 0 || TimeValue.nsecToMSec(System.nanoTime() - lastRefreshNS) < refreshInterval.millis())) {
+                    (refreshInterval.millis() < 0 || (System.nanoTime() - lastRefreshNS) < refreshInterval.nanos())) {
                 if (logger.isTraceEnabled()) {
                     logger.trace("using cache to retrieve plugins info");
                 }

--- a/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -81,7 +81,7 @@ public class PluginsService extends AbstractComponent {
     private PluginsInfo cachedPluginsInfo;
     private final TimeValue refreshInterval;
     private final boolean checkLucene;
-    private long lastRefresh;
+    private long lastRefreshNS;
 
     static class OnModuleReference {
         public final Class<? extends Module> moduleClass;
@@ -313,13 +313,13 @@ public class PluginsService extends AbstractComponent {
     synchronized public PluginsInfo info() {
         if (refreshInterval.millis() != 0) {
             if (cachedPluginsInfo != null &&
-                    (refreshInterval.millis() < 0 || (System.currentTimeMillis() - lastRefresh) < refreshInterval.millis())) {
+                    (refreshInterval.millis() < 0 || TimeValue.nsecToMSec(System.nanoTime() - lastRefreshNS) < refreshInterval.millis())) {
                 if (logger.isTraceEnabled()) {
                     logger.trace("using cache to retrieve plugins info");
                 }
                 return cachedPluginsInfo;
             }
-            lastRefresh = System.currentTimeMillis();
+            lastRefreshNS = System.nanoTime();
         }
 
         if (logger.isTraceEnabled()) {


### PR DESCRIPTION
I'm running a "power loss" ES test and noticed this strange log line from ES after reboot:

```
crashnode: [2015-05-08 05:10:57,381][DEBUG][index.gateway            ] [crashnode] [logs][4] recovery completed from [shard_gateway], took [4h]
```

The [4h] is completely wrong ... the recovery only took a minute or two.  Digging into it, I noticed that for some reason, on my Fedora Linux box, System.currentTimeMillis suddenly jumps 4 hours into the future, thus messing up this log line.  This is reproducible...

I think when we want to measure elapsed time we should use System.nanoTime, unless it's in some crazy hot spot (nanoTime is somewhat more costly).  currentTimeMillis pulls from the local clock and timezone, which can easily change... whereas nanoTime, on modern JVM/OS/hardware, should only monotonically increase.

When I changed RecoveryState.time to use nanoTime instead, the wrong [4h] output is fixed.

We use System.currentTimeMillis in a number of places in ES, and unfortunately I was only able to fix a subset of them in this PR because in the other places the timestamp is part of the API and I'm not sure if someone "relies" on that timestamp having come from currentTimeMillis...
