### PR TITLE
Query Refactoring: Adding getBuilderPrototype() method to all QueryParsers

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/AndQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/AndQueryBuilder.java
@@ -39,6 +39,8 @@ public class AndQueryBuilder extends QueryBuilder {
 
     private String queryName;
 
+    static final AndQueryBuilder PROTOTYPE = new AndQueryBuilder();
+
     public AndQueryBuilder(QueryBuilder... filters) {
         for (QueryBuilder filter : filters) {
             this.filters.add(filter);

--- a/src/main/java/org/elasticsearch/index/query/AndQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/AndQueryParser.java
@@ -115,4 +115,9 @@ public class AndQueryParser extends BaseQueryParserTemp {
         }
         return query;
     }
+
+    @Override
+    public AndQueryBuilder getBuilderPrototype() {
+        return AndQueryBuilder.PROTOTYPE;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/BoolQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/BoolQueryBuilder.java
@@ -51,6 +51,8 @@ public class BoolQueryBuilder extends QueryBuilder implements BoostableQueryBuil
 
     private String queryName;
 
+    static final BoolQueryBuilder PROTOTYPE = new BoolQueryBuilder();
+
     /**
      * Adds a query that <b>must</b> appear in the matching documents and will
      * contribute to scoring.

--- a/src/main/java/org/elasticsearch/index/query/BoolQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/BoolQueryParser.java
@@ -171,4 +171,9 @@ public class BoolQueryParser extends BaseQueryParserTemp {
         }
         return query;
     }
+
+    @Override
+    public BoolQueryBuilder getBuilderPrototype() {
+        return BoolQueryBuilder.PROTOTYPE;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/BoostingQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/BoostingQueryBuilder.java
@@ -47,8 +47,9 @@ public class BoostingQueryBuilder extends QueryBuilder implements BoostableQuery
 
     private float boost = -1;
 
-    public BoostingQueryBuilder() {
+    static final BoostingQueryBuilder PROTOTYPE = new BoostingQueryBuilder();
 
+    public BoostingQueryBuilder() {
     }
 
     public BoostingQueryBuilder positive(QueryBuilder positiveQuery) {

--- a/src/main/java/org/elasticsearch/index/query/BoostingQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/BoostingQueryParser.java
@@ -98,4 +98,9 @@ public class BoostingQueryParser extends BaseQueryParserTemp {
         }
         return boostingQuery;
     }
+
+    @Override
+    public BoostingQueryBuilder getBuilderPrototype() {
+        return BoostingQueryBuilder.PROTOTYPE;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/CommonTermsQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/CommonTermsQueryBuilder.java
@@ -72,6 +72,8 @@ public class CommonTermsQueryBuilder extends QueryBuilder implements BoostableQu
 
     private String queryName;
 
+    static final CommonTermsQueryBuilder PROTOTYPE = new CommonTermsQueryBuilder();
+
     /**
      * Constructs a new common terms query.
      */
@@ -84,6 +86,14 @@ public class CommonTermsQueryBuilder extends QueryBuilder implements BoostableQu
         }
         this.text = text;
         this.name = name;
+    }
+
+    /**
+     * private constructor used onyl internally
+     */
+    private CommonTermsQueryBuilder() {
+        this.text = null;
+        this.name = null;
     }
 
     /**

--- a/src/main/java/org/elasticsearch/index/query/CommonTermsQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/CommonTermsQueryParser.java
@@ -219,4 +219,9 @@ public class CommonTermsQueryParser extends BaseQueryParserTemp {
         query.setHighFreqMinimumNumberShouldMatch(highFreqMinimumShouldMatch);
         return query;
     }
+
+    @Override
+    public CommonTermsQueryBuilder getBuilderPrototype() {
+        return CommonTermsQueryBuilder.PROTOTYPE;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/ConstantScoreQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/ConstantScoreQueryBuilder.java
@@ -37,6 +37,8 @@ public class ConstantScoreQueryBuilder extends QueryBuilder implements Boostable
 
     private float boost = -1;
 
+    static final ConstantScoreQueryBuilder PROTOTYPE = new ConstantScoreQueryBuilder();
+
     /**
      * A query that wraps a query and simply returns a constant score equal to the
      * query boost for every document in the query.
@@ -45,6 +47,13 @@ public class ConstantScoreQueryBuilder extends QueryBuilder implements Boostable
      */
     public ConstantScoreQueryBuilder(QueryBuilder filterBuilder) {
         this.filterBuilder = Objects.requireNonNull(filterBuilder);
+    }
+
+    /**
+     * private constructor only used for serialization
+     */
+    private ConstantScoreQueryBuilder() {
+        this.filterBuilder = null;
     }
 
     /**

--- a/src/main/java/org/elasticsearch/index/query/ConstantScoreQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/ConstantScoreQueryParser.java
@@ -86,4 +86,9 @@ public class ConstantScoreQueryParser extends BaseQueryParserTemp {
         filter.setBoost(boost);
         return filter;
     }
+
+    @Override
+    public ConstantScoreQueryBuilder getBuilderPrototype() {
+        return ConstantScoreQueryBuilder.PROTOTYPE;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/DisMaxQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/DisMaxQueryBuilder.java
@@ -43,6 +43,8 @@ public class DisMaxQueryBuilder extends QueryBuilder implements BoostableQueryBu
 
     private String queryName;
 
+    static final DisMaxQueryBuilder PROTOTYPE = new DisMaxQueryBuilder();
+
     /**
      * Add a sub-query to this disjunction.
      */

--- a/src/main/java/org/elasticsearch/index/query/DisMaxQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/DisMaxQueryParser.java
@@ -111,4 +111,9 @@ public class DisMaxQueryParser extends BaseQueryParserTemp {
         }
         return query;
     }
