### PR TITLE
Don't write recoveryType twice

### DIFF
--- a/src/main/java/org/elasticsearch/indices/recovery/StartRecoveryRequest.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/StartRecoveryRequest.java
@@ -127,7 +127,6 @@ public class StartRecoveryRequest extends TransportRequest {
         if (out.getVersion().onOrAfter(Version.V_1_2_2)) {
             out.writeByte(recoveryType.id());
         }
-        out.writeByte(recoveryType.id());
     }
 
 }

--- a/src/test/java/org/elasticsearch/indices/recovery/StartRecoveryRequestTest.java
+++ b/src/test/java/org/elasticsearch/indices/recovery/StartRecoveryRequestTest.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.EOFException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -79,6 +80,7 @@ public class StartRecoveryRequestTest extends ElasticsearchTestCase {
         } else {
             assertThat(inRequest.recoveryType(), nullValue());
         }
+        assertThat(in.read(), equalTo(-1));
     }
 
 }


### PR DESCRIPTION
This caused scary warnings in the logs
Message not fully read (request) for [157] and action [internal:index/shard/recovery/start_recovery], resetting.

closes #11335

Must have happened while backporting #11179
