### PR TITLE
Remove the `ignore_conflicts` option.

### DIFF
--- a/docs/reference/indices/put-mapping.asciidoc
+++ b/docs/reference/indices/put-mapping.asciidoc
@@ -31,9 +31,7 @@ More information on how to define type mappings can be found in the
 
 When an existing mapping already exists under the given type, the two
 mapping definitions, the one already defined, and the new ones are
-merged. The `ignore_conflicts` parameters can be used to control if
-conflicts should be ignored or not, by default, it is set to `false`
-which means conflicts are *not* ignored.
+merged. If there are conflicts then the update will be rejected.
 
 The definition of conflict is really dependent on the type merged, but
 in general, if a different core type is defined, it is considered as a

--- a/docs/reference/migration/migrate_2_0.asciidoc
+++ b/docs/reference/migration/migrate_2_0.asciidoc
@@ -177,6 +177,7 @@ A `RoutingMissingException` is now thrown instead.
 
 * The setting `index.mapping.allow_type_wrapper` has been removed.  Documents should always be sent without the type as the root element.
 * The delete mappings API has been removed. Mapping types can no longer be deleted.
+* The `ignore_conflicts` option of the put mappings API has been removed. Conflicts can't be ignored anymore.
 
 ==== Removed type prefix on field names in queries
 Types can no longer be specified on fields within queries.  Instead, specify type restrictions in the search request.

