### PR TITLE
Make the script filter a query.

### DIFF
--- a/src/test/java/org/elasticsearch/search/scriptfilter/ScriptQuerySearchTests.java
+++ b/src/test/java/org/elasticsearch/search/scriptfilter/ScriptQuerySearchTests.java
@@ -41,7 +41,7 @@ import static org.hamcrest.Matchers.equalTo;
  *
  */
 @ElasticsearchIntegrationTest.ClusterScope(scope=ElasticsearchIntegrationTest.Scope.SUITE)
-public class ScriptFilterSearchTests extends ElasticsearchIntegrationTest {
+public class ScriptQuerySearchTests extends ElasticsearchIntegrationTest {
 
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {


### PR DESCRIPTION
This change changes the script filter so that it produces scorers with two-phase
iteration support instead of doc id sets with random-access.
