### PR TITLE
Adding JAVA_HOME to documents and env config file

### DIFF
--- a/docs/reference/setup/as-a-service.asciidoc
+++ b/docs/reference/setup/as-a-service.asciidoc
@@ -13,6 +13,7 @@ Each package features a configuration file, which allows you to set the followin
 [horizontal]
 `ES_USER`::               The user to run as, defaults to `elasticsearch`
 `ES_GROUP`::              The group to run as, defaults to `elasticsearch`
+`JAVA_HOME`::             Set the Java path
 `ES_HEAP_SIZE`::          The heap size to start with
 `ES_HEAP_NEWSIZE`::       The size of the new generation heap
 `ES_DIRECT_SIZE`::        The maximum size of the direct memory

--- a/src/packaging/common/env/elasticsearch
+++ b/src/packaging/common/env/elasticsearch
@@ -5,6 +5,9 @@
 # Elasticsearch home directory
 #ES_HOME=${packaging.elasticsearch.home.dir}
 
+# Elasticsearch Java path
+#JAVA_HOME=
+
 # Elasticsearch configuration directory
 #CONF_DIR=${packaging.elasticsearch.conf.dir}
 


### PR DESCRIPTION
JAVA_HOME can optionally be configured in the system config file used by deb/rpm packages.

Closes #11291
