### PR TITLE
Issue #10588 Display low disk watermark to be consistent with documentaiton

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/DiskUsage.java
+++ b/src/main/java/org/elasticsearch/cluster/DiskUsage.java
@@ -59,6 +59,10 @@ public class DiskUsage {
         return 100.0 * ((double)freeBytes / totalBytes);
     }
 
+    public double getUsedDiskAsPercentage() {
+        return 100.0 - getFreeDiskAsPercentage();
+    }
+
     public long getFreeBytes() {
         return freeBytes;
     }

--- a/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDecider.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDecider.java
@@ -142,20 +142,20 @@ public class DiskThresholdDecider extends AllocationDecider {
         private void warnAboutDiskIfNeeded(DiskUsage usage) {
             // Check absolute disk values
             if (usage.getFreeBytes() < DiskThresholdDecider.this.freeBytesThresholdHigh.bytes()) {
-                logger.warn("high disk watermark [{} free] exceeded on {}, shards will be relocated away from this node",
+                logger.warn("high disk watermark [{}] exceeded on {}, shards will be relocated away from this node",
                         DiskThresholdDecider.this.freeBytesThresholdHigh, usage);
             } else if (usage.getFreeBytes() < DiskThresholdDecider.this.freeBytesThresholdLow.bytes()) {
-                logger.info("low disk watermark [{} free] exceeded on {}, replicas will not be assigned to this node",
+                logger.info("low disk watermark [{}] exceeded on {}, replicas will not be assigned to this node",
                         DiskThresholdDecider.this.freeBytesThresholdLow, usage);
             }
 
             // Check percentage disk values
             if (usage.getFreeDiskAsPercentage() < DiskThresholdDecider.this.freeDiskThresholdHigh) {
-                logger.warn("high disk watermark [{} free] exceeded on {}, shards will be relocated away from this node",
+                logger.warn("high disk watermark [{}] exceeded on {}, shards will be relocated away from this node",
                         Strings.format1Decimals(DiskThresholdDecider.this.freeDiskThresholdHigh, "%"), usage);
             } else if (usage.getFreeDiskAsPercentage() < DiskThresholdDecider.this.freeDiskThresholdLow) {
-                logger.info("low disk watermark [{} free] exceeded on {}, replicas will not be assigned to this node",
-                        Strings.format1Decimals(DiskThresholdDecider.this.freeDiskThresholdLow, "%"), usage);
+                logger.info("low disk watermark [{}] exceeded on {}, replicas will not be assigned to this node",
+                        Strings.format1Decimals(100.0 - DiskThresholdDecider.this.freeDiskThresholdLow, "%"), usage);
             }
         }
 
@@ -235,6 +235,16 @@ public class DiskThresholdDecider extends AllocationDecider {
     }
 
     // For Testing
+    public Double getUsedDiskThresholdLow() {
+        return 100.0 - freeDiskThresholdLow;
+    }
+
+    // For Testing
+    public Double getUsedDiskThresholdHigh() {
+        return 100.0 - freeDiskThresholdHigh;
+    }
+
+    // For Testing
     public ByteSizeValue getFreeBytesThresholdLow() {
         return freeBytesThresholdLow;
     }
@@ -285,6 +295,7 @@ public class DiskThresholdDecider extends AllocationDecider {
 
     @Override
     public Decision canAllocate(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
+        double usedDiskThresholdLow = 100.0 - DiskThresholdDecider.this.freeDiskThresholdLow;
 
         // Always allow allocation if the decider is disabled
         if (!enabled) {
@@ -342,9 +353,11 @@ public class DiskThresholdDecider extends AllocationDecider {
 
         // First, check that the node currently over the low watermark
         double freeDiskPercentage = usage.getFreeDiskAsPercentage();
+        // Cache the used disk percentage for displaying disk percentages consistent with documentation
+        double usedDiskPercentage = usage.getUsedDiskAsPercentage();
         long freeBytes = usage.getFreeBytes();
         if (logger.isTraceEnabled()) {
-            logger.trace("Node [{}] has {}% free disk", node.nodeId(), freeDiskPercentage);
+            logger.trace("Node [{}] has {}% used disk", node.nodeId(), usedDiskPercentage);
         }
 
         // a flag for whether the primary shard has been previously allocated
@@ -387,9 +400,9 @@ public class DiskThresholdDecider extends AllocationDecider {
             // If the shard is a replica or has a primary that has already been allocated before, check the low threshold
             if (!shardRouting.primary() || (shardRouting.primary() && primaryHasBeenAllocated)) {
                 if (logger.isDebugEnabled()) {
-                    logger.debug("Less than the required {} free disk threshold ({} free) on node [{}], preventing allocation",
-                            Strings.format1Decimals(freeDiskThresholdLow, "%"),
-                            Strings.format1Decimals(freeDiskPercentage, "%"), node.nodeId());
+                    logger.debug("More than the required {} used disk threshold ({} used) on node [{}], preventing allocation",
+                            Strings.format1Decimals(usedDiskThresholdLow, "%"),
+                            Strings.format1Decimals(usedDiskPercentage, "%"), node.nodeId());
                 }
                 return allocation.decision(Decision.NO, NAME, "less than required [%s%%] free disk on node, free: [%s%%]",
                         freeDiskThresholdLow, freeDiskPercentage);
@@ -397,10 +410,10 @@ public class DiskThresholdDecider extends AllocationDecider {
                 // Allow the shard to be allocated because it is primary that
                 // has never been allocated if it's under the high watermark
                 if (logger.isDebugEnabled()) {
-                    logger.debug("Less than the required {} free disk threshold ({} free) on node [{}], " +
+                    logger.debug("More than the required {} used disk threshold ({} used) on node [{}], " +
                                     "but allowing allocation because primary has never been allocated",
-                            Strings.format1Decimals(freeDiskThresholdLow, "%"),
-                            Strings.format1Decimals(freeDiskPercentage, "%"), node.nodeId());
+                            Strings.format1Decimals(usedDiskThresholdLow, "%"),
+                            Strings.format1Decimals(usedDiskPercentage, "%"), node.nodeId());
                 }
                 return allocation.decision(Decision.YES, NAME, "primary has never been allocated before");
             } else {
@@ -413,7 +426,7 @@ public class DiskThresholdDecider extends AllocationDecider {
                             Strings.format1Decimals(freeDiskPercentage, "%"), node.nodeId());
                 }
                 return allocation.decision(Decision.NO, NAME, "less than required [%s%%] free disk on node, free: [%s%%]",
-                        freeDiskThresholdLow, freeDiskPercentage);
+                        100.0 - freeDiskThresholdLow, freeDiskPercentage);
             }
         }
 
@@ -431,8 +444,8 @@ public class DiskThresholdDecider extends AllocationDecider {
         if (freeSpaceAfterShard < freeDiskThresholdHigh) {
             logger.warn("After allocating, node [{}] would have less than the required {} free disk threshold ({} free), preventing allocation",
                     node.nodeId(), Strings.format1Decimals(freeDiskThresholdHigh, "%"), Strings.format1Decimals(freeSpaceAfterShard, "%"));
-            return allocation.decision(Decision.NO, NAME, "after allocation less than required [%s%%] free disk on node, free: [%s%%]",
-                    freeDiskThresholdLow, freeSpaceAfterShard);
+            return allocation.decision(Decision.NO, NAME, "after allocation more than required [%s%%] used disk on node, free: [%s%%]",
+                    usedDiskThresholdLow, freeSpaceAfterShard);
         }
 
         return allocation.decision(Decision.YES, NAME, "enough disk for shard on node, free: [%s]", new ByteSizeValue(freeBytes));

--- a/src/test/java/org/elasticsearch/cluster/DiskUsageTests.java
+++ b/src/test/java/org/elasticsearch/cluster/DiskUsageTests.java
@@ -30,6 +30,7 @@ public class DiskUsageTests extends ElasticsearchTestCase {
     public void diskUsageCalcTest() {
         DiskUsage du = new DiskUsage("node1", "n1", 100, 40);
         assertThat(du.getFreeDiskAsPercentage(), equalTo(40.0));
+        assertThat(du.getUsedDiskAsPercentage(), equalTo(100.0 - 40.0));
         assertThat(du.getFreeBytes(), equalTo(40L));
         assertThat(du.getUsedBytes(), equalTo(60L));
         assertThat(du.getTotalBytes(), equalTo(100L));
@@ -67,11 +68,13 @@ public class DiskUsageTests extends ElasticsearchTestCase {
                 assertThat(du.getTotalBytes(), equalTo(0L));
                 assertThat(du.getUsedBytes(), equalTo(-free));
                 assertThat(du.getFreeDiskAsPercentage(), equalTo(100.0));
+                assertThat(du.getUsedDiskAsPercentage(), equalTo(0.0));
             } else {
                 assertThat(du.getFreeBytes(), equalTo(free));
                 assertThat(du.getTotalBytes(), equalTo(total));
                 assertThat(du.getUsedBytes(), equalTo(total - free));
                 assertThat(du.getFreeDiskAsPercentage(), equalTo(100.0 * ((double) free / total)));
+                assertThat(du.getUsedDiskAsPercentage(), equalTo(100.0 - (100.0 * ((double) free / total))));
             }
         }
     }

--- a/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderUnitTests.java
+++ b/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderUnitTests.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.cluster.routing.allocation.decider;
 
 import com.google.common.collect.ImmutableMap;
+
 import org.elasticsearch.cluster.ClusterInfo;
 import org.elasticsearch.cluster.ClusterInfoService;
 import org.elasticsearch.cluster.DiskUsage;
@@ -63,6 +64,7 @@ public class DiskThresholdDeciderUnitTests extends ElasticsearchTestCase {
         assertThat(decider.getFreeDiskThresholdHigh(), equalTo(10.0d));
         assertThat(decider.getFreeBytesThresholdLow(), equalTo(ByteSizeValue.parseBytesSizeValue("0b")));
         assertThat(decider.getFreeDiskThresholdLow(), equalTo(15.0d));
+        assertThat(decider.getUsedDiskThresholdLow(), equalTo(85.0d));
         assertThat(decider.getRerouteInterval().seconds(), equalTo(60L));
         assertTrue(decider.isEnabled());
         assertTrue(decider.isIncludeRelocations());


### PR DESCRIPTION
This PR is an attempted fix for Issue #10588. I have added altered log entries, so that messages involving disk usage percentages display used disk percentages, rather than free disk percentages.

Change log entries, add convenience methods, unit tests
