### PR TITLE
Throw exception if unrecognized parameter in bulk action/metadata line

### DIFF
--- a/src/test/java/org/elasticsearch/action/bulk/BulkRequestTests.java
+++ b/src/test/java/org/elasticsearch/action/bulk/BulkRequestTests.java
@@ -117,4 +117,56 @@ public class BulkRequestTests extends ElasticsearchTestCase {
         assertThat(bulkRequest.requests().get(1), instanceOf(UpdateRequest.class));
         assertThat(bulkRequest.requests().get(2), instanceOf(DeleteRequest.class));
     }
+
+    @Test
+    public void testSimpleBulk6() throws Exception {
+        String bulkAction = copyToStringFromClasspath("/org/elasticsearch/action/bulk/simple-bulk6.json");
+        BulkRequest bulkRequest = new BulkRequest();
+        try {
+            bulkRequest.add(bulkAction.getBytes(Charsets.UTF_8), 0, bulkAction.length(), null, null);
+            fail("should have thrown an exception about the wrong format of line 1");
+        } catch (IllegalArgumentException e) {
+            assertThat("message contains error about the wrong format of line 1: " + e.getMessage(),
+                    e.getMessage().contains("Malformed action/metadata line [1], expected a simple value for field [_source] but found [START_OBJECT]"), equalTo(true));
+        }
+    }
+
+    @Test
+    public void testSimpleBulk7() throws Exception {
+        String bulkAction = copyToStringFromClasspath("/org/elasticsearch/action/bulk/simple-bulk7.json");
+        BulkRequest bulkRequest = new BulkRequest();
+        try {
+            bulkRequest.add(bulkAction.getBytes(Charsets.UTF_8), 0, bulkAction.length(), null, null);
+            fail("should have thrown an exception about the wrong format of line 5");
+        } catch (IllegalArgumentException e) {
+            assertThat("message contains error about the wrong format of line 5: " + e.getMessage(),
+                    e.getMessage().contains("Malformed action/metadata line [5], expected a simple value for field [_unkown] but found [START_ARRAY]"), equalTo(true));
+        }
+    }
+
+    @Test
+    public void testSimpleBulk8() throws Exception {
+        String bulkAction = copyToStringFromClasspath("/org/elasticsearch/action/bulk/simple-bulk8.json");
+        BulkRequest bulkRequest = new BulkRequest();
+        try {
+            bulkRequest.add(bulkAction.getBytes(Charsets.UTF_8), 0, bulkAction.length(), null, null);
+            fail("should have thrown an exception about the unknown paramater _foo");
+        } catch (IllegalArgumentException e) {
+            assertThat("message contains error about the unknown paramater _foo: " + e.getMessage(),
+                    e.getMessage().contains("Action/metadata line [3] contains an unknown parameter [_foo]"), equalTo(true));
+        }
+    }
+
+    @Test
+    public void testSimpleBulk9() throws Exception {
+        String bulkAction = copyToStringFromClasspath("/org/elasticsearch/action/bulk/simple-bulk9.json");
+        BulkRequest bulkRequest = new BulkRequest();
+        try {
+            bulkRequest.add(bulkAction.getBytes(Charsets.UTF_8), 0, bulkAction.length(), null, null);
+            fail("should have thrown an exception about the wrong format of line 3");
+        } catch (IllegalArgumentException e) {
+            assertThat("message contains error about the wrong format of line 3: " + e.getMessage(),
+                    e.getMessage().contains("Malformed action/metadata line [3], expected START_OBJECT or END_OBJECT but found [START_ARRAY]"), equalTo(true));
+        }
+    }
 }

--- a/src/test/java/org/elasticsearch/action/bulk/simple-bulk6.json
+++ b/src/test/java/org/elasticsearch/action/bulk/simple-bulk6.json
@@ -1,0 +1,6 @@
+{"index": {"_index": "test", "_type": "doc", "_source": {"hello": "world"}, "_id": 0}}
+{"field1": "value0"}
+{"index": {"_index": "test", "_type": "doc", "_id": 1}}
+{"field1": "value1"}
+{"index": {"_index": "test", "_type": "doc", "_id": 2}}
+{"field1": "value2"}

--- a/src/test/java/org/elasticsearch/action/bulk/simple-bulk7.json
+++ b/src/test/java/org/elasticsearch/action/bulk/simple-bulk7.json
@@ -1,0 +1,6 @@
+{"index": {"_index": "test", "_type": "doc", "_id": 0}}
+{"field1": "value0"}
+{"index": {"_index": "test", "_type": "doc", "_id": 1}}
+{"field1": "value1"}
+{"index": {"_index": "test", "_type": "doc", "_id": 2, "_unkown": ["foo", "bar"]}}
+{"field1": "value2"}

--- a/src/test/java/org/elasticsearch/action/bulk/simple-bulk8.json
+++ b/src/test/java/org/elasticsearch/action/bulk/simple-bulk8.json
@@ -1,0 +1,6 @@
+{"index": {"_index": "test", "_type": "doc", "_id": 0}}
+{"field1": "value0"}
+{"index": {"_index": "test", "_type": "doc", "_id": 1, "_foo": "bar"}}
+{"field1": "value1"}
+{"index": {"_index": "test", "_type": "doc", "_id": 2}}
+{"field1": "value2"}

--- a/src/test/java/org/elasticsearch/action/bulk/simple-bulk9.json
+++ b/src/test/java/org/elasticsearch/action/bulk/simple-bulk9.json
@@ -1,0 +1,4 @@
+{"index": {}}
+{"field1": "value0"}
+{"index": ["bar"] }
+{"field1": "value1"}


### PR DESCRIPTION
It now throws an exception when an action/metadataline of a bulk request contains an unknown parameter or object like:

``` json
{"index": {"_index": "test", "_type": "doc", "_id": 1, "_foo": "bar"}}
```

``` json
{"index": {"_index": "test", "_type": "doc", "_id": 2, "_unkown": ["foo", "bar"]}}
```

Closes #10977
