### PR TITLE
Make FieldNameAnalyzer less lenient.

### DIFF
--- a/src/main/java/org/elasticsearch/index/analysis/FieldNameAnalyzer.java
+++ b/src/main/java/org/elasticsearch/index/analysis/FieldNameAnalyzer.java
@@ -63,7 +63,9 @@ public final class FieldNameAnalyzer extends DelegatingAnalyzerWrapper {
         if (analyzer != null) {
             return analyzer;
         }
-        return defaultAnalyzer;
+        // Don't be lenient here and return the default analyzer
+        // Fields need to be explicitly added
+        throw new IllegalArgumentException("Field [" + name + "] has no associated analyzer");
     }
 
     /**
@@ -72,9 +74,11 @@ public final class FieldNameAnalyzer extends DelegatingAnalyzerWrapper {
     public FieldNameAnalyzer copyAndAddAll(Collection<? extends Map.Entry<String, Analyzer>> mappers) {
         CopyOnWriteHashMap<String, Analyzer> analyzers = this.analyzers;
         for (Map.Entry<String, Analyzer> entry : mappers) {
-            if (entry.getValue() != null) {
-                analyzers = analyzers.copyAndPut(entry.getKey(), entry.getValue());
+            Analyzer analyzer = entry.getValue();
+            if (analyzer == null) {
+                analyzer = defaultAnalyzer;
             }
+            analyzers = analyzers.copyAndPut(entry.getKey(), analyzer);
         }
         return new FieldNameAnalyzer(analyzers, defaultAnalyzer);
     }

--- a/src/main/java/org/elasticsearch/index/mapper/MapperAnalyzer.java
+++ b/src/main/java/org/elasticsearch/index/mapper/MapperAnalyzer.java
@@ -19,8 +19,6 @@
 
 package org.elasticsearch.index.mapper;
 
-import java.util.Objects;
-
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.DelegatingAnalyzerWrapper;
 import org.elasticsearch.index.analysis.FieldNameAnalyzer;


### PR DESCRIPTION
In case FieldNameAnalyzer does not find an explicit analyzer for a given
field name, it returns the default analyzer. This behaviour can hide bugs
where the analyzer fails to be propagated to FieldNameAnalyzer or an
analyzer is requested for a field which is not mapped.
