### PR TITLE
Bulk cluster state updates on index deletion

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataDeleteIndexService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataDeleteIndexService.java
@@ -37,9 +37,9 @@ import org.elasticsearch.common.util.concurrent.FutureUtils;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.threadpool.ThreadPool;
 
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.Semaphore;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -66,9 +66,11 @@ public class MetaDataDeleteIndexService extends AbstractComponent {
         this.nodeIndexDeletedAction = nodeIndexDeletedAction;
     }
 
-    public void deleteIndex(final Request request, final Listener userListener) {
+    public void deleteIndices(final Request request, final Listener userListener) {
+        Collection<String> indices = Arrays.asList(request.indices);
         final DeleteIndexListener listener = new DeleteIndexListener(userListener);
-        clusterService.submitStateUpdateTask("delete-index [" + request.index + "]", Priority.URGENT, new ClusterStateUpdateTask() {
+
+        clusterService.submitStateUpdateTask("delete-index " + indices, Priority.URGENT, new ClusterStateUpdateTask() {
 
             @Override
             public TimeValue timeout() {
@@ -82,34 +84,32 @@ public class MetaDataDeleteIndexService extends AbstractComponent {
 
             @Override
             public ClusterState execute(final ClusterState currentState) {
-                if (!currentState.metaData().hasConcreteIndex(request.index)) {
-                    throw new IndexNotFoundException(request.index);
-                }
-
-                logger.info("[{}] deleting index", request.index);
-
                 RoutingTable.Builder routingTableBuilder = RoutingTable.builder(currentState.routingTable());
-                routingTableBuilder.remove(request.index);
+                MetaData.Builder metaDataBuilder = MetaData.builder(currentState.metaData());
+                ClusterBlocks.Builder clusterBlocksBuilder = ClusterBlocks.builder().blocks(currentState.blocks());
 
-                MetaData newMetaData = MetaData.builder(currentState.metaData())
-                        .remove(request.index)
-                        .build();
+                for (final String index: indices) {
+                    if (!currentState.metaData().hasConcreteIndex(index)) {
+                        throw new IndexNotFoundException(index);
+                    }
 
-                RoutingAllocation.Result routingResult = allocationService.reroute(
-                        ClusterState.builder(currentState).routingTable(routingTableBuilder.build()).metaData(newMetaData).build());
+                    logger.debug("[{}] deleting index", index);
 
-                ClusterBlocks blocks = ClusterBlocks.builder().blocks(currentState.blocks()).removeIndexBlocks(request.index).build();
-
+                    routingTableBuilder.remove(index);
+                    clusterBlocksBuilder.removeIndexBlocks(index);
+                    metaDataBuilder.remove(index);
+                }
                 // wait for events from all nodes that it has been removed from their respective metadata...
                 int count = currentState.nodes().size();
                 // add the notifications that the store was deleted from *data* nodes
                 count += currentState.nodes().dataNodes().size();
-                final AtomicInteger counter = new AtomicInteger(count);
+                final AtomicInteger counter = new AtomicInteger(count * indices.size());
+
                 // this listener will be notified once we get back a notification based on the cluster state change below.
                 final NodeIndexDeletedAction.Listener nodeIndexDeleteListener = new NodeIndexDeletedAction.Listener() {
                     @Override
-                    public void onNodeIndexDeleted(String index, String nodeId) {
-                        if (index.equals(request.index)) {
+                    public void onNodeIndexDeleted(String deleted, String nodeId) {
+                        if (indices.contains(deleted)) {
                             if (counter.decrementAndGet() == 0) {
                                 listener.onResponse(new Response(true));
                                 nodeIndexDeletedAction.remove(this);
@@ -118,8 +118,8 @@ public class MetaDataDeleteIndexService extends AbstractComponent {
                     }
 
                     @Override
-                    public void onNodeIndexStoreDeleted(String index, String nodeId) {
-                        if (index.equals(request.index)) {
+                    public void onNodeIndexStoreDeleted(String deleted, String nodeId) {
+                        if (indices.contains(deleted)) {
                             if (counter.decrementAndGet() == 0) {
                                 listener.onResponse(new Response(true));
                                 nodeIndexDeletedAction.remove(this);
@@ -128,15 +128,15 @@ public class MetaDataDeleteIndexService extends AbstractComponent {
                     }
                 };
                 nodeIndexDeletedAction.add(nodeIndexDeleteListener);
-
-                listener.future = threadPool.schedule(request.timeout, ThreadPool.Names.SAME, new Runnable() {
-                    @Override
-                    public void run() {
-                        listener.onResponse(new Response(false));
-                        nodeIndexDeletedAction.remove(nodeIndexDeleteListener);
-                    }
+                listener.future = threadPool.schedule(request.timeout, ThreadPool.Names.SAME, () -> {
+                    listener.onResponse(new Response(false));
+                    nodeIndexDeletedAction.remove(nodeIndexDeleteListener);
                 });
 
+                MetaData newMetaData = metaDataBuilder.build();
+                ClusterBlocks blocks = clusterBlocksBuilder.build();
+                RoutingAllocation.Result routingResult = allocationService.reroute(
+                        ClusterState.builder(currentState).routingTable(routingTableBuilder.build()).metaData(newMetaData).build());
                 return ClusterState.builder(currentState).routingResult(routingResult).metaData(newMetaData).blocks(blocks).build();
             }
 
@@ -173,7 +173,6 @@ public class MetaDataDeleteIndexService extends AbstractComponent {
         }
     }
 
-
     public interface Listener {
 
         void onResponse(Response response);
@@ -183,13 +182,13 @@ public class MetaDataDeleteIndexService extends AbstractComponent {
 
     public static class Request {
 
-        final String index;
+        final String[] indices;
 
         TimeValue timeout = TimeValue.timeValueSeconds(10);
         TimeValue masterTimeout = MasterNodeRequest.DEFAULT_MASTER_NODE_TIMEOUT;
 
-        public Request(String index) {
-            this.index = index;
+        public Request(String[] indices) {
+            this.indices = indices;
         }
 
         public Request timeout(TimeValue timeout) {


### PR DESCRIPTION
This fix is related to https://github.com/elastic/elasticsearch/issues/7295

Currently a ClusterState update is issued for every index when deleting multiple indices, this causes timeout errors in most cases when deleting a large amount of indices. We changed the behavior so only one clusterState update (maximum two if some indices are locked ) is issued when deleting multiple indices. This makes large delete index operations much more faster and more fail-safe.
