### PR TITLE
Uid#createTypeUids to accept a collection of ids rather than a list

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/Uid.java
+++ b/src/main/java/org/elasticsearch/index/mapper/Uid.java
@@ -130,20 +130,19 @@ public final class Uid {
         return spare.get();
     }
 
-    public static BytesRef[] createTypeUids(Collection<String> types, Object ids) {
-        return createTypeUids(types, Collections.singletonList(ids));
+    public static BytesRef[] createUidsForTypesAndId(Collection<String> types, Object id) {
+        return createUidsForTypesAndIds(types, Collections.singletonList(id));
     }
 
-    public static BytesRef[] createTypeUids(Collection<String> types, List<? extends Object> ids) {
-        final int numIds = ids.size();
+    public static BytesRef[] createUidsForTypesAndIds(Collection<String> types, Collection<?> ids) {
         BytesRef[] uids = new BytesRef[types.size() * ids.size()];
         BytesRefBuilder typeBytes = new BytesRefBuilder();
         BytesRefBuilder idBytes = new BytesRefBuilder();
         int index = 0;
         for (String type : types) {
             typeBytes.copyChars(type);
-            for (int i = 0; i < numIds; i++, index++) {
-                uids[index] = Uid.createUidAsBytes(typeBytes.get(), BytesRefs.toBytesRef(ids.get(i), idBytes));
+            for (Object id : ids) {
+                uids[index++] = Uid.createUidAsBytes(typeBytes.get(), BytesRefs.toBytesRef(id, idBytes));
             }
         }
         return uids;

--- a/src/main/java/org/elasticsearch/index/mapper/internal/IdFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/IdFieldMapper.java
@@ -187,7 +187,7 @@ public class IdFieldMapper extends AbstractFieldMapper<String> implements RootMa
         if (fieldType.indexOptions() != IndexOptions.NONE || context == null) {
             return super.termQuery(value, context);
         }
-        final BytesRef[] uids = Uid.createTypeUids(context.queryTypes(), value);
+        final BytesRef[] uids = Uid.createUidsForTypesAndId(context.queryTypes(), value);
         if (uids.length == 1) {
             return new TermQuery(new Term(UidFieldMapper.NAME, uids[0]));
         } else {
@@ -200,7 +200,7 @@ public class IdFieldMapper extends AbstractFieldMapper<String> implements RootMa
         if (fieldType.indexOptions() != IndexOptions.NONE || context == null) {
             return super.termsQuery(values, context);
         }
-        return new TermsQuery(UidFieldMapper.NAME, Uid.createTypeUids(context.queryTypes(), values));
+        return new TermsQuery(UidFieldMapper.NAME, Uid.createUidsForTypesAndIds(context.queryTypes(), values));
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/IdsQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/IdsQueryParser.java
@@ -121,7 +121,7 @@ public class IdsQueryParser implements QueryParser {
             types = parseContext.mapperService().types();
         }
 
-        TermsQuery query = new TermsQuery(UidFieldMapper.NAME, Uid.createTypeUids(types, ids));
+        TermsQuery query = new TermsQuery(UidFieldMapper.NAME, Uid.createUidsForTypesAndIds(types, ids));
         query.setBoost(boost);
         if (queryName != null) {
             parseContext.addNamedQuery(queryName, query);


### PR DESCRIPTION
The downside of having createTypeUids accept a list only is that if you do provide a collection nothing breaks at compile time, but you end up calling the same method that accepts an object as second argument. Renamed both methods to avoid clashes to `createUidsForTypesAndId` and `createUidsForTypesAndIds`. The latter accepts now a Collection of Objects rather than just a List.
