### PR TITLE
Prevent PercolateResponse from serializing negative VLong

### DIFF
--- a/src/main/java/org/elasticsearch/action/percolate/PercolateResponse.java
+++ b/src/main/java/org/elasticsearch/action/percolate/PercolateResponse.java
@@ -52,6 +52,9 @@ public class PercolateResponse extends BroadcastOperationResponse implements Ite
     PercolateResponse(int totalShards, int successfulShards, int failedShards, List<ShardOperationFailedException> shardFailures,
                              Match[] matches, long count, long tookInMillis, InternalAggregations aggregations) {
         super(totalShards, successfulShards, failedShards, shardFailures);
+        if (tookInMillis < 0) {
+            throw new IllegalArgumentException("tookInMillis must be positive but was: " + tookInMillis);
+        }
         this.tookInMillis = tookInMillis;
         this.matches = matches;
         this.count = count;
@@ -60,6 +63,9 @@ public class PercolateResponse extends BroadcastOperationResponse implements Ite
 
     PercolateResponse(int totalShards, int successfulShards, int failedShards, List<ShardOperationFailedException> shardFailures, long tookInMillis, Match[] matches) {
         super(totalShards, successfulShards, failedShards, shardFailures);
+        if (tookInMillis < 0) {
+            throw new IllegalArgumentException("tookInMillis must be positive but was: " + tookInMillis);
+        }
         this.tookInMillis = tookInMillis;
         this.matches = matches;
     }

--- a/src/main/java/org/elasticsearch/action/percolate/TransportPercolateAction.java
+++ b/src/main/java/org/elasticsearch/action/percolate/TransportPercolateAction.java
@@ -143,12 +143,12 @@ public class TransportPercolateAction extends TransportBroadcastOperationAction<
         }
 
         if (shardResults == null) {
-            long tookInMillis = System.currentTimeMillis() - request.startTime;
+            long tookInMillis = Math.max(1, System.currentTimeMillis() - request.startTime);
             PercolateResponse.Match[] matches = request.onlyCount() ? null : PercolateResponse.EMPTY;
             return new PercolateResponse(shardsResponses.length(), successfulShards, failedShards, shardFailures, tookInMillis, matches);
         } else {
             PercolatorService.ReduceResult result = percolatorService.reduce(percolatorTypeId, shardResults);
-            long tookInMillis = System.currentTimeMillis() - request.startTime;
+            long tookInMillis =  Math.max(1, System.currentTimeMillis() - request.startTime);
             return new PercolateResponse(
                     shardsResponses.length(), successfulShards, failedShards, shardFailures,
                     result.matches(), result.count(), tookInMillis, result.reducedAggregations()


### PR DESCRIPTION
We are using a a VLong to serialize the PercolateResponse#tookInMillis. This
can due to several `System.currentTimeMillis()` implemenation details be negative.
We should prevent the negavite value for being serialized as a VLong and make sure
we use a valid value for this in the first place

Our CI ran into this here: http://build-us-00.elastic.co/job/es_core_master_suse/608/

```
  1> java.lang.RuntimeException: failed to check serialization - version [0.20.5] for streamable [org.elasticsearch.action.percolate.PercolateResponse@129e9df5]
  1>    at org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertVersionSerializable(ElasticsearchAssertions.java:644)
  1>    at org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertVersionSerializable(ElasticsearchAssertions.java:624)
  1>    at org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures(ElasticsearchAssertions.java:326)
  1>    at org.elasticsearch.percolator.RecoveryPercolatorTests$2.run(RecoveryPercolatorTests.java:334)
  1>    at java.lang.Thread.run(Thread.java:745)
  1> Caused by: java.lang.AssertionError
  1>    at org.elasticsearch.common.io.stream.StreamOutput.writeVLong(StreamOutput.java:159)
  1>    at org.elasticsearch.action.percolate.PercolateResponse.writeTo(PercolateResponse.java:178)
  1>    at org.elasticsearch.test.hamcrest.ElasticsearchAssertions.serialize(ElasticsearchAssertions.java:617)
  1>    at org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertVersionSerializable(ElasticsearchAssertions.java:637)
  1>    ... 4 more
```
