### PR TITLE
Update search.asciidoc

### DIFF
--- a/docs/reference/search.asciidoc
+++ b/docs/reference/search.asciidoc
@@ -32,7 +32,7 @@ only the relevant shard:
 
 [source,js]
 --------------------------------------------------
-$ curl -XGET 'http://localhost:9200/twitter/tweet/_search?routing=kimchy' -d '{
+$ curl -XPOST 'http://localhost:9200/twitter/tweet/_search?routing=kimchy' -d '{
     "query": {
         "filtered" : {
             "query" : {


### PR DESCRIPTION
I think the request should use the POST method. The GET method works fine with the request, but including data as the argument to the `-d` option leads the user to think of the POST method. It's also easier to use the query with tools like Postman if the method is POST.

I wouldn't say this is a high priority issue by any means.
