### PR TITLE
Decrement reference even if IndexShard#postRecovery barfs

### DIFF
--- a/src/main/java/org/elasticsearch/indices/recovery/RecoveryStatus.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoveryStatus.java
@@ -188,10 +188,13 @@ public class RecoveryStatus extends AbstractRefCounted {
     public void markAsDone() {
         if (finished.compareAndSet(false, true)) {
             assert tempFileNames.isEmpty() : "not all temporary files are renamed";
-            indexShard.postRecovery("peer recovery done");
-            // release the initial reference. recovery files will be cleaned as soon as ref count goes to zero, potentially now
-            decRef();
-            listener.onRecoveryDone(state());
+            try {
+                indexShard.postRecovery("peer recovery done");
+            } finally {
+                // release the initial reference. recovery files will be cleaned as soon as ref count goes to zero, potentially now
+                decRef();
+                listener.onRecoveryDone(state());
+            }
         }
     }
 

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoveryStatus.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoveryStatus.java
@@ -189,12 +189,14 @@ public class RecoveryStatus extends AbstractRefCounted {
         if (finished.compareAndSet(false, true)) {
             assert tempFileNames.isEmpty() : "not all temporary files are renamed";
             try {
+                // this might still throw an exception ie. if the shard is CLOSED due to some other event.
+                // it's safer to decrement the reference in a try finally here.
                 indexShard.postRecovery("peer recovery done");
             } finally {
                 // release the initial reference. recovery files will be cleaned as soon as ref count goes to zero, potentially now
                 decRef();
-                listener.onRecoveryDone(state());
             }
+            listener.onRecoveryDone(state());
         }
     }
 

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
@@ -262,7 +262,7 @@ public class RecoveryTarget extends AbstractComponent {
         }
     }
 
-    public static interface RecoveryListener {
+    public interface RecoveryListener {
         void onRecoveryDone(RecoveryState state);
 
         void onRecoveryFailure(RecoveryState state, RecoveryFailedException e, boolean sendShardFailure);


### PR DESCRIPTION
This can cause a reference leak if we call `IndexShard#postRecovery`
on an already closed shard.

a CI build failed here today:

```
1> [2015-05-18 13:45:50,829][DEBUG][index.store              ] [node_s0] [test][0] store reference count on close: 1
  1> [2015-05-18 13:45:50,829][TRACE][indices.recovery         ] [node_s0] [test][0] Got exception on recovery
  1> [test][0] CurrentState[CLOSED] Closed
  1>    at org.elasticsearch.index.shard.IndexShard.postRecovery(IndexShard.java:766)
  1>    at org.elasticsearch.indices.recovery.RecoveryStatus.markAsDone(RecoveryStatus.java:191)
  1>    at org.elasticsearch.indices.recovery.RecoveriesCollection.markRecoveryAsDone(RecoveriesCollection.java:131)
  1>    at org.elasticsearch.indices.recovery.RecoveryTarget.doRecovery(RecoveryTarget.java:196)
  1>    at org.elasticsearch.indices.recovery.RecoveryTarget.access$700(RecoveryTarget.java:71)
  1>    at org.elasticsearch.indices.recovery.RecoveryTarget$RecoveryRunner.doRun(RecoveryTarget.java:461)
  1>    at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:37)
  1>    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
  1>    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
  1>    at java.lang.Thread.run(Thread.java:745)
```

http://build-us-00.elastic.co/job/es_core_master_metal/9363/consoleFull
