### PR TITLE
Implement toXContent on ShardOpertionFailureException

### DIFF
--- a/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -22,16 +22,18 @@ package org.elasticsearch;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import org.elasticsearch.action.ShardOperationFailedException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexException;
 import org.elasticsearch.rest.HasRestHeaders;
 import org.elasticsearch.rest.RestStatus;
 
 import java.io.IOException;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * A base class for all elasticsearch exceptions.
@@ -288,6 +290,4 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
     public String toString() {
         return ExceptionsHelper.detailedMessage(this).trim();
     }
-
-
 }

--- a/src/main/java/org/elasticsearch/action/ActionWriteResponse.java
+++ b/src/main/java/org/elasticsearch/action/ActionWriteResponse.java
@@ -231,6 +231,11 @@ public abstract class ActionWriteResponse extends ActionResponse {
                 return status;
             }
 
+            @Override
+            public Throwable getCause() {
+                return cause;
+            }
+
             /**
              * @return Whether this failure occurred on a primary shard.
              * (this only reports true for delete by query)

--- a/src/main/java/org/elasticsearch/action/ShardOperationFailedException.java
+++ b/src/main/java/org/elasticsearch/action/ShardOperationFailedException.java
@@ -20,16 +20,23 @@
 package org.elasticsearch.action;
 
 import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexException;
 import org.elasticsearch.rest.RestStatus;
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 /**
  * An exception indicating that a failure occurred performing an operation on the shard.
  *
  *
  */
