### PR TITLE
Balance new shard allocations more evenly on multiple path.data

### DIFF
--- a/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -771,4 +771,17 @@ public class NodeEnvironment extends AbstractComponent implements Closeable {
     public Path resolveCustomLocation(@IndexSettings Settings indexSettings, final ShardId shardId) {
         return resolveCustomLocation(indexSettings, shardId.index().name()).resolve(Integer.toString(shardId.id()));
     }
+
+    /**
+     * Returns the {@code NodePath.path} for this shard.
+     */
+    public static Path shardStatePathToDataPath(Path shardPath) {
+        int count = shardPath.getNameCount();
+
+        // Sanity check:
+        assert Integer.parseInt(shardPath.getName(count-1).toString()) >= 0;
+        assert "indices".equals(shardPath.getName(count-3).toString());
+        
+        return shardPath.getParent().getParent().getParent();
+    }
 }

--- a/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/src/main/java/org/elasticsearch/index/IndexService.java
@@ -275,11 +275,9 @@ public class IndexService extends AbstractIndexComponent implements IndexCompone
 
     // NOTE: O(numShards) cost, but numShards should be smallish?
     private long getAvgShardSizeInBytes() throws IOException {
-        Iterator<IndexShard> it = this.iterator();
         long sum = 0;
         int count = 0;
-        while (it.hasNext()) {
-            IndexShard indexShard = it.next();
+        for(IndexShard indexShard : this) {
             sum += indexShard.store().stats().sizeInBytes();
             count++;
         }


### PR DESCRIPTION
This change adds a simplistic heuristic to try to balance new shard allocations across multiple data paths on one node.

It very roughly predicts (guesses!) how much disk space a shard will eventually use, as the max of the current avg. size of shards across the cluster, and 5% of current free space across all path.data on the current node, and then reserves space by counting how many shards are now assigned to each path.data.

Picking the best path.data for a new shard is using the same "most free space" logic, except it now deducts the reserved space.

I tested this on an EC2 instance with 2 SSDs with nearly the same amount of free space and confirmed we now put 2 shards on one SSD and 3 shards on the other, vs all 5 shards on a single path with master today, but I'm not sure how to make a standalone unit test ... maybe I can use a MockFS to fake up N path.datas with different free space?

This is just a heuristic, and it easily has adversarial cases that will fill up one path.data while other path.data on the same node still have plenty of space, and unfortunately ES can't recover from that today. E.g., DiskThresholdDecider won't even detect any problem (since it sums up total free space across all path.data) ... I think we should separately think about fixing that, but at least this change improves the current situation.

Closes #11122
