### PR TITLE
`require_field_match` now defaults to `true`

### DIFF
--- a/docs/reference/migration/migrate_2_0.asciidoc
+++ b/docs/reference/migration/migrate_2_0.asciidoc
@@ -508,3 +508,9 @@ Settings settings = ImmutableSettings.settingsBuilder()
         .put("cluster.name", "myClusterName").build();
 Client client = TransportClient.builder().settings(settings).build();
 --------------------------------------------------
+
+=== Highlighting
+
+The default value for the `require_field_match` option is `false` rather than
+`true`, meaning that the highlighters will take the fields that were queried
+into account by default, unless `require_field_match` is disabled.

--- a/docs/reference/migration/migrate_2_0.asciidoc
+++ b/docs/reference/migration/migrate_2_0.asciidoc
@@ -511,6 +511,11 @@ Client client = TransportClient.builder().settings(settings).build();
 
 === Highlighting
 
-The default value for the `require_field_match` option is `false` rather than
-`true`, meaning that the highlighters will take the fields that were queried
-into account by default, unless `require_field_match` is disabled.
+The default value for the `require_field_match` option is `true` rather than
+`false`, meaning that the highlighters will take the fields that were queried
+into account by default. That means for instance that highlighting any field
+when querying the `_all` field will produce no highlighted snippets by default,
+given that the match was on the `_all` field only. Querying the same fields
+that need to be highlighted is the cleaner solution to get back highlighted
+snippets. Otherwise `require_field_match` option can be set to `false` to
+ignore field names completely when highlighting.

--- a/docs/reference/search/request/highlighting.asciidoc
+++ b/docs/reference/search/request/highlighting.asciidoc
@@ -406,10 +406,10 @@ at the field level.
 [[field-match]]
 ==== Require Field Match
 
-`require_field_match` can be set to `true` which will cause a field to
-be highlighted only if a query matched that field. `false` means that
-terms are highlighted on all requested fields regardless if the query
-matches specifically on them.
+`require_field_match` can be set to `false` which will cause any field to
+be highlighted regardless of whether the query matched specifically on them.
+The default behaviour is `true`, meaning that only fields that hold a query
+match will be highlighted.
 
 [[boundary-characters]]
 ==== Boundary Characters

--- a/src/main/java/org/elasticsearch/search/highlight/HighlighterParseElement.java
+++ b/src/main/java/org/elasticsearch/search/highlight/HighlighterParseElement.java
@@ -82,7 +82,7 @@ public class HighlighterParseElement implements SearchParseElement {
 
         final SearchContextHighlight.FieldOptions.Builder globalOptionsBuilder = new SearchContextHighlight.FieldOptions.Builder()
                 .preTags(DEFAULT_PRE_TAGS).postTags(DEFAULT_POST_TAGS).scoreOrdered(false).highlightFilter(false)
-                .requireFieldMatch(false).forceSource(false).fragmentCharSize(100).numberOfFragments(5)
+                .requireFieldMatch(true).forceSource(false).fragmentCharSize(100).numberOfFragments(5)
                 .encoder("default").boundaryMaxScan(SimpleBoundaryScanner.DEFAULT_MAX_SCAN)
                 .boundaryChars(SimpleBoundaryScanner.DEFAULT_BOUNDARY_CHARS)
                 .noMatchSize(0).phraseLimit(256);

--- a/src/test/java/org/elasticsearch/search/highlight/HighlighterSearchTests.java
+++ b/src/test/java/org/elasticsearch/search/highlight/HighlighterSearchTests.java
@@ -1879,7 +1879,7 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
 
         logger.info("--> searching on _all, highlighting on field1");
         source = searchSource()
-                .query(termQuery("field1", "test"))
+                .query(termQuery("_all", "test"))
                 .highlight(highlight().field("field1").preTags("<xxx>").postTags("</xxx>").requireFieldMatch(false));
 
         searchResponse = client().search(searchRequest("test").source(source)).actionGet();
@@ -1888,7 +1888,7 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
 
         logger.info("--> searching on _all, highlighting on field2");
         source = searchSource()
-                .query(termQuery("field2", "quick"))
+                .query(termQuery("_all", "quick"))
                 .highlight(highlight().field("field2").order("score").preTags("<xxx>").postTags("</xxx>").requireFieldMatch(false));
 
         searchResponse = client().search(searchRequest("test").source(source)).actionGet();
@@ -1897,7 +1897,7 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
 
         logger.info("--> searching on _all, highlighting on field2");
         source = searchSource()
-                .query(matchPhraseQuery("field2", "quick brown"))
+                .query(matchPhraseQuery("_all", "quick brown"))
                 .highlight(highlight().field("field2").preTags("<xxx>").postTags("</xxx>").requireFieldMatch(false));
 
         searchResponse = client().search(searchRequest("test").source(source)).actionGet();
@@ -1908,8 +1908,8 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
         //lets fall back to the standard highlighter then, what people would do to highlight query matches
         logger.info("--> searching on _all, highlighting on field2, falling back to the plain highlighter");
         source = searchSource()
-                .query(matchPhraseQuery("field2", "quick brown"))
-                .highlight(highlight().field("field2").preTags("<xxx>").postTags("</xxx>").highlighterType("highlighter"));
+                .query(matchPhraseQuery("_all", "quick brown"))
+                .highlight(highlight().field("field2").preTags("<xxx>").postTags("</xxx>").highlighterType("highlighter").requireFieldMatch(false));
 
         searchResponse = client().search(searchRequest("test").source(source)).actionGet();
 


### PR DESCRIPTION
The default `false` for `require_field_match` is a bit odd and confusing for users, given that field names get ignored by default and every field gets highlighted if it contains terms extracted out of the query, regardless of which fields were queried. Changed the default to `true`, it can always be customized per request.

Closes #10627