+
+    @Override
+    public DisMaxQueryBuilder getBuilderPrototype() {
+        return DisMaxQueryBuilder.PROTOTYPE;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/ExistsQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/ExistsQueryBuilder.java
@@ -34,6 +34,8 @@ public class ExistsQueryBuilder extends QueryBuilder {
 
     private String queryName;
 
+    static final ExistsQueryBuilder PROTOTYPE = new ExistsQueryBuilder(null);
+
     public ExistsQueryBuilder(String name) {
         this.name = name;
     }

--- a/src/main/java/org/elasticsearch/index/query/ExistsQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/ExistsQueryParser.java
@@ -122,4 +122,9 @@ public class ExistsQueryParser extends BaseQueryParserTemp {
         return new ConstantScoreQuery(boolFilter);
     }
 
+    @Override
+    public ExistsQueryBuilder getBuilderPrototype() {
+        return ExistsQueryBuilder.PROTOTYPE;
+    }
+
 }

--- a/src/main/java/org/elasticsearch/index/query/FQueryFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/FQueryFilterParser.java
@@ -84,4 +84,9 @@ public class FQueryFilterParser extends BaseQueryParserTemp {
         }
         return query;
     }
+
+    @Override
+    public QueryFilterBuilder getBuilderPrototype() {
+        return QueryFilterBuilder.PROTOTYPE;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/FieldMaskingSpanQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/FieldMaskingSpanQueryBuilder.java
@@ -35,6 +35,8 @@ public class FieldMaskingSpanQueryBuilder extends QueryBuilder implements SpanQu
 
     private String queryName;
 
+    static final FieldMaskingSpanQueryBuilder PROTOTYPE = new FieldMaskingSpanQueryBuilder(null, null);
+
     public FieldMaskingSpanQueryBuilder(SpanQueryBuilder queryBuilder, String field) {
         this.queryBuilder = queryBuilder;
         this.field = field;

--- a/src/main/java/org/elasticsearch/index/query/FieldMaskingSpanQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/FieldMaskingSpanQueryParser.java
@@ -100,4 +100,9 @@ public class FieldMaskingSpanQueryParser extends BaseQueryParserTemp {
         }
         return query;
     }
+
+    @Override
+    public FieldMaskingSpanQueryBuilder getBuilderPrototype() {
+        return FieldMaskingSpanQueryBuilder.PROTOTYPE;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/FilteredQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/FilteredQueryBuilder.java
@@ -41,6 +41,8 @@ public class FilteredQueryBuilder extends QueryBuilder implements BoostableQuery
 
     private String queryName;
 
+    static final FilteredQueryBuilder PROTOTYPE = new FilteredQueryBuilder(null, null);
+
     /**
      * A query that applies a filter to the results of another query.
      *

--- a/src/main/java/org/elasticsearch/index/query/FilteredQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/FilteredQueryParser.java
@@ -118,4 +118,9 @@ public class FilteredQueryParser extends BaseQueryParserTemp {
         }
         return filteredQuery;
     }
+
+    @Override
+    public FilteredQueryBuilder getBuilderPrototype() {
+        return FilteredQueryBuilder.PROTOTYPE;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/FuzzyQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/FuzzyQueryBuilder.java
@@ -50,6 +50,8 @@ public class FuzzyQueryBuilder extends MultiTermQueryBuilder implements Boostabl
 
     private String queryName;
 
+    static final FuzzyQueryBuilder PROTOTYPE = new FuzzyQueryBuilder(null, null);
+
     /**
      * Constructs a new term query.
      *

--- a/src/main/java/org/elasticsearch/index/query/FuzzyQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/FuzzyQueryParser.java
@@ -130,4 +130,9 @@ public class FuzzyQueryParser extends BaseQueryParserTemp {
         }
         return query;
     }
+
+    @Override
+    public FuzzyQueryBuilder getBuilderPrototype() {
+        return FuzzyQueryBuilder.PROTOTYPE;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxQueryBuilder.java
@@ -44,6 +44,8 @@ public class GeoBoundingBoxQueryBuilder extends QueryBuilder {
     private String queryName;
     private String type;
 
+    static final GeoBoundingBoxQueryBuilder PROTOTYPE = new GeoBoundingBoxQueryBuilder(null);
+
     public GeoBoundingBoxQueryBuilder(String name) {
         this.name = name;
     }

--- a/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxQueryParser.java
@@ -74,14 +74,14 @@ public class GeoBoundingBoxQueryParser extends BaseQueryParserTemp {
         double bottom = Double.NaN;
         double left = Double.NaN;
         double right = Double.NaN;
-        
+
         String queryName = null;
         String currentFieldName = null;
         XContentParser.Token token;
         boolean normalize = true;
 
         GeoPoint sparse = new GeoPoint();
-        
+
         String type = "memory";
 
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
@@ -148,7 +148,7 @@ public class GeoBoundingBoxQueryParser extends BaseQueryParserTemp {
         final GeoPoint bottomRight = new GeoPoint(bottom, right);
 
         if (normalize) {
-            // Special case: if the difference bettween the left and right is 360 and the right is greater than the left, we are asking for 
+            // Special case: if the difference bettween the left and right is 360 and the right is greater than the left, we are asking for
             // the complete longitude range so need to set longitude to the complete longditude range
             boolean completeLonRange = ((right - left) % 360 == 0 && right > left);
             GeoUtils.normalizePoint(topLeft, true, !completeLonRange);
@@ -183,5 +183,10 @@ public class GeoBoundingBoxQueryParser extends BaseQueryParserTemp {
             parseContext.addNamedQuery(queryName, filter);
         }
         return filter;
-    }    
+    }
+
+    @Override
+    public GeoBoundingBoxQueryBuilder getBuilderPrototype() {
+        return GeoBoundingBoxQueryBuilder.PROTOTYPE;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/GeoDistanceQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoDistanceQueryBuilder.java
@@ -46,6 +46,8 @@ public class GeoDistanceQueryBuilder extends QueryBuilder {
 
     private String queryName;
 
+    static final GeoDistanceQueryBuilder PROTOTYPE = new GeoDistanceQueryBuilder(null);
+
     public GeoDistanceQueryBuilder(String name) {
         this.name = name;
     }

--- a/src/main/java/org/elasticsearch/index/query/GeoDistanceQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoDistanceQueryParser.java
@@ -162,4 +162,9 @@ public class GeoDistanceQueryParser extends BaseQueryParserTemp {
         }
         return query;
     }
+
+    @Override
+    public GeoDistanceQueryBuilder getBuilderPrototype() {
+        return GeoDistanceQueryBuilder.PROTOTYPE;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/GeoDistanceRangeQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoDistanceRangeQueryBuilder.java
@@ -48,6 +48,8 @@ public class GeoDistanceRangeQueryBuilder extends QueryBuilder {
 
     private String optimizeBbox;
 
+    static final GeoDistanceRangeQueryBuilder PROTOTYPE = new GeoDistanceRangeQueryBuilder(null);
+
     public GeoDistanceRangeQueryBuilder(String name) {
         this.name = name;
     }

--- a/src/main/java/org/elasticsearch/index/query/GeoDistanceRangeQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoDistanceRangeQueryParser.java
@@ -201,4 +201,9 @@ public class GeoDistanceRangeQueryParser extends BaseQueryParserTemp {
         }
         return query;
     }
+
+    @Override
+    public GeoDistanceRangeQueryBuilder getBuilderPrototype() {
+        return GeoDistanceRangeQueryBuilder.PROTOTYPE;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/GeoPolygonQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoPolygonQueryBuilder.java
@@ -40,6 +40,8 @@ public class GeoPolygonQueryBuilder extends QueryBuilder {
 
     private String queryName;
 
+    static final GeoPolygonQueryBuilder PROTOTYPE = new GeoPolygonQueryBuilder(null);
+
     public GeoPolygonQueryBuilder(String name) {
         this.name = name;
     }

--- a/src/main/java/org/elasticsearch/index/query/GeoPolygonQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoPolygonQueryParser.java
@@ -150,4 +150,9 @@ public class GeoPolygonQueryParser extends BaseQueryParserTemp {
         }
         return query;
     }
+
+    @Override
+    public GeoPolygonQueryBuilder getBuilderPrototype() {
+        return GeoPolygonQueryBuilder.PROTOTYPE;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/GeoShapeQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoShapeQueryBuilder.java
@@ -49,6 +49,8 @@ public class GeoShapeQueryBuilder extends QueryBuilder {
 
     private ShapeRelation relation = null;
 
+    static final GeoShapeQueryBuilder PROTOTYPE = new GeoShapeQueryBuilder(null, null);
+
     /**
      * Creates a new GeoShapeQueryBuilder whose Filter will be against the
      * given field name using the given Shape

--- a/src/main/java/org/elasticsearch/index/query/GeoShapeQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoShapeQueryParser.java
@@ -189,4 +189,9 @@ public class GeoShapeQueryParser extends BaseQueryParserTemp {
             throw new IllegalArgumentException("");
         }
     }
+
+    @Override
+    public GeoShapeQueryBuilder getBuilderPrototype() {
+        return GeoShapeQueryBuilder.PROTOTYPE;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/GeohashCellQuery.java
+++ b/src/main/java/org/elasticsearch/index/query/GeohashCellQuery.java
@@ -98,6 +98,7 @@ public class GeohashCellQuery {
         private String geohash;
         private int levels = -1;
         private boolean neighbors;
+        private static final Builder PROTOTYPE = new Builder(null);
 
 
         public Builder(String field) {
@@ -269,6 +270,11 @@ public class GeohashCellQuery {
             }
 
             return filter;
+        }
+
+        @Override
+        public GeohashCellQuery.Builder getBuilderPrototype() {
+            return Builder.PROTOTYPE;
         }
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/HasChildQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/HasChildQueryBuilder.java
@@ -45,6 +45,8 @@ public class HasChildQueryBuilder extends QueryBuilder implements BoostableQuery
 
     private QueryInnerHitBuilder innerHit = null;
 
+    static final HasChildQueryBuilder PROTOTYPE = new HasChildQueryBuilder(null, null);
+
     public HasChildQueryBuilder(String type, QueryBuilder queryBuilder) {
         this.childType = type;
         this.queryBuilder = queryBuilder;

--- a/src/main/java/org/elasticsearch/index/query/HasChildQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/HasChildQueryParser.java
@@ -187,4 +187,9 @@ public class HasChildQueryParser extends BaseQueryParserTemp {
         query.setBoost(boost);
         return query;
     }
+
+    @Override
+    public HasChildQueryBuilder getBuilderPrototype() {
+        return HasChildQueryBuilder.PROTOTYPE;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/HasParentQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/HasParentQueryBuilder.java
@@ -35,6 +35,7 @@ public class HasParentQueryBuilder extends QueryBuilder implements BoostableQuer
     private float boost = 1.0f;
     private String queryName;
     private QueryInnerHitBuilder innerHit = null;
+    static final HasParentQueryBuilder PROTOTYPE = new HasParentQueryBuilder(null, null);
 
     /**
      * @param parentType  The parent type

--- a/src/main/java/org/elasticsearch/index/query/HasParentQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/HasParentQueryParser.java
@@ -203,4 +203,9 @@ public class HasParentQueryParser extends BaseQueryParserTemp {
         }
     }
 
+    @Override
+    public HasParentQueryBuilder getBuilderPrototype() {
+        return HasParentQueryBuilder.PROTOTYPE;
+    }
+
 }

--- a/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.query;
 
 import com.google.common.collect.Sets;
+
 import org.apache.lucene.queries.TermsQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.cluster.metadata.MetaData;
@@ -48,6 +49,8 @@ public class IdsQueryBuilder extends QueryBuilder<IdsQueryBuilder> implements Bo
     private float boost = 1.0f;
 
     private String queryName;
+
+    static final IdsQueryBuilder PROTOTYPE = new IdsQueryBuilder();
 
     /**
      * Creates a new IdsQueryBuilder by optionally providing the types of the documents to look for

--- a/src/main/java/org/elasticsearch/index/query/IdsQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/IdsQueryParser.java
@@ -107,4 +107,9 @@ public class IdsQueryParser extends BaseQueryParser {
         query.validate();
         return query;
     }
+
+    @Override
+    public IdsQueryBuilder getBuilderPrototype() {
+        return IdsQueryBuilder.PROTOTYPE;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/IndicesQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/IndicesQueryBuilder.java
@@ -40,6 +40,8 @@ public class IndicesQueryBuilder extends QueryBuilder {
 
     private String queryName;
 
+    static final IndicesQueryBuilder PROTOTYPE = new IndicesQueryBuilder(null);
+
     public IndicesQueryBuilder(QueryBuilder queryBuilder, String... indices) {
         this.queryBuilder = queryBuilder;
         this.indices = indices;

--- a/src/main/java/org/elasticsearch/index/query/IndicesQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/IndicesQueryParser.java
@@ -157,4 +157,9 @@ public class IndicesQueryParser extends BaseQueryParserTemp {
         }
         return false;
     }
+
+    @Override
+    public IndicesQueryBuilder getBuilderPrototype() {
+        return IndicesQueryBuilder.PROTOTYPE;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/LimitQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/LimitQueryBuilder.java
@@ -32,6 +32,7 @@ public class LimitQueryBuilder extends QueryBuilder {
 
     public static final String NAME = "limit";
     private final int limit;
+    static final LimitQueryBuilder PROTOTYPE = new LimitQueryBuilder(-1);
 
     public LimitQueryBuilder(int limit) {
         this.limit = limit;

--- a/src/main/java/org/elasticsearch/index/query/LimitQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/LimitQueryParser.java
@@ -64,4 +64,9 @@ public class LimitQueryParser extends BaseQueryParserTemp {
         // this filter is deprecated and parses to a filter that matches everything
         return Queries.newMatchAllQuery();
     }
+
+    @Override
+    public LimitQueryBuilder getBuilderPrototype() {
+        return LimitQueryBuilder.PROTOTYPE;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/MatchAllQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/MatchAllQueryBuilder.java
@@ -37,6 +37,8 @@ public class MatchAllQueryBuilder extends QueryBuilder<MatchAllQueryBuilder> imp
 
     private float boost = 1.0f;
 
+    static final MatchAllQueryBuilder PROTOTYPE = new MatchAllQueryBuilder();
+
     /**
      * Sets the boost for this query.  Documents matching this query will (in addition to the normal
      * weightings) have their score multiplied by the boost provided.

--- a/src/main/java/org/elasticsearch/index/query/MatchAllQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MatchAllQueryParser.java
@@ -59,4 +59,9 @@ public class MatchAllQueryParser extends BaseQueryParser {
         }
         return queryBuilder;
     }
+
+    @Override
+    public MatchAllQueryBuilder getBuilderPrototype() {
+        return MatchAllQueryBuilder.PROTOTYPE;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/MatchQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/MatchQueryBuilder.java
@@ -94,6 +94,8 @@ public class MatchQueryBuilder extends QueryBuilder implements BoostableQueryBui
 
     private String queryName;
 
+    static final MatchQueryBuilder PROTOTYPE = new MatchQueryBuilder(null, null);
+
     /**
      * Constructs a new text query.
      */

--- a/src/main/java/org/elasticsearch/index/query/MatchQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MatchQueryParser.java
@@ -178,4 +178,9 @@ public class MatchQueryParser extends BaseQueryParserTemp {
         }
         return query;
     }
+
+    @Override
+    public MatchQueryBuilder getBuilderPrototype() {
+        return MatchQueryBuilder.PROTOTYPE;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/MissingQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/MissingQueryBuilder.java
@@ -38,6 +38,8 @@ public class MissingQueryBuilder extends QueryBuilder {
 
     private Boolean existence;
 
+    static final MissingQueryBuilder PROTOTYPE = new MissingQueryBuilder(null);
+
     public MissingQueryBuilder(String name) {
         this.name = name;
     }

--- a/src/main/java/org/elasticsearch/index/query/MissingQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MissingQueryParser.java
@@ -172,4 +172,9 @@ public class MissingQueryParser extends BaseQueryParserTemp {
         }
         return new ConstantScoreQuery(filter);
     }
+
+    @Override
+    public MissingQueryBuilder getBuilderPrototype() {
+        return MissingQueryBuilder.PROTOTYPE;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilder.java
@@ -152,6 +152,8 @@ public class MoreLikeThisQueryBuilder extends QueryBuilder implements BoostableQ
     private Boolean failOnUnsupportedField;
     private String queryName;
 
+    static final MoreLikeThisQueryBuilder PROTOTYPE = new MoreLikeThisQueryBuilder();
+
     /**
      * Constructs a new more like this query which uses the "_all" field.
      */

--- a/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryParser.java
@@ -355,4 +355,9 @@ public class MoreLikeThisQueryParser extends BaseQueryParserTemp {
             boolQuery.add(query, BooleanClause.Occur.MUST_NOT);
         }
     }
+
+    @Override
+    public MoreLikeThisQueryBuilder getBuilderPrototype() {
+        return MoreLikeThisQueryBuilder.PROTOTYPE;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/MultiMatchQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/MultiMatchQueryBuilder.java
@@ -80,6 +80,8 @@ public class MultiMatchQueryBuilder extends QueryBuilder implements BoostableQue
 
     private String queryName;
 
+    static final MultiMatchQueryBuilder PROTOTYPE = new MultiMatchQueryBuilder(null);
+
     public enum Type {
 
         /**

--- a/src/main/java/org/elasticsearch/index/query/MultiMatchQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MultiMatchQueryParser.java
@@ -197,4 +197,9 @@ public class MultiMatchQueryParser extends BaseQueryParserTemp {
             fieldNameWithBoosts.put(fField, fBoost);
         }
     }
+
+    @Override
+    public MultiMatchQueryBuilder getBuilderPrototype() {
+        return MultiMatchQueryBuilder.PROTOTYPE;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/NestedQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/NestedQueryBuilder.java
@@ -41,10 +41,21 @@ public class NestedQueryBuilder extends QueryBuilder implements BoostableQueryBu
 
     private QueryInnerHitBuilder innerHit;
 
+    static final NestedQueryBuilder PROTOTYPE = new NestedQueryBuilder();
+
     public NestedQueryBuilder(String path, QueryBuilder queryBuilder) {
         this.path = path;
         this.queryBuilder = Objects.requireNonNull(queryBuilder);
     }
+
+    /**
+     * private constructor only used internally
+     */
+    private NestedQueryBuilder() {
+        this.path = null;
+        this.queryBuilder = null;
+    }
+
     /**
      * The score mode.
      */

--- a/src/main/java/org/elasticsearch/index/query/NestedQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/NestedQueryParser.java
@@ -161,4 +161,9 @@ public class NestedQueryParser extends BaseQueryParserTemp {
         }
 
     }
+
+    @Override
+    public NestedQueryBuilder getBuilderPrototype() {
+        return NestedQueryBuilder.PROTOTYPE;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/NotQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/NotQueryBuilder.java
@@ -35,8 +35,17 @@ public class NotQueryBuilder extends QueryBuilder {
 
     private String queryName;
 
+    static final NotQueryBuilder PROTOTYPE = new NotQueryBuilder();
+
     public NotQueryBuilder(QueryBuilder filter) {
         this.filter = Objects.requireNonNull(filter);
+    }
+
+    /**
+     * private constructor for internal use
+     */
+    private NotQueryBuilder() {
+        this.filter = null;
     }
 
     public NotQueryBuilder queryName(String queryName) {

--- a/src/main/java/org/elasticsearch/index/query/NotQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/NotQueryParser.java
@@ -94,4 +94,9 @@ public class NotQueryParser extends BaseQueryParserTemp {
         }
         return notQuery;
     }
+
+    @Override
+    public NotQueryBuilder getBuilderPrototype() {
+        return NotQueryBuilder.PROTOTYPE;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/OrQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/OrQueryBuilder.java
@@ -40,6 +40,8 @@ public class OrQueryBuilder extends QueryBuilder {
 
     private String queryName;
 
+    static final OrQueryBuilder PROTOTYPE = new OrQueryBuilder();
+
     public OrQueryBuilder(QueryBuilder... filters) {
         Collections.addAll(this.filters, filters);
     }

--- a/src/main/java/org/elasticsearch/index/query/OrQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/OrQueryParser.java
@@ -112,4 +112,9 @@ public class OrQueryParser extends BaseQueryParserTemp {
         }
         return query;
     }
+
+    @Override
+    public OrQueryBuilder getBuilderPrototype() {
+        return OrQueryBuilder.PROTOTYPE;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/PrefixQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/PrefixQueryBuilder.java
@@ -40,6 +40,8 @@ public class PrefixQueryBuilder extends MultiTermQueryBuilder implements Boostab
 
     private String queryName;
 
+    static final PrefixQueryBuilder PROTOTYPE = new PrefixQueryBuilder(null, null);
+
     /**
      * A Query that matches documents containing terms with a specified prefix.
      *

--- a/src/main/java/org/elasticsearch/index/query/PrefixQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/PrefixQueryParser.java
@@ -115,4 +115,9 @@ public class PrefixQueryParser extends BaseQueryParserTemp {
         }
         return  query;
     }
+
+    @Override
+    public PrefixQueryBuilder getBuilderPrototype() {
+        return PrefixQueryBuilder.PROTOTYPE;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/QueryFilterBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryFilterBuilder.java
@@ -40,6 +40,8 @@ public class QueryFilterBuilder extends QueryBuilder {
 
     private String queryName;
 
+    static final QueryFilterBuilder PROTOTYPE = new QueryFilterBuilder(null);
+
     /**
      * A filter that simply wraps a query.
      *

--- a/src/main/java/org/elasticsearch/index/query/QueryFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryFilterParser.java
@@ -41,4 +41,9 @@ public class QueryFilterParser extends BaseQueryParserTemp {
     public Query parse(QueryParseContext parseContext) throws IOException, QueryParsingException {
         return new ConstantScoreQuery(parseContext.parseInnerQuery());
     }
+
+    @Override
+    public QueryFilterBuilder getBuilderPrototype() {
+        return QueryFilterBuilder.PROTOTYPE;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/QueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryParser.java
@@ -59,4 +59,9 @@ public interface QueryParser {
      * @throws QueryParsingException
      */
     QueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException;
+
+    /**
+     * @return an empty {@link QueryBuilder} instance for this parser that can be used for deserialization
+     */
+    QueryBuilder getBuilderPrototype();
 }

--- a/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
@@ -101,6 +101,8 @@ public class QueryStringQueryBuilder extends QueryBuilder implements BoostableQu
     /** To limit effort spent determinizing regexp queries. */
     private Integer maxDeterminizedStates;
 
+    static final QueryStringQueryBuilder PROTOTYPE = new QueryStringQueryBuilder(null);
+
     public QueryStringQueryBuilder(String queryString) {
         this.queryString = queryString;
     }

--- a/src/main/java/org/elasticsearch/index/query/QueryStringQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryStringQueryParser.java
@@ -245,4 +245,9 @@ public class QueryStringQueryParser extends BaseQueryParserTemp {
             throw new QueryParsingException(parseContext, "Failed to parse query [" + qpSettings.queryString() + "]", e);
         }
     }
+
+    @Override
+    public QueryStringQueryBuilder getBuilderPrototype() {
+        return QueryStringQueryBuilder.PROTOTYPE;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
@@ -59,6 +59,8 @@ public class RangeQueryBuilder extends MultiTermQueryBuilder<RangeQueryBuilder> 
 
     private String format;
 
+    static final RangeQueryBuilder PROTOTYPE = new RangeQueryBuilder(null);
+
     /**
      * A Query that matches documents within an range of terms.
      *

--- a/src/main/java/org/elasticsearch/index/query/RangeQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/RangeQueryParser.java
@@ -19,12 +19,9 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.search.TermRangeQuery;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.mapper.FieldMapper;
-import org.elasticsearch.index.mapper.core.DateFieldMapper;
 
 import java.io.IOException;
 
@@ -124,5 +121,10 @@ public class RangeQueryParser extends BaseQueryParser {
             .format(format);
         rangeQuery.validate();
         return rangeQuery;
+    }
+
+    @Override
+    public RangeQueryBuilder getBuilderPrototype() {
+        return RangeQueryBuilder.PROTOTYPE;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/RegexpQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/RegexpQueryBuilder.java
@@ -39,6 +39,7 @@ public class RegexpQueryBuilder extends MultiTermQueryBuilder implements Boostab
     private String queryName;
     private int maxDeterminizedStates = Operations.DEFAULT_MAX_DETERMINIZED_STATES;
     private boolean maxDetermizedStatesSet;
+    static final RegexpQueryBuilder PROTOTYPE = new RegexpQueryBuilder(null, null);
 
     /**
      * Constructs a new term query.

--- a/src/main/java/org/elasticsearch/index/query/RegexpQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/RegexpQueryParser.java
@@ -124,5 +124,10 @@ public class RegexpQueryParser extends BaseQueryParserTemp {
         return query;
     }
 
+    @Override
+    public RegexpQueryBuilder getBuilderPrototype() {
+        return RegexpQueryBuilder.PROTOTYPE;
+    }
+
 
 }

--- a/src/main/java/org/elasticsearch/index/query/ScriptQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/ScriptQueryBuilder.java
@@ -38,6 +38,8 @@ public class ScriptQueryBuilder extends QueryBuilder {
 
     private String queryName;
 
+    static final ScriptQueryBuilder PROTOTYPE = new ScriptQueryBuilder(null);
+
     public ScriptQueryBuilder(String script) {
         this.script = script;
     }

--- a/src/main/java/org/elasticsearch/index/query/ScriptQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/ScriptQueryParser.java
@@ -189,4 +189,9 @@ public class ScriptQueryParser extends BaseQueryParserTemp {
             };
         }
     }
+
+    @Override
+    public ScriptQueryBuilder getBuilderPrototype() {
+        return ScriptQueryBuilder.PROTOTYPE;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
@@ -43,6 +43,7 @@ public class SimpleQueryStringBuilder extends QueryBuilder {
     private Boolean lenient;
     private Boolean analyzeWildcard;
     private Locale locale;
+    static final SimpleQueryStringBuilder PROTOTYPE = new SimpleQueryStringBuilder(null);
 
     /**
      * Operators for the default_operator

--- a/src/main/java/org/elasticsearch/index/query/SimpleQueryStringParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SimpleQueryStringParser.java
@@ -230,4 +230,9 @@ public class SimpleQueryStringParser extends BaseQueryParserTemp {
         }
         return query;
     }
+
+    @Override
+    public SimpleQueryStringBuilder getBuilderPrototype() {
+        return SimpleQueryStringBuilder.PROTOTYPE;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/SpanContainingQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanContainingQueryBuilder.java
@@ -33,6 +33,7 @@ public class SpanContainingQueryBuilder extends QueryBuilder implements SpanQuer
     private SpanQueryBuilder little;
     private float boost = -1;
     private String queryName;
+    static final SpanContainingQueryBuilder PROTOTYPE = new SpanContainingQueryBuilder();
 
     /**
      * Sets the little clause, it must be contained within {@code big} for a match.

--- a/src/main/java/org/elasticsearch/index/query/SpanContainingQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanContainingQueryParser.java
@@ -95,4 +95,9 @@ public class SpanContainingQueryParser extends BaseQueryParserTemp {
         }
         return query;
     }
+
+    @Override
+    public SpanContainingQueryBuilder getBuilderPrototype() {
+        return SpanContainingQueryBuilder.PROTOTYPE;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/SpanFirstQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanFirstQueryBuilder.java
@@ -35,6 +35,8 @@ public class SpanFirstQueryBuilder extends QueryBuilder implements SpanQueryBuil
 
     private String queryName;
 
+    static final SpanFirstQueryBuilder SPAN_FIRST_QUERY_BUILDER = new SpanFirstQueryBuilder(null, -1);
+
     public SpanFirstQueryBuilder(SpanQueryBuilder matchBuilder, int end) {
         this.matchBuilder = matchBuilder;
         this.end = end;

--- a/src/main/java/org/elasticsearch/index/query/SpanFirstQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanFirstQueryParser.java
@@ -93,4 +93,9 @@ public class SpanFirstQueryParser extends BaseQueryParserTemp {
         }
         return query;
     }
+
+    @Override
+    public SpanFirstQueryBuilder getBuilderPrototype() {
+        return SpanFirstQueryBuilder.SPAN_FIRST_QUERY_BUILDER;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/SpanMultiTermQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanMultiTermQueryBuilder.java
@@ -26,6 +26,7 @@ public class SpanMultiTermQueryBuilder extends QueryBuilder implements SpanQuery
 
     public static final String NAME = "span_multi";
     private MultiTermQueryBuilder multiTermQueryBuilder;
+    static final SpanMultiTermQueryBuilder PROTOTYPE = new SpanMultiTermQueryBuilder(null);
 
     public SpanMultiTermQueryBuilder(MultiTermQueryBuilder multiTermQueryBuilder) {
         this.multiTermQueryBuilder = multiTermQueryBuilder;

--- a/src/main/java/org/elasticsearch/index/query/SpanMultiTermQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanMultiTermQueryParser.java
@@ -66,4 +66,9 @@ public class SpanMultiTermQueryParser extends BaseQueryParserTemp {
         parser.nextToken();
         return new SpanMultiTermQueryWrapper<>((MultiTermQuery) subQuery);
     }
+
+    @Override
+    public SpanMultiTermQueryBuilder getBuilderPrototype() {
+        return SpanMultiTermQueryBuilder.PROTOTYPE;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/SpanNearQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanNearQueryBuilder.java
@@ -40,6 +40,8 @@ public class SpanNearQueryBuilder extends QueryBuilder implements SpanQueryBuild
 
     private String queryName;
 
+    static final SpanNearQueryBuilder PROTOTYPE = new SpanNearQueryBuilder();
+
     public SpanNearQueryBuilder clause(SpanQueryBuilder clause) {
         clauses.add(clause);
         return this;

--- a/src/main/java/org/elasticsearch/index/query/SpanNearQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanNearQueryParser.java
@@ -106,4 +106,9 @@ public class SpanNearQueryParser extends BaseQueryParserTemp {
         }
         return query;
     }
+
+    @Override
+    public SpanNearQueryBuilder getBuilderPrototype() {
+        return SpanNearQueryBuilder.PROTOTYPE;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/SpanNotQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanNotQueryBuilder.java
@@ -41,6 +41,8 @@ public class SpanNotQueryBuilder extends QueryBuilder implements SpanQueryBuilde
 
     private String queryName;
 
+    static final SpanNotQueryBuilder PROTOTYPE = new SpanNotQueryBuilder();
+
     public SpanNotQueryBuilder include(SpanQueryBuilder include) {
         this.include = include;
         return this;

--- a/src/main/java/org/elasticsearch/index/query/SpanNotQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanNotQueryParser.java
@@ -126,4 +126,9 @@ public class SpanNotQueryParser extends BaseQueryParserTemp {
         }
         return query;
     }
+
+    @Override
+    public SpanNotQueryBuilder getBuilderPrototype() {
+        return SpanNotQueryBuilder.PROTOTYPE;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/SpanOrQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanOrQueryBuilder.java
@@ -34,6 +34,8 @@ public class SpanOrQueryBuilder extends QueryBuilder implements SpanQueryBuilder
 
     private String queryName;
 
+    static final SpanOrQueryBuilder PROTOTYPE = new SpanOrQueryBuilder();
+
     public SpanOrQueryBuilder clause(SpanQueryBuilder clause) {
         clauses.add(clause);
         return this;

--- a/src/main/java/org/elasticsearch/index/query/SpanOrQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanOrQueryParser.java
@@ -92,4 +92,9 @@ public class SpanOrQueryParser extends BaseQueryParserTemp {
         }
         return query;
     }
+
+    @Override
+    public SpanOrQueryBuilder getBuilderPrototype() {
+        return SpanOrQueryBuilder.PROTOTYPE;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/SpanTermQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanTermQueryBuilder.java
@@ -33,6 +33,7 @@ import org.elasticsearch.index.mapper.FieldMapper;
 public class SpanTermQueryBuilder extends BaseTermQueryBuilder<SpanTermQueryBuilder> implements SpanQueryBuilder {
 
     public static final String NAME = "span_term";
+    static final SpanTermQueryBuilder PROTOTYPE = new SpanTermQueryBuilder(null, null);
 
     /** @see BaseTermQueryBuilder#BaseTermQueryBuilder(String, String) */
     public SpanTermQueryBuilder(String name, String value) {

--- a/src/main/java/org/elasticsearch/index/query/SpanTermQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanTermQueryParser.java
@@ -92,4 +92,9 @@ public class SpanTermQueryParser extends BaseQueryParser {
         result.validate();
         return result;
     }
+
+    @Override
+    public SpanTermQueryBuilder getBuilderPrototype() {
+        return SpanTermQueryBuilder.PROTOTYPE;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/SpanWithinQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanWithinQueryBuilder.java
@@ -33,6 +33,7 @@ public class SpanWithinQueryBuilder extends QueryBuilder implements SpanQueryBui
     private SpanQueryBuilder little;
     private float boost = -1;
     private String queryName;
+    static final SpanWithinQueryBuilder PROTOTYPE = new SpanWithinQueryBuilder();
 
     /**
      * Sets the little clause, it must be contained within {@code big} for a match.

--- a/src/main/java/org/elasticsearch/index/query/SpanWithinQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanWithinQueryParser.java
@@ -95,4 +95,9 @@ public class SpanWithinQueryParser extends BaseQueryParserTemp {
         }
         return query;
     }
+
+    @Override
+    public SpanWithinQueryBuilder getBuilderPrototype() {
+        return SpanWithinQueryBuilder.PROTOTYPE;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/TemplateQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/TemplateQueryBuilder.java
@@ -39,6 +39,8 @@ public class TemplateQueryBuilder extends QueryBuilder {
 
     private ScriptService.ScriptType templateType;
 
+    static final TemplateQueryBuilder PROTOTYPE = new TemplateQueryBuilder(null, null);
+
     /**
      * @param template the template to use for that query.
      * @param vars the parameters to fill the template with.

--- a/src/main/java/org/elasticsearch/index/query/TemplateQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TemplateQueryParser.java
@@ -155,4 +155,9 @@ public class TemplateQueryParser extends BaseQueryParserTemp {
             return type + " " + template;
         }
     }
+
+    @Override
+    public TemplateQueryBuilder getBuilderPrototype() {
+        return TemplateQueryBuilder.PROTOTYPE;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/TermQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/TermQueryBuilder.java
@@ -31,6 +31,7 @@ import org.elasticsearch.index.mapper.FieldMapper;
 public class TermQueryBuilder extends BaseTermQueryBuilder<TermQueryBuilder> implements BoostableQueryBuilder<TermQueryBuilder> {
 
     public static final String NAME = "term";
+    static final TermQueryBuilder PROTOTYPE = new TermQueryBuilder(null, null);
 
     /** @see BaseTermQueryBuilder#BaseTermQueryBuilder(String, String) */
     public TermQueryBuilder(String fieldName, String value) {

--- a/src/main/java/org/elasticsearch/index/query/TermQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TermQueryParser.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.search.TermQuery;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.xcontent.XContentParser;
 
@@ -95,5 +94,10 @@ public class TermQueryParser extends BaseQueryParser {
         }
         termQuery.validate();
         return termQuery;
+    }
+
+    @Override
+    public TermQueryBuilder getBuilderPrototype() {
+        return TermQueryBuilder.PROTOTYPE;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/TermsQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/TermsQueryBuilder.java
@@ -45,6 +45,8 @@ public class TermsQueryBuilder extends QueryBuilder<TermsQueryBuilder> {
     private String lookupPath;
     private Boolean lookupCache;
 
+    static final TermsQueryBuilder PROTOTYPE = new TermsQueryBuilder(null, (Object) null);
+
     /**
      * A filter for a field based on several terms matching on any of them.
      *

--- a/src/main/java/org/elasticsearch/index/query/TermsQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TermsQueryParser.java
@@ -207,4 +207,9 @@ public class TermsQueryParser extends BaseQueryParserTemp {
         }
         return query;
     }
+
+    @Override
+    public TermsQueryBuilder getBuilderPrototype() {
+        return TermsQueryBuilder.PROTOTYPE;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/TypeQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/TypeQueryBuilder.java
@@ -27,6 +27,7 @@ public class TypeQueryBuilder extends QueryBuilder {
 
     public static final String NAME = "type";
     private final String type;
+    static final TypeQueryBuilder PROTOTYPE = new TypeQueryBuilder(null);
 
     public TypeQueryBuilder(String type) {
         this.type = type;

--- a/src/main/java/org/elasticsearch/index/query/TypeQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TypeQueryParser.java
@@ -62,7 +62,7 @@ public class TypeQueryParser extends BaseQueryParserTemp {
         parser.nextToken();
 
         Query filter;
-        //LUCENE 4 UPGRADE document mapper should use bytesref as well? 
+        //LUCENE 4 UPGRADE document mapper should use bytesref as well?
         DocumentMapper documentMapper = parseContext.mapperService().documentMapper(type.utf8ToString());
         if (documentMapper == null) {
             filter = new TermQuery(new Term(TypeFieldMapper.NAME, type));
@@ -70,5 +70,10 @@ public class TypeQueryParser extends BaseQueryParserTemp {
             filter = documentMapper.typeFilter();
         }
         return filter;
+    }
+
+    @Override
+    public TypeQueryBuilder getBuilderPrototype() {
+        return TypeQueryBuilder.PROTOTYPE;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/WildcardQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/WildcardQueryBuilder.java
@@ -45,6 +45,8 @@ public class WildcardQueryBuilder extends MultiTermQueryBuilder implements Boost
 
     private String queryName;
 
+    static final WildcardQueryBuilder PROTOTYPE = new WildcardQueryBuilder(null, null);
+
     /**
      * Implements the wildcard search query. Supported wildcards are <tt>*</tt>, which
      * matches any character sequence (including the empty one), and <tt>?</tt>,

--- a/src/main/java/org/elasticsearch/index/query/WildcardQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/WildcardQueryParser.java
@@ -108,4 +108,9 @@ public class WildcardQueryParser extends BaseQueryParserTemp {
         }
         return wildcardQuery;
     }
+
+    @Override
+    public WildcardQueryBuilder getBuilderPrototype() {
+        return WildcardQueryBuilder.PROTOTYPE;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/WrapperQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/WrapperQueryBuilder.java
@@ -46,6 +46,7 @@ public class WrapperQueryBuilder extends QueryBuilder {
     private final byte[] source;
     private final int offset;
     private final int length;
+    static final WrapperQueryBuilder PROTOTYPE = new WrapperQueryBuilder(null, -1, -1);
 
     /**
      * Creates a query builder given a query provided as a string

--- a/src/main/java/org/elasticsearch/index/query/WrapperQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/WrapperQueryParser.java
@@ -64,4 +64,9 @@ public class WrapperQueryParser extends BaseQueryParserTemp {
             return result;
         }
     }
+
+    @Override
+    public WrapperQueryBuilder getBuilderPrototype() {
+        return WrapperQueryBuilder.PROTOTYPE;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilder.java
@@ -49,6 +49,8 @@ public class FunctionScoreQueryBuilder extends QueryBuilder implements Boostable
     private ArrayList<ScoreFunctionBuilder> scoreFunctions = new ArrayList<>();
     private Float minScore = null;
 
+    static final FunctionScoreQueryBuilder PROTOTYPE = new FunctionScoreQueryBuilder();
+
     /**
      * Creates a function_score query that executes on documents that match query a query.
      * Query and filter will be wrapped into a filtered_query.

--- a/src/main/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryParser.java
@@ -277,4 +277,9 @@ public class FunctionScoreQueryParser implements QueryParser {
         Query query = parse(parseContext);
         return new QueryWrappingQueryBuilder(query);
     }
+
+    @Override
+    public FunctionScoreQueryBuilder getBuilderPrototype() {
+        return FunctionScoreQueryBuilder.PROTOTYPE;
+    }
 }

--- a/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
+++ b/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
@@ -191,6 +191,11 @@ public class SimpleIndexQueryParserTests extends ElasticsearchSingleNodeTest {
             assertEquals(XContentParser.Token.END_OBJECT, parseContext.parser().nextToken());
             return new DummyQueryBuilder();
         }
+
+        @Override
+        public DummyQueryBuilder getBuilderPrototype() {
+            return new DummyQueryBuilder();
+        }
     }
 
     private static class DummyQueryBuilder extends QueryBuilder {

--- a/src/test/java/org/elasticsearch/index/query/guice/MyJsonQueryParser.java
+++ b/src/test/java/org/elasticsearch/index/query/guice/MyJsonQueryParser.java
@@ -69,4 +69,9 @@ public class MyJsonQueryParser extends AbstractIndexComponent implements QueryPa
         Query query = parse(parseContext);
         return new QueryWrappingQueryBuilder(query);
     }
+
+    @Override
+    public QueryBuilder getBuilderPrototype() {
+        throw new UnsupportedOperationException("Not implemented in test class");
+    }
 }

--- a/src/test/java/org/elasticsearch/index/query/plugin/PluginJsonQueryParser.java
+++ b/src/test/java/org/elasticsearch/index/query/plugin/PluginJsonQueryParser.java
@@ -69,4 +69,9 @@ public class PluginJsonQueryParser extends AbstractIndexComponent implements Que
         Query query = parse(parseContext);
         return new QueryWrappingQueryBuilder(query);
     }
+
+    @Override
+    public QueryBuilder getBuilderPrototype() {
+        throw new UnsupportedOperationException("Not implemented in test class");
+    }
 }


### PR DESCRIPTION
Currently there is a registry for all QueryParsers accessible via the IndicesQueriesModule. For deserializing nested queries e.g. for the BoolQueryBuilder (https://github.com/elastic/elasticsearch/pull/11121) we need to look up query builders by their name to be able to deserialize using a prototype builder of the concrete class. This PR adds a getBuilderPrototype() method to each query parser so we can re-use the parser registry to get the corresponding builder using the query name. This might change in the future when we decide to register also builders or merger parsers and builders in a later stage of the refactoring. (see https://github.com/elastic/elasticsearch/pull/11121#discussion_r30214415) for past discussion. 
