### PR TITLE
ThreadPool: make sure no leaking threads are left behind in case of initialization failure

### DIFF
--- a/src/main/java/org/elasticsearch/threadpool/ThreadPoolModule.java
+++ b/src/main/java/org/elasticsearch/threadpool/ThreadPoolModule.java
@@ -27,14 +27,14 @@ import org.elasticsearch.common.settings.Settings;
  */
 public class ThreadPoolModule extends AbstractModule {
 
-    private final Settings settings;
+    private final ThreadPool threadPool;
 
-    public ThreadPoolModule(Settings settings) {
-        this.settings = settings;
+    public ThreadPoolModule(ThreadPool threadPool) {
+        this.threadPool = threadPool;
     }
 
     @Override
     protected void configure() {
-        bind(ThreadPool.class).asEagerSingleton();
+        bind(ThreadPool.class).toInstance(threadPool);
     }
 }

--- a/src/test/java/org/elasticsearch/index/query/TemplateQueryParserTest.java
+++ b/src/test/java/org/elasticsearch/index/query/TemplateQueryParserTest.java
@@ -77,7 +77,7 @@ public class TemplateQueryParserTest extends ElasticsearchTestCase {
         injector = new ModulesBuilder().add(
                 new EnvironmentModule(new Environment(settings)),
                 new SettingsModule(settings),
-                new ThreadPoolModule(settings),
+                new ThreadPoolModule(new ThreadPool(settings)),
                 new IndicesQueriesModule(),
                 new ScriptModule(settings),
                 new IndexSettingsModule(index, settings),

--- a/src/test/java/org/elasticsearch/index/query/plugin/IndexQueryParserPlugin2Tests.java
+++ b/src/test/java/org/elasticsearch/index/query/plugin/IndexQueryParserPlugin2Tests.java
@@ -70,7 +70,7 @@ public class IndexQueryParserPlugin2Tests extends ElasticsearchTestCase {
         Injector injector = new ModulesBuilder().add(
                 new EnvironmentModule(new Environment(settings)),
                 new SettingsModule(settings),
-                new ThreadPoolModule(settings),
+                new ThreadPoolModule(new ThreadPool(settings)),
                 new IndicesQueriesModule(),
                 new ScriptModule(settings),
                 new IndexSettingsModule(index, settings),

--- a/src/test/java/org/elasticsearch/index/query/plugin/IndexQueryParserPluginTests.java
+++ b/src/test/java/org/elasticsearch/index/query/plugin/IndexQueryParserPluginTests.java
@@ -75,7 +75,7 @@ public class IndexQueryParserPluginTests extends ElasticsearchTestCase {
         Injector injector = new ModulesBuilder().add(
                 new EnvironmentModule(new Environment(settings)),
                 new SettingsModule(settings),
-                new ThreadPoolModule(settings),
+                new ThreadPoolModule(new ThreadPool(settings)),
                 new IndicesQueriesModule(),
                 new ScriptModule(settings),
                 new IndexSettingsModule(index, settings),

--- a/src/test/java/org/elasticsearch/script/NativeScriptTests.java
+++ b/src/test/java/org/elasticsearch/script/NativeScriptTests.java
@@ -55,7 +55,7 @@ public class NativeScriptTests extends ElasticsearchTestCase {
                 .build();
         Injector injector = new ModulesBuilder().add(
                 new EnvironmentModule(new Environment(settings)),
-                new ThreadPoolModule(settings),
+                new ThreadPoolModule(new ThreadPool(settings)),
                 new SettingsModule(settings),
                 new ScriptModule(settings)).createInjector();
 

--- a/src/test/java/org/elasticsearch/threadpool/ThreadPoolSerializationTests.java
+++ b/src/test/java/org/elasticsearch/threadpool/ThreadPoolSerializationTests.java
@@ -95,7 +95,7 @@ public class ThreadPoolSerializationTests extends ElasticsearchTestCase {
     @Test
     public void testThatNegativeSettingAllowsToStart() throws InterruptedException {
         Settings settings = settingsBuilder().put("name", "index").put("threadpool.index.queue_size", "-1").build();
-        ThreadPool threadPool = new ThreadPool(settings, null);
+        ThreadPool threadPool = new ThreadPool(settings);
         assertThat(threadPool.info("index").getQueueSize(), is(nullValue()));
         terminate(threadPool);
     }

--- a/src/test/java/org/elasticsearch/threadpool/UpdateThreadPoolSettingsTests.java
+++ b/src/test/java/org/elasticsearch/threadpool/UpdateThreadPoolSettingsTests.java
@@ -54,7 +54,7 @@ public class UpdateThreadPoolSettingsTests extends ElasticsearchTestCase {
         ThreadPool threadPool = new ThreadPool(
                 ImmutableSettings.settingsBuilder()
                         .put("threadpool.search.type", "cached")
-                        .put("name","testCachedExecutorType").build(), null);
+                        .put("name","testCachedExecutorType").build());
 
         assertThat(info(threadPool, Names.SEARCH).getType(), equalTo("cached"));
         assertThat(info(threadPool, Names.SEARCH).getKeepAlive().minutes(), equalTo(5L));
@@ -109,7 +109,7 @@ public class UpdateThreadPoolSettingsTests extends ElasticsearchTestCase {
     public void testFixedExecutorType() throws InterruptedException {
         ThreadPool threadPool = new ThreadPool(settingsBuilder()
                 .put("threadpool.search.type", "fixed")
-                .put("name","testCachedExecutorType").build(), null);
+                .put("name","testCachedExecutorType").build());
 
         assertThat(threadPool.executor(Names.SEARCH), instanceOf(EsThreadPoolExecutor.class));
 
@@ -170,7 +170,7 @@ public class UpdateThreadPoolSettingsTests extends ElasticsearchTestCase {
         ThreadPool threadPool = new ThreadPool(settingsBuilder()
                 .put("threadpool.search.type", "scaling")
                 .put("threadpool.search.size", 10)
-                .put("name","testCachedExecutorType").build(), null);
+                .put("name","testCachedExecutorType").build());
 
         assertThat(info(threadPool, Names.SEARCH).getMin(), equalTo(1));
         assertThat(info(threadPool, Names.SEARCH).getMax(), equalTo(10));
@@ -204,7 +204,7 @@ public class UpdateThreadPoolSettingsTests extends ElasticsearchTestCase {
     public void testShutdownDownNowDoesntBlock() throws Exception {
         ThreadPool threadPool = new ThreadPool(ImmutableSettings.settingsBuilder()
                 .put("threadpool.search.type", "cached")
-                .put("name","testCachedExecutorType").build(), null);
+                .put("name","testCachedExecutorType").build());
 
         final CountDownLatch latch = new CountDownLatch(1);
         Executor oldExecutor = threadPool.executor(Names.SEARCH);
@@ -236,7 +236,7 @@ public class UpdateThreadPoolSettingsTests extends ElasticsearchTestCase {
                 .put("threadpool.my_pool2.type", "fixed")
                 .put("threadpool.my_pool2.size", "1")
                 .put("threadpool.my_pool2.queue_size", "1")
-                .put("name", "testCustomThreadPool").build(), null);
+                .put("name", "testCustomThreadPool").build());
 
         ThreadPoolInfo groups = threadPool.info();
         boolean foundPool1 = false;

--- a/src/test/java/org/elasticsearch/transport/NettySizeHeaderFrameDecoderTests.java
+++ b/src/test/java/org/elasticsearch/transport/NettySizeHeaderFrameDecoderTests.java
@@ -58,8 +58,8 @@ public class NettySizeHeaderFrameDecoderTests extends ElasticsearchTestCase {
 
     @Before
     public void startThreadPool() {
-        threadPool = new ThreadPool(settings, new NodeSettingsService(settings));
-
+        threadPool = new ThreadPool(settings);
+        threadPool.setNodeSettingsService(new NodeSettingsService(settings));
         NetworkService networkService = new NetworkService(settings);
         BigArrays bigArrays = new MockBigArrays(new MockPageCacheRecycler(settings, threadPool), new NoneCircuitBreakerService());
         nettyTransport = new NettyTransport(settings, threadPool, networkService, bigArrays, Version.CURRENT);


### PR DESCRIPTION
Our ThreadPool constructor creates a couple of threads (scheduler and timer) which might not get shut down if the initialization of a node fails. A guice error might occur for example, which causes the InternalNode constructor to throw an exception. In this case the two threads are left behind, which is not a big problem when running es standalone as the error will be intercepted and the jvm will be stopped as a whole. It can become more of a problem though when running es in embedded mode, as we'll end up with lingering threads or testing an handling of initialization failures.

Closes #9107
