### PR TITLE
Update project.name in bin/elasticsearch script

### DIFF
--- a/bin/elasticsearch
+++ b/bin/elasticsearch
@@ -57,7 +57,7 @@
 # Maven will replace the project.name with elasticsearch below. If that
 # hasn't been done, we assume that this is not a packaged version and the
 # user has forgotten to run Maven to create a package.
-IS_PACKAGED_VERSION='${project.name}'
+IS_PACKAGED_VERSION='${project.artifactId}'
 if [ "$IS_PACKAGED_VERSION" != "elasticsearch" ]; then
     cat >&2 << EOF
 Error: You must build the project with Maven or download a pre-built package


### PR DESCRIPTION
 Commit 60519911b4e50bcc958c924a768dca2ae618101b changed the project.name, preventing elasticsearch to start.
