### PR TITLE
Async fetch of shard started and store during allocation

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthResponse.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.admin.cluster.health;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
@@ -57,6 +58,7 @@ public class ClusterHealthResponse extends ActionResponse implements Iterable<Cl
     int initializingShards = 0;
     int unassignedShards = 0;
     int numberOfPendingTasks = 0;
+    int numberOfInFlightFetch = 0;
     boolean timedOut = false;
     ClusterHealthStatus status = ClusterHealthStatus.RED;
     private List<String> validationFailures;
@@ -67,12 +69,14 @@ public class ClusterHealthResponse extends ActionResponse implements Iterable<Cl
 
     /** needed for plugins BWC */
     public ClusterHealthResponse(String clusterName, String[] concreteIndices, ClusterState clusterState) {
-        this(clusterName, concreteIndices, clusterState, -1);
+        this(clusterName, concreteIndices, clusterState, -1, -1);
     }
 
-    public ClusterHealthResponse(String clusterName, String[] concreteIndices, ClusterState clusterState, int numberOfPendingTasks) {
+    public ClusterHealthResponse(String clusterName, String[] concreteIndices, ClusterState clusterState, int numberOfPendingTasks,
+                                 int numberOfInFlightFetch) {
         this.clusterName = clusterName;
         this.numberOfPendingTasks = numberOfPendingTasks;
+        this.numberOfInFlightFetch = numberOfInFlightFetch;
         RoutingTableValidation validation = clusterState.routingTable().validate(clusterState.metaData());
         validationFailures = validation.failures();
         numberOfNodes = clusterState.nodes().size();
@@ -166,6 +170,10 @@ public class ClusterHealthResponse extends ActionResponse implements Iterable<Cl
         return this.numberOfPendingTasks;
     }
 
+    public int getNumberOfInFlightFetch() {
+        return this.numberOfInFlightFetch;
+    }
+
     /**
      * <tt>true</tt> if the waitForXXX has timeout out and did not match.
      */
@@ -220,6 +228,10 @@ public class ClusterHealthResponse extends ActionResponse implements Iterable<Cl
                 validationFailures.add(in.readString());
             }
         }
+
+        if (in.getVersion().onOrAfter(Version.V_1_6_0)) {
+            numberOfInFlightFetch = in.readInt();
+        }
     }
 
     @Override
@@ -245,6 +257,10 @@ public class ClusterHealthResponse extends ActionResponse implements Iterable<Cl
         for (String failure : validationFailures) {
             out.writeString(failure);
         }
+
+        if (out.getVersion().onOrAfter(Version.V_1_6_0)) {
+            out.writeInt(numberOfInFlightFetch);
+        }
     }
 
 
@@ -268,6 +284,7 @@ public class ClusterHealthResponse extends ActionResponse implements Iterable<Cl
         static final XContentBuilderString NUMBER_OF_NODES = new XContentBuilderString("number_of_nodes");
         static final XContentBuilderString NUMBER_OF_DATA_NODES = new XContentBuilderString("number_of_data_nodes");
         static final XContentBuilderString NUMBER_OF_PENDING_TASKS = new XContentBuilderString("number_of_pending_tasks");
+        static final XContentBuilderString NUMBER_OF_IN_FLIGHT_FETCH = new XContentBuilderString("number_of_in_flight_fetch");
         static final XContentBuilderString ACTIVE_PRIMARY_SHARDS = new XContentBuilderString("active_primary_shards");
         static final XContentBuilderString ACTIVE_SHARDS = new XContentBuilderString("active_shards");
         static final XContentBuilderString RELOCATING_SHARDS = new XContentBuilderString("relocating_shards");
@@ -290,6 +307,7 @@ public class ClusterHealthResponse extends ActionResponse implements Iterable<Cl
         builder.field(Fields.INITIALIZING_SHARDS, getInitializingShards());
         builder.field(Fields.UNASSIGNED_SHARDS, getUnassignedShards());
         builder.field(Fields.NUMBER_OF_PENDING_TASKS, getNumberOfPendingTasks());
+        builder.field(Fields.NUMBER_OF_IN_FLIGHT_FETCH, getNumberOfInFlightFetch());
 
         String level = params.param("level", "cluster");
         boolean outputIndices = "indices".equals(level) || "shards".equals(level);

