### PR TITLE
Fix NPE when streaming commit stats

### DIFF
--- a/src/main/java/org/elasticsearch/index/engine/CommitStats.java
+++ b/src/main/java/org/elasticsearch/index/engine/CommitStats.java
@@ -94,7 +94,7 @@ public final class CommitStats implements Streamable, ToXContent {
         }
         userData = builder.immutableMap();
         generation = in.readLong();
-        id = in.readString();
+        id = in.readOptionalString();
         numDocs = in.readInt();
     }
 
@@ -106,7 +106,7 @@ public final class CommitStats implements Streamable, ToXContent {
             out.writeString(entry.getValue());
         }
         out.writeLong(generation);
-        out.writeString(id);
+        out.writeOptionalString(id);
         out.writeInt(numDocs);
     }
 

--- a/src/test/java/org/elasticsearch/index/engine/CommitStatsTests.java
+++ b/src/test/java/org/elasticsearch/index/engine/CommitStatsTests.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.elasticsearch.index.engine;
+
+import org.apache.lucene.index.SegmentInfos;
+import org.elasticsearch.common.io.stream.InputStreamStreamInput;
+import org.elasticsearch.common.io.stream.OutputStreamStreamOutput;
+import org.elasticsearch.test.ElasticsearchTestCase;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import static org.elasticsearch.test.VersionUtils.randomVersion;
+
+
+public class CommitStatsTests extends ElasticsearchTestCase {
+    public void testStreamingWithNullId() throws IOException {
+        SegmentInfos segmentInfos = new SegmentInfos();
+        CommitStats commitStats = new CommitStats(segmentInfos);
+        org.elasticsearch.Version targetNodeVersion = randomVersion(random());
+
+        ByteArrayOutputStream outBuffer = new ByteArrayOutputStream();
+        OutputStreamStreamOutput out = new OutputStreamStreamOutput(outBuffer);
+        out.setVersion(targetNodeVersion);
+        commitStats.writeTo(out);
+
+        ByteArrayInputStream inBuffer = new ByteArrayInputStream(outBuffer.toByteArray());
+        InputStreamStreamInput in = new InputStreamStreamInput(inBuffer);
+        in.setVersion(targetNodeVersion);
+        CommitStats readCommitStats = CommitStats.readCommitStatsFrom(in);
+        assertNull(readCommitStats.getId());
+    }
+}


### PR DESCRIPTION
commit id is only written from lucene 5 on and therefore can be null.
