### PR TITLE
Continually try to resolve a host that is unresolved

### DIFF
--- a/src/main/java/org/elasticsearch/common/transport/InetSocketTransportAddress.java
+++ b/src/main/java/org/elasticsearch/common/transport/InetSocketTransportAddress.java
@@ -78,6 +78,9 @@ public class InetSocketTransportAddress implements TransportAddress {
     }
 
     public InetSocketAddress address() {
+        if (address.isUnresolved()) {
+            address = new InetSocketAddress(address.getHostName(), address.getPort());
+        }
         return this.address;
     }
 


### PR DESCRIPTION
This is a basic fix for the issue described in https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/131

I'm not sure this behaviour is desirable as a default or whether it would make sense to honor Java's networkaddress.cache.ttl and networkaddress.cache.negative.ttl or make ES specific properties.
