### PR TITLE
Remove SmartNameFieldMappers

### DIFF
--- a/src/main/java/org/elasticsearch/action/fieldstats/TransportFieldStatsTransportAction.java
+++ b/src/main/java/org/elasticsearch/action/fieldstats/TransportFieldStatsTransportAction.java
@@ -39,6 +39,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.engine.Engine;
+import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.FieldMappers;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.shard.IndexShard;
@@ -133,12 +134,12 @@ public class TransportFieldStatsTransportAction extends TransportBroadcastOperat
         shard.readAllowed();
         try (Engine.Searcher searcher = shard.acquireSearcher("fieldstats")) {
             for (String field : request.getFields()) {
-                FieldMappers fieldMappers = mapperService.fullName(field);
-                if (fieldMappers != null) {
+                FieldMapper fieldMapper = mapperService.fullName(field);
+                if (fieldMapper != null) {
                     IndexReader reader = searcher.reader();
                     Terms terms = MultiFields.getTerms(reader, field);
                     if (terms != null) {
-                        fieldStats.put(field, fieldMappers.mapper().stats(terms, reader.maxDoc()));
+                        fieldStats.put(field, fieldMapper.stats(terms, reader.maxDoc()));
                     }
                 } else {
                     throw new IllegalArgumentException("field [" + field + "] doesn't exist");

--- a/src/main/java/org/elasticsearch/index/codec/PerFieldMappingPostingFormatCodec.java
+++ b/src/main/java/org/elasticsearch/index/codec/PerFieldMappingPostingFormatCodec.java
@@ -25,14 +25,9 @@ import org.apache.lucene.codecs.lucene50.Lucene50Codec;
 import org.apache.lucene.codecs.lucene50.Lucene50StoredFieldsFormat;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.lucene.Lucene;
-import org.elasticsearch.index.mapper.FieldMappers;
+import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.core.CompletionFieldMapper;
-import org.elasticsearch.search.suggest.completion.Completion090PostingsFormat;
-import org.elasticsearch.search.suggest.completion.Completion090PostingsFormat.CompletionLookupProvider;
-
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * {@link PerFieldMappingPostingFormatCodec This postings format} is the default
@@ -59,12 +54,12 @@ public class PerFieldMappingPostingFormatCodec extends Lucene50Codec {
 
     @Override
     public PostingsFormat getPostingsFormatForField(String field) {
-        final FieldMappers indexName = mapperService.indexName(field);
+        final FieldMapper indexName = mapperService.indexName(field);
         if (indexName == null) {
             logger.warn("no index mapper found for field: [{}] returning default postings format", field);
-        } else if (indexName.mapper() instanceof CompletionFieldMapper) {
+        } else if (indexName instanceof CompletionFieldMapper) {
             // CompletionFieldMapper needs a special postings format
-            final CompletionFieldMapper mapper = (CompletionFieldMapper) indexName.mapper();
+            final CompletionFieldMapper mapper = (CompletionFieldMapper) indexName;
             final PostingsFormat defaultFormat = super.getPostingsFormatForField(field);
             return mapper.postingsFormat(defaultFormat);
         }

--- a/src/main/java/org/elasticsearch/index/fieldvisitor/FieldsVisitor.java
+++ b/src/main/java/org/elasticsearch/index/fieldvisitor/FieldsVisitor.java
@@ -61,13 +61,13 @@ public abstract class FieldsVisitor extends StoredFieldVisitor {
         }
         // can't derive exact mapping type
         for (Map.Entry<String, List<Object>> entry : fields().entrySet()) {
-            FieldMappers fieldMappers = mapperService.indexName(entry.getKey());
+            FieldMapper fieldMappers = mapperService.indexName(entry.getKey());
             if (fieldMappers == null) {
                 continue;
             }
             List<Object> fieldValues = entry.getValue();
             for (int i = 0; i < fieldValues.size(); i++) {
-                fieldValues.set(i, fieldMappers.mapper().valueForSearch(fieldValues.get(i)));
+                fieldValues.set(i, fieldMappers.valueForSearch(fieldValues.get(i)));
             }
         }
     }

--- a/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -447,14 +447,16 @@ public class MapperService extends AbstractIndexComponent  {
     }
 
     /**
-     * Returns {@link FieldMappers} for all the {@link FieldMapper}s that are registered
-     * under the given indexName across all the different {@link DocumentMapper} types.
+     * Returns an {@link FieldMapper} which has the given index name.
      *
-     * @param indexName The indexName to return all the {@link FieldMappers} for across all {@link DocumentMapper}s.
-     * @return All the {@link FieldMappers} across all {@link DocumentMapper}s for the given indexName.
+     * If multiple types have fields with the same index name, the first is returned.
      */
-    public FieldMappers indexName(String indexName) {
-        return fieldMappers.indexName(indexName);
+    public FieldMapper indexName(String indexName) {
+        FieldMappers mappers = fieldMappers.indexName(indexName);
+        if (mappers == null) {
+            return null;
+        }
+        return mappers.mapper();
     }
 
     /**
@@ -464,15 +466,12 @@ public class MapperService extends AbstractIndexComponent  {
      * @param fullName The full name
      * @return All teh {@link FieldMappers} across all the {@link DocumentMapper}s for the given fullName.
      */
-    public FieldMappers fullName(String fullName) {
-        return fieldMappers.fullName(fullName);
-    }
-
-    /**
-     * Returns objects mappers based on the full path of the object.
-     */
-    public ObjectMappers objectMapper(String path) {
-        return fullPathObjectMappers.get(path);
+    public FieldMapper fullName(String fullName) {
+        FieldMappers mappers = fieldMappers.fullName(fullName);
+        if (mappers == null) {
+            return null;
+        }
+        return mappers.mapper();
     }
 
     /**
@@ -510,7 +509,7 @@ public class MapperService extends AbstractIndexComponent  {
 
     public SmartNameObjectMapper smartNameObjectMapper(String smartName, @Nullable String[] types) {
         if (types == null || types.length == 0 || types.length == 1 && types[0].equals("_all")) {
-            ObjectMappers mappers = objectMapper(smartName);
+            ObjectMappers mappers = fullPathObjectMappers.get(smartName);
             if (mappers != null) {
                 return new SmartNameObjectMapper(mappers.mapper(), guessDocMapper(smartName));
             }
@@ -537,61 +536,17 @@ public class MapperService extends AbstractIndexComponent  {
         return null;
     }
 
-    /**
-     * Same as {@link #smartNameFieldMappers(String)} but returns the first field mapper for it. Returns
-     * <tt>null</tt> if there is none.
-     */
     public FieldMapper smartNameFieldMapper(String smartName) {
-        FieldMappers fieldMappers = smartNameFieldMappers(smartName);
-        if (fieldMappers != null) {
-            return fieldMappers.mapper();
-        }
-        return null;
-    }
-
-    public FieldMapper smartNameFieldMapper(String smartName, @Nullable String[] types) {
-        FieldMappers fieldMappers = smartNameFieldMappers(smartName, types);
-        if (fieldMappers != null) {
-            return fieldMappers.mapper();
-        }
-        return null;
-    }
-
-    public FieldMappers smartNameFieldMappers(String smartName, @Nullable String[] types) {
-        if (types == null || types.length == 0) {
-            return smartNameFieldMappers(smartName);
-        }
-        for (String type : types) {
-            DocumentMapper documentMapper = mappers.get(type);
-            // we found a mapper
-            if (documentMapper != null) {
-                // see if we find a field for it
-                FieldMappers mappers = documentMapper.mappers().smartName(smartName);
-                if (mappers != null) {
-                    return mappers;
-                }
-            }
-        }
-        return null;
-    }
-
-    /**
-     * Same as {@link #smartName(String)}, except it returns just the field mappers.
-     */
-    public FieldMappers smartNameFieldMappers(String smartName) {
-        FieldMappers mappers = fullName(smartName);
-        if (mappers != null) {
-            return mappers;
+        FieldMapper mapper = fullName(smartName);
+        if (mapper != null) {
+            return mapper;
         }
         return indexName(smartName);
     }
 
-    public SmartNameFieldMappers smartName(String smartName, @Nullable String[] types) {
+    public FieldMapper smartNameFieldMapper(String smartName, @Nullable String[] types) {
         if (types == null || types.length == 0) {
-            return smartName(smartName);
-        }
-        if (types.length == 1 && types[0].equals("_all")) {
-            return smartName(smartName);
+            return smartNameFieldMapper(smartName);
         }
         for (String type : types) {
             DocumentMapper documentMapper = mappers.get(type);
@@ -600,29 +555,9 @@ public class MapperService extends AbstractIndexComponent  {
                 // see if we find a field for it
                 FieldMappers mappers = documentMapper.mappers().smartName(smartName);
                 if (mappers != null) {
-                    return new SmartNameFieldMappers(this, mappers, documentMapper, false);
+                    return mappers.mapper();
                 }
             }
-        }
-        return null;
-    }
-
-    /**
-     * Returns smart field mappers based on a smart name. A smart name is any of full name or index name.
-     * <p/>
-     * <p>It will first try to find it based on the full name (with the dots if its a compound name). If
-     * it is not found, will try and find it based on the indexName (which can be controlled in the mapping).
-     * <p/>
-     * <p>If nothing is found, returns null.
-     */
-    public SmartNameFieldMappers smartName(String smartName) {
-        FieldMappers fieldMappers = fullName(smartName);
-        if (fieldMappers != null) {
-            return new SmartNameFieldMappers(this, fieldMappers, null, false);
-        }
-        fieldMappers = indexName(smartName);
-        if (fieldMappers != null) {
-            return new SmartNameFieldMappers(this, fieldMappers, null, false);
         }
         return null;
     }
@@ -671,7 +606,7 @@ public class MapperService extends AbstractIndexComponent  {
         } else {
             do {
                 String objectPath = fieldName.substring(0, indexOf);
-                ObjectMappers objectMappers = objectMapper(objectPath);
+                ObjectMappers objectMappers = fullPathObjectMappers.get(objectPath);
                 if (objectMappers == null) {
                     indexOf = objectPath.lastIndexOf('.');
                     continue;
@@ -725,78 +660,6 @@ public class MapperService extends AbstractIndexComponent  {
         }
     }
 
-    public static class SmartNameFieldMappers {
-        private final MapperService mapperService;
-        private final FieldMappers fieldMappers;
-        private final DocumentMapper docMapper;
-
-        public SmartNameFieldMappers(MapperService mapperService, FieldMappers fieldMappers, @Nullable DocumentMapper docMapper, boolean explicitTypeInName) {
-            this.mapperService = mapperService;
-            this.fieldMappers = fieldMappers;
-            this.docMapper = docMapper;
-        }
-
-        /**
-         * Has at least one mapper for the field.
-         */
-        public boolean hasMapper() {
-            return !fieldMappers.isEmpty();
-        }
-
-        /**
-         * The first mapper for the smart named field.
-         */
-        public FieldMapper mapper() {
-            return fieldMappers.mapper();
-        }
-
-        /**
-         * All the field mappers for the smart name field.
-         */
-        public FieldMappers fieldMappers() {
-            return fieldMappers;
-        }
-
-        /**
-         * If the smart name was a typed field, with a type that we resolved, will return
-         * <tt>true</tt>.
-         */
-        public boolean hasDocMapper() {
-            return docMapper != null;
-        }
-
-        /**
-         * If the smart name was a typed field, with a type that we resolved, will return
-         * the document mapper for it.
-         */
-        public DocumentMapper docMapper() {
-            return docMapper;
-        }
-
-        /**
-         * The best effort search analyzer associated with this field.
-         */
-        public Analyzer searchAnalyzer() {
-            if (hasMapper()) {
-                Analyzer analyzer = mapper().searchAnalyzer();
-                if (analyzer != null) {
-                    return analyzer;
-                }
-            }
-            return mapperService.searchAnalyzer();
-        }
-
-        public Analyzer searchQuoteAnalyzer() {
-            if (hasMapper()) {
-                Analyzer analyzer = mapper().searchQuoteAnalyzer();
-                if (analyzer != null) {
-                    return analyzer;
-                }
-            }
-            return mapperService.searchQuoteAnalyzer();
-        }
-    }
-
     final class SmartIndexNameSearchAnalyzer extends DelegatingAnalyzerWrapper {
 
         private final Analyzer defaultAnalyzer;
@@ -808,14 +671,9 @@ public class MapperService extends AbstractIndexComponent  {
 
         @Override
         protected Analyzer getWrappedAnalyzer(String fieldName) {
-            FieldMappers mappers = fieldMappers.fullName(fieldName);
-            if (mappers != null && mappers.mapper() != null && mappers.mapper().searchAnalyzer() != null) {
-                return mappers.mapper().searchAnalyzer();
-            }
-
-            mappers = fieldMappers.indexName(fieldName);
-            if (mappers != null && mappers.mapper() != null && mappers.mapper().searchAnalyzer() != null) {
-                return mappers.mapper().searchAnalyzer();
+            FieldMapper mapper = smartNameFieldMapper(fieldName);
+            if (mapper != null && mapper.searchAnalyzer() != null) {
+                return mapper.searchAnalyzer();
             }
             return defaultAnalyzer;
         }
@@ -832,14 +690,9 @@ public class MapperService extends AbstractIndexComponent  {
 
         @Override
         protected Analyzer getWrappedAnalyzer(String fieldName) {
-            FieldMappers mappers = fieldMappers.fullName(fieldName);
-            if (mappers != null && mappers.mapper() != null && mappers.mapper().searchQuoteAnalyzer() != null) {
-                return mappers.mapper().searchQuoteAnalyzer();
-            }
-
-            mappers = fieldMappers.indexName(fieldName);
-            if (mappers != null && mappers.mapper() != null && mappers.mapper().searchQuoteAnalyzer() != null) {
-                return mappers.mapper().searchQuoteAnalyzer();
+            FieldMapper mapper = smartNameFieldMapper(fieldName);
+            if (mapper != null && mapper.searchQuoteAnalyzer() != null) {
+                return mapper.searchQuoteAnalyzer();
             }
             return defaultAnalyzer;
         }

--- a/src/main/java/org/elasticsearch/index/query/CommonTermsQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/CommonTermsQueryParser.java
@@ -31,7 +31,6 @@ import org.apache.lucene.util.BytesRefBuilder;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.mapper.FieldMapper;
-import org.elasticsearch.index.mapper.MapperService;
 
 import java.io.IOException;
 
@@ -163,11 +162,9 @@ public class CommonTermsQueryParser implements QueryParser {
         if (value == null) {
             throw new QueryParsingException(parseContext, "No text specified for text query");
         }
-        FieldMapper<?> mapper = null;
         String field;
-        MapperService.SmartNameFieldMappers smartNameFieldMappers = parseContext.smartFieldMappers(fieldName);
-        if (smartNameFieldMappers != null && smartNameFieldMappers.hasMapper()) {
-            mapper = smartNameFieldMappers.mapper();
+        FieldMapper<?> mapper = parseContext.fieldMapper(fieldName);
+        if (mapper != null) {
             field = mapper.names().indexName();
         } else {
             field = fieldName;
@@ -178,8 +175,8 @@ public class CommonTermsQueryParser implements QueryParser {
             if (mapper != null) {
                 analyzer = mapper.searchAnalyzer();
             }
-            if (analyzer == null && smartNameFieldMappers != null) {
-                analyzer = smartNameFieldMappers.searchAnalyzer();
+            if (analyzer == null && mapper != null) {
+                analyzer = parseContext.getSearchAnalyzer(mapper);
             }
             if (analyzer == null) {
                 analyzer = parseContext.mapperService().searchAnalyzer();
@@ -193,7 +190,7 @@ public class CommonTermsQueryParser implements QueryParser {
 
         ExtendedCommonTermsQuery commonsQuery = new ExtendedCommonTermsQuery(highFreqOccur, lowFreqOccur, maxTermFrequency, disableCoords, mapper);
         commonsQuery.setBoost(boost);
-        Query query = parseQueryString(commonsQuery, value.toString(), field, parseContext, analyzer, lowFreqMinimumShouldMatch, highFreqMinimumShouldMatch, smartNameFieldMappers);
+        Query query = parseQueryString(commonsQuery, value.toString(), field, parseContext, analyzer, lowFreqMinimumShouldMatch, highFreqMinimumShouldMatch);
         if (queryName != null) {
             parseContext.addNamedQuery(queryName, query);
         }
@@ -202,7 +199,7 @@ public class CommonTermsQueryParser implements QueryParser {
 
 
     private final Query parseQueryString(ExtendedCommonTermsQuery query, String queryString, String field, QueryParseContext parseContext,
-            Analyzer analyzer, String lowFreqMinimumShouldMatch, String highFreqMinimumShouldMatch, MapperService.SmartNameFieldMappers smartNameFieldMappers) throws IOException {
+            Analyzer analyzer, String lowFreqMinimumShouldMatch, String highFreqMinimumShouldMatch) throws IOException {
         // Logic similar to QueryParser#getFieldQuery
         int count = 0;
         try (TokenStream source = analyzer.tokenStream(field, queryString.toString())) {

--- a/src/main/java/org/elasticsearch/index/query/FuzzyQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/FuzzyQueryParser.java
@@ -22,13 +22,12 @@ package org.elasticsearch.index.query;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.FuzzyQuery;
 import org.apache.lucene.search.MultiTermQuery;
-import org.apache.lucene.search.MultiTermQuery.RewriteMethod;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.query.support.QueryParsers;
 
 import java.io.IOException;
@@ -115,11 +114,9 @@ public class FuzzyQueryParser implements QueryParser {
         }
 
         Query query = null;
-        MapperService.SmartNameFieldMappers smartNameFieldMappers = parseContext.smartFieldMappers(fieldName);
-        if (smartNameFieldMappers != null) {
-            if (smartNameFieldMappers.hasMapper()) {
-                query = smartNameFieldMappers.mapper().fuzzyQuery(value, fuzziness, prefixLength, maxExpansions, transpositions);
-            }
+        FieldMapper mapper = parseContext.fieldMapper(fieldName);
+        if (mapper != null) {
+            query = mapper.fuzzyQuery(value, fuzziness, prefixLength, maxExpansions, transpositions);
         }
         if (query == null) {
             query = new FuzzyQuery(new Term(fieldName, value), fuzziness.asDistance(value), prefixLength, maxExpansions, transpositions);

--- a/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxQueryParser.java
@@ -27,7 +27,6 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.fielddata.IndexGeoPointFieldData;
 import org.elasticsearch.index.mapper.FieldMapper;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.geo.GeoPointFieldMapper;
 import org.elasticsearch.index.search.geo.InMemoryGeoBoundingBoxQuery;
 import org.elasticsearch.index.search.geo.IndexedGeoBoundingBoxQuery;
@@ -161,11 +160,10 @@ public class GeoBoundingBoxQueryParser implements QueryParser {
             }
         }
 
-        MapperService.SmartNameFieldMappers smartMappers = parseContext.smartFieldMappers(fieldName);
-        if (smartMappers == null || !smartMappers.hasMapper()) {
+        FieldMapper mapper = parseContext.fieldMapper(fieldName);
+        if (mapper == null) {
             throw new QueryParsingException(parseContext, "failed to find geo_point field [" + fieldName + "]");
         }
-        FieldMapper<?> mapper = smartMappers.mapper();
         if (!(mapper instanceof GeoPointFieldMapper)) {
             throw new QueryParsingException(parseContext, "field [" + fieldName + "] is not a geo_point field");
         }

--- a/src/main/java/org/elasticsearch/index/query/GeoDistanceQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoDistanceQueryParser.java
@@ -29,7 +29,6 @@ import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.fielddata.IndexGeoPointFieldData;
 import org.elasticsearch.index.mapper.FieldMapper;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.geo.GeoPointFieldMapper;
 import org.elasticsearch.index.search.geo.GeoDistanceRangeQuery;
 
@@ -148,11 +147,10 @@ public class GeoDistanceQueryParser implements QueryParser {
             GeoUtils.normalizePoint(point, normalizeLat, normalizeLon);
         }
 
-        MapperService.SmartNameFieldMappers smartMappers = parseContext.smartFieldMappers(fieldName);
-        if (smartMappers == null || !smartMappers.hasMapper()) {
+        FieldMapper mapper = parseContext.fieldMapper(fieldName);
+        if (mapper == null) {
             throw new QueryParsingException(parseContext, "failed to find geo_point field [" + fieldName + "]");
         }
-        FieldMapper<?> mapper = smartMappers.mapper();
         if (!(mapper instanceof GeoPointFieldMapper)) {
             throw new QueryParsingException(parseContext, "field [" + fieldName + "] is not a geo_point field");
         }

--- a/src/main/java/org/elasticsearch/index/query/GeoDistanceRangeQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoDistanceRangeQueryParser.java
@@ -29,7 +29,6 @@ import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.fielddata.IndexGeoPointFieldData;
 import org.elasticsearch.index.mapper.FieldMapper;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.geo.GeoPointFieldMapper;
 import org.elasticsearch.index.search.geo.GeoDistanceRangeQuery;
 
@@ -188,11 +187,10 @@ public class GeoDistanceRangeQueryParser implements QueryParser {
             GeoUtils.normalizePoint(point, normalizeLat, normalizeLon);
         }
 
-        MapperService.SmartNameFieldMappers smartMappers = parseContext.smartFieldMappers(fieldName);
-        if (smartMappers == null || !smartMappers.hasMapper()) {
+        FieldMapper mapper = parseContext.fieldMapper(fieldName);
+        if (mapper == null) {
             throw new QueryParsingException(parseContext, "failed to find geo_point field [" + fieldName + "]");
         }
-        FieldMapper<?> mapper = smartMappers.mapper();
         if (!(mapper instanceof GeoPointFieldMapper)) {
             throw new QueryParsingException(parseContext, "field [" + fieldName + "] is not a geo_point field");
         }

--- a/src/main/java/org/elasticsearch/index/query/GeoPolygonQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoPolygonQueryParser.java
@@ -29,7 +29,6 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentParser.Token;
 import org.elasticsearch.index.fielddata.IndexGeoPointFieldData;
 import org.elasticsearch.index.mapper.FieldMapper;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.geo.GeoPointFieldMapper;
 import org.elasticsearch.index.search.geo.GeoPolygonQuery;
 
@@ -137,11 +136,10 @@ public class GeoPolygonQueryParser implements QueryParser {
             }
         }
 
-        MapperService.SmartNameFieldMappers smartMappers = parseContext.smartFieldMappers(fieldName);
-        if (smartMappers == null || !smartMappers.hasMapper()) {
+        FieldMapper mapper = parseContext.fieldMapper(fieldName);
+        if (mapper == null) {
             throw new QueryParsingException(parseContext, "failed to find geo_point field [" + fieldName + "]");
         }
-        FieldMapper<?> mapper = smartMappers.mapper();
         if (!(mapper instanceof GeoPointFieldMapper)) {
             throw new QueryParsingException(parseContext, "field [" + fieldName + "] is not a geo_point field");
         }

--- a/src/main/java/org/elasticsearch/index/query/GeoShapeQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoShapeQueryParser.java
@@ -32,7 +32,6 @@ import org.elasticsearch.common.geo.builders.ShapeBuilder;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.mapper.FieldMapper;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.geo.GeoShapeFieldMapper;
 import org.elasticsearch.index.search.shape.ShapeFetchService;
 import org.elasticsearch.search.internal.SearchContext;
@@ -139,12 +138,11 @@ public class GeoShapeQueryParser implements QueryParser {
             throw new QueryParsingException(parseContext, "No Shape Relation defined");
         }
 
-        MapperService.SmartNameFieldMappers smartNameFieldMappers = parseContext.smartFieldMappers(fieldName);
-        if (smartNameFieldMappers == null || !smartNameFieldMappers.hasMapper()) {
+        FieldMapper fieldMapper = parseContext.fieldMapper(fieldName);
+        if (fieldMapper == null) {
             throw new QueryParsingException(parseContext, "Failed to find geo_shape field [" + fieldName + "]");
         }
 
-        FieldMapper fieldMapper = smartNameFieldMappers.mapper();
         // TODO: This isn't the nicest way to check this
         if (!(fieldMapper instanceof GeoShapeFieldMapper)) {
             throw new QueryParsingException(parseContext, "Field [" + fieldName + "] is not a geo_shape");

--- a/src/main/java/org/elasticsearch/index/query/GeohashCellQuery.java
+++ b/src/main/java/org/elasticsearch/index/query/GeohashCellQuery.java
@@ -32,7 +32,6 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentParser.Token;
 import org.elasticsearch.index.mapper.FieldMapper;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.core.StringFieldMapper;
 import org.elasticsearch.index.mapper.geo.GeoPointFieldMapper;
 
@@ -237,12 +236,11 @@ public class GeohashCellQuery {
                 throw new QueryParsingException(parseContext, "no geohash value provided to geohash_cell filter");
             }
 
-            MapperService.SmartNameFieldMappers smartMappers = parseContext.smartFieldMappers(fieldName);
-            if (smartMappers == null || !smartMappers.hasMapper()) {
+            FieldMapper mapper = parseContext.fieldMapper(fieldName);
+            if (mapper == null) {
                 throw new QueryParsingException(parseContext, "failed to find geo_point field [" + fieldName + "]");
             }
 
-            FieldMapper<?> mapper = smartMappers.mapper();
             if (!(mapper instanceof GeoPointFieldMapper)) {
                 throw new QueryParsingException(parseContext, "field [" + fieldName + "] is not a geo_point field");
             }

--- a/src/main/java/org/elasticsearch/index/query/MissingQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MissingQueryParser.java
@@ -29,7 +29,7 @@ import org.apache.lucene.search.TermRangeQuery;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.mapper.FieldMappers;
+import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.internal.FieldNamesFieldMapper;
 
@@ -95,8 +95,7 @@ public class MissingQueryParser implements QueryParser {
             throw new QueryParsingException(parseContext, "missing must have either existence, or null_value, or both set to true");
         }
 
-        final FieldMappers fieldNamesMappers = parseContext.mapperService().fullName(FieldNamesFieldMapper.NAME);
-        final FieldNamesFieldMapper fieldNamesMapper = (FieldNamesFieldMapper)fieldNamesMappers.mapper();
+        final FieldNamesFieldMapper fieldNamesMapper = (FieldNamesFieldMapper)parseContext.mapperService().fullName(FieldNamesFieldMapper.NAME);
         MapperService.SmartNameObjectMapper smartNameObjectMapper = parseContext.smartObjectMapper(fieldPattern);
         if (smartNameObjectMapper != null && smartNameObjectMapper.hasMapper()) {
             // automatic make the object mapper pattern
@@ -118,20 +117,20 @@ public class MissingQueryParser implements QueryParser {
         if (existence) {
             BooleanQuery boolFilter = new BooleanQuery();
             for (String field : fields) {
-                MapperService.SmartNameFieldMappers smartNameFieldMappers = parseContext.smartFieldMappers(field);
+                FieldMapper mapper = parseContext.fieldMapper(field);
                 Query filter = null;
                 if (fieldNamesMapper != null && fieldNamesMapper.enabled()) {
                     final String f;
-                    if (smartNameFieldMappers != null && smartNameFieldMappers.hasMapper()) {
-                        f = smartNameFieldMappers.mapper().names().indexName();
+                    if (mapper != null) {
+                        f = mapper.names().indexName();
                     } else {
                         f = field;
                     }
                     filter = fieldNamesMapper.termQuery(f, parseContext);
                 }
                 // if _field_names are not indexed, we need to go the slow way
-                if (filter == null && smartNameFieldMappers != null && smartNameFieldMappers.hasMapper()) {
-                    filter = smartNameFieldMappers.mapper().rangeQuery(null, null, true, true, parseContext);
+                if (filter == null && mapper != null) {
+                    filter = mapper.rangeQuery(null, null, true, true, parseContext);
                 }
                 if (filter == null) {
                     filter = new TermRangeQuery(field, null, null, true, true);
@@ -145,9 +144,9 @@ public class MissingQueryParser implements QueryParser {
 
         if (nullValue) {
             for (String field : fields) {
-                MapperService.SmartNameFieldMappers smartNameFieldMappers = parseContext.smartFieldMappers(field);
-                if (smartNameFieldMappers != null && smartNameFieldMappers.hasMapper()) {
-                    nullFilter = smartNameFieldMappers.mapper().nullValueFilter();
+                FieldMapper mapper = parseContext.fieldMapper(field);
+                if (mapper != null) {
+                    nullFilter = mapper.nullValueFilter();
                 }
             }
         }

--- a/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryParser.java
@@ -37,6 +37,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.lucene.search.MoreLikeThisQuery;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.analysis.Analysis;
+import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.internal.UidFieldMapper;
 import org.elasticsearch.index.search.morelikethis.MoreLikeThisFetchService;
 import org.elasticsearch.search.internal.SearchContext;
@@ -164,7 +165,9 @@ public class MoreLikeThisQueryParser implements QueryParser {
                 } else if ("fields".equals(currentFieldName)) {
                     moreLikeFields = Lists.newLinkedList();
                     while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
-                        moreLikeFields.add(parseContext.indexName(parser.text()));
+                        String field = parser.text();
+                        FieldMapper mapper = parseContext.fieldMapper(field);
+                        moreLikeFields.add(mapper == null ? field : mapper.names().indexName());
                     }
                 } else if (Fields.DOCUMENT_IDS.match(currentFieldName, parseContext.parseFlags())) {
                     while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {

--- a/src/main/java/org/elasticsearch/index/query/PrefixQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/PrefixQueryParser.java
@@ -26,7 +26,7 @@ import org.apache.lucene.search.Query;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.query.support.QueryParsers;
 
 import java.io.IOException;
@@ -100,9 +100,9 @@ public class PrefixQueryParser implements QueryParser {
         MultiTermQuery.RewriteMethod method = QueryParsers.parseRewriteMethod(rewriteMethod, null);
 
         Query query = null;
-        MapperService.SmartNameFieldMappers smartNameFieldMappers = parseContext.smartFieldMappers(fieldName);
-        if (smartNameFieldMappers != null && smartNameFieldMappers.hasMapper()) {
-            query = smartNameFieldMappers.mapper().prefixQuery(value, method, parseContext);
+        FieldMapper mapper = parseContext.fieldMapper(fieldName);
+        if (mapper != null) {
+            query = mapper.prefixQuery(value, method, parseContext);
         }
         if (query == null) {
             PrefixQuery prefixQuery = new PrefixQuery(new Term(fieldName, BytesRefs.toBytesRef(value)));

--- a/src/main/java/org/elasticsearch/index/query/QueryParseContext.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryParseContext.java
@@ -22,6 +22,7 @@ package org.elasticsearch.index.query;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 
+import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.queryparser.classic.MapperQueryParser;
 import org.apache.lucene.queryparser.classic.QueryParserSettings;
 import org.apache.lucene.search.Filter;
@@ -282,32 +283,36 @@ public class QueryParseContext {
         }
     }
 
-    public FieldMapper fieldMapper(String name) {
-        FieldMappers fieldMappers = indexQueryParser.mapperService.smartNameFieldMappers(name, getTypes());
-        if (fieldMappers == null) {
-            return null;
-        }
-        return fieldMappers.mapper();
-    }
-
-    public String indexName(String name) {
-        FieldMapper smartMapper = fieldMapper(name);
-        if (smartMapper == null) {
-            return name;
-        }
-        return smartMapper.names().indexName();
-    }
-
     public List<String> simpleMatchToIndexNames(String pattern) {
         return indexQueryParser.mapperService.simpleMatchToIndexNames(pattern, getTypes());
     }
 
-    public MapperService.SmartNameFieldMappers smartFieldMappers(String name) {
-        return failIfFieldMappingNotFound(name, indexQueryParser.mapperService.smartName(name, getTypes()));
+    public FieldMapper fieldMapper(String name) {
+        return failIfFieldMappingNotFound(name, indexQueryParser.mapperService.smartNameFieldMapper(name, getTypes()));
     }
 
     public MapperService.SmartNameObjectMapper smartObjectMapper(String name) {
         return indexQueryParser.mapperService.smartNameObjectMapper(name, getTypes());
+    }
+
+    /** Gets the search analyzer for the given field, or the default if there is none present for the field
+     * TODO: remove this by moving defaults into mappers themselves
+     */
+    public Analyzer getSearchAnalyzer(FieldMapper mapper) {
+        if (mapper.searchAnalyzer() != null) {
+            return mapper.searchAnalyzer();
+        }
+        return mapperService().searchAnalyzer();
+    }
+
+    /** Gets the search quote nalyzer for the given field, or the default if there is none present for the field
+     * TODO: remove this by moving defaults into mappers themselves
+     */
+    public Analyzer getSearchQuoteAnalyzer(FieldMapper mapper) {
+        if (mapper.searchQuoteAnalyzer() != null) {
+            return mapper.searchQuoteAnalyzer();
+        }
+        return mapperService().searchQuoteAnalyzer();
     }
 
     public void setAllowUnmappedFields(boolean allowUnmappedFields) {
@@ -318,7 +323,7 @@ public class QueryParseContext {
         this.mapUnmappedFieldAsString = mapUnmappedFieldAsString;
     }
 
-    private MapperService.SmartNameFieldMappers failIfFieldMappingNotFound(String name, MapperService.SmartNameFieldMappers fieldMapping) {
+    private FieldMapper failIfFieldMappingNotFound(String name, FieldMapper fieldMapping) {
         if (allowUnmappedFields) {
             return fieldMapping;
         } else if (mapUnmappedFieldAsString){
@@ -326,7 +331,7 @@ public class QueryParseContext {
             // it would be better to pass the real index settings, but they are not easily accessible from here...
             Settings settings = ImmutableSettings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, indexQueryParser.getIndexCreatedVersion()).build();
             StringFieldMapper stringFieldMapper = builder.build(new Mapper.BuilderContext(settings, new ContentPath(1)));
-            return new MapperService.SmartNameFieldMappers(mapperService(), new FieldMappers(stringFieldMapper), null, false);
+            return stringFieldMapper;
         } else {
             Version indexCreatedVersion = indexQueryParser.getIndexCreatedVersion();
             if (fieldMapping == null && indexCreatedVersion.onOrAfter(Version.V_1_4_0_Beta1)) {

--- a/src/main/java/org/elasticsearch/index/query/RegexpQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/RegexpQueryParser.java
@@ -24,11 +24,10 @@ import org.apache.lucene.search.MultiTermQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.RegexpQuery;
 import org.apache.lucene.util.automaton.Operations;
-import org.apache.lucene.util.automaton.RegExp;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.query.support.QueryParsers;
 
 import java.io.IOException;
@@ -109,9 +108,9 @@ public class RegexpQueryParser implements QueryParser {
         MultiTermQuery.RewriteMethod method = QueryParsers.parseRewriteMethod(rewriteMethod, null);
 
         Query query = null;
-        MapperService.SmartNameFieldMappers smartNameFieldMappers = parseContext.smartFieldMappers(fieldName);
-        if (smartNameFieldMappers != null && smartNameFieldMappers.hasMapper()) {
-            query = smartNameFieldMappers.mapper().regexpQuery(value, flagsValue, maxDeterminizedStates, method, parseContext);
+        FieldMapper mapper = parseContext.fieldMapper(fieldName);
+        if (mapper != null) {
+            query = mapper.regexpQuery(value, flagsValue, maxDeterminizedStates, method, parseContext);
         }
         if (query == null) {
             RegexpQuery regexpQuery = new RegexpQuery(new Term(fieldName, BytesRefs.toBytesRef(value)), flagsValue, maxDeterminizedStates);

--- a/src/main/java/org/elasticsearch/index/query/SimpleQueryStringParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SimpleQueryStringParser.java
@@ -30,7 +30,7 @@ import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.LocaleUtils;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.FieldMapper;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -130,9 +130,9 @@ public class SimpleQueryStringParser implements QueryParser {
                                 fieldsAndWeights.put(fieldName, fBoost);
                             }
                         } else {
-                            MapperService.SmartNameFieldMappers mappers = parseContext.smartFieldMappers(fField);
-                            if (mappers != null && mappers.hasMapper()) {
-                                fieldsAndWeights.put(mappers.mapper().names().indexName(), fBoost);
+                            FieldMapper mapper = parseContext.fieldMapper(fField);
+                            if (mapper != null) {
+                                fieldsAndWeights.put(mapper.names().indexName(), fBoost);
                             } else {
                                 fieldsAndWeights.put(fField, fBoost);
                             }

--- a/src/main/java/org/elasticsearch/index/query/SpanTermQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanTermQueryParser.java
@@ -26,7 +26,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.FieldMapper;
 
 import java.io.IOException;
 
@@ -93,12 +93,10 @@ public class SpanTermQueryParser implements QueryParser {
         }
 
         BytesRef valueBytes = null;
-        MapperService.SmartNameFieldMappers smartNameFieldMappers = parseContext.smartFieldMappers(fieldName);
-        if (smartNameFieldMappers != null) {
-            if (smartNameFieldMappers.hasMapper()) {
-                fieldName = smartNameFieldMappers.mapper().names().indexName();
-                valueBytes = smartNameFieldMappers.mapper().indexedValueForSearch(value);
-            }
+        FieldMapper mapper = parseContext.fieldMapper(fieldName);
+        if (mapper != null) {
+            fieldName = mapper.names().indexName();
+            valueBytes = mapper.indexedValueForSearch(value);
         }
         if (valueBytes == null) {
             valueBytes = new BytesRef(value);

--- a/src/main/java/org/elasticsearch/index/query/TermQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TermQueryParser.java
@@ -25,7 +25,7 @@ import org.apache.lucene.search.TermQuery;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.FieldMapper;
 
 import java.io.IOException;
 
@@ -97,9 +97,9 @@ public class TermQueryParser implements QueryParser {
         }
 
         Query query = null;
-        MapperService.SmartNameFieldMappers smartNameFieldMappers = parseContext.smartFieldMappers(fieldName);
-        if (smartNameFieldMappers != null && smartNameFieldMappers.hasMapper()) {
-            query = smartNameFieldMappers.mapper().termQuery(value, parseContext);
+        FieldMapper mapper = parseContext.fieldMapper(fieldName);
+        if (mapper != null) {
+            query = mapper.termQuery(value, parseContext);
         }
         if (query == null) {
             query = new TermQuery(new Term(fieldName, BytesRefs.toBytesRef(value)));

--- a/src/main/java/org/elasticsearch/index/query/TermsQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TermsQueryParser.java
@@ -37,7 +37,6 @@ import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.index.mapper.FieldMapper;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.indices.cache.filter.terms.TermsLookup;
 import org.elasticsearch.search.internal.SearchContext;
 
@@ -74,7 +73,6 @@ public class TermsQueryParser implements QueryParser {
     public Query parse(QueryParseContext parseContext) throws IOException, QueryParsingException {
         XContentParser parser = parseContext.parser();
 
-        MapperService.SmartNameFieldMappers smartNameFieldMappers;
         String queryName = null;
         String currentFieldName = null;
 
@@ -160,13 +158,9 @@ public class TermsQueryParser implements QueryParser {
             throw new QueryParsingException(parseContext, "terms query requires a field name, followed by array of terms");
         }
 
-        FieldMapper<?> fieldMapper = null;
-        smartNameFieldMappers = parseContext.smartFieldMappers(fieldName);
-        if (smartNameFieldMappers != null) {
-            if (smartNameFieldMappers.hasMapper()) {
-                fieldMapper = smartNameFieldMappers.mapper();
-                fieldName = fieldMapper.names().indexName();
-            }
+        FieldMapper<?> fieldMapper = parseContext.fieldMapper(fieldName);
+        if (fieldMapper != null) {
+            fieldName = fieldMapper.names().indexName();
         }
 
         if (lookupId != null) {

--- a/src/main/java/org/elasticsearch/index/query/WildcardQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/WildcardQueryParser.java
@@ -25,7 +25,7 @@ import org.apache.lucene.search.WildcardQuery;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.query.support.QueryParsers;
 
 import java.io.IOException;
@@ -93,10 +93,10 @@ public class WildcardQueryParser implements QueryParser {
         }
 
         BytesRef valueBytes;
-        MapperService.SmartNameFieldMappers smartNameFieldMappers = parseContext.smartFieldMappers(fieldName);
-        if (smartNameFieldMappers != null && smartNameFieldMappers.hasMapper()) {
-            fieldName = smartNameFieldMappers.mapper().names().indexName();
-            valueBytes = smartNameFieldMappers.mapper().indexedValueForSearch(value);
+        FieldMapper mapper = parseContext.fieldMapper(fieldName);
+        if (mapper != null) {
+            fieldName = mapper.names().indexName();
+            valueBytes = mapper.indexedValueForSearch(value);
         } else {
             valueBytes = new BytesRef(value);
         }

--- a/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionParser.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionParser.java
@@ -40,7 +40,6 @@ import org.elasticsearch.index.fielddata.MultiGeoPointValues;
 import org.elasticsearch.index.fielddata.NumericDoubleValues;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 import org.elasticsearch.index.mapper.FieldMapper;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.core.DateFieldMapper;
 import org.elasticsearch.index.mapper.core.NumberFieldMapper;
 import org.elasticsearch.index.mapper.geo.GeoPointFieldMapper;
@@ -152,12 +151,11 @@ public abstract class DecayFunctionParser implements ScoreFunctionParser {
 
         // now, the field must exist, else we cannot read the value for
         // the doc later
-        MapperService.SmartNameFieldMappers smartMappers = parseContext.smartFieldMappers(fieldName);
-        if (smartMappers == null || !smartMappers.hasMapper()) {
+        FieldMapper mapper = parseContext.fieldMapper(fieldName);
+        if (mapper == null) {
             throw new QueryParsingException(parseContext, "Unknown field [" + fieldName + "]");
         }
 
-        FieldMapper<?> mapper = smartMappers.fieldMappers().mapper();
         // dates and time need special handling
         parser.nextToken();
         if (mapper instanceof DateFieldMapper) {

--- a/src/main/java/org/elasticsearch/index/search/MultiMatchQuery.java
+++ b/src/main/java/org/elasticsearch/index/search/MultiMatchQuery.java
@@ -30,7 +30,6 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.index.mapper.FieldMapper;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.MultiMatchQueryBuilder;
 import org.elasticsearch.index.query.QueryParseContext;
 
@@ -163,16 +162,16 @@ public class MultiMatchQuery extends MatchQuery {
             List<Tuple<String, Float>> missing = new ArrayList<>();
             for (Map.Entry<String, Float> entry : fieldNames.entrySet()) {
                 String name = entry.getKey();
-                MapperService.SmartNameFieldMappers smartNameFieldMappers = parseContext.smartFieldMappers(name);
-                if (smartNameFieldMappers != null && smartNameFieldMappers.hasMapper()) {
-                    Analyzer actualAnalyzer = getAnalyzer(smartNameFieldMappers.mapper(), smartNameFieldMappers);
-                    name = smartNameFieldMappers.mapper().names().indexName();
+                FieldMapper mapper = parseContext.fieldMapper(name);
+                if (mapper != null) {
+                    Analyzer actualAnalyzer = getAnalyzer(mapper);
+                    name = mapper.names().indexName();
                     if (!groups.containsKey(actualAnalyzer)) {
                        groups.put(actualAnalyzer, new ArrayList<FieldAndMapper>());
                     }
                     Float boost = entry.getValue();
                     boost = boost == null ? Float.valueOf(1.0f) : boost;
-                    groups.get(actualAnalyzer).add(new FieldAndMapper(name, smartNameFieldMappers.mapper(), boost));
+                    groups.get(actualAnalyzer).add(new FieldAndMapper(name, mapper, boost));
                 } else {
                     missing.add(new Tuple(name, entry.getValue()));
                 }

--- a/src/main/java/org/elasticsearch/indices/ttl/IndicesTTLService.java
+++ b/src/main/java/org/elasticsearch/indices/ttl/IndicesTTLService.java
@@ -41,6 +41,7 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.fieldvisitor.UidAndRoutingFieldsVisitor;
+import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.FieldMappers;
 import org.elasticsearch.index.mapper.Uid;
@@ -170,15 +171,11 @@ public class IndicesTTLService extends AbstractLifecycleComponent<IndicesTTLServ
                     continue;
                 }
 
-                // should be optimized with the hasTTL flag
-                FieldMappers ttlFieldMappers = indexService.mapperService().fullName(TTLFieldMapper.NAME);
-                if (ttlFieldMappers == null) {
-                    continue;
-                }
                 // check if ttl is enabled for at least one type of this index
                 boolean hasTTLEnabled = false;
-                for (FieldMapper ttlFieldMapper : ttlFieldMappers) {
-                    if (((TTLFieldMapper) ttlFieldMapper).enabled()) {
+                for (String type : indexService.mapperService().types()) {
+                    DocumentMapper documentType = indexService.mapperService().documentMapper(type);
+                    if (documentType.TTLFieldMapper().enabled()) {
                         hasTTLEnabled = true;
                         break;
                     }

--- a/src/main/java/org/elasticsearch/percolator/PercolateContext.java
+++ b/src/main/java/org/elasticsearch/percolator/PercolateContext.java
@@ -652,16 +652,6 @@ public class PercolateContext extends SearchContext {
     }
 
     @Override
-    public MapperService.SmartNameFieldMappers smartFieldMappers(String name) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public FieldMappers smartNameFieldMappers(String name) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public FieldMapper smartNameFieldMapper(String name) {
         return mapperService().smartNameFieldMapper(name, types);
     }

--- a/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
+++ b/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
@@ -44,6 +44,7 @@ import org.elasticsearch.index.fieldvisitor.FieldsVisitor;
 import org.elasticsearch.index.fieldvisitor.JustUidFieldsVisitor;
 import org.elasticsearch.index.fieldvisitor.UidAndSourceFieldsVisitor;
 import org.elasticsearch.index.mapper.DocumentMapper;
+import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.FieldMappers;
 import org.elasticsearch.index.mapper.internal.SourceFieldMapper;
 import org.elasticsearch.index.mapper.object.ObjectMapper;
@@ -67,7 +68,12 @@ import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.lookup.SourceLookup;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static org.elasticsearch.common.xcontent.XContentFactory.contentBuilder;
@@ -136,17 +142,17 @@ public class FetchPhase implements SearchPhase {
                     }
                     continue;
                 }
-                FieldMappers x = context.smartNameFieldMappers(fieldName);
-                if (x == null) {
+                FieldMapper mapper = context.smartNameFieldMapper(fieldName);
+                if (mapper == null) {
                     // Only fail if we know it is a object field, missing paths / fields shouldn't fail.
                     if (context.smartNameObjectMapper(fieldName) != null) {
                         throw new IllegalArgumentException("field [" + fieldName + "] isn't a leaf field");
                     }
-                } else if (x.mapper().fieldType().stored()) {
+                } else if (mapper.fieldType().stored()) {
                     if (fieldNames == null) {
                         fieldNames = new HashSet<>();
                     }
-                    fieldNames.add(x.mapper().names().indexName());
+                    fieldNames.add(mapper.names().indexName());
                 } else {
                     if (extractFieldNames == null) {
                         extractFieldNames = newArrayList();

--- a/src/main/java/org/elasticsearch/search/internal/DefaultSearchContext.java
+++ b/src/main/java/org/elasticsearch/search/internal/DefaultSearchContext.java
@@ -713,16 +713,6 @@ public class DefaultSearchContext extends SearchContext {
     }
 
     @Override
-    public MapperService.SmartNameFieldMappers smartFieldMappers(String name) {
-        return mapperService().smartName(name, request.types());
-    }
-
-    @Override
-    public FieldMappers smartNameFieldMappers(String name) {
-        return mapperService().smartNameFieldMappers(name, request.types());
-    }
-
-    @Override
     public FieldMapper smartNameFieldMapper(String name) {
         return mapperService().smartNameFieldMapper(name, request.types());
     }

--- a/src/main/java/org/elasticsearch/search/internal/FilteredSearchContext.java
+++ b/src/main/java/org/elasticsearch/search/internal/FilteredSearchContext.java
@@ -532,16 +532,6 @@ public abstract class FilteredSearchContext extends SearchContext {
     }
 
     @Override
-    public MapperService.SmartNameFieldMappers smartFieldMappers(String name) {
-        return in.smartFieldMappers(name);
-    }
-
-    @Override
-    public FieldMappers smartNameFieldMappers(String name) {
-        return in.smartNameFieldMappers(name);
-    }
-
-    @Override
     public FieldMapper smartNameFieldMapper(String name) {
         return in.smartNameFieldMapper(name);
     }

--- a/src/main/java/org/elasticsearch/search/internal/SearchContext.java
+++ b/src/main/java/org/elasticsearch/search/internal/SearchContext.java
@@ -343,10 +343,6 @@ public abstract class SearchContext implements Releasable, HasContextAndHeaders 
 
     public abstract ScanContext scanContext();
 
-    public abstract MapperService.SmartNameFieldMappers smartFieldMappers(String name);
-
-    public abstract FieldMappers smartNameFieldMappers(String name);
-
     public abstract FieldMapper smartNameFieldMapper(String name);
 
     /**

--- a/src/test/java/org/elasticsearch/index/mapper/DynamicMappingTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/DynamicMappingTests.java
@@ -166,8 +166,8 @@ public class DynamicMappingTests extends ElasticsearchSingleNodeTest {
     public void testDynamicMappingOnEmptyString() throws Exception {
         IndexService service = createIndex("test");
         client().prepareIndex("test", "type").setSource("empty_field", "").get();
-        FieldMappers mappers = service.mapperService().fullName("empty_field");
-        assertTrue(mappers != null && mappers.isEmpty() == false);
+        FieldMapper mapper = service.mapperService().fullName("empty_field");
+        assertNotNull(mapper);
     }
 
     public void testTypeNotCreatedOnIndexFailure() throws IOException, InterruptedException {

--- a/src/test/java/org/elasticsearch/test/TestSearchContext.java
+++ b/src/test/java/org/elasticsearch/test/TestSearchContext.java
@@ -552,16 +552,6 @@ public class TestSearchContext extends SearchContext {
     }
 
     @Override
-    public MapperService.SmartNameFieldMappers smartFieldMappers(String name) {
-        return null;
-    }
-
-    @Override
-    public FieldMappers smartNameFieldMappers(String name) {
-        return null;
-    }
-
-    @Override
     public FieldMapper<?> smartNameFieldMapper(String name) {
         if (mapperService() != null) {
             return mapperService().smartNameFieldMapper(name, types());


### PR DESCRIPTION
This change simplifies the users of the mapper service to no
longer have access to multiple fields for a single name. While
FieldMappersLookup still stores and gives access to multiple
fields for a single name, the current users of SmartNameFieldMappers already all
assumed a single field. The arbitrary selection of that field
when multiple exist is now isolated to the mapper service.
