### PR TITLE
Generate access to tests paths like other paths.

### DIFF
--- a/src/main/resources/org/elasticsearch/bootstrap/security.policy
+++ b/src/main/resources/org/elasticsearch/bootstrap/security.policy
@@ -32,18 +32,6 @@ grant codeBase "file:${{java.ext.dirs}}/*" {
 
 grant {
 
-  // system jar resources
-  permission java.io.FilePermission "${java.home}${/}-", "read";
-
-  // paths used for running tests
-  // compiled classes
-  permission java.io.FilePermission "${project.basedir}${/}target${/}classes${/}-", "read";
-  permission java.io.FilePermission "${project.basedir}${/}target${/}test-classes${/}-", "read";
-  // read permission for lib sigar
-  permission java.io.FilePermission "${project.basedir}${/}lib${/}sigar${/}-", "read";
-  // mvn custom ./m2/repository for dependency jars
-  permission java.io.FilePermission "${m2.repository}${/}-", "read";
-
   permission java.nio.file.LinkPermission "symbolic";
   permission groovy.security.GroovyCodeSourcePermission "/groovy/script";
 


### PR DESCRIPTION
Currently we have some static paths in our access rules for tests, that use the troublesome sysprop substitution mechanism (e.g. previous java.io.tmpdir issues) in the policy file.

Instead I would like to dynamically generate the paths like we do for any other paths. Besides actually working reliably (i am able to get some plugins working with security manager enabled with this PR, after building a custom JDK build to debug this nightmare), this also gives us additional control (e.g. throw a clear exception if pom does not pass the necessary settings through).

We also remove the unnecessary java.home permission (thats outdated).
