### PR TITLE
Add logging for failed TTL purges

### DIFF
--- a/src/main/java/org/elasticsearch/indices/ttl/IndicesTTLService.java
+++ b/src/main/java/org/elasticsearch/indices/ttl/IndicesTTLService.java
@@ -26,6 +26,7 @@ import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.SimpleCollector;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.bulk.TransportBulkAction;
@@ -280,12 +281,28 @@ public class IndicesTTLService extends AbstractLifecycleComponent<IndicesTTLServ
                 bulkAction.executeBulk(bulkRequest, new ActionListener<BulkResponse>() {
                     @Override
                     public void onResponse(BulkResponse bulkResponse) {
-                        logger.trace("bulk took " + bulkResponse.getTookInMillis() + "ms");
+                        if (bulkResponse.hasFailures()) {
+                            int failedItems = 0;
+                            for (BulkItemResponse response : bulkResponse) {
+                                if (response.isFailed()) failedItems++;
+                            }
+                            if (logger.isTraceEnabled()) {
+                                logger.trace("bulk deletion failures for [{}]/[{}] items, failure message: [{}]", failedItems, bulkResponse.getItems().length, bulkResponse.buildFailureMessage());
+                            } else {
+                                logger.error("bulk deletion failures for [{}]/[{}] items", failedItems, bulkResponse.getItems().length);
+                            }
+                        } else {
+                            logger.trace("bulk deletion took " + bulkResponse.getTookInMillis() + "ms");
+                        }
                     }
 
                     @Override
                     public void onFailure(Throwable e) {
-                        logger.warn("failed to execute bulk");
+                        if (logger.isTraceEnabled()) {
+                            logger.trace("failed to execute bulk", e);
+                        } else {
+                            logger.warn("failed to execute bulk: [{}]", e.getMessage());
+                        }
                     }
                 });
             } catch (Exception e) {


### PR DESCRIPTION
In order to get some information if the TTL purger thread could
successfully delete all documents per bulk exection, this commit
adds some logging. TRACE level logging will potentially contain
a lot of information about all the bulk failures.

Closes #11019
