### PR TITLE
Field stats: added index_constraint option

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/fieldstats/FieldStatsRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/fieldstats/FieldStatsRequest.java
@@ -22,10 +22,17 @@ package org.elasticsearch.action.fieldstats;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ValidateActions;
 import org.elasticsearch.action.support.broadcast.BroadcastRequest;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentParser.Token;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  */
@@ -33,15 +40,111 @@ public class FieldStatsRequest extends BroadcastRequest<FieldStatsRequest> {
 
     public final static String DEFAULT_LEVEL = "cluster";
 
-    private String[] fields;
+    private String[] fields = Strings.EMPTY_ARRAY;
     private String level = DEFAULT_LEVEL;
+    private IndexConstraint[] indexConstraints = new IndexConstraint[0];
 
-    public String[] fields() {
+    public String[] getFields() {
         return fields;
     }
 
-    public void fields(String[] fields) {
+    public void setFields(String[] fields) {
+        if (fields == null) {
+            throw new NullPointerException("specified fields can't be null");
+        }
         this.fields = fields;
+    }
+
+    public IndexConstraint[] getIndexConstraints() {
+        return indexConstraints;
+    }
+
+    public void setIndexConstraints(IndexConstraint[] indexConstraints) {
+        if (indexConstraints == null) {
+            throw new NullPointerException("specified index_contraints can't be null");
+        }
+        this.indexConstraints = indexConstraints;
+    }
+
+    public void source(BytesReference content) throws IOException {
+        List<IndexConstraint> indexConstraints = new ArrayList<>();
+        List<String> fields = new ArrayList<>();
+        try (XContentParser parser = XContentHelper.createParser(content)) {
+            String fieldName = null;
+            Token token = parser.nextToken();
+            assert token == Token.START_OBJECT;
+            for (token = parser.nextToken(); token != Token.END_OBJECT; token = parser.nextToken()) {
+                switch (token) {
+                    case FIELD_NAME:
+                        fieldName = parser.currentName();
+                        break;
+                    case START_OBJECT:
+                        if ("index_constraints".equals(fieldName)) {
+                            parseIndexContraints(indexConstraints, parser);
+                        } else {
+                            throw new IllegalArgumentException("unknown field [" + fieldName + "]");
+                        }
+                        break;
+                    case START_ARRAY:
+                        if ("fields".equals(fieldName)) {
+                            while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
+                                if (token.isValue()) {
+                                    fields.add(parser.text());
+                                } else {
+                                    throw new IllegalArgumentException("unexpected token [" + token + "]");
+                                }
+                            }
+                        } else {
+                            throw new IllegalArgumentException("unknown field [" + fieldName + "]");
+                        }
+                        break;
+                    default:
+                        throw new IllegalArgumentException("unexpected token [" + token + "]");
+                }
+            }
+        }
+        this.fields = fields.toArray(new String[fields.size()]);
+        this.indexConstraints = indexConstraints.toArray(new IndexConstraint[indexConstraints.size()]);
+    }
+
+    private void parseIndexContraints(List<IndexConstraint> indexConstraints, XContentParser parser) throws IOException {
+        Token token = parser.currentToken();
+        assert token == Token.START_OBJECT;
+        String field = null;
+        String currentName = null;
+        for (token = parser.nextToken(); token != Token.END_OBJECT; token = parser.nextToken()) {
+            if (token == Token.FIELD_NAME) {
+                field = currentName = parser.currentName();
+            } else if (token == Token.START_OBJECT) {
+                for (Token fieldToken = parser.nextToken(); fieldToken != Token.END_OBJECT; fieldToken = parser.nextToken()) {
+                    if (fieldToken == Token.FIELD_NAME) {
+                        currentName = parser.currentName();
+                    } else if (fieldToken == Token.START_OBJECT) {
+                        IndexConstraint.Property property = IndexConstraint.Property.parse(currentName);
+                        Token propertyToken = parser.nextToken();
+                        if (propertyToken != Token.FIELD_NAME) {
+                            throw new IllegalArgumentException("unexpected token [" + propertyToken + "]");
+                        }
+                        IndexConstraint.Comparison comparison = IndexConstraint.Comparison.parse(parser.currentName());
+                        propertyToken = parser.nextToken();
+                        if (propertyToken.isValue() == false) {
+                            throw new IllegalArgumentException("unexpected token [" + propertyToken + "]");
+                        }
+                        String value = parser.text();
+                        indexConstraints.add(new IndexConstraint(field, property, comparison, value));
+
+                        propertyToken = parser.nextToken();
+                        if (propertyToken != Token.END_OBJECT) {
+                            throw new IllegalArgumentException("unexpected token [" + propertyToken + "]");
+                        }
+                    } else {
+                        throw new IllegalArgumentException("unexpected token [" + fieldToken + "]");
+                    }
+                }
+            } else {
+                throw new IllegalArgumentException("unexpected token [" + token + "]");
+            }
+        }
     }
 
     public String level() {
@@ -58,6 +161,9 @@ public class FieldStatsRequest extends BroadcastRequest<FieldStatsRequest> {
         if ("cluster".equals(level) == false && "indices".equals(level) == false) {
             validationException = ValidateActions.addValidationError("invalid level option [" + level + "]", validationException);
         }
+        if (fields == null || fields.length == 0) {
+            validationException = ValidateActions.addValidationError("no fields specified", validationException);
+        }
         return validationException;
     }
 
@@ -65,6 +171,11 @@ public class FieldStatsRequest extends BroadcastRequest<FieldStatsRequest> {
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
         fields = in.readStringArray();
+        int size = in.readVInt();
+        indexConstraints = new IndexConstraint[size];
+        for (int i = 0; i < size; i++) {
+            indexConstraints[i] = new IndexConstraint(in);
+        }
         level = in.readString();
     }
 
@@ -72,6 +183,14 @@ public class FieldStatsRequest extends BroadcastRequest<FieldStatsRequest> {
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeStringArrayNullable(fields);
+        out.writeVInt(indexConstraints.length);
+        for (IndexConstraint indexConstraint : indexConstraints) {
+            out.writeString(indexConstraint.getField());
+            out.writeByte(indexConstraint.getProperty().getId());
+            out.writeByte(indexConstraint.getComparison().getId());
+            out.writeString(indexConstraint.getValue());
+        }
         out.writeString(level);
     }
+
 }

--- a/core/src/main/java/org/elasticsearch/action/fieldstats/FieldStatsRequestBuilder.java
+++ b/core/src/main/java/org/elasticsearch/action/fieldstats/FieldStatsRequestBuilder.java
@@ -31,7 +31,12 @@ public class FieldStatsRequestBuilder extends BroadcastOperationRequestBuilder<F
     }
 
     public FieldStatsRequestBuilder setFields(String... fields) {
-        request().fields(fields);
+        request().setFields(fields);
+        return this;
+    }
+
+    public FieldStatsRequestBuilder setIndexContraints(IndexConstraint... fields) {
+        request().setIndexConstraints(fields);
         return this;
     }
 

--- a/core/src/main/java/org/elasticsearch/action/fieldstats/FieldStatsShardRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/fieldstats/FieldStatsShardRequest.java
@@ -25,6 +25,9 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.shard.ShardId;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  */
@@ -37,7 +40,12 @@ public class FieldStatsShardRequest extends BroadcastShardRequest {
 
     public FieldStatsShardRequest(ShardId shardId, FieldStatsRequest request) {
         super(shardId, request);
-        this.fields = request.fields();
+        Set<String> fields = new HashSet<>();
+        fields.addAll(Arrays.asList(request.getFields()));
+        for (IndexConstraint indexConstraint : request.getIndexConstraints()) {
+            fields.add(indexConstraint.getField());
+        }
+        this.fields = fields.toArray(new String[fields.size()]);
     }
 
     public String[] getFields() {

--- a/core/src/main/java/org/elasticsearch/action/fieldstats/IndexConstraint.java
+++ b/core/src/main/java/org/elasticsearch/action/fieldstats/IndexConstraint.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.fieldstats;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+
+import java.io.IOException;
+import java.util.Locale;
+
+public class IndexConstraint {
+
+    private final String field;
+    private final Property property;
+    private final Comparison comparison;
+    private final String value;
+
+    IndexConstraint(StreamInput input) throws IOException {
+        this.field = input.readString();
+        this.property = Property.read(input.readByte());
+        this.comparison = Comparison.read(input.readByte());
+        this.value = input.readString();
+    }
+
+    public IndexConstraint(String field, Property property, Comparison comparison, String value) {
+        this.field = field;
+        this.property = property;
+        this.comparison = comparison;
+        this.value = value;
+    }
+
+    public String getField() {
+        return field;
+    }
+
+    public Comparison getComparison() {
+        return comparison;
+    }
+
+    public Property getProperty() {
+        return property;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public enum Property {
+
+        MIN((byte) 0),
+        MAX((byte) 1);
+
+        private final byte id;
+
+        Property(byte id) {
+            this.id = id;
+        }
+
+        public byte getId() {
+            return id;
+        }
+
+        public static Property read(byte id) {
+            switch (id) {
+                case 0:
+                    return MIN;
+                case 1:
+                    return MAX;
+                default:
+                    throw new IllegalArgumentException("Unknown property [" + id + "]");
+            }
+        }
+
+        public static Property parse(String value) {
+            value = value.toLowerCase(Locale.ROOT);
+            switch (value) {
+                case "min_value":
+                    return MIN;
+                case "max_value":
+                    return MAX;
+                default:
+                    throw new IllegalArgumentException("Unknown property [" + value + "]");
+            }
+        }
+
+    }
+
+    public enum Comparison {
+
+        LT((byte) 0),
+        LTE((byte) 1),
+        GT((byte) 2),
+        GTE((byte) 3);
+
+        private final byte id;
+
+        Comparison(byte id) {
+            this.id = id;
+        }
+
+        public byte getId() {
+            return id;
+        }
+
+        public static Comparison read(byte id) {
+            switch (id) {
+                case 0:
+                    return LT;
+                case 1:
+                    return LTE;
+                case 2:
+                    return GT;
+                case 3:
+                    return GTE;
+                default:
+                    throw new IllegalArgumentException("Unknown comparison [" + id + "]");
+            }
+        }
+
+        public static Comparison parse(String value) {
+            value = value.toLowerCase(Locale.ROOT);
+            switch (value) {
+                case "lt":
+                    return LT;
+                case "lte":
+                    return LTE;
+                case "gt":
+                    return GT;
+                case "gte":
+                    return GTE;
+                default:
+                    throw new IllegalArgumentException("Unknown comparison [" + value + "]");
+            }
+        }
+
+    }
+
+}

--- a/core/src/test/java/org/elasticsearch/action/fieldstats/FieldStatsRequestTest.java
+++ b/core/src/test/java/org/elasticsearch/action/fieldstats/FieldStatsRequestTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.fieldstats;
+
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.io.Streams;
+import org.elasticsearch.test.ElasticsearchTestCase;
+
+import static org.elasticsearch.action.fieldstats.IndexConstraint.Comparison.*;
+import static org.elasticsearch.action.fieldstats.IndexConstraint.Property.MAX;
+import static org.elasticsearch.action.fieldstats.IndexConstraint.Property.MIN;
+import static org.hamcrest.Matchers.equalTo;
+
+public class FieldStatsRequestTest extends ElasticsearchTestCase {
+
+    public void testFieldsParsing() throws Exception {
+        byte[] data = Streams.copyToBytesFromClasspath("/org/elasticsearch/action/fieldstats/fieldstats-index-constraints-request.json");
+        FieldStatsRequest request = new FieldStatsRequest();
+        request.source(new BytesArray(data));
+
+        assertThat(request.getFields().length, equalTo(5));
+        assertThat(request.getFields()[0], equalTo("field1"));
+        assertThat(request.getFields()[1], equalTo("field2"));
+        assertThat(request.getFields()[2], equalTo("field3"));
+        assertThat(request.getFields()[3], equalTo("field4"));
+        assertThat(request.getFields()[4], equalTo("field5"));
+
+        assertThat(request.getIndexConstraints().length, equalTo(6));
+        assertThat(request.getIndexConstraints()[0].getField(), equalTo("field2"));
+        assertThat(request.getIndexConstraints()[0].getValue(), equalTo("9"));
+        assertThat(request.getIndexConstraints()[0].getProperty(), equalTo(MAX));
+        assertThat(request.getIndexConstraints()[0].getComparison(), equalTo(GTE));
+        assertThat(request.getIndexConstraints()[1].getField(), equalTo("field3"));
+        assertThat(request.getIndexConstraints()[1].getValue(), equalTo("5"));
+        assertThat(request.getIndexConstraints()[1].getProperty(), equalTo(MIN));
+        assertThat(request.getIndexConstraints()[1].getComparison(), equalTo(GT));
+        assertThat(request.getIndexConstraints()[2].getField(), equalTo("field4"));
+        assertThat(request.getIndexConstraints()[2].getValue(), equalTo("a"));
+        assertThat(request.getIndexConstraints()[2].getProperty(), equalTo(MIN));
+        assertThat(request.getIndexConstraints()[2].getComparison(), equalTo(GTE));
+        assertThat(request.getIndexConstraints()[3].getField(), equalTo("field4"));
+        assertThat(request.getIndexConstraints()[3].getValue(), equalTo("g"));
+        assertThat(request.getIndexConstraints()[3].getProperty(), equalTo(MAX));
+        assertThat(request.getIndexConstraints()[3].getComparison(), equalTo(LTE));
+        assertThat(request.getIndexConstraints()[4].getField(), equalTo("field5"));
+        assertThat(request.getIndexConstraints()[4].getValue(), equalTo("2"));
+        assertThat(request.getIndexConstraints()[4].getProperty(), equalTo(MAX));
+        assertThat(request.getIndexConstraints()[4].getComparison(), equalTo(GT));
+        assertThat(request.getIndexConstraints()[5].getField(), equalTo("field5"));
+        assertThat(request.getIndexConstraints()[5].getValue(), equalTo("9"));
+        assertThat(request.getIndexConstraints()[5].getProperty(), equalTo(MAX));
+        assertThat(request.getIndexConstraints()[5].getComparison(), equalTo(LT));
+    }
+
+}

--- a/core/src/test/resources/org/elasticsearch/action/fieldstats/fieldstats-index-constraints-request.json
+++ b/core/src/test/resources/org/elasticsearch/action/fieldstats/fieldstats-index-constraints-request.json
@@ -1,0 +1,33 @@
+{
+  "fields" : [
+    "field1", "field2", "field3", "field4", "field5"
+  ],
+  "index_constraints": {
+    "field2": {
+      "max_value" : {
+        "gte": 9
+      }
+    },
+    "field3": {
+      "min_value" : {
+        "gt": 5
+      }
+    },
+    "field4": {
+      "min_value" : {
+        "gte": "a"
+      },
+      "max_value" : {
+        "lte": "g"
+      }
+    },
+    "field5": {
+      "max_value" : {
+        "gt": 2
+      },
+      "max_value" : {
+        "lt": 9
+      }
+    }
+  }
+}

--- a/docs/reference/search/field-stats.asciidoc
+++ b/docs/reference/search/field-stats.asciidoc
@@ -33,6 +33,17 @@ Supported request options:
 `level`::   Defines if field stats should be returned on a per index level or on a
             cluster wide level. Valid values are `indices` and `cluster` (default).
 
+Alternatively the `fields` option can also be defined in the request body:
+
+[source,js]
+--------------------------------------------------
+curl -XPOST 'http://localhost:9200/_field_stats?level=indices' -d '{
+   "fields" : ["rating"]
+}'
+--------------------------------------------------
+
+This is equivalent to the previous request.
+
 [float]
 === Field statistics
 
@@ -204,5 +215,47 @@ GET /_field_stats?fields=rating,answer_count,creation_date,display_name&level=in
 --------------------------------------------------
 
 <1> The `stack` key means it contains all field stats for the `stack` index.
+
+[float]
+=== Field stats index constraints
+
+Field stats index constraints allows to omit all field stats for indices that don't match with the constraint. An index
+constraint can exclude indices' field stats based on the `min_value` and `max_value` statistic. This option is only
+useful if the `level` option is set to `indices`.
+
+For example index constraints can be useful to find out the min and max value of a particular property of your data in
+a time based scenario. The following request only returns field stats for the `answer_count` property for indices
+holding questions created in the year 2014:
+
+[source,js]
+--------------------------------------------------
+curl -XPOST 'http://localhost:9200/_field_stats?level=indices' -d '{
+   "fields" : ["answer_count"] <1>
+   "index_constraints" : { <2>
+      "creation_date" : { <3>
+         "min_value" : { <4>
+            "gte" : "2014-01-01T00:00:00.000Z",
+         },
+         "max_value" : {
+            "lt" : "2015-01-01T00:00:00.000Z"
+         }
+      }
+   }
+}'
+--------------------------------------------------
+
+<1> The fields to compute and return field stats for.
+<2> The set index constraints. Note that index constrains can be defined for fields that aren't defined in the `fields` option.
+<3> Index constraints for the field `creation_date`.
+<4> An index constraint on the `min_value` property of a field statistic.
+
+For a field, index constraints can be defined on the `min_value` statistic, `max_value` statistic or both.
+Each index constraint support the following comparisons:
+
+[horizontal]
+`gte`:: 	Greater-than or equal to
+`gt`::  	Greater-than
+`lte`:: 	Less-than or equal to
+`lt`::  	Less-than
 
 ==================================================

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/field_stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/field_stats.json
@@ -41,6 +41,9 @@
         }
       }
     },