-public interface ShardOperationFailedException extends Streamable, Serializable {
+public interface ShardOperationFailedException extends Streamable, Serializable, ToXContent {
 
     /**
      * The index the operation failed on. Might return <tt>null</tt> if it can't be derived.
@@ -50,4 +57,9 @@ public interface ShardOperationFailedException extends Streamable, Serializable 
      * The status of the failure.
      */
     RestStatus status();
+
+    /**
+     * The cause of this failure
+     */
+    Throwable getCause();
 }

--- a/src/main/java/org/elasticsearch/action/percolate/PercolateResponse.java
+++ b/src/main/java/org/elasticsearch/action/percolate/PercolateResponse.java
@@ -116,7 +116,7 @@ public class PercolateResponse extends BroadcastOperationResponse implements Ite
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.field(Fields.TOOK, tookInMillis);
-        RestActions.buildBroadcastShardsHeader(builder, this);
+        RestActions.buildBroadcastShardsHeader(builder, params, this);
 
         builder.field(Fields.TOTAL, count);
         if (matches != null) {

--- a/src/main/java/org/elasticsearch/action/search/SearchResponse.java
+++ b/src/main/java/org/elasticsearch/action/search/SearchResponse.java
@@ -177,7 +177,7 @@ public class SearchResponse extends ActionResponse implements StatusToXContent {
         if (isTerminatedEarly() != null) {
             builder.field(Fields.TERMINATED_EARLY, isTerminatedEarly());
         }
-        RestActions.buildBroadcastShardsHeader(builder, getTotalShards(), getSuccessfulShards(), getFailedShards(), getShardFailures());
+        RestActions.buildBroadcastShardsHeader(builder, params, getTotalShards(), getSuccessfulShards(), getFailedShards(), getShardFailures());
         internalResponse.toXContent(builder, params);
         return builder;
     }

--- a/src/main/java/org/elasticsearch/action/search/ShardSearchFailure.java
+++ b/src/main/java/org/elasticsearch/action/search/ShardSearchFailure.java
@@ -40,7 +40,7 @@ import static org.elasticsearch.search.SearchShardTarget.readSearchShardTarget;
 /**
  * Represents a failure to search on a specific shard.
  */
-public class ShardSearchFailure implements ShardOperationFailedException, ToXContent {
+public class ShardSearchFailure implements ShardOperationFailedException {
 
     public static final ShardSearchFailure[] EMPTY_ARRAY = new ShardSearchFailure[0];
 
@@ -172,6 +172,7 @@ public class ShardSearchFailure implements ShardOperationFailedException, ToXCon
         return builder;
     }
 
+    @Override
     public Throwable getCause() {
         return cause;
     }

--- a/src/main/java/org/elasticsearch/action/support/DefaultShardOperationFailedException.java
+++ b/src/main/java/org/elasticsearch/action/support/DefaultShardOperationFailedException.java
@@ -24,6 +24,8 @@ import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ShardOperationFailedException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.shard.IndexShardException;
 import org.elasticsearch.rest.RestStatus;
 
@@ -81,6 +83,11 @@ public class DefaultShardOperationFailedException implements ShardOperationFaile
         return status;
     }
 
+    @Override
+    public Throwable getCause() {
+        return reason;
+    }
+
     public static DefaultShardOperationFailedException readShardOperationFailed(StreamInput in) throws IOException {
         DefaultShardOperationFailedException exp = new DefaultShardOperationFailedException();
         exp.readFrom(in);
@@ -113,5 +120,20 @@ public class DefaultShardOperationFailedException implements ShardOperationFaile
     @Override
     public String toString() {
         return "[" + index + "][" + shardId + "] failed, reason [" + reason() + "]";
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.field("shard", shardId());
+        builder.field("index", index());
+        builder.field("status", status.name());
+        if (reason != null) {
+            builder.field("reason");
+            builder.startObject();
+            ElasticsearchException.toXContent(builder, params, reason);
+            builder.endObject();
+        }
+        return builder;
+
     }
 }

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/cache/clear/RestClearIndicesCacheAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/cache/clear/RestClearIndicesCacheAction.java
@@ -62,7 +62,7 @@ public class RestClearIndicesCacheAction extends BaseRestHandler {
             @Override
             public RestResponse buildResponse(ClearIndicesCacheResponse response, XContentBuilder builder) throws Exception {
                 builder.startObject();
-                buildBroadcastShardsHeader(builder, response);
+                buildBroadcastShardsHeader(builder, request, response);
                 builder.endObject();
                 return new BytesRestResponse(OK, builder);
             }

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/flush/RestFlushAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/flush/RestFlushAction.java
@@ -60,7 +60,7 @@ public class RestFlushAction extends BaseRestHandler {
             @Override
             public RestResponse buildResponse(FlushResponse response, XContentBuilder builder) throws Exception {
                 builder.startObject();
-                buildBroadcastShardsHeader(builder, response);
+                buildBroadcastShardsHeader(builder, request, response);
                 builder.endObject();
                 return new BytesRestResponse(OK, builder);
             }

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/optimize/RestOptimizeAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/optimize/RestOptimizeAction.java
@@ -61,7 +61,7 @@ public class RestOptimizeAction extends BaseRestHandler {
             @Override
             public RestResponse buildResponse(OptimizeResponse response, XContentBuilder builder) throws Exception {
                 builder.startObject();
-                buildBroadcastShardsHeader(builder, response);
+                buildBroadcastShardsHeader(builder, request, response);
                 builder.endObject();
                 return new BytesRestResponse(OK, builder);
             }

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/refresh/RestRefreshAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/refresh/RestRefreshAction.java
@@ -58,7 +58,7 @@ public class RestRefreshAction extends BaseRestHandler {
             @Override
             public RestResponse buildResponse(RefreshResponse response, XContentBuilder builder) throws Exception {
                 builder.startObject();
-                buildBroadcastShardsHeader(builder, response);
+                buildBroadcastShardsHeader(builder, request, response);
                 builder.endObject();
                 return new BytesRestResponse(OK, builder);
             }

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/segments/RestIndicesSegmentsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/segments/RestIndicesSegmentsAction.java
@@ -54,7 +54,7 @@ public class RestIndicesSegmentsAction extends BaseRestHandler {
             @Override
             public RestResponse buildResponse(IndicesSegmentResponse response, XContentBuilder builder) throws Exception {
                 builder.startObject();
-                buildBroadcastShardsHeader(builder, response);
+                buildBroadcastShardsHeader(builder, request, response);
                 response.toXContent(builder, request);
                 builder.endObject();
                 return new BytesRestResponse(OK, builder);

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/stats/RestIndicesStatsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/stats/RestIndicesStatsAction.java
@@ -103,7 +103,7 @@ public class RestIndicesStatsAction extends BaseRestHandler {
             @Override
             public RestResponse buildResponse(IndicesStatsResponse response, XContentBuilder builder) throws Exception {
                 builder.startObject();
-                buildBroadcastShardsHeader(builder, response);
+                buildBroadcastShardsHeader(builder, request, response);
                 response.toXContent(builder, request);
                 builder.endObject();
                 return new BytesRestResponse(OK, builder);

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/upgrade/RestUpgradeAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/upgrade/RestUpgradeAction.java
@@ -87,7 +87,7 @@ public class RestUpgradeAction extends BaseRestHandler {
         });
     }
     
-    void handlePost(RestRequest request, RestChannel channel, Client client) {
+    void handlePost(final RestRequest request, RestChannel channel, Client client) {
         OptimizeRequest optimizeReq = new OptimizeRequest(Strings.splitStringByCommaToArray(request.param("index")));
         optimizeReq.flush(true);
         optimizeReq.upgrade(true);
@@ -97,7 +97,7 @@ public class RestUpgradeAction extends BaseRestHandler {
             @Override
             public RestResponse buildResponse(OptimizeResponse response, XContentBuilder builder) throws Exception {
                 builder.startObject();
-                buildBroadcastShardsHeader(builder, response);
+                buildBroadcastShardsHeader(builder, request, response);
                 builder.endObject();
                 return new BytesRestResponse(OK, builder);
             }

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/validate/query/RestValidateQueryAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/validate/query/RestValidateQueryAction.java
@@ -84,7 +84,7 @@ public class RestValidateQueryAction extends BaseRestHandler {
                 builder.startObject();
                 builder.field("valid", response.isValid());
 
-                buildBroadcastShardsHeader(builder, response);
+                buildBroadcastShardsHeader(builder, request, response);
 
                 if (response.getQueryExplanation() != null && !response.getQueryExplanation().isEmpty()) {
                     builder.startArray("explanations");

--- a/src/main/java/org/elasticsearch/rest/action/bulk/RestBulkAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/bulk/RestBulkAction.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.rest.action.bulk;
 
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionWriteResponse;
 import org.elasticsearch.action.WriteConsistencyLevel;
 import org.elasticsearch.action.bulk.BulkItemResponse;
@@ -102,7 +103,9 @@ public class RestBulkAction extends BaseRestHandler {
                     }
                     if (itemResponse.isFailed()) {
                         builder.field(Fields.STATUS, itemResponse.getFailure().getStatus().getStatus());
-                        builder.field(Fields.ERROR, itemResponse.getFailure().getMessage());
+                        builder.startObject(Fields.ERROR);
+                        ElasticsearchException.toXContent(builder, request, itemResponse.getFailure().getCause());
+                        builder.endObject();
                     } else {
                         ActionWriteResponse.ShardInfo shardInfo = itemResponse.getResponse().getShardInfo();
                         shardInfo.toXContent(builder, request);

--- a/src/main/java/org/elasticsearch/rest/action/count/RestCountAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/count/RestCountAction.java
@@ -85,7 +85,7 @@ public class RestCountAction extends BaseRestHandler {
                     builder.field("terminated_early", response.terminatedEarly());
                 }
                 builder.field("count", response.getCount());
-                buildBroadcastShardsHeader(builder, response);
+                buildBroadcastShardsHeader(builder, request, response);
 
                 builder.endObject();
                 return new BytesRestResponse(response.status(), builder);

--- a/src/main/java/org/elasticsearch/rest/action/fieldstats/RestFieldStatsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/fieldstats/RestFieldStatsAction.java
@@ -62,7 +62,7 @@ public class RestFieldStatsAction extends BaseRestHandler {
             @Override
             public RestResponse buildResponse(FieldStatsResponse response, XContentBuilder builder) throws Exception {
                 builder.startObject();
-                buildBroadcastShardsHeader(builder, response);
+                buildBroadcastShardsHeader(builder, request, response);
 
                 builder.startObject("indices");
                 for (Map.Entry<String, Map<String, FieldStats>> entry1 : response.getIndicesMergedFieldStats().entrySet()) {

--- a/src/main/java/org/elasticsearch/rest/action/suggest/RestSuggestAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/suggest/RestSuggestAction.java
@@ -72,7 +72,7 @@ public class RestSuggestAction extends BaseRestHandler {
             public RestResponse buildResponse(SuggestResponse response, XContentBuilder builder) throws Exception {
                 RestStatus restStatus = RestStatus.status(response.getSuccessfulShards(), response.getTotalShards(), response.getShardFailures());
                 builder.startObject();
-                buildBroadcastShardsHeader(builder, response);
+                buildBroadcastShardsHeader(builder, request, response);
                 Suggest suggest = response.getSuggest();
                 if (suggest != null) {
                     suggest.toXContent(builder, request);

--- a/src/main/java/org/elasticsearch/snapshots/Snapshot.java
+++ b/src/main/java/org/elasticsearch/snapshots/Snapshot.java
@@ -255,7 +255,9 @@ public class Snapshot implements Comparable<Snapshot>, ToXContent {
         builder.field(Fields.SUCCESSFUL_SHARDS, successfulShards);
         builder.startArray(Fields.FAILURES);
         for (SnapshotShardFailure shardFailure : shardFailures) {
-            SnapshotShardFailure.toXContent(shardFailure, builder, params);
+            builder.startObject();
+            shardFailure.toXContent(builder, params);
+            builder.endObject();
         }
         builder.endArray();
         builder.endObject();

--- a/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
+++ b/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
@@ -223,7 +223,9 @@ public class SnapshotInfo implements ToXContent, Streamable {
         }
         builder.startArray(Fields.FAILURES);
         for (SnapshotShardFailure shardFailure : shardFailures) {
-            SnapshotShardFailure.toXContent(shardFailure, builder, params);
+            builder.startObject();
+            shardFailure.toXContent(builder, params);
+            builder.endObject();
         }
         builder.endArray();
         builder.startObject(Fields.SHARDS);


### PR DESCRIPTION
ShardOperationFailureException implementations alread provide structured
exception support but it's not yet exposed on the interface. This change
allows nice rendering of structured REST exceptions also if searches fail on
only a subset of the shards etc.

Closes #11017

for instance 

``` JSON

PUT test2/test/1
{
  "foz": "bar"
}

GET _search?sort=foo
```

gives me now:

``` JSON

{
   "took": 2,
   "timed_out": false,
   "_shards": {
      "total": 7,
      "successful": 5,
      "failed": 2,
      "failures": [
         {
            "shard": 0,
            "index": "foo",
            "node": "2KRJGnOCRniCyyOcKw_ypg",
            "reason": {
               "type": "search_parse_exception",
               "reason": "Failed to parse source [{\"sort\":[{\"foo\":{}}]}]",
               "caused_by": {
                  "type": "search_parse_exception",
                  "reason": "No mapping found for [foo] in order to sort on"
               }
            }
         },
         {
            "shard": 0,
            "index": "foobar",
            "node": "2KRJGnOCRniCyyOcKw_ypg",
            "reason": {
               "type": "search_parse_exception",
               "reason": "Failed to parse source [{\"sort\":[{\"foo\":{}}]}]",
               "caused_by": {
                  "type": "search_parse_exception",
                  "reason": "No mapping found for [foo] in order to sort on"
               }
            }
         }
      ]
   },
   "hits": {
      "total": 1,
      "max_score": null,
      "hits": [
         {
            "_index": "test2",
            "_type": "test",
            "_id": "1",
```

similar for `_msearch`

``` JSON
GET _msearch
{"index": "test"}
{"sort": "foo"}
{"index": "_all"}
{"sort": "foo"}
```

now returns:

``` JSON
{
   "responses": [
      {
         "error": "SearchPhaseExecutionException[all shards failed]"
      },
      {
         "took": 28,
         "timed_out": false,
         "_shards": {
            "total": 12,
            "successful": 5,
            "failed": 7,
            "failures": [
               {
                  "shard": 0,
                  "index": "foo",
                  "node": "2KRJGnOCRniCyyOcKw_ypg",
                  "reason": {
                     "type": "search_parse_exception",
                     "reason": "Failed to parse source [{\"sort\": \"foo\"}]",
                     "line": 1,
                     "col": 2,
                     "caused_by": {
                        "type": "search_parse_exception",
                        "reason": "No mapping found for [foo] in order to sort on"
                     }
                  }
               },
```

bulk unfortunately still doesn't really work well here but it seems like a bigger thing and I wonder if we should do it at least for now
