### PR TITLE
Add support for applying setting filters when displaying repository settings

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/metadata/RepositoriesMetaData.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/RepositoriesMetaData.java
@@ -202,9 +202,7 @@ public class RepositoriesMetaData extends AbstractDiffable<Custom> implements Me
         builder.startObject(repository.name(), XContentBuilder.FieldCaseConversion.NONE);
         builder.field("type", repository.type());
         builder.startObject("settings");
-        for (Map.Entry<String, String> settingEntry : repository.settings().getAsMap().entrySet()) {
-            builder.field(settingEntry.getKey(), settingEntry.getValue());
-        }
+        repository.settings().toXContent(builder, params);
         builder.endObject();
 
         builder.endObject();

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/repositories/get/RestGetRepositoriesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/repositories/get/RestGetRepositoriesAction.java
@@ -27,6 +27,7 @@ import org.elasticsearch.cluster.metadata.RepositoryMetaData;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.settings.SettingsFilter;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.RestBuilderListener;
@@ -40,11 +41,14 @@ import static org.elasticsearch.rest.RestStatus.OK;
  */
 public class RestGetRepositoriesAction extends BaseRestHandler {
 
+    private final SettingsFilter settingsFilter;
+
     @Inject
-    public RestGetRepositoriesAction(Settings settings, RestController controller, Client client) {
+    public RestGetRepositoriesAction(Settings settings, RestController controller, Client client, SettingsFilter settingsFilter) {
         super(settings, controller, client);
         controller.registerHandler(GET, "/_snapshot", this);
         controller.registerHandler(GET, "/_snapshot/{repository}", this);
+        this.settingsFilter = settingsFilter;
     }
 
     @Override
@@ -53,6 +57,7 @@ public class RestGetRepositoriesAction extends BaseRestHandler {
         GetRepositoriesRequest getRepositoriesRequest = getRepositoryRequest(repositories);
         getRepositoriesRequest.masterNodeTimeout(request.paramAsTime("master_timeout", getRepositoriesRequest.masterNodeTimeout()));
         getRepositoriesRequest.local(request.paramAsBoolean("local", getRepositoriesRequest.local()));
+        settingsFilter.addFilterSettingParams(request);
         client.admin().cluster().getRepositories(getRepositoriesRequest, new RestBuilderListener<GetRepositoriesResponse>(channel) {
             @Override
             public RestResponse buildResponse(GetRepositoriesResponse response, XContentBuilder builder) throws Exception {

--- a/src/test/java/org/elasticsearch/snapshots/mockstore/MockRepositoryPlugin.java
+++ b/src/test/java/org/elasticsearch/snapshots/mockstore/MockRepositoryPlugin.java
@@ -19,8 +19,16 @@
 
 package org.elasticsearch.snapshots.mockstore;
 
+import org.elasticsearch.common.inject.AbstractModule;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Module;
+import org.elasticsearch.common.settings.SettingsFilter;
 import org.elasticsearch.plugins.AbstractPlugin;
 import org.elasticsearch.repositories.RepositoriesModule;
+
+import java.util.Collection;
+
+import static com.google.common.collect.Lists.newArrayList;
 
 public class MockRepositoryPlugin extends AbstractPlugin {
 
@@ -37,4 +45,27 @@ public class MockRepositoryPlugin extends AbstractPlugin {
     public void onModule(RepositoriesModule repositoriesModule) {
         repositoriesModule.registerRepository("mock", MockRepositoryModule.class);
     }
+
+    @Override
+    public Collection<Class<? extends Module>> modules() {
+        Collection<Class<? extends Module>> modules = newArrayList();
+        modules.add(SettingsFilteringModule.class);
+        return modules;
+    }
+
+    public static class SettingsFilteringModule extends AbstractModule {
+
+        @Override
+        protected void configure() {
+            bind(SettingsFilteringService.class).asEagerSingleton();
+        }
+    }
+
+    public static class SettingsFilteringService {
+        @Inject
+        public SettingsFilteringService(SettingsFilter settingsFilter) {
+            settingsFilter.addFilter("secret.mock.password");
+        }
+    }
+
 }


### PR DESCRIPTION
Currently all settings that were specified during repository creation are displayed. This commit enables  plugins such as cloud-aws to filter out sensitive settings from the repository.

Closes #11265
