### PR TITLE
fix #11086 termvector missing paths on 1.5 branch

### DIFF
--- a/rest-api-spec/api/termvector.json
+++ b/rest-api-spec/api/termvector.json
@@ -3,8 +3,8 @@
     "documentation" : "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html",
     "methods" : ["GET", "POST"],
     "url" : {
-      "path" : "/{index}/{type}/{id}/_termvector",
-      "paths" : ["/{index}/{type}/{id}/_termvector"],
+      "path" : "/{index}/{type}/_termvector",
+      "paths" : ["/{index}/{type}/_termvector", "/{index}/{type}/{id}/_termvector"],
       "parts" : {
         "index" : {
          "type" : "string",
@@ -18,8 +18,7 @@
         },
         "id" : {
            "type" : "string",
-           "description" : "The id of the document.",
-           "required" : true
+           "description" : "The id of the document."
          }
       },
       "params": {


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/pull/7530 introduced support for artificial documents

I submitted a PR to both es [master](https://github.com/elastic/elasticsearch/pull/8868/files) and [1.4](https://github.com/elastic/elasticsearch/pull/8869/files) branches but they are no longer reflected in the [1.5](https://github.com/elastic/elasticsearch/blob/v1.5.0/rest-api-spec/api/termvector.json) branch.
