### PR TITLE
Add engine failure on recovery finalization corruption back

### DIFF
--- a/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -420,6 +420,7 @@ public class RecoverySourceHandler {
                                     for (StoreFileMetaData md : metadata) {
                                         logger.debug("{} checking integrity for file {} after remove corruption exception", shard.shardId(), md);
                                         if (store.checkIntegrityNoException(md) == false) { // we are corrupted on the primary -- fail!
+                                            shard.engine().failEngine("recovery", corruptIndexException);
                                             logger.warn("{} Corrupted file detected {} checksum mismatch", shard.shardId(), md);
                                             throw corruptIndexException;
                                         }


### PR DESCRIPTION
This engine failure on finalization corruption was lost on refactorings and
should be added back.
