### PR TITLE
Fix geo bounds aggregation when longitude is 0

### DIFF
--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/geobounds/GeoBoundsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/geobounds/GeoBoundsAggregator.java
@@ -115,11 +115,11 @@ public final class GeoBoundsAggregator extends MetricsAggregator {
                         bottom = value.lat();
                     }
                     double posLeft = posLefts.get(bucket);
-                    if (value.lon() > 0 && value.lon() < posLeft) {
+                    if (value.lon() >= 0 && value.lon() < posLeft) {
                         posLeft = value.lon();
                     }
                     double posRight = posRights.get(bucket);
-                    if (value.lon() > 0 && value.lon() > posRight) {
+                    if (value.lon() >= 0 && value.lon() > posRight) {
                         posRight = value.lon();
                     }
                     double negLeft = negLefts.get(bucket);

--- a/src/test/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsTests.java
@@ -156,6 +156,10 @@ public class GeoBoundsTests extends ElasticsearchIntegrationTest {
                     .endObject()));
         }
 
+        builders.add(client().prepareIndex("idx_zero", "type").setSource(
+                jsonBuilder().startObject().array(SINGLE_VALUED_FIELD_NAME, 0.0, 1.0).endObject()));
+        assertAcked(prepareCreate("idx_zero").addMapping("type", SINGLE_VALUED_FIELD_NAME, "type=geo_point"));
+
         indexRandom(true, builders);
         ensureSearchable();
 
@@ -413,6 +417,24 @@ public class GeoBoundsTests extends ElasticsearchIntegrationTest {
             assertThat(geoBounds.bottomRight().getLat(), allOf(greaterThanOrEqualTo(-90.0), lessThanOrEqualTo(90.0)));
             assertThat(geoBounds.bottomRight().getLon(), allOf(greaterThanOrEqualTo(-180.0), lessThanOrEqualTo(180.0)));
         }
+    }
+
+    @Test
+    public void singleValuedFieldWithZeroLon() throws Exception {
+        SearchResponse response = client().prepareSearch("idx_zero")
+                .addAggregation(geoBounds("geoBounds").field(SINGLE_VALUED_FIELD_NAME).wrapLongitude(false)).execute().actionGet();
+
+        assertSearchResponse(response);
+
+        GeoBounds geoBounds = response.getAggregations().get("geoBounds");
+        assertThat(geoBounds, notNullValue());
+        assertThat(geoBounds.getName(), equalTo("geoBounds"));
+        GeoPoint topLeft = geoBounds.topLeft();
+        GeoPoint bottomRight = geoBounds.bottomRight();
+        assertThat(topLeft.lat(), equalTo(1.0));
+        assertThat(topLeft.lon(), equalTo(0.0));
+        assertThat(bottomRight.lat(), equalTo(1.0));
+        assertThat(bottomRight.lon(), equalTo(0.0));
     }
 
 }


### PR DESCRIPTION
When the longitude is zero for a document, the left and right bounds do not get updated in the geo bounds aggregation which can cause the bounds to be returned with Infinite values for longitude

Closes #11085
