### PR TITLE
Query refactoring: RangeQueryBuilder and Parser

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/BaseTermQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/BaseTermQueryBuilder.java
@@ -19,11 +19,9 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
-import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;

--- a/src/main/java/org/elasticsearch/index/query/BaseTermQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/BaseTermQueryBuilder.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
@@ -103,6 +104,9 @@ public abstract class BaseTermQueryBuilder<QB extends BoostableQueryBuilder<QB>>
 
     /**
      * Constructs a new base term query.
+     * In case value is assigned to a string, we internally convert it to a {@link BytesRef}
+     * because in {@link TermQueryParser} and {@link SpanTermQueryParser} string values are parsed to {@link BytesRef}
+     * and we want internal representation of query to be equal regardless of whether it was created from XContent or via Java API.
      *
      * @param fieldName  The name of the field
      * @param value The value of the term
@@ -121,7 +125,10 @@ public abstract class BaseTermQueryBuilder<QB extends BoostableQueryBuilder<QB>>
         return this.fieldName;
     }
 
-    /** Returns the value used in this query. */
+    /**
+     *  Returns the value used in this query.
+     *  If necessary, converts internal {@link BytesRef} representation back to string.
+     */
     public Object value() {
         return convertToStringIfBytesRef(this.value);
     }