--- a/rest-api-spec/api/indices.put_mapping.json
+++ b/rest-api-spec/api/indices.put_mapping.json
@@ -17,10 +17,6 @@
         }
       },
       "params": {
-        "ignore_conflicts": {
-          "type" : "boolean",
-          "description" : "Specify whether to ignore conflicts while updating the mapping (default: false)"
-        },
         "timeout": {
           "type" : "time",
           "description" : "Explicit operation timeout"

--- a/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingClusterStateUpdateRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingClusterStateUpdateRequest.java
@@ -30,8 +30,6 @@ public class PutMappingClusterStateUpdateRequest extends IndicesClusterStateUpda
 
     private String source;
 
-    private boolean ignoreConflicts = false;
-
     PutMappingClusterStateUpdateRequest() {
 
     }
@@ -51,15 +49,6 @@ public class PutMappingClusterStateUpdateRequest extends IndicesClusterStateUpda
 
     public PutMappingClusterStateUpdateRequest source(String source) {
         this.source = source;
-        return this;
-    }
-
-    public boolean ignoreConflicts() {
-        return ignoreConflicts;
-    }
-
-    public PutMappingClusterStateUpdateRequest ignoreConflicts(boolean ignoreConflicts) {
-        this.ignoreConflicts = ignoreConflicts;
         return this;
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingRequest.java
@@ -42,8 +42,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
  * {@link org.elasticsearch.client.Requests#putMappingRequest(String...)}.
  * <p/>
  * <p>If the mappings already exists, the new mappings will be merged with the new one. If there are elements
- * that can't be merged are detected, the request will be rejected unless the {@link #ignoreConflicts(boolean)}
- * is set. In such a case, the duplicate mappings will be rejected.
+ * that can't be merged are detected, the request will be rejected.
  *
  * @see org.elasticsearch.client.Requests#putMappingRequest(String...)
  * @see org.elasticsearch.client.IndicesAdminClient#putMapping(PutMappingRequest)
@@ -63,8 +62,6 @@ public class PutMappingRequest extends AcknowledgedRequest<PutMappingRequest> im
     private String type;
 
     private String source;
-
-    private boolean ignoreConflicts = false;
 
     PutMappingRequest() {
     }
@@ -239,25 +236,6 @@ public class PutMappingRequest extends AcknowledgedRequest<PutMappingRequest> im
         return this;
     }
 
-    /**
-     * If there is already a mapping definition registered against the type, then it will be merged. If there are
-     * elements that can't be merged are detected, the request will be rejected unless the
-     * {@link #ignoreConflicts(boolean)} is set. In such a case, the duplicate mappings will be rejected.
-     */
-    public boolean ignoreConflicts() {
-        return ignoreConflicts;
-    }
-
-    /**
-     * If there is already a mapping definition registered against the type, then it will be merged. If there are
-     * elements that can't be merged are detected, the request will be rejected unless the
-     * {@link #ignoreConflicts(boolean)} is set. In such a case, the duplicate mappings will be rejected.
-     */
-    public PutMappingRequest ignoreConflicts(boolean ignoreDuplicates) {
-        this.ignoreConflicts = ignoreDuplicates;
-        return this;
-    }
-
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
@@ -266,7 +244,6 @@ public class PutMappingRequest extends AcknowledgedRequest<PutMappingRequest> im
         type = in.readOptionalString();
         source = in.readString();
         readTimeout(in);
-        ignoreConflicts = in.readBoolean();
     }
 
     @Override
@@ -277,6 +254,5 @@ public class PutMappingRequest extends AcknowledgedRequest<PutMappingRequest> im
         out.writeOptionalString(type);
         out.writeString(source);
         writeTimeout(out);
-        out.writeBoolean(ignoreConflicts);
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingRequestBuilder.java
@@ -91,13 +91,4 @@ public class PutMappingRequestBuilder extends AcknowledgedRequestBuilder<PutMapp
         return this;
     }
 
-    /**
-     * If there is already a mapping definition registered against the type, then it will be merged. If there are
-     * elements that can't be merged are detected, the request will be rejected unless the
-     * {@link #setIgnoreConflicts(boolean)} is set. In such a case, the duplicate mappings will be rejected.
-     */
-    public PutMappingRequestBuilder setIgnoreConflicts(boolean ignoreConflicts) {
-        request.ignoreConflicts(ignoreConflicts);
-        return this;
-    }
 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/TransportPutMappingAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/TransportPutMappingAction.java
@@ -70,7 +70,7 @@ public class TransportPutMappingAction extends TransportMasterNodeOperationActio
         PutMappingClusterStateUpdateRequest updateRequest = new PutMappingClusterStateUpdateRequest()
                 .ackTimeout(request.timeout()).masterNodeTimeout(request.masterNodeTimeout())
                 .indices(concreteIndices).type(request.type())
-                .source(request.source()).ignoreConflicts(request.ignoreConflicts());
+                .source(request.source());
 
         metaDataMappingService.putMapping(updateRequest, new ActionListener<ClusterStateUpdateResponse>() {
 

--- a/src/main/java/org/elasticsearch/cluster/metadata/MetaDataMappingService.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MetaDataMappingService.java
@@ -382,8 +382,8 @@ public class MetaDataMappingService extends AbstractComponent {
                             if (existingMapper != null) {
                                 // first, simulate
                                 MergeResult mergeResult = existingMapper.merge(newMapper.mapping(), true);
-                                // if we have conflicts, and we are not supposed to ignore them, throw an exception
-                                if (!request.ignoreConflicts() && mergeResult.hasConflicts()) {
+                                // if we have conflicts, throw an exception
+                                if (mergeResult.hasConflicts()) {
                                     throw new MergeMappingException(mergeResult.buildConflicts());
                                 }
                             }

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/put/RestPutMappingAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/put/RestPutMappingAction.java
@@ -70,7 +70,6 @@ public class RestPutMappingAction extends BaseRestHandler {
         putMappingRequest.type(request.param("type"));
         putMappingRequest.source(request.content().toUtf8());
         putMappingRequest.timeout(request.paramAsTime("timeout", putMappingRequest.timeout()));
-        putMappingRequest.ignoreConflicts(request.paramAsBoolean("ignore_conflicts", putMappingRequest.ignoreConflicts()));
         putMappingRequest.masterNodeTimeout(request.paramAsTime("master_timeout", putMappingRequest.masterNodeTimeout()));
         putMappingRequest.indicesOptions(IndicesOptions.fromRequest(request, putMappingRequest.indicesOptions()));
         client.admin().indices().putMapping(putMappingRequest, new AcknowledgedRestListener<PutMappingResponse>(channel));

--- a/src/test/java/org/elasticsearch/index/mapper/multifield/MultiFieldsIntegrationTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/multifield/MultiFieldsIntegrationTests.java
@@ -76,7 +76,6 @@ public class MultiFieldsIntegrationTests extends ElasticsearchIntegrationTest {
         assertAcked(
                 client().admin().indices().preparePutMapping("my-index").setType("my-type")
                         .setSource(createPutMappingSource())
-                        .setIgnoreConflicts(true) // If updated with multi-field type, we need to ignore failures.
         );
 
         getMappingsResponse = client().admin().indices().prepareGetMappings("my-index").get();
@@ -240,70 +239,35 @@ public class MultiFieldsIntegrationTests extends ElasticsearchIntegrationTest {
     }
 
     private XContentBuilder createTypeSource() throws IOException {
-        if (randomBoolean()) {
-            return XContentFactory.jsonBuilder().startObject().startObject("my-type")
-                    .startObject("properties")
-                    .startObject("title")
-                    .field("type", "string")
-                    .startObject("fields")
-                    .startObject("not_analyzed")
-                    .field("type", "string")
-                    .field("index", "not_analyzed")
-                    .endObject()
-                    .endObject()
-                    .endObject()
-                    .endObject()
-                    .endObject().endObject();
-        } else {
-            return XContentFactory.jsonBuilder().startObject().startObject("my-type")
-                    .startObject("properties")
-                    .startObject("title")
-                    .field("type", "multi_field")
-                    .startObject("fields")
-                    .startObject("title")
-                    .field("type", "string")
-                    .endObject()
-                    .startObject("not_analyzed")
-                    .field("type", "string")
-                    .field("index", "not_analyzed")
-                    .endObject()
-                    .endObject()
-                    .endObject()
-                    .endObject()
-                    .endObject().endObject();
-        }
+        return XContentFactory.jsonBuilder().startObject().startObject("my-type")
+                .startObject("properties")
+                .startObject("title")
+                .field("type", "string")
+                .startObject("fields")
+                .startObject("not_analyzed")
+                .field("type", "string")
+                .field("index", "not_analyzed")
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject().endObject();
     }
 
     private XContentBuilder createPutMappingSource() throws IOException {
-        if (randomBoolean()) {
-            return XContentFactory.jsonBuilder().startObject().startObject("my-type")
-                    .startObject("properties")
-                    .startObject("title")
-                    .field("type", "string")
-                    .startObject("fields")
-                    .startObject("uncased")
-                    .field("type", "string")
-                    .field("analyzer", "whitespace")
-                    .endObject()
-                    .endObject()
-                    .endObject()
-                    .endObject()
-                    .endObject().endObject();
-        } else {
-            return XContentFactory.jsonBuilder().startObject().startObject("my-type")
-                    .startObject("properties")
-                    .startObject("title")
-                    .field("type", "multi_field")
-                    .startObject("fields")
-                    .startObject("uncased")
-                    .field("type", "string")
-                    .field("analyzer", "whitespace")
-                    .endObject()
-                    .endObject()
-                    .endObject()
-                    .endObject()
-                    .endObject().endObject();
-        }
+        return XContentFactory.jsonBuilder().startObject().startObject("my-type")
+                .startObject("properties")
+                .startObject("title")
+                .field("type", "string")
+                .startObject("fields")
+                .startObject("uncased")
+                .field("type", "string")
+                .field("analyzer", "whitespace")
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject().endObject();
     }
 
 }

--- a/src/test/java/org/elasticsearch/indices/mapping/UpdateMappingIntegrationTests.java
+++ b/src/test/java/org/elasticsearch/indices/mapping/UpdateMappingIntegrationTests.java
@@ -166,30 +166,6 @@ public class UpdateMappingIntegrationTests extends ElasticsearchIntegrationTest 
     }
 
     /*
-    First regression test for https://github.com/elasticsearch/elasticsearch/issues/3381
-     */
-    @Test
-    public void updateMappingWithIgnoredConflicts() throws Exception {
-
-        client().admin().indices().prepareCreate("test")
-                .setSettings(
-                        settingsBuilder()
-                                .put("index.number_of_shards", 2)
-                                .put("index.number_of_replicas", 0)
-                ).addMapping("type", "{\"type\":{\"properties\":{\"body\":{\"type\":\"string\"}}}}")
-                .execute().actionGet();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
-
-        PutMappingResponse putMappingResponse = client().admin().indices().preparePutMapping("test").setType("type")
-                .setSource("{\"type\":{\"properties\":{\"body\":{\"type\":\"integer\"}}}}")
-                .setIgnoreConflicts(true)
-                .execute().actionGet();
-
-        //no changes since the only one had a conflict and was ignored, we return
-        assertThat(putMappingResponse.isAcknowledged(), equalTo(true));
-    }
-
-    /*
     Second regression test for https://github.com/elasticsearch/elasticsearch/issues/3381
      */
     @Test


### PR DESCRIPTION
Mappings conflicts should not be ignored. If I read the history correctly, this
option was added when a mapping update to an existing field was considered a
conflict, even if the new mapping was exactly the same. Now that mapping updates
are smart enough to detect conflicting options, we don't need an option to
ignore conflicts.
