### PR TITLE
Improve `include`/`exclude` clause list speed and scalability

### DIFF
--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/support/IncludeExclude.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/support/IncludeExclude.java
@@ -34,7 +34,6 @@ import org.apache.lucene.util.automaton.ByteRunAutomaton;
 import org.apache.lucene.util.automaton.CompiledAutomaton;
 import org.apache.lucene.util.automaton.Operations;
 import org.apache.lucene.util.automaton.RegExp;
-import org.apache.lucene.util.automaton.TooComplexToDeterminizeException;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
@@ -396,15 +395,10 @@ public class IncludeExclude {
     }
 
     public StringFilter convertToStringFilter() {
-        try {
+        if (isRegexBased()) {
             return new AutomatonBackedStringFilter(toAutomaton());
-        } catch (TooComplexToDeterminizeException e) {
-            // Hard to pre-empt when this exception will occur due to the number
-            // terms and possible overlap of contents
-            // so we let it try and fall-back to Set based lookups if too
-            // complex.
-            return new TermListBackedStringFilter(includeValues, excludeValues);
         }
+        return new TermListBackedStringFilter(includeValues, excludeValues);
     }
 
     public OrdinalsFilter convertToOrdinalsFilter() {

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/support/IncludeExclude.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/support/IncludeExclude.java
@@ -34,9 +34,11 @@ import org.apache.lucene.util.automaton.ByteRunAutomaton;
 import org.apache.lucene.util.automaton.CompiledAutomaton;
 import org.apache.lucene.util.automaton.Operations;
 import org.apache.lucene.util.automaton.RegExp;
+import org.apache.lucene.util.automaton.TooComplexToDeterminizeException;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
+import org.elasticsearch.search.aggregations.support.ValuesSource.Bytes.WithOrdinals;
 
 import java.io.IOException;
 import java.util.HashSet;
@@ -80,33 +82,65 @@ public class IncludeExclude {
     }
 
     // Only used for the 'map' execution mode (ie. scripts)
-    public static class StringFilter {
+    public abstract static class StringFilter {
+        public abstract boolean accept(BytesRef value);
+    }
+
+    static class AutomatonBackedStringFilter extends StringFilter {
 
         private final ByteRunAutomaton runAutomaton;
 
-        private StringFilter(Automaton automaton) {
+        private AutomatonBackedStringFilter(Automaton automaton) {
             this.runAutomaton = new ByteRunAutomaton(automaton);
         }
 
         /**
          * Returns whether the given value is accepted based on the {@code include} & {@code exclude} patterns.
          */
+        @Override
         public boolean accept(BytesRef value) {
             return runAutomaton.run(value.bytes, value.offset, value.length);
         }
     }
 
-    public static class OrdinalsFilter {
+    static class TermListBackedStringFilter extends StringFilter {
+
+        private final Set<BytesRef> valids;
+        private final Set<BytesRef> invalids;
+
+        public TermListBackedStringFilter(Set<BytesRef> includeValues, Set<BytesRef> excludeValues) {
+            this.valids = includeValues;
+            this.invalids = excludeValues;
+        }
+
+        /**
+         * Returns whether the given value is accepted based on the
+         * {@code include} & {@code exclude} sets.
+         */
+        @Override
+        public boolean accept(BytesRef value) {
+            return ((valids == null) || (valids.contains(value))) && ((invalids == null) || (!invalids.contains(value)));
+        }
+    }
+
+    public static abstract class OrdinalsFilter {
+        public abstract LongBitSet acceptedGlobalOrdinals(RandomAccessOrds globalOrdinals, ValuesSource.Bytes.WithOrdinals valueSource) throws IOException;
+        
+    }
+
+    static class AutomatonBackedOrdinalsFilter extends OrdinalsFilter {
 
         private final CompiledAutomaton compiled;
 
-        private OrdinalsFilter(Automaton automaton) {
+        private AutomatonBackedOrdinalsFilter(Automaton automaton) {
             this.compiled = new CompiledAutomaton(automaton);
         }
 
         /**
          * Computes which global ordinals are accepted by this IncludeExclude instance.
+         * 
          */
+        @Override
         public LongBitSet acceptedGlobalOrdinals(RandomAccessOrds globalOrdinals, ValuesSource.Bytes.WithOrdinals valueSource) throws IOException {
             LongBitSet acceptedGlobalOrdinals = new LongBitSet(globalOrdinals.getValueCount());
             TermsEnum globalTermsEnum;
@@ -115,6 +149,43 @@ public class IncludeExclude {
             globalTermsEnum = compiled.getTermsEnum(globalTerms);
             for (BytesRef term = globalTermsEnum.next(); term != null; term = globalTermsEnum.next()) {
                 acceptedGlobalOrdinals.set(globalTermsEnum.ord());
+            }
+            return acceptedGlobalOrdinals;
+        }
+
+    }
+    
+    static class TermListBackedOrdinalsFilter extends OrdinalsFilter {
+
+        private final SortedSet<BytesRef> includeValues;
+        private final SortedSet<BytesRef> excludeValues;
+
+        public TermListBackedOrdinalsFilter(SortedSet<BytesRef> includeValues, SortedSet<BytesRef> excludeValues) {
+            this.includeValues = includeValues;
+            this.excludeValues = excludeValues;
+        }
+
+        @Override
+        public LongBitSet acceptedGlobalOrdinals(RandomAccessOrds globalOrdinals, WithOrdinals valueSource) throws IOException {
+            LongBitSet acceptedGlobalOrdinals = new LongBitSet(globalOrdinals.getValueCount());
+            if(includeValues!=null){
+                for (BytesRef term : includeValues) {
+                    long ord = globalOrdinals.lookupTerm(term);
+                    if (ord >= 0) {
+                        acceptedGlobalOrdinals.set(ord);
+                    }
+                }                
+            } else {
+                // default to all terms being acceptable
+                acceptedGlobalOrdinals.set(0, acceptedGlobalOrdinals.length());
+            }
+            if (excludeValues != null) {
+                for (BytesRef term : excludeValues) {
+                    long ord = globalOrdinals.lookupTerm(term);
+                    if (ord >= 0) {
+                        acceptedGlobalOrdinals.clear(ord);
+                    }
+                }
             }
             return acceptedGlobalOrdinals;
         }
@@ -325,11 +396,23 @@ public class IncludeExclude {
     }
 
     public StringFilter convertToStringFilter() {
-        return new StringFilter(toAutomaton());
+        try {
+            return new AutomatonBackedStringFilter(toAutomaton());
+        } catch (TooComplexToDeterminizeException e) {
+            // Hard to pre-empt when this exception will occur due to the number
+            // terms and possible overlap of contents
+            // so we let it try and fall-back to Set based lookups if too
+            // complex.
+            return new TermListBackedStringFilter(includeValues, excludeValues);
+        }
     }
 
     public OrdinalsFilter convertToOrdinalsFilter() {
-        return new OrdinalsFilter(toAutomaton());
+
+        if (isRegexBased()) {
+            return new AutomatonBackedOrdinalsFilter(toAutomaton());
+        }
+        return new TermListBackedOrdinalsFilter(includeValues, excludeValues);
     }
 
     public LongFilter convertToLongFilter() {


### PR DESCRIPTION
In the terms aggregations' IncludeExclude class the underlying automaton-backed implementation throws an error if there are too many states.
In these circumstances this fix falls-back to using an implementation based on Set lookups for the excluded terms.
If the global-ordinals execution mode is in effect this implementation also addresses the slowness identified in issue 11181 which is caused by traversing the TermsEnum - instead the excluded terms’ global ordinals are looked up individually and unset the bits of acceptable terms. This is significantly faster for high cardinality fields.

Closes #11176
