### PR TITLE
Fix cluster state task name for update snapshot task

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/TransportCreateSnapshotAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/TransportCreateSnapshotAction.java
@@ -66,7 +66,7 @@ public class TransportCreateSnapshotAction extends TransportMasterNodeOperationA
     @Override
     protected void masterOperation(final CreateSnapshotRequest request, ClusterState state, final ActionListener<CreateSnapshotResponse> listener) {
         SnapshotsService.SnapshotRequest snapshotRequest =
-                new SnapshotsService.SnapshotRequest("create_snapshot[" + request.snapshot() + "]", request.snapshot(), request.repository())
+                new SnapshotsService.SnapshotRequest("create_snapshot [" + request.snapshot() + "]", request.snapshot(), request.repository())
                         .indices(request.indices())
                         .indicesOptions(request.indicesOptions())
                         .partial(request.partial())

--- a/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -308,7 +308,7 @@ public class SnapshotsService extends AbstractLifecycleComponent<SnapshotsServic
                 endSnapshot(snapshot);
                 return;
             }
-            clusterService.submitStateUpdateTask("update_snapshot [" + snapshot + "]", new ProcessedClusterStateUpdateTask() {
+            clusterService.submitStateUpdateTask("update_snapshot [" + snapshot.snapshotId().getSnapshot() + "]", new ProcessedClusterStateUpdateTask() {
                 boolean accepted = false;
                 SnapshotMetaData.Entry updatedSnapshot;
                 String failure = null;


### PR DESCRIPTION
This commit fixes the name of the upated_snapshot task from something like "update_snapshot [org.elasticsearch.cluster.metadata.SnapshotMetaData$Entry@de00bc50]" to a more readable "update_snapshot [test-snap]"

Basically instead of logging:

```
[2015-05-15 19:31:54,258][DEBUG][cluster.service] [node_s0] processing [create_snapshot[test-snap]]: took 6ms done applying updated cluster_state (version: 21, uuid: asbLMhdqRSKhFvV2-h9JUw)
[2015-05-15 19:31:54,265][DEBUG][cluster.service] [node_s0] processing [update_snapshot [org.elasticsearch.cluster.metadata.SnapshotMetaData$Entry@de00bc50]]: execute
```

It now logs:

```
[2015-05-15 19:49:48,254][DEBUG][cluster.service] [node_s0] processing [create_snapshot [test-snap]]: took 6ms done applying updated cluster_state (version: 21, uuid: asbLMhdqRSKhFvV2-h9JUw)
[2015-05-15 19:49:48,268][DEBUG][cluster.service] [node_s0] processing [update_snapshot [test-snap]]: execute
```
