### PR TITLE
Query Refactoring: Moving parser NAME constant to corresponding query builder

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/AndQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/AndQueryBuilder.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.query;
 
 import com.google.common.collect.Lists;
+
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -31,6 +32,8 @@ import java.util.ArrayList;
  */
 @Deprecated
 public class AndQueryBuilder extends QueryBuilder {
+
+    public static final String NAME = "and";
 
     private ArrayList<QueryBuilder> filters = Lists.newArrayList();
 
@@ -60,7 +63,7 @@ public class AndQueryBuilder extends QueryBuilder {
 
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(AndQueryParser.NAME);
+        builder.startObject(NAME);
         builder.startArray("filters");
         for (QueryBuilder filter : filters) {
             filter.toXContent(builder, params);
@@ -73,7 +76,7 @@ public class AndQueryBuilder extends QueryBuilder {
     }
 
     @Override
-    protected String parserName() {
-        return AndQueryParser.NAME;
+    public String queryId() {
+        return NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/AndQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/AndQueryParser.java
@@ -36,15 +36,13 @@ import static com.google.common.collect.Lists.newArrayList;
 @Deprecated
 public class AndQueryParser extends BaseQueryParserTemp {
 
-    public static final String NAME = "and";
-
     @Inject
     public AndQueryParser() {
     }
 
     @Override
     public String[] names() {
-        return new String[]{NAME};
+        return new String[]{AndQueryBuilder.NAME};
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/BaseTermQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/BaseTermQueryBuilder.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 import java.util.Objects;
 
 public abstract class BaseTermQueryBuilder<QB extends BaseTermQueryBuilder<QB>> extends QueryBuilder<QB> implements BoostableQueryBuilder<QB> {
-    
+
     /** Name of field to match against. */
     protected final String fieldName;
 
@@ -158,7 +158,7 @@ public abstract class BaseTermQueryBuilder<QB extends BaseTermQueryBuilder<QB>> 
 
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(parserName());
+        builder.startObject(queryId());
         if (boost == 1.0f && queryName == null) {
             builder.field(fieldName, convertToStringIfBytesRef(this.value));
         } else {

--- a/src/main/java/org/elasticsearch/index/query/BoolQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/BoolQueryBuilder.java
@@ -31,6 +31,8 @@ import java.util.List;
  */
 public class BoolQueryBuilder extends QueryBuilder implements BoostableQueryBuilder<BoolQueryBuilder> {
 
+    public static final String NAME = "bool";
+
     private final List<QueryBuilder> mustClauses = new ArrayList<>();
 
     private final List<QueryBuilder> mustNotClauses = new ArrayList<>();
@@ -160,7 +162,7 @@ public class BoolQueryBuilder extends QueryBuilder implements BoostableQueryBuil
 
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject("bool");
+        builder.startObject(NAME);
         doXArrayContent("must", mustClauses, builder, params);
         doXArrayContent("filter", filterClauses, builder, params);
         doXArrayContent("must_not", mustNotClauses, builder, params);
@@ -200,7 +202,7 @@ public class BoolQueryBuilder extends QueryBuilder implements BoostableQueryBuil
     }
 
     @Override
-    protected String parserName() {
-        return BoolQueryParser.NAME;
+    public String queryId() {
+        return NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/BoolQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/BoolQueryParser.java
@@ -39,8 +39,6 @@ import static org.elasticsearch.common.lucene.search.Queries.fixNegativeQueryIfN
  */
 public class BoolQueryParser extends BaseQueryParserTemp {
 
-    public static final String NAME = "bool";
-
     @Inject
     public BoolQueryParser(Settings settings) {
         BooleanQuery.setMaxClauseCount(settings.getAsInt("index.query.bool.max_clause_count", settings.getAsInt("indices.query.bool.max_clause_count", BooleanQuery.getMaxClauseCount())));
@@ -48,7 +46,7 @@ public class BoolQueryParser extends BaseQueryParserTemp {
 
     @Override
     public String[] names() {
-        return new String[]{NAME};
+        return new String[]{BoolQueryBuilder.NAME};
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/BoostingQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/BoostingQueryBuilder.java
@@ -37,6 +37,8 @@ import java.io.IOException;
  */
 public class BoostingQueryBuilder extends QueryBuilder implements BoostableQueryBuilder<BoostingQueryBuilder> {
 
+    public static final String NAME = "boosting";
+
     private QueryBuilder positiveQuery;
 
     private QueryBuilder negativeQuery;
@@ -81,7 +83,7 @@ public class BoostingQueryBuilder extends QueryBuilder implements BoostableQuery
         if (negativeBoost == -1) {
             throw new IllegalArgumentException("boosting query requires negativeBoost to be set");
         }
-        builder.startObject(BoostingQueryParser.NAME);
+        builder.startObject(NAME);
         builder.field("positive");
         positiveQuery.toXContent(builder, params);
         builder.field("negative");
@@ -96,7 +98,7 @@ public class BoostingQueryBuilder extends QueryBuilder implements BoostableQuery
     }
 
     @Override
-    protected String parserName() {
-        return BoostingQueryParser.NAME;
+    public String queryId() {
+        return NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/BoostingQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/BoostingQueryParser.java
@@ -31,15 +31,13 @@ import java.io.IOException;
  */
 public class BoostingQueryParser extends BaseQueryParserTemp {
 
-    public static final String NAME = "boosting";
-
     @Inject
     public BoostingQueryParser() {
     }
 
     @Override
     public String[] names() {
-        return new String[]{NAME};
+        return new String[]{BoostingQueryBuilder.NAME};
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/CommonTermsQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/CommonTermsQueryBuilder.java
@@ -44,6 +44,8 @@ import java.io.IOException;
  */
 public class CommonTermsQueryBuilder extends QueryBuilder implements BoostableQueryBuilder<CommonTermsQueryBuilder> {
 
+    public static final String NAME = "common";
+
     public static enum Operator {
         OR, AND
     }
@@ -161,7 +163,7 @@ public class CommonTermsQueryBuilder extends QueryBuilder implements BoostableQu
 
     @Override
     public void doXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(CommonTermsQueryParser.NAME);
+        builder.startObject(NAME);
         builder.startObject(name);
 
         builder.field("query", text);
@@ -202,7 +204,7 @@ public class CommonTermsQueryBuilder extends QueryBuilder implements BoostableQu
     }
 
     @Override
-    protected String parserName() {
-        return CommonTermsQueryParser.NAME;
+    public String queryId() {
+        return NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/CommonTermsQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/CommonTermsQueryParser.java
@@ -39,8 +39,6 @@ import java.io.IOException;
  */
 public class CommonTermsQueryParser extends BaseQueryParserTemp {
 
-    public static final String NAME = "common";
-
     static final float DEFAULT_MAX_TERM_DOC_FREQ = 0.01f;
 
     static final Occur DEFAULT_HIGH_FREQ_OCCUR = Occur.SHOULD;
@@ -56,7 +54,7 @@ public class CommonTermsQueryParser extends BaseQueryParserTemp {
 
     @Override
     public String[] names() {
-        return new String[] { NAME };
+        return new String[] { CommonTermsQueryBuilder.NAME };
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/ConstantScoreQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/ConstantScoreQueryBuilder.java
@@ -31,6 +31,8 @@ import java.util.Objects;
  */
 public class ConstantScoreQueryBuilder extends QueryBuilder implements BoostableQueryBuilder<ConstantScoreQueryBuilder> {
 
+    public static final String NAME = "constant_score";
+
     private final QueryBuilder filterBuilder;
 
     private float boost = -1;
@@ -57,7 +59,7 @@ public class ConstantScoreQueryBuilder extends QueryBuilder implements Boostable
 
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(ConstantScoreQueryParser.NAME);
+        builder.startObject(NAME);
         builder.field("filter");
         filterBuilder.toXContent(builder, params);
 
@@ -68,7 +70,7 @@ public class ConstantScoreQueryBuilder extends QueryBuilder implements Boostable
     }
 
     @Override
-    protected String parserName() {
-        return ConstantScoreQueryParser.NAME;
+    public String queryId() {
+        return NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/ConstantScoreQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/ConstantScoreQueryParser.java
@@ -33,7 +33,6 @@ import java.io.IOException;
  */
 public class ConstantScoreQueryParser extends BaseQueryParserTemp {
 
-    public static final String NAME = "constant_score";
     private static final ParseField INNER_QUERY_FIELD = new ParseField("filter", "query");
 
     @Inject
@@ -42,7 +41,7 @@ public class ConstantScoreQueryParser extends BaseQueryParserTemp {
 
     @Override
     public String[] names() {
-        return new String[]{NAME, Strings.toCamelCase(NAME)};
+        return new String[]{ConstantScoreQueryBuilder.NAME, Strings.toCamelCase(ConstantScoreQueryBuilder.NAME)};
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/DisMaxQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/DisMaxQueryBuilder.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.search.Query;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -33,6 +32,8 @@ import static com.google.common.collect.Lists.newArrayList;
  * additional matching sub-queries.
  */
 public class DisMaxQueryBuilder extends QueryBuilder implements BoostableQueryBuilder<DisMaxQueryBuilder> {
+
+    public static final String NAME = "dis_max";
 
     private ArrayList<QueryBuilder> queries = newArrayList();
 
@@ -81,7 +82,7 @@ public class DisMaxQueryBuilder extends QueryBuilder implements BoostableQueryBu
 
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(DisMaxQueryParser.NAME);
+        builder.startObject(NAME);
         if (tieBreaker != -1) {
             builder.field("tie_breaker", tieBreaker);
         }
@@ -100,7 +101,7 @@ public class DisMaxQueryBuilder extends QueryBuilder implements BoostableQueryBu
     }
 
     @Override
-    protected String parserName() {
-        return DisMaxQueryParser.NAME;
+    public String queryId() {
+        return NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/DisMaxQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/DisMaxQueryParser.java
@@ -35,15 +35,13 @@ import static com.google.common.collect.Lists.newArrayList;
  */
 public class DisMaxQueryParser extends BaseQueryParserTemp {
 
-    public static final String NAME = "dis_max";
-
     @Inject
     public DisMaxQueryParser() {
     }
 
     @Override
     public String[] names() {
-        return new String[]{NAME, Strings.toCamelCase(NAME)};
+        return new String[]{DisMaxQueryBuilder.NAME, Strings.toCamelCase(DisMaxQueryBuilder.NAME)};
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/ExistsQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/ExistsQueryBuilder.java
@@ -28,6 +28,8 @@ import java.io.IOException;
  */
 public class ExistsQueryBuilder extends QueryBuilder {
 
+    public static final String NAME = "exists";
+
     private String name;
 
     private String queryName;
@@ -46,7 +48,7 @@ public class ExistsQueryBuilder extends QueryBuilder {
 
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(ExistsQueryParser.NAME);
+        builder.startObject(NAME);
         builder.field("field", name);
         if (queryName != null) {
             builder.field("_name", queryName);
@@ -55,7 +57,7 @@ public class ExistsQueryBuilder extends QueryBuilder {
     }
 
     @Override
-    protected String parserName() {
-        return ExistsQueryParser.NAME;
+    public String queryId() {
+        return NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/ExistsQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/ExistsQueryParser.java
@@ -39,15 +39,13 @@ import java.util.List;
  */
 public class ExistsQueryParser extends BaseQueryParserTemp {
 
-    public static final String NAME = "exists";
-
     @Inject
     public ExistsQueryParser() {
     }
 
     @Override
     public String[] names() {
-        return new String[]{NAME};
+        return new String[]{ExistsQueryBuilder.NAME};
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/FQueryFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/FQueryFilterParser.java
@@ -33,15 +33,13 @@ import java.io.IOException;
 @Deprecated
 public class FQueryFilterParser extends BaseQueryParserTemp {
 
-    public static final String NAME = "fquery";
-
     @Inject
     public FQueryFilterParser() {
     }
 
     @Override
     public String[] names() {
-        return new String[]{NAME};
+        return new String[]{QueryFilterBuilder.FQUERY_NAME};
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/FieldMaskingSpanQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/FieldMaskingSpanQueryBuilder.java
@@ -25,6 +25,8 @@ import java.io.IOException;
 
 public class FieldMaskingSpanQueryBuilder extends QueryBuilder implements SpanQueryBuilder, BoostableQueryBuilder<FieldMaskingSpanQueryBuilder> {
 
+    public static final String NAME = "field_masking_span";
+
     private final SpanQueryBuilder queryBuilder;
 
     private final String field;
@@ -32,7 +34,6 @@ public class FieldMaskingSpanQueryBuilder extends QueryBuilder implements SpanQu
     private float boost = -1;
 
     private String queryName;
-
 
     public FieldMaskingSpanQueryBuilder(SpanQueryBuilder queryBuilder, String field) {
         this.queryBuilder = queryBuilder;
@@ -55,7 +56,7 @@ public class FieldMaskingSpanQueryBuilder extends QueryBuilder implements SpanQu
 
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(FieldMaskingSpanQueryParser.NAME);
+        builder.startObject(NAME);
         builder.field("query");
         queryBuilder.toXContent(builder, params);
         builder.field("field", field);
@@ -69,7 +70,7 @@ public class FieldMaskingSpanQueryBuilder extends QueryBuilder implements SpanQu
     }
 
     @Override
-    protected String parserName() {
-        return FieldMaskingSpanQueryParser.NAME;
+    public String queryId() {
+        return NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/FieldMaskingSpanQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/FieldMaskingSpanQueryParser.java
@@ -34,15 +34,13 @@ import java.io.IOException;
  */
 public class FieldMaskingSpanQueryParser extends BaseQueryParserTemp {
 
-    public static final String NAME = "field_masking_span";
-
     @Inject
     public FieldMaskingSpanQueryParser() {
     }
 
     @Override
     public String[] names() {
-        return new String[]{NAME, Strings.toCamelCase(NAME)};
+        return new String[]{FieldMaskingSpanQueryBuilder.NAME, Strings.toCamelCase(FieldMaskingSpanQueryBuilder.NAME)};
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/FilteredQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/FilteredQueryBuilder.java
@@ -31,6 +31,8 @@ import java.io.IOException;
 @Deprecated
 public class FilteredQueryBuilder extends QueryBuilder implements BoostableQueryBuilder<FilteredQueryBuilder> {
 
+    public static final String NAME = "filtered";
+
     private final QueryBuilder queryBuilder;
 
     private final QueryBuilder filterBuilder;
@@ -70,7 +72,7 @@ public class FilteredQueryBuilder extends QueryBuilder implements BoostableQuery
 
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(FilteredQueryParser.NAME);
+        builder.startObject(NAME);
         if (queryBuilder != null) {
             builder.field("query");
             queryBuilder.toXContent(builder, params);
@@ -89,7 +91,7 @@ public class FilteredQueryBuilder extends QueryBuilder implements BoostableQuery
     }
 
     @Override
-    protected String parserName() {
-        return FilteredQueryParser.NAME;
+    public String queryId() {
+        return NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/FilteredQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/FilteredQueryParser.java
@@ -34,15 +34,13 @@ import java.io.IOException;
 @Deprecated
 public class FilteredQueryParser extends BaseQueryParserTemp {
 
-    public static final String NAME = "filtered";
-
     @Inject
     public FilteredQueryParser() {
     }
 
     @Override
     public String[] names() {
-        return new String[]{NAME};
+        return new String[]{FilteredQueryBuilder.NAME};
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/FuzzyQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/FuzzyQueryBuilder.java
@@ -29,6 +29,8 @@ import java.io.IOException;
  */
 public class FuzzyQueryBuilder extends MultiTermQueryBuilder implements BoostableQueryBuilder<FuzzyQueryBuilder> {
 
+    public static final String NAME = "fuzzy";
+
     private final String name;
 
     private final Object value;
@@ -104,7 +106,7 @@ public class FuzzyQueryBuilder extends MultiTermQueryBuilder implements Boostabl
 
     @Override
     public void doXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(FuzzyQueryParser.NAME);
+        builder.startObject(NAME);
         if (boost == -1 && fuzziness == null && prefixLength == null && queryName != null) {
             builder.field(name, value);
         } else {
@@ -137,7 +139,7 @@ public class FuzzyQueryBuilder extends MultiTermQueryBuilder implements Boostabl
     }
 
     @Override
-    protected String parserName() {
-        return FuzzyQueryParser.NAME;
+    public String queryId() {
+        return NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/FuzzyQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/FuzzyQueryParser.java
@@ -37,7 +37,6 @@ import java.io.IOException;
  */
 public class FuzzyQueryParser extends BaseQueryParserTemp {
 
-    public static final String NAME = "fuzzy";
     private static final Fuzziness DEFAULT_FUZZINESS = Fuzziness.AUTO;
     private static final ParseField FUZZINESS = Fuzziness.FIELD.withDeprecation("min_similarity");
 
@@ -48,7 +47,7 @@ public class FuzzyQueryParser extends BaseQueryParserTemp {
 
     @Override
     public String[] names() {
-        return new String[]{NAME};
+        return new String[]{FuzzyQueryBuilder.NAME};
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxQueryBuilder.java
@@ -27,6 +27,8 @@ import java.io.IOException;
 
 public class GeoBoundingBoxQueryBuilder extends QueryBuilder {
 
+    public static final String NAME = "geo_bbox";
+
     public static final String TOP_LEFT = GeoBoundingBoxQueryParser.TOP_LEFT;
     public static final String BOTTOM_RIGHT = GeoBoundingBoxQueryParser.BOTTOM_RIGHT;
 
@@ -34,7 +36,7 @@ public class GeoBoundingBoxQueryBuilder extends QueryBuilder {
     private static final int LEFT = 1;
     private static final int BOTTOM = 2;
     private static final int RIGHT = 3;
-    
+
     private final String name;
 
     private double[] box = {Double.NaN, Double.NaN, Double.NaN, Double.NaN};
@@ -105,7 +107,7 @@ public class GeoBoundingBoxQueryBuilder extends QueryBuilder {
     public GeoBoundingBoxQueryBuilder bottomLeft(String geohash) {
         return bottomLeft(GeoHashUtils.decode(geohash));
     }
-    
+
     /**
      * Adds top right point.
      *
@@ -155,8 +157,8 @@ public class GeoBoundingBoxQueryBuilder extends QueryBuilder {
         } else if(Double.isNaN(box[LEFT])) {
             throw new IllegalArgumentException("geo_bounding_box requires left longitude to be set");
         }
-                
-        builder.startObject(GeoBoundingBoxQueryParser.NAME);
+
+        builder.startObject(NAME);
 
         builder.startObject(name);
         builder.array(TOP_LEFT, box[LEFT], box[TOP]);
@@ -174,7 +176,7 @@ public class GeoBoundingBoxQueryBuilder extends QueryBuilder {
     }
 
     @Override
-    protected String parserName() {
-        return GeoBoundingBoxQueryParser.NAME;
+    public String queryId() {
+        return NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxQueryParser.java
@@ -53,7 +53,6 @@ public class GeoBoundingBoxQueryParser extends BaseQueryParserTemp {
     public static final String BOTTOMLEFT = "bottomLeft";
     public static final String BOTTOMRIGHT = "bottomRight";
 
-    public static final String NAME = "geo_bbox";
     public static final String FIELD = "field";
 
     @Inject
@@ -62,7 +61,7 @@ public class GeoBoundingBoxQueryParser extends BaseQueryParserTemp {
 
     @Override
     public String[] names() {
-        return new String[]{NAME, "geoBbox", "geo_bounding_box", "geoBoundingBox"};
+        return new String[]{GeoBoundingBoxQueryBuilder.NAME, "geoBbox", "geo_bounding_box", "geoBoundingBox"};
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/GeoDistanceQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoDistanceQueryBuilder.java
@@ -28,6 +28,8 @@ import java.util.Locale;
 
 public class GeoDistanceQueryBuilder extends QueryBuilder {
 
+    public static final String NAME = "geo_distance";
+
     private final String name;
 
     private String distance;
@@ -99,7 +101,7 @@ public class GeoDistanceQueryBuilder extends QueryBuilder {
 
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(GeoDistanceQueryParser.NAME);
+        builder.startObject(NAME);
         if (geohash != null) {
             builder.field(name, geohash);
         } else {
@@ -119,7 +121,7 @@ public class GeoDistanceQueryBuilder extends QueryBuilder {
     }
 
     @Override
-    protected String parserName() {
-        return GeoDistanceQueryParser.NAME;
+    public String queryId() {
+        return NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/GeoDistanceQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoDistanceQueryParser.java
@@ -44,15 +44,13 @@ import java.io.IOException;
  */
 public class GeoDistanceQueryParser extends BaseQueryParserTemp {
 
-    public static final String NAME = "geo_distance";
-
     @Inject
     public GeoDistanceQueryParser() {
     }
 
     @Override
     public String[] names() {
-        return new String[]{NAME, "geoDistance"};
+        return new String[]{GeoDistanceQueryBuilder.NAME, "geoDistance"};
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/GeoDistanceRangeQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoDistanceRangeQueryBuilder.java
@@ -27,6 +27,8 @@ import java.util.Locale;
 
 public class GeoDistanceRangeQueryBuilder extends QueryBuilder {
 
+    public static final String NAME = "geo_distance_range";
+
     private final String name;
 
     private Object from;
@@ -135,7 +137,7 @@ public class GeoDistanceRangeQueryBuilder extends QueryBuilder {
 
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(GeoDistanceRangeQueryParser.NAME);
+        builder.startObject(NAME);
         if (geohash != null) {
             builder.field(name, geohash);
         } else {
@@ -158,7 +160,7 @@ public class GeoDistanceRangeQueryBuilder extends QueryBuilder {
     }
 
     @Override
-    protected String parserName() {
-        return GeoDistanceQueryParser.NAME;
+    public String queryId() {
+        return NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/GeoDistanceRangeQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoDistanceRangeQueryParser.java
@@ -44,15 +44,13 @@ import java.io.IOException;
  */
 public class GeoDistanceRangeQueryParser extends BaseQueryParserTemp {
 
-    public static final String NAME = "geo_distance_range";
-
     @Inject
     public GeoDistanceRangeQueryParser() {
     }
 
     @Override
     public String[] names() {
-        return new String[]{NAME, "geoDistanceRange"};
+        return new String[]{GeoDistanceRangeQueryBuilder.NAME, "geoDistanceRange"};
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/GeoPolygonQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoPolygonQueryBuilder.java
@@ -30,8 +30,10 @@ import java.util.List;
 
 public class GeoPolygonQueryBuilder extends QueryBuilder {
 
+    public static final String NAME = "geo_polygon";
+
     public static final String POINTS = GeoPolygonQueryParser.POINTS;
-    
+
     private final String name;
 
     private final List<GeoPoint> shell = Lists.newArrayList();
@@ -61,7 +63,7 @@ public class GeoPolygonQueryBuilder extends QueryBuilder {
         shell.add(point);
         return this;
     }
-    
+
     /**
      * Sets the filter name for the filter that can be used when searching for matched_filters per hit.
      */
@@ -72,7 +74,7 @@ public class GeoPolygonQueryBuilder extends QueryBuilder {
 
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(GeoPolygonQueryParser.NAME);
+        builder.startObject(NAME);
 
         builder.startObject(name);
         builder.startArray(POINTS);
@@ -90,7 +92,7 @@ public class GeoPolygonQueryBuilder extends QueryBuilder {
     }
 
     @Override
-    protected String parserName() {
-        return GeoPolygonQueryParser.NAME;
+    public String queryId() {
+        return NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/GeoPolygonQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoPolygonQueryParser.java
@@ -49,7 +49,6 @@ import java.util.List;
  */
 public class GeoPolygonQueryParser extends BaseQueryParserTemp {
 
-    public static final String NAME = "geo_polygon";
     public static final String POINTS = "points";
 
     @Inject
@@ -58,7 +57,7 @@ public class GeoPolygonQueryParser extends BaseQueryParserTemp {
 
     @Override
     public String[] names() {
-        return new String[]{NAME, "geoPolygon"};
+        return new String[]{GeoPolygonQueryBuilder.NAME, "geoPolygon"};
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/GeoShapeQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoShapeQueryBuilder.java
@@ -31,6 +31,8 @@ import java.io.IOException;
  */
 public class GeoShapeQueryBuilder extends QueryBuilder {
 
+    public static final String NAME = "geo_shape";
+
     private final String name;
 
     private final ShapeBuilder shape;
@@ -46,7 +48,7 @@ public class GeoShapeQueryBuilder extends QueryBuilder {
     private String indexedShapePath;
 
     private ShapeRelation relation = null;
-    
+
     /**
      * Creates a new GeoShapeQueryBuilder whose Filter will be against the
      * given field name using the given Shape
@@ -148,7 +150,7 @@ public class GeoShapeQueryBuilder extends QueryBuilder {
 
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(GeoShapeQueryParser.NAME);
+        builder.startObject(NAME);
 
         builder.startObject(name);
 
@@ -185,7 +187,7 @@ public class GeoShapeQueryBuilder extends QueryBuilder {
     }
 
     @Override
-    protected String parserName() {
-        return GeoShapeQueryParser.NAME;
+    public String queryId() {
+        return NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/GeoShapeQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoShapeQueryParser.java
@@ -40,8 +40,6 @@ import java.io.IOException;
 
 public class GeoShapeQueryParser extends BaseQueryParserTemp {
 
-    public static final String NAME = "geo_shape";
-
     private ShapeFetchService fetchService;
 
     public static class DEFAULTS {
@@ -51,7 +49,7 @@ public class GeoShapeQueryParser extends BaseQueryParserTemp {
 
     @Override
     public String[] names() {
-        return new String[]{NAME, Strings.toCamelCase(NAME)};
+        return new String[]{GeoShapeQueryBuilder.NAME, Strings.toCamelCase(GeoShapeQueryBuilder.NAME)};
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/GeohashCellQuery.java
+++ b/src/main/java/org/elasticsearch/index/query/GeohashCellQuery.java
@@ -169,7 +169,7 @@ public class GeohashCellQuery {
         }
 
         @Override
-        protected String parserName() {
+        public String queryId() {
             return NAME;
         }
     }

--- a/src/main/java/org/elasticsearch/index/query/HasChildQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/HasChildQueryBuilder.java
@@ -25,6 +25,8 @@ import java.io.IOException;
 
 public class HasChildQueryBuilder extends QueryBuilder implements BoostableQueryBuilder<HasChildQueryBuilder> {
 
+    public static final String NAME = "has_child";
+
     private final QueryBuilder queryBuilder;
 
     private String childType;
@@ -109,7 +111,7 @@ public class HasChildQueryBuilder extends QueryBuilder implements BoostableQuery
 
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(HasChildQueryParser.NAME);
+        builder.startObject(NAME);
         builder.field("query");
         queryBuilder.toXContent(builder, params);
         builder.field("child_type", childType);
@@ -140,7 +142,7 @@ public class HasChildQueryBuilder extends QueryBuilder implements BoostableQuery
     }
 
     @Override
-    protected String parserName() {
-        return HasChildQueryParser.NAME;
+    public String queryId() {
+        return NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/HasChildQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/HasChildQueryParser.java
@@ -47,7 +47,6 @@ import java.io.IOException;
  */
 public class HasChildQueryParser extends BaseQueryParserTemp {
 
-    public static final String NAME = "has_child";
     private static final ParseField QUERY_FIELD = new ParseField("query", "filter");
 
     private final InnerHitsQueryParserHelper innerHitsQueryParserHelper;
@@ -59,7 +58,7 @@ public class HasChildQueryParser extends BaseQueryParserTemp {
 
     @Override
     public String[] names() {
-        return new String[] { NAME, Strings.toCamelCase(NAME) };
+        return new String[] { HasChildQueryBuilder.NAME, Strings.toCamelCase(HasChildQueryBuilder.NAME) };
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/HasParentQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/HasParentQueryBuilder.java
@@ -28,6 +28,7 @@ import java.io.IOException;
  */
 public class HasParentQueryBuilder extends QueryBuilder implements BoostableQueryBuilder<HasParentQueryBuilder> {
 
+    public static final String NAME = "has_parent";
     private final QueryBuilder queryBuilder;
     private final String parentType;
     private String scoreType;
@@ -76,7 +77,7 @@ public class HasParentQueryBuilder extends QueryBuilder implements BoostableQuer
 
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(HasParentQueryParser.NAME);
+        builder.startObject(NAME);
         builder.field("query");
         queryBuilder.toXContent(builder, params);
         builder.field("parent_type", parentType);
@@ -98,8 +99,8 @@ public class HasParentQueryBuilder extends QueryBuilder implements BoostableQuer
     }
 
     @Override
-    protected String parserName() {
-        return HasParentQueryParser.NAME;
+    public String queryId() {
+        return NAME;
     }
 }
 

--- a/src/main/java/org/elasticsearch/index/query/HasParentQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/HasParentQueryParser.java
@@ -45,7 +45,6 @@ import java.util.Set;
 
 public class HasParentQueryParser extends BaseQueryParserTemp {
 
-    public static final String NAME = "has_parent";
     private static final ParseField QUERY_FIELD = new ParseField("query", "filter");
 
     private final InnerHitsQueryParserHelper innerHitsQueryParserHelper;
@@ -57,7 +56,7 @@ public class HasParentQueryParser extends BaseQueryParserTemp {
 
     @Override
     public String[] names() {
-        return new String[]{NAME, Strings.toCamelCase(NAME)};
+        return new String[]{HasParentQueryBuilder.NAME, Strings.toCamelCase(HasParentQueryBuilder.NAME)};
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
@@ -39,6 +39,8 @@ import java.util.*;
  */
 public class IdsQueryBuilder extends QueryBuilder<IdsQueryBuilder> implements BoostableQueryBuilder<IdsQueryBuilder> {
 
+    public static final String NAME = "ids";
+
     private final Set<String> ids = Sets.newHashSet();
 
     private final String[] types;
@@ -117,7 +119,7 @@ public class IdsQueryBuilder extends QueryBuilder<IdsQueryBuilder> implements Bo
 
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(IdsQueryParser.NAME);
+        builder.startObject(NAME);
         if (types != null) {
             if (types.length == 1) {
                 builder.field("type", types[0]);
@@ -140,10 +142,11 @@ public class IdsQueryBuilder extends QueryBuilder<IdsQueryBuilder> implements Bo
     }
 
     @Override
-    protected String parserName() {
-        return IdsQueryParser.NAME;
+    public String queryId() {
+        return NAME;
     }
 
+    @Override
     public Query toQuery(QueryParseContext parseContext) throws IOException, QueryParsingException {
         Query query;
         if (this.ids.isEmpty()) {

--- a/src/main/java/org/elasticsearch/index/query/IdsQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/IdsQueryParser.java
@@ -32,15 +32,13 @@ import java.util.List;
  */
 public class IdsQueryParser extends BaseQueryParser {
 
-    public static final String NAME = "ids";
-
     @Inject
     public IdsQueryParser() {
     }
 
     @Override
     public String[] names() {
-        return new String[]{NAME};
+        return new String[]{IdsQueryBuilder.NAME};
     }
 
     /**

--- a/src/main/java/org/elasticsearch/index/query/IndicesQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/IndicesQueryBuilder.java
@@ -29,6 +29,8 @@ import java.io.IOException;
  */
 public class IndicesQueryBuilder extends QueryBuilder {
 
+    public static final String NAME = "indices";
+
     private final QueryBuilder queryBuilder;
 
     private final String[] indices;
@@ -69,7 +71,7 @@ public class IndicesQueryBuilder extends QueryBuilder {
 
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(IndicesQueryParser.NAME);
+        builder.startObject(NAME);
         builder.field("indices", indices);
         builder.field("query");
         queryBuilder.toXContent(builder, params);
@@ -86,7 +88,7 @@ public class IndicesQueryBuilder extends QueryBuilder {
     }
 
     @Override
-    protected String parserName() {
-        return IndicesQueryParser.NAME;
+    public String queryId() {
+        return NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/IndicesQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/IndicesQueryParser.java
@@ -38,7 +38,6 @@ import java.util.Collection;
  */
 public class IndicesQueryParser extends BaseQueryParserTemp {
 
-    public static final String NAME = "indices";
     private static final ParseField QUERY_FIELD = new ParseField("query", "filter");
     private static final ParseField NO_MATCH_QUERY = new ParseField("no_match_query", "no_match_filter");
 
@@ -52,7 +51,7 @@ public class IndicesQueryParser extends BaseQueryParserTemp {
 
     @Override
     public String[] names() {
-        return new String[]{NAME};
+        return new String[]{IndicesQueryBuilder.NAME};
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/LimitQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/LimitQueryBuilder.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 @Deprecated
 public class LimitQueryBuilder extends QueryBuilder {
 
+    public static final String NAME = "limit";
     private final int limit;
 
     public LimitQueryBuilder(int limit) {
@@ -38,13 +39,13 @@ public class LimitQueryBuilder extends QueryBuilder {
 
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(LimitQueryParser.NAME);
+        builder.startObject(NAME);
         builder.field("value", limit);
         builder.endObject();
     }
 
     @Override
-    protected String parserName() {
-        return LimitQueryParser.NAME;
+    public String queryId() {
+        return NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/LimitQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/LimitQueryParser.java
@@ -29,15 +29,13 @@ import java.io.IOException;
 @Deprecated
 public class LimitQueryParser extends BaseQueryParserTemp {
 
-    public static final String NAME = "limit";
-
     @Inject
     public LimitQueryParser() {
     }
 
     @Override
     public String[] names() {
-        return new String[]{NAME};
+        return new String[]{LimitQueryBuilder.NAME};
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/MatchAllQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/MatchAllQueryBuilder.java
@@ -33,6 +33,8 @@ import java.io.IOException;
  */
 public class MatchAllQueryBuilder extends QueryBuilder<MatchAllQueryBuilder> implements BoostableQueryBuilder<MatchAllQueryBuilder> {
 
+    public static final String NAME = "match_all";
+
     private float boost = 1.0f;
 
     /**
@@ -54,7 +56,7 @@ public class MatchAllQueryBuilder extends QueryBuilder<MatchAllQueryBuilder> imp
 
     @Override
     public void doXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(MatchAllQueryParser.NAME);
+        builder.startObject(NAME);
         if (boost != 1.0f) {
             builder.field("boost", boost);
         }
@@ -101,7 +103,7 @@ public class MatchAllQueryBuilder extends QueryBuilder<MatchAllQueryBuilder> imp
     }
 
     @Override
-    protected String parserName() {
-        return MatchAllQueryParser.NAME;
+    public String queryId() {
+        return NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/MatchAllQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MatchAllQueryParser.java
@@ -30,15 +30,13 @@ import java.io.IOException;
  */
 public class MatchAllQueryParser extends BaseQueryParser {
 
-    public static final String NAME = "match_all";
-
     @Inject
     public MatchAllQueryParser() {
     }
 
     @Override
     public String[] names() {
-        return new String[]{NAME, Strings.toCamelCase(NAME)};
+        return new String[]{MatchAllQueryBuilder.NAME, Strings.toCamelCase(MatchAllQueryBuilder.NAME)};
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/MatchQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/MatchQueryBuilder.java
@@ -31,6 +31,8 @@ import java.util.Locale;
  */
 public class MatchQueryBuilder extends QueryBuilder implements BoostableQueryBuilder<MatchQueryBuilder> {
 
+    public static final String NAME = "match";
+
     public enum Operator {
         OR,
         AND
@@ -218,7 +220,7 @@ public class MatchQueryBuilder extends QueryBuilder implements BoostableQueryBui
 
     @Override
     public void doXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(MatchQueryParser.NAME);
+        builder.startObject(NAME);
         builder.startObject(name);
 
         builder.field("query", text);
@@ -278,7 +280,7 @@ public class MatchQueryBuilder extends QueryBuilder implements BoostableQueryBui
     }
 
     @Override
-    protected String parserName() {
-        return MatchQueryParser.NAME;
+    public String queryId() {
+        return NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/MatchQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MatchQueryParser.java
@@ -37,8 +37,6 @@ import java.io.IOException;
  */
 public class MatchQueryParser extends BaseQueryParserTemp {
 
-    public static final String NAME = "match";
-
     @Inject
     public MatchQueryParser() {
     }
@@ -46,7 +44,7 @@ public class MatchQueryParser extends BaseQueryParserTemp {
     @Override
     public String[] names() {
         return new String[]{
-                NAME, "match_phrase", "matchPhrase", "match_phrase_prefix", "matchPhrasePrefix", "matchFuzzy", "match_fuzzy", "fuzzy_match"
+                MatchQueryBuilder.NAME, "match_phrase", "matchPhrase", "match_phrase_prefix", "matchPhrasePrefix", "matchFuzzy", "match_fuzzy", "fuzzy_match"
         };
     }
 

--- a/src/main/java/org/elasticsearch/index/query/MissingQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/MissingQueryBuilder.java
@@ -28,6 +28,8 @@ import java.io.IOException;
  */
 public class MissingQueryBuilder extends QueryBuilder {
 
+    public static final String NAME = "missing";
+
     private String name;
 
     private String queryName;
@@ -68,7 +70,7 @@ public class MissingQueryBuilder extends QueryBuilder {
 
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(MissingQueryParser.NAME);
+        builder.startObject(NAME);
         builder.field("field", name);
         if (nullValue != null) {
             builder.field("null_value", nullValue);
@@ -83,7 +85,7 @@ public class MissingQueryBuilder extends QueryBuilder {
     }
 
     @Override
-    protected String parserName() {
-        return MissingQueryParser.NAME;
+    public String queryId() {
+        return NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/MissingQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MissingQueryParser.java
@@ -39,7 +39,6 @@ import java.util.List;
  */
 public class MissingQueryParser extends BaseQueryParserTemp {
 
-    public static final String NAME = "missing";
     public static final boolean DEFAULT_NULL_VALUE = false;
     public static final boolean DEFAULT_EXISTENCE_VALUE = true;
 
@@ -49,7 +48,7 @@ public class MissingQueryParser extends BaseQueryParserTemp {
 
     @Override
     public String[] names() {
-        return new String[]{NAME};
+        return new String[]{MissingQueryBuilder.NAME};
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilder.java
@@ -132,6 +132,8 @@ public class MoreLikeThisQueryBuilder extends QueryBuilder implements BoostableQ
         }
     }
 
+    public static final String NAME = "mlt";
+
     private final String[] fields;
     private List<Item> docs = new ArrayList<>();
     private List<Item> ignoreDocs = new ArrayList<>();
@@ -369,7 +371,7 @@ public class MoreLikeThisQueryBuilder extends QueryBuilder implements BoostableQ
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
         String likeFieldName = MoreLikeThisQueryParser.Fields.LIKE.getPreferredName();
-        builder.startObject(MoreLikeThisQueryParser.NAME);
+        builder.startObject(NAME);
         if (fields != null) {
             builder.startArray("fields");
             for (String field : fields) {
@@ -435,7 +437,7 @@ public class MoreLikeThisQueryBuilder extends QueryBuilder implements BoostableQ
     }
 
     @Override
-    protected String parserName() {
-        return MoreLikeThisQueryParser.NAME;
+    public String queryId() {
+        return NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryParser.java
@@ -55,7 +55,6 @@ import static org.elasticsearch.index.mapper.Uid.createUidAsBytes;
  */
 public class MoreLikeThisQueryParser extends BaseQueryParserTemp {
 
-    public static final String NAME = "mlt";
     private MoreLikeThisFetchService fetchService = null;
 
     public static class Fields {
@@ -88,7 +87,7 @@ public class MoreLikeThisQueryParser extends BaseQueryParserTemp {
 
     @Override
     public String[] names() {
-        return new String[]{NAME, "more_like_this", "moreLikeThis"};
+        return new String[]{MoreLikeThisQueryBuilder.NAME, "more_like_this", "moreLikeThis"};
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/MultiMatchQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/MultiMatchQueryBuilder.java
@@ -39,6 +39,8 @@ import java.util.Locale;
  */
 public class MultiMatchQueryBuilder extends QueryBuilder implements BoostableQueryBuilder<MultiMatchQueryBuilder> {
 
+    public static final String NAME = "multi_match";
+
     private final Object text;
 
     private final List<String> fields;
@@ -77,7 +79,6 @@ public class MultiMatchQueryBuilder extends QueryBuilder implements BoostableQue
     private MatchQueryBuilder.ZeroTermsQuery zeroTermsQuery = null;
 
     private String queryName;
-
 
     public enum Type {
 
@@ -332,7 +333,7 @@ public class MultiMatchQueryBuilder extends QueryBuilder implements BoostableQue
 
     @Override
     public void doXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(MultiMatchQueryParser.NAME);
+        builder.startObject(NAME);
 
         builder.field("query", text);
         builder.startArray("fields");
@@ -407,7 +408,7 @@ public class MultiMatchQueryBuilder extends QueryBuilder implements BoostableQue
     }
 
     @Override
-    protected String parserName() {
-        return MultiMatchQueryParser.NAME;
+    public String queryId() {
+        return NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/MultiMatchQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MultiMatchQueryParser.java
@@ -39,8 +39,6 @@ import java.util.Map;
  */
 public class MultiMatchQueryParser extends BaseQueryParserTemp {
 
-    public static final String NAME = "multi_match";
-
     @Inject
     public MultiMatchQueryParser() {
     }
@@ -48,7 +46,7 @@ public class MultiMatchQueryParser extends BaseQueryParserTemp {
     @Override
     public String[] names() {
         return new String[]{
-                NAME, "multiMatch"
+                MultiMatchQueryBuilder.NAME, "multiMatch"
         };
     }
 
@@ -78,7 +76,7 @@ public class MultiMatchQueryParser extends BaseQueryParserTemp {
                 } else if (token.isValue()) {
                     extractFieldAndBoost(parseContext, parser, fieldNameWithBoosts);
                 } else {
-                    throw new QueryParsingException(parseContext, "[" + NAME + "] query does not support [" + currentFieldName + "]");
+                    throw new QueryParsingException(parseContext, "[" + MultiMatchQueryBuilder.NAME + "] query does not support [" + currentFieldName + "]");
                 }
             } else if (token.isValue()) {
                 if ("query".equals(currentFieldName)) {
@@ -88,7 +86,7 @@ public class MultiMatchQueryParser extends BaseQueryParserTemp {
                 } else if ("analyzer".equals(currentFieldName)) {
                     String analyzer = parser.text();
                     if (parseContext.analysisService().analyzer(analyzer) == null) {
-                        throw new QueryParsingException(parseContext, "[" + NAME + "] analyzer [" + parser.text() + "] not found");
+                        throw new QueryParsingException(parseContext, "[" + MultiMatchQueryBuilder.NAME + "] analyzer [" + parser.text() + "] not found");
                     }
                     multiMatchQuery.setAnalyzer(analyzer);
                 } else if ("boost".equals(currentFieldName)) {

--- a/src/main/java/org/elasticsearch/index/query/NestedQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/NestedQueryBuilder.java
@@ -27,6 +27,8 @@ import java.util.Objects;
 
 public class NestedQueryBuilder extends QueryBuilder implements BoostableQueryBuilder<NestedQueryBuilder> {
 
+    public static final String NAME = "nested";
+
     private final QueryBuilder queryBuilder;
 
     private final String path;
@@ -79,7 +81,7 @@ public class NestedQueryBuilder extends QueryBuilder implements BoostableQueryBu
 
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(NestedQueryParser.NAME);
+        builder.startObject(NAME);
         builder.field("query");
         queryBuilder.toXContent(builder, params);
         builder.field("path", path);
@@ -101,7 +103,7 @@ public class NestedQueryBuilder extends QueryBuilder implements BoostableQueryBu
     }
 
     @Override
-    protected final String parserName() {
-        return NestedQueryParser.NAME;
+    public final String queryId() {
+        return NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/NestedQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/NestedQueryParser.java
@@ -39,7 +39,6 @@ import java.io.IOException;
 
 public class NestedQueryParser extends BaseQueryParserTemp {
 
-    public static final String NAME = "nested";
     private static final ParseField FILTER_FIELD = new ParseField("filter").withAllDeprecated("query");
 
     private final InnerHitsQueryParserHelper innerHitsQueryParserHelper;
@@ -51,7 +50,7 @@ public class NestedQueryParser extends BaseQueryParserTemp {
 
     @Override
     public String[] names() {
-        return new String[]{NAME, Strings.toCamelCase(NAME)};
+        return new String[]{NestedQueryBuilder.NAME, Strings.toCamelCase(NestedQueryBuilder.NAME)};
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/NotQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/NotQueryBuilder.java
@@ -29,6 +29,8 @@ import java.util.Objects;
  */
 public class NotQueryBuilder extends QueryBuilder {
 
+    public static final String NAME = "not";
+
     private final QueryBuilder filter;
 
     private String queryName;
@@ -44,7 +46,7 @@ public class NotQueryBuilder extends QueryBuilder {
 
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(NotQueryParser.NAME);
+        builder.startObject(NAME);
         builder.field("query");
         filter.toXContent(builder, params);
         if (queryName != null) {
@@ -54,7 +56,7 @@ public class NotQueryBuilder extends QueryBuilder {
     }
 
     @Override
-    protected String parserName() {
-        return NotQueryParser.NAME;
+    public String queryId() {
+        return NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/NotQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/NotQueryParser.java
@@ -32,7 +32,6 @@ import java.io.IOException;
  */
 public class NotQueryParser extends BaseQueryParserTemp {
 
-    public static final String NAME = "not";
     private static final ParseField QUERY_FIELD = new ParseField("filter", "query");
 
     @Inject
@@ -41,7 +40,7 @@ public class NotQueryParser extends BaseQueryParserTemp {
 
     @Override
     public String[] names() {
-        return new String[]{NAME};
+        return new String[]{NotQueryBuilder.NAME};
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/OrQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/OrQueryBuilder.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.query;
 
 import com.google.common.collect.Lists;
+
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -32,6 +33,8 @@ import java.util.Collections;
  */
 @Deprecated
 public class OrQueryBuilder extends QueryBuilder {
+
+    public static final String NAME = "or";
 
     private ArrayList<QueryBuilder> filters = Lists.newArrayList();
 
@@ -56,7 +59,7 @@ public class OrQueryBuilder extends QueryBuilder {
 
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(OrQueryParser.NAME);
+        builder.startObject(NAME);
         builder.startArray("filters");
         for (QueryBuilder filter : filters) {
             filter.toXContent(builder, params);
@@ -69,7 +72,7 @@ public class OrQueryBuilder extends QueryBuilder {
     }
 
     @Override
-    protected String parserName() {
-        return OrQueryParser.NAME;
+    public String queryId() {
+        return NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/OrQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/OrQueryParser.java
@@ -36,15 +36,13 @@ import static com.google.common.collect.Lists.newArrayList;
 @Deprecated
 public class OrQueryParser extends BaseQueryParserTemp {
 
-    public static final String NAME = "or";
-
     @Inject
     public OrQueryParser() {
     }
 
     @Override
     public String[] names() {
-        return new String[]{NAME};
+        return new String[]{OrQueryBuilder.NAME};
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/PrefixQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/PrefixQueryBuilder.java
@@ -28,6 +28,8 @@ import java.io.IOException;
  */
 public class PrefixQueryBuilder extends MultiTermQueryBuilder implements BoostableQueryBuilder<PrefixQueryBuilder> {
 
+    public static final String NAME = "prefix";
+
     private final String name;
 
     private final String prefix;
@@ -74,7 +76,7 @@ public class PrefixQueryBuilder extends MultiTermQueryBuilder implements Boostab
 
     @Override
     public void doXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(PrefixQueryParser.NAME);
+        builder.startObject(NAME);
         if (boost == -1 && rewrite == null && queryName != null) {
             builder.field(name, prefix);
         } else {
@@ -95,7 +97,7 @@ public class PrefixQueryBuilder extends MultiTermQueryBuilder implements Boostab
     }
 
     @Override
-    protected String parserName() {
-        return PrefixQueryParser.NAME;
+    public String queryId() {
+        return NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/PrefixQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/PrefixQueryParser.java
@@ -36,15 +36,13 @@ import java.io.IOException;
  */
 public class PrefixQueryParser extends BaseQueryParserTemp {
 
-    public static final String NAME = "prefix";
-
     @Inject
     public PrefixQueryParser() {
     }
 
     @Override
     public String[] names() {
-        return new String[]{NAME};
+        return new String[]{PrefixQueryBuilder.NAME};
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/QueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryBuilder.java
@@ -50,6 +50,11 @@ public abstract class QueryBuilder<QB> extends ToXContentToBytes implements Writ
     }
 
     /**
+     * @return a unique name this query is identified with
+     */
+    public abstract String queryId();
+
+    /**
      * Converts this QueryBuilder to a lucene {@link Query}
      * @param parseContext additional information needed to construct the queries
      * @return the {@link Query}
@@ -58,15 +63,8 @@ public abstract class QueryBuilder<QB> extends ToXContentToBytes implements Writ
      */
     //norelease to be made abstract once all query builders override toQuery providing their own specific implementation.
     public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
-        return parseContext.indexQueryParserService().queryParser(parserName()).parse(parseContext);
+        return parseContext.indexQueryParserService().queryParser(queryId()).parse(parseContext);
     }
-
-    /**
-     * Temporary method that allows to retrieve the parser for each query.
-     * @return the name of the parser class the default {@link #toQuery(QueryParseContext)} method delegates to
-     */
-    //norelease to be removed once all query builders override toQuery providing their own specific implementation.
-    protected abstract String parserName();
 
     /**
      * Validate the query.

--- a/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
@@ -584,11 +584,10 @@ public abstract class QueryBuilders {
     }
 
     /**
-     * A terms lookup filter for the provided field name. A lookup terms filter can
-     * extract the terms to filter by from another doc in an index.
+     * A terms query that can extract the terms from another doc in an index.
      */
-    public static TermsLookupQueryBuilder termsLookupQuery(String name) {
-        return new TermsLookupQueryBuilder(name);
+    public static TermsQueryBuilder termsLookupQuery(String name) {
+        return new TermsQueryBuilder(name, (Object[]) null);
     }
 
     /**
@@ -674,7 +673,7 @@ public abstract class QueryBuilders {
     public static GeohashCellQuery.Builder geoHashCellQuery(String name, String geohash, boolean neighbors) {
         return new GeohashCellQuery.Builder(name, geohash, neighbors);
     }
-    
+
     /**
      * A filter to filter based on a polygon defined by a set of locations  / points.
      *

--- a/src/main/java/org/elasticsearch/index/query/QueryFilterBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryFilterBuilder.java
@@ -31,6 +31,11 @@ import java.io.IOException;
 @Deprecated
 public class QueryFilterBuilder extends QueryBuilder {
 
+    public static final String NAME = "query";
+
+    // this query builder creates query parsed by FQueryFilterParser in case queryName is set
+    public static final String FQUERY_NAME = "fquery";
+
     private final QueryBuilder queryBuilder;
 
     private String queryName;
@@ -55,10 +60,10 @@ public class QueryFilterBuilder extends QueryBuilder {
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
         if (queryName == null) {
-            builder.field(QueryFilterParser.NAME);
+            builder.field(NAME);
             queryBuilder.toXContent(builder, params);
         } else {
-            builder.startObject(FQueryFilterParser.NAME);
+            builder.startObject(FQUERY_NAME);
             builder.field("query");
             queryBuilder.toXContent(builder, params);
             if (queryName != null) {
@@ -69,7 +74,7 @@ public class QueryFilterBuilder extends QueryBuilder {
     }
 
     @Override
-    protected String parserName() {
-        return QueryFilterParser.NAME;
+    public String queryId() {
+        return NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/QueryFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryFilterParser.java
@@ -28,15 +28,13 @@ import java.io.IOException;
 @Deprecated
 public class QueryFilterParser extends BaseQueryParserTemp {
 
-    public static final String NAME = "query";
-
     @Inject
     public QueryFilterParser() {
     }
 
     @Override
     public String[] names() {
-        return new String[]{NAME};
+        return new String[]{QueryFilterBuilder.NAME};
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
@@ -40,6 +40,8 @@ import static com.google.common.collect.Lists.newArrayList;
  */
 public class QueryStringQueryBuilder extends QueryBuilder implements BoostableQueryBuilder<QueryStringQueryBuilder> {
 
+    public static final String NAME = "query_string";
+
     public enum Operator {
         OR,
         AND
@@ -344,7 +346,7 @@ public class QueryStringQueryBuilder extends QueryBuilder implements BoostableQu
 
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(QueryStringQueryParser.NAME);
+        builder.startObject(NAME);
         builder.field("query", queryString);
         if (defaultField != null) {
             builder.field("default_field", defaultField);
@@ -435,7 +437,7 @@ public class QueryStringQueryBuilder extends QueryBuilder implements BoostableQu
     }
 
     @Override
-    protected String parserName() {
-        return QueryStringQueryParser.NAME;
+    public String queryId() {
+        return NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/QueryStringQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryStringQueryParser.java
@@ -49,7 +49,6 @@ import static org.elasticsearch.common.lucene.search.Queries.fixNegativeQueryIfN
  */
 public class QueryStringQueryParser extends BaseQueryParserTemp {
 
-    public static final String NAME = "query_string";
     private static final ParseField FUZZINESS = Fuzziness.FIELD.withDeprecation("fuzzy_min_sim");
 
     private final boolean defaultAnalyzeWildcard;
@@ -63,7 +62,7 @@ public class QueryStringQueryParser extends BaseQueryParserTemp {
 
     @Override
     public String[] names() {
-        return new String[]{NAME, Strings.toCamelCase(NAME)};
+        return new String[]{QueryStringQueryBuilder.NAME, Strings.toCamelCase(QueryStringQueryBuilder.NAME)};
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/QueryWrappingQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryWrappingQueryBuilder.java
@@ -48,7 +48,7 @@ public class QueryWrappingQueryBuilder extends QueryBuilder {
     }
 
     @Override
-    protected final String parserName() {
+    public String queryId() {
         // this should not be called since we overwrite BaseQueryBuilder#toQuery() in this class
         throw new UnsupportedOperationException();
     }

--- a/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
@@ -40,6 +40,8 @@ import java.util.Objects;
  */
 public class RangeQueryBuilder extends MultiTermQueryBuilder<RangeQueryBuilder> implements BoostableQueryBuilder<RangeQueryBuilder> {
 
+    public static final String NAME = "range";
+
     private final String fieldName;
 
     private Object from;
@@ -247,7 +249,7 @@ public class RangeQueryBuilder extends MultiTermQueryBuilder<RangeQueryBuilder> 
 
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(RangeQueryParser.NAME);
+        builder.startObject(NAME);
         builder.startObject(fieldName);
         builder.field("from", convertToStringIfBytesRef(this.from));
         builder.field("to", convertToStringIfBytesRef(this.to));
@@ -270,8 +272,8 @@ public class RangeQueryBuilder extends MultiTermQueryBuilder<RangeQueryBuilder> 
     }
 
     @Override
-    protected String parserName() {
-        return RangeQueryParser.NAME;
+    public String queryId() {
+        return NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/RangeQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/RangeQueryParser.java
@@ -33,7 +33,6 @@ import java.io.IOException;
  */
 public class RangeQueryParser extends BaseQueryParser {
 
-    public static final String NAME = "range";
     private static final ParseField FIELDDATA_FIELD = new ParseField("fielddata").withAllDeprecated("[no replacement]");
 
     @Inject
@@ -42,7 +41,7 @@ public class RangeQueryParser extends BaseQueryParser {
 
     @Override
     public String[] names() {
-        return new String[] { NAME };
+        return new String[]{RangeQueryBuilder.NAME};
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/RegexpQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/RegexpQueryBuilder.java
@@ -29,6 +29,7 @@ import java.io.IOException;
  */
 public class RegexpQueryBuilder extends MultiTermQueryBuilder implements BoostableQueryBuilder<RegexpQueryBuilder> {
 
+    public static final String NAME = "regexp";
     private final String name;
     private final String regexp;
 
@@ -97,7 +98,7 @@ public class RegexpQueryBuilder extends MultiTermQueryBuilder implements Boostab
 
     @Override
     public void doXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(RegexpQueryParser.NAME);
+        builder.startObject(NAME);
         if (boost == -1 && rewrite == null && queryName != null) {
             builder.field(name, regexp);
         } else {
@@ -124,7 +125,7 @@ public class RegexpQueryBuilder extends MultiTermQueryBuilder implements Boostab
     }
 
     @Override
-    protected String parserName() {
-        return RegexpQueryParser.NAME;
+    public String queryId() {
+        return NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/RegexpQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/RegexpQueryParser.java
@@ -37,15 +37,13 @@ import java.io.IOException;
  */
 public class RegexpQueryParser extends BaseQueryParserTemp {
 
-    public static final String NAME = "regexp";
-
     @Inject
     public RegexpQueryParser() {
     }
 
     @Override
     public String[] names() {
-        return new String[]{NAME};
+        return new String[]{RegexpQueryBuilder.NAME};
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/ScriptQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/ScriptQueryBuilder.java
@@ -28,6 +28,8 @@ import static com.google.common.collect.Maps.newHashMap;
 
 public class ScriptQueryBuilder extends QueryBuilder {
 
+    public static final String NAME = "script";
+
     private final String script;
 
     private Map<String, Object> params;
@@ -75,7 +77,7 @@ public class ScriptQueryBuilder extends QueryBuilder {
 
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(ScriptQueryParser.NAME);
+        builder.startObject(NAME);
         builder.field("script", script);
         if (this.params != null) {
             builder.field("params", this.params);
@@ -90,7 +92,7 @@ public class ScriptQueryBuilder extends QueryBuilder {
     }
 
     @Override
-    protected String parserName() {
-        return ScriptQueryParser.NAME;
+    public String queryId() {
+        return NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/ScriptQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/ScriptQueryParser.java
@@ -47,15 +47,13 @@ import static com.google.common.collect.Maps.newHashMap;
  */
 public class ScriptQueryParser extends BaseQueryParserTemp {
 
-    public static final String NAME = "script";
-
     @Inject
     public ScriptQueryParser() {
     }
 
     @Override
     public String[] names() {
-        return new String[]{NAME};
+        return new String[]{ScriptQueryBuilder.NAME};
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
@@ -31,6 +31,7 @@ import java.util.Map;
  * query, but won't throw exceptions for any weird string syntax.
  */
 public class SimpleQueryStringBuilder extends QueryBuilder {
+    public static final String NAME = "simple_query_string";
     private Map<String, Float> fields = new HashMap<>();
     private String analyzer;
     private Operator operator;
@@ -142,7 +143,7 @@ public class SimpleQueryStringBuilder extends QueryBuilder {
 
     @Override
     public void doXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(SimpleQueryStringParser.NAME);
+        builder.startObject(NAME);
 
         builder.field("query", queryText);
 
@@ -200,7 +201,7 @@ public class SimpleQueryStringBuilder extends QueryBuilder {
     }
 
     @Override
-    protected String parserName() {
-        return SimpleQueryStringParser.NAME;
+    public String queryId() {
+        return NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/SimpleQueryStringFlag.java
+++ b/src/main/java/org/elasticsearch/index/query/SimpleQueryStringFlag.java
@@ -71,7 +71,7 @@ public enum SimpleQueryStringFlag {
                         magic |= flag.value();
                 }
             } catch (IllegalArgumentException iae) {
-                throw new IllegalArgumentException("Unknown " + SimpleQueryStringParser.NAME + " flag [" + s + "]");
+                throw new IllegalArgumentException("Unknown " + SimpleQueryStringBuilder.NAME + " flag [" + s + "]");
             }
         }
         return magic;

--- a/src/main/java/org/elasticsearch/index/query/SimpleQueryStringParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SimpleQueryStringParser.java
@@ -71,8 +71,6 @@ import java.util.Map;
  */
 public class SimpleQueryStringParser extends BaseQueryParserTemp {
 
-    public static final String NAME = "simple_query_string";
-
     @Inject
     public SimpleQueryStringParser(Settings settings) {
 
@@ -80,7 +78,7 @@ public class SimpleQueryStringParser extends BaseQueryParserTemp {
 
     @Override
     public String[] names() {
-        return new String[]{NAME, Strings.toCamelCase(NAME)};
+        return new String[]{SimpleQueryStringBuilder.NAME, Strings.toCamelCase(SimpleQueryStringBuilder.NAME)};
     }
 
     @Override
@@ -140,7 +138,7 @@ public class SimpleQueryStringParser extends BaseQueryParserTemp {
                     }
                 } else {
                     throw new QueryParsingException(parseContext,
- "[" + NAME + "] query does not support [" + currentFieldName
+ "[" + SimpleQueryStringBuilder.NAME + "] query does not support [" + currentFieldName
  + "]");
                 }
             } else if (token.isValue()) {
@@ -149,7 +147,7 @@ public class SimpleQueryStringParser extends BaseQueryParserTemp {
                 } else if ("analyzer".equals(currentFieldName)) {
                     analyzer = parseContext.analysisService().analyzer(parser.text());
                     if (analyzer == null) {
-                        throw new QueryParsingException(parseContext, "[" + NAME + "] analyzer [" + parser.text() + "] not found");
+                        throw new QueryParsingException(parseContext, "[" + SimpleQueryStringBuilder.NAME + "] analyzer [" + parser.text() + "] not found");
                     }
                 } else if ("field".equals(currentFieldName)) {
                     field = parser.text();
@@ -160,7 +158,7 @@ public class SimpleQueryStringParser extends BaseQueryParserTemp {
                     } else if ("and".equalsIgnoreCase(op)) {
                         defaultOperator = BooleanClause.Occur.MUST;
                     } else {
-                        throw new QueryParsingException(parseContext, "[" + NAME + "] default operator [" + op + "] is not allowed");
+                        throw new QueryParsingException(parseContext, "[" + SimpleQueryStringBuilder.NAME + "] default operator [" + op + "] is not allowed");
                     }
                 } else if ("flags".equals(currentFieldName)) {
                     if (parser.currentToken() != XContentParser.Token.VALUE_NUMBER) {
@@ -188,14 +186,14 @@ public class SimpleQueryStringParser extends BaseQueryParserTemp {
                 } else if ("minimum_should_match".equals(currentFieldName)) {
                     minimumShouldMatch = parser.textOrNull();
                 } else {
-                    throw new QueryParsingException(parseContext, "[" + NAME + "] unsupported field [" + parser.currentName() + "]");
+                    throw new QueryParsingException(parseContext, "[" + SimpleQueryStringBuilder.NAME + "] unsupported field [" + parser.currentName() + "]");
                 }
             }
         }
 
         // Query text is required
         if (queryBody == null) {
-            throw new QueryParsingException(parseContext, "[" + NAME + "] query text missing");
+            throw new QueryParsingException(parseContext, "[" + SimpleQueryStringBuilder.NAME + "] query text missing");
         }
 
         // Support specifying only a field instead of a map

--- a/src/main/java/org/elasticsearch/index/query/SpanContainingQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanContainingQueryBuilder.java
@@ -28,6 +28,7 @@ import java.io.IOException;
  */
 public class SpanContainingQueryBuilder extends QueryBuilder implements SpanQueryBuilder, BoostableQueryBuilder<SpanContainingQueryBuilder> {
 
+    public static final String NAME = "span_containing";
     private SpanQueryBuilder big;
     private SpanQueryBuilder little;
     private float boost = -1;
@@ -71,7 +72,7 @@ public class SpanContainingQueryBuilder extends QueryBuilder implements SpanQuer
         if (little == null) {
             throw new IllegalArgumentException("Must specify little clause when building a span_containing query");
         }
-        builder.startObject(SpanContainingQueryParser.NAME);
+        builder.startObject(NAME);
 
         builder.field("big");
         big.toXContent(builder, params);
@@ -91,7 +92,7 @@ public class SpanContainingQueryBuilder extends QueryBuilder implements SpanQuer
     }
 
     @Override
-    protected String parserName() {
-        return SpanContainingQueryParser.NAME;
+    public String queryId() {
+        return NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/SpanContainingQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanContainingQueryParser.java
@@ -33,15 +33,13 @@ import java.io.IOException;
  */
 public class SpanContainingQueryParser extends BaseQueryParserTemp {
 
-    public static final String NAME = "span_containing";
-
     @Inject
     public SpanContainingQueryParser() {
     }
 
     @Override
     public String[] names() {
-        return new String[]{NAME, Strings.toCamelCase(NAME)};
+        return new String[]{SpanContainingQueryBuilder.NAME, Strings.toCamelCase(SpanContainingQueryBuilder.NAME)};
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/SpanFirstQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanFirstQueryBuilder.java
@@ -25,6 +25,8 @@ import java.io.IOException;
 
 public class SpanFirstQueryBuilder extends QueryBuilder implements SpanQueryBuilder, BoostableQueryBuilder<SpanFirstQueryBuilder> {
 
+    public static final String NAME = "span_first";
+
     private final SpanQueryBuilder matchBuilder;
 
     private final int end;
@@ -54,7 +56,7 @@ public class SpanFirstQueryBuilder extends QueryBuilder implements SpanQueryBuil
 
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(SpanFirstQueryParser.NAME);
+        builder.startObject(NAME);
         builder.field("match");
         matchBuilder.toXContent(builder, params);
         builder.field("end", end);
@@ -68,7 +70,7 @@ public class SpanFirstQueryBuilder extends QueryBuilder implements SpanQueryBuil
     }
 
     @Override
-    protected String parserName() {
-        return SpanFirstQueryParser.NAME;
+    public String queryId() {
+        return NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/SpanFirstQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanFirstQueryParser.java
@@ -33,15 +33,13 @@ import java.io.IOException;
  */
 public class SpanFirstQueryParser extends BaseQueryParserTemp {
 
-    public static final String NAME = "span_first";
-
     @Inject
     public SpanFirstQueryParser() {
     }
 
     @Override
     public String[] names() {
-        return new String[]{NAME, Strings.toCamelCase(NAME)};
+        return new String[]{SpanFirstQueryBuilder.NAME, Strings.toCamelCase(SpanFirstQueryBuilder.NAME)};
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/SpanMultiTermQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanMultiTermQueryBuilder.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 
 public class SpanMultiTermQueryBuilder extends QueryBuilder implements SpanQueryBuilder {
 
+    public static final String NAME = "span_multi";
     private MultiTermQueryBuilder multiTermQueryBuilder;
 
     public SpanMultiTermQueryBuilder(MultiTermQueryBuilder multiTermQueryBuilder) {
@@ -33,14 +34,14 @@ public class SpanMultiTermQueryBuilder extends QueryBuilder implements SpanQuery
     @Override
     protected void doXContent(XContentBuilder builder, Params params)
             throws IOException {
-        builder.startObject(SpanMultiTermQueryParser.NAME);
+        builder.startObject(NAME);
         builder.field(SpanMultiTermQueryParser.MATCH_NAME);
         multiTermQueryBuilder.toXContent(builder, params);
         builder.endObject();
     }
 
     @Override
-    protected String parserName() {
-        return SpanMultiTermQueryParser.NAME;
+    public String queryId() {
+        return NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/SpanMultiTermQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanMultiTermQueryParser.java
@@ -33,7 +33,6 @@ import java.io.IOException;
  */
 public class SpanMultiTermQueryParser extends BaseQueryParserTemp {
 
-    public static final String NAME = "span_multi";
     public static final String MATCH_NAME = "match";
 
     @Inject
@@ -42,7 +41,7 @@ public class SpanMultiTermQueryParser extends BaseQueryParserTemp {
 
     @Override
     public String[] names() {
-        return new String[]{NAME, Strings.toCamelCase(NAME)};
+        return new String[]{SpanMultiTermQueryBuilder.NAME, Strings.toCamelCase(SpanMultiTermQueryBuilder.NAME)};
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/SpanNearQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanNearQueryBuilder.java
@@ -26,6 +26,8 @@ import java.util.ArrayList;
 
 public class SpanNearQueryBuilder extends QueryBuilder implements SpanQueryBuilder, BoostableQueryBuilder<SpanNearQueryBuilder> {
 
+    public static final String NAME = "span_near";
+
     private ArrayList<SpanQueryBuilder> clauses = new ArrayList<>();
 
     private Integer slop = null;
@@ -80,7 +82,7 @@ public class SpanNearQueryBuilder extends QueryBuilder implements SpanQueryBuild
         if (slop == null) {
             throw new IllegalArgumentException("Must set the slop when building a spanNear query");
         }
-        builder.startObject(SpanNearQueryParser.NAME);
+        builder.startObject(NAME);
         builder.startArray("clauses");
         for (SpanQueryBuilder clause : clauses) {
             clause.toXContent(builder, params);
@@ -103,7 +105,7 @@ public class SpanNearQueryBuilder extends QueryBuilder implements SpanQueryBuild
     }
 
     @Override
-    protected String parserName() {
-        return SpanNearQueryParser.NAME;
+    public String queryId() {
+        return NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/SpanNearQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanNearQueryParser.java
@@ -36,15 +36,13 @@ import static com.google.common.collect.Lists.newArrayList;
  */
 public class SpanNearQueryParser extends BaseQueryParserTemp {
 
-    public static final String NAME = "span_near";
-
     @Inject
     public SpanNearQueryParser() {
     }
 
     @Override
     public String[] names() {
-        return new String[]{NAME, Strings.toCamelCase(NAME)};
+        return new String[]{SpanNearQueryBuilder.NAME, Strings.toCamelCase(SpanNearQueryBuilder.NAME)};
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/SpanNotQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanNotQueryBuilder.java
@@ -25,6 +25,8 @@ import java.io.IOException;
 
 public class SpanNotQueryBuilder extends QueryBuilder implements SpanQueryBuilder, BoostableQueryBuilder<SpanNotQueryBuilder> {
 
+    public static final String NAME = "span_not";
+
     private SpanQueryBuilder include;
 
     private SpanQueryBuilder exclude;
@@ -93,7 +95,7 @@ public class SpanNotQueryBuilder extends QueryBuilder implements SpanQueryBuilde
              throw new IllegalArgumentException("spanNot can either use [dist] or [pre] & [post] (or none)");
         }
 
-        builder.startObject(SpanNotQueryParser.NAME);
+        builder.startObject(NAME);
         builder.field("include");
         include.toXContent(builder, params);
         builder.field("exclude");
@@ -117,7 +119,7 @@ public class SpanNotQueryBuilder extends QueryBuilder implements SpanQueryBuilde
     }
 
     @Override
-    protected String parserName() {
-        return SpanNotQueryParser.NAME;
+    public String queryId() {
+        return NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/SpanNotQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanNotQueryParser.java
@@ -33,15 +33,13 @@ import java.io.IOException;
  */
 public class SpanNotQueryParser extends BaseQueryParserTemp {
 
-    public static final String NAME = "span_not";
-
     @Inject
     public SpanNotQueryParser() {
     }
 
     @Override
     public String[] names() {
-        return new String[]{NAME, Strings.toCamelCase(NAME)};
+        return new String[]{SpanNotQueryBuilder.NAME, Strings.toCamelCase(SpanNotQueryBuilder.NAME)};
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/SpanOrQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanOrQueryBuilder.java
@@ -26,6 +26,8 @@ import java.util.ArrayList;
 
 public class SpanOrQueryBuilder extends QueryBuilder implements SpanQueryBuilder, BoostableQueryBuilder<SpanOrQueryBuilder> {
 
+    public static final String NAME = "span_or";
+
     private ArrayList<SpanQueryBuilder> clauses = new ArrayList<>();
 
     private float boost = -1;
@@ -56,7 +58,7 @@ public class SpanOrQueryBuilder extends QueryBuilder implements SpanQueryBuilder
         if (clauses.isEmpty()) {
             throw new IllegalArgumentException("Must have at least one clause when building a spanOr query");
         }
-        builder.startObject(SpanOrQueryParser.NAME);
+        builder.startObject(NAME);
         builder.startArray("clauses");
         for (SpanQueryBuilder clause : clauses) {
             clause.toXContent(builder, params);
@@ -72,7 +74,7 @@ public class SpanOrQueryBuilder extends QueryBuilder implements SpanQueryBuilder
     }
 
     @Override
-    protected String parserName() {
-        return SpanOrQueryParser.NAME;
+    public String queryId() {
+        return NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/SpanOrQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanOrQueryParser.java
@@ -36,15 +36,13 @@ import static com.google.common.collect.Lists.newArrayList;
  */
 public class SpanOrQueryParser extends BaseQueryParserTemp {
 
-    public static final String NAME = "span_or";
-
     @Inject
     public SpanOrQueryParser() {
     }
 
     @Override
     public String[] names() {
-        return new String[]{NAME, Strings.toCamelCase(NAME)};
+        return new String[]{SpanOrQueryBuilder.NAME, Strings.toCamelCase(SpanOrQueryBuilder.NAME)};
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/SpanTermQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanTermQueryBuilder.java
@@ -32,6 +32,8 @@ import org.elasticsearch.index.mapper.FieldMapper;
  */
 public class SpanTermQueryBuilder extends BaseTermQueryBuilder<SpanTermQueryBuilder> implements SpanQueryBuilder {
 
+    public static final String NAME = "span_term";
+
     /** @see BaseTermQueryBuilder#BaseTermQueryBuilder(String, String) */
     public SpanTermQueryBuilder(String name, String value) {
         super(name, (Object) value);
@@ -63,11 +65,6 @@ public class SpanTermQueryBuilder extends BaseTermQueryBuilder<SpanTermQueryBuil
     }
 
     @Override
-    protected String parserName() {
-        return SpanTermQueryParser.NAME;
-    }
-
-    @Override
     public Query toQuery(QueryParseContext context) {
         BytesRef valueBytes = null;
         String fieldName = this.fieldName;
@@ -91,5 +88,10 @@ public class SpanTermQueryBuilder extends BaseTermQueryBuilder<SpanTermQueryBuil
     @Override
     protected SpanTermQueryBuilder createBuilder(String fieldName, Object value) {
         return new SpanTermQueryBuilder(fieldName, value);
+    }
+
+    @Override
+    public String queryId() {
+        return NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/SpanTermQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanTermQueryParser.java
@@ -31,15 +31,13 @@ import java.io.IOException;
  */
 public class SpanTermQueryParser extends BaseQueryParser {
 
-    public static final String NAME = "span_term";
-
     @Inject
     public SpanTermQueryParser() {
     }
 
     @Override
     public String[] names() {
-        return new String[]{NAME, Strings.toCamelCase(NAME)};
+        return new String[]{SpanTermQueryBuilder.NAME, Strings.toCamelCase(SpanTermQueryBuilder.NAME)};
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/SpanWithinQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanWithinQueryBuilder.java
@@ -28,6 +28,7 @@ import java.io.IOException;
  */
 public class SpanWithinQueryBuilder extends QueryBuilder implements SpanQueryBuilder, BoostableQueryBuilder<SpanWithinQueryBuilder> {
 
+    public static final String NAME = "span_within";
     private SpanQueryBuilder big;
     private SpanQueryBuilder little;
     private float boost = -1;
@@ -71,7 +72,7 @@ public class SpanWithinQueryBuilder extends QueryBuilder implements SpanQueryBui
         if (little == null) {
             throw new IllegalArgumentException("Must specify little clause when building a span_within query");
         }
-        builder.startObject(SpanWithinQueryParser.NAME);
+        builder.startObject(NAME);
 
         builder.field("big");
         big.toXContent(builder, params);
@@ -91,7 +92,7 @@ public class SpanWithinQueryBuilder extends QueryBuilder implements SpanQueryBui
     }
 
     @Override
-    protected String parserName() {
-        return SpanWithinQueryParser.NAME;
+    public String queryId() {
+        return NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/SpanWithinQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanWithinQueryParser.java
@@ -33,15 +33,13 @@ import java.io.IOException;
  */
 public class SpanWithinQueryParser extends BaseQueryParserTemp {
 
-    public static final String NAME = "span_within";
-
     @Inject
     public SpanWithinQueryParser() {
     }
 
     @Override
     public String[] names() {
-        return new String[]{NAME, Strings.toCamelCase(NAME)};
+        return new String[]{SpanWithinQueryBuilder.NAME, Strings.toCamelCase(SpanWithinQueryBuilder.NAME)};
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/TemplateQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/TemplateQueryBuilder.java
@@ -29,6 +29,9 @@ import java.util.Map;
  * */
 public class TemplateQueryBuilder extends QueryBuilder {
 
+    /** Name to reference this type of query. */
+    public static final String NAME = "template";
+
     /** Parameters to fill the template with. */
     private Map<String, Object> vars;
     /** Template to fill.*/
@@ -57,7 +60,7 @@ public class TemplateQueryBuilder extends QueryBuilder {
 
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(TemplateQueryParser.NAME);
+        builder.startObject(NAME);
         String fieldname;
         switch(templateType){
             case FILE:
@@ -78,7 +81,7 @@ public class TemplateQueryBuilder extends QueryBuilder {
     }
 
     @Override
-    protected String parserName() {
-        return TemplateQueryParser.NAME;
+    public String queryId() {
+        return NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/TemplateQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TemplateQueryParser.java
@@ -41,8 +41,6 @@ import java.util.Map;
  * */
 public class TemplateQueryParser extends BaseQueryParserTemp {
 
-    /** Name to reference this type of query. */
-    public static final String NAME = "template";
     /** Name of query parameter containing the template string. */
     public static final String QUERY = "query";
     /** Name of query parameter containing the template parameters. */
@@ -64,7 +62,7 @@ public class TemplateQueryParser extends BaseQueryParserTemp {
 
     @Override
     public String[] names() {
-        return new String[] {NAME};
+        return new String[] {TemplateQueryBuilder.NAME};
     }
 
     /**

--- a/src/main/java/org/elasticsearch/index/query/TermQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/TermQueryBuilder.java
@@ -30,6 +30,8 @@ import org.elasticsearch.index.mapper.FieldMapper;
  */
 public class TermQueryBuilder extends BaseTermQueryBuilder<TermQueryBuilder> implements BoostableQueryBuilder<TermQueryBuilder> {
 
+    public static final String NAME = "term";
+
     /** @see BaseTermQueryBuilder#BaseTermQueryBuilder(String, String) */
     public TermQueryBuilder(String fieldName, String value) {
         super(fieldName, (Object) value);
@@ -88,7 +90,7 @@ public class TermQueryBuilder extends BaseTermQueryBuilder<TermQueryBuilder> imp
     }
 
     @Override
-    protected String parserName() {
-        return TermQueryParser.NAME;
+    public String queryId() {
+        return NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/TermQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TermQueryParser.java
@@ -30,15 +30,13 @@ import java.io.IOException;
  */
 public class TermQueryParser extends BaseQueryParser {
 
-    public static final String NAME = "term";
-
     @Inject
     public TermQueryParser() {
     }
 
     @Override
     public String[] names() {
-        return new String[]{NAME};
+        return new String[]{TermQueryBuilder.NAME};
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/TermsLookupQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/TermsLookupQueryBuilder.java
@@ -19,107 +19,20 @@
 
 package org.elasticsearch.index.query;
 
-import org.elasticsearch.common.xcontent.XContentBuilder;
-
-import java.io.IOException;
 
 /**
- * A filer for a field based on several terms matching on any of them.
+ * A filter for a field based on several terms matching on any of them.
+ * @deprecated use {@link TermsQueryBuilder#TermsQueryBuilder(name, lookupIndex, lookupType, lookupId)} instead.
  */
-public class TermsLookupQueryBuilder extends QueryBuilder {
-
-    private final String name;
-    private String lookupIndex;
-    private String lookupType;
-    private String lookupId;
-    private String lookupRouting;
-    private String lookupPath;
-    private Boolean lookupCache;
-
-    private String queryName;
+@Deprecated
+public class TermsLookupQueryBuilder extends TermsQueryBuilder {
 
     public TermsLookupQueryBuilder(String name) {
-        this.name = name;
-    }
-
-    /**
-     * Sets the filter name for the filter that can be used when searching for matched_filters per hit.
-     */
-    public TermsLookupQueryBuilder queryName(String queryName) {
-        this.queryName = queryName;
-        return this;
-    }
-
-    /**
-     * Sets the index name to lookup the terms from.
-     */
-    public TermsLookupQueryBuilder lookupIndex(String lookupIndex) {
-        this.lookupIndex = lookupIndex;
-        return this;
-    }
-
-    /**
-     * Sets the index type to lookup the terms from.
-     */
-    public TermsLookupQueryBuilder lookupType(String lookupType) {
-        this.lookupType = lookupType;
-        return this;
-    }
-
-    /**
-     * Sets the doc id to lookup the terms from.
-     */
-    public TermsLookupQueryBuilder lookupId(String lookupId) {
-        this.lookupId = lookupId;
-        return this;
-    }
-
-    /**
-     * Sets the path within the document to lookup the terms from.
-     */
-    public TermsLookupQueryBuilder lookupPath(String lookupPath) {
-        this.lookupPath = lookupPath;
-        return this;
-    }
-
-    public TermsLookupQueryBuilder lookupRouting(String lookupRouting) {
-        this.lookupRouting = lookupRouting;
-        return this;
-    }
-
-    public TermsLookupQueryBuilder lookupCache(boolean lookupCache) {
-        this.lookupCache = lookupCache;
-        return this;
+        super(name, (Object[]) null);
     }
 
     @Override
-    public void doXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(TermsQueryParser.NAME);
-
-        builder.startObject(name);
-        if (lookupIndex != null) {
-            builder.field("index", lookupIndex);
-        }
-        builder.field("type", lookupType);
-        builder.field("id", lookupId);
-        if (lookupRouting != null) {
-            builder.field("routing", lookupRouting);
-        }
-        if (lookupCache != null) {
-            builder.field("cache", lookupCache);
-        }
-        builder.field("path", lookupPath);
-        builder.endObject();
-
-        if (queryName != null) {
-            builder.field("_name", queryName);
-        }
-
-        builder.endObject();
-    }
-
-    @Override
-    protected String parserName() {
-        return TermsQueryParser.NAME;
+    public String queryId() {
+        return TermsQueryBuilder.NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/TermsQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/TermsQueryBuilder.java
@@ -24,9 +24,11 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import java.io.IOException;
 
 /**
- * A filer for a field based on several terms matching on any of them.
+ * A filter for a field based on several terms matching on any of them.
  */
-public class TermsQueryBuilder extends QueryBuilder {
+public class TermsQueryBuilder extends QueryBuilder<TermsQueryBuilder> {
+
+    public static final String NAME = "terms";
 
     private final String name;
 
@@ -36,8 +38,15 @@ public class TermsQueryBuilder extends QueryBuilder {
 
     private String execution;
 
+    private String lookupIndex;
+    private String lookupType;
+    private String lookupId;
+    private String lookupRouting;
+    private String lookupPath;
+    private Boolean lookupCache;
+
     /**
-     * A filer for a field based on several terms matching on any of them.
+     * A filter for a field based on several terms matching on any of them.
      *
      * @param name   The field name
      * @param values The terms
@@ -47,7 +56,7 @@ public class TermsQueryBuilder extends QueryBuilder {
     }
 
     /**
-     * A filer for a field based on several terms matching on any of them.
+     * A filter for a field based on several terms matching on any of them.
      *
      * @param name   The field name
      * @param values The terms
@@ -58,7 +67,7 @@ public class TermsQueryBuilder extends QueryBuilder {
     }
 
     /**
-     * A filer for a field based on several terms matching on any of them.
+     * A filter for a field based on several terms matching on any of them.
      *
      * @param name   The field name
      * @param values The terms
@@ -69,7 +78,7 @@ public class TermsQueryBuilder extends QueryBuilder {
     }
 
     /**
-     * A filer for a field based on several terms matching on any of them.
+     * A filter for a field based on several terms matching on any of them.
      *
      * @param name   The field name
      * @param values The terms
@@ -80,7 +89,7 @@ public class TermsQueryBuilder extends QueryBuilder {
     }
 
     /**
-     * A filer for a field based on several terms matching on any of them.
+     * A filter for a field based on several terms matching on any of them.
      *
      * @param name   The field name
      * @param values The terms
@@ -91,7 +100,7 @@ public class TermsQueryBuilder extends QueryBuilder {
     }
 
     /**
-     * A filer for a field based on several terms matching on any of them.
+     * A filter for a field based on several terms matching on any of them.
      *
      * @param name   The field name
      * @param values The terms
@@ -102,7 +111,7 @@ public class TermsQueryBuilder extends QueryBuilder {
     }
 
     /**
-     * A filer for a field based on several terms matching on any of them.
+     * A filter for a field based on several terms matching on any of them.
      *
      * @param name   The field name
      * @param values The terms
@@ -131,24 +140,80 @@ public class TermsQueryBuilder extends QueryBuilder {
         return this;
     }
 
+    /**
+     * Sets the index name to lookup the terms from.
+     */
+    public TermsQueryBuilder lookupIndex(String lookupIndex) {
+        this.lookupIndex = lookupIndex;
+        return this;
+    }
+
+    /**
+     * Sets the index type to lookup the terms from.
+     */
+    public TermsQueryBuilder lookupType(String lookupType) {
+        this.lookupType = lookupType;
+        return this;
+    }
+
+    /**
+     * Sets the doc id to lookup the terms from.
+     */
+    public TermsQueryBuilder lookupId(String lookupId) {
+        this.lookupId = lookupId;
+        return this;
+    }
+
+    /**
+     * Sets the path within the document to lookup the terms from.
+     */
+    public TermsQueryBuilder lookupPath(String lookupPath) {
+        this.lookupPath = lookupPath;
+        return this;
+    }
+
+    public TermsQueryBuilder lookupRouting(String lookupRouting) {
+        this.lookupRouting = lookupRouting;
+        return this;
+    }
+
+    public TermsQueryBuilder lookupCache(boolean lookupCache) {
+        this.lookupCache = lookupCache;
+        return this;
+    }
+
     @Override
     public void doXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(TermsQueryParser.NAME);
-        builder.field(name, values);
-
+        builder.startObject(NAME);
+        if (values == null) {
+            builder.startObject(name);
+            if (lookupIndex != null) {
+                builder.field("index", lookupIndex);
+            }
+            builder.field("type", lookupType);
+            builder.field("id", lookupId);
+            if (lookupRouting != null) {
+                builder.field("routing", lookupRouting);
+            }
+            if (lookupCache != null) {
+                builder.field("cache", lookupCache);
+            }
+            builder.field("path", lookupPath);
+            builder.endObject();
+        } else {
+            builder.field(name, values);
+        }
         if (execution != null) {
             builder.field("execution", execution);
         }
-
         if (queryName != null) {
             builder.field("_name", queryName);
         }
-
         builder.endObject();
     }
 
     @Override
-    protected String parserName() {
-        return TermsQueryParser.NAME;
+    public String queryId() {
+        return NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/TermsQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TermsQueryParser.java
@@ -48,7 +48,6 @@ import java.util.List;
  */
 public class TermsQueryParser extends BaseQueryParserTemp {
 
-    public static final String NAME = "terms";
     private static final ParseField MIN_SHOULD_MATCH_FIELD = new ParseField("min_match", "min_should_match").withAllDeprecated("Use [bool] query instead");
     private Client client;
 
@@ -61,7 +60,7 @@ public class TermsQueryParser extends BaseQueryParserTemp {
 
     @Override
     public String[] names() {
-        return new String[]{NAME, "in"};
+        return new String[]{TermsQueryBuilder.NAME, "in"};
     }
 
     @Inject(optional = true)
@@ -141,7 +140,7 @@ public class TermsQueryParser extends BaseQueryParserTemp {
                     // ignore
                 } else if (MIN_SHOULD_MATCH_FIELD.match(currentFieldName)) {
                     if (minShouldMatch != null) {
-                        throw new IllegalArgumentException("[" + currentFieldName + "] is not allowed in a filter context for the [" + NAME + "] query");
+                        throw new IllegalArgumentException("[" + currentFieldName + "] is not allowed in a filter context for the [" + TermsQueryBuilder.NAME + "] query");
                     }
                     minShouldMatch = parser.textOrNull();
                 } else if ("boost".equals(currentFieldName)) {

--- a/src/main/java/org/elasticsearch/index/query/TypeQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/TypeQueryBuilder.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 
 public class TypeQueryBuilder extends QueryBuilder {
 
+    public static final String NAME = "type";
     private final String type;
 
     public TypeQueryBuilder(String type) {
@@ -33,13 +34,13 @@ public class TypeQueryBuilder extends QueryBuilder {
 
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(TypeQueryParser.NAME);
+        builder.startObject(NAME);
         builder.field("value", type);
         builder.endObject();
     }
 
     @Override
-    protected String parserName() {
-        return TypeQueryParser.NAME;
+    public String queryId() {
+        return NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/TypeQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TypeQueryParser.java
@@ -32,15 +32,13 @@ import java.io.IOException;
 
 public class TypeQueryParser extends BaseQueryParserTemp {
 
-    public static final String NAME = "type";
-
     @Inject
     public TypeQueryParser() {
     }
 
     @Override
     public String[] names() {
-        return new String[]{NAME};
+        return new String[]{TypeQueryBuilder.NAME};
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/WildcardQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/WildcardQueryBuilder.java
@@ -33,6 +33,8 @@ import java.io.IOException;
  */
 public class WildcardQueryBuilder extends MultiTermQueryBuilder implements BoostableQueryBuilder<WildcardQueryBuilder> {
 
+    public static final String NAME = "wildcard";
+
     private final String name;
 
     private final String wildcard;
@@ -84,7 +86,7 @@ public class WildcardQueryBuilder extends MultiTermQueryBuilder implements Boost
 
     @Override
     public void doXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(WildcardQueryParser.NAME);
+        builder.startObject(NAME);
         if (boost == -1 && rewrite == null && queryName != null) {
             builder.field(name, wildcard);
         } else {
@@ -105,7 +107,7 @@ public class WildcardQueryBuilder extends MultiTermQueryBuilder implements Boost
     }
 
     @Override
-    protected String parserName() {
-        return WildcardQueryParser.NAME;
+    public String queryId() {
+        return NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/WildcardQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/WildcardQueryParser.java
@@ -35,15 +35,13 @@ import java.io.IOException;
  */
 public class WildcardQueryParser extends BaseQueryParserTemp {
 
-    public static final String NAME = "wildcard";
-
     @Inject
     public WildcardQueryParser() {
     }
 
     @Override
     public String[] names() {
-        return new String[]{NAME};
+        return new String[]{WildcardQueryBuilder.NAME};
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/WrapperQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/WrapperQueryBuilder.java
@@ -42,6 +42,7 @@ import java.io.IOException;
  */
 public class WrapperQueryBuilder extends QueryBuilder {
 
+    public static final String NAME = "wrapper";
     private final byte[] source;
     private final int offset;
     private final int length;
@@ -75,13 +76,13 @@ public class WrapperQueryBuilder extends QueryBuilder {
 
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(WrapperQueryParser.NAME);
+        builder.startObject(NAME);
         builder.field("query", source, offset, length);
         builder.endObject();
     }
 
     @Override
-    protected String parserName() {
-        return WrapperQueryParser.NAME;
+    public String queryId() {
+        return NAME;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/WrapperQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/WrapperQueryParser.java
@@ -31,15 +31,13 @@ import java.io.IOException;
  */
 public class WrapperQueryParser extends BaseQueryParserTemp {
 
-    public static final String NAME = "wrapper";
-
     @Inject
     public WrapperQueryParser() {
     }
 
     @Override
     public String[] names() {
-        return new String[]{NAME};
+        return new String[]{WrapperQueryBuilder.NAME};
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilder.java
@@ -202,7 +202,7 @@ public class FunctionScoreQueryBuilder extends QueryBuilder implements Boostable
     }
 
     @Override
-    protected String parserName() {
+    public String queryId() {
         return FunctionScoreQueryParser.NAME;
     }
 }

--- a/src/test/java/org/elasticsearch/index/query/BaseQueryTestCase.java
+++ b/src/test/java/org/elasticsearch/index/query/BaseQueryTestCase.java
@@ -199,9 +199,9 @@ public abstract class BaseQueryTestCase<QB extends QueryBuilder<QB>> extends Ela
         String contentString = testQuery.toString();
         XContentParser parser = XContentFactory.xContent(contentString).createParser(contentString);
         context.reset(parser);
-        assertQueryHeader(parser, testQuery.parserName());
+        assertQueryHeader(parser, testQuery.queryId());
 
-        QueryBuilder newQuery = queryParserService.queryParser(testQuery.parserName()).fromXContent(context);
+        QueryBuilder newQuery = queryParserService.queryParser(testQuery.queryId()).fromXContent(context);
         assertNotSame(newQuery, testQuery);
         assertEquals(newQuery, testQuery);
         assertEquals(newQuery.hashCode(), testQuery.hashCode());

--- a/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
+++ b/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
@@ -168,7 +168,7 @@ public class SimpleIndexQueryParserTests extends ElasticsearchSingleNodeTest {
 
     public static class DummyQueryParser extends AbstractIndexComponent implements QueryParser {
 
-        public static final String NAME = "dummy";
+
 
         @Inject
         public DummyQueryParser(Index index, Settings indexSettings) {
@@ -177,7 +177,7 @@ public class SimpleIndexQueryParserTests extends ElasticsearchSingleNodeTest {
 
         @Override
         public String[] names() {
-            return new String[] {NAME};
+            return new String[] {DummyQueryBuilder.NAME};
         }
 
         @Override
@@ -194,6 +194,9 @@ public class SimpleIndexQueryParserTests extends ElasticsearchSingleNodeTest {
     }
 
     private static class DummyQueryBuilder extends QueryBuilder {
+
+        public static final String NAME = "dummy";
+
         @Override
         protected void doXContent(XContentBuilder builder, Params params) throws IOException {
             builder.startObject("dummy").endObject();
@@ -207,8 +210,8 @@ public class SimpleIndexQueryParserTests extends ElasticsearchSingleNodeTest {
         }
 
         @Override
-        protected String parserName() {
-            return DummyQueryParser.NAME;
+        public String queryId() {
+            return NAME;
         }
     }
 

--- a/src/test/java/org/elasticsearch/transport/ContextAndHeaderTransportTests.java
+++ b/src/test/java/org/elasticsearch/transport/ContextAndHeaderTransportTests.java
@@ -122,7 +122,7 @@ public class ContextAndHeaderTransportTests extends ElasticsearchIntegrationTest
                 .setSource(jsonBuilder().startObject().field("username", "foo").endObject()).get();
         transportClient().admin().indices().prepareRefresh(queryIndex, lookupIndex).get();
 
-        TermsLookupQueryBuilder termsLookupFilterBuilder = QueryBuilders.termsLookupQuery("username").lookupIndex(lookupIndex).lookupType("type").lookupId("1").lookupPath("followers");
+        TermsQueryBuilder termsLookupFilterBuilder = QueryBuilders.termsLookupQuery("username").lookupIndex(lookupIndex).lookupType("type").lookupId("1").lookupPath("followers");
         BoolQueryBuilder queryBuilder = QueryBuilders.boolQuery().must(QueryBuilders.matchAllQuery()).must(termsLookupFilterBuilder);
 
         SearchResponse searchResponse = transportClient()


### PR DESCRIPTION
As part of the query refactoring, this PR moves the NAME field that currently identifies each query parser to the corresponding query builder. The reason for this, as discussed in https://github.com/elastic/elasticsearch/pull/11121#discussion_r30233757, is that we need still need to be able to link parser and builder implementations, but that the query builder is independent of the parser (queries don't necessarily need to be coverted to XContent any more). Builders don't need to know about their parsers, but parsers need to be linked to their respective builders.

This change does the following:
- move the NAME constants from the parsers to the builders, making sure they are unique
- rename the existing getParserName() in the Builder classes to queryId(), returning the unique NAME constant. This is now public so we can retrieve query name when coding against the QueryBuilder abstract class
-  modify the names() method in the parsers so it contains at least one member that is the query id
