### PR TITLE
Only load a plugin once from the classpath

### DIFF
--- a/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -422,8 +422,11 @@ public class PluginsService extends AbstractComponent {
         // Trying JVM plugins: looking for es-plugin.properties files
         try {
             Enumeration<URL> pluginUrls = settings.getClassLoader().getResources(esPluginPropertiesFile);
-            while (pluginUrls.hasMoreElements()) {
-                URL pluginUrl = pluginUrls.nextElement();
+
+            // use a set for uniqueness as some classloaders such as groovy's can return the same URL multiple times and
+            // these plugins should only be loaded once
+            HashSet<URL> uniqueUrls = new HashSet<>(Collections.list(pluginUrls));
+            for (URL pluginUrl : uniqueUrls) {
                 Properties pluginProps = new Properties();
                 InputStream is = null;
                 try {


### PR DESCRIPTION
Today, when loading plugins from the classpath we take the enumeration
given to us by the classloader and attempt to load every URL. This can
cause issues as certain classloaders, such as groovy's, will return the same
URL multiple times in the enumeration. When this happens, startup can fail
with guice errors as bindings have already been registered.

To workaround this, we create a set from the URLs returned by the classloader
to provide uniqueness.
