### PR TITLE
Make mapping updates atomic wrt document parsing.

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
@@ -422,17 +422,16 @@ public class DocumentMapper implements ToXContent {
     }
 
     private void addObjectMappers(Collection<ObjectMapper> objectMappers) {
-        try (ReleasableLock lock = mappingWriteLock.acquire()) {
-            MapBuilder<String, ObjectMapper> builder = MapBuilder.newMapBuilder(this.objectMappers);
-            for (ObjectMapper objectMapper : objectMappers) {
-                builder.put(objectMapper.fullPath(), objectMapper);
-                if (objectMapper.nested().isNested()) {
-                    hasNestedObjects = true;
-                }
+        assert mappingLock.isWriteLockedByCurrentThread();
+        MapBuilder<String, ObjectMapper> builder = MapBuilder.newMapBuilder(this.objectMappers);
+        for (ObjectMapper objectMapper : objectMappers) {
+            builder.put(objectMapper.fullPath(), objectMapper);
+            if (objectMapper.nested().isNested()) {
+                hasNestedObjects = true;
             }
-            this.objectMappers = builder.immutableMap();
-            mapperService.addObjectMappers(objectMappers);
         }
+        this.objectMappers = builder.immutableMap();
+        mapperService.addObjectMappers(objectMappers);
     }
 
     private MergeResult newMergeContext(boolean simulate) {

--- a/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
@@ -42,6 +42,7 @@ import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.text.StringAndBytesText;
 import org.elasticsearch.common.text.Text;
+import org.elasticsearch.common.util.concurrent.ReleasableLock;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
@@ -186,6 +187,7 @@ public class DocumentMapper implements ToXContent {
 
     private final Query typeFilter;
 
+    private final ReleasableLock mappingWriteLock;
     private final ReentrantReadWriteLock mappingLock;
 
     public DocumentMapper(MapperService mapperService, String index, @Nullable Settings indexSettings, DocumentMapperParser docMapperParser,
@@ -203,9 +205,10 @@ public class DocumentMapper implements ToXContent {
                 rootMappers.values().toArray(new RootMapper[rootMappers.values().size()]),
                 sourceTransforms.toArray(new SourceTransform[sourceTransforms.size()]),
                 meta);
-        this.documentParser = new DocumentParser(index, indexSettings, docMapperParser, this, mappingLock.readLock());
+        this.documentParser = new DocumentParser(index, indexSettings, docMapperParser, this, new ReleasableLock(mappingLock.readLock()));
 
         this.typeFilter = typeMapper().termQuery(type, null);
+        this.mappingWriteLock = new ReleasableLock(mappingLock.writeLock());
         this.mappingLock = mappingLock;
 
         if (rootMapper(ParentFieldMapper.class).active()) {
@@ -419,16 +422,17 @@ public class DocumentMapper implements ToXContent {
     }
 
     private void addObjectMappers(Collection<ObjectMapper> objectMappers) {
-        assert mappingLock.isWriteLockedByCurrentThread();
-        MapBuilder<String, ObjectMapper> builder = MapBuilder.newMapBuilder(this.objectMappers);
-        for (ObjectMapper objectMapper : objectMappers) {
-            builder.put(objectMapper.fullPath(), objectMapper);
-            if (objectMapper.nested().isNested()) {
-                hasNestedObjects = true;
+        try (ReleasableLock lock = mappingWriteLock.acquire()) {
+            MapBuilder<String, ObjectMapper> builder = MapBuilder.newMapBuilder(this.objectMappers);
+            for (ObjectMapper objectMapper : objectMappers) {
+                builder.put(objectMapper.fullPath(), objectMapper);
+                if (objectMapper.nested().isNested()) {
+                    hasNestedObjects = true;
+                }
             }
+            this.objectMappers = builder.immutableMap();
+            mapperService.addObjectMappers(objectMappers);
         }
-        this.objectMappers = builder.immutableMap();
-        mapperService.addObjectMappers(objectMappers);
     }
 
     private MergeResult newMergeContext(boolean simulate) {
@@ -479,8 +483,7 @@ public class DocumentMapper implements ToXContent {
     }
 
     public MergeResult merge(Mapping mapping, boolean simulate) {
-        mappingLock.writeLock().lock();
-        try {
+        try (ReleasableLock lock = mappingWriteLock.acquire()) {
             final MergeResult mergeResult = newMergeContext(simulate);
             this.mapping.merge(mapping, mergeResult);
             if (simulate == false) {
@@ -489,8 +492,6 @@ public class DocumentMapper implements ToXContent {
                 refreshSource();
             }
             return mergeResult;
-        } finally {
-            mappingLock.writeLock().unlock();
         }
     }
 

--- a/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -30,6 +30,7 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.joda.FormatDateTimeFormatter;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ReleasableLock;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentHelper;
@@ -61,9 +62,9 @@ class DocumentParser implements Closeable {
     private final Settings indexSettings;
     private final DocumentMapperParser docMapperParser;
     private final DocumentMapper docMapper;
-    private final Lock parseLock;
+    private final ReleasableLock parseLock;
 
-    public DocumentParser(String index, Settings indexSettings, DocumentMapperParser docMapperParser, DocumentMapper docMapper, Lock parseLock) {
+    public DocumentParser(String index, Settings indexSettings, DocumentMapperParser docMapperParser, DocumentMapper docMapper, ReleasableLock parseLock) {
         this.index = index;
         this.indexSettings = indexSettings;
         this.docMapperParser = docMapperParser;
@@ -72,11 +73,8 @@ class DocumentParser implements Closeable {
     }
 
     public ParsedDocument parseDocument(SourceToParse source, @Nullable DocumentMapper.ParseListener listener) throws MapperParsingException {
-        parseLock.lock();
-        try {
+        try (ReleasableLock lock = parseLock.acquire()){
             return innerParseDocument(source, listener);
-        } finally {
-            parseLock.unlock();
         }
     }
 

--- a/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -21,6 +21,7 @@ package org.elasticsearch.index.mapper;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
+
 import org.apache.lucene.document.Field;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
@@ -44,6 +45,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.locks.Lock;
 
 /** A parser for documents, given mappings from a DocumentMapper */
 class DocumentParser implements Closeable {
@@ -55,19 +57,30 @@ class DocumentParser implements Closeable {
         }
     };
 
-    private String index;
-    private Settings indexSettings;
-    private DocumentMapperParser docMapperParser;
-    private DocumentMapper docMapper;
+    private final String index;
+    private final Settings indexSettings;
+    private final DocumentMapperParser docMapperParser;
+    private final DocumentMapper docMapper;
+    private final Lock parseLock;
 
-    public DocumentParser(String index, Settings indexSettings, DocumentMapperParser docMapperParser, DocumentMapper docMapper) {
+    public DocumentParser(String index, Settings indexSettings, DocumentMapperParser docMapperParser, DocumentMapper docMapper, Lock parseLock) {
         this.index = index;
         this.indexSettings = indexSettings;
         this.docMapperParser = docMapperParser;
         this.docMapper = docMapper;
+        this.parseLock = parseLock;
     }
 
     public ParsedDocument parseDocument(SourceToParse source, @Nullable DocumentMapper.ParseListener listener) throws MapperParsingException {
+        parseLock.lock();
+        try {
+            return innerParseDocument(source, listener);
+        } finally {
+            parseLock.unlock();
+        }
+    }
+
+    private ParsedDocument innerParseDocument(SourceToParse source, @Nullable DocumentMapper.ParseListener listener) throws MapperParsingException {
         ParseContext.InternalParseContext context = cache.get();
 
         final Mapping mapping = docMapper.mapping();

--- a/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -1772,7 +1772,7 @@ public class InternalEngineTests extends ElasticsearchTestCase {
             MapperService mapperService = new MapperService(index, settings, analysisService, null, similarityLookupService, null);
             DocumentMapper.Builder b = new DocumentMapper.Builder(indexName, settings, rootBuilder);
             DocumentMapperParser parser = new DocumentMapperParser(index, settings, mapperService, analysisService, similarityLookupService, null);
-            this.docMapper = b.build(null, parser);
+            this.docMapper = b.build(mapperService, parser);
 
         }
 


### PR DESCRIPTION
When mapping updates happen concurrently with document parsing, bad things can
happen. For instance, when applying a mapping update we first update the Mapping
object which is used for parsing and then FieldNameAnalyzer which is used by
IndexWriter for analysis. So if you are unlucky, it could happen that a document
was parsed successfully without introducing dynamic updates yet IndexWriter does
not see its analyzer yet.

In order to fix this issue, mapping updates are now protected by a write lock
and document parsing is protected by the read lock associated with this write
lock. This ensures that no documents will be parsed while a mapping update is
being applied, so document parsing will either see none of the update or all of
it.
