### PR TITLE
Properly export JAVA_HOME as defined in defaults.

### DIFF
--- a/src/packaging/rpm/init.d/elasticsearch
+++ b/src/packaging/rpm/init.d/elasticsearch
@@ -69,6 +69,7 @@ fi
 checkJava() {
     if [ -x "$JAVA_HOME/bin/java" ]; then
         JAVA="$JAVA_HOME/bin/java"
+        export JAVA_HOME
     else
         JAVA=`which java`
     fi


### PR DESCRIPTION
Specifying JAVA_HOME in init defaults is not exported in RedHat init.d script.

There is no issue when a system java is available in $PATH. The issue occurs when java is not installed in $PATH and the which java command returns a JAVA version. If you try setting up JAVA_HOME without java in the path the init script fails to export JAVA_HOME for use in the elasticsearch user environment. This leaves elasticsearch lost as to where either JAVA_HOME or JAVA is.
