### PR TITLE
Fixes for #11044,  #11076, #11081 revoked #11038 (discuss and decline)

### DIFF
--- a/bin/elasticsearch
+++ b/bin/elasticsearch
@@ -54,6 +54,18 @@
 # environment variables.
 
 
+# We have to allow launch ES in Windows with bash (msys for ex) here it's adaptation of elasticsearch.bat
+if [[ $OSTYPE = *win* || $OSTYPE = msys ]]; then
+	echo "NOTICE: Launch simplifyed developer config for Windows"
+	# determine elasticsearch home
+	ES_HOME=`dirname "$0"`/..
+	# make ELASTICSEARCH_HOME absolute and windows-style
+	ES_HOME=$(cd "$ES_HOME"; pwd | sed -e 's/^\///' -e 's/\//\\/g' -e 's/^./\0:/')
+	. $ES_HOME/bin/elasticsearch.in.sh
+	"$JAVA_HOME/bin/java.exe" $JAVA_OPTS $ES_JAVA_OPTS $ES_PARAMS -cp "$ES_CLASSPATH" "org.elasticsearch.bootstrap.Elasticsearch"
+	exit $?;
+fi
+
 # Maven will replace the project.name with elasticsearch below. If that
 # hasn't been done, we assume that this is not a packaged version and the
 # user has forgotten to run Maven to create a package.

--- a/bin/elasticsearch.in.bat
+++ b/bin/elasticsearch.in.bat
@@ -85,5 +85,5 @@ set JAVA_OPTS=%JAVA_OPTS% -XX:+DisableExplicitGC
 REM Ensure UTF-8 encoding by default (e.g. filenames)
 set JAVA_OPTS=%JAVA_OPTS% -Dfile.encoding=UTF-8
 
