### PR TITLE
Don't throw an exception if repositories are unregistered with `*`

### DIFF
--- a/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
+++ b/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
@@ -191,6 +191,9 @@ public class RepositoriesService extends AbstractComponent implements ClusterSta
                         return ClusterState.builder(currentState).metaData(mdBuilder).build();
                     }
                 }
+                if (Regex.isMatchAllPattern(request.name)) { // we use a wildcard so we don't barf if it's not present.
+                    return currentState;
+                }
                 throw new RepositoryMissingException(request.name);
             }
 


### PR DESCRIPTION
Today we barf if repositories are unregistered with a `*` pattern. This
happens on almost every test and adds weird log messages. I dont' think
we should barf in that case.
