### PR TITLE
Add index name to log statements when settings update fails

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/metadata/MetaDataUpdateSettingsService.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MetaDataUpdateSettingsService.java
@@ -85,16 +85,16 @@ public class MetaDataUpdateSettingsService extends AbstractComponent implements 
 
                     final int dash = autoExpandReplicas.indexOf('-');
                     if (-1 == dash) {
-                        logger.warn("Unexpected value [{}] for setting [{}]; it should be dash delimited",
-                                autoExpandReplicas, IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS);
+                        logger.warn("failed to set [{}] for index [{}], it should be dash delimited [{}]",
+                                IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, indexMetaData.index(), autoExpandReplicas);
                         continue;
                     }
                     final String sMin = autoExpandReplicas.substring(0, dash);
                     try {
                         min = Integer.parseInt(sMin);
                     } catch (NumberFormatException e) {
-                        logger.warn("failed to set [{}], minimum value is not a number [{}]",
-                                e, IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, sMin);
+                        logger.warn("failed to set [{}] for index [{}], minimum value is not a number [{}]",
+                                e, IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, indexMetaData.index(), sMin);
                         continue;
                     }
                     String sMax = autoExpandReplicas.substring(dash + 1);
@@ -104,8 +104,8 @@ public class MetaDataUpdateSettingsService extends AbstractComponent implements 
                         try {
                             max = Integer.parseInt(sMax);
                         } catch (NumberFormatException e) {
-                            logger.warn("failed to set [{}], maximum value is neither [{}] nor a number [{}]",
-                                    e, IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, ALL_NODES_VALUE, sMax);
+                            logger.warn("failed to set [{}] for index [{}], maximum value is neither [{}] nor a number [{}]",
+                                    e, IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, indexMetaData.index(), ALL_NODES_VALUE, sMax);
                             continue;
                         }
                     }


### PR DESCRIPTION
When an index setting is invalid and fails to be set, a WARN statement is logged but it doesn't contain the index name, making tracking down and fixing the problem more difficult. This commit adds the index name to the log statement.

To see the differences in the log statements:

``` sh
# Create an index
curl -XPOST localhost:9200/foo
# Response
{"acknowledged":true}

# Add a setting value that isn't dash delimited
curl -XPUT localhost:9200/foo/_settings -d '{ "auto_expand_replicas": 2 }'
# Response
{"acknowledged":true}

# Current log statement
[2015-05-12 12:07:03,538][WARN ][cluster.metadata         ] [Hypnotia] Unexpected value [2] for setting [index.auto_expand_replicas]; it should be dash delimited

# Updated log statement
[2015-05-12 12:04:31,460][WARN ][cluster.metadata         ] [Spider-Ham] failed to set [index.auto_expand_replicas] for index [foo], it should be dash delimited [2]

# Add a setting value with a min value not a number
curl -XPUT localhost:9200/foo/_settings -d '{ "auto_expand_replicas": "a-b" }'
# Response
{"acknowledged":true}

# Current log statement
[2015-05-12 12:10:09,297][WARN ][cluster.metadata         ] [Hypnotia] failed to set [index.auto_expand_replicas], minimum value is not a number [a]

# Updated log statement
[2015-05-12 12:09:10,056][WARN ][cluster.metadata         ] [Spider-Ham] failed to set [index.auto_expand_replicas] for index [foo], minimum value is not a number [a]

# Add a setting value with a max value not a number or all
curl -XPUT localhost:9200/foo/_settings -d '{ "auto_expand_replicas": "0-a" }'
# Response
{"acknowledged":true}

# Current log statement
[2015-05-12 12:12:01,934][WARN ][cluster.metadata         ] [Hypnotia] failed to set [index.auto_expand_replicas], maximum value is neither [all] nor a number [a]

# Updated log statement
[2015-05-12 12:11:37,191][WARN ][cluster.metadata         ] [Spider-Ham] failed to set [index.auto_expand_replicas] for index [foo], maximum value is neither [all] nor a number [a]

```
