### PR TITLE
Add missing rewrite parameter to FuzzyQueryBuilder

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/FuzzyQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/FuzzyQueryBuilder.java
@@ -46,6 +46,8 @@ public class FuzzyQueryBuilder extends BaseQueryBuilder implements MultiTermQuer
     //LUCENE 4 UPGRADE  we need a testcase for this + documentation
     private Boolean transpositions;
 
+    private String rewrite;
+
     private String queryName;
 
     /**
@@ -89,6 +91,11 @@ public class FuzzyQueryBuilder extends BaseQueryBuilder implements MultiTermQuer
       return this;
     }
 
+    public FuzzyQueryBuilder rewrite(String rewrite) {
+        this.rewrite = rewrite;
+        return this;
+    }
+
     /**
      * Sets the query name for the filter that can be used when searching for matched_filters per hit.
      */
@@ -119,6 +126,9 @@ public class FuzzyQueryBuilder extends BaseQueryBuilder implements MultiTermQuer
             }
             if (maxExpansions != null) {
                 builder.field("max_expansions", maxExpansions);
+            }
+            if (rewrite != null) {
+                builder.field("rewrite", rewrite);
             }
             if (queryName != null) {
                 builder.field("_name", queryName);


### PR DESCRIPTION
We parse the rewrite field in `FuzzyQueryParser` but we don't allow to set it via `FuzzyQueryBuilder` for our java api users. Added missing field and setter.

Similar problems will be resolved with the query parser refactoring that we have been working on. The parser will only return an intermediate `Streamable` object, the same object that the java api users will use directly. No more building json through java api then, which can geet out of sync with what we actually parse.

Closes #11130
