### PR TITLE
Query refactoring: QueryBuilder to extend Writeable

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/BaseTermQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/BaseTermQueryBuilder.java
@@ -211,8 +211,8 @@ public abstract class BaseTermQueryBuilder<QB extends BaseTermQueryBuilder<QB>> 
     @Override
     public QB readFrom(StreamInput in) throws IOException {
         QB emptyBuilder = createBuilder(in.readString(), in.readGenericValue());
-        emptyBuilder.boost(in.readFloat());
-        emptyBuilder.queryName(in.readOptionalString());
+        emptyBuilder.boost = in.readFloat();
+        emptyBuilder.queryName = in.readOptionalString();
         return emptyBuilder;
     }
 

--- a/src/main/java/org/elasticsearch/index/query/BaseTermQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/BaseTermQueryBuilder.java
@@ -22,19 +22,18 @@ package org.elasticsearch.index.query;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 import java.util.Objects;
 
-public abstract class BaseTermQueryBuilder<QB extends BoostableQueryBuilder<QB>> extends QueryBuilder implements Streamable, BoostableQueryBuilder<QB> {
-
+public abstract class BaseTermQueryBuilder<QB extends BaseTermQueryBuilder<QB>> extends QueryBuilder<QB> implements BoostableQueryBuilder<QB> {
+    
     /** Name of field to match against. */
-    protected String fieldName;
+    protected final String fieldName;
 
     /** Value to find matches for. */
-    protected Object value;
+    protected final Object value;
 
     /** Query boost. */
     protected float boost = 1.0f;
@@ -114,10 +113,6 @@ public abstract class BaseTermQueryBuilder<QB extends BoostableQueryBuilder<QB>>
     public BaseTermQueryBuilder(String fieldName, Object value) {
         this.fieldName = fieldName;
         this.value = convertToBytesRefIfString(value);
-    }
-
-    BaseTermQueryBuilder() {
-        // for serialization only
     }
 
     /** Returns the field name used in this query. */
@@ -206,7 +201,6 @@ public abstract class BaseTermQueryBuilder<QB extends BoostableQueryBuilder<QB>>
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        @SuppressWarnings("rawtypes")
         BaseTermQueryBuilder other = (BaseTermQueryBuilder) obj;
         return Objects.equals(fieldName, other.fieldName) &&
                Objects.equals(value, other.value) &&
@@ -214,16 +208,16 @@ public abstract class BaseTermQueryBuilder<QB extends BoostableQueryBuilder<QB>>
                Objects.equals(queryName, other.queryName);
     }
 
-    /** Read the given parameters. */
     @Override
-    public void readFrom(StreamInput in) throws IOException {
-        fieldName = in.readString();
-        value = in.readGenericValue();
-        boost = in.readFloat();
-        queryName = in.readOptionalString();
+    public QB readFrom(StreamInput in) throws IOException {
+        QB emptyBuilder = createBuilder(in.readString(), in.readGenericValue());
+        emptyBuilder.boost(in.readFloat());
+        emptyBuilder.queryName(in.readOptionalString());
+        return emptyBuilder;
     }
 
-    /** Writes the given parameters. */
+    protected abstract QB createBuilder(String fieldName, Object value);
+
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(fieldName);

--- a/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
@@ -145,20 +145,21 @@ public class IdsQueryBuilder extends QueryBuilder<IdsQueryBuilder> implements Bo
     }
 
     public Query toQuery(QueryParseContext parseContext) throws IOException, QueryParsingException {
+        Query query;
         if (this.ids.isEmpty()) {
-            return Queries.newMatchNoDocsQuery();
-        }
-
-        Collection<String> typesForQuery;
-        if (types == null || types.length == 0) {
-            typesForQuery = parseContext.queryTypes();
-        } else if (types.length == 1 && MetaData.ALL.equals(types[0])) {
-            typesForQuery = parseContext.mapperService().types();
+             query = Queries.newMatchNoDocsQuery();
         } else {
-            typesForQuery = Sets.newHashSet(types);
-        }
+            Collection<String> typesForQuery;
+            if (types == null || types.length == 0) {
+                typesForQuery = parseContext.queryTypes();
+            } else if (types.length == 1 && MetaData.ALL.equals(types[0])) {
+                typesForQuery = parseContext.mapperService().types();
+            } else {
+                typesForQuery = Sets.newHashSet(types);
+            }
 
-        TermsQuery query = new TermsQuery(UidFieldMapper.NAME, Uid.createUidsForTypesAndIds(typesForQuery, ids));
+            query = new TermsQuery(UidFieldMapper.NAME, Uid.createUidsForTypesAndIds(typesForQuery, ids));
+        }
         query.setBoost(boost);
         if (queryName != null) {
             parseContext.addNamedQuery(queryName, query);

--- a/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
@@ -79,7 +79,7 @@ public class IdsQueryBuilder extends QueryBuilder<IdsQueryBuilder> implements Bo
     /**
      * Returns the ids for the query.
      */
-    public Collection<String> ids() {
+    public Set<String> ids() {
         return this.ids;
     }
 

--- a/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
@@ -19,51 +19,45 @@
 
 package org.elasticsearch.index.query;
 
-import com.google.common.collect.Iterables;
-
+import com.google.common.collect.Sets;
 import org.apache.lucene.queries.TermsQuery;
 import org.apache.lucene.search.Query;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.mapper.Uid;
 import org.elasticsearch.index.mapper.internal.UidFieldMapper;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 
 /**
  * A query that will return only documents matching specific ids (and a type).
  */
-public class IdsQueryBuilder extends QueryBuilder implements Streamable, BoostableQueryBuilder<IdsQueryBuilder> {
+public class IdsQueryBuilder extends QueryBuilder<IdsQueryBuilder> implements BoostableQueryBuilder<IdsQueryBuilder> {
 
-    private List<String> types = new ArrayList<>();
+    private final Set<String> ids = Sets.newHashSet();
 
-    private List<String> ids = new ArrayList<>();
+    private final String[] types;
 
     private float boost = 1.0f;
 
     private String queryName;
 
-    public IdsQueryBuilder() {
-        //for serialization only
-    }
-
-    public IdsQueryBuilder(String... types) {
-        this.types = (types == null || types.length == 0) ? new ArrayList<String>() : Arrays.asList(types);
+    /**
+     * Creates a new IdsQueryBuilder by optionally providing the types of the documents to look for
+     */
+    public IdsQueryBuilder(@Nullable String... types) {
+        this.types = types;
     }
 
     /**
-     * Get the types used in this query
-     * @return the types
+     * Returns the types used in this query
      */
-    public Collection<String> types() {
+    public String[] types() {
         return this.types;
     }
 
@@ -71,7 +65,7 @@ public class IdsQueryBuilder extends QueryBuilder implements Streamable, Boostab
      * Adds ids to the query.
      */
     public IdsQueryBuilder addIds(String... ids) {
-        this.ids.addAll(Arrays.asList(ids));
+        Collections.addAll(this.ids, ids);
         return this;
     }
 
@@ -83,7 +77,7 @@ public class IdsQueryBuilder extends QueryBuilder implements Streamable, Boostab
     }
 
     /**
-     * Gets the ids for the query.
+     * Returns the ids for the query.
      */
     public Collection<String> ids() {
         return this.ids;
@@ -125,14 +119,10 @@ public class IdsQueryBuilder extends QueryBuilder implements Streamable, Boostab
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(IdsQueryParser.NAME);
         if (types != null) {
-            if (types.size() == 1) {
-                builder.field("type", types.get(0));
+            if (types.length == 1) {
+                builder.field("type", types[0]);
             } else {
-                builder.startArray("types");
-                for (String type : types) {
-                    builder.value(type);
-                }
-                builder.endArray();
+                builder.array("types", types);
             }
         }
         builder.startArray("values");
@@ -140,7 +130,7 @@ public class IdsQueryBuilder extends QueryBuilder implements Streamable, Boostab
             builder.value(value);
         }
         builder.endArray();
-        if (boost != -1) {
+        if (boost != 1.0f) {
             builder.field("boost", boost);
         }
         if (queryName != null) {
@@ -159,11 +149,13 @@ public class IdsQueryBuilder extends QueryBuilder implements Streamable, Boostab
             return Queries.newMatchNoDocsQuery();
         }
 
-        Collection<String> typesForQuery = this.types;
-        if (typesForQuery == null || typesForQuery.isEmpty()) {
+        Collection<String> typesForQuery;
+        if (types == null || types.length == 0) {
             typesForQuery = parseContext.queryTypes();
-        } else if (typesForQuery.size() == 1 && Iterables.getFirst(typesForQuery, null).equals("_all")) {
+        } else if (types.length == 1 && MetaData.ALL.equals(types[0])) {
             typesForQuery = parseContext.mapperService().types();
+        } else {
+            typesForQuery = Sets.newHashSet(types);
         }
 
         TermsQuery query = new TermsQuery(UidFieldMapper.NAME, Uid.createUidsForTypesAndIds(typesForQuery, ids));
@@ -181,24 +173,25 @@ public class IdsQueryBuilder extends QueryBuilder implements Streamable, Boostab
     }
 
     @Override
-    public void readFrom(StreamInput in) throws IOException {
-        this.types = in.readStringList();
-        this.ids = in.readStringList();
-        queryName = in.readOptionalString();
-        boost = in.readFloat();
+    public IdsQueryBuilder readFrom(StreamInput in) throws IOException {
+        IdsQueryBuilder idsQueryBuilder = new IdsQueryBuilder(in.readStringArray());
+        idsQueryBuilder.addIds(in.readStringArray());
+        idsQueryBuilder.queryName(in.readOptionalString());
+        idsQueryBuilder.boost(in.readFloat());
+        return idsQueryBuilder;
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeStringList(this.types);
-        out.writeStringList(this.ids);
+        out.writeStringArray(this.types);
+        out.writeStringArray(this.ids.toArray(new String[this.ids.size()]));
         out.writeOptionalString(queryName);
         out.writeFloat(boost);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(ids, types, boost, queryName);
+        return Objects.hash(ids, Arrays.hashCode(types), boost, queryName);
     }
 
     @Override
@@ -211,7 +204,7 @@ public class IdsQueryBuilder extends QueryBuilder implements Streamable, Boostab
         }
         IdsQueryBuilder other = (IdsQueryBuilder) obj;
         return Objects.equals(ids, other.ids) &&
-               Objects.equals(types, other.types) &&
+               Arrays.equals(types, other.types) &&
                Objects.equals(boost, other.boost) &&
                Objects.equals(queryName, other.queryName);
     }

--- a/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
@@ -177,8 +177,8 @@ public class IdsQueryBuilder extends QueryBuilder<IdsQueryBuilder> implements Bo
     public IdsQueryBuilder readFrom(StreamInput in) throws IOException {
         IdsQueryBuilder idsQueryBuilder = new IdsQueryBuilder(in.readStringArray());
         idsQueryBuilder.addIds(in.readStringArray());
-        idsQueryBuilder.queryName(in.readOptionalString());
-        idsQueryBuilder.boost(in.readFloat());
+        idsQueryBuilder.queryName = in.readOptionalString();
+        idsQueryBuilder.boost = in.readFloat();
         return idsQueryBuilder;
     }
 

--- a/src/main/java/org/elasticsearch/index/query/IdsQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/IdsQueryParser.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.index.query;
 
 import com.google.common.collect.ImmutableList;
-
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.xcontent.XContentParser;
 

--- a/src/main/java/org/elasticsearch/index/query/MatchAllQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/MatchAllQueryBuilder.java
@@ -66,7 +66,6 @@ public class MatchAllQueryBuilder extends QueryBuilder<MatchAllQueryBuilder> imp
         if (this.boost == 1.0f) {
             return Queries.newMatchAllQuery();
         }
-
         MatchAllDocsQuery query = new MatchAllDocsQuery();
         query.setBoost(boost);
         return query;
@@ -92,7 +91,7 @@ public class MatchAllQueryBuilder extends QueryBuilder<MatchAllQueryBuilder> imp
     @Override
     public MatchAllQueryBuilder readFrom(StreamInput in) throws IOException {
         MatchAllQueryBuilder matchAllQueryBuilder = new MatchAllQueryBuilder();
-        matchAllQueryBuilder.boost(in.readFloat());
+        matchAllQueryBuilder.boost = in.readFloat();
         return matchAllQueryBuilder;
     }
 

--- a/src/main/java/org/elasticsearch/index/query/MatchAllQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/MatchAllQueryBuilder.java
@@ -23,7 +23,6 @@ import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
@@ -32,7 +31,7 @@ import java.io.IOException;
 /**
  * A query that matches on all documents.
  */
-public class MatchAllQueryBuilder extends QueryBuilder implements Streamable, BoostableQueryBuilder<MatchAllQueryBuilder> {
+public class MatchAllQueryBuilder extends QueryBuilder<MatchAllQueryBuilder> implements BoostableQueryBuilder<MatchAllQueryBuilder> {
 
     private float boost = 1.0f;
 
@@ -91,8 +90,10 @@ public class MatchAllQueryBuilder extends QueryBuilder implements Streamable, Bo
     }
 
     @Override
-    public void readFrom(StreamInput in) throws IOException {
-        this.boost = in.readFloat();
+    public MatchAllQueryBuilder readFrom(StreamInput in) throws IOException {
+        MatchAllQueryBuilder matchAllQueryBuilder = new MatchAllQueryBuilder();
+        matchAllQueryBuilder.boost(in.readFloat());
+        return matchAllQueryBuilder;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/MultiTermQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/MultiTermQueryBuilder.java
@@ -18,6 +18,6 @@
  */
 package org.elasticsearch.index.query;
 
-public abstract class MultiTermQueryBuilder extends QueryBuilder {
+public abstract class MultiTermQueryBuilder<QB extends MultiTermQueryBuilder<QB>> extends QueryBuilder<QB> {
 
 }

--- a/src/main/java/org/elasticsearch/index/query/QueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryBuilder.java
@@ -23,6 +23,9 @@ import org.apache.lucene.search.Query;
 import org.elasticsearch.action.support.ToXContentToBytes;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.lucene.BytesRefs;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentType;
 
@@ -32,7 +35,7 @@ import java.io.IOException;
  * Base class for all classes producing lucene queries.
  * Supports conversion to BytesReference and creation of lucene Query objects.
  */
-public abstract class QueryBuilder extends ToXContentToBytes {
+public abstract class QueryBuilder<QB> extends ToXContentToBytes implements Writeable<QB> {
 
     protected QueryBuilder() {
         super(XContentType.JSON);
@@ -102,5 +105,16 @@ public abstract class QueryBuilder extends ToXContentToBytes {
             return ((BytesRef) obj).utf8ToString();
         }
         return obj;
+    }
+
+    //norelease remove this once all builders implement readFrom themselves
+    @Override
+    public QB readFrom(StreamInput in) throws IOException {
+        return null;
+    }
+
+    //norelease remove this once all builders implement writeTo themselves
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
@@ -341,14 +341,14 @@ public class RangeQueryBuilder extends MultiTermQueryBuilder<RangeQueryBuilder> 
     @Override
     public RangeQueryBuilder readFrom(StreamInput in) throws IOException {
         RangeQueryBuilder rangeQueryBuilder = new RangeQueryBuilder(in.readString());
-        rangeQueryBuilder.from(in.readGenericValue());
-        rangeQueryBuilder.to(in.readGenericValue());
-        rangeQueryBuilder.includeLower(in.readBoolean());
-        rangeQueryBuilder.includeUpper(in.readBoolean());
-        rangeQueryBuilder.timeZone(in.readOptionalString());
-        rangeQueryBuilder.format(in.readOptionalString());
-        rangeQueryBuilder.boost(in.readFloat());
-        rangeQueryBuilder.queryName(in.readOptionalString());
+        rangeQueryBuilder.from = in.readGenericValue();
+        rangeQueryBuilder.to = in.readGenericValue();
+        rangeQueryBuilder.includeLower = in.readBoolean();
+        rangeQueryBuilder.includeUpper = in.readBoolean();
+        rangeQueryBuilder.timeZone = in.readOptionalString();
+        rangeQueryBuilder.format = in.readOptionalString();
+        rangeQueryBuilder.boost = in.readFloat();
+        rangeQueryBuilder.queryName = in.readOptionalString();
         return rangeQueryBuilder;
     }
 

--- a/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
@@ -24,7 +24,6 @@ import org.apache.lucene.search.TermRangeQuery;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.joda.DateMathParser;
 import org.elasticsearch.common.joda.Joda;
 import org.elasticsearch.common.lucene.BytesRefs;
@@ -39,9 +38,9 @@ import java.util.Objects;
 /**
  * A Query that matches documents within an range of terms.
  */
-public class RangeQueryBuilder extends MultiTermQueryBuilder implements Streamable, BoostableQueryBuilder<RangeQueryBuilder> {
+public class RangeQueryBuilder extends MultiTermQueryBuilder<RangeQueryBuilder> implements BoostableQueryBuilder<RangeQueryBuilder> {
 
-    private String fieldName;
+    private final String fieldName;
 
     private Object from;
 
@@ -65,10 +64,6 @@ public class RangeQueryBuilder extends MultiTermQueryBuilder implements Streamab
      */
     public RangeQueryBuilder(String fieldName) {
         this.fieldName = fieldName;
-    }
-
-    public RangeQueryBuilder() {
-        // for serialization
     }
 
     /**
@@ -344,16 +339,17 @@ public class RangeQueryBuilder extends MultiTermQueryBuilder implements Streamab
     }
 
     @Override
-    public void readFrom(StreamInput in) throws IOException {
-        this.fieldName = in.readString();
-        this.from = in.readGenericValue();
-        this.to = in.readGenericValue();
-        this.includeLower = in.readBoolean();
-        this.includeUpper = in.readBoolean();
-        this.timeZone = in.readOptionalString();
-        this.format = in.readOptionalString();
-        this.boost = in.readFloat();
-        this.queryName = in.readOptionalString();
+    public RangeQueryBuilder readFrom(StreamInput in) throws IOException {
+        RangeQueryBuilder rangeQueryBuilder = new RangeQueryBuilder(in.readString());
+        rangeQueryBuilder.from(in.readGenericValue());
+        rangeQueryBuilder.to(in.readGenericValue());
+        rangeQueryBuilder.includeLower(in.readBoolean());
+        rangeQueryBuilder.includeUpper(in.readBoolean());
+        rangeQueryBuilder.timeZone(in.readOptionalString());
+        rangeQueryBuilder.format(in.readOptionalString());
+        rangeQueryBuilder.boost(in.readFloat());
+        rangeQueryBuilder.queryName(in.readOptionalString());
+        return rangeQueryBuilder;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/SpanTermQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanTermQueryBuilder.java
@@ -70,6 +70,7 @@ public class SpanTermQueryBuilder extends BaseTermQueryBuilder<SpanTermQueryBuil
     @Override
     public Query toQuery(QueryParseContext context) {
         BytesRef valueBytes = null;
+        String fieldName = this.fieldName;
         FieldMapper mapper = context.fieldMapper(fieldName);
         if (mapper != null) {
             fieldName = mapper.names().indexName();
@@ -78,7 +79,7 @@ public class SpanTermQueryBuilder extends BaseTermQueryBuilder<SpanTermQueryBuil
         if (valueBytes == null) {
             valueBytes = BytesRefs.toBytesRef(this.value);
         }
-        
+
         SpanTermQuery query = new SpanTermQuery(new Term(fieldName, valueBytes));
         query.setBoost(boost);
         if (queryName != null) {

--- a/src/main/java/org/elasticsearch/index/query/SpanTermQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanTermQueryBuilder.java
@@ -31,33 +31,35 @@ import org.elasticsearch.index.mapper.FieldMapper;
  * @see SpanTermQuery
  */
 public class SpanTermQueryBuilder extends BaseTermQueryBuilder<SpanTermQueryBuilder> implements SpanQueryBuilder {
+
     /** @see BaseTermQueryBuilder#BaseTermQueryBuilder(String, String) */
     public SpanTermQueryBuilder(String name, String value) {
         super(name, (Object) value);
     }
+
     /** @see BaseTermQueryBuilder#BaseTermQueryBuilder(String, int) */
     public SpanTermQueryBuilder(String name, int value) {
         super(name, (Object) value);
     }
+
     /** @see BaseTermQueryBuilder#BaseTermQueryBuilder(String, long) */
     public SpanTermQueryBuilder(String name, long value) {
         super(name, (Object) value);
     }
+
     /** @see BaseTermQueryBuilder#BaseTermQueryBuilder(String, float) */
     public SpanTermQueryBuilder(String name, float value) {
         super(name, (Object) value);
     }
+
     /** @see BaseTermQueryBuilder#BaseTermQueryBuilder(String, double) */
     public SpanTermQueryBuilder(String name, double value) {
         super(name, (Object) value);
     }
+
     /** @see BaseTermQueryBuilder#BaseTermQueryBuilder(String, Object) */
     public SpanTermQueryBuilder(String name, Object value) {
         super(name, value);
-    }
-
-    public SpanTermQueryBuilder() {
-        // for testing and serialisation only
     }
 
     @Override
@@ -83,5 +85,10 @@ public class SpanTermQueryBuilder extends BaseTermQueryBuilder<SpanTermQueryBuil
             context.addNamedQuery(queryName, query);
         }
         return query;
+    }
+
+    @Override
+    protected SpanTermQueryBuilder createBuilder(String fieldName, Object value) {
+        return new SpanTermQueryBuilder(fieldName, value);
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/TermQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/TermQueryBuilder.java
@@ -28,7 +28,8 @@ import org.elasticsearch.index.mapper.FieldMapper;
 /**
  * A Query that matches documents containing a term.
  */
-public class TermQueryBuilder extends BaseTermQueryBuilder<TermQueryBuilder> {
+public class TermQueryBuilder extends BaseTermQueryBuilder<TermQueryBuilder> implements BoostableQueryBuilder<TermQueryBuilder> {
+
     /** @see BaseTermQueryBuilder#BaseTermQueryBuilder(String, String) */
     public TermQueryBuilder(String fieldName, String value) {
         super(fieldName, (Object) value);
@@ -64,10 +65,6 @@ public class TermQueryBuilder extends BaseTermQueryBuilder<TermQueryBuilder> {
         super(fieldName, value);
     }
 
-    public TermQueryBuilder() {
-        // for serialization only
-    }
-
     @Override
     public Query toQuery(QueryParseContext parseContext) {
         Query query = null;
@@ -83,6 +80,11 @@ public class TermQueryBuilder extends BaseTermQueryBuilder<TermQueryBuilder> {
             parseContext.addNamedQuery(queryName, query);
         }
         return query;
+    }
+
+    @Override
+    protected TermQueryBuilder createBuilder(String fieldName, Object value) {
+        return new TermQueryBuilder(fieldName, value);
     }
 
     @Override

--- a/src/test/java/org/elasticsearch/index/query/BaseQueryTestCase.java
+++ b/src/test/java/org/elasticsearch/index/query/BaseQueryTestCase.java
@@ -151,11 +151,13 @@ public abstract class BaseQueryTestCase<QB extends QueryBuilder<QB>> extends Ela
                 types[i] = randomFrom(currentTypes);
             }
         } else {
-            /*TODO if (randomBoolean()) {
+            /* norelease waiting for a fix on master that restores support for _all type
+            if (randomBoolean()) {
                 types = new String[]{MetaData.ALL};
             } else {
-
-            }*/
+                types = new String[0];
+            }
+            */
             types = new String[0];
         }
         //some query (e.g. range query) have a different behaviour depending on whether the current search context is set or not

--- a/src/test/java/org/elasticsearch/index/query/BaseQueryTestCase.java
+++ b/src/test/java/org/elasticsearch/index/query/BaseQueryTestCase.java
@@ -231,9 +231,11 @@ public abstract class BaseQueryTestCase<QB extends QueryBuilder<QB>> extends Ela
 
     /**
      * Run after default equality comparison between lucene expected query and result of {@link QueryBuilder#toQuery(QueryParseContext)}.
-     * Can contain additional assertions that are query specific.
+     * Can contain additional assertions that are query specific. Empty default implementation.
      */
-    protected abstract void assertLuceneQuery(QB queryBuilder, Query query, QueryParseContext context);
+    protected void assertLuceneQuery(QB queryBuilder, Query query, QueryParseContext context) {
+
+    }
 
     /**
      * Test serialization and deserialization of the test query.

--- a/src/test/java/org/elasticsearch/index/query/BaseQueryTestCase.java
+++ b/src/test/java/org/elasticsearch/index/query/BaseQueryTestCase.java
@@ -25,7 +25,6 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
-import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.compress.CompressedString;
 import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.inject.Injector;
@@ -152,11 +151,12 @@ public abstract class BaseQueryTestCase<QB extends QueryBuilder<QB>> extends Ela
                 types[i] = randomFrom(currentTypes);
             }
         } else {
-            if (randomBoolean()) {
+            /*TODO if (randomBoolean()) {
                 types = new String[]{MetaData.ALL};
             } else {
-                types = new String[0];
-            }
+
+            }*/
+            types = new String[0];
         }
         //some query (e.g. range query) have a different behaviour depending on whether the current search context is set or not
         //which is why we randomly set the search context, which will internally also do QueryParseContext.setTypes(types)

--- a/src/test/java/org/elasticsearch/index/query/BaseTermQueryTestCase.java
+++ b/src/test/java/org/elasticsearch/index/query/BaseTermQueryTestCase.java
@@ -19,36 +19,68 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.lucene.BytesRefs;
+import org.elasticsearch.index.mapper.FieldMapper;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 @Ignore
-public abstract class BaseTermQueryTestCase<QB extends QueryBuilder<QB>> extends BaseQueryTestCase<QB> {
+public abstract class BaseTermQueryTestCase<QB extends BaseTermQueryBuilder<QB>> extends BaseQueryTestCase<QB> {
     
-    protected Object createRandomValueObject() {
-        Object value = null;
+    protected final QB createTestQueryBuilder() {
+        String fieldName = null;
+        Object value;
         switch (randomIntBetween(0, 3)) {
-        case 0:
-            value = randomBoolean();
-            break;
-        case 1:
-            if (randomInt(10) > 0) {
-                value = randomAsciiOfLength(8);
-            } else {
-                // generate unicode string in 10% of cases
-                value = randomUnicodeOfLength(10);
-            }
-            break;
-        case 2:
-            value = randomInt(10000);
-            break;
-        case 3:
-            value = randomDouble();
-            break;
+            case 0:
+                if (randomBoolean()) {
+                    fieldName = BOOLEAN_FIELD_NAME;
+                }
+                value = randomBoolean();
+                break;
+            case 1:
+                if (randomBoolean()) {
+                    fieldName = STRING_FIELD_NAME;
+                }
+                if (frequently()) {
+                    value = randomAsciiOfLengthBetween(1, 10);
+                } else {
+                    // generate unicode string in 10% of cases
+                    value = randomUnicodeOfLength(10);
+                }
+                break;
+            case 2:
+                if (randomBoolean()) {
+                    fieldName = INT_FIELD_NAME;
+                }
+                value = randomInt(10000);
+                break;
+            case 3:
+                if (randomBoolean()) {
+                    fieldName = DOUBLE_FIELD_NAME;
+                }
+                value = randomDouble();
+                break;
+            default:
+                throw new UnsupportedOperationException();
         }
-        return value;
+
+        if (fieldName == null) {
+            fieldName = randomAsciiOfLengthBetween(1, 10);
+        }
+        QB query = createQueryBuilder(fieldName, value);
+        if (randomBoolean()) {
+            query.boost(2.0f / randomIntBetween(1, 20));
+        }
+        if (randomBoolean()) {
+            query.queryName(randomAsciiOfLengthBetween(1, 10));
+        }
+        return query;
     }
 
     protected abstract QB createQueryBuilder(String fieldName, Object value);
@@ -70,5 +102,33 @@ public abstract class BaseTermQueryTestCase<QB extends QueryBuilder<QB>> extends
         queryBuilder = createQueryBuilder("", null);
         assertNotNull(queryBuilder.validate());
         assertThat(queryBuilder.validate().validationErrors().size(), is(2));
+    }
+
+    @Override
+    protected Query createExpectedQuery(QB queryBuilder, QueryParseContext context) {
+        BytesRef value = null;
+        if (getCurrentTypes().length > 0) {
+            if (queryBuilder.fieldName().equals(BOOLEAN_FIELD_NAME) || queryBuilder.fieldName().equals(INT_FIELD_NAME) || queryBuilder.fieldName().equals(DOUBLE_FIELD_NAME)) {
+                FieldMapper mapper = context.fieldMapper(queryBuilder.fieldName());
+                value = mapper.indexedValueForSearch(queryBuilder.value);
+            }
+        }
+        if (value == null) {
+            value = BytesRefs.toBytesRef(queryBuilder.value);
+        }
+        Query termQuery = createLuceneTermQuery(new Term(queryBuilder.fieldName(), value));
+        termQuery.setBoost(queryBuilder.boost());
+        return termQuery;
+    }
+
+    protected abstract Query createLuceneTermQuery(Term term);
+
+    @Override
+    protected void assertLuceneQuery(QB queryBuilder, Query query, QueryParseContext context) {
+        assertThat(query.getBoost(), equalTo(queryBuilder.boost()));
+        if (queryBuilder.queryName() != null) {
+            Query namedQuery = context.copyNamedFilters().get(queryBuilder.queryName());
+            assertThat(namedQuery, equalTo(query));
+        }
     }
 }

--- a/src/test/java/org/elasticsearch/index/query/BaseTermQueryTestCase.java
+++ b/src/test/java/org/elasticsearch/index/query/BaseTermQueryTestCase.java
@@ -19,14 +19,13 @@
 
 package org.elasticsearch.index.query;
 
-import org.elasticsearch.common.io.stream.Streamable;
 import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
 
 @Ignore
-public abstract class BaseTermQueryTestCase<QB extends QueryBuilder & Streamable> extends BaseQueryTestCase<QB> {
+public abstract class BaseTermQueryTestCase<QB extends QueryBuilder<QB>> extends BaseQueryTestCase<QB> {
     
     protected Object createRandomValueObject() {
         Object value = null;

--- a/src/test/java/org/elasticsearch/index/query/BaseTermQueryTestCase.java
+++ b/src/test/java/org/elasticsearch/index/query/BaseTermQueryTestCase.java
@@ -125,7 +125,6 @@ public abstract class BaseTermQueryTestCase<QB extends BaseTermQueryBuilder<QB>>
 
     @Override
     protected void assertLuceneQuery(QB queryBuilder, Query query, QueryParseContext context) {
-        assertThat(query.getBoost(), equalTo(queryBuilder.boost()));
         if (queryBuilder.queryName() != null) {
             Query namedQuery = context.copyNamedFilters().get(queryBuilder.queryName());
             assertThat(namedQuery, equalTo(query));

--- a/src/test/java/org/elasticsearch/index/query/IdsQueryBuilderTest.java
+++ b/src/test/java/org/elasticsearch/index/query/IdsQueryBuilderTest.java
@@ -80,7 +80,6 @@ public class IdsQueryBuilderTest extends BaseQueryTestCase<IdsQueryBuilder> {
 
     @Override
     protected void assertLuceneQuery(IdsQueryBuilder queryBuilder, Query query, QueryParseContext context) {
-        assertThat(query.getBoost(), equalTo(queryBuilder.boost()));
         if (queryBuilder.queryName() != null) {
             Query namedQuery = context.copyNamedFilters().get(queryBuilder.queryName());
             assertThat(namedQuery, equalTo(query));

--- a/src/test/java/org/elasticsearch/index/query/MatchAllQueryBuilderTest.java
+++ b/src/test/java/org/elasticsearch/index/query/MatchAllQueryBuilderTest.java
@@ -22,17 +22,20 @@ package org.elasticsearch.index.query;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 
-import java.io.IOException;
-
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.equalTo;
 
 public class MatchAllQueryBuilderTest extends BaseQueryTestCase<MatchAllQueryBuilder> {
 
     @Override
-    protected void assertLuceneQuery(MatchAllQueryBuilder queryBuilder, Query query, QueryParseContext context) throws IOException {
-        assertThat(query, instanceOf(MatchAllDocsQuery.class));
-        assertThat(query.getBoost(), is(queryBuilder.boost()));
+    protected Query createExpectedQuery(MatchAllQueryBuilder queryBuilder, QueryParseContext context) {
+        MatchAllDocsQuery matchAllDocsQuery = new MatchAllDocsQuery();
+        matchAllDocsQuery.setBoost(queryBuilder.boost());
+        return matchAllDocsQuery;
+    }
+
+    @Override
+    protected void assertLuceneQuery(MatchAllQueryBuilder queryBuilder, Query query, QueryParseContext context) {
+        assertThat(query.getBoost(), equalTo(queryBuilder.boost()));
     }
 
     @Override

--- a/src/test/java/org/elasticsearch/index/query/MatchAllQueryBuilderTest.java
+++ b/src/test/java/org/elasticsearch/index/query/MatchAllQueryBuilderTest.java
@@ -22,8 +22,6 @@ package org.elasticsearch.index.query;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 
-import static org.hamcrest.Matchers.equalTo;
-
 public class MatchAllQueryBuilderTest extends BaseQueryTestCase<MatchAllQueryBuilder> {
 
     @Override
@@ -31,11 +29,6 @@ public class MatchAllQueryBuilderTest extends BaseQueryTestCase<MatchAllQueryBui
         MatchAllDocsQuery matchAllDocsQuery = new MatchAllDocsQuery();
         matchAllDocsQuery.setBoost(queryBuilder.boost());
         return matchAllDocsQuery;
-    }
-
-    @Override
-    protected void assertLuceneQuery(MatchAllQueryBuilder queryBuilder, Query query, QueryParseContext context) {
-        assertThat(query.getBoost(), equalTo(queryBuilder.boost()));
     }
 
     @Override

--- a/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTest.java
+++ b/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTest.java
@@ -130,7 +130,6 @@ public class RangeQueryBuilderTest extends BaseQueryTestCase<RangeQueryBuilder> 
 
     @Override
     protected void assertLuceneQuery(RangeQueryBuilder queryBuilder, Query query, QueryParseContext context) {
-        assertThat(query.getBoost(), equalTo(queryBuilder.boost()));
         if (queryBuilder.queryName() != null) {
             Query namedQuery = context.copyNamedFilters().get(queryBuilder.queryName());
             assertThat(namedQuery, equalTo(query));

--- a/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTest.java
+++ b/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTest.java
@@ -22,12 +22,15 @@ package org.elasticsearch.index.query;
 import org.apache.lucene.search.NumericRangeQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermRangeQuery;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.joda.DateMathParser;
 import org.elasticsearch.common.joda.Joda;
 import org.elasticsearch.common.lucene.BytesRefs;
-import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.index.mapper.ContentPath;
+import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.core.DateFieldMapper;
-import org.elasticsearch.index.mapper.core.DateFieldMapper.LateParsingQuery;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.Test;
@@ -37,7 +40,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
 public class RangeQueryBuilderTest extends BaseQueryTestCase<RangeQueryBuilder> {
@@ -90,35 +92,49 @@ public class RangeQueryBuilderTest extends BaseQueryTestCase<RangeQueryBuilder> 
     }
 
     @Override
-    protected void assertLuceneQuery(RangeQueryBuilder queryBuilder, Query query, QueryParseContext context) throws IOException {
-        assertThat(query.getBoost(), is(queryBuilder.boost()));
+    protected Query createExpectedQuery(RangeQueryBuilder queryBuilder, QueryParseContext context) throws IOException {
+        Query expectedQuery;
+        if (getCurrentTypes().length == 0 || (queryBuilder.fieldName().equals(DATE_FIELD_NAME) == false && queryBuilder.fieldName().equals(INT_FIELD_NAME) == false) ) {
+            expectedQuery = new TermRangeQuery(queryBuilder.fieldName(),
+                    BytesRefs.toBytesRef(queryBuilder.from()), BytesRefs.toBytesRef(queryBuilder.to()),
+                    queryBuilder.includeLower(), queryBuilder.includeUpper());
+
+        } else if (queryBuilder.fieldName().equals(DATE_FIELD_NAME)) {
+            DateFieldMapper.Builder fieldMapperBuilder = new DateFieldMapper.Builder(queryBuilder.fieldName());
+            DateFieldMapper fieldMapper = fieldMapperBuilder.build(new Mapper.BuilderContext(ImmutableSettings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT).build(), new ContentPath()));
+            DateMathParser dateMathParser = null;
+            if (queryBuilder.format() != null) {
+                dateMathParser = new DateMathParser(Joda.forPattern(queryBuilder.format()), DateFieldMapper.Defaults.TIME_UNIT);
+            }
+            DateTimeZone timeZone = null;
+            if( queryBuilder.timeZone() != null) {
+                timeZone = DateTimeZone.forID(queryBuilder.timeZone());
+            }
+            Long from = null;
+            if (queryBuilder.from() != null) {
+                from = fieldMapper.parseToMilliseconds(queryBuilder.from(), queryBuilder.includeLower(), timeZone, dateMathParser);
+            }
+            Long to = null;
+            if (queryBuilder.to() != null) {
+                to = fieldMapper.parseToMilliseconds(queryBuilder.to(), queryBuilder.includeLower(), timeZone, dateMathParser);
+            }
+            expectedQuery = fieldMapper.rangeQuery(from, to, queryBuilder.includeLower(), queryBuilder.includeUpper(), timeZone, dateMathParser, context);
+        } else if (queryBuilder.fieldName().equals(INT_FIELD_NAME)) {
+            expectedQuery = NumericRangeQuery.newIntRange(INT_FIELD_NAME, (Integer) queryBuilder.from(), (Integer) queryBuilder.to(), queryBuilder.includeLower(), queryBuilder.includeUpper());
+        } else {
+            throw new UnsupportedOperationException();
+        }
+        expectedQuery.setBoost(queryBuilder.boost());
+        return expectedQuery;
+    }
+
+    @Override
+    protected void assertLuceneQuery(RangeQueryBuilder queryBuilder, Query query, QueryParseContext context) {
+        assertThat(query.getBoost(), equalTo(queryBuilder.boost()));
         if (queryBuilder.queryName() != null) {
             Query namedQuery = context.copyNamedFilters().get(queryBuilder.queryName());
             assertThat(namedQuery, equalTo(query));
         }
-        String fieldName = queryBuilder.fieldName();
-        Query expectedQuery;
-        if (currentTypes.length == 0 || (fieldName.equals(DATE_FIELD_NAME) == false && fieldName.equals(INT_FIELD_NAME) == false) ) {
-            assertThat(query, instanceOf(TermRangeQuery.class));
-            expectedQuery = new TermRangeQuery(queryBuilder.fieldName(),
-                    BytesRefs.toBytesRef(queryBuilder.from()), BytesRefs.toBytesRef(queryBuilder.to()),
-                    queryBuilder.includeLower(), queryBuilder.includeUpper());
-            expectedQuery.setBoost(queryBuilder.boost());
-        } else if (fieldName.equals(DATE_FIELD_NAME)) {
-            assertThat(query, instanceOf(LateParsingQuery.class));
-            Long min = expectedDateLong(queryBuilder.from(), queryBuilder, context);
-            Long max = expectedDateLong(queryBuilder.to(), queryBuilder, context);
-            expectedQuery = NumericRangeQuery.newLongRange(DATE_FIELD_NAME, min, max, queryBuilder.includeLower(), queryBuilder.includeUpper());
-            expectedQuery = expectedQuery.rewrite(null);
-            query = query.rewrite(null);
-        } else if (fieldName.equals(INT_FIELD_NAME)) {
-            assertThat(query, instanceOf(NumericRangeQuery.class));
-            expectedQuery = NumericRangeQuery.newIntRange(INT_FIELD_NAME, (Integer) queryBuilder.from(), (Integer) queryBuilder.to(), queryBuilder.includeLower(), queryBuilder.includeUpper());
-            expectedQuery.setBoost(queryBuilder.boost());
-        } else {
-            throw new UnsupportedOperationException();
-        }
-        assertEquals(expectedQuery, query);
     }
 
     @Test
@@ -165,22 +181,5 @@ public class RangeQueryBuilderTest extends BaseQueryTestCase<RangeQueryBuilder> 
     @Override
     protected RangeQueryBuilder createEmptyQueryBuilder() {
         return new RangeQueryBuilder(null);
-    }
-
-    private Long expectedDateLong(Object value, RangeQueryBuilder queryBuilder, QueryParseContext context) {
-        FieldMapper mapper = context.fieldMapper(queryBuilder.fieldName());
-        DateMathParser dateParser = null;
-        if (queryBuilder.format()  != null) {
-            dateParser = new DateMathParser(Joda.forPattern(queryBuilder.format()), DateFieldMapper.Defaults.TIME_UNIT);
-        }
-        DateTimeZone dateTimeZone = null;
-        if (queryBuilder.timeZone() != null) {
-            dateTimeZone = DateTimeZone.forID(queryBuilder.timeZone());
-        }
-        Long expectedDate = null;
-        if (value != null) {
-            expectedDate = ((DateFieldMapper) mapper).parseToMilliseconds(value, queryBuilder.includeLower(), dateTimeZone, dateParser);
-        }
-        return expectedDate;
     }
 }

--- a/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTest.java
+++ b/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTest.java
@@ -98,7 +98,7 @@ public class RangeQueryBuilderTest extends BaseQueryTestCase<RangeQueryBuilder> 
         }
         String fieldName = queryBuilder.fieldName();
         Query expectedQuery;
-        if (!fieldName.equals(DATE_FIELD_NAME) && !fieldName.equals(INT_FIELD_NAME)) {
+        if (currentTypes.length == 0 || (fieldName.equals(DATE_FIELD_NAME) == false && fieldName.equals(INT_FIELD_NAME) == false) ) {
             assertThat(query, instanceOf(TermRangeQuery.class));
             expectedQuery = new TermRangeQuery(queryBuilder.fieldName(),
                     BytesRefs.toBytesRef(queryBuilder.from()), BytesRefs.toBytesRef(queryBuilder.to()),
@@ -111,10 +111,12 @@ public class RangeQueryBuilderTest extends BaseQueryTestCase<RangeQueryBuilder> 
             expectedQuery = NumericRangeQuery.newLongRange(DATE_FIELD_NAME, min, max, queryBuilder.includeLower(), queryBuilder.includeUpper());
             expectedQuery = expectedQuery.rewrite(null);
             query = query.rewrite(null);
-        } else {
+        } else if (fieldName.equals(INT_FIELD_NAME)) {
             assertThat(query, instanceOf(NumericRangeQuery.class));
             expectedQuery = NumericRangeQuery.newIntRange(INT_FIELD_NAME, (Integer) queryBuilder.from(), (Integer) queryBuilder.to(), queryBuilder.includeLower(), queryBuilder.includeUpper());
-            expectedQuery.setBoost(testQuery.boost());
+            expectedQuery.setBoost(queryBuilder.boost());
+        } else {
+            throw new UnsupportedOperationException();
         }
         assertEquals(expectedQuery, query);
     }
@@ -162,7 +164,7 @@ public class RangeQueryBuilderTest extends BaseQueryTestCase<RangeQueryBuilder> 
 
     @Override
     protected RangeQueryBuilder createEmptyQueryBuilder() {
-        return new RangeQueryBuilder();
+        return new RangeQueryBuilder(null);
     }
 
     private Long expectedDateLong(Object value, RangeQueryBuilder queryBuilder, QueryParseContext context) {

--- a/src/test/java/org/elasticsearch/index/query/SpanTermQueryBuilderTest.java
+++ b/src/test/java/org/elasticsearch/index/query/SpanTermQueryBuilderTest.java
@@ -33,7 +33,7 @@ public class SpanTermQueryBuilderTest extends BaseTermQueryTestCase<SpanTermQuer
 
     @Override
     protected SpanTermQueryBuilder createEmptyQueryBuilder() {
-        return new SpanTermQueryBuilder();
+        return new SpanTermQueryBuilder(null, null);
     }
     
     @Override

--- a/src/test/java/org/elasticsearch/index/query/SpanTermQueryBuilderTest.java
+++ b/src/test/java/org/elasticsearch/index/query/SpanTermQueryBuilderTest.java
@@ -19,15 +19,9 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.index.Term;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.spans.SpanTermQuery;
-import org.elasticsearch.common.lucene.BytesRefs;
-
-import java.io.IOException;
-
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
 
 public class SpanTermQueryBuilderTest extends BaseTermQueryTestCase<SpanTermQueryBuilder> {
 
@@ -41,31 +35,8 @@ public class SpanTermQueryBuilderTest extends BaseTermQueryTestCase<SpanTermQuer
         return new SpanTermQueryBuilder(fieldName, value);
     }
 
-    /** Returns a {@link SpanTermQueryBuilder} with random field name and value, optional random boost and queryname */
     @Override
-    protected SpanTermQueryBuilder createTestQueryBuilder() {
-        Object value = createRandomValueObject();
-        SpanTermQueryBuilder query = new SpanTermQueryBuilder(randomAsciiOfLength(8), value);
-        if (randomBoolean()) {
-            query.boost(2.0f / randomIntBetween(1, 20));
-        }
-        if (randomBoolean()) {
-            query.queryName(randomAsciiOfLength(8));
-        }
-        return query;
-    }
-
-    /** Checks the generated Lucene query against the {@link SpanTermQueryBuilder} it was created from. */
-    @Override
-    protected void assertLuceneQuery(SpanTermQueryBuilder queryBuilder, Query query, QueryParseContext context) throws IOException {
-        assertThat(query, instanceOf(SpanTermQuery.class));
-        assertThat(query.getBoost(), is(queryBuilder.boost()));
-        SpanTermQuery termQuery = (SpanTermQuery) query;
-        assertThat(termQuery.getTerm().field(), is(queryBuilder.fieldName()));
-        assertThat(termQuery.getTerm().bytes(), is(BytesRefs.toBytesRef(queryBuilder.value())));
-        if (queryBuilder.queryName() != null) {
-            Query namedQuery = context.copyNamedFilters().get(queryBuilder.queryName());
-            assertThat(namedQuery, equalTo((Query)termQuery));
-        }
+    protected Query createLuceneTermQuery(Term term) {
+        return new SpanTermQuery(term);
     }
 }

--- a/src/test/java/org/elasticsearch/index/query/TermQueryBuilderTest.java
+++ b/src/test/java/org/elasticsearch/index/query/TermQueryBuilderTest.java
@@ -19,13 +19,9 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.index.Term;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
-import org.elasticsearch.common.lucene.BytesRefs;
-
-import java.io.IOException;
-
-import static org.hamcrest.Matchers.*;
 
 public class TermQueryBuilderTest extends BaseTermQueryTestCase<TermQueryBuilder> {
 
@@ -42,31 +38,8 @@ public class TermQueryBuilderTest extends BaseTermQueryTestCase<TermQueryBuilder
         return new TermQueryBuilder(fieldName, value);
     }
 
-    /** Returns a TermQuery with random field name and value, optional random boost and queryname. */
     @Override
-    protected TermQueryBuilder createTestQueryBuilder() {
-        Object value = createRandomValueObject();
-        TermQueryBuilder query = new TermQueryBuilder(randomAsciiOfLength(8), value);
-        if (randomBoolean()) {
-            query.boost(2.0f / randomIntBetween(1, 20));
-        }
-        if (randomBoolean()) {
-            query.queryName(randomAsciiOfLengthBetween(1, 10));
-        }
-        return query;
-    }
-
-    /** Validates the Lucene query that was generated from a given {@link TermQueryBuilder}*/
-    @Override
-    protected void assertLuceneQuery(TermQueryBuilder queryBuilder, Query query, QueryParseContext context) throws IOException {
-        assertThat(query, instanceOf(TermQuery.class));
-        assertThat(query.getBoost(), is(queryBuilder.boost()));
-        TermQuery termQuery = (TermQuery) query;
-        assertThat(termQuery.getTerm().field(), is(queryBuilder.fieldName()));
-        assertThat(termQuery.getTerm().bytes(), is(BytesRefs.toBytesRef(queryBuilder.value())));
-        if (queryBuilder.queryName() != null) {
-            Query namedQuery = context.copyNamedFilters().get(queryBuilder.queryName());
-            assertThat(namedQuery, equalTo((Query)termQuery));
-        }
+    protected Query createLuceneTermQuery(Term term) {
+        return new TermQuery(term);
     }
 }

--- a/src/test/java/org/elasticsearch/index/query/TermQueryBuilderTest.java
+++ b/src/test/java/org/elasticsearch/index/query/TermQueryBuilderTest.java
@@ -31,7 +31,7 @@ public class TermQueryBuilderTest extends BaseTermQueryTestCase<TermQueryBuilder
 
     @Override
     protected TermQueryBuilder createEmptyQueryBuilder() {
-        return new TermQueryBuilder();
+        return new TermQueryBuilder(null, null);
     }
 
     /**
@@ -51,7 +51,7 @@ public class TermQueryBuilderTest extends BaseTermQueryTestCase<TermQueryBuilder
             query.boost(2.0f / randomIntBetween(1, 20));
         }
         if (randomBoolean()) {
-            query.queryName(randomAsciiOfLength(8));
+            query.queryName(randomAsciiOfLengthBetween(1, 10));
         }
         return query;
     }


### PR DESCRIPTION
QueryBuilders need to become streamable over the wire, so we can use them as our own intermediate query representation and send it over the wire. Using Writeable rather than Streamable allows us to restore some final fields and delete default constructor needed only for serialization purposes.

Taken the chance also to revise the internals of IdsQueryBuilder (modified some internal data type and added deduplication of ids to reduce bits to serialize). Expanded also IdsQueryBuilderTest, injected random types and improved comparison.

This PR is against the query-refactoring branch.
