### PR TITLE
Remove useless outdated forbidden-api version in `-Pdev` config.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1744,7 +1744,6 @@
                     <plugin>
                         <groupId>de.thetaphi</groupId>
                         <artifactId>forbiddenapis</artifactId>
-                        <version>1.5.1</version>
                         <executions>
                             <execution>
                                 <id>check-forbidden-apis</id>


### PR DESCRIPTION
Pointed out by @uschindler on https://github.com/elastic/elasticsearch-parent/pull/43
