### PR TITLE
Add tests.config support to BootstrapForTesting

### DIFF
--- a/src/main/resources/org/elasticsearch/bootstrap/security.policy
+++ b/src/main/resources/org/elasticsearch/bootstrap/security.policy
@@ -73,6 +73,8 @@ grant {
   permission java.lang.RuntimePermission "accessClassInPackage.sun.nio.ch";
   // needed by groovy engine
   permission java.lang.RuntimePermission "accessClassInPackage.sun.reflect";
+  // needed by aws core sdk (TODO: look into this)
+  permission java.lang.RuntimePermission "accessClassInPackage.sun.security.ssl";
 
   // needed by RandomizedRunner
   permission java.lang.RuntimePermission "accessDeclaredMembers";

--- a/src/test/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
+++ b/src/test/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
@@ -23,8 +23,10 @@ import org.apache.lucene.util.TestSecurityManager;
 import org.elasticsearch.bootstrap.Bootstrap;
 import org.elasticsearch.bootstrap.ESPolicy;
 import org.elasticsearch.bootstrap.Security;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.PathUtils;
 
+import java.io.FilePermission;
 import java.nio.file.Path;
 import java.security.Permissions;
 import java.security.Policy;
@@ -68,6 +70,10 @@ public class BootstrapForTesting {
                 Path javaTmpDir = PathUtils.get(Objects.requireNonNull(System.getProperty("java.io.tmpdir"), 
                                                                       "please set ${java.io.tmpdir} in pom.xml"));
                 Security.addPath(perms, javaTmpDir, "read,readlink,write,delete");
+                // custom test config file
+                if (Strings.hasLength(System.getProperty("tests.config"))) {
+                    perms.add(new FilePermission(System.getProperty("tests.config"), "read,readlink"));
+                }
                 Policy.setPolicy(new ESPolicy(perms));
                 System.setSecurityManager(new TestSecurityManager());
                 Security.selfTest();


### PR DESCRIPTION
Several plugins (e.g. elasticsearch-cloud-aws, elasticsearch-cloud-azure, elasticsearch-cloud-gce)
have integration tests that run with actual credentials to a remote service, so test runs
need access to this file.

These all require the tester (or jenkins) to supply the file with -Dtests.config. I think we should just add a simple rule here. 

I considered two alternatives:
1. solve it in maven by treating the external config as a test resource. I don't like this since its credentials in these cases, think about jenkins workspaces and so on.
2. just don't run these special integration test groups with security manager. I don't like this since then we can't be confident these plugins work!

With this PR, these aws and azure tests work with security manager enabled. I also had to add a permission for some crazy stuff in aws-core-sdk, I will look into that later and see if I can remove it.