-set ES_CLASSPATH=%ES_CLASSPATH%;%ES_HOME%/${project.build.finalName}.jar;%ES_HOME%/lib/${project.build.finalName}.jar;%ES_HOME%/lib/*;%ES_HOME%/lib/sigar/*
+set ES_CLASSPATH=%ES_CLASSPATH%;%ES_HOME%/lib/${project.build.finalName}.jar;%ES_HOME%/lib/*;%ES_HOME%/lib/sigar/*
 set ES_PARAMS=-Delasticsearch -Des-foreground=yes -Des.path.home="%ES_HOME%"

--- a/bin/elasticsearch.in.bat
+++ b/bin/elasticsearch.in.bat
@@ -85,5 +85,5 @@ set JAVA_OPTS=%JAVA_OPTS% -XX:+DisableExplicitGC
 REM Ensure UTF-8 encoding by default (e.g. filenames)
 set JAVA_OPTS=%JAVA_OPTS% -Dfile.encoding=UTF-8
 
-set ES_CLASSPATH=%ES_CLASSPATH%;%ES_HOME%/lib/${project.build.finalName}.jar;%ES_HOME%/lib/*;%ES_HOME%/lib/sigar/*
+set ES_CLASSPATH=%ES_CLASSPATH%;%ES_HOME%/${project.build.finalName}.jar;%ES_HOME%/lib/${project.build.finalName}.jar;%ES_HOME%/lib/*;%ES_HOME%/lib/sigar/*
 set ES_PARAMS=-Delasticsearch -Des-foreground=yes -Des.path.home="%ES_HOME%"

--- a/bin/elasticsearch.in.sh
+++ b/bin/elasticsearch.in.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if  [[ $OSTYPE = *win* || $OSTYPE = msys ]]; then
-	ES_CLASSPATH="$ES_HOME\\${project.build.finalName}.jar;$ES_HOME\\lib\\${project.build.finalName}.jar;$ES_HOME\\lib\\*;$ES_HOME\\lib\\sigar\\*"
+	ES_CLASSPATH="$ES_HOME\\lib\\${project.build.finalName}.jar;$ES_HOME\\lib\\*;$ES_HOME\\lib\\sigar\\*"
 else
 	ES_CLASSPATH="$ES_CLASSPATH:$ES_HOME/${project.build.finalName}.jar:$ES_HOME/lib/${project.build.finalName}.jar:$ES_HOME/lib/*:$ES_HOME/lib/sigar/*"
 fi

--- a/bin/elasticsearch.in.sh
+++ b/bin/elasticsearch.in.sh
@@ -3,7 +3,7 @@
 if  [[ $OSTYPE = *win* || $OSTYPE = msys ]]; then
 	ES_CLASSPATH="$ES_HOME\\lib\\${project.build.finalName}.jar;$ES_HOME\\lib\\*;$ES_HOME\\lib\\sigar\\*"
 else
-	ES_CLASSPATH="$ES_CLASSPATH:$ES_HOME/${project.build.finalName}.jar:$ES_HOME/lib/${project.build.finalName}.jar:$ES_HOME/lib/*:$ES_HOME/lib/sigar/*"
+	ES_CLASSPATH="$ES_CLASSPATH:$ES_HOME/lib/${project.build.finalName}.jar:$ES_HOME/lib/*:$ES_HOME/lib/sigar/*"
 fi
 
 if [ "x$ES_MIN_MEM" = "x" ]; then

--- a/bin/elasticsearch.in.sh
+++ b/bin/elasticsearch.in.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 
-ES_CLASSPATH="$ES_CLASSPATH:$ES_HOME/lib/${project.build.finalName}.jar:$ES_HOME/lib/*:$ES_HOME/lib/sigar/*"
+if  [[ $OSTYPE = *win* || $OSTYPE = msys ]]; then
+	ES_CLASSPATH="$ES_HOME\\${project.build.finalName}.jar;$ES_HOME\\lib\\${project.build.finalName}.jar;$ES_HOME\\lib\\*;$ES_HOME\\lib\\sigar\\*"
+else
+	ES_CLASSPATH="$ES_CLASSPATH:$ES_HOME/${project.build.finalName}.jar:$ES_HOME/lib/${project.build.finalName}.jar:$ES_HOME/lib/*:$ES_HOME/lib/sigar/*"
+fi
 
 if [ "x$ES_MIN_MEM" = "x" ]; then
     ES_MIN_MEM=${packaging.elasticsearch.heap.min}
@@ -68,3 +72,8 @@ JAVA_OPTS="$JAVA_OPTS -XX:+DisableExplicitGC"
 
 # Ensure UTF-8 encoding by default (e.g. filenames)
 JAVA_OPTS="$JAVA_OPTS -Dfile.encoding=UTF-8"
+
+# For windows we must set ES_PARAMS same as in elasticsearch.in.bat
+if  [[ $OSTYPE = *win* || $OSTYPE = msys ]]; then
+	ES_PARAMS=" -Delasticsearch -Des-foreground=yes -Des.path.home=$ES_HOME "
+fi

--- a/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeRequest.java
@@ -48,6 +48,8 @@ public class AnalyzeRequest extends SingleCustomOperationRequest<AnalyzeRequest>
 
     private String field;
 
+    private String alldata;
+
     AnalyzeRequest() {
 
     }
@@ -63,6 +65,15 @@ public class AnalyzeRequest extends SingleCustomOperationRequest<AnalyzeRequest>
 
     public String text() {
         return this.text;
+    }
+
+    public boolean allData(){
+        return alldata!=null && (alldata.equals("1") || alldata.equalsIgnoreCase("true") );
+    }
+
+    public AnalyzeRequest allData(String alldataparam) {
+        this.alldata = alldataparam;
+        return this;
     }
 
     public AnalyzeRequest text(String text) {
@@ -139,6 +150,7 @@ public class AnalyzeRequest extends SingleCustomOperationRequest<AnalyzeRequest>
         tokenFilters = in.readStringArray();
         charFilters = in.readStringArray();
         field = in.readOptionalString();
+        alldata = in.readOptionalString();
     }
 
     @Override
@@ -150,5 +162,6 @@ public class AnalyzeRequest extends SingleCustomOperationRequest<AnalyzeRequest>
         out.writeStringArray(tokenFilters);
         out.writeStringArray(charFilters);
         out.writeOptionalString(field);
+        out.writeOptionalString(alldata);
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeResponse.java
@@ -42,16 +42,31 @@ public class AnalyzeResponse extends ActionResponse implements Iterable<AnalyzeR
         private int endOffset;
         private int position;
         private String type;
+        private int flags;
+        private int increment;
+        private String payload;
+        private boolean keyword;
+        private boolean alldata;
 
         AnalyzeToken() {
         }
 
         public AnalyzeToken(String term, int position, int startOffset, int endOffset, String type) {
+            this(false,term,position,startOffset,endOffset,type,0,0,false,""); //keep initial sygnaure for back compatibility
+        }
+
+        public AnalyzeToken(boolean alldata,String term, int position, int startOffset, int endOffset, String type,
+                            int flags,int increment,boolean keyword, String payload) {
+            this.alldata = alldata;
             this.term = term;
             this.position = position;
             this.startOffset = startOffset;
             this.endOffset = endOffset;
+            this.flags = flags;
             this.type = type;
+            this.increment = increment;
+            this.payload =payload;
+            this.keyword = keyword;
         }
 
         public String getTerm() {
@@ -70,6 +85,13 @@ public class AnalyzeResponse extends ActionResponse implements Iterable<AnalyzeR
             return this.position;
         }
 
+        public int getFlags() { return  this.flags; }
+        public boolean isAlldata() { return  this.alldata; }
+
+        public int getIncrement() { return  this.increment; }
+        public boolean getKeyword() { return  this.keyword; }
+        public String getPayload() { return  this.payload; }
+
         public String getType() {
             return this.type;
         }
@@ -82,20 +104,31 @@ public class AnalyzeResponse extends ActionResponse implements Iterable<AnalyzeR
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
+            alldata = in.readBoolean();
             term = in.readString();
             startOffset = in.readInt();
             endOffset = in.readInt();
             position = in.readVInt();
             type = in.readOptionalString();
+            flags = in.readInt();
+            increment = in.readInt();
+            keyword = in.readBoolean();
+            payload = in.readOptionalString();
+
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
+            out.writeBoolean(alldata);
             out.writeString(term);
             out.writeInt(startOffset);
             out.writeInt(endOffset);
             out.writeVInt(position);
             out.writeOptionalString(type);
+            out.writeInt(flags);
+            out.writeInt(increment);
+            out.writeBoolean(keyword);
+            out.writeOptionalString(payload);
         }
     }
 
@@ -127,6 +160,12 @@ public class AnalyzeResponse extends ActionResponse implements Iterable<AnalyzeR
             builder.field(Fields.END_OFFSET, token.getEndOffset());
             builder.field(Fields.TYPE, token.getType());
             builder.field(Fields.POSITION, token.getPosition());
+            if(token.isAlldata()) {
+                builder.field(Fields.FLAGS, token.getFlags());
+                builder.field(Fields.INCREMENT, token.getIncrement());
+                builder.field(Fields.KEYWORD, token.getKeyword());
+                builder.field(Fields.PAYLOAD, token.getPayload());
+            }
             builder.endObject();
         }
         builder.endArray();
@@ -159,5 +198,9 @@ public class AnalyzeResponse extends ActionResponse implements Iterable<AnalyzeR
         static final XContentBuilderString END_OFFSET = new XContentBuilderString("end_offset");
         static final XContentBuilderString TYPE = new XContentBuilderString("type");
         static final XContentBuilderString POSITION = new XContentBuilderString("position");
+        static final XContentBuilderString FLAGS = new XContentBuilderString("flags");
+        static final XContentBuilderString INCREMENT = new XContentBuilderString("increment");
+        static final XContentBuilderString KEYWORD = new XContentBuilderString("keyword");
+        static final XContentBuilderString PAYLOAD = new XContentBuilderString("payload");
     }
 }

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/analyze/RestAnalyzeAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/analyze/RestAnalyzeAction.java
@@ -59,6 +59,7 @@ public class RestAnalyzeAction extends BaseRestHandler {
 
         AnalyzeRequest analyzeRequest = new AnalyzeRequest(request.param("index"));
         analyzeRequest.text(text);
+        analyzeRequest.allData(request.param("alldata"));
         analyzeRequest.preferLocal(request.paramAsBoolean("prefer_local", analyzeRequest.preferLocalShard()));
         analyzeRequest.analyzer(request.param("analyzer"));
         analyzeRequest.field(request.param("field"));

--- a/src/test/java/org/elasticsearch/cluster/metadata/MetaDataBuilderTests.java
+++ b/src/test/java/org/elasticsearch/cluster/metadata/MetaDataBuilderTests.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.cluster.metadata;
+
+import com.sun.xml.internal.ws.api.config.management.policy.ManagementAssertion;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.junit.Test;
+import org.junit.Assert.*;
+
+/**
+ * Created by comdiv on 10.05.2015.
+ */
+public class MetaDataBuilderTests extends ElasticsearchTestCase {
+    @Test
+    public void CanUpdateSettings(){
+        ImmutableSettings.Builder targetBuilder = ImmutableSettings.settingsBuilder();
+        targetBuilder.put("a","1");
+        targetBuilder.put("b","2");
+        Settings target = targetBuilder.build();
+        ImmutableSettings.Builder sourceBuilder = ImmutableSettings.settingsBuilder();
+        sourceBuilder.put("a","3");
+        sourceBuilder.put("c","4");
+        Settings source = sourceBuilder.build();
+        Settings merged = MetaData.Builder.getUpdatedSettings(source,target);
+        assertNotSame("it's new instance",merged,source);
+        assertNotSame("it's new instance",merged,target);
+        assertEquals("3", merged.get("a"));
+        assertEquals("2", merged.get("b"));
+        assertEquals("4",merged.get("c"));
+    }
+
+    @Test
+    public void SupportSettingRemoval(){
+        ImmutableSettings.Builder targetBuilder = ImmutableSettings.settingsBuilder();
+        targetBuilder.put("a","1");
+        targetBuilder.put("b","2");
+        Settings target = targetBuilder.build();
+        ImmutableSettings.Builder sourceBuilder = ImmutableSettings.settingsBuilder();
+        sourceBuilder.put("a","__REMOVE__");
+        sourceBuilder.put("c","4");
+        Settings source = sourceBuilder.build();
+        Settings merged = MetaData.Builder.getUpdatedSettings(source,target);
+        assertFalse(merged.getAsStructuredMap().containsKey("a"));
+        assertEquals("2",merged.get("b"));
+        assertEquals("4",merged.get("c"));
+    }
+
+    @Test
+    public void SupportHierarhicalSettingRemoval(){
+        ImmutableSettings.Builder targetBuilder = ImmutableSettings.settingsBuilder();
+        targetBuilder.put("a.x","1");
+        targetBuilder.put("a.y","2");
+        targetBuilder.put("b","2");
+        Settings target = targetBuilder.build();
+        ImmutableSettings.Builder sourceBuilder = ImmutableSettings.settingsBuilder();
+        sourceBuilder.put("a","__REMOVE__");
+        sourceBuilder.put("c","4");
+        Settings source = sourceBuilder.build();
+        Settings merged = MetaData.Builder.getUpdatedSettings(source,target);
+        assertFalse(merged.getAsStructuredMap().containsKey("a"));
+        assertFalse(merged.getAsStructuredMap().containsKey("a.x"));
+        assertFalse(merged.getAsStructuredMap().containsKey("a.y"));
+        assertEquals("2",merged.get("b"));
+        assertEquals("4",merged.get("c"));
+    }
+}


### PR DESCRIPTION
Summary:
1) elasticsearch shell script will be usable from Windows msys bash without changes for Unix (#11044)

2) POST /index/_analyze now will have additional ?alldata=true parameter to allow include flags, increment, payload, keyword info in returned token's JSON  (#11076)

3) PUT /index/_settings now will have ability to completly remove parameters and sub-trees from
settings with special ```"__REMOVE__"``` value  (#11081)
#11076, #11081 have corresponded tests
