### PR TITLE
Fix multi level parent/child bug

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/HasChildQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/HasChildQueryParser.java
@@ -142,7 +142,7 @@ public class HasChildQueryParser implements QueryParser {
         }
 
         if (innerHits != null) {
-            InnerHitsContext.ParentChildInnerHits parentChildInnerHits = new InnerHitsContext.ParentChildInnerHits(innerHits.v2(), innerQuery, null, childDocMapper);
+            InnerHitsContext.ParentChildInnerHits parentChildInnerHits = new InnerHitsContext.ParentChildInnerHits(innerHits.v2(), innerQuery, null, parseContext.mapperService(), childDocMapper);
             String name = innerHits.v1() != null ? innerHits.v1() : childType;
             parseContext.addInnerHits(name, parentChildInnerHits);
         }

--- a/src/main/java/org/elasticsearch/index/query/HasParentQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/HasParentQueryParser.java
@@ -150,7 +150,7 @@ public class HasParentQueryParser implements QueryParser {
         }
 
         if (innerHits != null) {
-            InnerHitsContext.ParentChildInnerHits parentChildInnerHits = new InnerHitsContext.ParentChildInnerHits(innerHits.v2(), innerQuery, null, parentDocMapper);
+            InnerHitsContext.ParentChildInnerHits parentChildInnerHits = new InnerHitsContext.ParentChildInnerHits(innerHits.v2(), innerQuery, null, parseContext.mapperService(), parentDocMapper);
             String name = innerHits.v1() != null ? innerHits.v1() : parentType;
             parseContext.addInnerHits(name, parentChildInnerHits);
         }

--- a/src/main/java/org/elasticsearch/search/fetch/innerhits/InnerHitsParseElement.java
+++ b/src/main/java/org/elasticsearch/search/fetch/innerhits/InnerHitsParseElement.java
@@ -150,7 +150,7 @@ public class InnerHitsParseElement implements SearchParseElement {
         if (documentMapper == null) {
             throw new IllegalArgumentException("type [" + type + "] doesn't exist");
         }
-        return new InnerHitsContext.ParentChildInnerHits(parseResult.context(), parseResult.query(), parseResult.childInnerHits(), documentMapper);
+        return new InnerHitsContext.ParentChildInnerHits(parseResult.context(), parseResult.query(), parseResult.childInnerHits(), parseContext.mapperService(), documentMapper);
     }
 
     private InnerHitsContext.NestedInnerHits parseNested(XContentParser parser, QueryParseContext parseContext, SearchContext searchContext, String nestedPath) throws Exception {


### PR DESCRIPTION
If the search hit is a child of the inner hit definition then an empty inner hit response was returned even if there is a matching parent document.
