### PR TITLE
Remove need for generics in ContextAndHeaderHolder

### DIFF
--- a/src/main/java/org/elasticsearch/common/ContextAndHeaderHolder.java
+++ b/src/main/java/org/elasticsearch/common/ContextAndHeaderHolder.java
@@ -31,7 +31,7 @@ import java.util.Set;
 /**
  *
  */
-public class ContextAndHeaderHolder<T> implements HasContextAndHeaders {
+public class ContextAndHeaderHolder implements HasContextAndHeaders {
 
     private ObjectObjectHashMap<Object, Object> context;
     protected Map<String, Object> headers;
@@ -113,12 +113,11 @@ public class ContextAndHeaderHolder<T> implements HasContextAndHeaders {
 
     @SuppressWarnings("unchecked")
     @Override
-    public final T putHeader(String key, Object value) {
+    public final void putHeader(String key, Object value) {
         if (headers == null) {
             headers = new HashMap<>();
         }
         headers.put(key, value);
-        return (T) this;
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/org/elasticsearch/common/HasHeaders.java
+++ b/src/main/java/org/elasticsearch/common/HasHeaders.java
@@ -26,7 +26,7 @@ import java.util.Set;
  */
 public interface HasHeaders {
 
-    <V> V putHeader(String key, V value);
+    <V> void putHeader(String key, V value);
 
     <V> V getHeader(String key);
 

--- a/src/main/java/org/elasticsearch/percolator/PercolateContext.java
+++ b/src/main/java/org/elasticsearch/percolator/PercolateContext.java
@@ -45,7 +45,6 @@ import org.elasticsearch.index.cache.bitset.BitsetFilterCache;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.fielddata.IndexFieldDataService;
 import org.elasticsearch.index.mapper.FieldMapper;
-import org.elasticsearch.index.mapper.FieldMappers;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.index.query.IndexQueryParserService;
@@ -683,7 +682,7 @@ public class PercolateContext extends SearchContext {
 
     @Override
     public <V> V putInContext(Object key, Object value) {
-        assert false : "percolatocontext does not support contexts & headers";
+        assert false : "percolatecontext does not support contexts & headers";
         return null;
     }
 
@@ -724,13 +723,12 @@ public class PercolateContext extends SearchContext {
 
     @Override
     public void copyContextFrom(HasContext other) {
-        assert false : "percolatocontext does not support contexts & headers";
+        assert false : "percolatecontext does not support contexts & headers";
     }
 
     @Override
-    public <V> V putHeader(String key, V value) {
-        assert false : "percolatocontext does not support contexts & headers";
-        return value;
+    public <V> void putHeader(String key, V value) {
+        assert false : "percolatecontext does not support contexts & headers";
     }
 
     @Override
@@ -750,11 +748,11 @@ public class PercolateContext extends SearchContext {
 
     @Override
     public void copyHeadersFrom(HasHeaders from) {
-        assert false : "percolatocontext does not support contexts & headers";
+        assert false : "percolatecontext does not support contexts & headers";
     }
 
     @Override
     public void copyContextAndHeadersFrom(HasContextAndHeaders other) {
-        assert false : "percolatocontext does not support contexts & headers";
+        assert false : "percolatecontext does not support contexts & headers";
     }
 }

--- a/src/main/java/org/elasticsearch/search/internal/DefaultSearchContext.java
+++ b/src/main/java/org/elasticsearch/search/internal/DefaultSearchContext.java
@@ -788,8 +788,8 @@ public class DefaultSearchContext extends SearchContext {
     }
 
     @Override
-    public <V> V putHeader(String key, V value) {
-        return request.putHeader(key, value);
+    public <V> void putHeader(String key, V value) {
+        request.putHeader(key, value);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/internal/FilteredSearchContext.java
+++ b/src/main/java/org/elasticsearch/search/internal/FilteredSearchContext.java
@@ -597,8 +597,8 @@ public abstract class FilteredSearchContext extends SearchContext {
     }
 
     @Override
-    public <V> V putHeader(String key, V value) {
-        return in.putHeader(key, value);
+    public <V> void putHeader(String key, V value) {
+        in.putHeader(key, value);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/transport/TransportMessage.java
+++ b/src/main/java/org/elasticsearch/transport/TransportMessage.java
@@ -26,13 +26,12 @@ import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.transport.TransportAddress;
 
 import java.io.IOException;
-import java.util.HashMap;
 
 /**
  * The transport message is also a {@link ContextAndHeaderHolder context holder} that holds <b>transient</b> context, that is,
  * the context is not serialized with message.
  */
-public abstract class TransportMessage<TM extends TransportMessage<TM>> extends ContextAndHeaderHolder<TM> implements Streamable {
+public abstract class TransportMessage<TM extends TransportMessage<TM>> extends ContextAndHeaderHolder implements Streamable {
 
     private TransportAddress remoteAddress;
 
@@ -40,13 +39,7 @@ public abstract class TransportMessage<TM extends TransportMessage<TM>> extends 
     }
 
     protected TransportMessage(TM message) {
-        // create a new copy of the headers/context, since we are creating a new request
-        // which might have its headers/context changed in the context of that specific request
-
-        if (message.headers != null) {
-            this.headers = new HashMap<>(message.headers);
-        }
-        copyContextFrom(message);
+        copyContextAndHeadersFrom(message);
     }
 
     public void remoteAddress(TransportAddress remoteAddress) {

--- a/src/test/java/org/elasticsearch/test/TestSearchContext.java
+++ b/src/test/java/org/elasticsearch/test/TestSearchContext.java
@@ -638,9 +638,7 @@ public class TestSearchContext extends SearchContext {
     }
 
     @Override
-    public <V> V putHeader(String key, V value) {
-        return value;
-    }
+    public <V> void putHeader(String key, V value) {}
 
     @Override
     public <V> V getHeader(String key) {

--- a/src/test/java/org/elasticsearch/transport/TransportMessageTests.java
+++ b/src/test/java/org/elasticsearch/transport/TransportMessageTests.java
@@ -51,6 +51,10 @@ public class TransportMessageTests extends ElasticsearchTestCase {
         assertThat((String) message.getHeader("key1"), equalTo("value1"));
         assertThat((String) message.getHeader("key2"), equalTo("value2"));
         assertThat(message.isContextEmpty(), is(true));
+
+        // ensure that casting is not needed
+        String key1 = message.getHeader("key1");
+        assertThat(key1, is("value1"));
     }
 
     @Test
@@ -66,6 +70,18 @@ public class TransportMessageTests extends ElasticsearchTestCase {
         assertThat((String) m2.getHeader("key1"), equalTo("value1"));
         assertThat((String) m2.getHeader("key2"), equalTo("value2"));
         assertThat((String) m2.getFromContext("key3"), equalTo("value3"));
+
+        // ensure that casting is not needed
+        String key3 = m2.getFromContext("key3");
+        assertThat(key3, is("value3"));
+        testContext(m2, "key3", "value3");
+    }
+
+    // ensure that generic arg like this is not needed: TransportMessage<?> transportMessage
+    private void testContext(TransportMessage transportMessage, String key, String expectedValue) {
+        String result = transportMessage.getFromContext(key);
+        assertThat(result, is(expectedValue));
+
     }
 
     private static class Message extends TransportMessage<Message> {


### PR DESCRIPTION
Generics were only needed for setting a header, that returned
the object being set (most likely the request), but none of
the other methods did this.
