### PR TITLE
Added an R client to community clients page

### DIFF
--- a/docs/community/clients.asciidoc
+++ b/docs/community/clients.asciidoc
@@ -218,3 +218,6 @@ See the {client}/net-api/current/index.html[official Elasticsearch .NET client].
 === R
 * https://github.com/Tomesch/elasticsearch[elasticsearch]
   R client for Elasticsearch
+
+* https://github.com/ropensci/elastic[elastic]: 
+  A general purpose R client for Elasticsearch


### PR DESCRIPTION
I maintain an R client called `elastic` at https://github.com/ropensci/elastic
