### PR TITLE
Propagate headers & contexts to sub-requests

### DIFF
--- a/src/main/java/org/elasticsearch/action/percolate/TransportPercolateAction.java
+++ b/src/main/java/org/elasticsearch/action/percolate/TransportPercolateAction.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.action.percolate;
 
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ShardOperationFailedException;
 import org.elasticsearch.action.get.GetRequest;

--- a/src/main/java/org/elasticsearch/action/support/single/shard/TransportShardSingleOperationAction.java
+++ b/src/main/java/org/elasticsearch/action/support/single/shard/TransportShardSingleOperationAction.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.support.single.shard;
 
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.NoShardAvailableActionException;

--- a/src/main/java/org/elasticsearch/common/HasContext.java
+++ b/src/main/java/org/elasticsearch/common/HasContext.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common;
+
+import com.carrotsearch.hppc.ObjectObjectAssociativeContainer;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
+
+public interface HasContext {
+
+    /**
+     * Attaches the given value to the context.
+     *
+     * @return  The previous value that was associated with the given key in the context, or
+     *          {@code null} if there was none.
+     */
+    <V> V putInContext(Object key, Object value);
+
+    /**
+     * Attaches the given values to the context
+     */
+    void putAllInContext(ObjectObjectAssociativeContainer<Object, Object> map);
+
+    /**
+     * @return  The context value that is associated with the given key
+     *
+     * @see     #putInContext(Object, Object)
+     */
+    <V> V getFromContext(Object key);
+
+    /**
+     * @param defaultValue  The default value that should be returned for the given key, if no
+     *                      value is currently associated with it.
+     *
+     * @return  The value that is associated with the given key in the context
+     *
+     * @see     #putInContext(Object, Object)
+     */
+    <V> V getFromContext(Object key, V defaultValue);
+
+    /**
+     * Checks if the context contains an entry with the given key
+     */
+    boolean hasInContext(Object key);
+
+    /**
+     * @return  The number of values attached in the context.
+     */
+    int contextSize();
+
+    /**
+     * Checks if the context is empty.
+     */
+    boolean isContextEmpty();
+
+    /**
+     * @return  A safe immutable copy of the current context.
+     */
+    ImmutableOpenMap<Object, Object> getContext();
+
+    /**
+     * Copies the context from the given context holder to this context holder. Any shared keys between
+     * the two context will be overridden by the given context holder.
+     */
+    void copyContextFrom(HasContext other);
+}

--- a/src/main/java/org/elasticsearch/common/HasContextAndHeaders.java
+++ b/src/main/java/org/elasticsearch/common/HasContextAndHeaders.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common;
+
+/**
+ * marker interface
+ */
+public interface HasContextAndHeaders extends HasContext, HasHeaders {
+
+    /**
+     * copies over the context and the headers
+     * @param other another object supporting headers and context
+     */
+    void copyContextAndHeadersFrom(HasContextAndHeaders other);
+
+}

--- a/src/main/java/org/elasticsearch/common/HasHeaders.java
+++ b/src/main/java/org/elasticsearch/common/HasHeaders.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common;
+
+import java.util.Set;
+
+/**
+ *
+ */
+public interface HasHeaders {
+
+    <V> V putHeader(String key, V value);
+
+    <V> V getHeader(String key);
+
+    boolean hasHeader(String key);
+
+    Set<String> getHeaders();
+
+    void copyHeadersFrom(HasHeaders from);
+}

--- a/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryParser.java
@@ -21,7 +21,6 @@ package org.elasticsearch.index.query;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.queries.TermsQuery;
 import org.apache.lucene.search.BooleanClause;
@@ -40,6 +39,7 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.analysis.Analysis;
 import org.elasticsearch.index.mapper.internal.UidFieldMapper;
 import org.elasticsearch.index.search.morelikethis.MoreLikeThisFetchService;
+import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -245,6 +245,7 @@ public class MoreLikeThisQueryParser implements QueryParser {
         if (!likeItems.isEmpty()) {
             // set default index, type and fields if not specified
             MultiTermVectorsRequest items = likeItems;
+
             for (TermVectorsRequest item : ignoreItems) {
                 items.add(item);
             }
@@ -272,7 +273,7 @@ public class MoreLikeThisQueryParser implements QueryParser {
                 }
             }
             // fetching the items with multi-termvectors API
-            BooleanQuery boolQuery = new BooleanQuery();
+            items.copyContextAndHeadersFrom(SearchContext.current());
             MultiTermVectorsResponse responses = fetchService.fetchResponse(items);
 
             // getting the Fields for liked items
@@ -286,6 +287,7 @@ public class MoreLikeThisQueryParser implements QueryParser {
                 }
             }
 
+            BooleanQuery boolQuery = new BooleanQuery();
             boolQuery.add(mltQuery, BooleanClause.Occur.SHOULD);
 
             // exclude the items from the search

