### PR TITLE
Update setup.asciidoc

### DIFF
--- a/docs/reference/setup.asciidoc
+++ b/docs/reference/setup.asciidoc
@@ -63,6 +63,23 @@ known-bad version of Java is used. added[1.5.0]
 The version of Java to use can be configured by setting the `JAVA_HOME`
 environment variable.
 
+[float]
+[[JAVA_HOME]]
+=== JAVA_HOME environment varriable for *NIX Systems
+The `JAVA_HOME` environment variable can be configured for the elasticsearch 
+process by editing `/etc/default/elasticsearch` to include 
+
+[source,sh]
+--------------------------------------------------
+JAVA_HOME=/path/to/java
+--------------------------------------------------
+
+If you're planning on running Elasticsearch as a Service on a *NIX system, 
+in a production environment, this configuration is prefered.
+
+Please see https://www.elastic.co/guide/en/elasticsearch/reference/1.x/setup-service.html[Elasticsearch as a Service] for more setup-information, such as 
+configuring the elasticsearch service to start on bootup.
+
 --
 
 include::setup/configuration.asciidoc[]

--- a/docs/reference/setup.asciidoc
+++ b/docs/reference/setup.asciidoc
@@ -79,7 +79,6 @@ in a production environment, this configuration is prefered.
 
 Please see https://www.elastic.co/guide/en/elasticsearch/reference/1.x/setup-service.html[Elasticsearch as a Service] for more setup-information, such as 
 configuring the elasticsearch service to start on bootup.
-
 --
 
 include::setup/configuration.asciidoc[]

--- a/docs/reference/setup.asciidoc
+++ b/docs/reference/setup.asciidoc
@@ -67,12 +67,15 @@ environment variable.
 [[JAVA_HOME]]
 === JAVA_HOME environment varriable for *NIX Systems
 The `JAVA_HOME` environment variable can be configured for the elasticsearch 
-process by editing `/etc/default/elasticsearch` to include 
+process by the following
 
 [source,sh]
 --------------------------------------------------
 JAVA_HOME=/path/to/java
 --------------------------------------------------
+
+The location of the configuration file will vary with your *NIX distribution.
+For Debian Systems add `JAVA_HOME` to `/etc/default/elasticsearch`.
 
 If you're planning on running Elasticsearch as a Service on a *NIX system, 
 in a production environment, this configuration is prefered.


### PR DESCRIPTION
Configuring JAVA_HOME for the elasticsearch process on *NIX systems.
It's common in  a DevOps environment to configure the JAVA_HOME environment variable for a specific  process (like elasticsearch) instead of system-wide.
Elasticsearch already has process specific environmental variables located in /etc/default/elasticsearch
I've tested the JAVA_HOME from /etc/default/elasticsearch and it works as expected.
