### PR TITLE
don't exclude rest tests yamls from test-framework jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1517,6 +1517,7 @@
                                 <signaturesFile>dev-tools/forbidden/all-signatures.txt</signaturesFile>
                             </signaturesFiles>
                             <signatures>${forbidden.test.signatures}</signatures>
+                            <suppressAnnotations><annotation>**.SuppressForbidden</annotation></suppressAnnotations>
                         </configuration>
                         <phase>test-compile</phase>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -787,8 +787,6 @@
                                 <!-- unit tests for test framework classes-->
                                 <exclude>org/elasticsearch/test/test/**/*</exclude>
                             </excludes>
-                            <!-- Resources are large and not really helpful as "test sources". -->
-                            <excludeResources>true</excludeResources>
                         </configuration>
                     </execution>
                 </executions>
@@ -1539,6 +1537,7 @@
                         </goals>
                         <configuration>
                             <includes>
+                                <include>rest-api-spec/**/*</include>
                                 <include>org/elasticsearch/test/**/*</include>
                                 <include>org/elasticsearch/bootstrap/BootstrapForTesting.class</include>
                                 <include>org/elasticsearch/common/cli/CliToolTestCase.class</include>

--- a/src/test/java/org/elasticsearch/test/rest/spec/RestSpec.java
+++ b/src/test/java/org/elasticsearch/test/rest/spec/RestSpec.java
@@ -19,12 +19,14 @@
 package org.elasticsearch.test.rest.spec;
 
 import com.google.common.collect.Maps;
