### PR TITLE
Don't truncate TopDocs after rescoring

### DIFF
--- a/src/main/java/org/elasticsearch/search/rescore/RescorePhase.java
+++ b/src/main/java/org/elasticsearch/search/rescore/RescorePhase.java
@@ -60,11 +60,6 @@ public class RescorePhase extends AbstractComponent implements SearchPhase {
             for (RescoreSearchContext ctx : context.rescore()) {
                 topDocs = ctx.rescorer().rescore(topDocs, context, ctx);
             }
-            if (context.size() < topDocs.scoreDocs.length) {
-                ScoreDoc[] hits = new ScoreDoc[context.size()];
-                System.arraycopy(topDocs.scoreDocs, 0, hits, 0, hits.length);
-                topDocs = new TopDocs(topDocs.totalHits, hits, topDocs.getMaxScore());
-            }
             context.queryResult().topDocs(topDocs);
         } catch (IOException e) {
             throw new ElasticsearchException("Rescore Phase Failed", e);


### PR DESCRIPTION
I'm not sure why we had this fragment from #7707 ... it is over-trimming `TopDocs` such that you get `size-from` results instead of `size`, which is wrong when `from != 0`.

Closes #11277 
