### PR TITLE
Remove filter from PhraseSuggester collate

### DIFF
--- a/docs/reference/search/suggesters/phrase-suggest.asciidoc
+++ b/docs/reference/search/suggesters/phrase-suggest.asciidoc
@@ -162,13 +162,13 @@ can contain misspellings (See parameter descriptions below).
     is wrapped rather than each token.
 
 `collate`::
-    Checks each suggestion against the specified `query` or `filter` to
-    prune suggestions for which no matching docs exist in the index.
-    The collate query for a suggestion is run only on the local shard from which
-    the suggestion has been generated from. Either a `query` or a `filter` must
-    be specified, and it is run as a <<query-dsl-template-query,`template` query>>.
+    Checks each suggestion against the specified `query` to prune suggestions
+    for which no matching docs exist in the index. The collate query for a
+    suggestion is run only on the local shard from which the suggestion has
+    been generated from. The `query` must be specified, and it is run as
+    a <<query-dsl-template-query,`template` query>>.
     The current suggestion is automatically made available as the `{{suggestion}}`
-    variable, which should be used in your query/filter.  You can still specify
+    variable, which should be used in your query.  You can still specify
     your own template `params` -- the `suggestion` value will be added to the
     variables you specify. Additionally, you can specify a `prune` to control
     if all phrase suggestions will be returned, when set to `true` the suggestions

--- a/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestParser.java
+++ b/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestParser.java
@@ -137,7 +137,7 @@ public final class PhraseSuggestParser implements SuggestContextParser {
                     while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
                         if (token == XContentParser.Token.FIELD_NAME) {
                             fieldName = parser.currentName();
-                        } else if ("query".equals(fieldName) || "filter".equals(fieldName)) {
+                        } else if ("query".equals(fieldName)) {
                             String templateNameOrTemplateContent;
                             if (token == XContentParser.Token.START_OBJECT) {
                                 XContentBuilder builder = XContentBuilder.builder(parser.contentType().xContent());
@@ -147,20 +147,13 @@ public final class PhraseSuggestParser implements SuggestContextParser {
                                 templateNameOrTemplateContent = parser.text();
                             }
                             if (templateNameOrTemplateContent == null) {
-                                throw new IllegalArgumentException("suggester[phrase][collate] no query/filter found in collate object");
-                            }
-                            if (suggestion.getCollateFilterScript() != null) {
-                                throw new IllegalArgumentException("suggester[phrase][collate] filter already set, doesn't support additional [" + fieldName + "]");
+                                throw new IllegalArgumentException("suggester[phrase][collate] no query found in collate object");
                             }
                             if (suggestion.getCollateQueryScript() != null) {
                                 throw new IllegalArgumentException("suggester[phrase][collate] query already set, doesn't support additional [" + fieldName + "]");
                             }
                             CompiledScript compiledScript = suggester.scriptService().compile(new Script(MustacheScriptEngineService.NAME, templateNameOrTemplateContent, ScriptType.INLINE, null), ScriptContext.Standard.SEARCH);
-                            if ("query".equals(fieldName)) {
-                                suggestion.setCollateQueryScript(compiledScript);
-                            } else {
-                                suggestion.setCollateFilterScript(compiledScript);
-                            }
+                            suggestion.setCollateQueryScript(compiledScript);
                         } else if ("params".equals(fieldName)) {
                             suggestion.setCollateScriptParams(parser.map());
                         } else if ("prune".equals(fieldName)) {

--- a/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilder.java
+++ b/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilder.java
@@ -42,8 +42,6 @@ public final class PhraseSuggestionBuilder extends SuggestionBuilder<PhraseSugge
     private String preTag;
     private String postTag;
     private String collateQuery;
-    private String collateFilter;
-    private String collatePreference;
     private Map<String, Object> collateParams;
     private Boolean collatePrune;
 
@@ -179,22 +177,6 @@ public final class PhraseSuggestionBuilder extends SuggestionBuilder<PhraseSugge
     }
 
     /**
-     * Sets a filter used for filtering out suggested phrases (collation).
-     */
-    public PhraseSuggestionBuilder collateFilter(String collateFilter) {
-        this.collateFilter = collateFilter;
-        return this;
-    }
-
-    /**
-     * Sets routing preferences for executing filter query (collation).
-     */
-    public PhraseSuggestionBuilder collatePreference(String collatePreference) {
-        this.collatePreference = collatePreference;
-        return this;
-    }
-
-    /**
      * Sets additional params for collate script
      */
     public PhraseSuggestionBuilder collateParams(Map<String, Object> collateParams) {
@@ -254,17 +236,9 @@ public final class PhraseSuggestionBuilder extends SuggestionBuilder<PhraseSugge
             builder.field("post_tag", postTag);
             builder.endObject();
         }
-        if (collateQuery != null || collateFilter != null) {
+        if (collateQuery != null) {
             builder.startObject("collate");
-            if (collateQuery != null) {
-                builder.field("query", collateQuery);
-            }
-            if (collateFilter != null) {
-                builder.field("filter", collateFilter);
-            }
-            if (collatePreference != null) {
-                builder.field("preference", collatePreference);
-            }
+            builder.field("query", collateQuery);
             if (collateParams != null) {
                 builder.field("params", collateParams);
             }

--- a/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionContext.java
+++ b/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionContext.java
@@ -204,14 +204,6 @@ class PhraseSuggestionContext extends SuggestionContext {
         this.collateQueryScript = collateQueryScript;
     }
 
-    CompiledScript getCollateFilterScript() {
-        return collateFilterScript;
-    }
-
-    void setCollateFilterScript(CompiledScript collateFilterScript) {
-        this.collateFilterScript = collateFilterScript;
-    }
-
     Map<String, Object> getCollateScriptParams() {
         return collateScriptParams;
     }


### PR DESCRIPTION
This commit removes the ability to use `filter` for PhraseSuggester collate.
Only `query` can be used for collation.
Internally, a collate query is executed as an exists query. So specifying a
filter does not have any benefits.
