### PR TITLE
Remove unnecessary permissions.

### DIFF
--- a/src/main/resources/org/elasticsearch/bootstrap/security.policy
+++ b/src/main/resources/org/elasticsearch/bootstrap/security.policy
@@ -32,13 +32,13 @@ grant codeBase "file:${{java.ext.dirs}}/*" {
 
 grant {
 
-  permission java.nio.file.LinkPermission "symbolic";
+  // Allow executing groovy scripts with codesource of /groovy/script
   permission groovy.security.GroovyCodeSourcePermission "/groovy/script";
 
   // Allow connecting to the internet anywhere
   permission java.net.SocketPermission "*", "accept,listen,connect,resolve";
 
-  // Basic permissions needed for Lucene / Elasticsearch to work:
+  // Allow read/write to all system properties
   permission java.util.PropertyPermission "*", "read,write";
 
   // needed by junit4's gson usage 
@@ -74,13 +74,13 @@ grant {
   // needed by groovy engine
   permission java.lang.RuntimePermission "accessClassInPackage.sun.reflect";
 
+  // needed by RandomizedRunner
   permission java.lang.RuntimePermission "accessDeclaredMembers";
+  // needed by RandomizedRunner
   permission java.lang.RuntimePermission "getStackTrace";
 
   // needed by RandomizedRunner
   permission java.lang.RuntimePermission "setDefaultUncaughtExceptionHandler";
-
-  permission java.lang.RuntimePermission "usePolicy";
 
   // needed by JMX instead of getFileSystemAttributes, seems like a bug...
   permission java.lang.RuntimePermission "getFileStoreAttributes";
@@ -91,18 +91,9 @@ grant {
   // needed by plugin manager to set unix permissions
   permission java.lang.RuntimePermission "accessUserInformation";
 
-  // These two *have* to be spelled out a separate
-  permission java.lang.management.ManagementPermission "control";
+  // needed by jvminfo for monitoring the jvm
   permission java.lang.management.ManagementPermission "monitor";
 
-  permission java.net.NetPermission "*";
+  // needed by JDKESLoggerTests
   permission java.util.logging.LoggingPermission "control";
-  permission javax.management.MBeanPermission "*", "*";
-  permission javax.management.MBeanServerPermission "*";
-  permission javax.management.MBeanTrustPermission "*";
-
-  // Needed for some things in DNS caching in the JVM
-  permission java.security.SecurityPermission "getProperty.networkaddress.cache.ttl";
-  permission java.security.SecurityPermission "getProperty.networkaddress.cache.negative.ttl";
-
 };

--- a/src/test/java/org/elasticsearch/bootstrap/SecurityTests.java
+++ b/src/test/java/org/elasticsearch/bootstrap/SecurityTests.java
@@ -156,6 +156,8 @@ public class SecurityTests extends ElasticsearchTestCase {
             Files.createSymbolicLink(linkExists, exists);
         } catch (UnsupportedOperationException | IOException e) {
             assumeNoException("test requires filesystem that supports symbolic links", e);
+        } catch (SecurityException e) {
+            assumeNoException("test cannot create symbolic links with security manager enabled", e);
         }
         Security.ensureDirectoryExists(linkExists);
         Files.createTempFile(linkExists, null, null);
@@ -170,6 +172,8 @@ public class SecurityTests extends ElasticsearchTestCase {
             Files.createSymbolicLink(brokenLink, p.resolve("nonexistent"));
         } catch (UnsupportedOperationException | IOException e) {
             assumeNoException("test requires filesystem that supports symbolic links", e);
+        } catch (SecurityException e) {
+            assumeNoException("test cannot create symbolic links with security manager enabled", e);
         }
         try {
             Security.ensureDirectoryExists(brokenLink);

--- a/src/test/java/org/elasticsearch/common/PidFileTests.java
+++ b/src/test/java/org/elasticsearch/common/PidFileTests.java
@@ -56,7 +56,7 @@ public class PidFileTests extends ElasticsearchTestCase {
                     Path link = dir.resolve("link_to_real_path");
                     Files.createSymbolicLink(link, parent.getFileName());
                     parent = link;
-                } catch (UnsupportedOperationException ex) {
+                } catch (UnsupportedOperationException | IOException | SecurityException ex) {
                    // fine - no links on this system
                 }
 


### PR DESCRIPTION
Also document remaining permissions, so we have an explanation for each one.

For the case of LinkPermission, its special, as it allows access to any file on the system. We don't really need the possibility to create symlinks, and the two tests doing it need guards anyway for the windows case, etc.