--- a/src/main/java/org/elasticsearch/index/search/shape/ShapeFetchService.java
+++ b/src/main/java/org/elasticsearch/index/search/shape/ShapeFetchService.java
@@ -48,17 +48,17 @@ public class ShapeFetchService extends AbstractComponent {
     /**
      * Fetches the Shape with the given ID in the given type and index.
      *
-     * @param id        ID of the Shape to fetch
-     * @param type      Index type where the Shape is indexed
-     * @param index     Index where the Shape is indexed
+     * @param getRequest GetRequest containing index, type and id
      * @param path      Name or path of the field in the Shape Document where the Shape itself is located
      * @return Shape with the given ID
      * @throws IOException Can be thrown while parsing the Shape Document and extracting the Shape
      */
-    public ShapeBuilder fetch(String id, String type, String index, String path) throws IOException {
-        GetResponse response = client.get(new GetRequest(index, type, id).preference("_local").operationThreaded(false)).actionGet();
+    public ShapeBuilder fetch(GetRequest getRequest,String path) throws IOException {
+        getRequest.preference("_local");
+        getRequest.operationThreaded(false);
+        GetResponse response = client.get(getRequest).actionGet();
         if (!response.isExists()) {
-            throw new IllegalArgumentException("Shape with ID [" + id + "] in type [" + type + "] not found");
+            throw new IllegalArgumentException("Shape with ID [" + getRequest.id() + "] in type [" + getRequest.type() + "] not found");
         }
 
         String[] pathElements = Strings.splitStringToArray(path, '.');
@@ -81,7 +81,7 @@ public class ShapeFetchService extends AbstractComponent {
                     }
                 }
             }
-            throw new IllegalStateException("Shape with name [" + id + "] found but missing " + path + " field");
+            throw new IllegalStateException("Shape with name [" + getRequest.id() + "] found but missing " + path + " field");
         } finally {
             if (parser != null) {
                 parser.close();

--- a/src/main/java/org/elasticsearch/percolator/PercolateContext.java
+++ b/src/main/java/org/elasticsearch/percolator/PercolateContext.java
@@ -18,8 +18,8 @@
  */
 package org.elasticsearch.percolator;
 
+import com.carrotsearch.hppc.ObjectObjectAssociativeContainer;
 import com.google.common.collect.ImmutableList;
-
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.LeafReaderContext;
@@ -32,6 +32,10 @@ import org.apache.lucene.util.Counter;
 import org.elasticsearch.action.percolate.PercolateShardRequest;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.cache.recycler.PageCacheRecycler;
+import org.elasticsearch.common.HasContext;
+import org.elasticsearch.common.HasContextAndHeaders;
+import org.elasticsearch.common.HasHeaders;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.text.StringText;
 import org.elasticsearch.common.util.BigArrays;
@@ -61,11 +65,7 @@ import org.elasticsearch.search.fetch.innerhits.InnerHitsContext;
 import org.elasticsearch.search.fetch.script.ScriptFieldsContext;
 import org.elasticsearch.search.fetch.source.FetchSourceContext;
 import org.elasticsearch.search.highlight.SearchContextHighlight;
-import org.elasticsearch.search.internal.ContextIndexSearcher;
-import org.elasticsearch.search.internal.InternalSearchHit;
-import org.elasticsearch.search.internal.InternalSearchHitField;
-import org.elasticsearch.search.internal.SearchContext;
-import org.elasticsearch.search.internal.ShardSearchRequest;
+import org.elasticsearch.search.internal.*;
 import org.elasticsearch.search.lookup.LeafSearchLookup;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.search.query.QuerySearchResult;
@@ -73,9 +73,7 @@ import org.elasticsearch.search.rescore.RescoreSearchContext;
 import org.elasticsearch.search.scan.ScanContext;
 import org.elasticsearch.search.suggest.SuggestionSearchContext;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.ConcurrentMap;
 
 /**
@@ -693,4 +691,80 @@ public class PercolateContext extends SearchContext {
         throw new UnsupportedOperationException();
     }
 
+    @Override
+    public <V> V putInContext(Object key, Object value) {
+        assert false : "percolatocontext does not support contexts & headers";
+        return null;
+    }
+
+    @Override
+    public void putAllInContext(ObjectObjectAssociativeContainer<Object, Object> map) {
+        assert false : "percolatocontext does not support contexts & headers";
+    }
+
+    @Override
+    public <V> V getFromContext(Object key) {
+        return null;
+    }
+
+    @Override
+    public <V> V getFromContext(Object key, V defaultValue) {
+        return defaultValue;
+    }
+
+    @Override
+    public boolean hasInContext(Object key) {
+        return false;
+    }
+
+    @Override
+    public int contextSize() {
+        return 0;
+    }
+
+    @Override
+    public boolean isContextEmpty() {
+        return true;
+    }
+
+    @Override
+    public ImmutableOpenMap<Object, Object> getContext() {
+        return ImmutableOpenMap.of();
+    }
+
+    @Override
+    public void copyContextFrom(HasContext other) {
+        assert false : "percolatocontext does not support contexts & headers";
+    }
+
+    @Override
+    public <V> V putHeader(String key, V value) {
+        assert false : "percolatocontext does not support contexts & headers";
+        return value;
+    }
+
+    @Override
+    public <V> V getHeader(String key) {
+        return null;
+    }
+
+    @Override
+    public boolean hasHeader(String key) {
+        return false;
+    }
+
+    @Override
+    public Set<String> getHeaders() {
+        return Collections.EMPTY_SET;
+    }
+
+    @Override
+    public void copyHeadersFrom(HasHeaders from) {
+        assert false : "percolatocontext does not support contexts & headers";
+    }
+
+    @Override
+    public void copyContextAndHeadersFrom(HasContextAndHeaders other) {
+        assert false : "percolatocontext does not support contexts & headers";
+    }
 }

--- a/src/main/java/org/elasticsearch/rest/RestRequest.java
+++ b/src/main/java/org/elasticsearch/rest/RestRequest.java
@@ -20,7 +20,7 @@
 package org.elasticsearch.rest;
 
 import org.elasticsearch.common.Booleans;
-import org.elasticsearch.common.ContextHolder;
+import org.elasticsearch.common.ContextAndHeaderHolder;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -38,7 +38,7 @@ import static org.elasticsearch.common.unit.TimeValue.parseTimeValue;
 /**
  *
  */
-public abstract class RestRequest extends ContextHolder implements ToXContent.Params {
+public abstract class RestRequest extends ContextAndHeaderHolder implements ToXContent.Params {
 
     public enum Method {
         GET, POST, PUT, DELETE, OPTIONS, HEAD

--- a/src/main/java/org/elasticsearch/script/ScriptService.java
+++ b/src/main/java/org/elasticsearch/script/ScriptService.java
@@ -25,7 +25,6 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.RemovalListener;
 import com.google.common.cache.RemovalNotification;
 import com.google.common.collect.ImmutableMap;
-
 import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.delete.DeleteRequest;
@@ -57,6 +56,7 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.index.query.TemplateQueryParser;
 import org.elasticsearch.script.groovy.GroovyScriptEngineService;
+import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.watcher.FileChangesListener;
 import org.elasticsearch.watcher.FileWatcher;
@@ -288,6 +288,7 @@ public class ScriptService extends AbstractComponent implements Closeable {
         }
         scriptLang = validateScriptLanguage(scriptLang);
         GetRequest getRequest = new GetRequest(SCRIPT_INDEX, scriptLang, id);
+        getRequest.copyContextAndHeadersFrom(SearchContext.current());
         GetResponse responseFields = client.get(getRequest).actionGet();
         if (responseFields.isExists()) {
             return getScriptFromResponse(responseFields);

--- a/src/main/java/org/elasticsearch/search/internal/DefaultSearchContext.java
+++ b/src/main/java/org/elasticsearch/search/internal/DefaultSearchContext.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.search.internal;
 
+import com.carrotsearch.hppc.ObjectObjectAssociativeContainer;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
@@ -33,7 +34,11 @@ import org.apache.lucene.search.Sort;
 import org.apache.lucene.util.Counter;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.cache.recycler.PageCacheRecycler;
+import org.elasticsearch.common.HasContext;
+import org.elasticsearch.common.HasContextAndHeaders;
+import org.elasticsearch.common.HasHeaders;
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.lucene.search.function.BoostScoreFunction;
@@ -72,6 +77,7 @@ import org.elasticsearch.search.suggest.SuggestionSearchContext;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 /**
  *
@@ -79,101 +85,56 @@ import java.util.List;
 public class DefaultSearchContext extends SearchContext {
 
     private final long id;
-
     private final ShardSearchRequest request;
-
     private final SearchShardTarget shardTarget;
     private final Counter timeEstimateCounter;
-
     private SearchType searchType;
-
     private final Engine.Searcher engineSearcher;
-
     private final ScriptService scriptService;
-
     private final PageCacheRecycler pageCacheRecycler;
-
     private final BigArrays bigArrays;
-
     private final IndexShard indexShard;
-
     private final IndexService indexService;
-
     private final ContextIndexSearcher searcher;
-
     private final DfsSearchResult dfsResult;
-
     private final QuerySearchResult queryResult;
-
     private final FetchSearchResult fetchResult;
-
     // lazy initialized only if needed
     private ScanContext scanContext;
-
     private float queryBoost = 1.0f;
-
     // timeout in millis
     private long timeoutInMillis = -1;
-
     // terminate after count
     private int terminateAfter = DEFAULT_TERMINATE_AFTER;
-
-
     private List<String> groupStats;
-
     private Scroll scroll;
-
     private boolean explain;
-
     private boolean version = false; // by default, we don't return versions
-
     private List<String> fieldNames;
     private FieldDataFieldsContext fieldDataFields;
     private ScriptFieldsContext scriptFields;
     private FetchSourceContext fetchSourceContext;
-
     private int from = -1;
-
     private int size = -1;
-
     private Sort sort;
-
     private Float minimumScore;
-
     private boolean trackScores = false; // when sorting, track scores as well...
-
     private ParsedQuery originalQuery;
-
     private Query query;
-
     private ParsedQuery postFilter;
-
     private Query aliasFilter;
-
     private int[] docIdsToLoad;
-
     private int docsIdsToLoadFrom;
-
     private int docsIdsToLoadSize;
-
     private SearchContextAggregations aggregations;
-
     private SearchContextHighlight highlight;
-
     private SuggestionSearchContext suggest;
-
     private List<RescoreSearchContext> rescore;
-
     private SearchLookup searchLookup;
-
     private boolean queryRewritten;
-
     private volatile long keepAlive;
-
     private ScoreDoc lastEmittedDoc;
-
     private volatile long lastAccessTime = -1;
-
     private InnerHitsContext innerHitsContext;
 
     public DefaultSearchContext(long id, ShardSearchRequest request, SearchShardTarget shardTarget,
@@ -789,5 +750,80 @@ public class DefaultSearchContext extends SearchContext {
     @Override
     public InnerHitsContext innerHits() {
         return innerHitsContext;
+    }
+
+    @Override
+    public <V> V putInContext(Object key, Object value) {
+        return request.putInContext(key, value);
+    }
+
+    @Override
+    public void putAllInContext(ObjectObjectAssociativeContainer<Object, Object> map) {
+        request.putAllInContext(map);
+    }
+
+    @Override
+    public <V> V getFromContext(Object key) {
+        return request.getFromContext(key);
+    }
+
+    @Override
+    public <V> V getFromContext(Object key, V defaultValue) {
+        return request.getFromContext(key, defaultValue);
+    }
+
+    @Override
+    public boolean hasInContext(Object key) {
+        return request.hasInContext(key);
+    }
+
+    @Override
+    public int contextSize() {
+        return request.contextSize();
+    }
+
+    @Override
+    public boolean isContextEmpty() {
+        return request.isContextEmpty();
+    }
+
+    @Override
+    public ImmutableOpenMap<Object, Object> getContext() {
+        return request.getContext();
+    }
+
+    @Override
+    public void copyContextFrom(HasContext other) {
+        request.copyContextFrom(other);
+    }
+
+    @Override
+    public <V> V putHeader(String key, V value) {
+        return request.putHeader(key, value);
+    }
+
+    @Override
+    public <V> V getHeader(String key) {
+        return request.getHeader(key);
+    }
+
+    @Override
+    public boolean hasHeader(String key) {
+        return request.hasHeader(key);
+    }
+
+    @Override
+    public Set<String> getHeaders() {
+        return request.getHeaders();
+    }
+
+    @Override
+    public void copyHeadersFrom(HasHeaders from) {
+        request.copyHeadersFrom(from);
+    }
+
+    @Override
+    public void copyContextAndHeadersFrom(HasContextAndHeaders other) {
+        request.copyContextAndHeadersFrom(other);
     }
 }

--- a/src/main/java/org/elasticsearch/search/internal/FilteredSearchContext.java
+++ b/src/main/java/org/elasticsearch/search/internal/FilteredSearchContext.java
@@ -19,22 +19,25 @@
 
 package org.elasticsearch.search.internal;
 
+import com.carrotsearch.hppc.ObjectObjectAssociativeContainer;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.util.Counter;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.cache.recycler.PageCacheRecycler;
+import org.elasticsearch.common.HasContext;
+import org.elasticsearch.common.HasContextAndHeaders;
+import org.elasticsearch.common.HasHeaders;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.index.analysis.AnalysisService;
 import org.elasticsearch.index.cache.bitset.BitsetFilterCache;
-import org.elasticsearch.index.cache.filter.FilterCache;
 import org.elasticsearch.index.fielddata.IndexFieldDataService;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.FieldMappers;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.IndexQueryParserService;
-import org.elasticsearch.index.query.ParsedQuery;
 import org.elasticsearch.index.query.ParsedQuery;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.similarity.SimilarityService;
@@ -56,6 +59,7 @@ import org.elasticsearch.search.scan.ScanContext;
 import org.elasticsearch.search.suggest.SuggestionSearchContext;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  */
@@ -557,4 +561,78 @@ public abstract class FilteredSearchContext extends SearchContext {
         return in.timeEstimateCounter();
     }
 
+    @Override
+    public <V> V putInContext(Object key, Object value) {
+        return in.putInContext(key, value);
+    }
+
+    @Override
+    public void putAllInContext(ObjectObjectAssociativeContainer<Object, Object> map) {
+        in.putAllInContext(map);
+    }
+
+    @Override
+    public <V> V getFromContext(Object key) {
+        return in.getFromContext(key);
+    }
+
+    @Override
+    public <V> V getFromContext(Object key, V defaultValue) {
+        return in.getFromContext(key, defaultValue);
+    }
+
+    @Override
+    public boolean hasInContext(Object key) {
+        return in.hasInContext(key);
+    }
+
+    @Override
+    public int contextSize() {
+        return in.contextSize();
+    }
+
+    @Override
+    public boolean isContextEmpty() {
+        return in.isContextEmpty();
+    }
+
+    @Override
+    public ImmutableOpenMap<Object, Object> getContext() {
+        return in.getContext();
+    }
+
+    @Override
+    public void copyContextFrom(HasContext other) {
+        in.copyContextFrom(other);
+    }
+
+    @Override
+    public <V> V putHeader(String key, V value) {
+        return in.putHeader(key, value);
+    }
+
+    @Override
+    public <V> V getHeader(String key) {
+        return in.getHeader(key);
+    }
+
+    @Override
+    public boolean hasHeader(String key) {
+        return in.hasHeader(key);
+    }
+
+    @Override
+    public Set<String> getHeaders() {
+        return in.getHeaders();
+    }
+
+    @Override
+    public void copyHeadersFrom(HasHeaders from) {
+        in.copyHeadersFrom(from);
+    }
+
+    @Override
+    public void copyContextAndHeadersFrom(HasContextAndHeaders other) {
+        in.copyContextAndHeadersFrom(other);
+    }
 }

--- a/src/main/java/org/elasticsearch/search/internal/SearchContext.java
+++ b/src/main/java/org/elasticsearch/search/internal/SearchContext.java
@@ -28,6 +28,9 @@ import org.apache.lucene.search.Sort;
 import org.apache.lucene.util.Counter;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.cache.recycler.PageCacheRecycler;
+import org.elasticsearch.common.HasContext;
+import org.elasticsearch.common.HasContextAndHeaders;
+import org.elasticsearch.common.HasHeaders;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.lease.Releasables;
@@ -67,7 +70,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  */
-public abstract class SearchContext implements Releasable {
+public abstract class SearchContext implements Releasable, HasContextAndHeaders {
 
     private static ThreadLocal<SearchContext> current = new ThreadLocal<>();
     public final static int DEFAULT_TERMINATE_AFTER = 0;

--- a/src/main/java/org/elasticsearch/search/internal/ShardSearchLocalRequest.java
+++ b/src/main/java/org/elasticsearch/search/internal/ShardSearchLocalRequest.java
@@ -22,6 +22,7 @@ package org.elasticsearch.search.internal;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.common.ContextAndHeaderHolder;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
@@ -57,22 +58,15 @@ import static org.elasticsearch.search.Scroll.readScroll;
  * </pre>
  */
 
-public class ShardSearchLocalRequest implements ShardSearchRequest {
+public class ShardSearchLocalRequest extends ContextAndHeaderHolder implements ShardSearchRequest {
 
     private String index;
-
     private int shardId;
-
     private int numberOfShards;
-
     private SearchType searchType;
-
     private Scroll scroll;
-
     private String[] types = Strings.EMPTY_ARRAY;
-
     private String[] filteringAliases;
-
     private BytesReference source;
     private BytesReference extraSource;
     private BytesReference templateSource;
@@ -80,7 +74,6 @@ public class ShardSearchLocalRequest implements ShardSearchRequest {
     private ScriptService.ScriptType templateType;
     private Map<String, Object> templateParams;
     private Boolean queryCache;
-
     private long nowInMillis;
 
     ShardSearchLocalRequest() {
@@ -90,7 +83,6 @@ public class ShardSearchLocalRequest implements ShardSearchRequest {
                             String[] filteringAliases, long nowInMillis) {
         this(shardRouting.shardId(), numberOfShards, searchRequest.searchType(),
                 searchRequest.source(), searchRequest.types(), searchRequest.queryCache());
-
         this.extraSource = searchRequest.extraSource();
         this.templateSource = searchRequest.templateSource();
         this.templateName = searchRequest.templateName();
@@ -99,6 +91,7 @@ public class ShardSearchLocalRequest implements ShardSearchRequest {
         this.scroll = searchRequest.scroll();
         this.filteringAliases = filteringAliases;
         this.nowInMillis = nowInMillis;
+        copyContextAndHeadersFrom(searchRequest);
     }
 
     public ShardSearchLocalRequest(String[] types, long nowInMillis) {

--- a/src/main/java/org/elasticsearch/search/internal/ShardSearchRequest.java
+++ b/src/main/java/org/elasticsearch/search/internal/ShardSearchRequest.java
@@ -20,6 +20,9 @@
 package org.elasticsearch.search.internal;
 
 import org.elasticsearch.action.search.SearchType;
+import org.elasticsearch.common.HasContext;
+import org.elasticsearch.common.HasContextAndHeaders;
+import org.elasticsearch.common.HasHeaders;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.Scroll;
@@ -32,7 +35,7 @@ import java.util.Map;
  * It provides all the methods that the {@link org.elasticsearch.search.internal.SearchContext} needs.
  * Provides a cache key based on its content that can be used to cache shard level response.
  */
-public interface ShardSearchRequest {
+public interface ShardSearchRequest extends HasContextAndHeaders {
 
     String index();
 

--- a/src/main/java/org/elasticsearch/search/suggest/SuggestParseElement.java
+++ b/src/main/java/org/elasticsearch/search/suggest/SuggestParseElement.java
@@ -51,6 +51,7 @@ public final class SuggestParseElement implements SearchParseElement {
 
     public SuggestionSearchContext parseInternal(XContentParser parser, MapperService mapperService, IndexQueryParserService queryParserService, String index, int shardId) throws IOException {
         SuggestionSearchContext suggestionSearchContext = new SuggestionSearchContext();
+
         BytesRef globalText = null;
         String fieldName = null;
         Map<String, SuggestionContext> suggestionContexts = newHashMap();

--- a/src/main/java/org/elasticsearch/transport/TransportMessage.java
+++ b/src/main/java/org/elasticsearch/transport/TransportMessage.java
@@ -19,25 +19,20 @@
 
 package org.elasticsearch.transport;
 
-import org.elasticsearch.common.ContextHolder;
+import org.elasticsearch.common.ContextAndHeaderHolder;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.transport.TransportAddress;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
 
 /**
- * The transport message is also a {@link ContextHolder context holder} that holds <b>transient</b> context, that is,
+ * The transport message is also a {@link ContextAndHeaderHolder context holder} that holds <b>transient</b> context, that is,
  * the context is not serialized with message.
  */
-public abstract class TransportMessage<TM extends TransportMessage<TM>> extends ContextHolder implements Streamable {
-
-    private Map<String, Object> headers;
+public abstract class TransportMessage<TM extends TransportMessage<TM>> extends ContextAndHeaderHolder<TM> implements Streamable {
 
     private TransportAddress remoteAddress;
 
@@ -48,8 +43,8 @@ public abstract class TransportMessage<TM extends TransportMessage<TM>> extends 
         // create a new copy of the headers/context, since we are creating a new request
         // which might have its headers/context changed in the context of that specific request
 
-        if (((TransportMessage<?>) message).headers != null) {
-            this.headers = new HashMap<>(((TransportMessage<?>) message).headers);
+        if (message.headers != null) {
+            this.headers = new HashMap<>(message.headers);
         }
         copyContextFrom(message);
     }
@@ -60,28 +55,6 @@ public abstract class TransportMessage<TM extends TransportMessage<TM>> extends 
 
     public TransportAddress remoteAddress() {
         return remoteAddress;
-    }
-
-    @SuppressWarnings("unchecked")
-    public final TM putHeader(String key, Object value) {
-        if (headers == null) {
-            headers = new HashMap<>();
-        }
-        headers.put(key, value);
-        return (TM) this;
-    }
-
-    @SuppressWarnings("unchecked")
-    public final <V> V getHeader(String key) {
-        return headers != null ? (V) headers.get(key) : null;
-    }
-
-    public final boolean hasHeader(String key) {
-        return headers != null && headers.containsKey(key);
-    }
-
-    public Set<String> getHeaders() {
-        return headers != null ? headers.keySet() : Collections.<String>emptySet();
     }
 
     @Override

--- a/src/test/java/org/elasticsearch/test/TestSearchContext.java
+++ b/src/test/java/org/elasticsearch/test/TestSearchContext.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.test;
 
+import com.carrotsearch.hppc.ObjectObjectAssociativeContainer;
 import org.apache.lucene.search.Filter;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreDoc;
@@ -25,6 +26,10 @@ import org.apache.lucene.search.Sort;
 import org.apache.lucene.util.Counter;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.cache.recycler.PageCacheRecycler;
+import org.elasticsearch.common.HasContext;
+import org.elasticsearch.common.HasContextAndHeaders;
+import org.elasticsearch.common.HasHeaders;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.analysis.AnalysisService;
@@ -59,7 +64,9 @@ import org.elasticsearch.search.scan.ScanContext;
 import org.elasticsearch.search.suggest.SuggestionSearchContext;
 import org.elasticsearch.threadpool.ThreadPool;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 public class TestSearchContext extends SearchContext {
 
@@ -597,4 +604,72 @@ public class TestSearchContext extends SearchContext {
         throw new UnsupportedOperationException();
     }
 
+    @Override
+    public <V> V putInContext(Object key, Object value) {
+        return null;
+    }
+
+    @Override
+    public void putAllInContext(ObjectObjectAssociativeContainer<Object, Object> map) {
+    }
+
+    @Override
+    public <V> V getFromContext(Object key) {
+        return null;
+    }
+
+    @Override
+    public <V> V getFromContext(Object key, V defaultValue) {
+        return defaultValue;
+    }
+
+    @Override
+    public boolean hasInContext(Object key) {
+        return false;
+    }
+
+    @Override
+    public int contextSize() {
+        return 0;
+    }
+
+    @Override
+    public boolean isContextEmpty() {
+        return true;
+    }
+
+    @Override
+    public ImmutableOpenMap<Object, Object> getContext() {
+        return ImmutableOpenMap.of();
+    }
+
+    @Override
+    public void copyContextFrom(HasContext other) {
+    }
+
+    @Override
+    public <V> V putHeader(String key, V value) {
+        return value;
+    }
+
+    @Override
+    public <V> V getHeader(String key) {
+        return null;
+    }
+
+    @Override
+    public boolean hasHeader(String key) {
+        return false;
+    }
+
+    @Override
+    public Set<String> getHeaders() {
+        return Collections.EMPTY_SET;
+    }
+
+    @Override
+    public void copyHeadersFrom(HasHeaders from) {}
+
+    @Override
+    public void copyContextAndHeadersFrom(HasContextAndHeaders other) {}
 }

--- a/src/test/java/org/elasticsearch/transport/ContextAndHeaderTransportTests.java
+++ b/src/test/java/org/elasticsearch/transport/ContextAndHeaderTransportTests.java
@@ -1,0 +1,438 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.transport;
+
+import com.carrotsearch.ant.tasks.junit4.dependencies.com.google.common.collect.ImmutableList;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.elasticsearch.action.*;
+import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
+import org.elasticsearch.action.get.GetRequest;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.indexedscripts.put.PutIndexedScriptRequest;
+import org.elasticsearch.action.indexedscripts.put.PutIndexedScriptResponse;
+import org.elasticsearch.action.percolate.PercolateResponse;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.support.ActionFilter;
+import org.elasticsearch.action.termvectors.MultiTermVectorsRequest;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.client.FilterClient;
+import org.elasticsearch.common.inject.AbstractModule;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Module;
+import org.elasticsearch.common.inject.PreProcessModule;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.http.HttpServerTransport;
+import org.elasticsearch.index.query.*;
+import org.elasticsearch.plugins.AbstractPlugin;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.script.groovy.GroovyScriptEngineService;
+import org.elasticsearch.script.mustache.MustacheScriptEngineService;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
+import org.elasticsearch.test.rest.client.http.HttpRequestBuilder;
+import org.elasticsearch.test.rest.client.http.HttpResponse;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.*;
+
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
+import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.node.Node.HTTP_ENABLED;
+import static org.elasticsearch.rest.RestStatus.OK;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.Scope.SUITE;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.*;
+import static org.hamcrest.Matchers.*;
+
+@ClusterScope(scope = SUITE)
+public class ContextAndHeaderTransportTests extends ElasticsearchIntegrationTest {
+
+    private static final List<ActionRequest> requests = Collections.synchronizedList(new ArrayList<ActionRequest>());
+    private String randomHeaderKey = randomAsciiOfLength(10);
+    private String randomHeaderValue = randomAsciiOfLength(20);
+    private String queryIndex = "query-" + randomAsciiOfLength(10).toLowerCase(Locale.ROOT);
+    private String lookupIndex = "lookup-" + randomAsciiOfLength(10).toLowerCase(Locale.ROOT);
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return settingsBuilder()
+                .put(super.nodeSettings(nodeOrdinal))
+                .put("plugin.types", ActionLoggingPlugin.class.getName())
+                .put("script.indexed", "on")
+                .put(HTTP_ENABLED, true)
+                .build();
+    }
+
+    @Before
+    public void createIndices() throws Exception {
+        String mapping = jsonBuilder().startObject().startObject("type")
+                .startObject("properties")
+                .startObject("location").field("type", "geo_shape").endObject()
+                .startObject("name").field("type", "string").endObject()
+                .startObject("title").field("type", "string").field("analyzer", "text").endObject()
+                .endObject()
+                .endObject().endObject().string();
+
+        Settings settings = settingsBuilder()
+                .put(indexSettings())
+                .put(SETTING_NUMBER_OF_SHARDS, 1) // A single shard will help to keep the tests repeatable.
+                .put("index.analysis.analyzer.text.tokenizer", "standard")
+                .putArray("index.analysis.analyzer.text.filter", "lowercase", "my_shingle")
+                .put("index.analysis.filter.my_shingle.type", "shingle")
+                .put("index.analysis.filter.my_shingle.output_unigrams", true)
+                .put("index.analysis.filter.my_shingle.min_shingle_size", 2)
+                .put("index.analysis.filter.my_shingle.max_shingle_size", 3)
+                .build();
+        assertAcked(transportClient().admin().indices().prepareCreate(lookupIndex)
+                .setSettings(settings).addMapping("type", mapping));
+        assertAcked(transportClient().admin().indices().prepareCreate(queryIndex)
+                .setSettings(settings).addMapping("type", mapping));
+        ensureGreen(queryIndex, lookupIndex);
+
+        requests.clear();
+    }
+
+    @After
+    public void checkAllRequestsContainHeaders() {
+        assertRequestsContainHeader(IndexRequest.class);
+        assertRequestsContainHeader(RefreshRequest.class);
+
+    /*
+        for (ActionRequest request : requests) {
+            String msg = String.format(Locale.ROOT, "Expected request [%s] to have randomized header key set", request.getClass().getSimpleName());
+            assertThat(msg, request.hasHeader(randomHeaderKey), is(true));
+            assertThat(request.getHeader(randomHeaderKey).toString(), is(randomHeaderValue));
+        }
+    */
+    }
+
+    // TODO check context as well
+
+    @Test
+    public void testThatTermsLookupGetRequestContainsContextAndHeaders() throws Exception {
+        transportClient().prepareIndex(lookupIndex, "type", "1")
+                .setSource(jsonBuilder().startObject().array("followers", "foo", "bar", "baz").endObject()).get();
+        transportClient().prepareIndex(queryIndex, "type", "1")
+                .setSource(jsonBuilder().startObject().field("username", "foo").endObject()).get();
+        transportClient().admin().indices().prepareRefresh(queryIndex, lookupIndex).get();
+
+        TermsLookupQueryBuilder termsLookupFilterBuilder = QueryBuilders.termsLookupQuery("username").lookupIndex(lookupIndex).lookupType("type").lookupId("1").lookupPath("followers");
+        BoolQueryBuilder queryBuilder = QueryBuilders.boolQuery().must(QueryBuilders.matchAllQuery()).must(termsLookupFilterBuilder);
+
+        SearchResponse searchResponse = transportClient()
+                .prepareSearch(queryIndex)
+                .setQuery(queryBuilder)
+                .get();
+        assertNoFailures(searchResponse);
+        assertHitCount(searchResponse, 1);
+
+        assertGetRequestsContainHeaders();
+    }
+
+    @Test
+    public void testThatGeoShapeQueryGetRequestContainsContextAndHeaders() throws Exception {
+        indexRandom(false, false,
+                transportClient().prepareIndex(lookupIndex, "type", "1").setSource(jsonBuilder().startObject()
+                        .field("name", "Munich Suburban Area")
+                        .startObject("location")
+                        .field("type", "polygon")
+                        .startArray("coordinates").startArray()
+                        .startArray().value(11.34).value(48.25).endArray()
+                        .startArray().value(11.68).value(48.25).endArray()
+                        .startArray().value(11.65).value(48.06).endArray()
+                        .startArray().value(11.37).value(48.13).endArray()
+                        .startArray().value(11.34).value(48.25).endArray() // close the polygon
+                        .endArray().endArray()
+                        .endObject()
+                        .endObject()),
+                // second document
+                transportClient().prepareIndex(queryIndex, "type", "1").setSource(jsonBuilder().startObject()
+                        .field("name", "Munich Center")
+                        .startObject("location")
+                        .field("type", "point")
+                        .startArray("coordinates").value(11.57).value(48.13).endArray()
+                        .endObject()
+                        .endObject())
+        );
+        transportClient().admin().indices().prepareRefresh(lookupIndex, queryIndex).get();
+
+        GeoShapeQueryBuilder queryBuilder = QueryBuilders.geoShapeQuery("location", "1", "type")
+                .indexedShapeIndex(lookupIndex)
+                .indexedShapePath("location");
+
+        SearchResponse searchResponse = transportClient()
+                .prepareSearch(queryIndex)
+                .setQuery(queryBuilder)
+                .get();
+        assertNoFailures(searchResponse);
+        assertHitCount(searchResponse, 1);
+        assertThat(requests, hasSize(greaterThan(0)));
+
+        assertGetRequestsContainHeaders();
+    }
+
+    @Test
+    public void testThatMoreLikeThisQueryMultiTermVectorRequestContainsContextAndHeaders() throws Exception {
+        indexRandom(false, false,
+                transportClient().prepareIndex(lookupIndex, "type", "1")
+                        .setSource(jsonBuilder().startObject().field("name", "Star Wars - The new republic").endObject()),
+                transportClient().prepareIndex(queryIndex, "type", "1")
+                        .setSource(jsonBuilder().startObject().field("name", "Jar Jar Binks - A horrible mistake").endObject()),
+                transportClient().prepareIndex(queryIndex, "type", "2")
+                        .setSource(jsonBuilder().startObject().field("name", "Star Wars - Return of the jedi").endObject()));
+        transportClient().admin().indices().prepareRefresh(lookupIndex, queryIndex).get();
+
+        MoreLikeThisQueryBuilder moreLikeThisQueryBuilder = QueryBuilders.moreLikeThisQuery("name")
+                .addItem(new MoreLikeThisQueryBuilder.Item(lookupIndex, "type", "1"))
+                .minTermFreq(1)
+                .minDocFreq(1);
+
+        SearchResponse searchResponse = transportClient()
+                .prepareSearch(queryIndex)
+                .setQuery(moreLikeThisQueryBuilder)
+                .get();
+        assertNoFailures(searchResponse);
+        assertHitCount(searchResponse, 1);
+
+        assertRequestsContainHeader(MultiTermVectorsRequest.class);
+    }
+
+    @Test
+    public void testThatPercolatingExistingDocumentGetRequestContainsContextAndHeaders() throws Exception {
+        indexRandom(false,
+                transportClient().prepareIndex(lookupIndex, ".percolator", "1")
+                        .setSource(jsonBuilder().startObject().startObject("query").startObject("match").field("name", "star wars").endObject().endObject().endObject()),
+                transportClient().prepareIndex(lookupIndex, "type", "1")
+                        .setSource(jsonBuilder().startObject().field("name", "Star Wars - The new republic").endObject())
+        );
+        transportClient().admin().indices().prepareRefresh(lookupIndex).get();
+
+        GetRequest getRequest = transportClient().prepareGet(lookupIndex, "type", "1").request();
+        PercolateResponse response = transportClient().preparePercolate().setDocumentType("type").setGetRequest(getRequest).get();
+        assertThat(response.getCount(), is(1l));
+
+        assertGetRequestsContainHeaders();
+    }
+
+    @Test
+    public void testThatIndexedScriptGetRequestContainsContextAndHeaders() throws Exception {
+        PutIndexedScriptResponse scriptResponse = transportClient().preparePutIndexedScript(GroovyScriptEngineService.NAME, "my_script",
+                jsonBuilder().startObject().field("script", "_score * 10").endObject().string()
+        ).get();
+        assertThat(scriptResponse.isCreated(), is(true));
+
+        indexRandom(false, false, transportClient().prepareIndex(queryIndex, "type", "1")
+                .setSource(jsonBuilder().startObject().field("name", "Star Wars - The new republic").endObject()));
+        transportClient().admin().indices().prepareRefresh(queryIndex).get();
+
+        // custom content, not sure how to specify "script_id" otherwise in the API
+        XContentBuilder builder = jsonBuilder().startObject().startObject("function_score").field("boost_mode", "replace").startArray("functions")
+                .startObject().startObject("script_score").field("script_id", "my_script").field("lang", "groovy").endObject().endObject().endArray().endObject().endObject();
+
+        SearchResponse searchResponse = transportClient()
+                .prepareSearch(queryIndex)
+                .setQuery(builder)
+                .get();
+        assertNoFailures(searchResponse);
+        assertHitCount(searchResponse, 1);
+        assertThat(searchResponse.getHits().getMaxScore(), is(10.0f));
+
+        assertGetRequestsContainHeaders(".scripts");
+        assertRequestsContainHeader(PutIndexedScriptRequest.class);
+    }
+
+    @Test
+    public void testThatSearchTemplatesWithIndexedTemplatesGetRequestContainsContextAndHeaders() throws Exception {
+        PutIndexedScriptResponse scriptResponse = transportClient().preparePutIndexedScript(MustacheScriptEngineService.NAME, "the_template",
+                jsonBuilder().startObject().startObject("template").startObject("query").startObject("match")
+                        .field("name", "{{query_string}}").endObject().endObject().endObject().endObject().string()
+        ).get();
+        assertThat(scriptResponse.isCreated(), is(true));
+
+        indexRandom(false, false, transportClient().prepareIndex(queryIndex, "type", "1")
+                .setSource(jsonBuilder().startObject().field("name", "Star Wars - The new republic").endObject()));
+        transportClient().admin().indices().prepareRefresh(queryIndex).get();
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("query_string", "star wars");
+
+        SearchResponse searchResponse = transportClient().prepareSearch(queryIndex)
+                .setTemplateName("the_template")
+                .setTemplateParams(params)
+                .setTemplateType(ScriptService.ScriptType.INDEXED)
+                .get();
+
+        assertNoFailures(searchResponse);
+        assertHitCount(searchResponse, 1);
+
+        assertGetRequestsContainHeaders(".scripts");
+        assertRequestsContainHeader(PutIndexedScriptRequest.class);
+    }
+
+    @Test
+    public void testThatRelevantHttpHeadersBecomeRequestHeaders() throws Exception {
+        String releventHeaderName = "relevant_" + randomHeaderKey;
+        for (RestController restController : internalCluster().getDataNodeInstances(RestController.class)) {
+            restController.registerRelevantHeaders(releventHeaderName);
+        }
+
+        CloseableHttpClient httpClient = HttpClients.createDefault();
+        HttpResponse response = new HttpRequestBuilder(httpClient)
+                .httpTransport(internalCluster().getDataNodeInstance(HttpServerTransport.class))
+                .addHeader(randomHeaderKey, randomHeaderValue)
+                .addHeader(releventHeaderName, randomHeaderValue)
+                .path("/" + queryIndex + "/_search")
+                .execute();
+
+        assertThat(response, hasStatus(OK));
+        List<SearchRequest> searchRequests = getRequests(SearchRequest.class);
+        assertThat(searchRequests, hasSize(greaterThan(0)));
+        for (SearchRequest searchRequest : searchRequests) {
+            assertThat(searchRequest.hasHeader(releventHeaderName), is(true));
+            // was not specified, thus is not included
+            assertThat(searchRequest.hasHeader(randomHeaderKey), is(false));
+        }
+    }
+
+    private <T> List<T> getRequests(Class<T> clazz) {
+        List<T> results = new ArrayList<>();
+        for (ActionRequest request : requests) {
+            if (request.getClass().equals(clazz)) {
+                results.add((T) request);
+            }
+        }
+
+        return results;
+    }
+
+    private void assertRequestsContainHeader(Class<? extends ActionRequest> clazz) {
+        List<? extends ActionRequest> classRequests = getRequests(clazz);
+        for (ActionRequest request : classRequests) {
+            assertRequestContainsHeader(request);
+        }
+    }
+
+    private void assertGetRequestsContainHeaders() {
+        assertGetRequestsContainHeaders(this.lookupIndex);
+    }
+
+    private void assertGetRequestsContainHeaders(String index) {
+        List<GetRequest> getRequests = getRequests(GetRequest.class);
+        assertThat(getRequests, hasSize(greaterThan(0)));
+
+        for (GetRequest request : getRequests) {
+            if (!request.index().equals(index)) {
+                continue;
+            }
+            assertRequestContainsHeader(request);
+        }
+    }
+
+    private void assertRequestContainsHeader(ActionRequest request) {
+        String msg = String.format(Locale.ROOT, "Expected header %s to be in request %s", randomHeaderKey, request.getClass().getName());
+        if (request instanceof IndexRequest) {
+            IndexRequest indexRequest = (IndexRequest) request;
+            msg = String.format(Locale.ROOT, "Expected header %s to be in index request %s/%s/%s", randomHeaderKey,
+                    indexRequest.index(), indexRequest.type(), indexRequest.id());
+        }
+        assertThat(msg, request.hasHeader(randomHeaderKey), is(true));
+        assertThat(request.getHeader(randomHeaderKey).toString(), is(randomHeaderValue));
+    }
+
+    /**
+     * a transport client that adds our random header
+     */
+    private Client transportClient() {
+        Client transportClient = internalCluster().transportClient();
+        FilterClient filterClient = new FilterClient(transportClient) {
+            @Override
+            protected <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder>> void doExecute(Action<Request, Response, RequestBuilder> action, Request request, ActionListener<Response> listener) {
+                request.putHeader(randomHeaderKey, randomHeaderValue);
+                super.doExecute(action, request, listener);
+            }
+        };
+
+        return filterClient;
+    }
+
+    public static class ActionLoggingPlugin extends AbstractPlugin {
+
+        @Override
+        public String name() {
+            return "test-action-logging";
+        }
+
+        @Override
+        public String description() {
+            return "Test action logging";
+        }
+
+        @Override
+        public Collection<Class<? extends Module>> modules() {
+            return ImmutableList.of(ActionLoggingModule.class);
+        }
+    }
+
+    public static class ActionLoggingModule extends AbstractModule implements PreProcessModule {
+
+
+        @Override
+        protected void configure() {
+            bind(LoggingFilter.class).asEagerSingleton();
+        }
+
+        @Override
+        public void processModule(Module module) {
+            if (module instanceof ActionModule) {
+                ((ActionModule)module).registerFilter(LoggingFilter.class);
+            }
+        }
+    }
+
+    public static class LoggingFilter extends ActionFilter.Simple {
+
+        @Inject
+        public LoggingFilter(Settings settings) {
+            super(settings);
+        }
+
+        @Override
+        public int order() {
+            return 999;
+        }
+
+        @Override
+        protected boolean apply(String action, ActionRequest request, ActionListener listener) {
+            requests.add(request);
+            return true;
+        }
+
+        @Override
+        protected boolean apply(String action, ActionResponse response, ActionListener listener) {
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Whenever a query parser (or any other component) issues another
request as part of a request, the headers and the context has to
be supplied as well.

In order to do this, the `SearchContext` has to have those headers
available, which in turn means, the shard level request needs to
copy those from the original `SearchRequest`

This commit introduces two new interface to supply the needed methods
to work with context and headers.

Closes #10979
