### PR TITLE
Add test group for third-party tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -616,6 +616,8 @@
                                 <tests.timeoutSuite>${tests.timeoutSuite}</tests.timeoutSuite>
                                 <tests.showSuccess>${tests.showSuccess}</tests.showSuccess>
                                 <tests.integration>${tests.integration}</tests.integration>
+                                <tests.thirdparty>${tests.thirdparty}</tests.thirdparty>
+                                <tests.config>${tests.config}</tests.config>
                                 <tests.client.ratio>${tests.client.ratio}</tests.client.ratio>
                                 <tests.enable_mock_modules>${tests.enable_mock_modules}</tests.enable_mock_modules>
                                 <tests.assertion.disabled>${tests.assertion.disabled}</tests.assertion.disabled>

--- a/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
@@ -243,6 +243,26 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
     public @interface Integration {
     }
 
+    /**
+     * Property that controls whether ThirdParty Integration tests are run (not the default).
+     */
+    public static final String SYSPROP_THIRDPARTY = "tests.thirdparty";
+
+    /**
+     * Annotation for third-party integration tests.
+     * <p>
+     * These are tests the require a third-party service in order to run. They
+     * may require the user to manually configure an external process (such as rabbitmq),
+     * or may additionally require some external configuration (e.g. AWS credentials)
+     * via the {@code tests.config} system property.
+     */
+    @Inherited
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE)
+    @TestGroup(enabled = false, sysProperty = ElasticsearchIntegrationTest.SYSPROP_THIRDPARTY)
+    public @interface ThirdParty {
+    }
+
     /** node names of the corresponding clusters will start with these prefixes */
     public static final String SUITE_CLUSTER_NODE_PREFIX = "node_s";
     public static final String TEST_CLUSTER_NODE_PREFIX = "node_t";


### PR DESCRIPTION
We have quite a few integration tests across plugins that interact with third-party components. These can't run without additional setup/information: for example AWS/GCE/Azure cloud tests need you to pass a configuration file with credentials. RabbitMQ, CouchDB tests need you to start those processes up on your machine before running the test, and so on.

All of these plugins have duplicate test configurations in pom.xml to handle this case, yet its a common and general one. I think instead we should support `-Dtests.thirdparty=true / @ThirdParty` as a test group/annotation in the es test framework, and plumb it through es-parent, so that its consistent, and so we can remove all the duplicate build logic in these plugins.

See https://github.com/elastic/elasticsearch-parent/issues/41
