### PR TITLE
Add `path.shared_data`, change `index.data_path` to be relative

### DIFF
--- a/src/main/java/org/elasticsearch/bootstrap/Security.java
+++ b/src/main/java/org/elasticsearch/bootstrap/Security.java
@@ -67,6 +67,7 @@ public class Security {
         for (Path path : environment.dataWithClusterFiles()) {
             addPath(policy, path, "read,readlink,write,delete");
         }
+        addPath(policy, environment.sharedDataFile(), "read,readlink,write,delete");
         if (environment.pidFile() != null) {
             addPath(policy, environment.pidFile().getParent(), "read,readlink,write,delete");
         }

--- a/src/main/java/org/elasticsearch/env/Environment.java
+++ b/src/main/java/org/elasticsearch/env/Environment.java
@@ -44,6 +44,8 @@ public class Environment {
 
     private final Path[] dataFiles;
 
+    private final Path sharedDataFile;
+
     private final Path[] dataWithClusterFiles;
 
     private final Path configFile;
@@ -104,6 +106,12 @@ public class Environment {
             dataWithClusterFiles = new Path[]{homeFile.resolve("data").resolve(ClusterName.clusterNameFromSettings(settings).value())};
         }
 
+        if (settings.get("path.shared_data") != null) {
+            sharedDataFile = PathUtils.get(cleanPath(settings.get("path.shared_data")));
+        } else {
+            sharedDataFile = homeFile.resolve("data");
+        }
+
         if (settings.get("path.logs") != null) {
             logsFile = PathUtils.get(cleanPath(settings.get("path.logs")));
         } else {
@@ -143,6 +151,13 @@ public class Environment {
      */
     public Path[] dataWithClusterFiles() {
         return dataWithClusterFiles;
+    }
+
+    /**
+     * The shared data location
+     */
+    public Path sharedDataFile() {
+        return sharedDataFile;
     }
 
     /**

--- a/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -96,6 +96,7 @@ public class NodeEnvironment extends AbstractComponent implements Closeable {
     }
 
     private final NodePath[] nodePaths;
+    private final Path sharedDataPath;
     private final Lock[] locks;
 
     private final boolean addNodeId;
@@ -124,6 +125,7 @@ public class NodeEnvironment extends AbstractComponent implements Closeable {
 
         if (!DiscoveryNode.nodeRequiresLocalStorage(settings)) {
             nodePaths = null;
+            sharedDataPath = null;
             locks = null;
             localNodeId = -1;
             return;
@@ -131,6 +133,7 @@ public class NodeEnvironment extends AbstractComponent implements Closeable {
 
         final NodePath[] nodePaths = new NodePath[environment.dataWithClusterFiles().length];
         final Lock[] locks = new Lock[nodePaths.length];
+        sharedDataPath = environment.sharedDataFile();
 
         int localNodeId = -1;
         IOException lastException = null;
@@ -696,9 +699,9 @@ public class NodeEnvironment extends AbstractComponent implements Closeable {
             // This assert is because this should be caught by MetaDataCreateIndexService
             assert customPathsEnabled;
             if (addNodeId) {
-                return PathUtils.get(customDataDir, Integer.toString(this.localNodeId));
+                return sharedDataPath.resolve(customDataDir).resolve(Integer.toString(this.localNodeId));
             } else {
-                return PathUtils.get(customDataDir);
+                return sharedDataPath.resolve(customDataDir);
             }
         } else {
             throw new IllegalArgumentException("no custom " + IndexMetaData.SETTING_DATA_PATH + " setting available");

--- a/src/main/java/org/elasticsearch/node/Node.java
+++ b/src/main/java/org/elasticsearch/node/Node.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.node;
 
 import org.elasticsearch.Build;
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionModule;
 import org.elasticsearch.cache.recycler.PageCacheRecycler;
@@ -142,8 +141,9 @@ public class Node implements Releasable {
 
         if (logger.isDebugEnabled()) {
             Environment env = tuple.v2();
-            logger.debug("using home [{}], config [{}], data [{}], logs [{}], plugins [{}]",
-                    env.homeFile(), env.configFile(), Arrays.toString(env.dataFiles()), env.logsFile(), env.pluginsFile());
+            logger.debug("using home [{}], config [{}], data [{}], shared_data [{}], logs [{}], plugins [{}]",
+                    env.homeFile(), env.configFile(), Arrays.toString(env.dataFiles()),
+                    env.sharedDataFile(), env.logsFile(), env.pluginsFile());
         }
 
         this.pluginsService = new PluginsService(tuple.v1(), tuple.v2());


### PR DESCRIPTION
This allows `path.shared_data` to be added to the security manager while
still allowing a custom `data_path` for indices using shadow replicas.

For example, configuring `path.shared_data: /tmp/foo`, then created an
index with:

```
POST /myindex
{
  "index": {
    "number_of_shards": 1,
    "number_of_replicas": 1,
    "data_path": "bar/baz",
    "shadow_replicas": true
  }
}
```

The index will then reside in `/tmp/foo/bar/baz`.

`path.shared_data` defaults to `${path.home}/data` if not specified.