--- a/src/main/java/org/elasticsearch/index/query/QueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryBuilder.java
@@ -87,7 +87,7 @@ public abstract class QueryBuilder extends ToXContentToBytes {
      * @param obj the input object
      * @return the same input object or a {@link BytesRef} representation if input was of type string
      */
-    public static Object convertToBytesRefIfString(Object obj) {
+    protected static Object convertToBytesRefIfString(Object obj) {
         if (obj instanceof String) {
             return BytesRefs.toBytesRef(obj);
         }
@@ -101,7 +101,7 @@ public abstract class QueryBuilder extends ToXContentToBytes {
      * @param obj the input object
      * @return the same input object or a utf8 string if input was of type {@link BytesRef}
      */
-    public static Object convertToStringIfBytesRef(Object obj) {
+    protected static Object convertToStringIfBytesRef(Object obj) {
         if (obj instanceof BytesRef) {
             return ((BytesRef) obj).utf8ToString();
         }

--- a/src/main/java/org/elasticsearch/index/query/QueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryBuilder.java
@@ -21,6 +21,10 @@ package org.elasticsearch.index.query;
 
 import org.apache.lucene.search.Query;
 import org.elasticsearch.action.support.ToXContentToBytes;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentType;
 
@@ -51,7 +55,7 @@ public abstract class QueryBuilder extends ToXContentToBytes {
      * @throws QueryParsingException
      * @throws IOException
      */
-    //norelease to be made abstract once all query builders override toQuery providing their own specific implementation.
+    //norelease to be removed once all query builders override toQuery providing their own specific implementation.
     public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
         return parseContext.indexQueryParserService().queryParser(parserName()).parse(parseContext);
     }
@@ -74,5 +78,34 @@ public abstract class QueryBuilder extends ToXContentToBytes {
         return null;
     }
 
+<<<<<<< HEAD:src/main/java/org/elasticsearch/index/query/QueryBuilder.java
     protected abstract void doXContent(XContentBuilder builder, Params params) throws IOException;
+=======
+    /**
+     * This helper method checks if the object passed in is a string, if so it
+     * converts it to a {@link BytesRef}.
+     * @param obj the input object
+     * @return the same input object or a {@link BytesRef} representation if input was of type string
+     */
+    public static Object convertToBytesRefIfString(Object obj) {
+        if (obj instanceof String) {
+            return BytesRefs.toBytesRef(obj);
+        }
+        return obj;
+    }
+
+
+    /**
+     * This helper method checks if the object passed in is a {@link BytesRef}, if so it
+     * converts it to a utf8 string.
+     * @param obj the input object
+     * @return the same input object or a utf8 string if input was of type {@link BytesRef}
+     */
+    public static Object convertToStringIfBytesRef(Object obj) {
+        if (obj instanceof BytesRef) {
+            return ((BytesRef) obj).utf8ToString();
+        }
+        return obj;
+    }
+>>>>>>> Fixed problems with lower/upper bounds and serialization, moved helper code for String/BytesRef conversion to base class:src/main/java/org/elasticsearch/index/query/BaseQueryBuilder.java
 }

--- a/src/main/java/org/elasticsearch/index/query/QueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryBuilder.java
@@ -22,8 +22,6 @@ package org.elasticsearch.index.query;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.action.support.ToXContentToBytes;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentType;
@@ -55,7 +53,7 @@ public abstract class QueryBuilder extends ToXContentToBytes {
      * @throws QueryParsingException
      * @throws IOException
      */
-    //norelease to be removed once all query builders override toQuery providing their own specific implementation.
+    //norelease to be made abstract once all query builders override toQuery providing their own specific implementation.
     public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
         return parseContext.indexQueryParserService().queryParser(parserName()).parse(parseContext);
     }
@@ -78,9 +76,8 @@ public abstract class QueryBuilder extends ToXContentToBytes {
         return null;
     }
 
-<<<<<<< HEAD:src/main/java/org/elasticsearch/index/query/QueryBuilder.java
     protected abstract void doXContent(XContentBuilder builder, Params params) throws IOException;
-=======
+
     /**
      * This helper method checks if the object passed in is a string, if so it
      * converts it to a {@link BytesRef}.
@@ -94,7 +91,6 @@ public abstract class QueryBuilder extends ToXContentToBytes {
         return obj;
     }
 
-
     /**
      * This helper method checks if the object passed in is a {@link BytesRef}, if so it
      * converts it to a utf8 string.
@@ -107,5 +103,4 @@ public abstract class QueryBuilder extends ToXContentToBytes {
         }
         return obj;
     }
->>>>>>> Fixed problems with lower/upper bounds and serialization, moved helper code for String/BytesRef conversion to base class:src/main/java/org/elasticsearch/index/query/BaseQueryBuilder.java
 }

--- a/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
@@ -21,6 +21,7 @@ package org.elasticsearch.index.query;
 
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermRangeQuery;
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
@@ -80,6 +81,9 @@ public class RangeQueryBuilder extends MultiTermQueryBuilder implements Streamab
 
     /**
      * The from part of the range query. Null indicates unbounded.
+     * In case lower bound is assigned to a string, we internally convert it to a {@link BytesRef} because
+     * in {@link RangeQueryParser} field are later parsed as {@link BytesRef} and we need internal representation
+     * of query to be equal regardless of whether it was created from XContent or via Java API.
      */
     public RangeQueryBuilder from(Object from, boolean includeLower) {
         this.from = convertToBytesRefIfString(from);
@@ -133,6 +137,9 @@ public class RangeQueryBuilder extends MultiTermQueryBuilder implements Streamab
 
     /**
      * Gets the upper range value for this query.
+     * In case upper bound is assigned to a string, we internally convert it to a {@link BytesRef} because
+     * in {@link RangeQueryParser} field are later parsed as {@link BytesRef} and we need internal representation
+     * of query to be equal regardless of whether it was created from XContent or via Java API.
      */
     public Object to() {
         return convertToStringIfBytesRef(this.to);

--- a/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
@@ -19,16 +19,30 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermRangeQuery;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.joda.DateMathParser;
+import org.elasticsearch.common.joda.Joda;
+import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.core.DateFieldMapper;
+import org.joda.time.DateTimeZone;
 
 import java.io.IOException;
+import java.util.Objects;
 
 /**
  * A Query that matches documents within an range of terms.
  */
-public class RangeQueryBuilder extends MultiTermQueryBuilder implements BoostableQueryBuilder<RangeQueryBuilder> {
+public class RangeQueryBuilder extends MultiTermQueryBuilder implements Streamable, BoostableQueryBuilder<RangeQueryBuilder> {
 
-    private final String name;
+    private String fieldname;
 
     private Object from;
 
@@ -39,172 +53,190 @@ public class RangeQueryBuilder extends MultiTermQueryBuilder implements Boostabl
 
     private boolean includeUpper = true;
 
-    private float boost = -1;
+    private float boost = 1.0f;
 
     private String queryName;
+
+    private String format;
 
     /**
      * A Query that matches documents within an range of terms.
      *
-     * @param name The field name
+     * @param fieldname The field name
      */
-    public RangeQueryBuilder(String name) {
-        this.name = name;
+    public RangeQueryBuilder(String fieldname) {
+        this.fieldname = fieldname;
+    }
+
+    public RangeQueryBuilder() {
+        // for serialization
+    }
+
+    /**
+     * Get the field name for this query.
+     */
+    public String fieldname() {
+        return this.fieldname;
+    }
+
+    /**
+     * The from part of the range query. Null indicates unbounded.
+     */
+    public RangeQueryBuilder from(Object from, boolean includeLower, boolean includeUpper) {
+        if (from instanceof String) {
+            this.from = BytesRefs.toBytesRef(from);
+        } else {
+            this.from = from;
+        }
+        this.includeLower = includeLower;
+        this.includeUpper = includeUpper;
+        return this;
     }
 
     /**
      * The from part of the range query. Null indicates unbounded.
      */
     public RangeQueryBuilder from(Object from) {
-        this.from = from;
-        return this;
+        return from(from, true, true);
     }
 
     /**
      * The from part of the range query. Null indicates unbounded.
      */
     public RangeQueryBuilder from(String from) {
-        this.from = from;
-        return this;
+        return from((Object) from, true, true);
     }
 
     /**
      * The from part of the range query. Null indicates unbounded.
      */
     public RangeQueryBuilder from(int from) {
-        this.from = from;
-        return this;
+        return from((Object) from, true, true);
     }
 
     /**
      * The from part of the range query. Null indicates unbounded.
      */
     public RangeQueryBuilder from(long from) {
-        this.from = from;
-        return this;
+        return from((Object) from, true, true);
     }
 
     /**
      * The from part of the range query. Null indicates unbounded.
      */
     public RangeQueryBuilder from(float from) {
-        this.from = from;
-        return this;
+        return from((Object) from, true, true);
     }
 
     /**
      * The from part of the range query. Null indicates unbounded.
      */
     public RangeQueryBuilder from(double from) {
-        this.from = from;
-        return this;
+        return from((Object) from, true, true);
     }
 
     /**
-     * The from part of the range query. Null indicates unbounded.
+     * Gets the lower range value for this query.
      */
-    public RangeQueryBuilder gt(String from) {
-        this.from = from;
-        this.includeLower = false;
-        return this;
+    public Object from() {
+        return this.from;
     }
 
     /**
      * The from part of the range query. Null indicates unbounded.
      */
     public RangeQueryBuilder gt(Object from) {
-        this.from = from;
-        this.includeLower = false;
-        return this;
+        return from((Object) from, false, true);
+    }
+
+    /**
+     * The from part of the range query. Null indicates unbounded.
+     */
+    public RangeQueryBuilder gt(String from) {
+        return from((Object) from, false, true);
     }
 
     /**
      * The from part of the range query. Null indicates unbounded.
      */
     public RangeQueryBuilder gt(int from) {
-        this.from = from;
-        this.includeLower = false;
-        return this;
+        return from((Object) from, false, true);
     }
 
     /**
      * The from part of the range query. Null indicates unbounded.
      */
     public RangeQueryBuilder gt(long from) {
-        this.from = from;
-        this.includeLower = false;
-        return this;
+        return from((Object) from, false, true);
     }
 
     /**
      * The from part of the range query. Null indicates unbounded.
      */
     public RangeQueryBuilder gt(float from) {
-        this.from = from;
-        this.includeLower = false;
-        return this;
+        return from((Object) from, false, true);
     }
 
     /**
      * The from part of the range query. Null indicates unbounded.
      */
     public RangeQueryBuilder gt(double from) {
-        this.from = from;
-        this.includeLower = false;
-        return this;
+        return from((Object) from, false, true);
     }
 
     /**
      * The from part of the range query. Null indicates unbounded.
      */
     public RangeQueryBuilder gte(String from) {
-        this.from = from;
-        this.includeLower = true;
-        return this;
+        return from((Object) from, true, true);
     }
 
     /**
      * The from part of the range query. Null indicates unbounded.
      */
     public RangeQueryBuilder gte(Object from) {
-        this.from = from;
-        this.includeLower = true;
-        return this;
+        return from(from, true, true);
     }
 
     /**
      * The from part of the range query. Null indicates unbounded.
      */
     public RangeQueryBuilder gte(int from) {
-        this.from = from;
-        this.includeLower = true;
-        return this;
+        return from((Object) from, true, true);
     }
 
     /**
      * The from part of the range query. Null indicates unbounded.
      */
     public RangeQueryBuilder gte(long from) {
-        this.from = from;
-        this.includeLower = true;
-        return this;
+        return from((Object) from, true, true);
     }
 
     /**
      * The from part of the range query. Null indicates unbounded.
      */
     public RangeQueryBuilder gte(float from) {
-        this.from = from;
-        this.includeLower = true;
-        return this;
+        return from((Object) from, true, true);
     }
 
     /**
      * The from part of the range query. Null indicates unbounded.
      */
     public RangeQueryBuilder gte(double from) {
-        this.from = from;
-        this.includeLower = true;
+        return from((Object) from, true, true);
+    }
+
+    /**
+     * The to part of the range query. Null indicates unbounded.
+     */
+    public RangeQueryBuilder to(Object to, boolean includeLower, boolean includeUpper) {
+        if (to instanceof String) {
+            this.to = BytesRefs.toBytesRef(to);
+        } else {
+            this.to = to;
+        }
+        this.includeLower = includeLower;
+        this.includeUpper = includeUpper;
         return this;
     }
 
@@ -212,156 +244,133 @@ public class RangeQueryBuilder extends MultiTermQueryBuilder implements Boostabl
      * The to part of the range query. Null indicates unbounded.
      */
     public RangeQueryBuilder to(Object to) {
-        this.to = to;
-        return this;
+        return to(to, true, true);
     }
 
     /**
      * The to part of the range query. Null indicates unbounded.
      */
     public RangeQueryBuilder to(String to) {
-        this.to = to;
-        return this;
+        return to(to, true, true);
     }
 
     /**
      * The to part of the range query. Null indicates unbounded.
      */
     public RangeQueryBuilder to(int to) {
-        this.to = to;
-        return this;
+        return to(to, true, true);
     }
 
     /**
      * The to part of the range query. Null indicates unbounded.
      */
     public RangeQueryBuilder to(long to) {
-        this.to = to;
-        return this;
+        return to(to, true, true);
     }
 
     /**
      * The to part of the range query. Null indicates unbounded.
      */
     public RangeQueryBuilder to(float to) {
-        this.to = to;
-        return this;
+        return to(to, true, true);
     }
 
     /**
      * The to part of the range query. Null indicates unbounded.
      */
     public RangeQueryBuilder to(double to) {
-        this.to = to;
-        return this;
+        return to(to, true, true);
+    }
+
+    /**
+     * Gets the upper range value for this query.
+     */
+    public Object to() {
+        return this.to;
     }
 
     /**
      * The to part of the range query. Null indicates unbounded.
      */
     public RangeQueryBuilder lt(String to) {
-        this.to = to;
-        this.includeUpper = false;
-        return this;
+        return to(to, true, false);
     }
 
     /**
      * The to part of the range query. Null indicates unbounded.
      */
     public RangeQueryBuilder lt(Object to) {
-        this.to = to;
-        this.includeUpper = false;
-        return this;
+        return to(to, true, false);
     }
 
     /**
      * The to part of the range query. Null indicates unbounded.
      */
     public RangeQueryBuilder lt(int to) {
-        this.to = to;
-        this.includeUpper = false;
-        return this;
+        return to(to, true, false);
     }
 
     /**
      * The to part of the range query. Null indicates unbounded.
      */
     public RangeQueryBuilder lt(long to) {
-        this.to = to;
-        this.includeUpper = false;
-        return this;
+        return to(to, true, false);
     }
 
     /**
      * The to part of the range query. Null indicates unbounded.
      */
     public RangeQueryBuilder lt(float to) {
-        this.to = to;
-        this.includeUpper = false;
-        return this;
+        return to(to, true, false);
     }
 
     /**
      * The to part of the range query. Null indicates unbounded.
      */
     public RangeQueryBuilder lt(double to) {
-        this.to = to;
-        this.includeUpper = false;
-        return this;
+        return to(to, true, false);
     }
 
     /**
      * The to part of the range query. Null indicates unbounded.
      */
     public RangeQueryBuilder lte(String to) {
-        this.to = to;
-        this.includeUpper = true;
-        return this;
+        return to(to, true, true);
     }
 
     /**
      * The to part of the range query. Null indicates unbounded.
      */
     public RangeQueryBuilder lte(Object to) {
-        this.to = to;
-        this.includeUpper = true;
-        return this;
+        return to(to, true, true);
     }
 
     /**
      * The to part of the range query. Null indicates unbounded.
      */
     public RangeQueryBuilder lte(int to) {
-        this.to = to;
-        this.includeUpper = true;
-        return this;
+        return to(to, true, true);
     }
 
     /**
      * The to part of the range query. Null indicates unbounded.
      */
     public RangeQueryBuilder lte(long to) {
-        this.to = to;
-        this.includeUpper = true;
-        return this;
+        return to(to, true, true);
     }
 
     /**
      * The to part of the range query. Null indicates unbounded.
      */
     public RangeQueryBuilder lte(float to) {
-        this.to = to;
-        this.includeUpper = true;
-        return this;
+        return to(to, true, true);
     }
 
     /**
      * The to part of the range query. Null indicates unbounded.
      */
     public RangeQueryBuilder lte(double to) {
-        this.to = to;
-        this.includeUpper = true;
-        return this;
+        return to(to, true, true);
     }
 
     /**
@@ -373,11 +382,25 @@ public class RangeQueryBuilder extends MultiTermQueryBuilder implements Boostabl
     }
 
     /**
+     * Gets the includeLower flag for this query.
+     */
+    public boolean includeLower() {
+        return this.includeLower;
+    }
+
+    /**
      * Should the upper bound be included or not. Defaults to <tt>true</tt>.
      */
     public RangeQueryBuilder includeUpper(boolean includeUpper) {
         this.includeUpper = includeUpper;
         return this;
+    }
+
+    /**
+     * Gets the includeUpper flag for this query.
+     */
+    public boolean includeUpper() {
+        return this.includeLower;
     }
 
     /**
@@ -391,11 +414,25 @@ public class RangeQueryBuilder extends MultiTermQueryBuilder implements Boostabl
     }
 
     /**
+     * Gets the boost factor for the query.
+     */
+    public float boost() {
+        return this.boost;
+    }
+
+    /**
      * Sets the query name for the filter that can be used when searching for matched_filters per hit.
      */
     public RangeQueryBuilder queryName(String queryName) {
         this.queryName = queryName;
         return this;
+    }
+
+    /**
+     * Gets the query name for the query.
+     */
+    public String queryName() {
+        return this.queryName;
     }
 
     /**
@@ -406,18 +443,37 @@ public class RangeQueryBuilder extends MultiTermQueryBuilder implements Boostabl
         return this;
     }
 
+    /**
+     * In case of format field, we can parse the from/to fields using this time format
+     */
+    public RangeQueryBuilder format(String format) {
+        this.format = format;
+        return this;
+    }
+
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(RangeQueryParser.NAME);
-        builder.startObject(name);
-        builder.field("from", from);
-        builder.field("to", to);
+        builder.startObject(fieldname);
+        if (this.from instanceof BytesRef) {
+            builder.field("from", ((BytesRef) this.from).utf8ToString());
+        } else {
+            builder.field("from", from);
+        }
+        if (this.to instanceof BytesRef) {
+            builder.field("to", ((BytesRef) this.to).utf8ToString());
+        } else {
+            builder.field("to", to);
+        }
         if (timeZone != null) {
             builder.field("time_zone", timeZone);
         }
+        if (format != null) {
+            builder.field("format", format);
+        }
         builder.field("include_lower", includeLower);
         builder.field("include_upper", includeUpper);
-        if (boost != -1) {
+        if (boost != 1.0f) {
             builder.field("boost", boost);
         }
         builder.endObject();
@@ -432,4 +488,119 @@ public class RangeQueryBuilder extends MultiTermQueryBuilder implements Boostabl
         return RangeQueryParser.NAME;
     }
 
+    @Override
+    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
+        Query query = null;
+        MapperService.SmartNameFieldMappers smartNameFieldMappers = parseContext.smartFieldMappers(this.fieldname);
+        if (smartNameFieldMappers != null) {
+            if (smartNameFieldMappers.hasMapper()) {
+                FieldMapper mapper = smartNameFieldMappers.mapper();
+                if (mapper instanceof DateFieldMapper) {
+                    if ((from instanceof Number || to instanceof Number) && timeZone != null) {
+                        throw new QueryParsingException(parseContext,
+                                "[range] time_zone when using ms since epoch format as it's UTC based can not be applied to [" + this.fieldname
+                                        + "]");
+                    }
+                    DateMathParser forcedDateParser = null;
+                    if (this.format  != null) {
+                        forcedDateParser = new DateMathParser(Joda.forPattern(this.format), DateFieldMapper.Defaults.TIME_UNIT);
+                    }
+                    query = ((DateFieldMapper) mapper).rangeQuery(from, to, includeLower, includeUpper, DateTimeZone.forID(this.timeZone), forcedDateParser, parseContext);
+                } else  {
+                    if (timeZone != null) {
+                        throw new QueryParsingException(parseContext, "[range] time_zone can not be applied to non date field ["
+                                + this.fieldname + "]");
+                    }
+                    //LUCENE 4 UPGRADE Mapper#rangeQuery should use bytesref as well?
+                    query = mapper.rangeQuery(from, to, includeLower, includeUpper, parseContext);
+                }
+
+            }
+        }
+        if (query == null) {
+            query = new TermRangeQuery(this.fieldname, BytesRefs.toBytesRef(from), BytesRefs.toBytesRef(to), includeLower, includeUpper);
+        }
+        query.setBoost(boost);
+        if (queryName != null) {
+            parseContext.addNamedQuery(queryName, query);
+        }
+        return query;
+    }
+
+    @Override
+    public QueryValidationException validate() {
+        QueryValidationException validationException = null;
+        if (this.fieldname == null || this.fieldname.isEmpty()) {
+            validationException = QueryValidationException.addValidationError("field name cannot be null or empty.", validationException);
+        }
+        if (this.timeZone != null) {
+            try {
+                DateTimeZone.forID(this.timeZone);
+            } catch (Exception e) {
+                validationException = QueryValidationException.addValidationError("error parsing timezone." + e.getMessage(),
+                        validationException);
+            }
+        }
+        if (this.format != null) {
+            try {
+                Joda.forPattern(this.format);
+            } catch (Exception e) {
+                validationException = QueryValidationException.addValidationError("error parsing format." + e.getMessage(),
+                        validationException);
+            }
+        }
+        return validationException;
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        this.fieldname = in.readString();
+        this.from = in.readGenericValue();
+        this.to = in.readGenericValue();
+        this.includeLower = in.readBoolean();
+        this.includeLower = in.readBoolean();
+        this.timeZone = in.readOptionalString();
+        this.format = in.readOptionalString();
+        this.boost = in.readFloat();
+        this.queryName = in.readOptionalString();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(this.fieldname);
+        out.writeGenericValue(this.from);
+        out.writeGenericValue(this.to);
+        out.writeBoolean(this.includeLower);
+        out.writeBoolean(this.includeUpper);
+        out.writeOptionalString(this.timeZone);
+        out.writeOptionalString(this.format);
+        out.writeFloat(this.boost);
+        out.writeOptionalString(this.queryName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(fieldname, from, to, timeZone, includeLower, includeUpper,
+                boost, queryName, format);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        RangeQueryBuilder other = (RangeQueryBuilder) obj;
+        return Objects.equals(fieldname, other.fieldname) &&
+               Objects.equals(from, other.from) &&
+               Objects.equals(to, other.to) &&
+               Objects.equals(timeZone, other.timeZone) &&
+               Objects.equals(includeLower, other.includeLower) &&
+               Objects.equals(includeUpper, other.includeUpper) &&
+               Objects.equals(boost, other.boost) &&
+               Objects.equals(queryName, other.queryName) &&
+               Objects.equals(format, other.format);
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.search.NumericRangeQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermRangeQuery;
 import org.apache.lucene.util.BytesRef;

--- a/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
@@ -41,7 +41,7 @@ import java.util.Objects;
  */
 public class RangeQueryBuilder extends MultiTermQueryBuilder implements Streamable, BoostableQueryBuilder<RangeQueryBuilder> {
 
-    private String fieldname;
+    private String fieldName;
 
     private Object from;
 
@@ -61,10 +61,10 @@ public class RangeQueryBuilder extends MultiTermQueryBuilder implements Streamab
     /**
      * A Query that matches documents within an range of terms.
      *
-     * @param fieldname The field name
+     * @param fieldName The field name
      */
-    public RangeQueryBuilder(String fieldname) {
-        this.fieldname = fieldname;
+    public RangeQueryBuilder(String fieldName) {
+        this.fieldName = fieldName;
     }
 
     public RangeQueryBuilder() {
@@ -74,8 +74,8 @@ public class RangeQueryBuilder extends MultiTermQueryBuilder implements Streamab
     /**
      * Get the field name for this query.
      */
-    public String fieldname() {
-        return this.fieldname;
+    public String fieldName() {
+        return this.fieldName;
     }
 
     /**
@@ -98,7 +98,7 @@ public class RangeQueryBuilder extends MultiTermQueryBuilder implements Streamab
      * Gets the lower range value for this query.
      */
     public Object from() {
-        return convertToBytesRefIfString(this.from);
+        return convertToStringIfBytesRef(this.from);
     }
 
     /**
@@ -135,7 +135,7 @@ public class RangeQueryBuilder extends MultiTermQueryBuilder implements Streamab
      * Gets the upper range value for this query.
      */
     public Object to() {
-        return convertToBytesRefIfString(this.to);
+        return convertToStringIfBytesRef(this.to);
     }
 
     /**
@@ -247,7 +247,7 @@ public class RangeQueryBuilder extends MultiTermQueryBuilder implements Streamab
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(RangeQueryParser.NAME);
-        builder.startObject(fieldname);
+        builder.startObject(fieldName);
         builder.field("from", convertToStringIfBytesRef(this.from));
         builder.field("to", convertToStringIfBytesRef(this.to));
         if (timeZone != null) {
@@ -276,14 +276,14 @@ public class RangeQueryBuilder extends MultiTermQueryBuilder implements Streamab
     @Override
     public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
         Query query = null;
-        MapperService.SmartNameFieldMappers smartNameFieldMappers = parseContext.smartFieldMappers(this.fieldname);
+        MapperService.SmartNameFieldMappers smartNameFieldMappers = parseContext.smartFieldMappers(this.fieldName);
         if (smartNameFieldMappers != null) {
             if (smartNameFieldMappers.hasMapper()) {
                 FieldMapper<?> mapper = smartNameFieldMappers.mapper();
                 if (mapper instanceof DateFieldMapper) {
                     if ((from instanceof Number || to instanceof Number) && timeZone != null) {
                         throw new QueryParsingException(parseContext,
-                                "[range] time_zone when using ms since epoch format as it's UTC based can not be applied to [" + this.fieldname
+                                "[range] time_zone when using ms since epoch format as it's UTC based can not be applied to [" + this.fieldName
                                         + "]");
                     }
                     DateMathParser forcedDateParser = null;
@@ -298,7 +298,7 @@ public class RangeQueryBuilder extends MultiTermQueryBuilder implements Streamab
                 } else  {
                     if (timeZone != null) {
                         throw new QueryParsingException(parseContext, "[range] time_zone can not be applied to non date field ["
-                                + this.fieldname + "]");
+                                + this.fieldName + "]");
                     }
                     //LUCENE 4 UPGRADE Mapper#rangeQuery should use bytesref as well?
                     query = mapper.rangeQuery(from, to, includeLower, includeUpper, parseContext);
@@ -307,7 +307,7 @@ public class RangeQueryBuilder extends MultiTermQueryBuilder implements Streamab
             }
         }
         if (query == null) {
-            query = new TermRangeQuery(this.fieldname, BytesRefs.toBytesRef(from), BytesRefs.toBytesRef(to), includeLower, includeUpper);
+            query = new TermRangeQuery(this.fieldName, BytesRefs.toBytesRef(from), BytesRefs.toBytesRef(to), includeLower, includeUpper);
         }
         query.setBoost(boost);
         if (queryName != null) {
@@ -319,7 +319,7 @@ public class RangeQueryBuilder extends MultiTermQueryBuilder implements Streamab
     @Override
     public QueryValidationException validate() {
         QueryValidationException validationException = null;
-        if (this.fieldname == null || this.fieldname.isEmpty()) {
+        if (this.fieldName == null || this.fieldName.isEmpty()) {
             validationException = QueryValidationException.addValidationError("field name cannot be null or empty.", validationException);
         }
         if (this.timeZone != null) {
@@ -343,7 +343,7 @@ public class RangeQueryBuilder extends MultiTermQueryBuilder implements Streamab
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        this.fieldname = in.readString();
+        this.fieldName = in.readString();
         this.from = in.readGenericValue();
         this.to = in.readGenericValue();
         this.includeLower = in.readBoolean();
@@ -356,7 +356,7 @@ public class RangeQueryBuilder extends MultiTermQueryBuilder implements Streamab
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeString(this.fieldname);
+        out.writeString(this.fieldName);
         out.writeGenericValue(this.from);
         out.writeGenericValue(this.to);
         out.writeBoolean(this.includeLower);
@@ -369,7 +369,7 @@ public class RangeQueryBuilder extends MultiTermQueryBuilder implements Streamab
 
     @Override
     public int hashCode() {
-        return Objects.hash(fieldname, from, to, timeZone, includeLower, includeUpper,
+        return Objects.hash(fieldName, from, to, timeZone, includeLower, includeUpper,
                 boost, queryName, format);
     }
 
@@ -382,7 +382,7 @@ public class RangeQueryBuilder extends MultiTermQueryBuilder implements Streamab
             return false;
         }
         RangeQueryBuilder other = (RangeQueryBuilder) obj;
-        return Objects.equals(fieldname, other.fieldname) &&
+        return Objects.equals(fieldName, other.fieldName) &&
                Objects.equals(from, other.from) &&
                Objects.equals(to, other.to) &&
                Objects.equals(timeZone, other.timeZone) &&

--- a/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.search.NumericRangeQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermRangeQuery;
 import org.apache.lucene.util.BytesRef;

--- a/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
@@ -98,7 +98,7 @@ public class RangeQueryBuilder extends MultiTermQueryBuilder implements Streamab
      * Gets the lower range value for this query.
      */
     public Object from() {
-        return this.from;
+        return convertToBytesRefIfString(this.from);
     }
 
     /**
@@ -135,7 +135,7 @@ public class RangeQueryBuilder extends MultiTermQueryBuilder implements Streamab
      * Gets the upper range value for this query.
      */
     public Object to() {
-        return this.to;
+        return convertToBytesRefIfString(this.to);
     }
 
     /**
@@ -223,11 +223,25 @@ public class RangeQueryBuilder extends MultiTermQueryBuilder implements Streamab
     }
 
     /**
+     * In case of date field, gets the from/to fields timezone adjustment
+     */
+    public String timeZone() {
+        return this.timeZone;
+    }
+
+    /**
      * In case of format field, we can parse the from/to fields using this time format
      */
     public RangeQueryBuilder format(String format) {
         this.format = format;
         return this;
+    }
+
+    /**
+     * Gets the format field to parse the from/to fields
+     */
+    public String format() {
+        return this.format;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
@@ -82,14 +82,13 @@ public class RangeQueryBuilder extends MultiTermQueryBuilder implements Streamab
     /**
      * The from part of the range query. Null indicates unbounded.
      */
-    public RangeQueryBuilder from(Object from, boolean includeLower, boolean includeUpper) {
+    public RangeQueryBuilder from(Object from, boolean includeLower) {
         if (from instanceof String) {
             this.from = BytesRefs.toBytesRef(from);
         } else {
             this.from = from;
         }
         this.includeLower = includeLower;
-        this.includeUpper = includeUpper;
         return this;
     }
 
@@ -97,42 +96,7 @@ public class RangeQueryBuilder extends MultiTermQueryBuilder implements Streamab
      * The from part of the range query. Null indicates unbounded.
      */
     public RangeQueryBuilder from(Object from) {
-        return from(from, true, true);
-    }
-
-    /**
-     * The from part of the range query. Null indicates unbounded.
-     */
-    public RangeQueryBuilder from(String from) {
-        return from((Object) from, true, true);
-    }
-
-    /**
-     * The from part of the range query. Null indicates unbounded.
-     */
-    public RangeQueryBuilder from(int from) {
-        return from((Object) from, true, true);
-    }
-
-    /**
-     * The from part of the range query. Null indicates unbounded.
-     */
-    public RangeQueryBuilder from(long from) {
-        return from((Object) from, true, true);
-    }
-
-    /**
-     * The from part of the range query. Null indicates unbounded.
-     */
-    public RangeQueryBuilder from(float from) {
-        return from((Object) from, true, true);
-    }
-
-    /**
-     * The from part of the range query. Null indicates unbounded.
-     */
-    public RangeQueryBuilder from(double from) {
-        return from((Object) from, true, true);
+        return from(from, this.includeLower);
     }
 
     /**
@@ -146,96 +110,25 @@ public class RangeQueryBuilder extends MultiTermQueryBuilder implements Streamab
      * The from part of the range query. Null indicates unbounded.
      */
     public RangeQueryBuilder gt(Object from) {
-        return from((Object) from, false, true);
-    }
-
-    /**
-     * The from part of the range query. Null indicates unbounded.
-     */
-    public RangeQueryBuilder gt(String from) {
-        return from((Object) from, false, true);
-    }
-
-    /**
-     * The from part of the range query. Null indicates unbounded.
-     */
-    public RangeQueryBuilder gt(int from) {
-        return from((Object) from, false, true);
-    }
-
-    /**
-     * The from part of the range query. Null indicates unbounded.
-     */
-    public RangeQueryBuilder gt(long from) {
-        return from((Object) from, false, true);
-    }
-
-    /**
-     * The from part of the range query. Null indicates unbounded.
-     */
-    public RangeQueryBuilder gt(float from) {
-        return from((Object) from, false, true);
-    }
-
-    /**
-     * The from part of the range query. Null indicates unbounded.
-     */
-    public RangeQueryBuilder gt(double from) {
-        return from((Object) from, false, true);
-    }
-
-    /**
-     * The from part of the range query. Null indicates unbounded.
-     */
-    public RangeQueryBuilder gte(String from) {
-        return from((Object) from, true, true);
+        return from(from, false);
     }
 
     /**
      * The from part of the range query. Null indicates unbounded.
      */
     public RangeQueryBuilder gte(Object from) {
-        return from(from, true, true);
-    }
-
-    /**
-     * The from part of the range query. Null indicates unbounded.
-     */
-    public RangeQueryBuilder gte(int from) {
-        return from((Object) from, true, true);
-    }
-
-    /**
-     * The from part of the range query. Null indicates unbounded.
-     */
-    public RangeQueryBuilder gte(long from) {
-        return from((Object) from, true, true);
-    }
-
-    /**
-     * The from part of the range query. Null indicates unbounded.
-     */
-    public RangeQueryBuilder gte(float from) {
-        return from((Object) from, true, true);
-    }
-
-    /**
-     * The from part of the range query. Null indicates unbounded.
-     */
-    public RangeQueryBuilder gte(double from) {
-        return from((Object) from, true, true);
+        return from(from, true);
     }
 
     /**
      * The to part of the range query. Null indicates unbounded.
      */
-    public RangeQueryBuilder to(Object to, boolean includeLower, boolean includeUpper) {
+    public RangeQueryBuilder to(Object to, boolean includeUpper) {
         if (to instanceof String) {
             this.to = BytesRefs.toBytesRef(to);
         } else {
             this.to = to;
         }
-        this.includeLower = includeLower;
         this.includeUpper = includeUpper;
         return this;
     }
@@ -244,42 +137,7 @@ public class RangeQueryBuilder extends MultiTermQueryBuilder implements Streamab
      * The to part of the range query. Null indicates unbounded.
      */
     public RangeQueryBuilder to(Object to) {
-        return to(to, true, true);
-    }
-
-    /**
-     * The to part of the range query. Null indicates unbounded.
-     */
-    public RangeQueryBuilder to(String to) {
-        return to(to, true, true);
-    }
-
-    /**
-     * The to part of the range query. Null indicates unbounded.
-     */
-    public RangeQueryBuilder to(int to) {
-        return to(to, true, true);
-    }
-
-    /**
-     * The to part of the range query. Null indicates unbounded.
-     */
-    public RangeQueryBuilder to(long to) {
-        return to(to, true, true);
-    }
-
-    /**
-     * The to part of the range query. Null indicates unbounded.
-     */
-    public RangeQueryBuilder to(float to) {
-        return to(to, true, true);
-    }
-
-    /**
-     * The to part of the range query. Null indicates unbounded.
-     */
-    public RangeQueryBuilder to(double to) {
-        return to(to, true, true);
+        return to(to, this.includeUpper);
     }
 
     /**
@@ -292,85 +150,15 @@ public class RangeQueryBuilder extends MultiTermQueryBuilder implements Streamab
     /**
      * The to part of the range query. Null indicates unbounded.
      */
-    public RangeQueryBuilder lt(String to) {
-        return to(to, true, false);
-    }
-
-    /**
-     * The to part of the range query. Null indicates unbounded.
-     */
     public RangeQueryBuilder lt(Object to) {
-        return to(to, true, false);
-    }
-
-    /**
-     * The to part of the range query. Null indicates unbounded.
-     */
-    public RangeQueryBuilder lt(int to) {
-        return to(to, true, false);
-    }
-
-    /**
-     * The to part of the range query. Null indicates unbounded.
-     */
-    public RangeQueryBuilder lt(long to) {
-        return to(to, true, false);
-    }
-
-    /**
-     * The to part of the range query. Null indicates unbounded.
-     */
-    public RangeQueryBuilder lt(float to) {
-        return to(to, true, false);
-    }
-
-    /**
-     * The to part of the range query. Null indicates unbounded.
-     */
-    public RangeQueryBuilder lt(double to) {
-        return to(to, true, false);
-    }
-
-    /**
-     * The to part of the range query. Null indicates unbounded.
-     */
-    public RangeQueryBuilder lte(String to) {
-        return to(to, true, true);
+        return to(to, false);
     }
 
     /**
      * The to part of the range query. Null indicates unbounded.
      */
     public RangeQueryBuilder lte(Object to) {
-        return to(to, true, true);
-    }
-
-    /**
-     * The to part of the range query. Null indicates unbounded.
-     */
-    public RangeQueryBuilder lte(int to) {
-        return to(to, true, true);
-    }
-
-    /**
-     * The to part of the range query. Null indicates unbounded.
-     */
-    public RangeQueryBuilder lte(long to) {
-        return to(to, true, true);
-    }
-
-    /**
-     * The to part of the range query. Null indicates unbounded.
-     */
-    public RangeQueryBuilder lte(float to) {
-        return to(to, true, true);
-    }
-
-    /**
-     * The to part of the range query. Null indicates unbounded.
-     */
-    public RangeQueryBuilder lte(double to) {
-        return to(to, true, true);
+        return to(to, true);
     }
 
     /**
@@ -505,7 +293,11 @@ public class RangeQueryBuilder extends MultiTermQueryBuilder implements Streamab
                     if (this.format  != null) {
                         forcedDateParser = new DateMathParser(Joda.forPattern(this.format), DateFieldMapper.Defaults.TIME_UNIT);
                     }
-                    query = ((DateFieldMapper) mapper).rangeQuery(from, to, includeLower, includeUpper, DateTimeZone.forID(this.timeZone), forcedDateParser, parseContext);
+                    DateTimeZone dateTimeZone = null;
+                    if (this.timeZone != null) {
+                        dateTimeZone = DateTimeZone.forID(this.timeZone);
+                    }
+                    query = ((DateFieldMapper) mapper).rangeQuery(from, to, includeLower, includeUpper, dateTimeZone, forcedDateParser, parseContext);
                 } else  {
                     if (timeZone != null) {
                         throw new QueryParsingException(parseContext, "[range] time_zone can not be applied to non date field ["

--- a/src/main/java/org/elasticsearch/index/query/RangeQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/RangeQueryParser.java
@@ -111,14 +111,15 @@ public class RangeQueryParser extends BaseQueryParser {
             }
         }
 
-        // move to the next end object, to close the field name
-        token = parser.nextToken();
-        if (token != XContentParser.Token.END_OBJECT) {
-            throw new QueryParsingException(parseContext, "[range] query malformed, does not end with an object");
-        }
         RangeQueryBuilder rangeQuery = new RangeQueryBuilder(fieldName);
-        rangeQuery.from(from).to(to).includeLower(includeLower).includeUpper(includeUpper).timeZone(timeZone).boost(boost)
-                .queryName(queryName).format(format);
+        rangeQuery.from(from)
+            .to(to)
+            .includeLower(includeLower)
+            .includeUpper(includeUpper)
+            .timeZone(timeZone)
+            .boost(boost)
+            .queryName(queryName)
+            .format(format);
         rangeQuery.validate();
         return rangeQuery;
     }

--- a/src/main/java/org/elasticsearch/index/query/RangeQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/RangeQueryParser.java
@@ -19,25 +19,16 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.search.Query;
-import org.apache.lucene.search.TermRangeQuery;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.joda.DateMathParser;
-import org.elasticsearch.common.joda.Joda;
-import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.mapper.FieldMapper;
-import org.elasticsearch.index.mapper.MapperService;
-import org.elasticsearch.index.mapper.core.DateFieldMapper;
-import org.joda.time.DateTimeZone;
 
 import java.io.IOException;
 
 /**
  *
  */
-public class RangeQueryParser extends BaseQueryParserTemp {
+public class RangeQueryParser extends BaseQueryParser {
 
     public static final String NAME = "range";
     private static final ParseField FIELDDATA_FIELD = new ParseField("fielddata").withAllDeprecated("[no replacement]");
@@ -48,11 +39,11 @@ public class RangeQueryParser extends BaseQueryParserTemp {
 
     @Override
     public String[] names() {
-        return new String[]{NAME};
+        return new String[] { NAME };
     }
 
     @Override
-    public Query parse(QueryParseContext parseContext) throws IOException, QueryParsingException {
+    public RangeQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
         XContentParser parser = parseContext.parser();
 
         String fieldName = null;
@@ -60,10 +51,10 @@ public class RangeQueryParser extends BaseQueryParserTemp {
         Object to = null;
         boolean includeLower = true;
         boolean includeUpper = true;
-        DateTimeZone timeZone = null;
-        DateMathParser forcedDateParser = null;
+        String timeZone = null;
         float boost = 1.0f;
         String queryName = null;
+        String format = null;
 
         String currentFieldName = null;
         XContentParser.Token token;
@@ -101,9 +92,9 @@ public class RangeQueryParser extends BaseQueryParserTemp {
                             to = parser.objectBytes();
                             includeUpper = true;
                         } else if ("time_zone".equals(currentFieldName) || "timeZone".equals(currentFieldName)) {
-                            timeZone = DateTimeZone.forID(parser.text());
+                            timeZone = parser.text();
                         } else if ("format".equals(currentFieldName)) {
-                            forcedDateParser = new DateMathParser(Joda.forPattern(parser.text()), DateFieldMapper.Defaults.TIME_UNIT);
+                            format = parser.text();
                         } else {
                             throw new QueryParsingException(parseContext, "[range] query does not support [" + currentFieldName + "]");
                         }
@@ -120,36 +111,15 @@ public class RangeQueryParser extends BaseQueryParserTemp {
             }
         }
 
-        Query query = null;
-        MapperService.SmartNameFieldMappers smartNameFieldMappers = parseContext.smartFieldMappers(fieldName);
-        if (smartNameFieldMappers != null) {
-            if (smartNameFieldMappers.hasMapper()) {
-                FieldMapper mapper = smartNameFieldMappers.mapper();
-                if (mapper instanceof DateFieldMapper) {
-                    if ((from instanceof Number || to instanceof Number) && timeZone != null) {
-                        throw new QueryParsingException(parseContext,
-                                "[range] time_zone when using ms since epoch format as it's UTC based can not be applied to [" + fieldName
-                                        + "]");
-                    }
-                    query = ((DateFieldMapper) mapper).rangeQuery(from, to, includeLower, includeUpper, timeZone, forcedDateParser, parseContext);
-                } else  {
-                    if (timeZone != null) {
-                        throw new QueryParsingException(parseContext, "[range] time_zone can not be applied to non date field ["
-                                + fieldName + "]");
-                    }
-                    //LUCENE 4 UPGRADE Mapper#rangeQuery should use bytesref as well?
-                    query = mapper.rangeQuery(from, to, includeLower, includeUpper, parseContext);
-                }
-
-            }
+        // move to the next end object, to close the field name
+        token = parser.nextToken();
+        if (token != XContentParser.Token.END_OBJECT) {
+            throw new QueryParsingException(parseContext, "[range] query malformed, does not end with an object");
         }
-        if (query == null) {
-            query = new TermRangeQuery(fieldName, BytesRefs.toBytesRef(from), BytesRefs.toBytesRef(to), includeLower, includeUpper);
-        }
-        query.setBoost(boost);
-        if (queryName != null) {
-            parseContext.addNamedQuery(queryName, query);
-        }
-        return query;
+        RangeQueryBuilder rangeQuery = new RangeQueryBuilder(fieldName);
+        rangeQuery.from(from).to(to).includeLower(includeLower).includeUpper(includeUpper).timeZone(timeZone).boost(boost)
+                .queryName(queryName).format(format);
+        rangeQuery.validate();
+        return rangeQuery;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/TermQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/TermQueryBuilder.java
@@ -68,6 +68,57 @@ public class TermQueryBuilder extends BaseTermQueryBuilder<TermQueryBuilder> {
         // for serialization only
     }
 
+    /**
+     * @return the field name used in this query
+     */
+    @Override
+    public String fieldName() {
+        return this.fieldName;
+    }
+
+    /**
+     * @return the value used in this query
+     */
+    @Override
+    public Object value() {
+        return this.value;
+    }
+
+    /**
+     * Sets the boost for this query.  Documents matching this query will (in addition to the normal
+     * weightings) have their score multiplied by the boost provided.
+     */
+    @Override
+    public TermQueryBuilder boost(float boost) {
+        this.boost = boost;
+        return this;
+    }
+
+    /**
+     * Gets the boost for this query.
+     */
+    @Override
+    public float boost() {
+        return this.boost;
+    }
+
+    /**
+     * Sets the query name for the query.
+     */
+    @Override
+    public TermQueryBuilder queryName(String queryName) {
+        this.queryName = queryName;
+        return this;
+    }
+
+    /**
+     * Gets the query name for the query.
+     */
+    @Override
+    public String queryName() {
+        return this.queryName;
+    }
+
     @Override
     public Query toQuery(QueryParseContext parseContext) {
         Query query = null;
@@ -89,4 +140,5 @@ public class TermQueryBuilder extends BaseTermQueryBuilder<TermQueryBuilder> {
     protected String parserName() {
         return TermQueryParser.NAME;
     }
+
 }

--- a/src/main/java/org/elasticsearch/index/query/TermQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/TermQueryBuilder.java
@@ -140,5 +140,4 @@ public class TermQueryBuilder extends BaseTermQueryBuilder<TermQueryBuilder> {
     protected String parserName() {
         return TermQueryParser.NAME;
     }
-
 }

--- a/src/main/java/org/elasticsearch/index/query/TermQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/TermQueryBuilder.java
@@ -68,57 +68,6 @@ public class TermQueryBuilder extends BaseTermQueryBuilder<TermQueryBuilder> {
         // for serialization only
     }
 
-    /**
-     * @return the field name used in this query
-     */
-    @Override
-    public String fieldName() {
-        return this.fieldName;
-    }
-
-    /**
-     * @return the value used in this query
-     */
-    @Override
-    public Object value() {
-        return this.value;
-    }
-
-    /**
-     * Sets the boost for this query.  Documents matching this query will (in addition to the normal
-     * weightings) have their score multiplied by the boost provided.
-     */
-    @Override
-    public TermQueryBuilder boost(float boost) {
-        this.boost = boost;
-        return this;
-    }
-
-    /**
-     * Gets the boost for this query.
-     */
-    @Override
-    public float boost() {
-        return this.boost;
-    }
-
-    /**
-     * Sets the query name for the query.
-     */
-    @Override
-    public TermQueryBuilder queryName(String queryName) {
-        this.queryName = queryName;
-        return this;
-    }
-
-    /**
-     * Gets the query name for the query.
-     */
-    @Override
-    public String queryName() {
-        return this.queryName;
-    }
-
     @Override
     public Query toQuery(QueryParseContext parseContext) {
         Query query = null;

--- a/src/test/java/org/elasticsearch/index/query/BaseQueryTestCase.java
+++ b/src/test/java/org/elasticsearch/index/query/BaseQueryTestCase.java
@@ -69,6 +69,7 @@ import static org.hamcrest.Matchers.*;
 public abstract class BaseQueryTestCase<QB extends QueryBuilder & Streamable> extends ElasticsearchTestCase {
 
     protected static final String DATE_FIELD_NAME = "age";
+    protected static final String INT_FIELD_NAME = "price";
     private static Injector injector;
     private static IndexQueryParserService queryParserService;
     private static Index index;
@@ -110,7 +111,9 @@ public abstract class BaseQueryTestCase<QB extends QueryBuilder & Streamable> ex
         ).createInjector();
         queryParserService = injector.getInstance(IndexQueryParserService.class);
         MapperService mapperService = queryParserService.mapperService;
-        CompressedString mapping = new CompressedString(PutMappingRequest.buildFromSimplifiedDef("type", DATE_FIELD_NAME, "type=date").string());
+        CompressedString mapping = new CompressedString(PutMappingRequest.buildFromSimplifiedDef("type",
+                DATE_FIELD_NAME, "type=date",
+                INT_FIELD_NAME, "type=integer").string());
         mapperService.merge("type", mapping, true);
     }
 

--- a/src/test/java/org/elasticsearch/index/query/BaseQueryTestCase.java
+++ b/src/test/java/org/elasticsearch/index/query/BaseQueryTestCase.java
@@ -23,6 +23,7 @@ import com.carrotsearch.randomizedtesting.annotations.Repeat;
 
 import org.apache.lucene.search.Query;
 import org.elasticsearch.Version;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.compress.CompressedString;
@@ -62,13 +63,12 @@ import org.junit.Test;
 
 import java.io.IOException;
 
-import static org.elasticsearch.common.io.Streams.copyToStringFromClasspath;
-
 import static org.hamcrest.Matchers.*;
 
 @Ignore
 public abstract class BaseQueryTestCase<QB extends QueryBuilder & Streamable> extends ElasticsearchTestCase {
 
+    protected static final String DATE_FIELD_NAME = "age";
     private static Injector injector;
     private static IndexQueryParserService queryParserService;
     private static Index index;
@@ -110,8 +110,8 @@ public abstract class BaseQueryTestCase<QB extends QueryBuilder & Streamable> ex
         ).createInjector();
         queryParserService = injector.getInstance(IndexQueryParserService.class);
         MapperService mapperService = queryParserService.mapperService;
-        String mapping = copyToStringFromClasspath("/org/elasticsearch/index/query/mapping.json");
-        mapperService.merge("person", new CompressedString(mapping), true);
+        CompressedString mapping = new CompressedString(PutMappingRequest.buildFromSimplifiedDef("type", DATE_FIELD_NAME, "type=date").string());
+        mapperService.merge("type", mapping, true);
     }
 
     @AfterClass

--- a/src/test/java/org/elasticsearch/index/query/BaseQueryTestCase.java
+++ b/src/test/java/org/elasticsearch/index/query/BaseQueryTestCase.java
@@ -142,6 +142,7 @@ public abstract class BaseQueryTestCase<QB extends QueryBuilder & Streamable> ex
         testQuery = createTestQueryBuilder();
         QueryParseContext context = createContext();
         String contentString = testQuery.toString();
+        System.out.println(contentString);
         XContentParser parser = XContentFactory.xContent(contentString).createParser(contentString);
         context.reset(parser);
         assertQueryHeader(parser, testQuery.parserName());

--- a/src/test/java/org/elasticsearch/index/query/BaseQueryTestCase.java
+++ b/src/test/java/org/elasticsearch/index/query/BaseQueryTestCase.java
@@ -160,7 +160,7 @@ public abstract class BaseQueryTestCase<QB extends QueryBuilder & Streamable> ex
     public void testToQuery() throws IOException {
         testQuery = createTestQueryBuilder();
         QueryParseContext context = createContext();
-        context.setMapUnmappedFieldAsString(true);
+        context.setAllowUnmappedFields(true);
         assertLuceneQuery(testQuery, testQuery.toQuery(context), context);
     }
 

--- a/src/test/java/org/elasticsearch/index/query/BaseQueryTestCase.java
+++ b/src/test/java/org/elasticsearch/index/query/BaseQueryTestCase.java
@@ -20,10 +20,12 @@
 package org.elasticsearch.index.query;
 
 import com.carrotsearch.randomizedtesting.annotations.Repeat;
+
 import org.apache.lucene.search.Query;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.common.compress.CompressedString;
 import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.inject.Injector;
 import org.elasticsearch.common.inject.ModulesBuilder;
@@ -42,6 +44,7 @@ import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexNameModule;
 import org.elasticsearch.index.analysis.AnalysisModule;
 import org.elasticsearch.index.cache.IndexCacheModule;
+import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.functionscore.FunctionScoreModule;
 import org.elasticsearch.index.settings.IndexSettingsModule;
 import org.elasticsearch.index.similarity.SimilarityModule;
@@ -58,6 +61,8 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
+
+import static org.elasticsearch.common.io.Streams.copyToStringFromClasspath;
 
 import static org.hamcrest.Matchers.*;
 
@@ -104,6 +109,9 @@ public abstract class BaseQueryTestCase<QB extends QueryBuilder & Streamable> ex
                 }
         ).createInjector();
         queryParserService = injector.getInstance(IndexQueryParserService.class);
+        MapperService mapperService = queryParserService.mapperService;
+        String mapping = copyToStringFromClasspath("/org/elasticsearch/index/query/mapping.json");
+        mapperService.merge("person", new CompressedString(mapping), true);
     }
 
     @AfterClass

--- a/src/test/java/org/elasticsearch/index/query/BaseQueryTestCase.java
+++ b/src/test/java/org/elasticsearch/index/query/BaseQueryTestCase.java
@@ -78,9 +78,10 @@ public abstract class BaseQueryTestCase<QB extends QueryBuilder & Streamable> ex
 
     /**
      * Setup for the whole base test class.
+     * @throws IOException
      */
     @BeforeClass
-    public static void init() {
+    public static void init() throws IOException {
         Settings settings = ImmutableSettings.settingsBuilder()
                 .put("name", BaseQueryTestCase.class.toString())
                 .put("path.home", createTempDir())
@@ -161,7 +162,7 @@ public abstract class BaseQueryTestCase<QB extends QueryBuilder & Streamable> ex
         assertNotSame(newQuery, testQuery);
         assertEquals(newQuery, testQuery);
     }
-    
+
     /**
      * Test creates the {@link Query} from the {@link QueryBuilder} under test and delegates the
      * assertions being made on the result to the implementing subclass.
@@ -184,11 +185,11 @@ public abstract class BaseQueryTestCase<QB extends QueryBuilder & Streamable> ex
         testQuery = createTestQueryBuilder();
         try (BytesStreamOutput output = new BytesStreamOutput()) {
             testQuery.writeTo(output);
-    
+
             try (BytesStreamInput in = new BytesStreamInput(output.bytes())) {
                 QB deserializedQuery = createEmptyQueryBuilder();
                 deserializedQuery.readFrom(in);
-        
+
                 assertEquals(deserializedQuery, testQuery);
                 assertNotSame(deserializedQuery, testQuery);
             }

--- a/src/test/java/org/elasticsearch/index/query/BaseQueryTestCase.java
+++ b/src/test/java/org/elasticsearch/index/query/BaseQueryTestCase.java
@@ -142,7 +142,6 @@ public abstract class BaseQueryTestCase<QB extends QueryBuilder & Streamable> ex
         testQuery = createTestQueryBuilder();
         QueryParseContext context = createContext();
         String contentString = testQuery.toString();
-        System.out.println(contentString);
         XContentParser parser = XContentFactory.xContent(contentString).createParser(contentString);
         context.reset(parser);
         assertQueryHeader(parser, testQuery.parserName());

--- a/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTest.java
+++ b/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTest.java
@@ -47,14 +47,16 @@ public class RangeQueryBuilderTest extends BaseQueryTestCase<RangeQueryBuilder> 
 
     @Override
     protected RangeQueryBuilder createTestQueryBuilder() {
-        RangeQueryBuilder query = new RangeQueryBuilder(randomAsciiOfLengthBetween(1, 10));
+        RangeQueryBuilder query;
         // switch between numeric and date ranges
         if (randomBoolean()) {
+            // also switch between mapped integer and unmapped double fields
             if (randomBoolean()) {
                 query = new RangeQueryBuilder(INT_FIELD_NAME);
                 query.from(randomIntBetween(1, 100));
                 query.to(randomIntBetween(101, 200));
             } else {
+                query = new RangeQueryBuilder(randomAsciiOfLengthBetween(1, 10));
                 query.from(0.0-randomDouble());
                 query.to(randomDouble());
             }
@@ -89,31 +91,31 @@ public class RangeQueryBuilderTest extends BaseQueryTestCase<RangeQueryBuilder> 
     @Override
     protected void assertLuceneQuery(RangeQueryBuilder queryBuilder, Query query, QueryParseContext context) throws IOException {
         assertThat(query.getBoost(), is(queryBuilder.boost()));
-        String fieldname = queryBuilder.fieldname();
-        if (!fieldname.equals(DATE_FIELD_NAME) && !fieldname.equals(INT_FIELD_NAME)) {
-            assertThat(query, instanceOf(TermRangeQuery.class));
-            TermRangeQuery termRangeQuery = (TermRangeQuery) query;
-            assertThat(termRangeQuery.includesLower(), is(queryBuilder.includeLower()));
-            assertThat(termRangeQuery.includesUpper(), is(queryBuilder.includeUpper()));
-            assertThat(termRangeQuery.getLowerTerm(), is(BytesRefs.toBytesRef(queryBuilder.from())));
-            assertThat(termRangeQuery.getUpperTerm(), is(BytesRefs.toBytesRef(queryBuilder.to())));
-            assertThat(termRangeQuery.getField(), is(fieldname));
-        } else if (fieldname.equals(DATE_FIELD_NAME)) {
-            assertThat(query, instanceOf(LateParsingQuery.class));
-            Long min = expectedDateLong(queryBuilder.from(), queryBuilder, context);
-            Long max = expectedDateLong(queryBuilder.to(), queryBuilder, context);
-            Query expectedQuery = NumericRangeQuery.newLongRange(DATE_FIELD_NAME, min, max, queryBuilder.includeLower(), queryBuilder.includeUpper());
-            assertEquals(query.rewrite(null), expectedQuery.rewrite(null));
-        } else {
-            assertThat(query, instanceOf(NumericRangeQuery.class));
-            Query expectedQuery = NumericRangeQuery.newIntRange(INT_FIELD_NAME, (Integer) queryBuilder.from(), (Integer) queryBuilder.to(), queryBuilder.includeLower(), queryBuilder.includeUpper());
-            expectedQuery.setBoost(testQuery.boost());
-            assertEquals(query, expectedQuery);
-        }
         if (queryBuilder.queryName() != null) {
             Query namedQuery = context.copyNamedFilters().get(queryBuilder.queryName());
             assertThat(namedQuery, equalTo(query));
         }
+        String fieldname = queryBuilder.fieldname();
+        Query expectedQuery;
+        if (!fieldname.equals(DATE_FIELD_NAME) && !fieldname.equals(INT_FIELD_NAME)) {
+            assertThat(query, instanceOf(TermRangeQuery.class));
+            expectedQuery = new TermRangeQuery(queryBuilder.fieldname(),
+                    BytesRefs.toBytesRef(queryBuilder.from()), BytesRefs.toBytesRef(queryBuilder.to()),
+                    queryBuilder.includeLower(), queryBuilder.includeUpper());
+            expectedQuery.setBoost(queryBuilder.boost());
+        } else if (fieldname.equals(DATE_FIELD_NAME)) {
+            assertThat(query, instanceOf(LateParsingQuery.class));
+            Long min = expectedDateLong(queryBuilder.from(), queryBuilder, context);
+            Long max = expectedDateLong(queryBuilder.to(), queryBuilder, context);
+            expectedQuery = NumericRangeQuery.newLongRange(DATE_FIELD_NAME, min, max, queryBuilder.includeLower(), queryBuilder.includeUpper());
+            expectedQuery = expectedQuery.rewrite(null);
+            query = query.rewrite(null);
+        } else {
+            assertThat(query, instanceOf(NumericRangeQuery.class));
+            expectedQuery = NumericRangeQuery.newIntRange(INT_FIELD_NAME, (Integer) queryBuilder.from(), (Integer) queryBuilder.to(), queryBuilder.includeLower(), queryBuilder.includeUpper());
+            expectedQuery.setBoost(testQuery.boost());
+        }
+        assertEquals(expectedQuery, query);
     }
 
     @Test
@@ -135,6 +137,26 @@ public class RangeQueryBuilderTest extends BaseQueryTestCase<RangeQueryBuilder> 
 
         rangeQueryBuilder.timeZone("xXx").format("broken_xx");
         assertThat(rangeQueryBuilder.validate().validationErrors().size(), is(2));
+    }
+
+    /**
+     * Specifying a timezone together with a numeric range query should throw an error.
+     */
+    @Test(expected=QueryParsingException.class)
+    public void testToQueryNonDateWithTimezone() throws QueryParsingException, IOException {
+        RangeQueryBuilder query = new RangeQueryBuilder(INT_FIELD_NAME);
+        query.from(1).to(10).timeZone("UTC");
+        query.toQuery(createContext());
+    }
+
+    /**
+     * Specifying a timezone together with a numeric to or from fields should throw an error.
+     */
+    @Test(expected=QueryParsingException.class)
+    public void testToQueryNumericFromAndTimezone() throws QueryParsingException, IOException {
+        RangeQueryBuilder query = new RangeQueryBuilder(DATE_FIELD_NAME);
+        query.from(1).to(10).timeZone("UTC");
+        query.toQuery(createContext());
     }
 
     @Override

--- a/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTest.java
+++ b/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTest.java
@@ -57,7 +57,7 @@ public class RangeQueryBuilderTest extends BaseQueryTestCase<RangeQueryBuilder> 
                 query.to(randomDouble());
             }
         } else {
-            query = new RangeQueryBuilder("born");
+            query = new RangeQueryBuilder(DATE_FIELD_NAME);
             query.from(new DateTime(System.currentTimeMillis() - randomIntBetween(0, 1000000)).toString());
             query.to(new DateTime(System.currentTimeMillis() + randomIntBetween(0, 1000000)).toString());
             if (randomBoolean()) {
@@ -87,7 +87,7 @@ public class RangeQueryBuilderTest extends BaseQueryTestCase<RangeQueryBuilder> 
     @Override
     protected void assertLuceneQuery(RangeQueryBuilder queryBuilder, Query query, QueryParseContext context) throws IOException {
         assertThat(query.getBoost(), is(queryBuilder.boost()));
-        if (!queryBuilder.fieldname().equals("born")) {
+        if (!queryBuilder.fieldname().equals(DATE_FIELD_NAME)) {
             assertThat(query, instanceOf(TermRangeQuery.class));
             TermRangeQuery termRangeQuery = (TermRangeQuery) query;
             assertThat(termRangeQuery.includesLower(), is(queryBuilder.includeLower()));
@@ -102,7 +102,7 @@ public class RangeQueryBuilderTest extends BaseQueryTestCase<RangeQueryBuilder> 
             String expectedLowerBracket = queryBuilder.includeLower() ? "[" : "{";
             String expectedUpperBracket = queryBuilder.includeUpper() ? "]" : "}";
             String queryString = query.rewrite(null).toString();
-            assertThat(queryString, is("born:"+expectedLowerBracket+expectedFromDate+" TO "+expectedToDate+expectedUpperBracket));
+            assertThat(queryString, is(DATE_FIELD_NAME+":"+expectedLowerBracket+expectedFromDate+" TO "+expectedToDate+expectedUpperBracket));
         }
         if (queryBuilder.queryName() != null) {
             Query namedQuery = context.copyNamedFilters().get(queryBuilder.queryName());

--- a/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTest.java
+++ b/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTest.java
@@ -54,8 +54,8 @@ public class RangeQueryBuilderTest extends BaseQueryTestCase<RangeQueryBuilder> 
             query.from(randomIntBetween(1, 100));
             query.to(randomIntBetween(101, 200));
         } else {
-            query.from(new DateTime(System.currentTimeMillis() - randomIntBetween(0, 100000)).toString());
-            query.from(new DateTime(System.currentTimeMillis() + randomIntBetween(0, 100000)).toString());
+            query.from(new DateTime(System.currentTimeMillis() - randomIntBetween(0, 1000000)).toString());
+            query.to(new DateTime(System.currentTimeMillis() + randomIntBetween(0, 1000000)).toString());
             if (randomBoolean()) {
                 query.timeZone(TIMEZONE_IDS.get(randomIntBetween(0, TIMEZONE_IDS.size())));
             }
@@ -90,7 +90,7 @@ public class RangeQueryBuilderTest extends BaseQueryTestCase<RangeQueryBuilder> 
     }
 
     @Test
-    public void testValidation() {
+    public void testValidate() {
         RangeQueryBuilder rangeQueryBuilder = new RangeQueryBuilder("");
         assertThat(rangeQueryBuilder.validate().validationErrors().size(), is(1));
 

--- a/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTest.java
+++ b/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTest.java
@@ -50,17 +50,19 @@ public class RangeQueryBuilderTest extends BaseQueryTestCase<RangeQueryBuilder> 
         RangeQueryBuilder query;
         // switch between numeric and date ranges
         if (randomBoolean()) {
-            // also switch between mapped integer and unmapped double fields
             if (randomBoolean()) {
+                // use mapped integer field for numeric range queries
                 query = new RangeQueryBuilder(INT_FIELD_NAME);
                 query.from(randomIntBetween(1, 100));
                 query.to(randomIntBetween(101, 200));
             } else {
+                // use unmapped field for numeric range queries
                 query = new RangeQueryBuilder(randomAsciiOfLengthBetween(1, 10));
                 query.from(0.0-randomDouble());
                 query.to(randomDouble());
             }
         } else {
+            // use mapped date field, using date string representation
             query = new RangeQueryBuilder(DATE_FIELD_NAME);
             query.from(new DateTime(System.currentTimeMillis() - randomIntBetween(0, 1000000)).toString());
             query.to(new DateTime(System.currentTimeMillis() + randomIntBetween(0, 1000000)).toString());
@@ -95,15 +97,15 @@ public class RangeQueryBuilderTest extends BaseQueryTestCase<RangeQueryBuilder> 
             Query namedQuery = context.copyNamedFilters().get(queryBuilder.queryName());
             assertThat(namedQuery, equalTo(query));
         }
-        String fieldname = queryBuilder.fieldname();
+        String fieldName = queryBuilder.fieldName();
         Query expectedQuery;
-        if (!fieldname.equals(DATE_FIELD_NAME) && !fieldname.equals(INT_FIELD_NAME)) {
+        if (!fieldName.equals(DATE_FIELD_NAME) && !fieldName.equals(INT_FIELD_NAME)) {
             assertThat(query, instanceOf(TermRangeQuery.class));
-            expectedQuery = new TermRangeQuery(queryBuilder.fieldname(),
+            expectedQuery = new TermRangeQuery(queryBuilder.fieldName(),
                     BytesRefs.toBytesRef(queryBuilder.from()), BytesRefs.toBytesRef(queryBuilder.to()),
                     queryBuilder.includeLower(), queryBuilder.includeUpper());
             expectedQuery.setBoost(queryBuilder.boost());
-        } else if (fieldname.equals(DATE_FIELD_NAME)) {
+        } else if (fieldName.equals(DATE_FIELD_NAME)) {
             assertThat(query, instanceOf(LateParsingQuery.class));
             Long min = expectedDateLong(queryBuilder.from(), queryBuilder, context);
             Long max = expectedDateLong(queryBuilder.to(), queryBuilder, context);
@@ -165,7 +167,7 @@ public class RangeQueryBuilderTest extends BaseQueryTestCase<RangeQueryBuilder> 
     }
 
     private Long expectedDateLong(Object value, RangeQueryBuilder queryBuilder, QueryParseContext context) {
-        SmartNameFieldMappers smartFieldMappers = context.smartFieldMappers(queryBuilder.fieldname());
+        SmartNameFieldMappers smartFieldMappers = context.smartFieldMappers(queryBuilder.fieldName());
         FieldMapper<?> mapper = smartFieldMappers.mapper();
         DateMathParser dateParser = null;
         if (queryBuilder.format()  != null) {

--- a/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTest.java
+++ b/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTest.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query;
+
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermRangeQuery;
+import org.elasticsearch.common.lucene.BytesRefs;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+
+public class RangeQueryBuilderTest extends BaseQueryTestCase<RangeQueryBuilder> {
+
+    private static final List<String> TIMEZONE_IDS = new ArrayList<>(DateTimeZone.getAvailableIDs());
+
+    @Override
+    protected RangeQueryBuilder createTestQueryBuilder() {
+        RangeQueryBuilder query = new RangeQueryBuilder(randomAsciiOfLength(8));
+        if (randomBoolean()) {
+            query.boost(2.0f / randomIntBetween(1, 20));
+        }
+        if (randomBoolean()) {
+            query.queryName(randomAsciiOfLength(8));
+        }
+        query.includeLower(randomBoolean()).includeUpper(randomBoolean());
+        // switch between numeric and date ranges
+        if (randomBoolean()) {
+            query.from(randomIntBetween(1, 100));
+            query.to(randomIntBetween(101, 200));
+        } else {
+            query.from(new DateTime(System.currentTimeMillis() - randomIntBetween(0, 100000)).toString());
+            query.from(new DateTime(System.currentTimeMillis() + randomIntBetween(0, 100000)).toString());
+            if (randomBoolean()) {
+                query.timeZone(TIMEZONE_IDS.get(randomIntBetween(0, TIMEZONE_IDS.size())));
+            }
+            if (randomBoolean()) {
+                query.format("yyyy-MM-ddTHH:mm:ss.SSSZZ");
+            }
+        }
+
+        if (randomBoolean()) {
+            query.from(null);
+        }
+        if (randomBoolean()) {
+            query.to(null);
+        }
+        return query;
+    }
+
+    @Override
+    protected void assertLuceneQuery(RangeQueryBuilder queryBuilder, Query query, QueryParseContext context) throws IOException {
+        assertThat(query, instanceOf(TermRangeQuery.class));
+        assertThat(query.getBoost(), is(queryBuilder.boost()));
+        TermRangeQuery termRangeQuery = (TermRangeQuery) query;
+        assertThat(termRangeQuery.includesLower(), is(queryBuilder.includeLower()));
+        assertThat(termRangeQuery.includesUpper(), is(queryBuilder.includeUpper()));
+        assertThat(termRangeQuery.getLowerTerm(), is(BytesRefs.toBytesRef(queryBuilder.from())));
+        assertThat(termRangeQuery.getUpperTerm(), is(BytesRefs.toBytesRef(queryBuilder.to())));
+        assertThat(termRangeQuery.getField(), is(queryBuilder.fieldname()));
+        if (queryBuilder.queryName() != null) {
+            Query namedQuery = context.copyNamedFilters().get(queryBuilder.queryName());
+            assertThat(namedQuery, equalTo((Query) termRangeQuery));
+        }
+    }
+
+    @Test
+    public void testValidation() {
+        RangeQueryBuilder rangeQueryBuilder = new RangeQueryBuilder("");
+        assertThat(rangeQueryBuilder.validate().validationErrors().size(), is(1));
+
+        rangeQueryBuilder = new RangeQueryBuilder("okay").timeZone("UTC");
+        assertNull(rangeQueryBuilder.validate());
+
+        rangeQueryBuilder.timeZone("blab");
+        assertThat(rangeQueryBuilder.validate().validationErrors().size(), is(1));
+
+        rangeQueryBuilder.timeZone("UTC").format("basicDate");
+        assertNull(rangeQueryBuilder.validate());
+
+        rangeQueryBuilder.timeZone("UTC").format("broken_xx");
+        assertThat(rangeQueryBuilder.validate().validationErrors().size(), is(1));
+
+        rangeQueryBuilder.timeZone("xXx").format("broken_xx");
+        assertThat(rangeQueryBuilder.validate().validationErrors().size(), is(2));
+    }
+
+    @Override
+    protected RangeQueryBuilder createEmptyQueryBuilder() {
+        return new RangeQueryBuilder();
+    }
+
+}


### PR DESCRIPTION
Split the parse(QueryParseContext ctx) method into a parsing and a query building part, adding Streamable for serialization and hashCode(), equals() for better testing.
Add basic unit test for Builder and Parser.

PR goes agains query-refacoring feature branch.
