### PR TITLE
Display low disk watermark to be consistent with documentation

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/DiskUsage.java
+++ b/src/main/java/org/elasticsearch/cluster/DiskUsage.java
@@ -59,6 +59,10 @@ public class DiskUsage {
         return 100.0 * ((double)freeBytes / totalBytes);
     }
 
+    public double getUsedDiskAsPercentage() {
+        return 100.0 - getFreeDiskAsPercentage();
+    }
+
     public long getFreeBytes() {
         return freeBytes;
     }

--- a/src/test/java/org/elasticsearch/cluster/DiskUsageTests.java
+++ b/src/test/java/org/elasticsearch/cluster/DiskUsageTests.java
@@ -30,6 +30,7 @@ public class DiskUsageTests extends ElasticsearchTestCase {
     public void diskUsageCalcTest() {
         DiskUsage du = new DiskUsage("node1", "n1", 100, 40);
         assertThat(du.getFreeDiskAsPercentage(), equalTo(40.0));
+        assertThat(du.getUsedDiskAsPercentage(), equalTo(100.0 - 40.0));
         assertThat(du.getFreeBytes(), equalTo(40L));
         assertThat(du.getUsedBytes(), equalTo(60L));
         assertThat(du.getTotalBytes(), equalTo(100L));
@@ -67,11 +68,13 @@ public class DiskUsageTests extends ElasticsearchTestCase {
                 assertThat(du.getTotalBytes(), equalTo(0L));
                 assertThat(du.getUsedBytes(), equalTo(-free));
                 assertThat(du.getFreeDiskAsPercentage(), equalTo(100.0));
+                assertThat(du.getUsedDiskAsPercentage(), equalTo(0.0));
             } else {
                 assertThat(du.getFreeBytes(), equalTo(free));
                 assertThat(du.getTotalBytes(), equalTo(total));
                 assertThat(du.getUsedBytes(), equalTo(total - free));
                 assertThat(du.getFreeDiskAsPercentage(), equalTo(100.0 * ((double) free / total)));
+                assertThat(du.getUsedDiskAsPercentage(), equalTo(100.0 - (100.0 * ((double) free / total))));
             }
         }
     }

--- a/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderUnitTests.java
+++ b/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderUnitTests.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.cluster.routing.allocation.decider;
 
 import com.google.common.collect.ImmutableMap;
+
 import org.elasticsearch.cluster.ClusterInfo;
 import org.elasticsearch.cluster.ClusterInfoService;
 import org.elasticsearch.cluster.DiskUsage;
@@ -62,6 +63,7 @@ public class DiskThresholdDeciderUnitTests extends ElasticsearchTestCase {
         assertThat(decider.getFreeDiskThresholdHigh(), equalTo(10.0d));
         assertThat(decider.getFreeBytesThresholdLow(), equalTo(ByteSizeValue.parseBytesSizeValue("0b")));
         assertThat(decider.getFreeDiskThresholdLow(), equalTo(15.0d));
+        assertThat(decider.getUsedDiskThresholdLow(), equalTo(85.0d));
         assertThat(decider.getRerouteInterval().seconds(), equalTo(60L));
         assertTrue(decider.isEnabled());
         assertTrue(decider.isIncludeRelocations());


### PR DESCRIPTION
This PR is an attempted fix for Issue #10588. I have added altered log entries, so that messages involving disk usage percentages display used disk percentages, rather than free disk percentages.

Closes #10588 
