### PR TITLE
Do not specialize TermQuery vs. TermsQuery.

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/core/AbstractFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/AbstractFieldMapper.java
@@ -479,23 +479,11 @@ public abstract class AbstractFieldMapper implements FieldMapper {
 
     @Override
     public Query termsQuery(List values, @Nullable QueryParseContext context) {
-        switch (values.size()) {
-        case 0:
-            return Queries.newMatchNoDocsQuery();
-        case 1:
-            // When there is a single term, it's important to return a term filter so that
-            // it can return a DocIdSet that is directly backed by a postings list, instead
-            // of loading everything into a bit set and returning an iterator based on the
-            // bit set
-            return termQuery(values.get(0), context);
-        default:
-            BytesRef[] bytesRefs = new BytesRef[values.size()];
-            for (int i = 0; i < bytesRefs.length; i++) {
-                bytesRefs[i] = indexedValueForSearch(values.get(i));
-            }
-            return new TermsQuery(names.indexName(), bytesRefs);
-            
+        BytesRef[] bytesRefs = new BytesRef[values.size()];
+        for (int i = 0; i < bytesRefs.length; i++) {
+            bytesRefs[i] = indexedValueForSearch(values.get(i));
         }
+        return new TermsQuery(names.indexName(), bytesRefs);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/mapper/internal/IdFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/IdFieldMapper.java
@@ -188,11 +188,7 @@ public class IdFieldMapper extends AbstractFieldMapper implements RootMapper {
             return super.termQuery(value, context);
         }
         final BytesRef[] uids = Uid.createUidsForTypesAndId(context.queryTypes(), value);
-        if (uids.length == 1) {
-            return new TermQuery(new Term(UidFieldMapper.NAME, uids[0]));
-        } else {
-            return new TermsQuery(UidFieldMapper.NAME, uids);
-        }
+        return new TermsQuery(UidFieldMapper.NAME, uids);
     }
 
     @Override

--- a/src/test/java/org/elasticsearch/index/mapper/string/SimpleStringMappingTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/string/SimpleStringMappingTests.java
@@ -519,18 +519,4 @@ public class SimpleStringMappingTests extends ElasticsearchSingleNodeTest {
         assertTrue(mergeResult.buildConflicts()[0].contains("cannot enable norms"));
     }
 
-    public void testTermsQuery() throws Exception {
-        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
-                .startObject("properties").startObject("field").field("type", "string").field("index", "not_analyzed").endObject().endObject()
-                .endObject().endObject().string();
-
-        DocumentMapper defaultMapper = parser.parse(mapping);
-        FieldMapper mapper = defaultMapper.mappers().getMapper("field");
-        assertNotNull(mapper);
-        assertTrue(mapper instanceof StringFieldMapper);
-        assertEquals(Queries.newMatchNoDocsQuery(), mapper.termsQuery(Collections.emptyList(), null));
-        assertEquals(new TermQuery(new Term("field", "value")), mapper.termsQuery(Collections.singletonList("value"), null));
-        assertEquals(new TermsQuery(new Term("field", "value1"), new Term("field", "value2")), mapper.termsQuery(Arrays.asList("value1", "value2"), null));
-    }
-
 }


### PR DESCRIPTION
We had some code that created a TermQuery instead of a TermsQuery when there
was a single term, which is not useful anymore now that TermsQuery rewrites to
a disjunction when there are few terms:
  https://issues.apache.org/jira/browse/LUCENE-6360
