### PR TITLE
Upgrade the dependency on t-digest (3.0 -> 3.1)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -295,7 +295,7 @@
         <dependency>
             <groupId>com.tdunning</groupId>
             <artifactId>t-digest</artifactId>
-            <version>3.0</version>
+            <version>3.1</version>
             <scope>compile</scope>
         </dependency>
 

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/tdigest/TDigestState.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/tdigest/TDigestState.java
@@ -43,7 +43,7 @@ public class TDigestState extends AVLTreeDigest {
 
     public static void write(TDigestState state, StreamOutput out) throws IOException {
         out.writeDouble(state.compression);
-        out.writeVInt(state.centroidCount());
+        out.writeVInt(state.centroids().size());
         for (Centroid centroid : state.centroids()) {
             out.writeDouble(centroid.mean());
             out.writeVLong(centroid.count());


### PR DESCRIPTION
Hi,

t-digest 3.1 has a minor incompatibility with the version 3.0 currently used by Elasticsearch, here is a patch fixing it.