--- a/src/main/java/org/elasticsearch/action/support/nodes/NodesOperationResponse.java
+++ b/src/main/java/org/elasticsearch/action/support/nodes/NodesOperationResponse.java
@@ -21,7 +21,9 @@ package org.elasticsearch.action.support.nodes;
 
 import com.google.common.collect.Maps;
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -44,6 +46,14 @@ public abstract class NodesOperationResponse<NodeResponse extends NodeOperationR
     protected NodesOperationResponse(ClusterName clusterName, NodeResponse[] nodes) {
         this.clusterName = clusterName;
         this.nodes = nodes;
+    }
+
+    /**
+     * The failed nodes, if set to be captured.
+     */
+    @Nullable
+    public FailedNodeException[] failures() {
+        return null;
     }
 
     public ClusterName getClusterName() {

--- a/src/main/java/org/elasticsearch/cluster/routing/allocation/RoutingAllocation.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/allocation/RoutingAllocation.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.cluster.routing.allocation;
 
+import com.google.common.collect.ImmutableSet;
 import org.elasticsearch.cluster.ClusterInfo;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
@@ -215,6 +216,17 @@ public class RoutingAllocation {
         }
         Set<String> nodes = ignoredShardToNodes.get(shardId);
         return nodes != null && nodes.contains(nodeId);
+    }
+
+    public Set<String> getIgnoreNodes(ShardId shardId) {
+        if (ignoredShardToNodes == null) {
+            return ImmutableSet.of();
+        }
+        Set<String> ignore = ignoredShardToNodes.get(shardId);
+        if (ignore == null) {
+            return ImmutableSet.of();
+        }
+        return ImmutableSet.copyOf(ignore);
     }
 
     /**

--- a/src/main/java/org/elasticsearch/gateway/AsyncShardFetch.java
+++ b/src/main/java/org/elasticsearch/gateway/AsyncShardFetch.java
@@ -1,0 +1,388 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.gateway;
+
+import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
+import com.google.common.collect.ImmutableSet;
+import org.elasticsearch.ElasticsearchTimeoutException;
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.FailedNodeException;
+import org.elasticsearch.action.support.nodes.NodeOperationResponse;
+import org.elasticsearch.action.support.nodes.NodesOperationResponse;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.lease.Releasable;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.transport.ReceiveTimeoutTransportException;
+
+import java.util.*;
+
+/**
+ * Allows to asynchronously fetch shard related data from other nodes for allocation, without blocking
+ * the cluster update thread.
+ * <p/>
+ * The async fetch logic maintains a map of which nodes are being fetched from in an async manner,
+ * and once the results are back, it makes sure to schedule a reroute to make sure those results will
+ * be taken into account.
+ */
+public abstract class AsyncShardFetch<T extends NodeOperationResponse> implements Releasable {
+
+    /**
+     * An action that lists the relevant shard data that needs to be fetched.
+     */
+    public interface List<NodesResponse extends NodesOperationResponse<NodeResponse>, NodeResponse extends NodeOperationResponse> {
+        void list(ShardId shardId, IndexMetaData indexMetaData, String[] nodesIds, ActionListener<NodesResponse> listener);
+    }
+
+    protected final ESLogger logger;
+    private final ShardId shardId;
+    private final List<NodesOperationResponse<T>, T> action;
+    private final Map<String, NodeEntry<T>> cache = new HashMap<>();
+    private final Set<String> nodesToIgnore = new HashSet<>();
+    private boolean closed;
+
+    @SuppressWarnings("unchecked")
+    protected AsyncShardFetch(ESLogger logger, ShardId shardId, List<? extends NodesOperationResponse<T>, T> action) {
+        this.logger = logger;
+        this.shardId = shardId;
+        this.action = (List<NodesOperationResponse<T>, T>) action;
+    }
+
+    public synchronized void close() {
+        this.closed = true;
+    }
+
+    /**
+     * Returns the number of async fetches that are currently ongoing.
+     */
+    public synchronized int getNumberOfInFlightFetches() {
+        int count = 0;
+        for (NodeEntry<T> nodeEntry : cache.values()) {
+            if (nodeEntry.isFetching()) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    /**
+     * Fetches the data for the relevant shard. If there any ongoing async fetches going on, or new ones have
+     * been initiated by this call, the result will have no data.
+     * <p/>
+     * The ignoreNodes are nodes that are supposed to be ignored for this round, since fetching is async, we need
+     * to keep them around and make sure we add them back when all the responses are fetched and returned.
+     */
+    public synchronized FetchResult<T> fetchData(DiscoveryNodes nodes, MetaData metaData, Set<String> ignoreNodes) {
+        if (closed) {
+            throw new IllegalStateException(shardId + ": can't fetch data on closed async fetch");
+        }
+        nodesToIgnore.addAll(ignoreNodes);
+        fillShardCacheWithDataNodes(cache, nodes);
+        Set<NodeEntry<T>> nodesToFetch = findNodesToFetch(cache);
+        if (nodesToFetch.isEmpty() == false) {
+            // mark all node as fetching and go ahead and async fetch them
+            for (NodeEntry<T> nodeEntry : nodesToFetch) {
+                nodeEntry.markAsFetching();
+            }
+            String[] nodesIds = new String[nodesToFetch.size()];
+            int index = 0;
+            for (NodeEntry<T> nodeEntry : nodesToFetch) {
+                nodesIds[index++] = nodeEntry.getNodeId();
+            }
+            asyncFetch(shardId, nodesIds, metaData);
+        }
+
+        // if we are still fetching, return null to indicate it
+        if (hasAnyNodeFetching(cache) == true) {
+            return new FetchResult<>(shardId, null, ImmutableSet.<String>of(), ImmutableSet.<String>of());
+        } else {
+            // nothing to fetch, yay, build the return value
+            Map<DiscoveryNode, T> fetchData = new HashMap<>();
+            Set<String> failedNodes = new HashSet<>();
+            for (Iterator<Map.Entry<String, NodeEntry<T>>> it = cache.entrySet().iterator(); it.hasNext(); ) {
+                Map.Entry<String, NodeEntry<T>> entry = it.next();
+                String nodeId = entry.getKey();
+                NodeEntry<T> nodeEntry = entry.getValue();
+
+                DiscoveryNode node = nodes.get(nodeId);
+                if (node != null) {
+                    if (nodeEntry.isFailed() == true) {
+                        // if its failed, remove it from the list of nodes, so if this run doesn't work
+                        // we try again next round to fetch it again
+                        it.remove();
+                        failedNodes.add(nodeEntry.getNodeId());
+                    } else {
+                        if (nodeEntry.getValue() != null) {
+                            fetchData.put(node, nodeEntry.getValue());
+                        }
+                    }
+                }
+            }
+            Set<String> allIgnoreNodes = ImmutableSet.copyOf(nodesToIgnore);
+            // clear the nodes to ignore, we had a successful run in fetching everything we can
+            // we need to try them if another full run is needed
+            nodesToIgnore.clear();
+            // if at least one node failed, make sure to have a protective reroute
+            // here, just case this round won't find anything, and we need to retry fetching data
+            if (failedNodes.isEmpty() == false || allIgnoreNodes.isEmpty() == false) {
+                reroute(shardId, "at_least_one_node_failed");
+            }
+            return new FetchResult<>(shardId, fetchData, failedNodes, allIgnoreNodes);
+        }
+    }
+
+    /**
+     * Called by the response handler of the async action to fetch data. Verifies that its still working
+     * on the same cache generation, otherwise the results are discarded. It then goes and fills the relevant data for
+     * the shard (response + failures), issueing a reroute at the end of it to make sure there will be another round
+     * of allocations taking this new data into account.
+     */
+    protected synchronized void processAsyncFetch(ShardId shardId, T[] responses, FailedNodeException[] failures) {
+        if (closed) {
+            // we are closed, no need to process this async fetch at all
+            return;
+        }
+        if (responses != null) {
+            for (T response : responses) {
+                NodeEntry<T> nodeEntry = cache.get(response.getNode().getId());
+                // if the entry is there, and not marked as failed already, process it
+                if (nodeEntry != null && nodeEntry.isFailed() == false) {
+                    nodeEntry.doneFetching(response);
+                }
+            }
+        }
+        if (failures != null) {
+            for (FailedNodeException failure : failures) {
+                NodeEntry<T> nodeEntry = cache.get(failure.nodeId());
+                // if the entry is there, and not marked as failed already, process it
+                if (nodeEntry != null && nodeEntry.isFailed() == false) {
+                    Throwable unwrappedCause = ExceptionsHelper.unwrapCause(failure.getCause());
+                    // if the request got rejected or timed out, we need to try it again next time...
+                    if (unwrappedCause instanceof EsRejectedExecutionException || unwrappedCause instanceof ReceiveTimeoutTransportException || unwrappedCause instanceof ElasticsearchTimeoutException) {
+                        nodeEntry.restartFetching();
+                    } else {
+                        logger.warn("{}: failed to list shard for {} on node [{}]", failure, shardId, getClass().getSimpleName(), failure.nodeId());
+                        nodeEntry.doneFetching(failure.getCause());
+                    }
+                }
+            }
+        }
+        reroute(shardId, "post_response");
+    }
+
+    /**
+     * Implement this in order to scheduled another round that causes a call to fetch data.
+     */
+    protected abstract void reroute(ShardId shardId, String reason);
+
+    /**
+     * Fills the shard fetched data with new (data) nodes and a fresh NodeEntry, and removes from
+     * it nodes that are no longer part of the state.
+     */
+    private void fillShardCacheWithDataNodes(Map<String, NodeEntry<T>> shardCache, DiscoveryNodes nodes) {
+        // verify that all current data nodes are there
+        for (ObjectObjectCursor<String, DiscoveryNode> cursor : nodes.dataNodes()) {
+            DiscoveryNode node = cursor.value;
+            if (shardCache.containsKey(node.getId()) == false) {
+                shardCache.put(node.getId(), new NodeEntry<T>(node.getId()));
+            }
+        }
+        // remove nodes that are not longer part of the data nodes set
+        for (Iterator<String> it = shardCache.keySet().iterator(); it.hasNext(); ) {
+            String nodeId = it.next();
+            if (nodes.nodeExists(nodeId) == false) {
+                it.remove();
+            }
+        }
+    }
+
+    /**
+     * Finds all the nodes that need to be fetched. Those are nodes that have no
+     * data, and are not in fetch mode.
+     */
+    private Set<NodeEntry<T>> findNodesToFetch(Map<String, NodeEntry<T>> shardCache) {
+        Set<NodeEntry<T>> nodesToFetch = new HashSet<>();
+        for (NodeEntry<T> nodeEntry : shardCache.values()) {
+            if (nodeEntry.hasData() == false && nodeEntry.isFetching() == false) {
+                nodesToFetch.add(nodeEntry);
+            }
+        }
+        return nodesToFetch;
+    }
+
+    /**
+     * Are there any nodes that are fetching data?
+     */
+    private boolean hasAnyNodeFetching(Map<String, NodeEntry<T>> shardCache) {
+        for (NodeEntry<T> nodeEntry : shardCache.values()) {
+            if (nodeEntry.isFetching()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Async fetches data for the provided shard with the set of nodes that need to be fetched from.
+     */
+    // visible for testing
+    void asyncFetch(final ShardId shardId, final String[] nodesIds, final MetaData metaData) {
+        IndexMetaData indexMetaData = metaData.index(shardId.getIndex());
+        action.list(shardId, indexMetaData, nodesIds, new ActionListener<NodesOperationResponse<T>>() {
+            @Override
+            public void onResponse(NodesOperationResponse<T> response) {
+                processAsyncFetch(shardId, response.getNodes(), response.failures());
+            }
+
+            @Override
+            public void onFailure(Throwable e) {
+                FailedNodeException[] failures = new FailedNodeException[nodesIds.length];
+                for (int i = 0; i < failures.length; i++) {
+                    failures[i] = new FailedNodeException(nodesIds[i], "total failure in fetching", e);
+                }
+                processAsyncFetch(shardId, null, failures);
+            }
+        });
+    }
+
+    /**
+     * The result of a fetch operation. Make sure to first check {@link #hasData()} before
+     * fetching the actual data.
+     */
+    public static class FetchResult<T extends NodeOperationResponse> {
+
+        private final ShardId shardId;
+        private final Map<DiscoveryNode, T> data;
+        private final Set<String> failedNodes;
+        private final Set<String> ignoreNodes;
+
+        public FetchResult(ShardId shardId, Map<DiscoveryNode, T> data, Set<String> failedNodes, Set<String> ignoreNodes) {
+            this.shardId = shardId;
+            this.data = data;
+            this.failedNodes = failedNodes;
+            this.ignoreNodes = ignoreNodes;
+        }
+
+        /**
+         * Does the result actually contain data? If not, then there are on going fetch
+         * operations happening, and it should wait for it.
+         */
+        public boolean hasData() {
+            return data != null;
+        }
+
+        /**
+         * Returns the actual data, note, make sure to check {@link #hasData()} first and
+         * only use this when there is an actual data.
+         */
+        public Map<DiscoveryNode, T> getData() {
+            assert data != null : "getData should only be called if there is data to be fetched, please check hasData first";
+            return this.data;
+        }
+
+        /**
+         * Process any changes needed to the allocation based on this fetch result.
+         */
+        public void processAllocation(RoutingAllocation allocation) {
+            for (String ignoreNode : ignoreNodes) {
+                allocation.addIgnoreShardForNode(shardId, ignoreNode);
+            }
+        }
+    }
+
+    /**
+     * A node entry, holding the state of the fetched data for a specific shard
+     * for a giving node.
+     */
+    static class NodeEntry<T> {
+        private final String nodeId;
+        private boolean fetching;
+        @Nullable
+        private T value;
+        private boolean valueSet;
+        private Throwable failure;
+
+        public NodeEntry(String nodeId) {
+            this.nodeId = nodeId;
+        }
+
+        String getNodeId() {
+            return this.nodeId;
+        }
+
+        boolean isFetching() {
+            return fetching;
+        }
+
+        void markAsFetching() {
+            assert fetching == false : "double marking a node as fetching";
+            fetching = true;
+        }
+
+        void doneFetching(T value) {
+            assert fetching == true : "setting value but not in fetching mode";
+            assert failure == null : "setting value when failure already set";
+            this.valueSet = true;
+            this.value = value;
+            this.fetching = false;
+        }
+
+        void doneFetching(Throwable failure) {
+            assert fetching == true : "setting value but not in fetching mode";
+            assert valueSet == false : "setting failure when already set value";
+            assert failure != null : "setting failure can't be null";
+            this.failure = failure;
+            this.fetching = false;
+        }
+
+        void restartFetching() {
+            assert fetching == true : "restarting fetching, but not in fetching mode";
+            assert valueSet == false : "value can't be set when restarting fetching";
+            assert failure == null : "failure can't be set when restarting fetching";
+            this.fetching = false;
+        }
+
+        boolean isFailed() {
+            return failure != null;
+        }
+
+        boolean hasData() {
+            return valueSet == true || failure != null;
+        }
+
+        Throwable getFailure() {
+            assert hasData() : "getting failure when data has not been fetched";
+            return failure;
+        }
+
+        @Nullable
+        T getValue() {
+            assert failure == null : "trying to fetch value, but its marked as failed, check isFailed";
+            assert valueSet == true : "value is not set, hasn't been fetched yet";
+            return value;
+        }
+    }
+}

--- a/src/main/java/org/elasticsearch/gateway/GatewayAllocator.java
+++ b/src/main/java/org/elasticsearch/gateway/GatewayAllocator.java
@@ -20,15 +20,14 @@
 package org.elasticsearch.gateway;
 
 import com.carrotsearch.hppc.ObjectLongHashMap;
-import com.carrotsearch.hppc.ObjectHashSet;
 import com.carrotsearch.hppc.cursors.ObjectCursor;
-import com.carrotsearch.hppc.predicates.ObjectPredicate;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.apache.lucene.util.CollectionUtil;
-import org.elasticsearch.ExceptionsHelper;
-import org.elasticsearch.action.FailedNodeException;
+import org.elasticsearch.action.support.nodes.NodeOperationResponse;
+import org.elasticsearch.action.support.nodes.NodesOperationResponse;
+import org.elasticsearch.cluster.*;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -37,21 +36,23 @@ import org.elasticsearch.cluster.routing.MutableShardRouting;
 import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.RoutingNodes;
 import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.routing.allocation.FailedRerouteAllocation;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
 import org.elasticsearch.cluster.routing.allocation.StartedRerouteAllocation;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision;
+import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.lease.Releasables;
+import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
-import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.index.settings.IndexSettings;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.store.StoreFileMetaData;
 import org.elasticsearch.indices.store.TransportNodesListShardStoreMetaData;
-import org.elasticsearch.transport.ConnectTransportException;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentMap;
@@ -63,42 +64,74 @@ public class GatewayAllocator extends AbstractComponent {
 
     public static final String INDEX_RECOVERY_INITIAL_SHARDS = "index.recovery.initial_shards";
 
-    private final TransportNodesListGatewayStartedShards listGatewayStartedShards;
-
-    private final TransportNodesListShardStoreMetaData listShardStoreMetaData;
-
-    private final ConcurrentMap<ShardId, Map<DiscoveryNode, TransportNodesListShardStoreMetaData.StoreFilesMetaData>> cachedStores = ConcurrentCollections.newConcurrentMap();
-
-    private final ConcurrentMap<ShardId, ObjectLongHashMap<DiscoveryNode>> cachedShardsState = ConcurrentCollections.newConcurrentMap();
-
-    private final TimeValue listTimeout;
-
     private final String initialShards;
 
-    @Inject
-    public GatewayAllocator(Settings settings,
-                            TransportNodesListGatewayStartedShards listGatewayStartedShards, TransportNodesListShardStoreMetaData listShardStoreMetaData) {
-        super(settings);
-        this.listGatewayStartedShards = listGatewayStartedShards;
-        this.listShardStoreMetaData = listShardStoreMetaData;
+    private final TransportNodesListGatewayStartedShards startedAction;
+    private final TransportNodesListShardStoreMetaData storeAction;
+    private ClusterService clusterService;
+    private AllocationService allocationService;
 
-        this.listTimeout = settings.getAsTime("gateway.list_timeout", settings.getAsTime("gateway.local.list_timeout", TimeValue.timeValueSeconds(30)));
+    private final ConcurrentMap<ShardId, AsyncShardFetch<TransportNodesListGatewayStartedShards.NodeGatewayStartedShards>> asyncFetchStarted = ConcurrentCollections.newConcurrentMap();
+    private final ConcurrentMap<ShardId, AsyncShardFetch<TransportNodesListShardStoreMetaData.NodeStoreFilesMetaData>> asyncFetchStore = ConcurrentCollections.newConcurrentMap();
+
+    @Inject
+    public GatewayAllocator(Settings settings, TransportNodesListGatewayStartedShards startedAction, TransportNodesListShardStoreMetaData storeAction) {
+        super(settings);
+        this.startedAction = startedAction;
+        this.storeAction = storeAction;
+
         this.initialShards = settings.get("gateway.initial_shards", settings.get("gateway.local.initial_shards", "quorum"));
 
-        logger.debug("using initial_shards [{}], list_timeout [{}]", initialShards, listTimeout);
+        logger.debug("using initial_shards [{}]", initialShards);
+    }
+
+    public void setReallocation(final ClusterService clusterService, final AllocationService allocationService) {
+        this.clusterService = clusterService;
+        this.allocationService = allocationService;
+        clusterService.add(new ClusterStateListener() {
+            @Override
+            public void clusterChanged(ClusterChangedEvent event) {
+                boolean cleanCache = false;
+                DiscoveryNode localNode = event.state().nodes().localNode();
+                if (localNode != null) {
+                    if (localNode.masterNode() == true && event.localNodeMaster() == false) {
+                        cleanCache = true;
+                    }
+                } else {
+                    cleanCache = true;
+                }
+                if (cleanCache) {
+                    Releasables.close(asyncFetchStarted.values());
+                    asyncFetchStarted.clear();
+                    Releasables.close(asyncFetchStore.values());
+                    asyncFetchStore.clear();
+                }
+            }
+        });
+    }
+
+    public int getNumberOfInFlightFetch() {
+        int count = 0;
+        for (AsyncShardFetch<TransportNodesListGatewayStartedShards.NodeGatewayStartedShards> fetch : asyncFetchStarted.values()) {
+            count += fetch.getNumberOfInFlightFetches();
+        }
+        for (AsyncShardFetch<TransportNodesListShardStoreMetaData.NodeStoreFilesMetaData> fetch : asyncFetchStore.values()) {
+            count += fetch.getNumberOfInFlightFetches();
+        }
+        return count;
     }
 
     public void applyStartedShards(StartedRerouteAllocation allocation) {
-        for (ShardRouting shardRouting : allocation.startedShards()) {
-            cachedStores.remove(shardRouting.shardId());
-            cachedShardsState.remove(shardRouting.shardId());
+        for (ShardRouting shard : allocation.startedShards()) {
+            Releasables.close(asyncFetchStarted.remove(shard.shardId()));
+            Releasables.close(asyncFetchStore.remove(shard.shardId()));
         }
     }
 
     public void applyFailedShards(FailedRerouteAllocation allocation) {
-        for (ShardRouting failedShard : allocation.failedShards()) {
-            cachedStores.remove(failedShard.shardId());
-            cachedShardsState.remove(failedShard.shardId());
+        for (ShardRouting shard : allocation.failedShards()) {
+            Releasables.close(asyncFetchStarted.remove(shard.shardId()));
+            Releasables.close(asyncFetchStore.remove(shard.shardId()));
         }
     }
 
@@ -131,7 +164,37 @@ public class GatewayAllocator extends AbstractComponent {
                 continue;
             }
 
-            ObjectLongHashMap<DiscoveryNode> nodesState = buildShardStates(nodes, shard, metaData.index(shard.index()));
+            AsyncShardFetch<TransportNodesListGatewayStartedShards.NodeGatewayStartedShards> fetch = asyncFetchStarted.get(shard.shardId());
+            if (fetch == null) {
+                fetch = new InternalAsyncFetch<>(logger, shard.shardId(), startedAction, clusterService, allocationService);
+                asyncFetchStarted.put(shard.shardId(), fetch);
+            }
+            AsyncShardFetch.FetchResult<TransportNodesListGatewayStartedShards.NodeGatewayStartedShards> shardState = fetch.fetchData(nodes, metaData, allocation.getIgnoreNodes(shard.shardId()));
+            if (shardState.hasData() == false) {
+                // still fetching data, remove from the unassigned, and try the next
+                unassignedIterator.remove();
+                routingNodes.ignoredUnassigned().add(shard);
+                continue;
+            }
+            shardState.processAllocation(allocation);
+
+            IndexMetaData indexMetaData = metaData.index(shard.getIndex());
+
+            /**
+             * Build a map of DiscoveryNodes to shard state number for the given shard.
+             * A state of -1 means the shard does not exist on the node, where any
+             * shard state >= 0 is the state version of the shard on that node's disk.
+             *
+             * A shard on shared storage will return at least shard state 0 for all
+             * nodes, indicating that the shard can be allocated to any node.
+             */
+            ObjectLongHashMap<DiscoveryNode> nodesState = new ObjectLongHashMap<>();
+            for (TransportNodesListGatewayStartedShards.NodeGatewayStartedShards nodeShardState : shardState.getData().values()) {
+                long version = nodeShardState.version();
+                // -1 version means it does not exists, which is what the API returns, and what we expect to
+                logger.trace("[{}] on node [{}] has version [{}] of shard", shard, nodeShardState.getNode(), version);
+                nodesState.put(nodeShardState.getNode(), version);
+            }
 
             int numberOfAllocationsFound = 0;
             long highestVersion = -1;
@@ -140,7 +203,6 @@ public class GatewayAllocator extends AbstractComponent {
             assert !nodesState.containsKey(null);
             final Object[] keys = nodesState.keys;
             final long[] values = nodesState.values;
-            IndexMetaData indexMetaData = routingNodes.metaData().index(shard.index());
             Settings idxSettings = indexMetaData.settings();
             for (int i = 0; i < keys.length; i++) {
                 if (keys[i] == null) {
@@ -312,6 +374,9 @@ public class GatewayAllocator extends AbstractComponent {
         unassignedIterator = routingNodes.unassigned().iterator();
         while (unassignedIterator.hasNext()) {
             MutableShardRouting shard = unassignedIterator.next();
+            if (shard.primary()) {
+                continue;
+            }
 
             // pre-check if it can be allocated to any node that currently exists, so we won't list the store for it for nothing
             boolean canBeAllocatedToAtLeastOneNode = false;
@@ -330,18 +395,33 @@ public class GatewayAllocator extends AbstractComponent {
             }
 
             if (!canBeAllocatedToAtLeastOneNode) {
+                // still fetching data, remove from the unassigned, and try the next
+                unassignedIterator.remove();
+                routingNodes.ignoredUnassigned().add(shard);
                 continue;
             }
 
-            Map<DiscoveryNode, TransportNodesListShardStoreMetaData.StoreFilesMetaData> shardStores = buildShardStores(nodes, shard);
+            AsyncShardFetch<TransportNodesListShardStoreMetaData.NodeStoreFilesMetaData> fetch = asyncFetchStore.get(shard.shardId());
+            if (fetch == null) {
+                fetch = new InternalAsyncFetch<>(logger, shard.shardId(), storeAction, clusterService, allocationService);
+                asyncFetchStore.put(shard.shardId(), fetch);
+            }
+            AsyncShardFetch.FetchResult<TransportNodesListShardStoreMetaData.NodeStoreFilesMetaData> shardStores = fetch.fetchData(nodes, metaData, allocation.getIgnoreNodes(shard.shardId()));
+            if (shardStores.hasData() == false) {
+                // still fetching data, remove from the unassigned, and try the next
+                unassignedIterator.remove();
+                routingNodes.ignoredUnassigned().add(shard);
+                continue; // still fetching
+            }
+            shardStores.processAllocation(allocation);
 
             long lastSizeMatched = 0;
             DiscoveryNode lastDiscoNodeMatched = null;
             RoutingNode lastNodeMatched = null;
 
-            for (Map.Entry<DiscoveryNode, TransportNodesListShardStoreMetaData.StoreFilesMetaData> nodeStoreEntry : shardStores.entrySet()) {
+            for (Map.Entry<DiscoveryNode, TransportNodesListShardStoreMetaData.NodeStoreFilesMetaData> nodeStoreEntry : shardStores.getData().entrySet()) {
                 DiscoveryNode discoNode = nodeStoreEntry.getKey();
-                TransportNodesListShardStoreMetaData.StoreFilesMetaData storeFilesMetaData = nodeStoreEntry.getValue();
+                TransportNodesListShardStoreMetaData.StoreFilesMetaData storeFilesMetaData = nodeStoreEntry.getValue().storeFilesMetaData();
                 logger.trace("{}: checking node [{}]", shard, discoNode);
 
                 if (storeFilesMetaData == null) {
@@ -373,31 +453,34 @@ public class GatewayAllocator extends AbstractComponent {
                         assert primaryShard.active();
                         DiscoveryNode primaryNode = nodes.get(primaryShard.currentNodeId());
                         if (primaryNode != null) {
-                            TransportNodesListShardStoreMetaData.StoreFilesMetaData primaryNodeStore = shardStores.get(primaryNode);
-                            if (primaryNodeStore != null && primaryNodeStore.allocated()) {
-                                long sizeMatched = 0;
+                            TransportNodesListShardStoreMetaData.NodeStoreFilesMetaData primaryNodeFilesStore = shardStores.getData().get(primaryNode);
+                            if (primaryNodeFilesStore != null) {
+                                TransportNodesListShardStoreMetaData.StoreFilesMetaData primaryNodeStore = primaryNodeFilesStore.storeFilesMetaData();
+                                if (primaryNodeStore != null && primaryNodeStore.allocated()) {
+                                    long sizeMatched = 0;
 
-                                String primarySyncId = primaryNodeStore.syncId();
-                                String replicaSyncId = storeFilesMetaData.syncId();
-                                // see if we have a sync id we can make use of
-                                if (replicaSyncId != null && replicaSyncId.equals(primarySyncId)) {
-                                    logger.trace("{}: node [{}] has same sync id {} as primary", shard, discoNode.name(), replicaSyncId);
-                                    lastNodeMatched = node;
-                                    lastSizeMatched = Long.MAX_VALUE;
-                                    lastDiscoNodeMatched = discoNode;
-                                } else {
-                                    for (StoreFileMetaData storeFileMetaData : storeFilesMetaData) {
-                                        String metaDataFileName = storeFileMetaData.name();
-                                        if (primaryNodeStore.fileExists(metaDataFileName) && primaryNodeStore.file(metaDataFileName).isSame(storeFileMetaData)) {
-                                            sizeMatched += storeFileMetaData.length();
-                                        }
-                                    }
-                                    logger.trace("{}: node [{}] has [{}/{}] bytes of re-usable data",
-                                            shard, discoNode.name(), new ByteSizeValue(sizeMatched), sizeMatched);
-                                    if (sizeMatched > lastSizeMatched) {
-                                        lastSizeMatched = sizeMatched;
-                                        lastDiscoNodeMatched = discoNode;
+                                    String primarySyncId = primaryNodeStore.syncId();
+                                    String replicaSyncId = storeFilesMetaData.syncId();
+                                    // see if we have a sync id we can make use of
+                                    if (replicaSyncId != null && replicaSyncId.equals(primarySyncId)) {
+                                        logger.trace("{}: node [{}] has same sync id {} as primary", shard, discoNode.name(), replicaSyncId);
                                         lastNodeMatched = node;
+                                        lastSizeMatched = Long.MAX_VALUE;
+                                        lastDiscoNodeMatched = discoNode;
+                                    } else {
+                                        for (StoreFileMetaData storeFileMetaData : storeFilesMetaData) {
+                                            String metaDataFileName = storeFileMetaData.name();
+                                            if (primaryNodeStore.fileExists(metaDataFileName) && primaryNodeStore.file(metaDataFileName).isSame(storeFileMetaData)) {
+                                                sizeMatched += storeFileMetaData.length();
+                                            }
+                                        }
+                                        logger.trace("{}: node [{}] has [{}/{}] bytes of re-usable data",
+                                                shard, discoNode.name(), new ByteSizeValue(sizeMatched), sizeMatched);
+                                        if (sizeMatched > lastSizeMatched) {
+                                            lastSizeMatched = sizeMatched;
+                                            lastDiscoNodeMatched = discoNode;
+                                            lastNodeMatched = node;
+                                        }
                                     }
                                 }
                             }
@@ -430,104 +513,38 @@ public class GatewayAllocator extends AbstractComponent {
         return changed;
     }
 
-    /**
-     * Build a map of DiscoveryNodes to shard state number for the given shard.
-     * A state of -1 means the shard does not exist on the node, where any
-     * shard state >= 0 is the state version of the shard on that node's disk.
-     *
-     * A shard on shared storage will return at least shard state 0 for all
-     * nodes, indicating that the shard can be allocated to any node.
-     */
-    private ObjectLongHashMap<DiscoveryNode> buildShardStates(final DiscoveryNodes nodes, MutableShardRouting shard, IndexMetaData indexMetaData) {
-        ObjectLongHashMap<DiscoveryNode> shardStates = cachedShardsState.get(shard.shardId());
-        ObjectHashSet<String> nodeIds;
-        if (shardStates == null) {
-            shardStates = new ObjectLongHashMap<>();
-            cachedShardsState.put(shard.shardId(), shardStates);
-            nodeIds = new ObjectHashSet<>(nodes.dataNodes().keys());
-        } else {
-            // clean nodes that have failed
-            shardStates.keys().removeAll(new ObjectPredicate<DiscoveryNode>() {
+    static class InternalAsyncFetch<T extends NodeOperationResponse> extends AsyncShardFetch<T> {
+
+        private final ClusterService clusterService;
+        private final AllocationService allocationService;
+
+        public InternalAsyncFetch(ESLogger logger, ShardId shardId, List<? extends NodesOperationResponse<T>, T> action,
+                                  ClusterService clusterService, AllocationService allocationService) {
+            super(logger, shardId, action);
+            this.clusterService = clusterService;
+            this.allocationService = allocationService;
+        }
+
+        @Override
+        protected void reroute(ShardId shardId, String reason) {
+            clusterService.submitStateUpdateTask("async_shard_fetch(" + getClass().getSimpleName() + ") " + shardId + ", reasons (" + reason + ")", Priority.HIGH, new ClusterStateUpdateTask() {
                 @Override
-                public boolean apply(DiscoveryNode node) {
-                    return !nodes.nodeExists(node.id());
+                public ClusterState execute(ClusterState currentState) throws Exception {
+                    if (currentState.nodes().masterNode() == null) {
+                        return currentState;
+                    }
+                    RoutingAllocation.Result routingResult = allocationService.reroute(currentState);
+                    if (!routingResult.changed()) {
+                        return currentState;
+                    }
+                    return ClusterState.builder(currentState).routingResult(routingResult).build();
+                }
+
+                @Override
+                public void onFailure(String source, Throwable t) {
+                    logger.warn("failed to perform reroute post async fetch for {}", t, source);
                 }
             });
-            nodeIds = new ObjectHashSet<>();
-            // we have stored cached from before, see if the nodes changed, if they have, go fetch again
-            for (ObjectCursor<DiscoveryNode> cursor : nodes.dataNodes().values()) {
-                DiscoveryNode node = cursor.value;
-                if (!shardStates.containsKey(node)) {
-                    nodeIds.add(node.id());
-                }
-            }
         }
-        if (nodeIds.isEmpty()) {
-            return shardStates;
-        }
-
-        String[] nodesIdsArray = nodeIds.toArray(String.class);
-        TransportNodesListGatewayStartedShards.NodesGatewayStartedShards response = listGatewayStartedShards.list(shard.shardId(), indexMetaData.getUUID(), nodesIdsArray, listTimeout).actionGet();
-        logListActionFailures(shard, "state", response.failures());
-
-        for (TransportNodesListGatewayStartedShards.NodeGatewayStartedShards nodeShardState : response) {
-            long version = nodeShardState.version();
-            // -1 version means it does not exists, which is what the API returns, and what we expect to
-            logger.trace("[{}] on node [{}] has version [{}] of shard",
-                    shard, nodeShardState.getNode(), version);
-            shardStates.put(nodeShardState.getNode(), version);
-        }
-        return shardStates;
-    }
-
-    private void logListActionFailures(MutableShardRouting shard, String actionType, FailedNodeException[] failures) {
-        for (final FailedNodeException failure : failures) {
-            Throwable cause = ExceptionsHelper.unwrapCause(failure);
-            if (cause instanceof ConnectTransportException) {
-                continue;
-            }
-            // we log warn here. debug logs with full stack traces will be logged if debug logging is turned on for TransportNodeListGatewayStartedShards
-            logger.warn("{}: failed to list shard {} on node [{}]", failure, shard.shardId(), actionType, failure.nodeId());
-        }
-    }
-
-    private Map<DiscoveryNode, TransportNodesListShardStoreMetaData.StoreFilesMetaData> buildShardStores(DiscoveryNodes nodes, MutableShardRouting shard) {
-        Map<DiscoveryNode, TransportNodesListShardStoreMetaData.StoreFilesMetaData> shardStores = cachedStores.get(shard.shardId());
-        ObjectHashSet<String> nodesIds;
-        if (shardStores == null) {
-            shardStores = Maps.newHashMap();
-            cachedStores.put(shard.shardId(), shardStores);
-            nodesIds = new ObjectHashSet<>(nodes.dataNodes().keys());
-        } else {
-            nodesIds = new ObjectHashSet<>();
-            // clean nodes that have failed
-            for (Iterator<DiscoveryNode> it = shardStores.keySet().iterator(); it.hasNext(); ) {
-                DiscoveryNode node = it.next();
-                if (!nodes.nodeExists(node.id())) {
-                    it.remove();
-                }
-            }
-
-            for (ObjectCursor<DiscoveryNode> cursor : nodes.dataNodes().values()) {
-                DiscoveryNode node = cursor.value;
-                if (!shardStores.containsKey(node)) {
-                    nodesIds.add(node.id());
-                }
-            }
-        }
-
-        if (!nodesIds.isEmpty()) {
-            String[] nodesIdsArray = nodesIds.toArray(String.class);
-            TransportNodesListShardStoreMetaData.NodesStoreFilesMetaData nodesStoreFilesMetaData = listShardStoreMetaData.list(shard.shardId(), false, nodesIdsArray, listTimeout).actionGet();
-            logListActionFailures(shard, "stores", nodesStoreFilesMetaData.failures());
-
-            for (TransportNodesListShardStoreMetaData.NodeStoreFilesMetaData nodeStoreFilesMetaData : nodesStoreFilesMetaData) {
-                if (nodeStoreFilesMetaData.storeFilesMetaData() != null) {
-                    shardStores.put(nodeStoreFilesMetaData.getNode(), nodeStoreFilesMetaData.storeFilesMetaData());
-                }
-            }
-        }
-
-        return shardStores;
     }
 }

--- a/src/main/java/org/elasticsearch/node/Node.java
+++ b/src/main/java/org/elasticsearch/node/Node.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.node;
 
 import org.elasticsearch.Build;
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionModule;
 import org.elasticsearch.cache.recycler.PageCacheRecycler;
@@ -56,6 +55,7 @@ import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.EnvironmentModule;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.env.NodeEnvironmentModule;
+import org.elasticsearch.gateway.GatewayAllocator;
 import org.elasticsearch.gateway.GatewayModule;
 import org.elasticsearch.gateway.GatewayService;
 import org.elasticsearch.http.HttpServer;
@@ -258,6 +258,10 @@ public class Node implements Releasable {
         injector.getInstance(SearchService.class).start();
         injector.getInstance(MonitorService.class).start();
         injector.getInstance(RestController.class).start();
+
+        // TODO hack around circular dependecncies problems
+        injector.getInstance(GatewayAllocator.class).setReallocation(injector.getInstance(ClusterService.class), injector.getInstance(AllocationService.class));
+
         DiscoveryService discoService = injector.getInstance(DiscoveryService.class).start();
         discoService.waitForInitialState();
 

--- a/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
+++ b/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
@@ -77,6 +77,8 @@ public class ThreadPool extends AbstractComponent {
         public static final String WARMER = "warmer";
         public static final String SNAPSHOT = "snapshot";
         public static final String OPTIMIZE = "optimize";
+        public static final String FETCH_SHARD_STARTED = "fetch_shard_started";
+        public static final String FETCH_SHARD_STORE = "fetch_shard_store";
     }
 
     public static final String THREADPOOL_GROUP = "threadpool.";
@@ -125,6 +127,8 @@ public class ThreadPool extends AbstractComponent {
                 .put(Names.WARMER, settingsBuilder().put("type", "scaling").put("keep_alive", "5m").put("size", halfProcMaxAt5).build())
                 .put(Names.SNAPSHOT, settingsBuilder().put("type", "scaling").put("keep_alive", "5m").put("size", halfProcMaxAt5).build())
                 .put(Names.OPTIMIZE, settingsBuilder().put("type", "fixed").put("size", 1).build())
+                .put(Names.FETCH_SHARD_STARTED, settingsBuilder().put("type", "scaling").put("keep_alive", "5m").put("size", availableProcessors * 2).build())
+                .put(Names.FETCH_SHARD_STORE, settingsBuilder().put("type", "scaling").put("keep_alive", "5m").put("size", availableProcessors * 2).build())
                 .build();
 
         Map<String, ExecutorHolder> executors = Maps.newHashMap();

--- a/src/test/java/org/elasticsearch/cluster/ClusterHealthResponsesTests.java
+++ b/src/test/java/org/elasticsearch/cluster/ClusterHealthResponsesTests.java
@@ -195,11 +195,13 @@ public class ClusterHealthResponsesTests extends ElasticsearchTestCase {
         }
         ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT).metaData(metaData).routingTable(routingTable).build();
         int pendingTasks = randomIntBetween(0, 200);
-        ClusterHealthResponse clusterHealth = new ClusterHealthResponse("bla", clusterState.metaData().concreteIndices(IndicesOptions.strictExpand(), (String[]) null), clusterState, pendingTasks);
+        int inFlight = randomIntBetween(0, 200);
+        ClusterHealthResponse clusterHealth = new ClusterHealthResponse("bla", clusterState.metaData().concreteIndices(IndicesOptions.strictExpand(), (String[]) null), clusterState, pendingTasks, inFlight);
         logger.info("cluster status: {}, expected {}", clusterHealth.getStatus(), counter.status());
         clusterHealth = maybeSerialize(clusterHealth);
         assertClusterHealth(clusterHealth, counter);
         assertThat(clusterHealth.getNumberOfPendingTasks(), Matchers.equalTo(pendingTasks));
+        assertThat(clusterHealth.getNumberOfInFlightFetch(), Matchers.equalTo(inFlight));
     }
 
     ClusterHealthResponse maybeSerialize(ClusterHealthResponse clusterHealth) throws IOException {
@@ -227,7 +229,7 @@ public class ClusterHealthResponsesTests extends ElasticsearchTestCase {
         metaData.put(indexMetaData, true);
         routingTable.add(indexRoutingTable);
         ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT).metaData(metaData).routingTable(routingTable).build();
-        ClusterHealthResponse clusterHealth = new ClusterHealthResponse("bla", clusterState.metaData().concreteIndices(IndicesOptions.strictExpand(), (String[]) null), clusterState, 0);
+        ClusterHealthResponse clusterHealth = new ClusterHealthResponse("bla", clusterState.metaData().concreteIndices(IndicesOptions.strictExpand(), (String[]) null), clusterState, 0, 0);
         clusterHealth = maybeSerialize(clusterHealth);
         // currently we have no cluster level validation failures as index validation issues are reported per index.
         assertThat(clusterHealth.getValidationFailures(), Matchers.hasSize(0));

--- a/src/test/java/org/elasticsearch/gateway/AsyncShardFetchTests.java
+++ b/src/test/java/org/elasticsearch/gateway/AsyncShardFetchTests.java
@@ -1,0 +1,323 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.gateway;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableSet;
+import org.elasticsearch.Version;
+import org.elasticsearch.action.FailedNodeException;
+import org.elasticsearch.action.support.nodes.NodeOperationResponse;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.transport.DummyTransportAddress;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.sameInstance;
+
+/**
+ */
+public class AsyncShardFetchTests extends ElasticsearchTestCase {
+
+    private final DiscoveryNode node1 = new DiscoveryNode("node1", DummyTransportAddress.INSTANCE, Version.CURRENT);
+    private final Response response1 = new Response(node1);
+    private final Throwable failure1 = new Throwable("simulated failure 1");
+    private final DiscoveryNode node2 = new DiscoveryNode("node2", DummyTransportAddress.INSTANCE, Version.CURRENT);
+    private final Response response2 = new Response(node2);
+    private final Throwable failure2 = new Throwable("simulate failure 2");
+
+    private ThreadPool threadPool;
+    private TestFetch test;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        this.threadPool = new ThreadPool(getTestName());
+        this.test = new TestFetch(threadPool);
+    }
+
+    @After
+    public void terminate() throws Exception {
+        terminate(threadPool);
+    }
+
+    @Test
+    public void testClose() throws Exception {
+        DiscoveryNodes nodes = DiscoveryNodes.builder().put(node1).build();
+        test.addSimulation(node1.getId(), response1);
+
+        // first fetch, no data, still on going
+        AsyncShardFetch.FetchResult<Response> fetchData = test.fetchData(nodes, MetaData.EMPTY_META_DATA, ImmutableSet.<String>of());
+        assertThat(fetchData.hasData(), equalTo(false));
+        assertThat(test.reroute.get(), equalTo(0));
+
+        // fire a response, wait on reroute incrementing
+        test.fireSimulationAndWait(node1.getId());
+        // verify we get back the data node
+        assertThat(test.reroute.get(), equalTo(1));
+        test.close();
+        try {
+            test.fetchData(nodes, MetaData.EMPTY_META_DATA, ImmutableSet.<String>of());
+            fail("fetch data should fail when closed");
+        } catch (IllegalStateException e) {
+            // all is well
+        }
+    }
+
+
+    @Test
+    public void testFullCircleSingleNodeSuccess() throws Exception {
+        DiscoveryNodes nodes = DiscoveryNodes.builder().put(node1).build();
+        test.addSimulation(node1.getId(), response1);
+
+        // first fetch, no data, still on going
+        AsyncShardFetch.FetchResult<Response> fetchData = test.fetchData(nodes, MetaData.EMPTY_META_DATA, ImmutableSet.<String>of());
+        assertThat(fetchData.hasData(), equalTo(false));
+        assertThat(test.reroute.get(), equalTo(0));
+
+        // fire a response, wait on reroute incrementing
+        test.fireSimulationAndWait(node1.getId());
+        // verify we get back the data node
+        assertThat(test.reroute.get(), equalTo(1));
+        fetchData = test.fetchData(nodes, MetaData.EMPTY_META_DATA, ImmutableSet.<String>of());
+        assertThat(fetchData.hasData(), equalTo(true));
+        assertThat(fetchData.getData().size(), equalTo(1));
+        assertThat(fetchData.getData().get(node1), sameInstance(response1));
+    }
+
+    @Test
+    public void testFullCircleSingleNodeFailure() throws Exception {
+        DiscoveryNodes nodes = DiscoveryNodes.builder().put(node1).build();
+        // add a failed response for node1
+        test.addSimulation(node1.getId(), failure1);
+
+        // first fetch, no data, still on going
+        AsyncShardFetch.FetchResult<Response> fetchData = test.fetchData(nodes, MetaData.EMPTY_META_DATA, ImmutableSet.<String>of());
+        assertThat(fetchData.hasData(), equalTo(false));
+        assertThat(test.reroute.get(), equalTo(0));
+
+        // fire a response, wait on reroute incrementing
+        test.fireSimulationAndWait(node1.getId());
+        // failure, fetched data exists, but has no data
+        assertThat(test.reroute.get(), equalTo(1));
+        fetchData = test.fetchData(nodes, MetaData.EMPTY_META_DATA, ImmutableSet.<String>of());
+        assertThat(fetchData.hasData(), equalTo(true));
+        assertThat(fetchData.getData().size(), equalTo(0));
+
+        // on failure, we reset the failure on a successive call to fetchData, and try again afterwards
+        test.addSimulation(node1.getId(), response1);
+        fetchData = test.fetchData(nodes, MetaData.EMPTY_META_DATA, ImmutableSet.<String>of());
+        assertThat(fetchData.hasData(), equalTo(false));
+
+        test.fireSimulationAndWait(node1.getId());
+        // 2 reroutes, cause we have a failure that we clear
+        assertThat(test.reroute.get(), equalTo(3));
+        fetchData = test.fetchData(nodes, MetaData.EMPTY_META_DATA, ImmutableSet.<String>of());
+        assertThat(fetchData.hasData(), equalTo(true));
+        assertThat(fetchData.getData().size(), equalTo(1));
+        assertThat(fetchData.getData().get(node1), sameInstance(response1));
+    }
+
+    @Test
+    public void testTwoNodesOnSetup() throws Exception {
+        DiscoveryNodes nodes = DiscoveryNodes.builder().put(node1).put(node2).build();
+        test.addSimulation(node1.getId(), response1);
+        test.addSimulation(node2.getId(), response2);
+
+        // no fetched data, 2 requests still on going
+        AsyncShardFetch.FetchResult<Response> fetchData = test.fetchData(nodes, MetaData.EMPTY_META_DATA, ImmutableSet.<String>of());
+        assertThat(fetchData.hasData(), equalTo(false));
+        assertThat(test.reroute.get(), equalTo(0));
+
+        // fire the first response, it should trigger a reroute
+        test.fireSimulationAndWait(node1.getId());
+        // there is still another on going request, so no data
+        assertThat(test.getNumberOfInFlightFetches(), equalTo(1));
+        fetchData = test.fetchData(nodes, MetaData.EMPTY_META_DATA, ImmutableSet.<String>of());
+        assertThat(fetchData.hasData(), equalTo(false));
+
+        // fire the second simulation, this should allow us to get the data
+        test.fireSimulationAndWait(node2.getId());
+        // no more ongoing requests, we should fetch the data
+        assertThat(test.reroute.get(), equalTo(2));
+        fetchData = test.fetchData(nodes, MetaData.EMPTY_META_DATA, ImmutableSet.<String>of());
+        assertThat(fetchData.hasData(), equalTo(true));
+        assertThat(fetchData.getData().size(), equalTo(2));
+        assertThat(fetchData.getData().get(node1), sameInstance(response1));
+        assertThat(fetchData.getData().get(node2), sameInstance(response2));
+    }
+
+    @Test
+    public void testTwoNodesOnSetupAndFailure() throws Exception {
+        DiscoveryNodes nodes = DiscoveryNodes.builder().put(node1).put(node2).build();
+        test.addSimulation(node1.getId(), response1);
+        test.addSimulation(node2.getId(), failure2);
+
+        // no fetched data, 2 requests still on going
+        AsyncShardFetch.FetchResult<Response> fetchData = test.fetchData(nodes, MetaData.EMPTY_META_DATA, ImmutableSet.<String>of());
+        assertThat(fetchData.hasData(), equalTo(false));
+        assertThat(test.reroute.get(), equalTo(0));
+
+        // fire the first response, it should trigger a reroute
+        test.fireSimulationAndWait(node1.getId());
+        assertThat(test.reroute.get(), equalTo(1));
+        fetchData = test.fetchData(nodes, MetaData.EMPTY_META_DATA, ImmutableSet.<String>of());
+        assertThat(fetchData.hasData(), equalTo(false));
+
+        // fire the second simulation, this should allow us to get the data
+        test.fireSimulationAndWait(node2.getId());
+        assertThat(test.reroute.get(), equalTo(2));
+        // since one of those failed, we should only have one entry
+        fetchData = test.fetchData(nodes, MetaData.EMPTY_META_DATA, ImmutableSet.<String>of());
+        assertThat(fetchData.hasData(), equalTo(true));
+        assertThat(fetchData.getData().size(), equalTo(1));
+        assertThat(fetchData.getData().get(node1), sameInstance(response1));
+    }
+
+    @Test
+    public void testTwoNodesAddedInBetween() throws Exception {
+        DiscoveryNodes nodes = DiscoveryNodes.builder().put(node1).build();
+        test.addSimulation(node1.getId(), response1);
+
+        // no fetched data, 2 requests still on going
+        AsyncShardFetch.FetchResult<Response> fetchData = test.fetchData(nodes, MetaData.EMPTY_META_DATA, ImmutableSet.<String>of());
+        assertThat(fetchData.hasData(), equalTo(false));
+        assertThat(test.reroute.get(), equalTo(0));
+
+        // fire the first response, it should trigger a reroute
+        test.fireSimulationAndWait(node1.getId());
+
+        // now, add a second node to the nodes, it should add it to the ongoing requests
+        nodes = DiscoveryNodes.builder(nodes).put(node2).build();
+        test.addSimulation(node2.getId(), response2);
+        // no fetch data, has a new node introduced
+        fetchData = test.fetchData(nodes, MetaData.EMPTY_META_DATA, ImmutableSet.<String>of());
+        assertThat(fetchData.hasData(), equalTo(false));
+
+        // fire the second simulation, this should allow us to get the data
+        test.fireSimulationAndWait(node2.getId());
+
+        // since one of those failed, we should only have one entry
+        fetchData = test.fetchData(nodes, MetaData.EMPTY_META_DATA, ImmutableSet.<String>of());
+        assertThat(fetchData.hasData(), equalTo(true));
+        assertThat(fetchData.getData().size(), equalTo(2));
+        assertThat(fetchData.getData().get(node1), sameInstance(response1));
+        assertThat(fetchData.getData().get(node2), sameInstance(response2));
+    }
+
+    static class TestFetch extends AsyncShardFetch<Response> {
+
+        static class Entry {
+            public final Response response;
+            public final Throwable failure;
+            private final CountDownLatch executeLatch = new CountDownLatch(1);
+            private final CountDownLatch waitLatch = new CountDownLatch(1);
+
+            public Entry(Response response, Throwable failure) {
+                this.response = response;
+                this.failure = failure;
+            }
+        }
+
+        private final ThreadPool threadPool;
+        private final Map<String, Entry> simulations = new ConcurrentHashMap<>();
+        private AtomicInteger reroute = new AtomicInteger();
+
+        public TestFetch(ThreadPool threadPool) {
+            super(Loggers.getLogger(TestFetch.class), new ShardId("test", 1), null);
+            this.threadPool = threadPool;
+        }
+
+        public void addSimulation(String nodeId, Response response) {
+            simulations.put(nodeId, new Entry(response, null));
+        }
+
+        public void addSimulation(String nodeId, Throwable t) {
+            simulations.put(nodeId, new Entry(null, t));
+        }
+
+        public void fireSimulationAndWait(String nodeId) throws InterruptedException {
+            simulations.get(nodeId).executeLatch.countDown();
+            simulations.get(nodeId).waitLatch.await();
+            simulations.remove(nodeId);
+        }
+
+        @Override
+        protected void reroute(ShardId shardId, String reason) {
+            reroute.incrementAndGet();
+        }
+
+        @Override
+        protected void asyncFetch(final ShardId shardId, String[] nodesIds, MetaData metaData) {
+            for (final String nodeId : nodesIds) {
+                threadPool.generic().execute(new Runnable() {
+                    @Override
+                    public void run() {
+                        Entry entry = null;
+                        try {
+                            entry = simulations.get(nodeId);
+                            if (entry == null) {
+                                // we are simulating a master node switch, wait for it to not be null
+                                awaitBusy(new Predicate<Object>() {
+                                    @Override
+                                    public boolean apply(Object input) {
+                                        return simulations.containsKey(nodeId);
+                                    }
+                                });
+                            }
+                            assert entry != null;
+                            entry.executeLatch.await();
+                            if (entry.failure != null) {
+                                processAsyncFetch(shardId, null, new FailedNodeException[]{new FailedNodeException(nodeId, "unexpected", entry.failure)});
+                            } else {
+                                processAsyncFetch(shardId, new Response[]{entry.response}, null);
+                            }
+                        } catch (Throwable e) {
+                            logger.error("unexpected failure", e);
+                        } finally {
+                            if (entry != null) {
+                                entry.waitLatch.countDown();
+                            }
+                        }
+                    }
+                });
+            }
+        }
+    }
+
+
+    static class Response extends NodeOperationResponse {
+
+        public Response(DiscoveryNode node) {
+            super(node);
+        }
+    }
+}

--- a/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
@@ -877,24 +877,13 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
             @Override
             public void run() {
                 for (Client client : clients()) {
+                    ClusterHealthResponse clusterHealth = client.admin().cluster().prepareHealth().setLocal(true).get();
+                    assertThat("client " + client  + " still has in flight fetch", clusterHealth.getNumberOfInFlightFetch(), equalTo(0));
                     PendingClusterTasksResponse pendingTasks = client.admin().cluster().preparePendingClusterTasks().setLocal(true).get();
                     assertThat("client " + client + " still has pending tasks " + pendingTasks.prettyPrint(), pendingTasks, Matchers.emptyIterable());
+                    clusterHealth = client.admin().cluster().prepareHealth().setLocal(true).get();
+                    assertThat("client " + client  + " still has in flight fetch", clusterHealth.getNumberOfInFlightFetch(), equalTo(0));
                 }
-            }
-        });
-        assertNoTimeout(client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).get());
-    }
-
-    /**
-     * Waits until the elected master node has no pending tasks.
-     */
-    public void waitNoPendingTasksOnMaster() throws Exception {
-        assertNoTimeout(client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).get());
-        assertBusy(new Runnable() {
-            @Override
-            public void run() {
-                PendingClusterTasksResponse pendingTasks = client().admin().cluster().preparePendingClusterTasks().setLocal(true).get();
-                assertThat("master still has pending tasks " + pendingTasks.prettyPrint(), pendingTasks, Matchers.emptyIterable());
             }
         });
         assertNoTimeout(client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).get());


### PR DESCRIPTION
Today, when a primary shard is not allocated we go to all the nodes to find where it is allocated (listing its started state). When we allocate a replica shard, we head to all the nodes and list its store to allocate the replica on a node that holds the closest matching index files to the primary.

Those two operations today execute synchronously within the GatewayAllocator, which means they execute in a sync manner within the cluster update thread. For large clusters, or environments with very slow disk, those operations will stall the cluster update thread, making it seem like its stuck.

Worse, if the FS is really slow, we timeout after 30s the operation (to not stall the cluster update thread completely). This means that we will have another run for the primary shard if we didn't find one, or we won't find the best node to place a shard since it might have timed out (listing stores need to list all files and read the checksum at the end of each file).

On top of that, this sync operation happen one shard at a time, so its effectively compounding the problem in a serial manner the more shards we have and the slower FS is...

This change moves to perform both listing the shard started states and the shard stores to an async manner. During the allocation by the GatewayAllocator, if data needs to be fetched from a node, it is done in an async fashion, with the response triggering a reroute to make sure the results will be taken into account. Also, if there are on going operations happening, the relevant shard data will not be taken into account until all the ongoing listing operations are done executing.

The execution of listing shard states and stores has been moved to their own respective thread pools (scaling, so will go down to 0 when not needed anymore, unbounded queue, since we don't want to timeout, just let it execute based on how fast the local FS is). This is needed sine we are going to blast nodes with a lot of requests and we need to make sure there is no thread explosion.

This change also improves the handling of shard failures coming from a specific node. Today, those nodes were ignored from allocation only for the single reroute round. Now, since fetching is async, we need to keep those failures around at least until a single successful fetch without the node is done, to make sure not to repeat allocating to the failed node all the time.

Note, if before the indication of slow allocation was high pending tasks since the allocator was waiting for responses, not the pending tasks will be much smaller. In order to still indicate that the cluster is in the middle of fetching shard data, 2 attributes were added to the cluster health API, indicating the number of ongoing fetches of both started shards and shard store.

Closes #9502