+
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.test.rest.support.FileUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
@@ -54,10 +56,10 @@ public class RestSpec {
     /**
      * Parses the complete set of REST spec available under the provided directories
      */
-    public static RestSpec parseFrom(String optionalPathPrefix, String... paths) throws IOException {
+    public static RestSpec parseFrom(FileSystem fileSystem, String optionalPathPrefix, String... paths) throws IOException {
         RestSpec restSpec = new RestSpec();
         for (String path : paths) {
-            for (Path jsonFile : FileUtils.findJsonSpec(optionalPathPrefix, path)) {
+            for (Path jsonFile : FileUtils.findJsonSpec(fileSystem, optionalPathPrefix, path)) {
                 try (InputStream stream = Files.newInputStream(jsonFile)) {
                     XContentParser parser = JsonXContent.jsonXContent.createParser(stream);
                     RestApi restApi = new RestApiParser().parse(parser);

--- a/src/test/java/org/elasticsearch/test/rest/test/FileUtilsTests.java
+++ b/src/test/java/org/elasticsearch/test/rest/test/FileUtilsTests.java
@@ -81,22 +81,16 @@ public class FileUtilsTests extends ElasticsearchTestCase {
         Files.createFile(file);
 
         //load from directory outside of the classpath
-        yamlSuites = FileUtils.findYamlSuites(dir.getFileSystem(), "/rest-api-spec/test", "get/10_basic", dir.toAbsolutePath().toString());
+        yamlSuites = FileUtils.findYamlSuites(dir.getFileSystem(), "/rest-api-spec/test", dir.toAbsolutePath().toString());
         assertThat(yamlSuites, notNullValue());
-        assertThat(yamlSuites.size(), equalTo(2));
-        assertThat(yamlSuites.containsKey("get"), equalTo(true));
-        assertThat(yamlSuites.get("get").size(), equalTo(1));
-        assertSingleFile(yamlSuites.get("get"), "get", "10_basic.yaml");
+        assertThat(yamlSuites.size(), equalTo(1));
         assertThat(yamlSuites.containsKey(dir.getFileName().toString()), equalTo(true));
         assertSingleFile(yamlSuites.get(dir.getFileName().toString()), dir.getFileName().toString(), file.getFileName().toString());
 
         //load from external file (optional extension)
-        yamlSuites = FileUtils.findYamlSuites(dir.getFileSystem(), "/rest-api-spec/test", "get/10_basic", dir.resolve("test_loading").toAbsolutePath().toString());
+        yamlSuites = FileUtils.findYamlSuites(dir.getFileSystem(), "/rest-api-spec/test", dir.resolve("test_loading").toAbsolutePath().toString());
         assertThat(yamlSuites, notNullValue());
-        assertThat(yamlSuites.size(), equalTo(2));
-        assertThat(yamlSuites.containsKey("get"), equalTo(true));
-        assertThat(yamlSuites.get("get").size(), equalTo(1));
-        assertSingleFile(yamlSuites.get("get"), "get", "10_basic.yaml");
+        assertThat(yamlSuites.size(), equalTo(1));
         assertThat(yamlSuites.containsKey(dir.getFileName().toString()), equalTo(true));
         assertSingleFile(yamlSuites.get(dir.getFileName().toString()), dir.getFileName().toString(), file.getFileName().toString());
     }

--- a/src/test/java/org/elasticsearch/test/rest/test/FileUtilsTests.java
+++ b/src/test/java/org/elasticsearch/test/rest/test/FileUtilsTests.java
@@ -35,29 +35,29 @@ public class FileUtilsTests extends ElasticsearchTestCase {
 
     @Test
     public void testLoadSingleYamlSuite() throws Exception {
-        Map<String,Set<Path>> yamlSuites = FileUtils.findYamlSuites("/rest-api-spec/test", "/rest-api-spec/test/get/10_basic");
+        Map<String,Set<Path>> yamlSuites = FileUtils.findYamlSuites(null, "/rest-api-spec/test", "/rest-api-spec/test/get/10_basic");
         assertSingleFile(yamlSuites, "get", "10_basic.yaml");
 
         //the path prefix is optional
-        yamlSuites = FileUtils.findYamlSuites("/rest-api-spec/test", "get/10_basic.yaml");
+        yamlSuites = FileUtils.findYamlSuites(null, "/rest-api-spec/test", "get/10_basic.yaml");
         assertSingleFile(yamlSuites, "get", "10_basic.yaml");
 
         //extension .yaml is optional
-        yamlSuites = FileUtils.findYamlSuites("/rest-api-spec/test", "get/10_basic");
+        yamlSuites = FileUtils.findYamlSuites(null, "/rest-api-spec/test", "get/10_basic");
         assertSingleFile(yamlSuites, "get", "10_basic.yaml");
     }
 
     @Test
     public void testLoadMultipleYamlSuites() throws Exception {
         //single directory
-        Map<String,Set<Path>> yamlSuites = FileUtils.findYamlSuites("/rest-api-spec/test", "get");
+        Map<String,Set<Path>> yamlSuites = FileUtils.findYamlSuites(null, "/rest-api-spec/test", "get");
         assertThat(yamlSuites, notNullValue());
         assertThat(yamlSuites.size(), equalTo(1));
         assertThat(yamlSuites.containsKey("get"), equalTo(true));
         assertThat(yamlSuites.get("get").size(), greaterThan(1));
 
         //multiple directories
-        yamlSuites = FileUtils.findYamlSuites("/rest-api-spec/test", "get", "index");
+        yamlSuites = FileUtils.findYamlSuites(null, "/rest-api-spec/test", "get", "index");
         assertThat(yamlSuites, notNullValue());
         assertThat(yamlSuites.size(), equalTo(2));
         assertThat(yamlSuites.containsKey("get"), equalTo(true));
@@ -66,7 +66,7 @@ public class FileUtilsTests extends ElasticsearchTestCase {
         assertThat(yamlSuites.get("index").size(), greaterThan(1));
 
         //multiple paths, which can be both directories or yaml test suites (with optional file extension)
-        yamlSuites = FileUtils.findYamlSuites("/rest-api-spec/test", "indices.optimize/10_basic", "index");
+        yamlSuites = FileUtils.findYamlSuites(null, "/rest-api-spec/test", "indices.optimize/10_basic", "index");
         assertThat(yamlSuites, notNullValue());
         assertThat(yamlSuites.size(), equalTo(2));
         assertThat(yamlSuites.containsKey("indices.optimize"), equalTo(true));
@@ -81,7 +81,7 @@ public class FileUtilsTests extends ElasticsearchTestCase {
         Files.createFile(file);
 
         //load from directory outside of the classpath
-        yamlSuites = FileUtils.findYamlSuites("/rest-api-spec/test", "get/10_basic", dir.toAbsolutePath().toString());
+        yamlSuites = FileUtils.findYamlSuites(dir.getFileSystem(), "/rest-api-spec/test", "get/10_basic", dir.toAbsolutePath().toString());
         assertThat(yamlSuites, notNullValue());
         assertThat(yamlSuites.size(), equalTo(2));
         assertThat(yamlSuites.containsKey("get"), equalTo(true));
@@ -91,7 +91,7 @@ public class FileUtilsTests extends ElasticsearchTestCase {
         assertSingleFile(yamlSuites.get(dir.getFileName().toString()), dir.getFileName().toString(), file.getFileName().toString());
 
         //load from external file (optional extension)
-        yamlSuites = FileUtils.findYamlSuites("/rest-api-spec/test", "get/10_basic", dir.resolve("test_loading").toAbsolutePath().toString());
+        yamlSuites = FileUtils.findYamlSuites(dir.getFileSystem(), "/rest-api-spec/test", "get/10_basic", dir.resolve("test_loading").toAbsolutePath().toString());
         assertThat(yamlSuites, notNullValue());
         assertThat(yamlSuites.size(), equalTo(2));
         assertThat(yamlSuites.containsKey("get"), equalTo(true));


### PR DESCRIPTION
Some plugins subclass these rest tests in a hacky way, by having a separate checkout of elasticsearch and specifying lots of things with -Dsysprops.

Besides being hacky, it won't work under security manager.

Instead, don't exclude from the test jar (its only 150KB compressed to the test jar), so that subclassing the test just works.
