### PR TITLE
`detect_noop` now understands `null` as a valid value

### DIFF
--- a/src/main/java/org/elasticsearch/common/xcontent/XContentHelper.java
+++ b/src/main/java/org/elasticsearch/common/xcontent/XContentHelper.java
@@ -20,7 +20,9 @@
 package org.elasticsearch.common.xcontent;
 
 import com.google.common.base.Charsets;
+import com.google.common.base.Objects;
 import com.google.common.collect.Maps;
+
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.bytes.BytesArray;
@@ -260,11 +262,11 @@ public class XContentHelper {
             if (modified) {
                 continue;
             }
-            if (!checkUpdatesAreUnequal || old == null) {
+            if (!checkUpdatesAreUnequal) {
                 modified = true;
                 continue;
             }
-            modified = !old.equals(changesEntry.getValue());
+            modified = !Objects.equal(old, changesEntry.getValue());
         }
         return modified;
     }


### PR DESCRIPTION
If the source contrains a null value for a field then detect_noop should
consider setting it to null again to be a noop.

Closes #11208
