### PR TITLE
Query refactoring: BoolQueryBuilder and Parser

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -509,6 +509,20 @@ public abstract class StreamInput extends InputStream {
         return namedWriteable.readFrom(this);
     }
 
+    /**
+     * Reads a list of {@link NamedWriteable} from the current stream, by first reading its size and then
+     * reading the individual objects using {@link #readNamedWriteable()}.
+     */
+    public <C> List<C> readNamedWritableList() throws IOException {
+        List<C> list = new ArrayList<>();
+        int size = readInt();
+        for (int i = 0; i < size; i++) {
+            C obj = readNamedWriteable();
+            list.add(obj);
+        }
+        return list;
+    }
+
     public static StreamInput wrap(BytesReference reference) {
         if (reference.hasArray() == false) {
             reference = reference.toBytesArray();

--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -457,4 +457,15 @@ public abstract class StreamOutput extends OutputStream {
         writeString(namedWriteable.getName());
         namedWriteable.writeTo(this);
     }
+
+    /**
+     * Writes a list of {@link NamedWriteable} to the current stream, by first writing its size and then iterating over the objects
+     * in the list
+     */
+    public void writeNamedWritableList(List<? extends NamedWriteable> list) throws IOException {
+        writeInt(list.size());
+        for (NamedWriteable obj : list) {
+            writeNamedWriteable(obj);
+        }
+    }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/QueryParseContext.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryParseContext.java
@@ -267,18 +267,37 @@ public class QueryParseContext {
         return result;
     }
 
+    /**
+     * @deprecated replaced by calls to parseInnerFilterToQueryBuilder() for the resulting queries
+     */
     @Nullable
+    @Deprecated
     public Query parseInnerFilter() throws QueryParsingException, IOException {
+        QueryBuilder builder = parseInnerFilterToQueryBuilder();
+        Query result = null;
+        if (builder != null) {
+            result = builder.toQuery(this);
+        }
+        return result;
+    }
+
+    /**
+     * @return
+     * @throws QueryParsingException
+     * @throws IOException
+     */
+    @Nullable
+    public QueryBuilder parseInnerFilterToQueryBuilder() throws QueryParsingException, IOException {
         final boolean originalIsFilter = isFilter;
         try {
             isFilter = true;
-            return parseInnerQuery();
+            return parseInnerQueryBuilder();
         } finally {
             isFilter = originalIsFilter;
         }
     }
 
-    public Query parseInnerFilter(String queryName) throws IOException, QueryParsingException {
+    public QueryBuilder parseInnerFilterToQueryBuilder(String queryName) throws IOException, QueryParsingException {
         final boolean originalIsFilter = isFilter;
         try {
             isFilter = true;
@@ -286,10 +305,20 @@ public class QueryParseContext {
             if (queryParser == null) {
                 throw new QueryParsingException(this, "No query registered for [" + queryName + "]");
             }
-            return queryParser.parse(this);
+            return queryParser.fromXContent(this);
         } finally {
             isFilter = originalIsFilter;
         }
+    }
+
+    /**
+     * @deprecated replaced by calls to parseInnerFilterToQueryBuilder(String queryName) for the resulting queries
+     */
+    @Nullable
+    @Deprecated
+    public Query parseInnerFilter(String queryName) throws IOException, QueryParsingException {
+        QueryBuilder builder = parseInnerFilterToQueryBuilder(queryName);
+        return (builder != null) ? builder.toQuery(this) : null;
     }
 
     public Collection<String> simpleMatchToIndexNames(String pattern) {

--- a/core/src/test/java/org/elasticsearch/index/query/BoolQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/BoolQueryBuilderTest.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query;
+
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.BooleanClause.Occur;
+import org.elasticsearch.common.lucene.search.Queries;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.elasticsearch.common.lucene.search.Queries.fixNegativeQueryIfNeeded;
+
+public class BoolQueryBuilderTest extends BaseQueryTestCase<BoolQueryBuilder> {
+
+    @Override
+    protected void assertLuceneQuery(BoolQueryBuilder queryBuilder, Query query, QueryParseContext context) {
+        if (queryBuilder.queryName() != null) {
+            Query namedQuery = context.copyNamedFilters().get(queryBuilder.queryName());
+            if (queryBuilder.hasClauses()) {
+                assertThat(namedQuery, equalTo(query));
+            } else {
+                assertNull(namedQuery);
+            }
+        }
+    }
+
+    @Override
+    protected BoolQueryBuilder createTestQueryBuilder() {
+        BoolQueryBuilder query = new BoolQueryBuilder();
+        if (randomBoolean()) {
+            query.boost(2.0f / randomIntBetween(1, 20));
+        }
+        if (randomBoolean()) {
+            query.adjustPureNegative(randomBoolean());
+        }
+        if (randomBoolean()) {
+            query.disableCoord(randomBoolean());
+        }
+        if (randomBoolean()) {
+            query.minimumNumberShouldMatch(randomIntBetween(1, 10));
+        }
+        int mustClauses = randomIntBetween(0, 3);
+        for (int i = 0; i < mustClauses; i++) {
+            query.must(RandomQueryBuilder.create(random()));
+        }
+        int mustNotClauses = randomIntBetween(0, 3);
+        for (int i = 0; i < mustNotClauses; i++) {
+            query.mustNot(RandomQueryBuilder.create(random()));
+        }
+        int shouldClauses = randomIntBetween(0, 3);
+        for (int i = 0; i < shouldClauses; i++) {
+            query.should(RandomQueryBuilder.create(random()));
+        }
+        int filterClauses = randomIntBetween(0, 3);
+        for (int i = 0; i < filterClauses; i++) {
+            query.filter(RandomQueryBuilder.create(random()));
+        }
+        if (randomBoolean()) {
+            query.queryName(randomUnicodeOfLengthBetween(3, 15));
+        }
+        return query;
+    }
+
+    @Override
+    protected BoolQueryBuilder createEmptyQueryBuilder() {
+        return new BoolQueryBuilder();
+    }
+
+    @Override
+    protected Query createExpectedQuery(BoolQueryBuilder queryBuilder, QueryParseContext context) throws IOException {
+        if (!queryBuilder.hasClauses()) {
+            return new MatchAllDocsQuery();
+        }
+
+        BooleanQuery boolQuery = new BooleanQuery(queryBuilder.disableCoord());
+        boolQuery.setBoost(queryBuilder.boost());
+        addBooleanClauses(context, boolQuery, queryBuilder.must(), BooleanClause.Occur.MUST);
+        addBooleanClauses(context, boolQuery, queryBuilder.mustNot(), BooleanClause.Occur.MUST_NOT);
+        addBooleanClauses(context, boolQuery, queryBuilder.should(), BooleanClause.Occur.SHOULD);
+        addBooleanClauses(context, boolQuery, queryBuilder.filter(), BooleanClause.Occur.FILTER);
+
+        Queries.applyMinimumShouldMatch(boolQuery, queryBuilder.minimumNumberShouldMatch());
+        Query returnedQuery = queryBuilder.adjustPureNegative() ? fixNegativeQueryIfNeeded(boolQuery) : boolQuery;
+        return returnedQuery;
+    }
+
+    private static void addBooleanClauses(QueryParseContext parseContext, BooleanQuery booleanQuery, List<QueryBuilder> clauses, Occur occurs)
+            throws IOException {
+        for (QueryBuilder query : clauses) {
+            booleanQuery.add(new BooleanClause(query.toQuery(parseContext), occurs));
+        }
+    }
+}

--- a/core/src/test/java/org/elasticsearch/index/query/RandomQueryBuilder.java
+++ b/core/src/test/java/org/elasticsearch/index/query/RandomQueryBuilder.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query;
+
+import com.carrotsearch.randomizedtesting.generators.RandomInts;
+
+import java.util.Random;
+
+/**
+ * Utility class for creating random QueryBuilders.
+ * So far only leaf queries like {@link MatchAllQueryBuilder}, {@link TermQueryBuilder} or
+ * {@link IdsQueryBuilder} are returned.
+ */
+public class RandomQueryBuilder {
+
+    /**
+     * @param r random seed
+     * @return a random {@link QueryBuilder}
+     */
+    public static QueryBuilder create(Random r) {
+        QueryBuilder query = null;
+        switch (RandomInts.randomIntBetween(r, 0, 2)) {
+        case 0:
+            return new MatchAllQueryBuilderTest().createTestQueryBuilder();
+        case 1:
+            return new TermQueryBuilderTest().createTestQueryBuilder();
+        case 2:
+            return new IdsQueryBuilderTest().createTestQueryBuilder();
+        }
+        return query;
+    }
+}


### PR DESCRIPTION
Refactors BoolQueryBuilder and Parser. Splits the parse() method into a parsing and a query building part, adding NamedWriteable implementation for serialization and hashCode(), equals() for testing.

This change also adds tests using fixed set of leaf queries (Terms, Ids, MatchAll) as nested Queries in test query setup. Also QueryParseContext is adapted to return QueryBuilder instances for inner filter parses instead of previously returning Query instances, keeping old methods in place but deprecating them.

Relates to #10217

PR goes agains query-refacoring feature branch.
