### PR TITLE
Use our provided JNA library, versus one installed on the system

### DIFF
--- a/bin/elasticsearch.in.bat
+++ b/bin/elasticsearch.in.bat
@@ -85,5 +85,8 @@ set JAVA_OPTS=%JAVA_OPTS% -XX:+DisableExplicitGC
 REM Ensure UTF-8 encoding by default (e.g. filenames)
 set JAVA_OPTS=%JAVA_OPTS% -Dfile.encoding=UTF-8
 
+REM Use our provided JNA always versus the system one
+set JAVA_OPTS=%JAVA_OPTS% -Djna.nosys=true
+
 set ES_CLASSPATH=%ES_CLASSPATH%;%ES_HOME%/lib/${project.build.finalName}.jar;%ES_HOME%/lib/*;%ES_HOME%/lib/sigar/*
 set ES_PARAMS=-Delasticsearch -Des-foreground=yes -Des.path.home="%ES_HOME%"

--- a/bin/elasticsearch.in.sh
+++ b/bin/elasticsearch.in.sh
@@ -68,3 +68,6 @@ JAVA_OPTS="$JAVA_OPTS -XX:+DisableExplicitGC"
 
 # Ensure UTF-8 encoding by default (e.g. filenames)
 JAVA_OPTS="$JAVA_OPTS -Dfile.encoding=UTF-8"
+
+# Use our provided JNA always versus the system one
+JAVA_OPTS="$JAVA_OPTS -Djna.nosys=true"

--- a/pom.xml
+++ b/pom.xml
@@ -469,6 +469,7 @@
                 <argument>-XX:+HeapDumpOnOutOfMemoryError</argument>
                 <argument>-XX:+DisableExplicitGC</argument>
                 <argument>-Dfile.encoding=UTF-8</argument>
+                <argument>-Djna.nosys=true</argument>
                 <argument>-Delasticsearch</argument>
               </arguments>
             </configuration>


### PR DESCRIPTION
The JNA provided by the system might be older/incompatible and not work.

It happened easily with my system openjdk because some package installed an older JNA .so (from version 3). This means things like mlockall don't work with current master and that JDK because of "dll hell".

By specifying -Djna.nosys=true, we always use the bundled native library over anything else that happens to be on the system.  In most cases this is just the same logic already happening, unless you have DLL hell.

See docs in the source code: https://github.com/twall/jna/blob/master/src/com/sun/jna/Native.java#L64-L77

Only potential downside is as described in those docs: users with special security configurations might have to configure this differently. But they have to do special configuration for JNA to work anyway! On the other hand, it will work out of box better in the general case, where there is a conflict.

Tested on linux (including my JDK with conflicting JNA library), mac, and windows.
