### PR TITLE
Transport: remove support for reading/writing list of strings, use arrays instead

### DIFF
--- a/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -336,21 +336,6 @@ public abstract class StreamInput extends InputStream {
         return ret;
     }
 
-    /**
-     * Read in a list of strings. List can be empty but not {@code null}.
-     */
-    public List<String> readStringList() throws IOException {
-        int size = readVInt();
-        if (size == 0) {
-            return Collections.emptyList();
-        }
-        List<String> ret = new ArrayList<>(size);
-        for (int i = 0; i < size; i++) {
-            ret.add(readString());
-        }
-        return ret;
-    }
-
     @Nullable
     public Map<String, Object> readMap() throws IOException {
         return (Map<String, Object>) readGenericValue();

--- a/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -294,16 +294,6 @@ public abstract class StreamOutput extends OutputStream {
     }
 
     /**
-     * Write a list of strings. List can be empty but not {@code null}.
-     */
-    public void writeStringList(List<String> stringList) throws IOException {
-        writeVInt(stringList.size());
-        for (String s : stringList) {
-            writeString(s);
-        }
-    }
-
-    /**
      * Writes a string array, for nullable string, writes it as 0 (empty string).
      */
     public void writeStringArrayNullable(@Nullable String[] array) throws IOException {

--- a/src/test/java/org/elasticsearch/common/io/streams/BytesStreamsTests.java
+++ b/src/test/java/org/elasticsearch/common/io/streams/BytesStreamsTests.java
@@ -28,8 +28,6 @@ import org.elasticsearch.test.ElasticsearchTestCase;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import java.util.Arrays;
-
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -284,7 +282,6 @@ public class BytesStreamsTests extends ElasticsearchTestCase {
         out.writeGenericValue(doubleArray);
         out.writeString("hello");
         out.writeString("goodbye");
-        out.writeStringList(Arrays.asList(new String[]{"Hello", "Again"}));
         out.writeGenericValue(BytesRefs.toBytesRef("bytesref"));
         StreamInput in = StreamInput.wrap(out.bytes().toBytes());
         assertThat(in.readBoolean(), equalTo(false));
@@ -302,7 +299,6 @@ public class BytesStreamsTests extends ElasticsearchTestCase {
         assertThat(in.readGenericValue(), equalTo((Object)doubleArray));
         assertThat(in.readString(), equalTo("hello"));
         assertThat(in.readString(), equalTo("goodbye"));
-        assertThat(in.readStringList(), equalTo(Arrays.asList(new String[]{"Hello", "Again"})));
         assertThat(in.readGenericValue(), equalTo((Object)BytesRefs.toBytesRef("bytesref")));
         in.close();
         out.close();


### PR DESCRIPTION
We recently introduced support for reading and writing list of strings as part of #11056, but that was an oversight, we should be using arrays instead.
