### PR TITLE
Query DSL: deprecate BytesFilterBuilder in favour of WrapperFilterBuilder

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/BytesFilterBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/BytesFilterBuilder.java
@@ -27,14 +27,16 @@ import java.io.IOException;
 /**
  * FilterBuilder that constructs filters from {@link org.elasticsearch.common.bytes.BytesReference}
  * source
+ *
+ * @deprecated replace with {@link WrapperFilterBuilder}
  */
+@Deprecated
 public class BytesFilterBuilder extends BaseFilterBuilder {
 
     private final BytesReference source;
 
     public BytesFilterBuilder(BytesReference source) {
         this.source = source;
-
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/FilterBuilders.java
+++ b/src/main/java/org/elasticsearch/index/query/FilterBuilders.java
@@ -553,19 +553,34 @@ public abstract class FilterBuilders {
         return new IndicesFilterBuilder(filter, indices);
     }
 
+    /**
+     * A Filter builder which allows building a query thanks to a JSON string or binary data.
+     */
     public static WrapperFilterBuilder wrapperFilter(String filter) {
         return new WrapperFilterBuilder(filter);
     }
 
+    /**
+     * A Filter builder which allows building a query thanks to a JSON string or binary data.
+     */
     public static WrapperFilterBuilder wrapperFilter(byte[] data, int offset, int length) {
         return new WrapperFilterBuilder(data, offset, length);
     }
 
     /**
+     * A Filter builder which allows building a query thanks to a JSON string or binary data.
+     */
+    public static WrapperFilterBuilder wrapperFilter(BytesReference source) {
+        return new WrapperFilterBuilder(source);
+    }
+
+    /**
      * Constructs a bytes filter to generate a filter from a {@link BytesReference} source
+     * @deprecated replace with {@link #wrapperFilter(byte[], int, int)}
      *
      * @param source The filter source
      */
+    @Deprecated
     public static BytesFilterBuilder bytesFilter(BytesReference source) {
         return new BytesFilterBuilder(source);
     }

--- a/src/main/java/org/elasticsearch/index/query/WrapperFilterBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/WrapperFilterBuilder.java
@@ -18,20 +18,15 @@
  */
 
 package org.elasticsearch.index.query;
-/**
- * Created by IntelliJ IDEA.
- * User: cedric
- * Date: 12/07/11
- * Time: 11:30
- */
 
 import com.google.common.base.Charsets;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 
 /**
- * A Filter builder which allows building a filter thanks to a JSON string or binary data. This is useful when you want
+ * A Filter builder which allows building a query given JSON string or binary data provided as input. This is useful when you want
  * to use the Java Builder API but still have JSON filter strings at hand that you want to combine with other
  * query builders.
  */
@@ -41,16 +36,31 @@ public class WrapperFilterBuilder extends BaseFilterBuilder {
     private final int offset;
     private final int length;
 
+    /**
+     * Creates a filter builder given a query provided as a string
+     */
     public WrapperFilterBuilder(String source) {
         this.source = source.getBytes(Charsets.UTF_8);
         this.offset = 0;
         this.length = this.source.length;
     }
 
+    /**
+     * Creates a filter builder given a query provided as a bytes array
+     */
     public WrapperFilterBuilder(byte[] source, int offset, int length) {
         this.source = source;
         this.offset = offset;
         this.length = length;
+    }
+
+    /**
+     * Creates a filter builder given a query provided as a {@link BytesReference}
+     */
+    public WrapperFilterBuilder(BytesReference source) {
+        this.source = source.array();
+        this.offset = source.arrayOffset();
+        this.length = source.length();
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggester.java
+++ b/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggester.java
@@ -168,7 +168,7 @@ public final class PhraseSuggester extends Suggester<PhraseSuggestionContext> {
             if (isFilter) {
                 req = client.prepareSearch()
                         .setPreference(suggestions.getPreference())
-                        .setQuery(QueryBuilders.constantScoreQuery(FilterBuilders.bytesFilter(querySource)))
+                        .setQuery(QueryBuilders.constantScoreQuery(FilterBuilders.wrapperFilter(querySource)))
                         .setSearchType(SearchType.COUNT)
                         .setTerminateAfter(1);
             } else {


### PR DESCRIPTION
BytesFilterBuilder got removed from master and is now deprecated in 1.x. WrapperFilterBuilder should be used instead.

Relates to #10919
