### PR TITLE
MLT depricated

### DIFF
--- a/docs/reference/query-dsl/queries/flt-query.asciidoc
+++ b/docs/reference/query-dsl/queries/flt-query.asciidoc
@@ -1,8 +1,6 @@
 [[query-dsl-flt-query]]
 === Fuzzy Like This Query
 
-deprecated[1.6.0, This query will be removed in Elasticsearch 2.0]
-
 Fuzzy like this query find documents that are "like" provided text by
 running it against one or more fields.
 

--- a/docs/reference/query-dsl/queries/mlt-query.asciidoc
+++ b/docs/reference/query-dsl/queries/mlt-query.asciidoc
@@ -1,6 +1,8 @@
 [[query-dsl-mlt-query]]
 === More Like This Query
 
+deprecated[1.6.0, This query will be removed in Elasticsearch 2.0]
+
 The More Like This Query (MLT Query) finds documents that are "like" a given
 set of documents. In order to do so, MLT selects a set of representative terms
 of these input documents, forms a query using these terms, executes the query


### PR DESCRIPTION
According to #10736 More Like This is deprecated, not Fuzzy Like This. I tried to find issue about FLT deprecation, but I could not.