-    "body": null
+    "body": {
+      "description": "Field json objects containing the name and optionally a range to filter out indices result, that have results outside the defined bounds",
+      "required": false
+    }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/field_stats/10_basics.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/field_stats/10_basics.yaml
@@ -50,3 +50,44 @@
   - match: { indices.test_1.fields.number.doc_count: 1 }
   - match: { indices.test_1.fields.number.min_value: 123 }
   - match: { indices.test_1.fields.number.max_value: 123 }
+
+---
+"Field stats with filtering":
+  - do:
+      index:
+          index:  test_1
+          type:   test
+          id:     id_1
+          body:   { foo: "bar", number: 123 }
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      field_stats:
+          level:  indices
+          index:  test_1
+          body: { fields: ["foo"], index_constraints: { number: { min_value : { gte: 100 } } }}
+
+  - match: { indices.test_1.fields.foo.max_doc: 1 }
+  - match: { indices.test_1.fields.foo.doc_count: 1 }
+  - match: { indices.test_1.fields.foo.min_value: "bar" }
+  - match: { indices.test_1.fields.foo.max_value: "bar" }
+  - is_false: indices.test_1.fields.number
+
+  - do:
+      field_stats:
+          level:  indices
+          index:  test_1
+          body: { fields: ["foo"], index_constraints : { number: { min_value : { gte: 200} } }}
+
+  - is_false: indices.test_1
+
+---
+"Field stats both source and fields":
+  - do:
+      catch: request
+      field_stats:
+          index:  test_1
+          fields : ["foo"]
+          body: { fields: ["foo"]}


### PR DESCRIPTION
Field stats index constraints allows to omit all field stats for indices that don't match with the index constraint. An index constraint can exclude indices' field stats based on a field's `min_value` and `max_value` statistics.

For example index constraints can be useful to find out the min and max value of a particular property of your data in a time based scenario. The following request only returns field stats for the `answer_count` property for indices holding questions created in the year 2014:

``` bash
curl -XPOST 'http://localhost:9200/_field_stats?level=indices' -d '{
   "fields" : ["answer_count"]
   "index_constraints" : {
      "creation_date" : {
         "min_value" : {
            "gte" : "2014-01-01T00:00:00.000Z",
         },
         "max_value" : {
            "lt" : "2015-01-01T00:00:00.000Z"
         }
      }
   }
}'
```

PR for #11187
