### PR TITLE
Remove generics from FieldMapper

### DIFF
--- a/src/main/java/org/apache/lucene/queries/ExtendedCommonTermsQuery.java
+++ b/src/main/java/org/apache/lucene/queries/ExtendedCommonTermsQuery.java
@@ -36,9 +36,9 @@ import java.io.IOException;
  */
 public class ExtendedCommonTermsQuery extends CommonTermsQuery {
 
-    private final FieldMapper<?> mapper;
+    private final FieldMapper mapper;
 
-    public ExtendedCommonTermsQuery(Occur highFreqOccur, Occur lowFreqOccur, float maxTermFrequency, boolean disableCoord, FieldMapper<?> mapper) {
+    public ExtendedCommonTermsQuery(Occur highFreqOccur, Occur lowFreqOccur, float maxTermFrequency, boolean disableCoord, FieldMapper mapper) {
         super(highFreqOccur, lowFreqOccur, maxTermFrequency, disableCoord);
         this.mapper = mapper;
     }

--- a/src/main/java/org/elasticsearch/action/admin/indices/analyze/TransportAnalyzeAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/analyze/TransportAnalyzeAction.java
@@ -109,7 +109,7 @@ public class TransportAnalyzeAction extends TransportSingleCustomOperationAction
             if (indexService == null) {
                 throw new IllegalArgumentException("No index provided, and trying to analyzer based on a specific field which requires the index parameter");
             }
-            FieldMapper<?> fieldMapper = indexService.mapperService().smartNameFieldMapper(request.field());
+            FieldMapper fieldMapper = indexService.mapperService().smartNameFieldMapper(request.field());
             if (fieldMapper != null) {
                 if (fieldMapper.isNumeric()) {
                     throw new IllegalArgumentException("Can't process field [" + request.field() + "], Analysis requests are not supported on numeric fields");

--- a/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsIndexAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsIndexAction.java
@@ -178,29 +178,29 @@ public class TransportGetFieldMappingsIndexAction extends TransportSingleCustomO
         final DocumentFieldMappers allFieldMappers = documentMapper.mappers();
         for (String field : request.fields()) {
             if (Regex.isMatchAllPattern(field)) {
-                for (FieldMapper<?> fieldMapper : allFieldMappers) {
+                for (FieldMapper fieldMapper : allFieldMappers) {
                     addFieldMapper(fieldMapper.names().fullName(), fieldMapper, fieldMappings, request.includeDefaults());
                 }
             } else if (Regex.isSimpleMatchPattern(field)) {
                 // go through the field mappers 3 times, to make sure we give preference to the resolve order: full name, index name, name.
                 // also make sure we only store each mapper once.
-                Collection<FieldMapper<?>> remainingFieldMappers = Lists.newLinkedList(allFieldMappers);
-                for (Iterator<FieldMapper<?>> it = remainingFieldMappers.iterator(); it.hasNext(); ) {
-                    final FieldMapper<?> fieldMapper = it.next();
+                Collection<FieldMapper> remainingFieldMappers = Lists.newLinkedList(allFieldMappers);
+                for (Iterator<FieldMapper> it = remainingFieldMappers.iterator(); it.hasNext(); ) {
+                    final FieldMapper fieldMapper = it.next();
                     if (Regex.simpleMatch(field, fieldMapper.names().fullName())) {
                         addFieldMapper(fieldMapper.names().fullName(), fieldMapper, fieldMappings, request.includeDefaults());
                         it.remove();
                     }
                 }
-                for (Iterator<FieldMapper<?>> it = remainingFieldMappers.iterator(); it.hasNext(); ) {
-                    final FieldMapper<?> fieldMapper = it.next();
+                for (Iterator<FieldMapper> it = remainingFieldMappers.iterator(); it.hasNext(); ) {
+                    final FieldMapper fieldMapper = it.next();
                     if (Regex.simpleMatch(field, fieldMapper.names().indexName())) {
                         addFieldMapper(fieldMapper.names().indexName(), fieldMapper, fieldMappings, request.includeDefaults());
                         it.remove();
                     }
                 }
-                for (Iterator<FieldMapper<?>> it = remainingFieldMappers.iterator(); it.hasNext(); ) {
-                    final FieldMapper<?> fieldMapper = it.next();
+                for (Iterator<FieldMapper> it = remainingFieldMappers.iterator(); it.hasNext(); ) {
+                    final FieldMapper fieldMapper = it.next();
                     if (Regex.simpleMatch(field, fieldMapper.names().shortName())) {
                         addFieldMapper(fieldMapper.names().shortName(), fieldMapper, fieldMappings, request.includeDefaults());
                         it.remove();
@@ -209,7 +209,7 @@ public class TransportGetFieldMappingsIndexAction extends TransportSingleCustomO
 
             } else {
                 // not a pattern
-                FieldMapper<?> fieldMapper = allFieldMappers.smartNameFieldMapper(field);
+                FieldMapper fieldMapper = allFieldMappers.smartNameFieldMapper(field);
                 if (fieldMapper != null) {
                     addFieldMapper(field, fieldMapper, fieldMappings, request.includeDefaults());
                 } else if (request.probablySingleFieldRequest()) {
@@ -220,7 +220,7 @@ public class TransportGetFieldMappingsIndexAction extends TransportSingleCustomO
         return fieldMappings.immutableMap();
     }
 
-    private void addFieldMapper(String field, FieldMapper<?> fieldMapper, MapBuilder<String, FieldMappingMetaData> fieldMappings, boolean includeDefaults) {
+    private void addFieldMapper(String field, FieldMapper fieldMapper, MapBuilder<String, FieldMappingMetaData> fieldMappings, boolean includeDefaults) {
         if (fieldMappings.containsKey(field)) {
             return;
         }

--- a/src/main/java/org/elasticsearch/index/fielddata/IndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/IndexFieldData.java
@@ -228,7 +228,7 @@ public interface IndexFieldData<FD extends AtomicFieldData> extends IndexCompone
 
     interface Builder {
 
-        IndexFieldData<?> build(Index index, @IndexSettings Settings indexSettings, FieldMapper<?> mapper, IndexFieldDataCache cache,
+        IndexFieldData<?> build(Index index, @IndexSettings Settings indexSettings, FieldMapper mapper, IndexFieldDataCache cache,
                              CircuitBreakerService breakerService, MapperService mapperService);
     }
 

--- a/src/main/java/org/elasticsearch/index/fielddata/IndexFieldDataService.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/IndexFieldDataService.java
@@ -225,7 +225,7 @@ public class IndexFieldDataService extends AbstractIndexComponent {
     }
 
     @SuppressWarnings("unchecked")
-    public <IFD extends IndexFieldData<?>> IFD getForField(FieldMapper<?> mapper) {
+    public <IFD extends IndexFieldData<?>> IFD getForField(FieldMapper mapper) {
         final FieldMapper.Names fieldNames = mapper.names();
         final FieldDataType type = mapper.fieldDataType();
         if (type == null) {

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/BytesBinaryDVIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/BytesBinaryDVIndexFieldData.java
@@ -64,7 +64,7 @@ public class BytesBinaryDVIndexFieldData extends DocValuesIndexFieldData impleme
     public static class Builder implements IndexFieldData.Builder {
 
         @Override
-        public IndexFieldData<?> build(Index index, Settings indexSettings, FieldMapper<?> mapper, IndexFieldDataCache cache,
+        public IndexFieldData<?> build(Index index, Settings indexSettings, FieldMapper mapper, IndexFieldDataCache cache,
                                        CircuitBreakerService breakerService, MapperService mapperService) {
             // Ignore breaker
             final Names fieldNames = mapper.names();

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/DisabledIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/DisabledIndexFieldData.java
@@ -39,7 +39,7 @@ public final class DisabledIndexFieldData extends AbstractIndexFieldData<AtomicF
 
     public static class Builder implements IndexFieldData.Builder {
         @Override
-        public IndexFieldData<AtomicFieldData> build(Index index, @IndexSettings Settings indexSettings, FieldMapper<?> mapper,
+        public IndexFieldData<AtomicFieldData> build(Index index, @IndexSettings Settings indexSettings, FieldMapper mapper,
                                                         IndexFieldDataCache cache, CircuitBreakerService breakerService, MapperService mapperService) {
             // Ignore Circuit Breaker
             return new DisabledIndexFieldData(index, indexSettings, mapper.names(), mapper.fieldDataType(), cache);

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/DocValuesIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/DocValuesIndexFieldData.java
@@ -90,7 +90,7 @@ public abstract class DocValuesIndexFieldData {
         }
 
         @Override
-        public IndexFieldData<?> build(Index index, Settings indexSettings, FieldMapper<?> mapper, IndexFieldDataCache cache,
+        public IndexFieldData<?> build(Index index, Settings indexSettings, FieldMapper mapper, IndexFieldDataCache cache,
                                        CircuitBreakerService breakerService, MapperService mapperService) {
             // Ignore Circuit Breaker
             final FieldMapper.Names fieldNames = mapper.names();

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/DoubleArrayIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/DoubleArrayIndexFieldData.java
@@ -72,7 +72,7 @@ public class DoubleArrayIndexFieldData extends AbstractIndexFieldData<AtomicNume
     public static class Builder implements IndexFieldData.Builder {
 
         @Override
-        public IndexFieldData<?> build(Index index, @IndexSettings Settings indexSettings, FieldMapper<?> mapper, IndexFieldDataCache cache,
+        public IndexFieldData<?> build(Index index, @IndexSettings Settings indexSettings, FieldMapper mapper, IndexFieldDataCache cache,
                                        CircuitBreakerService breakerService, MapperService mapperService) {
             return new DoubleArrayIndexFieldData(index, indexSettings, mapper.names(), mapper.fieldDataType(), cache, breakerService);
         }

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/FSTBytesIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/FSTBytesIndexFieldData.java
@@ -46,7 +46,7 @@ public class FSTBytesIndexFieldData extends AbstractIndexOrdinalsFieldData {
     public static class Builder implements IndexFieldData.Builder {
 
         @Override
-        public IndexOrdinalsFieldData build(Index index, @IndexSettings Settings indexSettings, FieldMapper<?> mapper,
+        public IndexOrdinalsFieldData build(Index index, @IndexSettings Settings indexSettings, FieldMapper mapper,
                                                              IndexFieldDataCache cache, CircuitBreakerService breakerService, MapperService mapperService) {
             return new FSTBytesIndexFieldData(index, indexSettings, mapper.names(), mapper.fieldDataType(), cache, breakerService);
         }

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/FloatArrayIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/FloatArrayIndexFieldData.java
@@ -71,7 +71,7 @@ public class FloatArrayIndexFieldData extends AbstractIndexFieldData<AtomicNumer
     public static class Builder implements IndexFieldData.Builder {
 
         @Override
-        public IndexFieldData<?> build(Index index, @IndexSettings Settings indexSettings, FieldMapper<?> mapper, IndexFieldDataCache cache,
+        public IndexFieldData<?> build(Index index, @IndexSettings Settings indexSettings, FieldMapper mapper, IndexFieldDataCache cache,
                                        CircuitBreakerService breakerService, MapperService mapperService) {
             return new FloatArrayIndexFieldData(index, indexSettings, mapper.names(), mapper.fieldDataType(), cache, breakerService);
         }

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointBinaryDVIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointBinaryDVIndexFieldData.java
@@ -62,7 +62,7 @@ public class GeoPointBinaryDVIndexFieldData extends DocValuesIndexFieldData impl
     public static class Builder implements IndexFieldData.Builder {
 
         @Override
-        public IndexFieldData<?> build(Index index, Settings indexSettings, FieldMapper<?> mapper, IndexFieldDataCache cache,
+        public IndexFieldData<?> build(Index index, Settings indexSettings, FieldMapper mapper, IndexFieldDataCache cache,
                                        CircuitBreakerService breakerService, MapperService mapperService) {
             // Ignore breaker
             final FieldMapper.Names fieldNames = mapper.names();

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointCompressedIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointCompressedIndexFieldData.java
@@ -52,7 +52,7 @@ public class GeoPointCompressedIndexFieldData extends AbstractIndexGeoPointField
     public static class Builder implements IndexFieldData.Builder {
 
         @Override
-        public IndexFieldData<?> build(Index index, @IndexSettings Settings indexSettings, FieldMapper<?> mapper, IndexFieldDataCache cache,
+        public IndexFieldData<?> build(Index index, @IndexSettings Settings indexSettings, FieldMapper mapper, IndexFieldDataCache cache,
                                        CircuitBreakerService breakerService, MapperService mapperService) {
             FieldDataType type = mapper.fieldDataType();
             final String precisionAsString = type.getSettings().get(PRECISION_KEY);

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointDoubleArrayIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointDoubleArrayIndexFieldData.java
@@ -46,7 +46,7 @@ public class GeoPointDoubleArrayIndexFieldData extends AbstractIndexGeoPointFiel
     public static class Builder implements IndexFieldData.Builder {
 
         @Override
-        public IndexFieldData<?> build(Index index, @IndexSettings Settings indexSettings, FieldMapper<?> mapper, IndexFieldDataCache cache,
+        public IndexFieldData<?> build(Index index, @IndexSettings Settings indexSettings, FieldMapper mapper, IndexFieldDataCache cache,
                                        CircuitBreakerService breakerService, MapperService mapperService) {
             return new GeoPointDoubleArrayIndexFieldData(index, indexSettings, mapper.names(), mapper.fieldDataType(), cache, breakerService);
         }

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/IndexIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/IndexIndexFieldData.java
@@ -46,7 +46,7 @@ public class IndexIndexFieldData extends AbstractIndexOrdinalsFieldData {
     public static class Builder implements IndexFieldData.Builder {
 
         @Override
-        public IndexFieldData<?> build(Index index, Settings indexSettings, FieldMapper<?> mapper, IndexFieldDataCache cache,
+        public IndexFieldData<?> build(Index index, Settings indexSettings, FieldMapper mapper, IndexFieldDataCache cache,
                 CircuitBreakerService breakerService, MapperService mapperService) {
             return new IndexIndexFieldData(index, mapper.names());
         }

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/PackedArrayIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/PackedArrayIndexFieldData.java
@@ -85,7 +85,7 @@ public class PackedArrayIndexFieldData extends AbstractIndexFieldData<AtomicNume
         }
 
         @Override
-        public IndexFieldData<AtomicNumericFieldData> build(Index index, @IndexSettings Settings indexSettings, FieldMapper<?> mapper,
+        public IndexFieldData<AtomicNumericFieldData> build(Index index, @IndexSettings Settings indexSettings, FieldMapper mapper,
                                                             IndexFieldDataCache cache, CircuitBreakerService breakerService, MapperService mapperService) {
             return new PackedArrayIndexFieldData(index, indexSettings, mapper.names(), mapper.fieldDataType(), cache, numericType, breakerService);
         }

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/PagedBytesIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/PagedBytesIndexFieldData.java
@@ -47,7 +47,7 @@ public class PagedBytesIndexFieldData extends AbstractIndexOrdinalsFieldData {
     public static class Builder implements IndexFieldData.Builder {
 
         @Override
-        public IndexOrdinalsFieldData build(Index index, @IndexSettings Settings indexSettings, FieldMapper<?> mapper,
+        public IndexOrdinalsFieldData build(Index index, @IndexSettings Settings indexSettings, FieldMapper mapper,
                                                                IndexFieldDataCache cache, CircuitBreakerService breakerService, MapperService mapperService) {
             return new PagedBytesIndexFieldData(index, indexSettings, mapper.names(), mapper.fieldDataType(), cache, breakerService);
         }

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/ParentChildIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/ParentChildIndexFieldData.java
@@ -225,7 +225,7 @@ public class ParentChildIndexFieldData extends AbstractIndexFieldData<AtomicPare
     public static class Builder implements IndexFieldData.Builder {
 
         @Override
-        public IndexFieldData<?> build(Index index, @IndexSettings Settings indexSettings, FieldMapper<?> mapper,
+        public IndexFieldData<?> build(Index index, @IndexSettings Settings indexSettings, FieldMapper mapper,
                                        IndexFieldDataCache cache, CircuitBreakerService breakerService,
                                        MapperService mapperService) {
             return new ParentChildIndexFieldData(index, indexSettings, mapper.names(), mapper.fieldDataType(), cache,

--- a/src/main/java/org/elasticsearch/index/fieldvisitor/FieldsVisitor.java
+++ b/src/main/java/org/elasticsearch/index/fieldvisitor/FieldsVisitor.java
@@ -74,7 +74,7 @@ public abstract class FieldsVisitor extends StoredFieldVisitor {
 
     public void postProcess(DocumentMapper documentMapper) {
         for (Map.Entry<String, List<Object>> entry : fields().entrySet()) {
-            FieldMapper<?> fieldMapper = documentMapper.mappers().indexName(entry.getKey()).mapper();
+            FieldMapper fieldMapper = documentMapper.mappers().indexName(entry.getKey()).mapper();
             if (fieldMapper == null) {
                 continue;
             }

--- a/src/main/java/org/elasticsearch/index/get/ShardGetService.java
+++ b/src/main/java/org/elasticsearch/index/get/ShardGetService.java
@@ -242,7 +242,7 @@ public class ShardGetService extends AbstractIndexShardComponent {
                                 searchLookup.source().setSource(source.source);
                             }
 
-                            FieldMapper<?> fieldMapper = docMapper.mappers().smartNameFieldMapper(field);
+                            FieldMapper fieldMapper = docMapper.mappers().smartNameFieldMapper(field);
                             if (fieldMapper == null) {
                                 if (docMapper.objectMappers().get(field) != null) {
                                     // Only fail if we know it is a object field, missing paths / fields shouldn't fail.
@@ -314,7 +314,7 @@ public class ShardGetService extends AbstractIndexShardComponent {
         }
     }
 
-    protected boolean shouldGetFromSource(boolean ignoreErrorsOnGeneratedFields, DocumentMapper docMapper, FieldMapper<?> fieldMapper) {
+    protected boolean shouldGetFromSource(boolean ignoreErrorsOnGeneratedFields, DocumentMapper docMapper, FieldMapper fieldMapper) {
         if (!fieldMapper.isGenerated()) {
             //if the field is always there we check if either source mapper is enabled, in which case we get the field
             // from source, or, if the field is stored, in which case we have to get if from source here also (we are in the translog phase, doc not indexed yet, we annot access the stored fields)

--- a/src/main/java/org/elasticsearch/index/mapper/DocumentFieldMappers.java
+++ b/src/main/java/org/elasticsearch/index/mapper/DocumentFieldMappers.java
@@ -34,7 +34,7 @@ import java.util.Map;
 /**
  *
  */
-public final class DocumentFieldMappers implements Iterable<FieldMapper<?>> {
+public final class DocumentFieldMappers implements Iterable<FieldMapper> {
 
     private final FieldMappersLookup fieldMappers;
 
@@ -55,23 +55,23 @@ public final class DocumentFieldMappers implements Iterable<FieldMapper<?>> {
         this.searchQuoteAnalyzer = searchQuoteAnalyzer;
     }
 
-    public DocumentFieldMappers copyAndAllAll(Collection<FieldMapper<?>> newMappers) {
+    public DocumentFieldMappers copyAndAllAll(Collection<FieldMapper> newMappers) {
         FieldMappersLookup fieldMappers = this.fieldMappers.copyAndAddAll(newMappers);
-        FieldNameAnalyzer indexAnalyzer = this.indexAnalyzer.copyAndAddAll(Collections2.transform(newMappers, new Function<FieldMapper<?>, Map.Entry<String, Analyzer>>() {
+        FieldNameAnalyzer indexAnalyzer = this.indexAnalyzer.copyAndAddAll(Collections2.transform(newMappers, new Function<FieldMapper, Map.Entry<String, Analyzer>>() {
             @Override
-            public Map.Entry<String, Analyzer> apply(FieldMapper<?> input) {
+            public Map.Entry<String, Analyzer> apply(FieldMapper input) {
                 return Maps.immutableEntry(input.names().indexName(), input.indexAnalyzer());
             }
         }));
-        FieldNameAnalyzer searchAnalyzer = this.searchAnalyzer.copyAndAddAll(Collections2.transform(newMappers, new Function<FieldMapper<?>, Map.Entry<String, Analyzer>>() {
+        FieldNameAnalyzer searchAnalyzer = this.searchAnalyzer.copyAndAddAll(Collections2.transform(newMappers, new Function<FieldMapper, Map.Entry<String, Analyzer>>() {
             @Override
-            public Map.Entry<String, Analyzer> apply(FieldMapper<?> input) {
+            public Map.Entry<String, Analyzer> apply(FieldMapper input) {
                 return Maps.immutableEntry(input.names().indexName(), input.searchAnalyzer());
             }
         }));
-        FieldNameAnalyzer searchQuoteAnalyzer = this.searchQuoteAnalyzer.copyAndAddAll(Collections2.transform(newMappers, new Function<FieldMapper<?>, Map.Entry<String, Analyzer>>() {
+        FieldNameAnalyzer searchQuoteAnalyzer = this.searchQuoteAnalyzer.copyAndAddAll(Collections2.transform(newMappers, new Function<FieldMapper, Map.Entry<String, Analyzer>>() {
             @Override
-            public Map.Entry<String, Analyzer> apply(FieldMapper<?> input) {
+            public Map.Entry<String, Analyzer> apply(FieldMapper input) {
                 return Maps.immutableEntry(input.names().indexName(), input.searchQuoteAnalyzer());
             }
         }));
@@ -113,7 +113,7 @@ public final class DocumentFieldMappers implements Iterable<FieldMapper<?>> {
         return fieldMappers.smartName(name);
     }
 
-    public FieldMapper<?> smartNameFieldMapper(String name) {
+    public FieldMapper smartNameFieldMapper(String name) {
         return fieldMappers.smartNameFieldMapper(name);
     }
 
@@ -145,7 +145,7 @@ public final class DocumentFieldMappers implements Iterable<FieldMapper<?>> {
         return this.searchQuoteAnalyzer;
     }
 
-    public Iterator<FieldMapper<?>> iterator() {
+    public Iterator<FieldMapper> iterator() {
         return fieldMappers.iterator();
     }
 }

--- a/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
@@ -196,7 +196,7 @@ public class DocumentMapper implements ToXContent {
 
         // collect all the mappers for this type
         List<ObjectMapper> newObjectMappers = new ArrayList<>();
-        List<FieldMapper<?>> newFieldMappers = new ArrayList<>();
+        List<FieldMapper> newFieldMappers = new ArrayList<>();
         for (RootMapper rootMapper : this.mapping.rootMappers) {
             if (rootMapper instanceof FieldMapper) {
                 newFieldMappers.add((FieldMapper) rootMapper);
@@ -387,7 +387,7 @@ public class DocumentMapper implements ToXContent {
         return DocumentParser.transformSourceAsMap(mapping, sourceAsMap);
     }
 
-    private void addFieldMappers(Collection<FieldMapper<?>> fieldMappers) {
+    private void addFieldMappers(Collection<FieldMapper> fieldMappers) {
         assert mappingLock.isWriteLockedByCurrentThread();
         this.fieldMappers = this.fieldMappers.copyAndAllAll(fieldMappers);
         mapperService.addFieldMappers(fieldMappers);
@@ -410,11 +410,11 @@ public class DocumentMapper implements ToXContent {
         return new MergeResult(simulate) {
 
             final List<String> conflicts = new ArrayList<>();
-            final List<FieldMapper<?>> newFieldMappers = new ArrayList<>();
+            final List<FieldMapper> newFieldMappers = new ArrayList<>();
             final List<ObjectMapper> newObjectMappers = new ArrayList<>();
 
             @Override
-            public void addFieldMappers(Collection<FieldMapper<?>> fieldMappers) {
+            public void addFieldMappers(Collection<FieldMapper> fieldMappers) {
                 assert simulate() == false;
                 newFieldMappers.addAll(fieldMappers);
             }
@@ -426,7 +426,7 @@ public class DocumentMapper implements ToXContent {
             }
 
             @Override
-            public Collection<FieldMapper<?>> getNewFieldMappers() {
+            public Collection<FieldMapper> getNewFieldMappers() {
                 return newFieldMappers;
             }
 

--- a/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -600,7 +600,7 @@ class DocumentParser implements Closeable {
     }
 
     /** Creates instances of the fields that the current field should be copied to */
-    private static void parseCopyFields(ParseContext context, FieldMapper<?> fieldMapper, ImmutableList<String> copyToFields) throws IOException {
+    private static void parseCopyFields(ParseContext context, FieldMapper fieldMapper, ImmutableList<String> copyToFields) throws IOException {
         if (!context.isWithinCopyTo() && copyToFields.isEmpty() == false) {
             context = context.createCopyToContext();
             for (String field : copyToFields) {

--- a/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -24,7 +24,6 @@ import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.index.Terms;
-import org.apache.lucene.search.Filter;
 import org.apache.lucene.search.MultiTermQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
@@ -42,7 +41,7 @@ import java.util.List;
 /**
  *
  */
-public interface FieldMapper<T> extends Mapper {
+public interface FieldMapper extends Mapper {
 
     String DOC_VALUES_FORMAT = "doc_values_format";
 
@@ -195,7 +194,7 @@ public interface FieldMapper<T> extends Mapper {
     /**
      * Returns the actual value of the field.
      */
-    T value(Object value);
+    Object value(Object value);
 
     /**
      * Returns the value that will be used as a result for search. Can be only of specific types... .

--- a/src/main/java/org/elasticsearch/index/mapper/FieldMappersLookup.java
+++ b/src/main/java/org/elasticsearch/index/mapper/FieldMappersLookup.java
@@ -32,7 +32,7 @@ import java.util.List;
 /**
  * A class that holds a map of field mappers from name, index name, and full name.
  */
-class FieldMappersLookup implements Iterable<FieldMapper<?>> {
+class FieldMappersLookup implements Iterable<FieldMapper> {
 
     /** Full field name to mappers */
     private final CopyOnWriteHashMap<String, FieldMappers> mappers;
@@ -49,10 +49,10 @@ class FieldMappersLookup implements Iterable<FieldMapper<?>> {
     /**
      * Return a new instance that contains the union of this instance and the provided mappers.
      */
-    public FieldMappersLookup copyAndAddAll(Collection<FieldMapper<?>> newMappers) {
+    public FieldMappersLookup copyAndAddAll(Collection<FieldMapper> newMappers) {
         CopyOnWriteHashMap<String, FieldMappers> map = this.mappers;
 
-        for (FieldMapper<?> mapper : newMappers) {
+        for (FieldMapper mapper : newMappers) {
             String key = mapper.names().fullName();
             FieldMappers mappers = map.get(key);
 
@@ -116,7 +116,7 @@ class FieldMappersLookup implements Iterable<FieldMapper<?>> {
      */
     public List<String> simpleMatchToIndexNames(String pattern) {
         List<String> fields = Lists.newArrayList();
-        for (FieldMapper<?> fieldMapper : this) {
+        for (FieldMapper fieldMapper : this) {
             if (Regex.simpleMatch(pattern, fieldMapper.names().fullName())) {
                 fields.add(fieldMapper.names().indexName());
             } else if (Regex.simpleMatch(pattern, fieldMapper.names().indexName())) {
@@ -131,7 +131,7 @@ class FieldMappersLookup implements Iterable<FieldMapper<?>> {
      */
     public List<String> simpleMatchToFullName(String pattern) {
         List<String> fields = Lists.newArrayList();
-        for (FieldMapper<?> fieldMapper : this) {
+        for (FieldMapper fieldMapper : this) {
             if (Regex.simpleMatch(pattern, fieldMapper.names().fullName())) {
                 fields.add(fieldMapper.names().fullName());
             } else if (Regex.simpleMatch(pattern, fieldMapper.names().indexName())) {
@@ -158,7 +158,7 @@ class FieldMappersLookup implements Iterable<FieldMapper<?>> {
      * and return the first mapper for it (see {@link org.elasticsearch.index.mapper.FieldMappers#mapper()}).
      */
     @Nullable
-    public FieldMapper<?> smartNameFieldMapper(String name) {
+    public FieldMapper smartNameFieldMapper(String name) {
         FieldMappers fieldMappers = smartName(name);
         if (fieldMappers == null) {
             return null;
@@ -166,12 +166,12 @@ class FieldMappersLookup implements Iterable<FieldMapper<?>> {
         return fieldMappers.mapper();
     }
 
-    public Iterator<FieldMapper<?>> iterator() {
+    public Iterator<FieldMapper> iterator() {
         final Iterator<FieldMappers> fieldsItr = mappers.values().iterator();
         if (fieldsItr.hasNext() == false) {
             return Collections.emptyIterator();
         }
-        return new Iterator<FieldMapper<?>>() {
+        return new Iterator<FieldMapper>() {
             Iterator<FieldMapper> fieldValuesItr = fieldsItr.next().iterator();
             @Override
             public boolean hasNext() {

--- a/src/main/java/org/elasticsearch/index/mapper/MapperUtils.java
+++ b/src/main/java/org/elasticsearch/index/mapper/MapperUtils.java
@@ -43,7 +43,7 @@ public enum MapperUtils {
             }
 
             @Override
-            public void addFieldMappers(Collection<FieldMapper<?>> fieldMappers) {
+            public void addFieldMappers(Collection<FieldMapper> fieldMappers) {
                 // no-op
             }
 
@@ -53,7 +53,7 @@ public enum MapperUtils {
             }
 
             @Override
-            public Collection<FieldMapper<?>> getNewFieldMappers() {
+            public Collection<FieldMapper> getNewFieldMappers() {
                 throw new UnsupportedOperationException("Strict merge result does not support new field mappers");
             }
 
@@ -86,13 +86,13 @@ public enum MapperUtils {
     }
 
     /** Split mapper and its descendants into object and field mappers. */
-    public static void collect(Mapper mapper, Collection<ObjectMapper> objectMappers, Collection<FieldMapper<?>> fieldMappers) {
+    public static void collect(Mapper mapper, Collection<ObjectMapper> objectMappers, Collection<FieldMapper> fieldMappers) {
         if (mapper instanceof RootObjectMapper) {
             // root mapper isn't really an object mapper
         } else if (mapper instanceof ObjectMapper) {
             objectMappers.add((ObjectMapper)mapper);
-        } else if (mapper instanceof FieldMapper<?>) {
-            fieldMappers.add((FieldMapper<?>)mapper);
+        } else if (mapper instanceof FieldMapper) {
+            fieldMappers.add((FieldMapper)mapper);
         }
         for (Mapper child : mapper) {
             collect(child, objectMappers, fieldMappers);

--- a/src/main/java/org/elasticsearch/index/mapper/MergeResult.java
+++ b/src/main/java/org/elasticsearch/index/mapper/MergeResult.java
@@ -34,11 +34,11 @@ public abstract class MergeResult {
         this.simulate = simulate;
     }
 
-    public abstract void addFieldMappers(Collection<FieldMapper<?>> fieldMappers);
+    public abstract void addFieldMappers(Collection<FieldMapper> fieldMappers);
 
     public abstract void addObjectMappers(Collection<ObjectMapper> objectMappers);
 
-    public abstract Collection<FieldMapper<?>> getNewFieldMappers();
+    public abstract Collection<FieldMapper> getNewFieldMappers();
 
     public abstract Collection<ObjectMapper> getNewObjectMappers();
 

--- a/src/main/java/org/elasticsearch/index/mapper/core/AbstractFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/AbstractFieldMapper.java
@@ -78,7 +78,7 @@ import java.util.TreeMap;
 /**
  *
  */
-public abstract class AbstractFieldMapper<T> implements FieldMapper<T> {
+public abstract class AbstractFieldMapper implements FieldMapper {
 
     public static class Defaults {
         public static final FieldType FIELD_TYPE = new FieldType();
@@ -879,7 +879,7 @@ public abstract class AbstractFieldMapper<T> implements FieldMapper<T> {
         public void merge(Mapper mergeWith, MergeResult mergeResult) throws MergeMappingException {
             AbstractFieldMapper mergeWithMultiField = (AbstractFieldMapper) mergeWith;
 
-            List<FieldMapper<?>> newFieldMappers = null;
+            List<FieldMapper> newFieldMappers = null;
             ImmutableOpenMap.Builder<String, FieldMapper> newMappersBuilder = null;
 
             for (ObjectCursor<FieldMapper> cursor : mergeWithMultiField.multiFields.mappers.values()) {

--- a/src/main/java/org/elasticsearch/index/mapper/core/BinaryFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/BinaryFieldMapper.java
@@ -61,7 +61,7 @@ import static org.elasticsearch.index.mapper.core.TypeParsers.parseField;
 /**
  *
  */
-public class BinaryFieldMapper extends AbstractFieldMapper<BytesReference> {
+public class BinaryFieldMapper extends AbstractFieldMapper {
 
     public static final String CONTENT_TYPE = "binary";
 

--- a/src/main/java/org/elasticsearch/index/mapper/core/BooleanFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/BooleanFieldMapper.java
@@ -54,7 +54,7 @@ import static org.elasticsearch.index.mapper.core.TypeParsers.parseField;
 /**
  * A field mapper for boolean fields.
  */
-public class BooleanFieldMapper extends AbstractFieldMapper<Boolean> {
+public class BooleanFieldMapper extends AbstractFieldMapper {
 
     public static final String CONTENT_TYPE = "boolean";
 

--- a/src/main/java/org/elasticsearch/index/mapper/core/ByteFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/ByteFieldMapper.java
@@ -61,7 +61,7 @@ import static org.elasticsearch.index.mapper.core.TypeParsers.parseNumberField;
 /**
  *
  */
-public class ByteFieldMapper extends NumberFieldMapper<Byte> {
+public class ByteFieldMapper extends NumberFieldMapper {
 
     public static final String CONTENT_TYPE = "byte";
 

--- a/src/main/java/org/elasticsearch/index/mapper/core/CompletionFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/CompletionFieldMapper.java
@@ -67,7 +67,7 @@ import static org.elasticsearch.index.mapper.core.TypeParsers.parseMultiField;
 /**
  *
  */
-public class CompletionFieldMapper extends AbstractFieldMapper<String> {
+public class CompletionFieldMapper extends AbstractFieldMapper {
 
     public static final String CONTENT_TYPE = "completion";
 

--- a/src/main/java/org/elasticsearch/index/mapper/core/DateFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/DateFieldMapper.java
@@ -71,7 +71,7 @@ import static org.elasticsearch.index.mapper.MapperBuilders.dateField;
 import static org.elasticsearch.index.mapper.core.TypeParsers.parseDateTimeFormatter;
 import static org.elasticsearch.index.mapper.core.TypeParsers.parseNumberField;
 
-public class DateFieldMapper extends NumberFieldMapper<Long> {
+public class DateFieldMapper extends NumberFieldMapper {
 
     public static final String CONTENT_TYPE = "date";
 

--- a/src/main/java/org/elasticsearch/index/mapper/core/DoubleFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/DoubleFieldMapper.java
@@ -66,7 +66,7 @@ import static org.elasticsearch.index.mapper.core.TypeParsers.parseNumberField;
 /**
  *
  */
-public class DoubleFieldMapper extends NumberFieldMapper<Double> {
+public class DoubleFieldMapper extends NumberFieldMapper {
 
     public static final String CONTENT_TYPE = "double";
 

--- a/src/main/java/org/elasticsearch/index/mapper/core/FloatFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/FloatFieldMapper.java
@@ -67,7 +67,7 @@ import static org.elasticsearch.index.mapper.core.TypeParsers.parseNumberField;
 /**
  *
  */
-public class FloatFieldMapper extends NumberFieldMapper<Float> {
+public class FloatFieldMapper extends NumberFieldMapper {
 
     public static final String CONTENT_TYPE = "float";
 

--- a/src/main/java/org/elasticsearch/index/mapper/core/IntegerFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/IntegerFieldMapper.java
@@ -62,7 +62,7 @@ import static org.elasticsearch.index.mapper.core.TypeParsers.parseNumberField;
 /**
  *
  */
-public class IntegerFieldMapper extends NumberFieldMapper<Integer> {
+public class IntegerFieldMapper extends NumberFieldMapper {
 
     public static final String CONTENT_TYPE = "integer";
 

--- a/src/main/java/org/elasticsearch/index/mapper/core/LongFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/LongFieldMapper.java
@@ -62,7 +62,7 @@ import static org.elasticsearch.index.mapper.core.TypeParsers.parseNumberField;
 /**
  *
  */
-public class LongFieldMapper extends NumberFieldMapper<Long> {
+public class LongFieldMapper extends NumberFieldMapper {
 
     public static final String CONTENT_TYPE = "long";
 

--- a/src/main/java/org/elasticsearch/index/mapper/core/NumberFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/NumberFieldMapper.java
@@ -61,7 +61,7 @@ import java.util.List;
 /**
  *
  */
-public abstract class NumberFieldMapper<T extends Number> extends AbstractFieldMapper<T> implements AllFieldMapper.IncludeInAll {
+public abstract class NumberFieldMapper extends AbstractFieldMapper implements AllFieldMapper.IncludeInAll {
 
     public static class Defaults extends AbstractFieldMapper.Defaults {
         

--- a/src/main/java/org/elasticsearch/index/mapper/core/ShortFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/ShortFieldMapper.java
@@ -63,7 +63,7 @@ import static org.elasticsearch.index.mapper.core.TypeParsers.parseNumberField;
 /**
  *
  */
-public class ShortFieldMapper extends NumberFieldMapper<Short> {
+public class ShortFieldMapper extends NumberFieldMapper {
 
     public static final String CONTENT_TYPE = "short";
     public static final int DEFAULT_PRECISION_STEP = 8;

--- a/src/main/java/org/elasticsearch/index/mapper/core/StringFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/StringFieldMapper.java
@@ -54,7 +54,7 @@ import static org.elasticsearch.index.mapper.core.TypeParsers.parseMultiField;
 /**
  *
  */
-public class StringFieldMapper extends AbstractFieldMapper<String> implements AllFieldMapper.IncludeInAll {
+public class StringFieldMapper extends AbstractFieldMapper implements AllFieldMapper.IncludeInAll {
 
     public static final String CONTENT_TYPE = "string";
 

--- a/src/main/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapper.java
@@ -82,7 +82,7 @@ import static org.elasticsearch.index.mapper.core.TypeParsers.parsePathType;
  * "lon" : 2.1
  * }
  */
-public class GeoPointFieldMapper extends AbstractFieldMapper<GeoPoint> implements ArrayValueMapperParser {
+public class GeoPointFieldMapper extends AbstractFieldMapper implements ArrayValueMapperParser {
 
     public static final String CONTENT_TYPE = "geo_point";
 

--- a/src/main/java/org/elasticsearch/index/mapper/geo/GeoShapeFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/geo/GeoShapeFieldMapper.java
@@ -71,7 +71,7 @@ import static org.elasticsearch.index.mapper.MapperBuilders.geoShapeField;
  * ]
  * }
  */
-public class GeoShapeFieldMapper extends AbstractFieldMapper<String> {
+public class GeoShapeFieldMapper extends AbstractFieldMapper {
 
     public static final String CONTENT_TYPE = "geo_shape";
 

--- a/src/main/java/org/elasticsearch/index/mapper/internal/AllFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/AllFieldMapper.java
@@ -60,7 +60,7 @@ import static org.elasticsearch.index.mapper.core.TypeParsers.parseField;
 /**
  *
  */
-public class AllFieldMapper extends AbstractFieldMapper<String> implements RootMapper {
+public class AllFieldMapper extends AbstractFieldMapper implements RootMapper {
 
     public interface IncludeInAll extends Mapper {
 

--- a/src/main/java/org/elasticsearch/index/mapper/internal/FieldNamesFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/FieldNamesFieldMapper.java
@@ -55,7 +55,7 @@ import static org.elasticsearch.index.mapper.core.TypeParsers.parseField;
  *
  * Added in Elasticsearch 1.3.
  */
-public class FieldNamesFieldMapper extends AbstractFieldMapper<String> implements RootMapper {
+public class FieldNamesFieldMapper extends AbstractFieldMapper implements RootMapper {
 
     public static final String NAME = "_field_names";
 

--- a/src/main/java/org/elasticsearch/index/mapper/internal/IdFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/IdFieldMapper.java
@@ -65,7 +65,7 @@ import static org.elasticsearch.index.mapper.core.TypeParsers.parseField;
 /**
  * 
  */
-public class IdFieldMapper extends AbstractFieldMapper<String> implements RootMapper {
+public class IdFieldMapper extends AbstractFieldMapper implements RootMapper {
 
     public static final String NAME = "_id";
 

--- a/src/main/java/org/elasticsearch/index/mapper/internal/IndexFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/IndexFieldMapper.java
@@ -50,7 +50,7 @@ import static org.elasticsearch.index.mapper.core.TypeParsers.parseField;
 /**
  *
  */
-public class IndexFieldMapper extends AbstractFieldMapper<String> implements RootMapper {
+public class IndexFieldMapper extends AbstractFieldMapper implements RootMapper {
 
     public static final String NAME = "_index";
 

--- a/src/main/java/org/elasticsearch/index/mapper/internal/ParentFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/ParentFieldMapper.java
@@ -60,7 +60,7 @@ import static org.elasticsearch.index.mapper.MapperBuilders.parent;
 /**
  *
  */
-public class ParentFieldMapper extends AbstractFieldMapper<Uid> implements RootMapper {
+public class ParentFieldMapper extends AbstractFieldMapper implements RootMapper {
 
     public static final String NAME = "_parent";
 

--- a/src/main/java/org/elasticsearch/index/mapper/internal/RoutingFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/RoutingFieldMapper.java
@@ -50,7 +50,7 @@ import static org.elasticsearch.index.mapper.core.TypeParsers.parseField;
 /**
  *
  */
-public class RoutingFieldMapper extends AbstractFieldMapper<String> implements RootMapper {
+public class RoutingFieldMapper extends AbstractFieldMapper implements RootMapper {
 
     public static final String NAME = "_routing";
     public static final String CONTENT_TYPE = "_routing";

--- a/src/main/java/org/elasticsearch/index/mapper/internal/SourceFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/SourceFieldMapper.java
@@ -66,7 +66,7 @@ import static org.elasticsearch.index.mapper.MapperBuilders.source;
 /**
  *
  */
-public class SourceFieldMapper extends AbstractFieldMapper<byte[]> implements RootMapper {
+public class SourceFieldMapper extends AbstractFieldMapper implements RootMapper {
 
     public static final String NAME = "_source";
 

--- a/src/main/java/org/elasticsearch/index/mapper/internal/TypeFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/TypeFieldMapper.java
@@ -56,7 +56,7 @@ import static org.elasticsearch.index.mapper.core.TypeParsers.parseField;
 /**
  *
  */
-public class TypeFieldMapper extends AbstractFieldMapper<String> implements RootMapper {
+public class TypeFieldMapper extends AbstractFieldMapper implements RootMapper {
 
     public static final String NAME = "_type";
 

--- a/src/main/java/org/elasticsearch/index/mapper/internal/UidFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/UidFieldMapper.java
@@ -52,7 +52,7 @@ import static org.elasticsearch.index.mapper.core.TypeParsers.parseField;
 /**
  *
  */
-public class UidFieldMapper extends AbstractFieldMapper<Uid> implements RootMapper {
+public class UidFieldMapper extends AbstractFieldMapper implements RootMapper {
 
     public static final String NAME = "_uid";
 

--- a/src/main/java/org/elasticsearch/index/mapper/internal/VersionFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/VersionFieldMapper.java
@@ -44,7 +44,7 @@ import java.util.Map;
 import static org.elasticsearch.index.mapper.MapperBuilders.version;
 
 /** Mapper for the _version field. */
-public class VersionFieldMapper extends AbstractFieldMapper<Long> implements RootMapper {
+public class VersionFieldMapper extends AbstractFieldMapper implements RootMapper {
 
     public static final String NAME = "_version";
     public static final String CONTENT_TYPE = "_version";

--- a/src/main/java/org/elasticsearch/index/mapper/ip/IpFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/ip/IpFieldMapper.java
@@ -65,7 +65,7 @@ import static org.elasticsearch.index.mapper.core.TypeParsers.parseNumberField;
 /**
  *
  */
-public class IpFieldMapper extends NumberFieldMapper<Long> {
+public class IpFieldMapper extends NumberFieldMapper {
 
     public static final String CONTENT_TYPE = "ip";
 

--- a/src/main/java/org/elasticsearch/index/mapper/object/ObjectMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/object/ObjectMapper.java
@@ -513,7 +513,7 @@ public class ObjectMapper implements Mapper, AllFieldMapper.IncludeInAll, Clonea
 
         List<Mapper> mappersToPut = new ArrayList<>();
         List<ObjectMapper> newObjectMappers = new ArrayList<>();
-        List<FieldMapper<?>> newFieldMappers = new ArrayList<>();
+        List<FieldMapper> newFieldMappers = new ArrayList<>();
         for (Mapper mapper : mergeWithObject) {
             Mapper mergeWithMapper = mapper;
             Mapper mergeIntoMapper = mappers.get(mergeWithMapper.name());

--- a/src/main/java/org/elasticsearch/index/percolator/QueriesLoaderCollector.java
+++ b/src/main/java/org/elasticsearch/index/percolator/QueriesLoaderCollector.java
@@ -54,7 +54,7 @@ final class QueriesLoaderCollector extends SimpleCollector {
     QueriesLoaderCollector(PercolatorQueriesRegistry percolator, ESLogger logger, MapperService mapperService, IndexFieldDataService indexFieldDataService) {
         this.percolator = percolator;
         this.logger = logger;
-        final FieldMapper<?> uidMapper = mapperService.smartNameFieldMapper(UidFieldMapper.NAME);
+        final FieldMapper uidMapper = mapperService.smartNameFieldMapper(UidFieldMapper.NAME);
         this.uidFieldData = indexFieldDataService.getForField(uidMapper);
     }
 

--- a/src/main/java/org/elasticsearch/index/query/CommonTermsQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/CommonTermsQueryParser.java
@@ -163,7 +163,7 @@ public class CommonTermsQueryParser implements QueryParser {
             throw new QueryParsingException(parseContext, "No text specified for text query");
         }
         String field;
-        FieldMapper<?> mapper = parseContext.fieldMapper(fieldName);
+        FieldMapper mapper = parseContext.fieldMapper(fieldName);
         if (mapper != null) {
             field = mapper.names().indexName();
         } else {

--- a/src/main/java/org/elasticsearch/index/query/QueryParseContext.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryParseContext.java
@@ -186,7 +186,7 @@ public class QueryParseContext {
         return indexQueryParser.bitsetFilterCache.getBitDocIdSetFilter(filter);
     }
 
-    public <IFD extends IndexFieldData<?>> IFD getForField(FieldMapper<?> mapper) {
+    public <IFD extends IndexFieldData<?>> IFD getForField(FieldMapper mapper) {
         return indexQueryParser.fieldDataService.getForField(mapper);
     }
 

--- a/src/main/java/org/elasticsearch/index/query/TermsQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TermsQueryParser.java
@@ -158,7 +158,7 @@ public class TermsQueryParser implements QueryParser {
             throw new QueryParsingException(parseContext, "terms query requires a field name, followed by array of terms");
         }
 
-        FieldMapper<?> fieldMapper = parseContext.fieldMapper(fieldName);
+        FieldMapper fieldMapper = parseContext.fieldMapper(fieldName);
         if (fieldMapper != null) {
             fieldName = fieldMapper.names().indexName();
         }

--- a/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionParser.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionParser.java
@@ -162,8 +162,8 @@ public abstract class DecayFunctionParser implements ScoreFunctionParser {
             return parseDateVariable(fieldName, parser, parseContext, (DateFieldMapper) mapper, mode);
         } else if (mapper instanceof GeoPointFieldMapper) {
             return parseGeoVariable(fieldName, parser, parseContext, (GeoPointFieldMapper) mapper, mode);
-        } else if (mapper instanceof NumberFieldMapper<?>) {
-            return parseNumberVariable(fieldName, parser, parseContext, (NumberFieldMapper<?>) mapper, mode);
+        } else if (mapper instanceof NumberFieldMapper) {
+            return parseNumberVariable(fieldName, parser, parseContext, (NumberFieldMapper) mapper, mode);
         } else {
             throw new QueryParsingException(parseContext, "Field " + fieldName + " is of type " + mapper.fieldType()
                     + ", but only numeric types are supported.");
@@ -171,7 +171,7 @@ public abstract class DecayFunctionParser implements ScoreFunctionParser {
     }
 
     private AbstractDistanceScoreFunction parseNumberVariable(String fieldName, XContentParser parser, QueryParseContext parseContext,
-            NumberFieldMapper<?> mapper, MultiValueMode mode) throws IOException {
+            NumberFieldMapper mapper, MultiValueMode mode) throws IOException {
         XContentParser.Token token;
         String parameterName = null;
         double scale = 0;

--- a/src/main/java/org/elasticsearch/index/query/functionscore/random/RandomScoreFunctionParser.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/random/RandomScoreFunctionParser.java
@@ -82,7 +82,7 @@ public class RandomScoreFunctionParser implements ScoreFunctionParser {
             }
         }
 
-        final FieldMapper<?> mapper = SearchContext.current().mapperService().smartNameFieldMapper("_uid");
+        final FieldMapper mapper = SearchContext.current().mapperService().smartNameFieldMapper("_uid");
         if (mapper == null) {
             // mapper could be null if we are on a shard with no docs yet, so this won't actually be used
             return new RandomScoreFunction();

--- a/src/main/java/org/elasticsearch/index/search/MatchQuery.java
+++ b/src/main/java/org/elasticsearch/index/search/MatchQuery.java
@@ -253,7 +253,7 @@ public class MatchQuery {
             return query;
         }
 
-        public Query createCommonTermsQuery(String field, String queryText, Occur highFreqOccur, Occur lowFreqOccur, float maxTermFrequency, FieldMapper<?> mapper) {
+        public Query createCommonTermsQuery(String field, String queryText, Occur highFreqOccur, Occur lowFreqOccur, float maxTermFrequency, FieldMapper mapper) {
             Query booleanQuery = createBooleanQuery(field, queryText, lowFreqOccur);
             if (booleanQuery != null && booleanQuery instanceof BooleanQuery) {
                 BooleanQuery bq = (BooleanQuery) booleanQuery;

--- a/src/main/java/org/elasticsearch/percolator/PercolatorService.java
+++ b/src/main/java/org/elasticsearch/percolator/PercolatorService.java
@@ -752,7 +752,7 @@ public class PercolatorService extends AbstractComponent {
                     hls = new ArrayList<>(topDocs.scoreDocs.length);
                 }
 
-                final FieldMapper<?> uidMapper = context.mapperService().smartNameFieldMapper(UidFieldMapper.NAME);
+                final FieldMapper uidMapper = context.mapperService().smartNameFieldMapper(UidFieldMapper.NAME);
                 final IndexFieldData<?> uidFieldData = context.fieldData().getForField(uidMapper);
                 int i = 0;
                 for (ScoreDoc scoreDoc : topDocs.scoreDocs) {

--- a/src/main/java/org/elasticsearch/percolator/QueryCollector.java
+++ b/src/main/java/org/elasticsearch/percolator/QueryCollector.java
@@ -73,7 +73,7 @@ abstract class QueryCollector extends SimpleCollector {
         this.logger = logger;
         this.queries = context.percolateQueries();
         this.searcher = context.docSearcher();
-        final FieldMapper<?> uidMapper = context.mapperService().smartNameFieldMapper(UidFieldMapper.NAME);
+        final FieldMapper uidMapper = context.mapperService().smartNameFieldMapper(UidFieldMapper.NAME);
         this.uidFieldData = context.fieldData().getForField(uidMapper);
         this.isNestedDoc = isNestedDoc;
 

--- a/src/main/java/org/elasticsearch/script/expression/ExpressionScriptEngineService.java
+++ b/src/main/java/org/elasticsearch/script/expression/ExpressionScriptEngineService.java
@@ -152,7 +152,7 @@ public class ExpressionScriptEngineService extends AbstractComponent implements 
                     throw new ExpressionScriptCompilationException("Variable [" + variable + "] does not follow an allowed format of either doc['field'] or doc['field'].method()");
                 }
 
-                FieldMapper<?> field = mapper.smartNameFieldMapper(fieldname);
+                FieldMapper field = mapper.smartNameFieldMapper(fieldname);
 
                 if (field == null) {
                     throw new ExpressionScriptCompilationException("Field [" + fieldname + "] used in expression does not exist in mappings");
@@ -174,7 +174,7 @@ public class ExpressionScriptEngineService extends AbstractComponent implements 
         return new ExpressionScript((Expression)compiledScript, bindings, specialValue);
     }
 
-    protected ValueSource getMethodValueSource(FieldMapper<?> field, IndexFieldData<?> fieldData, String fieldName, String methodName) {
+    protected ValueSource getMethodValueSource(FieldMapper field, IndexFieldData<?> fieldData, String fieldName, String methodName) {
         switch (methodName) {
             case GET_YEAR_METHOD:
                 return getDateMethodValueSource(field, fieldData, fieldName, methodName, Calendar.YEAR);
@@ -205,7 +205,7 @@ public class ExpressionScriptEngineService extends AbstractComponent implements 
         }
     }
 
-    protected ValueSource getDateMethodValueSource(FieldMapper<?> field, IndexFieldData<?> fieldData, String fieldName, String methodName, int calendarType) {
+    protected ValueSource getDateMethodValueSource(FieldMapper field, IndexFieldData<?> fieldData, String fieldName, String methodName, int calendarType) {
         if (!(field instanceof DateFieldMapper)) {
             throw new IllegalArgumentException("Member method [" + methodName + "] can only be used with a date field type, not the field [" + fieldName + "].");
         }

--- a/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/src/main/java/org/elasticsearch/search/SearchService.java
@@ -839,7 +839,7 @@ public class SearchService extends AbstractLifecycleComponent<SearchService> {
             final MapperService mapperService = indexShard.mapperService();
             final ObjectSet<String> warmUp = new ObjectHashSet<>();
             for (DocumentMapper docMapper : mapperService.docMappers(false)) {
-                for (FieldMapper<?> fieldMapper : docMapper.mappers()) {
+                for (FieldMapper fieldMapper : docMapper.mappers()) {
                     final String indexName = fieldMapper.names().indexName();
                     if (fieldMapper.fieldType().indexOptions() != IndexOptions.NONE && !fieldMapper.fieldType().omitNorms() && fieldMapper.normsLoading(defaultLoading) == Loading.EAGER) {
                         warmUp.add(indexName);
@@ -893,9 +893,9 @@ public class SearchService extends AbstractLifecycleComponent<SearchService> {
         @Override
         public TerminationHandle warmNewReaders(final IndexShard indexShard, IndexMetaData indexMetaData, final WarmerContext context, ThreadPool threadPool) {
             final MapperService mapperService = indexShard.mapperService();
-            final Map<String, FieldMapper<?>> warmUp = new HashMap<>();
+            final Map<String, FieldMapper> warmUp = new HashMap<>();
             for (DocumentMapper docMapper : mapperService.docMappers(false)) {
-                for (FieldMapper<?> fieldMapper : docMapper.mappers()) {
+                for (FieldMapper fieldMapper : docMapper.mappers()) {
                     final FieldDataType fieldDataType = fieldMapper.fieldDataType();
                     if (fieldDataType == null) {
                         continue;
@@ -915,7 +915,7 @@ public class SearchService extends AbstractLifecycleComponent<SearchService> {
             final Executor executor = threadPool.executor(executor());
             final CountDownLatch latch = new CountDownLatch(context.searcher().reader().leaves().size() * warmUp.size());
             for (final LeafReaderContext ctx : context.searcher().reader().leaves()) {
-                for (final FieldMapper<?> fieldMapper : warmUp.values()) {
+                for (final FieldMapper fieldMapper : warmUp.values()) {
                     executor.execute(new Runnable() {
 
                         @Override
@@ -947,9 +947,9 @@ public class SearchService extends AbstractLifecycleComponent<SearchService> {
         @Override
         public TerminationHandle warmTopReader(final IndexShard indexShard, IndexMetaData indexMetaData, final WarmerContext context, ThreadPool threadPool) {
             final MapperService mapperService = indexShard.mapperService();
-            final Map<String, FieldMapper<?>> warmUpGlobalOrdinals = new HashMap<>();
+            final Map<String, FieldMapper> warmUpGlobalOrdinals = new HashMap<>();
             for (DocumentMapper docMapper : mapperService.docMappers(false)) {
-                for (FieldMapper<?> fieldMapper : docMapper.mappers()) {
+                for (FieldMapper fieldMapper : docMapper.mappers()) {
                     final FieldDataType fieldDataType = fieldMapper.fieldDataType();
                     if (fieldDataType == null) {
                         continue;
@@ -967,7 +967,7 @@ public class SearchService extends AbstractLifecycleComponent<SearchService> {
             final IndexFieldDataService indexFieldDataService = indexShard.indexFieldDataService();
             final Executor executor = threadPool.executor(executor());
             final CountDownLatch latch = new CountDownLatch(warmUpGlobalOrdinals.size());
-            for (final FieldMapper<?> fieldMapper : warmUpGlobalOrdinals.values()) {
+            for (final FieldMapper fieldMapper : warmUpGlobalOrdinals.values()) {
                 executor.execute(new Runnable() {
                     @Override
                     public void run() {

--- a/src/main/java/org/elasticsearch/search/aggregations/support/FieldContext.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/support/FieldContext.java
@@ -29,7 +29,7 @@ public class FieldContext {
 
     private final String field;
     private final IndexFieldData<?> indexFieldData;
-    private final FieldMapper<?> mapper;
+    private final FieldMapper mapper;
 
     /**
      * Constructs a field data context for the given field and its index field data

--- a/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceParser.java
@@ -158,7 +158,7 @@ public class ValuesSourceParser<VS extends ValuesSource> {
             return config;
         }
 
-        FieldMapper<?> mapper = context.smartNameFieldMapperFromAnyType(input.field);
+        FieldMapper mapper = context.smartNameFieldMapperFromAnyType(input.field);
         if (mapper == null) {
             Class<VS> valuesSourceType = valueType != null ? (Class<VS>) valueType.getValuesSourceType() : this.valuesSourceType;
             ValuesSourceConfig<VS> config = new ValuesSourceConfig<>(valuesSourceType);

--- a/src/main/java/org/elasticsearch/search/highlight/FastVectorHighlighter.java
+++ b/src/main/java/org/elasticsearch/search/highlight/FastVectorHighlighter.java
@@ -61,7 +61,7 @@ public class FastVectorHighlighter implements Highlighter {
         SearchContextHighlight.Field field = highlighterContext.field;
         SearchContext context = highlighterContext.context;
         FetchSubPhase.HitContext hitContext = highlighterContext.hitContext;
-        FieldMapper<?> mapper = highlighterContext.mapper;
+        FieldMapper mapper = highlighterContext.mapper;
 
         if (!(mapper.fieldType().storeTermVectors() && mapper.fieldType().storeTermVectorOffsets() && mapper.fieldType().storeTermVectorPositions())) {
             throw new IllegalArgumentException("the field [" + highlighterContext.fieldName + "] should be indexed with term vector with position offsets to be used with fast vector highlighter");

--- a/src/main/java/org/elasticsearch/search/highlight/HighlightPhase.java
+++ b/src/main/java/org/elasticsearch/search/highlight/HighlightPhase.java
@@ -91,7 +91,7 @@ public class HighlightPhase extends AbstractComponent implements FetchSubPhase {
             }
 
             for (String fieldName : fieldNamesToHighlight) {
-                FieldMapper<?> fieldMapper = getMapperForField(fieldName, context, hitContext);
+                FieldMapper fieldMapper = getMapperForField(fieldName, context, hitContext);
                 if (fieldMapper == null) {
                     continue;
                 }
@@ -130,7 +130,7 @@ public class HighlightPhase extends AbstractComponent implements FetchSubPhase {
         hitContext.hit().highlightFields(highlightFields);
     }
 
-    private FieldMapper<?> getMapperForField(String fieldName, SearchContext searchContext, HitContext hitContext) {
+    private FieldMapper getMapperForField(String fieldName, SearchContext searchContext, HitContext hitContext) {
         DocumentMapper documentMapper = searchContext.mapperService().documentMapper(hitContext.hit().type());
         // TODO: no need to lookup the doc mapper with unambiguous field names? just look at the mapper service
         return documentMapper.mappers().smartNameFieldMapper(fieldName);

--- a/src/main/java/org/elasticsearch/search/highlight/HighlightUtils.java
+++ b/src/main/java/org/elasticsearch/search/highlight/HighlightUtils.java
@@ -42,7 +42,7 @@ public final class HighlightUtils {
 
     }
 
-    static List<Object> loadFieldValues(SearchContextHighlight.Field field, FieldMapper<?> mapper, SearchContext searchContext, FetchSubPhase.HitContext hitContext) throws IOException {
+    static List<Object> loadFieldValues(SearchContextHighlight.Field field, FieldMapper mapper, SearchContext searchContext, FetchSubPhase.HitContext hitContext) throws IOException {
         //percolator needs to always load from source, thus it sets the global force source to true
         boolean forceSource = searchContext.highlight().forceSource(field);
         List<Object> textsToHighlight;

--- a/src/main/java/org/elasticsearch/search/highlight/HighlighterContext.java
+++ b/src/main/java/org/elasticsearch/search/highlight/HighlighterContext.java
@@ -31,12 +31,12 @@ public class HighlighterContext {
 
     public final String fieldName;
     public final SearchContextHighlight.Field field;
-    public final FieldMapper<?> mapper;
+    public final FieldMapper mapper;
     public final SearchContext context;
     public final FetchSubPhase.HitContext hitContext;
     public final HighlightQuery query;
 
-    public HighlighterContext(String fieldName, SearchContextHighlight.Field field, FieldMapper<?> mapper, SearchContext context,
+    public HighlighterContext(String fieldName, SearchContextHighlight.Field field, FieldMapper mapper, SearchContext context,
             FetchSubPhase.HitContext hitContext, HighlightQuery query) {
         this.fieldName = fieldName;
         this.field = field;

--- a/src/main/java/org/elasticsearch/search/highlight/PlainHighlighter.java
+++ b/src/main/java/org/elasticsearch/search/highlight/PlainHighlighter.java
@@ -56,16 +56,16 @@ public class PlainHighlighter implements Highlighter {
         SearchContextHighlight.Field field = highlighterContext.field;
         SearchContext context = highlighterContext.context;
         FetchSubPhase.HitContext hitContext = highlighterContext.hitContext;
-        FieldMapper<?> mapper = highlighterContext.mapper;
+        FieldMapper mapper = highlighterContext.mapper;
 
         Encoder encoder = field.fieldOptions().encoder().equals("html") ? HighlightUtils.Encoders.HTML : HighlightUtils.Encoders.DEFAULT;
 
         if (!hitContext.cache().containsKey(CACHE_KEY)) {
-            Map<FieldMapper<?>, org.apache.lucene.search.highlight.Highlighter> mappers = Maps.newHashMap();
+            Map<FieldMapper, org.apache.lucene.search.highlight.Highlighter> mappers = Maps.newHashMap();
             hitContext.cache().put(CACHE_KEY, mappers);
         }
         @SuppressWarnings("unchecked")
-        Map<FieldMapper<?>, org.apache.lucene.search.highlight.Highlighter> cache = (Map<FieldMapper<?>, org.apache.lucene.search.highlight.Highlighter>) hitContext.cache().get(CACHE_KEY);
+        Map<FieldMapper, org.apache.lucene.search.highlight.Highlighter> cache = (Map<FieldMapper, org.apache.lucene.search.highlight.Highlighter>) hitContext.cache().get(CACHE_KEY);
 
         org.apache.lucene.search.highlight.Highlighter entry = cache.get(mapper);
         if (entry == null) {

--- a/src/main/java/org/elasticsearch/search/highlight/PostingsHighlighter.java
+++ b/src/main/java/org/elasticsearch/search/highlight/PostingsHighlighter.java
@@ -48,7 +48,7 @@ public class PostingsHighlighter implements Highlighter {
     @Override
     public HighlightField highlight(HighlighterContext highlighterContext) {
 
-        FieldMapper<?> fieldMapper = highlighterContext.mapper;
+        FieldMapper fieldMapper = highlighterContext.mapper;
         SearchContextHighlight.Field field = highlighterContext.field;
         if (fieldMapper.fieldType().indexOptions() != IndexOptions.DOCS_AND_FREQS_AND_POSITIONS_AND_OFFSETS) {
             throw new IllegalArgumentException("the field [" + highlighterContext.fieldName + "] should be indexed with positions and offsets in the postings list to be used with postings highlighter");
@@ -169,7 +169,7 @@ public class PostingsHighlighter implements Highlighter {
     }
 
     private static class HighlighterEntry {
-        Map<FieldMapper<?>, MapperHighlighterEntry> mappers = Maps.newHashMap();
+        Map<FieldMapper, MapperHighlighterEntry> mappers = Maps.newHashMap();
     }
 
     private static class MapperHighlighterEntry {

--- a/src/main/java/org/elasticsearch/search/highlight/vectorhighlight/FragmentBuilderHelper.java
+++ b/src/main/java/org/elasticsearch/search/highlight/vectorhighlight/FragmentBuilderHelper.java
@@ -46,7 +46,7 @@ public final class FragmentBuilderHelper {
      * Fixes problems with broken analysis chains if positions and offsets are messed up that can lead to
      * {@link StringIndexOutOfBoundsException} in the {@link FastVectorHighlighter}
      */
-    public static WeightedFragInfo fixWeightedFragInfo(FieldMapper<?> mapper, Field[] values, WeightedFragInfo fragInfo) {
+    public static WeightedFragInfo fixWeightedFragInfo(FieldMapper mapper, Field[] values, WeightedFragInfo fragInfo) {
         assert fragInfo != null : "FragInfo must not be null";
         assert mapper.names().indexName().equals(values[0].name()) : "Expected FieldMapper for field " + values[0].name();
         if (!fragInfo.getSubInfos().isEmpty() && (containsBrokenAnalysis(mapper.indexAnalyzer()))) {

--- a/src/main/java/org/elasticsearch/search/highlight/vectorhighlight/SimpleFragmentsBuilder.java
+++ b/src/main/java/org/elasticsearch/search/highlight/vectorhighlight/SimpleFragmentsBuilder.java
@@ -29,9 +29,9 @@ import org.elasticsearch.index.mapper.FieldMapper;
  * that corrects offsets for broken analysis chains. 
  */
 public class SimpleFragmentsBuilder extends org.apache.lucene.search.vectorhighlight.SimpleFragmentsBuilder {
-    protected final FieldMapper<?> mapper;
+    protected final FieldMapper mapper;
 
-    public SimpleFragmentsBuilder(FieldMapper<?> mapper,
+    public SimpleFragmentsBuilder(FieldMapper mapper,
                                         String[] preTags, String[] postTags, BoundaryScanner boundaryScanner) {
         super(preTags, postTags, boundaryScanner);
         this.mapper = mapper;

--- a/src/main/java/org/elasticsearch/search/highlight/vectorhighlight/SourceScoreOrderFragmentsBuilder.java
+++ b/src/main/java/org/elasticsearch/search/highlight/vectorhighlight/SourceScoreOrderFragmentsBuilder.java
@@ -40,13 +40,13 @@ import java.util.List;
  */
 public class SourceScoreOrderFragmentsBuilder extends ScoreOrderFragmentsBuilder {
 
-    private final FieldMapper<?> mapper;
+    private final FieldMapper mapper;
 
     private final SearchContext searchContext;
 
     private final FetchSubPhase.HitContext hitContext;
 
-    public SourceScoreOrderFragmentsBuilder(FieldMapper<?> mapper, SearchContext searchContext,
+    public SourceScoreOrderFragmentsBuilder(FieldMapper mapper, SearchContext searchContext,
                                             FetchSubPhase.HitContext hitContext, String[] preTags, String[] postTags, BoundaryScanner boundaryScanner) {
         super(preTags, postTags, boundaryScanner);
         this.mapper = mapper;

--- a/src/main/java/org/elasticsearch/search/highlight/vectorhighlight/SourceSimpleFragmentsBuilder.java
+++ b/src/main/java/org/elasticsearch/search/highlight/vectorhighlight/SourceSimpleFragmentsBuilder.java
@@ -41,7 +41,7 @@ public class SourceSimpleFragmentsBuilder extends SimpleFragmentsBuilder {
 
     private final FetchSubPhase.HitContext hitContext;
 
-    public SourceSimpleFragmentsBuilder(FieldMapper<?> mapper, SearchContext searchContext,
+    public SourceSimpleFragmentsBuilder(FieldMapper mapper, SearchContext searchContext,
                                         FetchSubPhase.HitContext hitContext, String[] preTags, String[] postTags, BoundaryScanner boundaryScanner) {
         super(mapper, preTags, postTags, boundaryScanner);
         this.searchContext = searchContext;

--- a/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortParser.java
+++ b/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortParser.java
@@ -139,7 +139,7 @@ public class GeoDistanceSortParser implements SortParser {
             throw new IllegalArgumentException("sort_mode [sum] isn't supported for sorting by geo distance");
         }
 
-        FieldMapper<?> mapper = context.smartNameFieldMapper(fieldName);
+        FieldMapper mapper = context.smartNameFieldMapper(fieldName);
         if (mapper == null) {
             throw new IllegalArgumentException("failed to find mapper for [" + fieldName + "] for geo distance based sort");
         }

--- a/src/main/java/org/elasticsearch/search/sort/SortParseElement.java
+++ b/src/main/java/org/elasticsearch/search/sort/SortParseElement.java
@@ -208,7 +208,7 @@ public class SortParseElement implements SearchParseElement {
                 sortFields.add(SORT_DOC);
             }
         } else {
-            FieldMapper<?> fieldMapper = context.smartNameFieldMapper(fieldName);
+            FieldMapper fieldMapper = context.smartNameFieldMapper(fieldName);
             if (fieldMapper == null) {
                 if (unmappedType != null) {
                     fieldMapper = context.mapperService().unmappedFieldMapper(unmappedType);

--- a/src/main/java/org/elasticsearch/search/suggest/context/GeolocationContextMapping.java
+++ b/src/main/java/org/elasticsearch/search/suggest/context/GeolocationContextMapping.java
@@ -253,7 +253,7 @@ public class GeolocationContextMapping extends ContextMapping {
     public ContextConfig parseContext(ParseContext parseContext, XContentParser parser) throws IOException, ElasticsearchParseException {
 
         if(fieldName != null) {
-            FieldMapper<?> mapper = parseContext.docMapper().mappers().getMapper(fieldName);
+            FieldMapper mapper = parseContext.docMapper().mappers().getMapper(fieldName);
             if(!(mapper instanceof GeoPointFieldMapper)) {
                 throw new ElasticsearchParseException("referenced field must be mapped to geo_point");
             }

--- a/src/test/java/org/elasticsearch/index/fielddata/AbstractFieldDataTests.java
+++ b/src/test/java/org/elasticsearch/index/fielddata/AbstractFieldDataTests.java
@@ -65,7 +65,7 @@ public abstract class AbstractFieldDataTests extends ElasticsearchSingleNodeTest
     }
 
     public <IFD extends IndexFieldData<?>> IFD getForField(FieldDataType type, String fieldName, boolean docValues) {
-        final FieldMapper<?> mapper;
+        final FieldMapper mapper;
         final BuilderContext context = new BuilderContext(indexService.settingsService().getSettings(), new ContentPath(1));
         if (type.getType().equals("string")) {
             mapper = MapperBuilders.stringField(fieldName).tokenized(false).docValues(docValues).fieldDataSettings(type.getSettings()).build(context);

--- a/src/test/java/org/elasticsearch/index/fielddata/IndexFieldDataServiceTests.java
+++ b/src/test/java/org/elasticsearch/index/fielddata/IndexFieldDataServiceTests.java
@@ -61,7 +61,7 @@ public class IndexFieldDataServiceTests extends ElasticsearchSingleNodeTest {
                 assertTrue(fd instanceof PagedBytesIndexFieldData);
             }
 
-            for (FieldMapper<?> mapper : Arrays.asList(
+            for (FieldMapper mapper : Arrays.asList(
                     new ByteFieldMapper.Builder("int").docValues(docValues).build(ctx),
                     new ShortFieldMapper.Builder("int").docValues(docValues).build(ctx),
                     new IntegerFieldMapper.Builder("int").docValues(docValues).build(ctx),
@@ -107,7 +107,7 @@ public class IndexFieldDataServiceTests extends ElasticsearchSingleNodeTest {
         assertTrue(fd instanceof FSTBytesIndexFieldData);
 
         final Settings fdSettings = ImmutableSettings.builder().put("format", "array").build();
-        for (FieldMapper<?> mapper : Arrays.asList(
+        for (FieldMapper mapper : Arrays.asList(
                 new ByteFieldMapper.Builder("int").fieldDataSettings(DOC_VALUES_SETTINGS).fieldDataSettings(fdSettings).build(ctx),
                 new ShortFieldMapper.Builder("int").fieldDataSettings(DOC_VALUES_SETTINGS).fieldDataSettings(fdSettings).build(ctx),
                 new IntegerFieldMapper.Builder("int").fieldDataSettings(DOC_VALUES_SETTINGS).fieldDataSettings(fdSettings).build(ctx),

--- a/src/test/java/org/elasticsearch/index/mapper/FieldMappersLookupTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/FieldMappersLookupTests.java
@@ -49,7 +49,7 @@ public class FieldMappersLookupTests extends ElasticsearchTestCase {
         assertNull(lookup.smartName("foo"));
         assertNull(lookup.smartNameFieldMapper("foo"));
         assertNull(lookup.get("foo"));
-        Iterator<FieldMapper<?>> itr = lookup.iterator();
+        Iterator<FieldMapper> itr = lookup.iterator();
         assertNotNull(itr);
         assertFalse(itr.hasNext());
     }
@@ -141,7 +141,7 @@ public class FieldMappersLookupTests extends ElasticsearchTestCase {
         lookup = lookup.copyAndAddAll(newList(f1));
 
         try {
-            Iterator<FieldMapper<?>> itr = lookup.iterator();
+            Iterator<FieldMapper> itr = lookup.iterator();
             assertTrue(itr.hasNext());
             assertEquals(f1, itr.next());
             itr.remove();
@@ -168,12 +168,12 @@ public class FieldMappersLookupTests extends ElasticsearchTestCase {
         }
     }
 
-    static List<FieldMapper<?>> newList(FieldMapper<?>... mapper) {
+    static List<FieldMapper> newList(FieldMapper... mapper) {
         return Lists.newArrayList(mapper);
     }
 
     // this sucks how much must be overriden just do get a dummy field mapper...
-    static class FakeFieldMapper extends AbstractFieldMapper<String> {
+    static class FakeFieldMapper extends AbstractFieldMapper {
         static Settings dummySettings = ImmutableSettings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT.id).build();
         public FakeFieldMapper(String fullName, String indexName) {
             super(new Names(fullName, indexName, indexName, fullName), 1.0f, AbstractFieldMapper.Defaults.FIELD_TYPE, null, null, null, null, null, null, dummySettings, null, null);

--- a/src/test/java/org/elasticsearch/index/mapper/core/BooleanFieldMapperTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/core/BooleanFieldMapperTests.java
@@ -87,7 +87,7 @@ public class BooleanFieldMapperTests extends ElasticsearchSingleNodeTest {
                 .endObject().endObject().string();
 
         DocumentMapper defaultMapper = parser.parse(mapping);
-        FieldMapper<?> mapper = defaultMapper.mappers().getMapper("field");
+        FieldMapper mapper = defaultMapper.mappers().getMapper("field");
         XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
         mapper.toXContent(builder, ToXContent.EMPTY_PARAMS);
         builder.endObject();

--- a/src/test/java/org/elasticsearch/index/mapper/date/SimpleDateMappingTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/date/SimpleDateMappingTests.java
@@ -88,7 +88,7 @@ public class SimpleDateMappingTests extends ElasticsearchSingleNodeTest {
         assertNotNull(doc.dynamicMappingsUpdate());
         client().admin().indices().preparePutMapping("test-0").setType("type").setSource(doc.dynamicMappingsUpdate().toString()).get();
 
-        FieldMapper<?> fieldMapper = defaultMapper.mappers().smartNameFieldMapper("date_field1");
+        FieldMapper fieldMapper = defaultMapper.mappers().smartNameFieldMapper("date_field1");
         assertThat(fieldMapper, instanceOf(DateFieldMapper.class));
         fieldMapper = defaultMapper.mappers().smartNameFieldMapper("date_field2");
         assertThat(fieldMapper, instanceOf(DateFieldMapper.class));

--- a/src/test/java/org/elasticsearch/index/mapper/externalvalues/ExternalMapper.java
+++ b/src/test/java/org/elasticsearch/index/mapper/externalvalues/ExternalMapper.java
@@ -60,7 +60,7 @@ import static org.elasticsearch.index.mapper.core.TypeParsers.parseMultiField;
  * .point GeoPoint type
  * .shape GeoShape type
  */
-public class ExternalMapper extends AbstractFieldMapper<Object> {
+public class ExternalMapper extends AbstractFieldMapper {
     /**
      * Returns the actual value of the field.
      *

--- a/src/test/java/org/elasticsearch/index/mapper/string/SimpleStringMappingTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/string/SimpleStringMappingTests.java
@@ -281,7 +281,7 @@ public class SimpleStringMappingTests extends ElasticsearchSingleNodeTest {
     }
     
     private Map<String, Object> getSerializedMap(String fieldName, DocumentMapper mapper) throws Exception {
-        FieldMapper<?> fieldMapper = mapper.mappers().smartNameFieldMapper(fieldName);
+        FieldMapper fieldMapper = mapper.mappers().smartNameFieldMapper(fieldName);
         XContentBuilder builder = JsonXContent.contentBuilder().startObject();
         fieldMapper.toXContent(builder, ToXContent.EMPTY_PARAMS).endObject();
         builder.close();
@@ -525,7 +525,7 @@ public class SimpleStringMappingTests extends ElasticsearchSingleNodeTest {
                 .endObject().endObject().string();
 
         DocumentMapper defaultMapper = parser.parse(mapping);
-        FieldMapper<?> mapper = defaultMapper.mappers().getMapper("field");
+        FieldMapper mapper = defaultMapper.mappers().getMapper("field");
         assertNotNull(mapper);
         assertTrue(mapper instanceof StringFieldMapper);
         assertEquals(Queries.newMatchNoDocsQuery(), mapper.termsQuery(Collections.emptyList(), null));

--- a/src/test/java/org/elasticsearch/test/TestSearchContext.java
+++ b/src/test/java/org/elasticsearch/test/TestSearchContext.java
@@ -552,7 +552,7 @@ public class TestSearchContext extends SearchContext {
     }
 
     @Override
-    public FieldMapper<?> smartNameFieldMapper(String name) {
+    public FieldMapper smartNameFieldMapper(String name) {
         if (mapperService() != null) {
             return mapperService().smartNameFieldMapper(name, types());
         }
@@ -560,7 +560,7 @@ public class TestSearchContext extends SearchContext {
     }
 
     @Override
-    public FieldMapper<?> smartNameFieldMapperFromAnyType(String name) {
+    public FieldMapper smartNameFieldMapperFromAnyType(String name) {
         if (mapperService() != null) {
             return mapperService().smartNameFieldMapper(name);
         }


### PR DESCRIPTION
FieldMapper is currently generic, where the templated type
is only used as the return of a single function, value(Object).
This change simply removes this generic type. It is not needed. The
implementations of value() now have a covariant return (so
those methods have not changed).
