### PR TITLE
Make synced flush attempt async to run it easily from a TransportAction

### DIFF
--- a/src/test/java/org/elasticsearch/gateway/RecoveryFromGatewayTests.java
+++ b/src/test/java/org/elasticsearch/gateway/RecoveryFromGatewayTests.java
@@ -40,6 +40,7 @@ import org.elasticsearch.indices.recovery.RecoveryState;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
 import org.elasticsearch.test.InternalTestCluster.RestartCallback;
+import org.elasticsearch.test.SyncedFlushUtil;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.test.store.MockFSDirectoryService;
 import org.junit.Test;
@@ -401,7 +402,7 @@ public class RecoveryFromGatewayTests extends ElasticsearchIntegrationTest {
             int numShards = Integer.parseInt(client().admin().indices().prepareGetSettings("test").get().getSetting("test", "index.number_of_shards"));
             SyncedFlushService syncedFlushService = internalCluster().getInstance(SyncedFlushService.class);
             for (int i = 0; i < numShards; i++) {
-                assertTrue(syncedFlushService.attemptSyncedFlush(new ShardId("test", i)).success());
+                assertTrue(SyncedFlushUtil.attemptSyncedFlush(syncedFlushService, new ShardId("test", i)).success());
             }
             assertSyncIdsNotNull();
         }

--- a/src/test/java/org/elasticsearch/indices/FlushTest.java
+++ b/src/test/java/org/elasticsearch/indices/FlushTest.java
@@ -26,6 +26,7 @@ import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.SyncedFlushUtil;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.junit.Test;
 
@@ -88,7 +89,7 @@ public class FlushTest extends ElasticsearchIntegrationTest {
             assertNull(shardStats.getCommitStats().getUserData().get(Engine.SYNC_COMMIT_ID));
         }
 
-        SyncedFlushService.SyncedFlushResult result = internalCluster().getInstance(SyncedFlushService.class).attemptSyncedFlush(new ShardId("test", 0));
+        SyncedFlushService.SyncedFlushResult result = SyncedFlushUtil.attemptSyncedFlush(internalCluster().getInstance(SyncedFlushService.class), new ShardId("test", 0));
         assertTrue(result.success());
         assertThat(result.totalShards(), equalTo(indexStats.getShards().length));
         assertThat(result.successfulShards(), equalTo(indexStats.getShards().length));

--- a/src/test/java/org/elasticsearch/test/SyncedFlushUtil.java
+++ b/src/test/java/org/elasticsearch/test/SyncedFlushUtil.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.test;
+
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.indices.SyncedFlushService;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+
+/** Utils for SyncedFlush */
+public class SyncedFlushUtil {
+
+    private SyncedFlushUtil() {
+
+    }
+
+    /**
+     * Blocking version of {@link SyncedFlushService#attemptSyncedFlush(ShardId, ActionListener)}
+     */
+    public static SyncedFlushService.SyncedFlushResult attemptSyncedFlush(SyncedFlushService service, ShardId shardId) {
+        final CountDownLatch countDown = new CountDownLatch(1);
+        final AtomicReference<SyncedFlushService.SyncedFlushResult> result = new AtomicReference<>();
+        final AtomicReference<Throwable> exception = new AtomicReference<>();
+        service.attemptSyncedFlush(shardId, new ActionListener<SyncedFlushService.SyncedFlushResult>() {
+            @Override
+            public void onResponse(SyncedFlushService.SyncedFlushResult syncedFlushResult) {
+                result.compareAndSet(null, syncedFlushResult);
+                countDown.countDown();
+            }
+
+            @Override
+            public void onFailure(Throwable e) {
+                exception.compareAndSet(null, e);
+                countDown.countDown();
+            }
+        });
+        try {
+            countDown.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        if (exception.get() != null) {
+            throw ExceptionsHelper.convertToElastic(exception.get());
+        }
+        return result.get();
+    }
+
+}


### PR DESCRIPTION
Today we enforce blocking which doesnt' really fit in the elasticsearch model
this commit adds async execution to the synced flush service by passing a
ActinListener to the service returing immediately.
