### PR TITLE
Allow disabling of sigar via settings

### DIFF
--- a/src/main/java/org/elasticsearch/monitor/sigar/SigarService.java
+++ b/src/main/java/org/elasticsearch/monitor/sigar/SigarService.java
@@ -34,22 +34,23 @@ public class SigarService extends AbstractComponent {
     @Inject
     public SigarService(Settings settings) {
         super(settings);
-
         Sigar sigar = null;
-        try {
-            sigar = new Sigar();
-            // call it to make sure the library was loaded
-            sigar.getPid();
-            logger.trace("sigar loaded successfully");
-        } catch (Throwable t) {
-            logger.trace("failed to load sigar", t);
-            if (sigar != null) {
-                try {
-                    sigar.close();
-                } catch (Throwable t1) {
-                    // ignore
-                } finally {
-                    sigar = null;
+        if (settings.getAsBoolean("bootstrap.sigar", true)) {
+            try {
+                sigar = new Sigar();
+                // call it to make sure the library was loaded
+                sigar.getPid();
+                logger.trace("sigar loaded successfully");
+            } catch (Throwable t) {
+                logger.trace("failed to load sigar", t);
+                if (sigar != null) {
+                    try {
+                        sigar.close();
+                    } catch (Throwable t1) {
+                        // ignore
+                    } finally {
+                        sigar = null;
+                    }
                 }
             }
         }

--- a/src/test/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
+++ b/src/test/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
@@ -49,7 +49,7 @@ public class BootstrapForTesting {
 
     static {
         // just like bootstrap, initialize natives, then SM
-        Bootstrap.initializeNatives(true, true);
+        Bootstrap.initializeNatives(true, true, true);
 
         // make sure java.io.tmpdir exists always (in case code uses it in a static initializer)
         Path javaTmpDir = PathUtils.get(Objects.requireNonNull(System.getProperty("java.io.tmpdir"),

--- a/src/test/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/src/test/java/org/elasticsearch/test/InternalTestCluster.java
@@ -90,6 +90,7 @@ import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
 import org.elasticsearch.indices.fielddata.cache.IndicesFieldDataCache;
 import org.elasticsearch.indices.recovery.RecoverySettings;
+import org.elasticsearch.monitor.sigar.SigarService;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.node.service.NodeService;
 import org.elasticsearch.plugins.PluginsService;
@@ -277,6 +278,7 @@ public final class InternalTestCluster extends TestCluster {
                 builder.put("path.data", dataPath.toString());
             }
         }
+        builder.put("bootstrap.sigar", rarely());
         builder.put("path.home", baseDir);
         builder.put("path.repo", baseDir.resolve("repos"));
         builder.put("transport.tcp.port", BASE_PORT + "-" + (BASE_PORT+100));


### PR DESCRIPTION
Sigar can only be disabled by removing the binaries. This is tricky for our
tests and might cause a lot of trouble if a user wants or needs to do it.
This commit allows to disable sigar with a simple boolean flag in the settings.

This safes me 20% for tests with `tests.slow=true` 
