### PR TITLE
Cleanup field name handling

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsIndexAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsIndexAction.java
@@ -201,8 +201,8 @@ public class TransportGetFieldMappingsIndexAction extends TransportSingleCustomO
                 }
                 for (Iterator<FieldMapper<?>> it = remainingFieldMappers.iterator(); it.hasNext(); ) {
                     final FieldMapper<?> fieldMapper = it.next();
-                    if (Regex.simpleMatch(field, fieldMapper.names().name())) {
-                        addFieldMapper(fieldMapper.names().name(), fieldMapper, fieldMappings, request.includeDefaults());
+                    if (Regex.simpleMatch(field, fieldMapper.names().shortName())) {
+                        addFieldMapper(fieldMapper.names().shortName(), fieldMapper, fieldMappings, request.includeDefaults());
                         it.remove();
                     }
                 }

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/DisabledIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/DisabledIndexFieldData.java
@@ -61,7 +61,7 @@ public final class DisabledIndexFieldData extends AbstractIndexFieldData<AtomicF
     }
 
     private IllegalStateException fail() {
-        return new IllegalStateException("Field data loading is forbidden on " + getFieldNames().name());
+        return new IllegalStateException("Field data loading is forbidden on " + getFieldNames().fullName());
     }
 
 }

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/DocValuesIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/DocValuesIndexFieldData.java
@@ -97,7 +97,7 @@ public abstract class DocValuesIndexFieldData {
             final Settings fdSettings = mapper.fieldDataType().getSettings();
             final Map<String, Settings> filter = fdSettings.getGroups("filter");
             if (filter != null && !filter.isEmpty()) {
-                throw new IllegalArgumentException("Doc values field data doesn't support filters [" + fieldNames.name() + "]");
+                throw new IllegalArgumentException("Doc values field data doesn't support filters [" + fieldNames.fullName() + "]");
             }
 
             if (BINARY_INDEX_FIELD_NAMES.contains(fieldNames.indexName())) {

--- a/src/main/java/org/elasticsearch/index/mapper/ContentPath.java
+++ b/src/main/java/org/elasticsearch/index/mapper/ContentPath.java
@@ -19,12 +19,9 @@
 
 package org.elasticsearch.index.mapper;
 
-/**
- *
- */
 public class ContentPath {
 
-    public static enum Type {
+    public enum Type {
         JUST_NAME,
         FULL,
     }
@@ -40,8 +37,6 @@ public class ContentPath {
     private int index = 0;
 
     private String[] path = new String[10];
-
-    private String sourcePath;
 
     public ContentPath() {
         this(0);
@@ -60,7 +55,6 @@ public class ContentPath {
 
     public void reset() {
         this.index = 0;
-        this.sourcePath = null;
     }
 
     public void add(String name) {
@@ -98,15 +92,5 @@ public class ContentPath {
 
     public void pathType(Type type) {
         this.pathType = type;
-    }
-
-    public String sourcePath(String sourcePath) {
-        String orig = this.sourcePath;
-        this.sourcePath = sourcePath;
-        return orig;
-    }
-
-    public String sourcePath() {
-        return this.sourcePath;
     }
 }

--- a/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -44,41 +44,34 @@ import java.util.List;
  */
 public interface FieldMapper<T> extends Mapper {
 
-    public static final String DOC_VALUES_FORMAT = "doc_values_format";
+    String DOC_VALUES_FORMAT = "doc_values_format";
 
-    public static class Names {
+    class Names {
 
-        private final String name;
+        private final String shortName;
 
         private final String indexName;
 
-        private final String indexNameClean;
+        private final String originalIndexName;
 
         private final String fullName;
-
-        private final String sourcePath;
 
         public Names(String name) {
             this(name, name, name, name);
         }
 
-        public Names(String name, String indexName, String indexNameClean, String fullName) {
-            this(name, indexName, indexNameClean, fullName, fullName);
-        }
-
-        public Names(String name, String indexName, String indexNameClean, String fullName, @Nullable String sourcePath) {
-            this.name = name;
+        public Names(String shortName, String indexName, String originalIndexName, String fullName) {
+            this.shortName = shortName;
             this.indexName = indexName;
-            this.indexNameClean = indexNameClean;
+            this.originalIndexName = originalIndexName;
             this.fullName = fullName;
-            this.sourcePath = sourcePath == null ? this.fullName : sourcePath;
         }
 
         /**
          * The logical name of the field.
          */
-        public String name() {
-            return name;
+        public String shortName() {
+            return shortName;
         }
 
         /**
@@ -90,10 +83,10 @@ public interface FieldMapper<T> extends Mapper {
         }
 
         /**
-         * The cleaned index name, before any "path" modifications performed on it.
+         * The original index name, before any "path" modifications performed on it.
          */
-        public String indexNameClean() {
-            return indexNameClean;
+        public String originalIndexName() {
+            return originalIndexName;
         }
 
         /**
@@ -101,27 +94,6 @@ public interface FieldMapper<T> extends Mapper {
          */
         public String fullName() {
             return fullName;
-        }
-
-        /**
-         * The dot path notation to extract the value from source.
-         */
-        public String sourcePath() {
-            return sourcePath;
-        }
-
-        /**
-         * Creates a new index term based on the provided value.
-         */
-        public Term createIndexNameTerm(String value) {
-            return new Term(indexName, value);
-        }
-
-        /**
-         * Creates a new index term based on the provided value.
-         */
-        public Term createIndexNameTerm(BytesRef value) {
-            return new Term(indexName, value);
         }
 
         @Override
@@ -132,25 +104,23 @@ public interface FieldMapper<T> extends Mapper {
 
             if (!fullName.equals(names.fullName)) return false;
             if (!indexName.equals(names.indexName)) return false;
-            if (!indexNameClean.equals(names.indexNameClean)) return false;
-            if (!name.equals(names.name)) return false;
-            if (!sourcePath.equals(names.sourcePath)) return false;
+            if (!originalIndexName.equals(names.originalIndexName)) return false;
+            if (!shortName.equals(names.shortName)) return false;
 
             return true;
         }
 
         @Override
         public int hashCode() {
-            int result = name.hashCode();
+            int result = shortName.hashCode();
             result = 31 * result + indexName.hashCode();
-            result = 31 * result + indexNameClean.hashCode();
+            result = 31 * result + originalIndexName.hashCode();
             result = 31 * result + fullName.hashCode();
-            result = 31 * result + sourcePath.hashCode();
             return result;
         }
     }
 
-    public static enum Loading {
+    enum Loading {
         LAZY {
             @Override
             public String toString() {
@@ -220,7 +190,7 @@ public interface FieldMapper<T> extends Mapper {
     /**
      * List of fields where this field should be copied to
      */
-    public AbstractFieldMapper.CopyTo copyTo();
+    AbstractFieldMapper.CopyTo copyTo();
 
     /**
      * Returns the actual value of the field.
@@ -285,7 +255,7 @@ public interface FieldMapper<T> extends Mapper {
      *
      * @return If the field is available before indexing or not.
      * */
-    public boolean isGenerated();
+    boolean isGenerated();
 
     /**
      * Parse using the provided {@link ParseContext} and return a mapping

--- a/src/main/java/org/elasticsearch/index/mapper/core/CompletionFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/CompletionFieldMapper.java
@@ -461,7 +461,7 @@ public class CompletionFieldMapper extends AbstractFieldMapper<String> {
     
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(name())
+        builder.startObject(names().shortName())
                 .field(Fields.TYPE, CONTENT_TYPE);
         
         builder.field(Fields.ANALYZER, indexAnalyzer.name());

--- a/src/main/java/org/elasticsearch/index/mapper/core/TokenCountFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/TokenCountFieldMapper.java
@@ -144,7 +144,7 @@ public class TokenCountFieldMapper extends IntegerFieldMapper {
             if (valueAndBoost.value() == null) {
                 count = nullValue();
             } else {
-                count = countPositions(analyzer.analyzer().tokenStream(name(), valueAndBoost.value()));
+                count = countPositions(analyzer.analyzer().tokenStream(names().shortName(), valueAndBoost.value()));
             }
             addIntegerFields(context, fields, count, valueAndBoost.boost());
         }

--- a/src/main/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapper.java
@@ -515,7 +515,7 @@ public class GeoPointFieldMapper extends AbstractFieldMapper<GeoPoint> implement
     public Mapper parse(ParseContext context) throws IOException {
         ContentPath.Type origPathType = context.path().pathType();
         context.path().pathType(pathType);
-        context.path().add(name());
+        context.path().add(names().shortName());
 
         GeoPoint sparse = context.parseExternalValue(GeoPoint.class);
         

--- a/src/main/java/org/elasticsearch/index/mapper/internal/AllFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/AllFieldMapper.java
@@ -193,7 +193,7 @@ public class AllFieldMapper extends AbstractFieldMapper<String> implements RootM
 
     @Override
     public Query termQuery(Object value, QueryParseContext context) {
-        return queryStringTermQuery(names().createIndexNameTerm(indexedValueForSearch(value)));
+        return queryStringTermQuery(createTerm(value));
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/mapper/internal/TypeFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/TypeFieldMapper.java
@@ -133,7 +133,7 @@ public class TypeFieldMapper extends AbstractFieldMapper<String> implements Root
         if (fieldType.indexOptions() == IndexOptions.NONE) {
             return new ConstantScoreQuery(new PrefixQuery(new Term(UidFieldMapper.NAME, Uid.typePrefixAsBytes(BytesRefs.toBytesRef(value)))));
         }
-        return new ConstantScoreQuery(new TermQuery(names().createIndexNameTerm(BytesRefs.toBytesRef(value))));
+        return new ConstantScoreQuery(new TermQuery(createTerm(value)));
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/mapper/internal/UidFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/UidFieldMapper.java
@@ -184,12 +184,8 @@ public class UidFieldMapper extends AbstractFieldMapper<Uid> implements RootMapp
         return Uid.createUid(value.toString());
     }
 
-    public Term term(String type, String id) {
-        return term(Uid.createUid(type, id));
-    }
-
     public Term term(String uid) {
-        return names().createIndexNameTerm(uid);
+        return createTerm(uid);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -534,7 +534,7 @@ public class IndexShard extends AbstractIndexShardComponent {
     public Engine.Delete prepareDelete(String type, String id, long version, VersionType versionType, Engine.Operation.Origin origin) {
         long startTime = System.nanoTime();
         final DocumentMapper documentMapper = docMapper(type).v1();
-        return new Engine.Delete(type, id, documentMapper.uidMapper().term(type, id), version, versionType, origin, startTime, false);
+        return new Engine.Delete(type, id, documentMapper.uidMapper().term(Uid.createUid(type, id)), version, versionType, origin, startTime, false);
     }
 
     public void delete(Engine.Delete delete) {

--- a/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/src/main/java/org/elasticsearch/search/SearchService.java
@@ -924,10 +924,10 @@ public class SearchService extends AbstractLifecycleComponent<SearchService> {
                                 final long start = System.nanoTime();
                                 indexFieldDataService.getForField(fieldMapper).load(ctx);
                                 if (indexShard.warmerService().logger().isTraceEnabled()) {
-                                    indexShard.warmerService().logger().trace("warmed fielddata for [{}], took [{}]", fieldMapper.names().name(), TimeValue.timeValueNanos(System.nanoTime() - start));
+                                    indexShard.warmerService().logger().trace("warmed fielddata for [{}], took [{}]", fieldMapper.names().fullName(), TimeValue.timeValueNanos(System.nanoTime() - start));
                                 }
                             } catch (Throwable t) {
-                                indexShard.warmerService().logger().warn("failed to warm-up fielddata for [{}]", t, fieldMapper.names().name());
+                                indexShard.warmerService().logger().warn("failed to warm-up fielddata for [{}]", t, fieldMapper.names().fullName());
                             } finally {
                                 latch.countDown();
                             }
@@ -976,10 +976,10 @@ public class SearchService extends AbstractLifecycleComponent<SearchService> {
                             IndexFieldData.Global ifd = indexFieldDataService.getForField(fieldMapper);
                             ifd.loadGlobal(context.reader());
                             if (indexShard.warmerService().logger().isTraceEnabled()) {
-                                indexShard.warmerService().logger().trace("warmed global ordinals for [{}], took [{}]", fieldMapper.names().name(), TimeValue.timeValueNanos(System.nanoTime() - start));
+                                indexShard.warmerService().logger().trace("warmed global ordinals for [{}], took [{}]", fieldMapper.names().fullName(), TimeValue.timeValueNanos(System.nanoTime() - start));
                             }
                         } catch (Throwable t) {
-                            indexShard.warmerService().logger().warn("failed to warm-up global ordinals for [{}]", t, fieldMapper.names().name());
+                            indexShard.warmerService().logger().warn("failed to warm-up global ordinals for [{}]", t, fieldMapper.names().fullName());
                         } finally {
                             latch.countDown();
                         }

--- a/src/main/java/org/elasticsearch/search/highlight/HighlightUtils.java
+++ b/src/main/java/org/elasticsearch/search/highlight/HighlightUtils.java
@@ -57,7 +57,7 @@ public final class HighlightUtils {
         } else {
             SourceLookup sourceLookup = searchContext.lookup().source();
             sourceLookup.setSegmentAndDocument(hitContext.readerContext(), hitContext.docId());
-            textsToHighlight = sourceLookup.extractRawValues(hitContext.getSourcePath(mapper.names().sourcePath()));
+            textsToHighlight = sourceLookup.extractRawValues(hitContext.getSourcePath(mapper.names().fullName()));
         }
         assert textsToHighlight != null;
         return textsToHighlight;

--- a/src/main/java/org/elasticsearch/search/highlight/vectorhighlight/SourceScoreOrderFragmentsBuilder.java
+++ b/src/main/java/org/elasticsearch/search/highlight/vectorhighlight/SourceScoreOrderFragmentsBuilder.java
@@ -60,7 +60,7 @@ public class SourceScoreOrderFragmentsBuilder extends ScoreOrderFragmentsBuilder
         SourceLookup sourceLookup = searchContext.lookup().source();
         sourceLookup.setSegmentAndDocument((LeafReaderContext) reader.getContext(), docId);
 
-        List<Object> values = sourceLookup.extractRawValues(hitContext.getSourcePath(mapper.names().sourcePath()));
+        List<Object> values = sourceLookup.extractRawValues(hitContext.getSourcePath(mapper.names().fullName()));
         Field[] fields = new Field[values.size()];
         for (int i = 0; i < values.size(); i++) {
             fields[i] = new Field(mapper.names().indexName(), values.get(i).toString(), TextField.TYPE_NOT_STORED);

--- a/src/main/java/org/elasticsearch/search/highlight/vectorhighlight/SourceSimpleFragmentsBuilder.java
+++ b/src/main/java/org/elasticsearch/search/highlight/vectorhighlight/SourceSimpleFragmentsBuilder.java
@@ -56,7 +56,7 @@ public class SourceSimpleFragmentsBuilder extends SimpleFragmentsBuilder {
         SourceLookup sourceLookup = searchContext.lookup().source();
         sourceLookup.setSegmentAndDocument((LeafReaderContext) reader.getContext(), docId);
 
-        List<Object> values = sourceLookup.extractRawValues(hitContext.getSourcePath(mapper.names().sourcePath()));
+        List<Object> values = sourceLookup.extractRawValues(hitContext.getSourcePath(mapper.names().fullName()));
         if (values.isEmpty()) {
             return EMPTY_FIELDS;
         }

--- a/src/test/java/org/elasticsearch/index/mapper/externalvalues/ExternalMapper.java
+++ b/src/test/java/org/elasticsearch/index/mapper/externalvalues/ExternalMapper.java
@@ -236,7 +236,7 @@ public class ExternalMapper extends AbstractFieldMapper<Object> {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(name());
+        builder.startObject(names().shortName());
         builder.field("type", mapperName);
         multiFields.toXContent(builder, params);
         builder.endObject();

--- a/src/test/java/org/elasticsearch/search/suggest/completion/CompletionPostingsFormatTest.java
+++ b/src/test/java/org/elasticsearch/search/suggest/completion/CompletionPostingsFormatTest.java
@@ -306,7 +306,7 @@ public class CompletionPostingsFormatTest extends ElasticsearchTestCase {
         assertThat(reader.leaves().size(), equalTo(1));
         assertThat(reader.leaves().get(0).reader().numDocs(), equalTo(weights.length));
         LeafReaderContext atomicReaderContext = reader.leaves().get(0);
-        Terms luceneTerms = atomicReaderContext.reader().terms(mapper.name());
+        Terms luceneTerms = atomicReaderContext.reader().terms(mapper.names().fullName());
         Lookup lookup = ((Completion090PostingsFormat.CompletionTerms) luceneTerms).getLookup(mapper, new CompletionSuggestionContext(null));
         reader.close();
         writer.close();


### PR DESCRIPTION
This clarifies some of the uses of names, so that the ambiguous
"name" is mostly no longer used (does this include path or not?).
sourcePath is also removed as it was not used. Not all the
uses of .name() have been cleaned up because Mapper still has
this, and ObjectMapper depends on it returning the short name,
but I would like to leave finishing that cleanup for a future issue.
