### PR TITLE
Ensure empty string completion inputs are not indexed

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/core/CompletionFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/CompletionFieldMapper.java
@@ -369,6 +369,9 @@ public class CompletionFieldMapper extends AbstractFieldMapper<String> {
         payload = payload == null ? EMPTY : payload;
         if (surfaceForm == null) { // no surface form use the input
             for (String input : inputs) {
+                if (input.length() == 0) {
+                    continue;
+                }
                 BytesRef suggestPayload = analyzingSuggestLookupProvider.buildPayload(new BytesRef(
                         input), weight, payload);
                 context.doc().add(getCompletionField(ctx, input, suggestPayload));
@@ -377,6 +380,9 @@ public class CompletionFieldMapper extends AbstractFieldMapper<String> {
             BytesRef suggestPayload = analyzingSuggestLookupProvider.buildPayload(new BytesRef(
                     surfaceForm), weight, payload);
             for (String input : inputs) {
+                if (input.length() == 0) {
+                    continue;
+                }
                 context.doc().add(getCompletionField(ctx, input, suggestPayload));
             }
         }

--- a/src/test/java/org/elasticsearch/search/suggest/ContextSuggestSearchTests.java
+++ b/src/test/java/org/elasticsearch/search/suggest/ContextSuggestSearchTests.java
@@ -435,6 +435,34 @@ public class ContextSuggestSearchTests extends ElasticsearchIntegrationTest {
 
     }
 
+    @Test // see issue #10987
+    public void testEmptySuggestion() throws Exception {
+        String mapping = jsonBuilder()
+                .startObject()
+                .startObject(TYPE)
+                .startObject("properties")
+                .startObject(FIELD)
+                .field("type", "completion")
+                .startObject("context")
+                .startObject("type_context")
+                .field("path", "_type")
+                .field("type", "category")
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject()
+                .string();
+
+        assertAcked(client().admin().indices().prepareCreate(INDEX).addMapping(TYPE, mapping).get());
+        ensureGreen();
+
+        client().prepareIndex(INDEX, TYPE, "1").setSource(FIELD, "")
+                .setRefresh(true).get();
+
+    }
+
     @Test
     public void testMultiValueField() throws Exception {
         assertAcked(prepareCreate(INDEX).addMapping(TYPE, createMapping(TYPE, ContextBuilder.reference("st", "category"))));


### PR DESCRIPTION
This PR ensures completion entries with an input of an empty string never gets indexed into the underlying FST. 

There is no way to retrieve an entry associated with an empty string through the _suggest API, so these entries should never be part of the underlying index, as they can never be retrieved but might bloat the FST with their context, weight, payload, etc.

closes #10987
