### PR TITLE
Simplify Transport*OperationAction names

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthRequest.java
@@ -22,7 +22,7 @@ package org.elasticsearch.action.admin.cluster.health;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.action.support.master.MasterNodeReadOperationRequest;
+import org.elasticsearch.action.support.master.MasterNodeReadRequest;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -37,7 +37,7 @@ import static org.elasticsearch.common.unit.TimeValue.readTimeValue;
 /**
  *
  */
-public class ClusterHealthRequest extends MasterNodeReadOperationRequest<ClusterHealthRequest> implements IndicesRequest.Replaceable {
+public class ClusterHealthRequest extends MasterNodeReadRequest<ClusterHealthRequest> implements IndicesRequest.Replaceable {
 
     private String[] indices;
     private TimeValue timeout = new TimeValue(30, TimeUnit.SECONDS);

--- a/src/main/java/org/elasticsearch/action/admin/cluster/health/TransportClusterHealthAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/health/TransportClusterHealthAction.java
@@ -22,7 +22,7 @@ package org.elasticsearch.action.admin.cluster.health;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.action.support.master.TransportMasterNodeReadOperationAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeReadAction;
 import org.elasticsearch.cluster.*;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.common.Strings;
@@ -37,7 +37,7 @@ import org.elasticsearch.transport.TransportService;
 /**
  *
  */
-public class TransportClusterHealthAction extends TransportMasterNodeReadOperationAction<ClusterHealthRequest, ClusterHealthResponse> {
+public class TransportClusterHealthAction extends TransportMasterNodeReadAction<ClusterHealthRequest, ClusterHealthResponse> {
 
     private final ClusterName clusterName;
     private final GatewayAllocator gatewayAllocator;

--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/NodeHotThreads.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/NodeHotThreads.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.action.admin.cluster.node.hotthreads;
 
-import org.elasticsearch.action.support.nodes.NodeOperationResponse;
+import org.elasticsearch.action.support.nodes.BaseNodeResponse;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -28,7 +28,7 @@ import java.io.IOException;
 
 /**
  */
-public class NodeHotThreads extends NodeOperationResponse {
+public class NodeHotThreads extends BaseNodeResponse {
 
     private String hotThreads;
 

--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/NodesHotThreadsRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/NodesHotThreadsRequest.java
@@ -20,7 +20,7 @@
 package org.elasticsearch.action.admin.cluster.node.hotthreads;
 
 import org.elasticsearch.Version;
-import org.elasticsearch.action.support.nodes.NodesOperationRequest;
+import org.elasticsearch.action.support.nodes.BaseNodesRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.unit.TimeValue;
@@ -30,7 +30,7 @@ import java.util.concurrent.TimeUnit;
 
 /**
  */
-public class NodesHotThreadsRequest extends NodesOperationRequest<NodesHotThreadsRequest> {
+public class NodesHotThreadsRequest extends BaseNodesRequest<NodesHotThreadsRequest> {
 
     int threads = 3;
     String type = "cpu";

--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/NodesHotThreadsResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/NodesHotThreadsResponse.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.action.admin.cluster.node.hotthreads;
 
-import org.elasticsearch.action.support.nodes.NodesOperationResponse;
+import org.elasticsearch.action.support.nodes.BaseNodesResponse;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -28,7 +28,7 @@ import java.io.IOException;
 
 /**
  */
-public class NodesHotThreadsResponse extends NodesOperationResponse<NodeHotThreads> {
+public class NodesHotThreadsResponse extends BaseNodesResponse<NodeHotThreads> {
 
     NodesHotThreadsResponse() {
     }

--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/TransportNodesHotThreadsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/TransportNodesHotThreadsAction.java
@@ -22,8 +22,8 @@ package org.elasticsearch.action.admin.cluster.node.hotthreads;
 import com.google.common.collect.Lists;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.nodes.NodeOperationRequest;
-import org.elasticsearch.action.support.nodes.TransportNodesOperationAction;
+import org.elasticsearch.action.support.nodes.BaseNodeRequest;
+import org.elasticsearch.action.support.nodes.TransportNodesAction;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.common.inject.Inject;
@@ -41,7 +41,7 @@ import java.util.concurrent.atomic.AtomicReferenceArray;
 /**
  *
  */
-public class TransportNodesHotThreadsAction extends TransportNodesOperationAction<NodesHotThreadsRequest, NodesHotThreadsResponse, TransportNodesHotThreadsAction.NodeRequest, NodeHotThreads> {
+public class TransportNodesHotThreadsAction extends TransportNodesAction<NodesHotThreadsRequest, NodesHotThreadsResponse, TransportNodesHotThreadsAction.NodeRequest, NodeHotThreads> {
 
     @Inject
     public TransportNodesHotThreadsAction(Settings settings, ClusterName clusterName, ThreadPool threadPool,
@@ -92,7 +92,7 @@ public class TransportNodesHotThreadsAction extends TransportNodesOperationActio
         return false;
     }
 
-    static class NodeRequest extends NodeOperationRequest {
+    static class NodeRequest extends BaseNodeRequest {
 
         NodesHotThreadsRequest request;
 

--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodeInfo.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodeInfo.java
@@ -22,7 +22,7 @@ package org.elasticsearch.action.admin.cluster.node.info;
 import com.google.common.collect.ImmutableMap;
 import org.elasticsearch.Build;
 import org.elasticsearch.Version;
-import org.elasticsearch.action.support.nodes.NodeOperationResponse;
+import org.elasticsearch.action.support.nodes.BaseNodeResponse;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -42,7 +42,7 @@ import java.util.Map;
 /**
  * Node information (static, does not change over time).
  */
-public class NodeInfo extends NodeOperationResponse {
+public class NodeInfo extends BaseNodeResponse {
 
     @Nullable
     private ImmutableMap<String, String> serviceAttributes;

--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequest.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.action.admin.cluster.node.info;
 
-import org.elasticsearch.action.support.nodes.NodesOperationRequest;
+import org.elasticsearch.action.support.nodes.BaseNodesRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -28,7 +28,7 @@ import java.io.IOException;
 /**
  * A request to get node (cluster) level information.
  */
-public class NodesInfoRequest extends NodesOperationRequest<NodesInfoRequest> {
+public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
 
     private boolean settings = true;
     private boolean os = true;

--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoResponse.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.action.admin.cluster.node.info;
 
-import org.elasticsearch.action.support.nodes.NodesOperationResponse;
+import org.elasticsearch.action.support.nodes.BaseNodesResponse;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -34,7 +34,7 @@ import java.util.Map;
 /**
  *
  */
-public class NodesInfoResponse extends NodesOperationResponse<NodeInfo> implements ToXContent {
+public class NodesInfoResponse extends BaseNodesResponse<NodeInfo> implements ToXContent {
 
     public NodesInfoResponse() {
     }

--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/info/TransportNodesInfoAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/info/TransportNodesInfoAction.java
@@ -20,8 +20,8 @@
 package org.elasticsearch.action.admin.cluster.node.info;
 
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.nodes.NodeOperationRequest;
-import org.elasticsearch.action.support.nodes.TransportNodesOperationAction;
+import org.elasticsearch.action.support.nodes.BaseNodeRequest;
+import org.elasticsearch.action.support.nodes.TransportNodesAction;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.common.inject.Inject;
@@ -40,7 +40,7 @@ import java.util.concurrent.atomic.AtomicReferenceArray;
 /**
  *
  */
-public class TransportNodesInfoAction extends TransportNodesOperationAction<NodesInfoRequest, NodesInfoResponse, TransportNodesInfoAction.NodeInfoRequest, NodeInfo> {
+public class TransportNodesInfoAction extends TransportNodesAction<NodesInfoRequest, NodesInfoResponse, TransportNodesInfoAction.NodeInfoRequest, NodeInfo> {
 
     private final NodeService nodeService;
 
@@ -87,7 +87,7 @@ public class TransportNodesInfoAction extends TransportNodesOperationAction<Node
         return false;
     }
 
-    static class NodeInfoRequest extends NodeOperationRequest {
+    static class NodeInfoRequest extends BaseNodeRequest {
 
         NodesInfoRequest request;
 

--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
@@ -19,11 +19,9 @@
 
 package org.elasticsearch.action.admin.cluster.node.stats;
 
-import org.elasticsearch.Version;
-import org.elasticsearch.action.support.nodes.NodeOperationResponse;
+import org.elasticsearch.action.support.nodes.BaseNodeResponse;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.Nullable;
-import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ToXContent;
@@ -31,7 +29,6 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.http.HttpStats;
 import org.elasticsearch.indices.NodeIndicesStats;
 import org.elasticsearch.indices.breaker.AllCircuitBreakerStats;
-import org.elasticsearch.indices.breaker.CircuitBreakerStats;
 import org.elasticsearch.monitor.fs.FsStats;
 import org.elasticsearch.monitor.jvm.JvmStats;
 import org.elasticsearch.monitor.network.NetworkStats;
@@ -46,7 +43,7 @@ import java.util.Map;
 /**
  * Node statistics (dynamic, changes depending on when created).
  */
-public class NodeStats extends NodeOperationResponse implements ToXContent {
+public class NodeStats extends BaseNodeResponse implements ToXContent {
 
     private long timestamp;
 

--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsRequest.java
@@ -20,7 +20,7 @@
 package org.elasticsearch.action.admin.cluster.node.stats;
 
 import org.elasticsearch.action.admin.indices.stats.CommonStatsFlags;
-import org.elasticsearch.action.support.nodes.NodesOperationRequest;
+import org.elasticsearch.action.support.nodes.BaseNodesRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -29,7 +29,7 @@ import java.io.IOException;
 /**
  * A request to get node (cluster) level stats.
  */
-public class NodesStatsRequest extends NodesOperationRequest<NodesStatsRequest> {
+public class NodesStatsRequest extends BaseNodesRequest<NodesStatsRequest> {
 
     private CommonStatsFlags indices = new CommonStatsFlags();
     private boolean os;

--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsResponse.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.action.admin.cluster.node.stats;
 
-import org.elasticsearch.action.support.nodes.NodesOperationResponse;
+import org.elasticsearch.action.support.nodes.BaseNodesResponse;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -32,7 +32,7 @@ import java.io.IOException;
 /**
  *
  */
-public class NodesStatsResponse extends NodesOperationResponse<NodeStats> implements ToXContent {
+public class NodesStatsResponse extends BaseNodesResponse<NodeStats> implements ToXContent {
 
     NodesStatsResponse() {
     }

--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/TransportNodesStatsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/TransportNodesStatsAction.java
@@ -21,8 +21,8 @@ package org.elasticsearch.action.admin.cluster.node.stats;
 
 import com.google.common.collect.Lists;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.nodes.NodeOperationRequest;
-import org.elasticsearch.action.support.nodes.TransportNodesOperationAction;
+import org.elasticsearch.action.support.nodes.BaseNodeRequest;
+import org.elasticsearch.action.support.nodes.TransportNodesAction;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.common.inject.Inject;
@@ -40,7 +40,7 @@ import java.util.concurrent.atomic.AtomicReferenceArray;
 /**
  *
  */
-public class TransportNodesStatsAction extends TransportNodesOperationAction<NodesStatsRequest, NodesStatsResponse, TransportNodesStatsAction.NodeStatsRequest, NodeStats> {
+public class TransportNodesStatsAction extends TransportNodesAction<NodesStatsRequest, NodesStatsResponse, TransportNodesStatsAction.NodeStatsRequest, NodeStats> {
 
     private final NodeService nodeService;
 
@@ -87,7 +87,7 @@ public class TransportNodesStatsAction extends TransportNodesOperationAction<Nod
         return false;
     }
 
-    static class NodeStatsRequest extends NodeOperationRequest {
+    static class NodeStatsRequest extends BaseNodeRequest {
 
         NodesStatsRequest request;
 

--- a/src/main/java/org/elasticsearch/action/admin/cluster/repositories/delete/TransportDeleteRepositoryAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/repositories/delete/TransportDeleteRepositoryAction.java
@@ -21,7 +21,7 @@ package org.elasticsearch.action.admin.cluster.repositories.delete;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ack.ClusterStateUpdateResponse;
@@ -36,7 +36,7 @@ import org.elasticsearch.transport.TransportService;
 /**
  * Transport action for unregister repository operation
  */
-public class TransportDeleteRepositoryAction extends TransportMasterNodeOperationAction<DeleteRepositoryRequest, DeleteRepositoryResponse> {
+public class TransportDeleteRepositoryAction extends TransportMasterNodeAction<DeleteRepositoryRequest, DeleteRepositoryResponse> {
 
     private final RepositoriesService repositoriesService;
 

--- a/src/main/java/org/elasticsearch/action/admin/cluster/repositories/get/GetRepositoriesRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/repositories/get/GetRepositoriesRequest.java
@@ -19,9 +19,8 @@
 
 package org.elasticsearch.action.admin.cluster.repositories.get;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
-import org.elasticsearch.action.support.master.MasterNodeReadOperationRequest;
+import org.elasticsearch.action.support.master.MasterNodeReadRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -33,7 +32,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 /**
  * Get repository request
  */
-public class GetRepositoriesRequest extends MasterNodeReadOperationRequest<GetRepositoriesRequest> {
+public class GetRepositoriesRequest extends MasterNodeReadRequest<GetRepositoriesRequest> {
 
     private String[] repositories = Strings.EMPTY_ARRAY;
 

--- a/src/main/java/org/elasticsearch/action/admin/cluster/repositories/get/TransportGetRepositoriesAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/repositories/get/TransportGetRepositoriesAction.java
@@ -22,7 +22,7 @@ package org.elasticsearch.action.admin.cluster.repositories.get;
 import com.google.common.collect.ImmutableList;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.master.TransportMasterNodeReadOperationAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeReadAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
@@ -39,7 +39,7 @@ import org.elasticsearch.transport.TransportService;
 /**
  * Transport action for get repositories operation
  */
-public class TransportGetRepositoriesAction extends TransportMasterNodeReadOperationAction<GetRepositoriesRequest, GetRepositoriesResponse> {
+public class TransportGetRepositoriesAction extends TransportMasterNodeReadAction<GetRepositoriesRequest, GetRepositoriesResponse> {
 
     @Inject
     public TransportGetRepositoriesAction(Settings settings, TransportService transportService, ClusterService clusterService,

--- a/src/main/java/org/elasticsearch/action/admin/cluster/repositories/put/TransportPutRepositoryAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/repositories/put/TransportPutRepositoryAction.java
@@ -21,7 +21,7 @@ package org.elasticsearch.action.admin.cluster.repositories.put;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ack.ClusterStateUpdateResponse;
@@ -36,7 +36,7 @@ import org.elasticsearch.transport.TransportService;
 /**
  * Transport action for register repository operation
  */
-public class TransportPutRepositoryAction extends TransportMasterNodeOperationAction<PutRepositoryRequest, PutRepositoryResponse> {
+public class TransportPutRepositoryAction extends TransportMasterNodeAction<PutRepositoryRequest, PutRepositoryResponse> {
 
     private final RepositoriesService repositoriesService;
 

--- a/src/main/java/org/elasticsearch/action/admin/cluster/repositories/verify/TransportVerifyRepositoryAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/repositories/verify/TransportVerifyRepositoryAction.java
@@ -21,7 +21,7 @@ package org.elasticsearch.action.admin.cluster.repositories.verify;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -37,7 +37,7 @@ import org.elasticsearch.transport.TransportService;
 /**
  * Transport action for verifying repository operation
  */
-public class TransportVerifyRepositoryAction extends TransportMasterNodeOperationAction<VerifyRepositoryRequest, VerifyRepositoryResponse> {
+public class TransportVerifyRepositoryAction extends TransportMasterNodeAction<VerifyRepositoryRequest, VerifyRepositoryResponse> {
 
     private final RepositoriesService repositoriesService;
 

--- a/src/main/java/org/elasticsearch/action/admin/cluster/reroute/TransportClusterRerouteAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/reroute/TransportClusterRerouteAction.java
@@ -21,7 +21,7 @@ package org.elasticsearch.action.admin.cluster.reroute;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -38,7 +38,7 @@ import org.elasticsearch.transport.TransportService;
 
 /**
  */
-public class TransportClusterRerouteAction extends TransportMasterNodeOperationAction<ClusterRerouteRequest, ClusterRerouteResponse> {
+public class TransportClusterRerouteAction extends TransportMasterNodeAction<ClusterRerouteRequest, ClusterRerouteResponse> {
 
     private final AllocationService allocationService;
 

--- a/src/main/java/org/elasticsearch/action/admin/cluster/settings/TransportClusterUpdateSettingsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/settings/TransportClusterUpdateSettingsAction.java
@@ -22,7 +22,7 @@ package org.elasticsearch.action.admin.cluster.settings;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -49,7 +49,7 @@ import static org.elasticsearch.cluster.ClusterState.builder;
 /**
  *
  */
-public class TransportClusterUpdateSettingsAction extends TransportMasterNodeOperationAction<ClusterUpdateSettingsRequest, ClusterUpdateSettingsResponse> {
+public class TransportClusterUpdateSettingsAction extends TransportMasterNodeAction<ClusterUpdateSettingsRequest, ClusterUpdateSettingsResponse> {
 
     private final AllocationService allocationService;
 

--- a/src/main/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsRequest.java
@@ -22,7 +22,7 @@ package org.elasticsearch.action.admin.cluster.shards;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.action.support.master.MasterNodeReadOperationRequest;
+import org.elasticsearch.action.support.master.MasterNodeReadRequest;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -32,7 +32,7 @@ import java.io.IOException;
 
 /**
  */
-public class ClusterSearchShardsRequest extends MasterNodeReadOperationRequest<ClusterSearchShardsRequest> implements IndicesRequest.Replaceable {
+public class ClusterSearchShardsRequest extends MasterNodeReadRequest<ClusterSearchShardsRequest> implements IndicesRequest.Replaceable {
     private String[] indices;
     @Nullable
     private String routing;

--- a/src/main/java/org/elasticsearch/action/admin/cluster/shards/TransportClusterSearchShardsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/shards/TransportClusterSearchShardsAction.java
@@ -21,7 +21,7 @@ package org.elasticsearch.action.admin.cluster.shards;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.master.TransportMasterNodeReadOperationAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeReadAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
@@ -42,7 +42,7 @@ import static com.google.common.collect.Sets.newHashSet;
 
 /**
  */
-public class TransportClusterSearchShardsAction extends TransportMasterNodeReadOperationAction<ClusterSearchShardsRequest, ClusterSearchShardsResponse> {
+public class TransportClusterSearchShardsAction extends TransportMasterNodeReadAction<ClusterSearchShardsRequest, ClusterSearchShardsResponse> {
 
     @Inject
     public TransportClusterSearchShardsAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool, ActionFilters actionFilters) {

--- a/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotRequest.java
@@ -23,7 +23,7 @@ import org.elasticsearch.ElasticsearchGenerationException;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.action.support.master.MasterNodeOperationRequest;
+import org.elasticsearch.action.support.master.MasterNodeRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -60,7 +60,7 @@ import static org.elasticsearch.common.xcontent.support.XContentMapValues.nodeBo
  * <li>must not contain invalid file name characters {@link org.elasticsearch.common.Strings#INVALID_FILENAME_CHARS} </li>
  * </ul>
  */
-public class CreateSnapshotRequest extends MasterNodeOperationRequest<CreateSnapshotRequest> implements IndicesRequest.Replaceable {
+public class CreateSnapshotRequest extends MasterNodeRequest<CreateSnapshotRequest> implements IndicesRequest.Replaceable {
 
     private String snapshot;
 

--- a/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/TransportCreateSnapshotAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/TransportCreateSnapshotAction.java
@@ -21,7 +21,7 @@ package org.elasticsearch.action.admin.cluster.snapshots.create;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
@@ -37,7 +37,7 @@ import org.elasticsearch.transport.TransportService;
 /**
  * Transport action for create snapshot operation
  */
-public class TransportCreateSnapshotAction extends TransportMasterNodeOperationAction<CreateSnapshotRequest, CreateSnapshotResponse> {
+public class TransportCreateSnapshotAction extends TransportMasterNodeAction<CreateSnapshotRequest, CreateSnapshotResponse> {
     private final SnapshotsService snapshotsService;
 
     @Inject

--- a/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/delete/DeleteSnapshotRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/delete/DeleteSnapshotRequest.java
@@ -20,7 +20,7 @@
 package org.elasticsearch.action.admin.cluster.snapshots.delete;
 
 import org.elasticsearch.action.ActionRequestValidationException;
-import org.elasticsearch.action.support.master.MasterNodeOperationRequest;
+import org.elasticsearch.action.support.master.MasterNodeRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -35,7 +35,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
  * files that are associated with this particular snapshot. All files that are shared with
  * at least one other existing snapshot are left intact.
  */
-public class DeleteSnapshotRequest extends MasterNodeOperationRequest<DeleteSnapshotRequest> {
+public class DeleteSnapshotRequest extends MasterNodeRequest<DeleteSnapshotRequest> {
 
     private String repository;
 

--- a/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/delete/TransportDeleteSnapshotAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/delete/TransportDeleteSnapshotAction.java
@@ -21,7 +21,7 @@ package org.elasticsearch.action.admin.cluster.snapshots.delete;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
@@ -36,7 +36,7 @@ import org.elasticsearch.transport.TransportService;
 /**
  * Transport action for delete snapshot operation
  */
-public class TransportDeleteSnapshotAction extends TransportMasterNodeOperationAction<DeleteSnapshotRequest, DeleteSnapshotResponse> {
+public class TransportDeleteSnapshotAction extends TransportMasterNodeAction<DeleteSnapshotRequest, DeleteSnapshotResponse> {
     private final SnapshotsService snapshotsService;
 
     @Inject

--- a/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsRequest.java
@@ -20,7 +20,7 @@
 package org.elasticsearch.action.admin.cluster.snapshots.get;
 
 import org.elasticsearch.action.ActionRequestValidationException;
-import org.elasticsearch.action.support.master.MasterNodeOperationRequest;
+import org.elasticsearch.action.support.master.MasterNodeRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -32,7 +32,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 /**
  * Get snapshot request
  */
-public class GetSnapshotsRequest extends MasterNodeOperationRequest<GetSnapshotsRequest> {
+public class GetSnapshotsRequest extends MasterNodeRequest<GetSnapshotsRequest> {
 
     public static final String ALL_SNAPSHOTS = "_all";
     public static final String CURRENT_SNAPSHOT = "_current";

--- a/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/TransportGetSnapshotsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/TransportGetSnapshotsAction.java
@@ -22,7 +22,7 @@ package org.elasticsearch.action.admin.cluster.snapshots.get;
 import com.google.common.collect.ImmutableList;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
@@ -39,7 +39,7 @@ import org.elasticsearch.transport.TransportService;
 /**
  * Transport Action for get snapshots operation
  */
-public class TransportGetSnapshotsAction extends TransportMasterNodeOperationAction<GetSnapshotsRequest, GetSnapshotsResponse> {
+public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSnapshotsRequest, GetSnapshotsResponse> {
     private final SnapshotsService snapshotsService;
 
     @Inject

--- a/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
@@ -23,7 +23,7 @@ import org.elasticsearch.ElasticsearchGenerationException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.action.support.master.MasterNodeOperationRequest;
+import org.elasticsearch.action.support.master.MasterNodeRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -48,7 +48,7 @@ import static org.elasticsearch.common.xcontent.support.XContentMapValues.nodeBo
 /**
  * Restore snapshot request
  */
-public class RestoreSnapshotRequest extends MasterNodeOperationRequest<RestoreSnapshotRequest> {
+public class RestoreSnapshotRequest extends MasterNodeRequest<RestoreSnapshotRequest> {
 
     private String snapshot;
 

--- a/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/TransportRestoreSnapshotAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/TransportRestoreSnapshotAction.java
@@ -21,7 +21,7 @@ package org.elasticsearch.action.admin.cluster.snapshots.restore;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
@@ -37,7 +37,7 @@ import org.elasticsearch.transport.TransportService;
 /**
  * Transport action for restore snapshot operation
  */
-public class TransportRestoreSnapshotAction extends TransportMasterNodeOperationAction<RestoreSnapshotRequest, RestoreSnapshotResponse> {
+public class TransportRestoreSnapshotAction extends TransportMasterNodeAction<RestoreSnapshotRequest, RestoreSnapshotResponse> {
     private final RestoreService restoreService;
 
     @Inject

--- a/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotIndexShardStatus.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotIndexShardStatus.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.action.admin.cluster.snapshots.status;
 
-import org.elasticsearch.action.support.broadcast.BroadcastShardOperationResponse;
+import org.elasticsearch.action.support.broadcast.BroadcastShardResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ToXContent;
@@ -32,7 +32,7 @@ import java.io.IOException;
 
 /**
  */
-public class SnapshotIndexShardStatus extends BroadcastShardOperationResponse implements ToXContent {
+public class SnapshotIndexShardStatus extends BroadcastShardResponse implements ToXContent {
 
     private SnapshotIndexShardStage stage = SnapshotIndexShardStage.INIT;
 

--- a/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotsStatusRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotsStatusRequest.java
@@ -20,7 +20,7 @@
 package org.elasticsearch.action.admin.cluster.snapshots.status;
 
 import org.elasticsearch.action.ActionRequestValidationException;
-import org.elasticsearch.action.support.master.MasterNodeOperationRequest;
+import org.elasticsearch.action.support.master.MasterNodeRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -32,7 +32,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 /**
  * Get snapshot status request
  */
-public class SnapshotsStatusRequest extends MasterNodeOperationRequest<SnapshotsStatusRequest> {
+public class SnapshotsStatusRequest extends MasterNodeRequest<SnapshotsStatusRequest> {
 
     private String repository = "_all";
 

--- a/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportNodesSnapshotsStatus.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportNodesSnapshotsStatus.java
@@ -47,7 +47,7 @@ import java.util.concurrent.atomic.AtomicReferenceArray;
 /**
  * Transport client that collects snapshot shard statuses from data nodes
  */
-public class TransportNodesSnapshotsStatus extends TransportNodesOperationAction<TransportNodesSnapshotsStatus.Request, TransportNodesSnapshotsStatus.NodesSnapshotStatus, TransportNodesSnapshotsStatus.NodeRequest, TransportNodesSnapshotsStatus.NodeSnapshotStatus> {
+public class TransportNodesSnapshotsStatus extends TransportNodesAction<TransportNodesSnapshotsStatus.Request, TransportNodesSnapshotsStatus.NodesSnapshotStatus, TransportNodesSnapshotsStatus.NodeRequest, TransportNodesSnapshotsStatus.NodeSnapshotStatus> {
 
     public static final String ACTION_NAME = SnapshotsStatusAction.NAME + "[nodes]";
 
@@ -128,7 +128,7 @@ public class TransportNodesSnapshotsStatus extends TransportNodesOperationAction
         return true;
     }
 
-    static class Request extends NodesOperationRequest<Request> {
+    static class Request extends BaseNodesRequest<Request> {
 
         private SnapshotId[] snapshotIds;
 
@@ -157,7 +157,7 @@ public class TransportNodesSnapshotsStatus extends TransportNodesOperationAction
         }
     }
 
-    public static class NodesSnapshotStatus extends NodesOperationResponse<NodeSnapshotStatus> {
+    public static class NodesSnapshotStatus extends BaseNodesResponse<NodeSnapshotStatus> {
 
         private FailedNodeException[] failures;
 
@@ -194,7 +194,7 @@ public class TransportNodesSnapshotsStatus extends TransportNodesOperationAction
     }
 
 
-    static class NodeRequest extends NodeOperationRequest {
+    static class NodeRequest extends BaseNodeRequest {
 
         private SnapshotId[] snapshotIds;
 
@@ -230,7 +230,7 @@ public class TransportNodesSnapshotsStatus extends TransportNodesOperationAction
         }
     }
 
-    public static class NodeSnapshotStatus extends NodeOperationResponse {
+    public static class NodeSnapshotStatus extends BaseNodeResponse {
 
         private ImmutableMap<SnapshotId, ImmutableMap<ShardId, SnapshotIndexShardStatus>> status;
 

--- a/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportSnapshotsStatusAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportSnapshotsStatusAction.java
@@ -23,7 +23,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
@@ -49,7 +49,7 @@ import static com.google.common.collect.Sets.newHashSet;
 
 /**
  */
-public class TransportSnapshotsStatusAction extends TransportMasterNodeOperationAction<SnapshotsStatusRequest, SnapshotsStatusResponse> {
+public class TransportSnapshotsStatusAction extends TransportMasterNodeAction<SnapshotsStatusRequest, SnapshotsStatusResponse> {
 
     private final SnapshotsService snapshotsService;
 

--- a/src/main/java/org/elasticsearch/action/admin/cluster/state/ClusterStateRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/state/ClusterStateRequest.java
@@ -19,11 +19,10 @@
 
 package org.elasticsearch.action.admin.cluster.state;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.action.support.master.MasterNodeReadOperationRequest;
+import org.elasticsearch.action.support.master.MasterNodeReadRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -33,7 +32,7 @@ import java.io.IOException;
 /**
  *
  */
-public class ClusterStateRequest extends MasterNodeReadOperationRequest<ClusterStateRequest> implements IndicesRequest.Replaceable {
+public class ClusterStateRequest extends MasterNodeReadRequest<ClusterStateRequest> implements IndicesRequest.Replaceable {
 
     private boolean routingTable = true;
     private boolean nodes = true;

--- a/src/main/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateAction.java
@@ -22,7 +22,7 @@ package org.elasticsearch.action.admin.cluster.state;
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.master.TransportMasterNodeReadOperationAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeReadAction;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -39,7 +39,7 @@ import org.elasticsearch.transport.TransportService;
 /**
  *
  */
-public class TransportClusterStateAction extends TransportMasterNodeReadOperationAction<ClusterStateRequest, ClusterStateResponse> {
+public class TransportClusterStateAction extends TransportMasterNodeReadAction<ClusterStateRequest, ClusterStateResponse> {
 
     private final ClusterName clusterName;
 

--- a/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodeResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodeResponse.java
@@ -23,7 +23,7 @@ import org.elasticsearch.action.admin.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
 import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
 import org.elasticsearch.action.admin.indices.stats.ShardStats;
-import org.elasticsearch.action.support.nodes.NodeOperationResponse;
+import org.elasticsearch.action.support.nodes.BaseNodeResponse;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -31,7 +31,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
 
-public class ClusterStatsNodeResponse extends NodeOperationResponse {
+public class ClusterStatsNodeResponse extends BaseNodeResponse {
 
     private NodeInfo nodeInfo;
     private NodeStats nodeStats;

--- a/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsRequest.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.action.admin.cluster.stats;
 
-import org.elasticsearch.action.support.nodes.NodesOperationRequest;
+import org.elasticsearch.action.support.nodes.BaseNodesRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -28,7 +28,7 @@ import java.io.IOException;
 /**
  * A request to get cluster level stats.
  */
-public class ClusterStatsRequest extends NodesOperationRequest<ClusterStatsRequest> {
+public class ClusterStatsRequest extends BaseNodesRequest<ClusterStatsRequest> {
 
     ClusterStatsRequest() {
     }

--- a/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsResponse.java
@@ -20,7 +20,7 @@
 package org.elasticsearch.action.admin.cluster.stats;
 
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthStatus;
-import org.elasticsearch.action.support.nodes.NodesOperationResponse;
+import org.elasticsearch.action.support.nodes.BaseNodesResponse;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -37,7 +37,7 @@ import java.util.Map;
 /**
  *
  */
-public class ClusterStatsResponse extends NodesOperationResponse<ClusterStatsNodeResponse> implements ToXContent {
+public class ClusterStatsResponse extends BaseNodesResponse<ClusterStatsNodeResponse> implements ToXContent {
 
     ClusterStatsNodes nodesStats;
     ClusterStatsIndices indicesStats;

--- a/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
@@ -26,8 +26,8 @@ import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
 import org.elasticsearch.action.admin.indices.stats.CommonStatsFlags;
 import org.elasticsearch.action.admin.indices.stats.ShardStats;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.nodes.NodeOperationRequest;
-import org.elasticsearch.action.support.nodes.TransportNodesOperationAction;
+import org.elasticsearch.action.support.nodes.BaseNodeRequest;
+import org.elasticsearch.action.support.nodes.TransportNodesAction;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
@@ -51,7 +51,7 @@ import java.util.concurrent.atomic.AtomicReferenceArray;
 /**
  *
  */
-public class TransportClusterStatsAction extends TransportNodesOperationAction<ClusterStatsRequest, ClusterStatsResponse,
+public class TransportClusterStatsAction extends TransportNodesAction<ClusterStatsRequest, ClusterStatsResponse,
         TransportClusterStatsAction.ClusterStatsNodeRequest, ClusterStatsNodeResponse> {
 
     private static final CommonStatsFlags SHARD_STATS_FLAGS = new CommonStatsFlags(CommonStatsFlags.Flag.Docs, CommonStatsFlags.Flag.Store,
@@ -142,7 +142,7 @@ public class TransportClusterStatsAction extends TransportNodesOperationAction<C
         return false;
     }
 
-    static class ClusterStatsNodeRequest extends NodeOperationRequest {
+    static class ClusterStatsNodeRequest extends BaseNodeRequest {
 
         ClusterStatsRequest request;
 

--- a/src/main/java/org/elasticsearch/action/admin/cluster/tasks/PendingClusterTasksRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/tasks/PendingClusterTasksRequest.java
@@ -19,17 +19,12 @@
 
 package org.elasticsearch.action.admin.cluster.tasks;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
-import org.elasticsearch.action.support.master.MasterNodeReadOperationRequest;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
-
-import java.io.IOException;
+import org.elasticsearch.action.support.master.MasterNodeReadRequest;
 
 /**
  */
-public class PendingClusterTasksRequest extends MasterNodeReadOperationRequest<PendingClusterTasksRequest> {
+public class PendingClusterTasksRequest extends MasterNodeReadRequest<PendingClusterTasksRequest> {
 
     @Override
     public ActionRequestValidationException validate() {

--- a/src/main/java/org/elasticsearch/action/admin/cluster/tasks/TransportPendingClusterTasksAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/tasks/TransportPendingClusterTasksAction.java
@@ -21,7 +21,7 @@ package org.elasticsearch.action.admin.cluster.tasks;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.master.TransportMasterNodeReadOperationAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeReadAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
@@ -33,7 +33,7 @@ import org.elasticsearch.transport.TransportService;
 
 /**
  */
-public class TransportPendingClusterTasksAction extends TransportMasterNodeReadOperationAction<PendingClusterTasksRequest, PendingClusterTasksResponse> {
+public class TransportPendingClusterTasksAction extends TransportMasterNodeReadAction<PendingClusterTasksRequest, PendingClusterTasksResponse> {
 
     private final ClusterService clusterService;
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/alias/TransportIndicesAliasesAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/alias/TransportIndicesAliasesAction.java
@@ -23,7 +23,7 @@ import com.google.common.collect.Sets;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest.AliasActions;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ack.ClusterStateUpdateResponse;
@@ -42,7 +42,7 @@ import java.util.*;
 /**
  * Add/remove aliases action
  */
-public class TransportIndicesAliasesAction extends TransportMasterNodeOperationAction<IndicesAliasesRequest, IndicesAliasesResponse> {
+public class TransportIndicesAliasesAction extends TransportMasterNodeAction<IndicesAliasesRequest, IndicesAliasesResponse> {
 
     private final MetaDataIndexAliasesService indexAliasesService;
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/alias/exists/TransportAliasesExistAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/alias/exists/TransportAliasesExistAction.java
@@ -21,7 +21,7 @@ package org.elasticsearch.action.admin.indices.alias.exists;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.alias.get.GetAliasesRequest;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.master.TransportMasterNodeReadOperationAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeReadAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
@@ -33,7 +33,7 @@ import org.elasticsearch.transport.TransportService;
 
 /**
  */
-public class TransportAliasesExistAction extends TransportMasterNodeReadOperationAction<GetAliasesRequest, AliasesExistResponse> {
+public class TransportAliasesExistAction extends TransportMasterNodeReadAction<GetAliasesRequest, AliasesExistResponse> {
 
     @Inject
     public TransportAliasesExistAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool, ActionFilters actionFilters) {

--- a/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesRequest.java
@@ -18,11 +18,10 @@
  */
 package org.elasticsearch.action.admin.indices.alias.get;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.AliasesRequest;
 import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.action.support.master.MasterNodeReadOperationRequest;
+import org.elasticsearch.action.support.master.MasterNodeReadRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -31,7 +30,7 @@ import java.io.IOException;
 
 /**
  */
-public class GetAliasesRequest extends MasterNodeReadOperationRequest<GetAliasesRequest> implements AliasesRequest {
+public class GetAliasesRequest extends MasterNodeReadRequest<GetAliasesRequest> implements AliasesRequest {
 
     private String[] indices = Strings.EMPTY_ARRAY;
     private String[] aliases = Strings.EMPTY_ARRAY;

--- a/src/main/java/org/elasticsearch/action/admin/indices/alias/get/TransportGetAliasesAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/alias/get/TransportGetAliasesAction.java
@@ -20,7 +20,7 @@ package org.elasticsearch.action.admin.indices.alias.get;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.master.TransportMasterNodeReadOperationAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeReadAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
@@ -36,7 +36,7 @@ import java.util.List;
 
 /**
  */
-public class TransportGetAliasesAction extends TransportMasterNodeReadOperationAction<GetAliasesRequest, GetAliasesResponse> {
+public class TransportGetAliasesAction extends TransportMasterNodeReadAction<GetAliasesRequest, GetAliasesResponse> {
 
     @Inject
     public TransportGetAliasesAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool, ActionFilters actionFilters) {

--- a/src/main/java/org/elasticsearch/action/admin/indices/cache/clear/ClearIndicesCacheRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/cache/clear/ClearIndicesCacheRequest.java
@@ -19,8 +19,7 @@
 
 package org.elasticsearch.action.admin.indices.cache.clear;
 
-import org.elasticsearch.Version;
-import org.elasticsearch.action.support.broadcast.BroadcastOperationRequest;
+import org.elasticsearch.action.support.broadcast.BroadcastRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -29,7 +28,7 @@ import java.io.IOException;
 /**
  *
  */
-public class ClearIndicesCacheRequest extends BroadcastOperationRequest<ClearIndicesCacheRequest> {
+public class ClearIndicesCacheRequest extends BroadcastRequest<ClearIndicesCacheRequest> {
 
     private boolean filterCache = false;
     private boolean fieldDataCache = false;

--- a/src/main/java/org/elasticsearch/action/admin/indices/cache/clear/ClearIndicesCacheResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/cache/clear/ClearIndicesCacheResponse.java
@@ -20,7 +20,7 @@
 package org.elasticsearch.action.admin.indices.cache.clear;
 
 import org.elasticsearch.action.ShardOperationFailedException;
-import org.elasticsearch.action.support.broadcast.BroadcastOperationResponse;
+import org.elasticsearch.action.support.broadcast.BroadcastResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -32,7 +32,7 @@ import java.util.List;
  *
  *
  */
-public class ClearIndicesCacheResponse extends BroadcastOperationResponse {
+public class ClearIndicesCacheResponse extends BroadcastResponse {
 
     ClearIndicesCacheResponse() {
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/cache/clear/ShardClearIndicesCacheRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/cache/clear/ShardClearIndicesCacheRequest.java
@@ -19,8 +19,7 @@
 
 package org.elasticsearch.action.admin.indices.cache.clear;
 
-import org.elasticsearch.Version;
-import org.elasticsearch.action.support.broadcast.BroadcastShardOperationRequest;
+import org.elasticsearch.action.support.broadcast.BroadcastShardRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.shard.ShardId;
@@ -30,7 +29,7 @@ import java.io.IOException;
 /**
  *
  */
-class ShardClearIndicesCacheRequest extends BroadcastShardOperationRequest {
+class ShardClearIndicesCacheRequest extends BroadcastShardRequest {
 
     private boolean filterCache = false;
     private boolean fieldDataCache = false;

--- a/src/main/java/org/elasticsearch/action/admin/indices/cache/clear/ShardClearIndicesCacheResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/cache/clear/ShardClearIndicesCacheResponse.java
@@ -19,13 +19,13 @@
 
 package org.elasticsearch.action.admin.indices.cache.clear;
 
-import org.elasticsearch.action.support.broadcast.BroadcastShardOperationResponse;
+import org.elasticsearch.action.support.broadcast.BroadcastShardResponse;
 import org.elasticsearch.index.shard.ShardId;
 
 /**
  *
  */
-class ShardClearIndicesCacheResponse extends BroadcastShardOperationResponse {
+class ShardClearIndicesCacheResponse extends BroadcastShardResponse {
 
     ShardClearIndicesCacheResponse() {
     }

--- a/src/main/java/org/elasticsearch/action/admin/indices/cache/clear/TransportClearIndicesCacheAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/cache/clear/TransportClearIndicesCacheAction.java
@@ -23,7 +23,7 @@ import org.elasticsearch.action.ShardOperationFailedException;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.DefaultShardOperationFailedException;
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationFailedException;
-import org.elasticsearch.action.support.broadcast.TransportBroadcastOperationAction;
+import org.elasticsearch.action.support.broadcast.TransportBroadcastAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
@@ -47,7 +47,7 @@ import static com.google.common.collect.Lists.newArrayList;
 /**
  * Indices clear cache action.
  */
-public class TransportClearIndicesCacheAction extends TransportBroadcastOperationAction<ClearIndicesCacheRequest, ClearIndicesCacheResponse, ShardClearIndicesCacheRequest, ShardClearIndicesCacheResponse> {
+public class TransportClearIndicesCacheAction extends TransportBroadcastAction<ClearIndicesCacheRequest, ClearIndicesCacheResponse, ShardClearIndicesCacheRequest, ShardClearIndicesCacheResponse> {
 
     private final IndicesService indicesService;
     private final IndicesQueryCache indicesQueryCache;

--- a/src/main/java/org/elasticsearch/action/admin/indices/close/TransportCloseIndexAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/close/TransportCloseIndexAction.java
@@ -22,7 +22,7 @@ package org.elasticsearch.action.admin.indices.close;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.DestructiveOperations;
-import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ack.ClusterStateUpdateResponse;
@@ -38,7 +38,7 @@ import org.elasticsearch.transport.TransportService;
 /**
  * Close index action
  */
-public class TransportCloseIndexAction extends TransportMasterNodeOperationAction<CloseIndexRequest, CloseIndexResponse> {
+public class TransportCloseIndexAction extends TransportMasterNodeAction<CloseIndexRequest, CloseIndexResponse> {
 
     private final MetaDataIndexStateService indexStateService;
     private final DestructiveOperations destructiveOperations;

--- a/src/main/java/org/elasticsearch/action/admin/indices/create/TransportCreateIndexAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/create/TransportCreateIndexAction.java
@@ -21,7 +21,7 @@ package org.elasticsearch.action.admin.indices.create;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ack.ClusterStateUpdateResponse;
@@ -37,7 +37,7 @@ import org.elasticsearch.transport.TransportService;
 /**
  * Create index action.
  */
-public class TransportCreateIndexAction extends TransportMasterNodeOperationAction<CreateIndexRequest, CreateIndexResponse> {
+public class TransportCreateIndexAction extends TransportMasterNodeAction<CreateIndexRequest, CreateIndexResponse> {
 
     private final MetaDataCreateIndexService createIndexService;
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/delete/DeleteIndexRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/delete/DeleteIndexRequest.java
@@ -23,7 +23,7 @@ import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
-import org.elasticsearch.action.support.master.MasterNodeOperationRequest;
+import org.elasticsearch.action.support.master.MasterNodeRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.unit.TimeValue;
@@ -37,7 +37,7 @@ import static org.elasticsearch.common.unit.TimeValue.readTimeValue;
 /**
  * A request to delete an index. Best created with {@link org.elasticsearch.client.Requests#deleteIndexRequest(String)}.
  */
-public class DeleteIndexRequest extends MasterNodeOperationRequest<DeleteIndexRequest> implements IndicesRequest.Replaceable {
+public class DeleteIndexRequest extends MasterNodeRequest<DeleteIndexRequest> implements IndicesRequest.Replaceable {
 
     private String[] indices;
     // Delete index should work by default on both open and closed indices.

--- a/src/main/java/org/elasticsearch/action/admin/indices/delete/TransportDeleteIndexAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/delete/TransportDeleteIndexAction.java
@@ -22,7 +22,7 @@ package org.elasticsearch.action.admin.indices.delete;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.DestructiveOperations;
-import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
@@ -38,7 +38,7 @@ import org.elasticsearch.transport.TransportService;
 /**
  * Delete index action.
  */
-public class TransportDeleteIndexAction extends TransportMasterNodeOperationAction<DeleteIndexRequest, DeleteIndexResponse> {
+public class TransportDeleteIndexAction extends TransportMasterNodeAction<DeleteIndexRequest, DeleteIndexResponse> {
 
     private final MetaDataDeleteIndexService deleteIndexService;
     private final DestructiveOperations destructiveOperations;

--- a/src/main/java/org/elasticsearch/action/admin/indices/exists/indices/IndicesExistsRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/exists/indices/IndicesExistsRequest.java
@@ -19,11 +19,10 @@
 
 package org.elasticsearch.action.admin.indices.exists.indices;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.action.support.master.MasterNodeReadOperationRequest;
+import org.elasticsearch.action.support.master.MasterNodeReadRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -32,7 +31,7 @@ import java.io.IOException;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
-public class IndicesExistsRequest extends MasterNodeReadOperationRequest<IndicesExistsRequest> implements IndicesRequest.Replaceable {
+public class IndicesExistsRequest extends MasterNodeReadRequest<IndicesExistsRequest> implements IndicesRequest.Replaceable {
 
     private String[] indices = Strings.EMPTY_ARRAY;
     private IndicesOptions indicesOptions = IndicesOptions.fromOptions(false, false, true, true);

--- a/src/main/java/org/elasticsearch/action/admin/indices/exists/indices/TransportIndicesExistsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/exists/indices/TransportIndicesExistsAction.java
@@ -22,7 +22,7 @@ package org.elasticsearch.action.admin.indices.exists.indices;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.action.support.master.TransportMasterNodeReadOperationAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeReadAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
@@ -36,7 +36,7 @@ import org.elasticsearch.transport.TransportService;
 /**
  * Indices exists action.
  */
-public class TransportIndicesExistsAction extends TransportMasterNodeReadOperationAction<IndicesExistsRequest, IndicesExistsResponse> {
+public class TransportIndicesExistsAction extends TransportMasterNodeReadAction<IndicesExistsRequest, IndicesExistsResponse> {
 
     @Inject
     public TransportIndicesExistsAction(Settings settings, TransportService transportService, ClusterService clusterService,

--- a/src/main/java/org/elasticsearch/action/admin/indices/exists/types/TransportTypesExistsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/exists/types/TransportTypesExistsAction.java
@@ -20,7 +20,7 @@ package org.elasticsearch.action.admin.indices.exists.types;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.master.TransportMasterNodeReadOperationAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeReadAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
@@ -35,7 +35,7 @@ import org.elasticsearch.transport.TransportService;
 /**
  * Types exists transport action.
  */
-public class TransportTypesExistsAction extends TransportMasterNodeReadOperationAction<TypesExistsRequest, TypesExistsResponse> {
+public class TransportTypesExistsAction extends TransportMasterNodeReadAction<TypesExistsRequest, TypesExistsResponse> {
 
     @Inject
     public TransportTypesExistsAction(Settings settings, TransportService transportService, ClusterService clusterService,

--- a/src/main/java/org/elasticsearch/action/admin/indices/exists/types/TypesExistsRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/exists/types/TypesExistsRequest.java
@@ -18,11 +18,10 @@
  */
 package org.elasticsearch.action.admin.indices.exists.types;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.action.support.master.MasterNodeReadOperationRequest;
+import org.elasticsearch.action.support.master.MasterNodeReadRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -32,7 +31,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 
 /**
  */
-public class TypesExistsRequest extends MasterNodeReadOperationRequest<TypesExistsRequest> implements IndicesRequest.Replaceable {
+public class TypesExistsRequest extends MasterNodeReadRequest<TypesExistsRequest> implements IndicesRequest.Replaceable {
 
     private String[] indices;
     private String[] types;

--- a/src/main/java/org/elasticsearch/action/admin/indices/flush/FlushRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/flush/FlushRequest.java
@@ -19,9 +19,8 @@
 
 package org.elasticsearch.action.admin.indices.flush;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequest;
-import org.elasticsearch.action.support.broadcast.BroadcastOperationRequest;
+import org.elasticsearch.action.support.broadcast.BroadcastRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -38,7 +37,7 @@ import java.io.IOException;
  * @see org.elasticsearch.client.IndicesAdminClient#flush(FlushRequest)
  * @see FlushResponse
  */
-public class FlushRequest extends BroadcastOperationRequest<FlushRequest> {
+public class FlushRequest extends BroadcastRequest<FlushRequest> {
 
     private boolean force = false;
     private boolean waitIfOngoing = false;

--- a/src/main/java/org/elasticsearch/action/admin/indices/flush/FlushResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/flush/FlushResponse.java
@@ -20,7 +20,7 @@
 package org.elasticsearch.action.admin.indices.flush;
 
 import org.elasticsearch.action.ShardOperationFailedException;
-import org.elasticsearch.action.support.broadcast.BroadcastOperationResponse;
+import org.elasticsearch.action.support.broadcast.BroadcastResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -32,7 +32,7 @@ import java.util.List;
  *
  *
  */
-public class FlushResponse extends BroadcastOperationResponse {
+public class FlushResponse extends BroadcastResponse {
 
     FlushResponse() {
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/flush/ShardFlushRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/flush/ShardFlushRequest.java
@@ -19,8 +19,7 @@
 
 package org.elasticsearch.action.admin.indices.flush;
 
-import org.elasticsearch.Version;
-import org.elasticsearch.action.support.broadcast.BroadcastShardOperationRequest;
+import org.elasticsearch.action.support.broadcast.BroadcastShardRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.shard.ShardId;
@@ -30,7 +29,7 @@ import java.io.IOException;
 /**
  *
  */
-class ShardFlushRequest extends BroadcastShardOperationRequest {
+class ShardFlushRequest extends BroadcastShardRequest {
     private FlushRequest request = new FlushRequest();
 
     ShardFlushRequest() {

--- a/src/main/java/org/elasticsearch/action/admin/indices/flush/ShardFlushResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/flush/ShardFlushResponse.java
@@ -19,13 +19,13 @@
 
 package org.elasticsearch.action.admin.indices.flush;
 
-import org.elasticsearch.action.support.broadcast.BroadcastShardOperationResponse;
+import org.elasticsearch.action.support.broadcast.BroadcastShardResponse;
 import org.elasticsearch.index.shard.ShardId;
 
 /**
  *
  */
-class ShardFlushResponse extends BroadcastShardOperationResponse {
+class ShardFlushResponse extends BroadcastShardResponse {
 
     ShardFlushResponse() {
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/flush/TransportFlushAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/flush/TransportFlushAction.java
@@ -23,7 +23,7 @@ import org.elasticsearch.action.ShardOperationFailedException;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.DefaultShardOperationFailedException;
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationFailedException;
-import org.elasticsearch.action.support.broadcast.TransportBroadcastOperationAction;
+import org.elasticsearch.action.support.broadcast.TransportBroadcastAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
@@ -45,7 +45,7 @@ import static com.google.common.collect.Lists.newArrayList;
 /**
  * Flush Action.
  */
-public class TransportFlushAction extends TransportBroadcastOperationAction<FlushRequest, FlushResponse, ShardFlushRequest, ShardFlushResponse> {
+public class TransportFlushAction extends TransportBroadcastAction<FlushRequest, FlushResponse, ShardFlushRequest, ShardFlushResponse> {
 
     private final IndicesService indicesService;
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/TransportPutMappingAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/TransportPutMappingAction.java
@@ -21,7 +21,7 @@ package org.elasticsearch.action.admin.indices.mapping.put;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ack.ClusterStateUpdateResponse;
@@ -36,7 +36,7 @@ import org.elasticsearch.transport.TransportService;
 /**
  * Put mapping action.
  */
-public class TransportPutMappingAction extends TransportMasterNodeOperationAction<PutMappingRequest, PutMappingResponse> {
+public class TransportPutMappingAction extends TransportMasterNodeAction<PutMappingRequest, PutMappingResponse> {
 
     private final MetaDataMappingService metaDataMappingService;
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/open/TransportOpenIndexAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/open/TransportOpenIndexAction.java
@@ -22,7 +22,7 @@ package org.elasticsearch.action.admin.indices.open;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.DestructiveOperations;
-import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ack.ClusterStateUpdateResponse;
@@ -38,7 +38,7 @@ import org.elasticsearch.transport.TransportService;
 /**
  * Open index action
  */
-public class TransportOpenIndexAction extends TransportMasterNodeOperationAction<OpenIndexRequest, OpenIndexResponse> {
+public class TransportOpenIndexAction extends TransportMasterNodeAction<OpenIndexRequest, OpenIndexResponse> {
 
     private final MetaDataIndexStateService indexStateService;
     private final DestructiveOperations destructiveOperations;

--- a/src/main/java/org/elasticsearch/action/admin/indices/optimize/OptimizeRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/optimize/OptimizeRequest.java
@@ -19,8 +19,7 @@
 
 package org.elasticsearch.action.admin.indices.optimize;
 
-import org.elasticsearch.Version;
-import org.elasticsearch.action.support.broadcast.BroadcastOperationRequest;
+import org.elasticsearch.action.support.broadcast.BroadcastRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -37,7 +36,7 @@ import java.io.IOException;
  * @see org.elasticsearch.client.IndicesAdminClient#optimize(OptimizeRequest)
  * @see OptimizeResponse
  */
-public class OptimizeRequest extends BroadcastOperationRequest<OptimizeRequest> {
+public class OptimizeRequest extends BroadcastRequest<OptimizeRequest> {
 
     public static final class Defaults {
         public static final int MAX_NUM_SEGMENTS = -1;

--- a/src/main/java/org/elasticsearch/action/admin/indices/optimize/OptimizeResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/optimize/OptimizeResponse.java
@@ -20,7 +20,7 @@
 package org.elasticsearch.action.admin.indices.optimize;
 
 import org.elasticsearch.action.ShardOperationFailedException;
-import org.elasticsearch.action.support.broadcast.BroadcastOperationResponse;
+import org.elasticsearch.action.support.broadcast.BroadcastResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -32,7 +32,7 @@ import java.util.List;
  *
  *
  */
-public class OptimizeResponse extends BroadcastOperationResponse {
+public class OptimizeResponse extends BroadcastResponse {
 
     OptimizeResponse() {
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/optimize/ShardOptimizeRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/optimize/ShardOptimizeRequest.java
@@ -20,8 +20,7 @@
 package org.elasticsearch.action.admin.indices.optimize;
 
 
-import org.elasticsearch.Version;
-import org.elasticsearch.action.support.broadcast.BroadcastShardOperationRequest;
+import org.elasticsearch.action.support.broadcast.BroadcastShardRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.shard.ShardId;
@@ -31,7 +30,7 @@ import java.io.IOException;
 /**
  *
  */
-final class ShardOptimizeRequest extends BroadcastShardOperationRequest {
+final class ShardOptimizeRequest extends BroadcastShardRequest {
 
     private OptimizeRequest request = new OptimizeRequest();
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/optimize/ShardOptimizeResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/optimize/ShardOptimizeResponse.java
@@ -19,13 +19,13 @@
 
 package org.elasticsearch.action.admin.indices.optimize;
 
-import org.elasticsearch.action.support.broadcast.BroadcastShardOperationResponse;
+import org.elasticsearch.action.support.broadcast.BroadcastShardResponse;
 import org.elasticsearch.index.shard.ShardId;
 
 /**
  *
  */
-class ShardOptimizeResponse extends BroadcastShardOperationResponse {
+class ShardOptimizeResponse extends BroadcastShardResponse {
 
     ShardOptimizeResponse() {
     }

--- a/src/main/java/org/elasticsearch/action/admin/indices/optimize/TransportOptimizeAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/optimize/TransportOptimizeAction.java
@@ -23,7 +23,7 @@ import org.elasticsearch.action.ShardOperationFailedException;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.DefaultShardOperationFailedException;
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationFailedException;
-import org.elasticsearch.action.support.broadcast.TransportBroadcastOperationAction;
+import org.elasticsearch.action.support.broadcast.TransportBroadcastAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
@@ -45,7 +45,7 @@ import static com.google.common.collect.Lists.newArrayList;
 /**
  * Optimize index/indices action.
  */
-public class TransportOptimizeAction extends TransportBroadcastOperationAction<OptimizeRequest, OptimizeResponse, ShardOptimizeRequest, ShardOptimizeResponse> {
+public class TransportOptimizeAction extends TransportBroadcastAction<OptimizeRequest, OptimizeResponse, ShardOptimizeRequest, ShardOptimizeResponse> {
 
     private final IndicesService indicesService;
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/recovery/RecoveryRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/recovery/RecoveryRequest.java
@@ -19,17 +19,17 @@
 
 package org.elasticsearch.action.admin.indices.recovery;
 
-import java.io.IOException;
-
-import org.elasticsearch.action.support.broadcast.BroadcastOperationRequest;
+import org.elasticsearch.action.support.broadcast.BroadcastRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
+import java.io.IOException;
+
 /**
  * Request for recovery information
  */
-public class RecoveryRequest extends BroadcastOperationRequest<RecoveryRequest> {
+public class RecoveryRequest extends BroadcastRequest<RecoveryRequest> {
 
     private boolean detailed = false;       // Provides extra details in the response
     private boolean activeOnly = false;     // Only reports on active recoveries

--- a/src/main/java/org/elasticsearch/action/admin/indices/recovery/RecoveryResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/recovery/RecoveryResponse.java
@@ -20,7 +20,7 @@
 package org.elasticsearch.action.admin.indices.recovery;
 
 import org.elasticsearch.action.ShardOperationFailedException;
-import org.elasticsearch.action.support.broadcast.BroadcastOperationResponse;
+import org.elasticsearch.action.support.broadcast.BroadcastResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ToXContent;
@@ -35,7 +35,7 @@ import java.util.Map;
 /**
  * Information regarding the recovery state of indices and their associated shards.
  */
-public class RecoveryResponse extends BroadcastOperationResponse implements ToXContent {
+public class RecoveryResponse extends BroadcastResponse implements ToXContent {
 
     private boolean detailed = false;
     private Map<String, List<ShardRecoveryResponse>> shardResponses = new HashMap<>();

--- a/src/main/java/org/elasticsearch/action/admin/indices/recovery/ShardRecoveryResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/recovery/ShardRecoveryResponse.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.action.admin.indices.recovery;
 
-import org.elasticsearch.action.support.broadcast.BroadcastShardOperationResponse;
+import org.elasticsearch.action.support.broadcast.BroadcastShardResponse;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -33,7 +33,7 @@ import java.io.IOException;
 /**
  * Information regarding the recovery state of a shard.
  */
-public class ShardRecoveryResponse extends BroadcastShardOperationResponse implements ToXContent {
+public class ShardRecoveryResponse extends BroadcastShardResponse implements ToXContent {
 
     RecoveryState recoveryState;
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/recovery/TransportRecoveryAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/recovery/TransportRecoveryAction.java
@@ -23,8 +23,8 @@ import org.elasticsearch.action.ShardOperationFailedException;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.DefaultShardOperationFailedException;
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationFailedException;
-import org.elasticsearch.action.support.broadcast.BroadcastShardOperationRequest;
-import org.elasticsearch.action.support.broadcast.TransportBroadcastOperationAction;
+import org.elasticsearch.action.support.broadcast.BroadcastShardRequest;
+import org.elasticsearch.action.support.broadcast.TransportBroadcastAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
@@ -51,7 +51,7 @@ import java.util.concurrent.atomic.AtomicReferenceArray;
  * Transport action for shard recovery operation. This transport action does not actually
  * perform shard recovery, it only reports on recoveries (both active and complete).
  */
-public class TransportRecoveryAction extends TransportBroadcastOperationAction<RecoveryRequest, RecoveryResponse, TransportRecoveryAction.ShardRecoveryRequest, ShardRecoveryResponse> {
+public class TransportRecoveryAction extends TransportBroadcastAction<RecoveryRequest, RecoveryResponse, TransportRecoveryAction.ShardRecoveryRequest, ShardRecoveryResponse> {
 
     private final IndicesService indicesService;
 
@@ -149,7 +149,7 @@ public class TransportRecoveryAction extends TransportBroadcastOperationAction<R
         return state.blocks().indicesBlockedException(ClusterBlockLevel.READ, concreteIndices);
     }
 
-    static class ShardRecoveryRequest extends BroadcastShardOperationRequest {
+    static class ShardRecoveryRequest extends BroadcastShardRequest {
 
         ShardRecoveryRequest() {
         }

--- a/src/main/java/org/elasticsearch/action/admin/indices/refresh/RefreshRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/refresh/RefreshRequest.java
@@ -20,11 +20,7 @@
 package org.elasticsearch.action.admin.indices.refresh;
 
 import org.elasticsearch.action.ActionRequest;
-import org.elasticsearch.action.support.broadcast.BroadcastOperationRequest;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
-
-import java.io.IOException;
+import org.elasticsearch.action.support.broadcast.BroadcastRequest;
 
 /**
  * A refresh request making all operations performed since the last refresh available for search. The (near) real-time
@@ -35,7 +31,7 @@ import java.io.IOException;
  * @see org.elasticsearch.client.IndicesAdminClient#refresh(RefreshRequest)
  * @see RefreshResponse
  */
-public class RefreshRequest extends BroadcastOperationRequest<RefreshRequest> {
+public class RefreshRequest extends BroadcastRequest<RefreshRequest> {
 
 
     RefreshRequest() {

--- a/src/main/java/org/elasticsearch/action/admin/indices/refresh/RefreshResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/refresh/RefreshResponse.java
@@ -20,7 +20,7 @@
 package org.elasticsearch.action.admin.indices.refresh;
 
 import org.elasticsearch.action.ShardOperationFailedException;
-import org.elasticsearch.action.support.broadcast.BroadcastOperationResponse;
+import org.elasticsearch.action.support.broadcast.BroadcastResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -32,7 +32,7 @@ import java.util.List;
  *
  *
  */
-public class RefreshResponse extends BroadcastOperationResponse {
+public class RefreshResponse extends BroadcastResponse {
 
     RefreshResponse() {
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/refresh/ShardRefreshRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/refresh/ShardRefreshRequest.java
@@ -19,17 +19,13 @@
 
 package org.elasticsearch.action.admin.indices.refresh;
 
-import org.elasticsearch.action.support.broadcast.BroadcastShardOperationRequest;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.action.support.broadcast.BroadcastShardRequest;
 import org.elasticsearch.index.shard.ShardId;
-
-import java.io.IOException;
 
 /**
  *
  */
-class ShardRefreshRequest extends BroadcastShardOperationRequest {
+class ShardRefreshRequest extends BroadcastShardRequest {
 
     ShardRefreshRequest() {
     }

--- a/src/main/java/org/elasticsearch/action/admin/indices/refresh/ShardRefreshResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/refresh/ShardRefreshResponse.java
@@ -19,13 +19,13 @@
 
 package org.elasticsearch.action.admin.indices.refresh;
 
-import org.elasticsearch.action.support.broadcast.BroadcastShardOperationResponse;
+import org.elasticsearch.action.support.broadcast.BroadcastShardResponse;
 import org.elasticsearch.index.shard.ShardId;
 
 /**
  *
  */
-class ShardRefreshResponse extends BroadcastShardOperationResponse {
+class ShardRefreshResponse extends BroadcastShardResponse {
 
     ShardRefreshResponse() {
     }

--- a/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportRefreshAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportRefreshAction.java
@@ -23,7 +23,7 @@ import org.elasticsearch.action.ShardOperationFailedException;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.DefaultShardOperationFailedException;
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationFailedException;
-import org.elasticsearch.action.support.broadcast.TransportBroadcastOperationAction;
+import org.elasticsearch.action.support.broadcast.TransportBroadcastAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
@@ -45,7 +45,7 @@ import static com.google.common.collect.Lists.newArrayList;
 /**
  * Refresh action.
  */
-public class TransportRefreshAction extends TransportBroadcastOperationAction<RefreshRequest, RefreshResponse, ShardRefreshRequest, ShardRefreshResponse> {
+public class TransportRefreshAction extends TransportBroadcastAction<RefreshRequest, RefreshResponse, ShardRefreshRequest, ShardRefreshResponse> {
 
     private final IndicesService indicesService;
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/seal/SealIndicesRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/seal/SealIndicesRequest.java
@@ -19,14 +19,14 @@
 
 package org.elasticsearch.action.admin.indices.seal;
 
-import org.elasticsearch.action.support.broadcast.BroadcastOperationRequest;
+import org.elasticsearch.action.support.broadcast.BroadcastRequest;
 
 import java.util.Arrays;
 
 /**
  * A request to seal one or more indices.
  */
-public class SealIndicesRequest extends BroadcastOperationRequest {
+public class SealIndicesRequest extends BroadcastRequest {
 
     SealIndicesRequest() {
     }

--- a/src/main/java/org/elasticsearch/action/admin/indices/segments/IndicesSegmentResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/segments/IndicesSegmentResponse.java
@@ -24,7 +24,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.apache.lucene.util.Accountable;
 import org.elasticsearch.action.ShardOperationFailedException;
-import org.elasticsearch.action.support.broadcast.BroadcastOperationResponse;
+import org.elasticsearch.action.support.broadcast.BroadcastResponse;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -36,12 +36,11 @@ import org.elasticsearch.index.engine.Segment;
 
 import java.io.IOException;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-public class IndicesSegmentResponse extends BroadcastOperationResponse implements ToXContent {
+public class IndicesSegmentResponse extends BroadcastResponse implements ToXContent {
 
     private ShardSegments[] shards;
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/segments/IndicesSegmentsRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/segments/IndicesSegmentsRequest.java
@@ -19,15 +19,14 @@
 
 package org.elasticsearch.action.admin.indices.segments;
 
-import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.action.support.broadcast.BroadcastOperationRequest;
+import org.elasticsearch.action.support.broadcast.BroadcastRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
 
-public class IndicesSegmentsRequest extends BroadcastOperationRequest<IndicesSegmentsRequest> {
+public class IndicesSegmentsRequest extends BroadcastRequest<IndicesSegmentsRequest> {
 
     protected boolean verbose = false;
     

--- a/src/main/java/org/elasticsearch/action/admin/indices/segments/ShardSegments.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/segments/ShardSegments.java
@@ -20,7 +20,7 @@
 package org.elasticsearch.action.admin.indices.segments;
 
 import com.google.common.collect.ImmutableList;
-import org.elasticsearch.action.support.broadcast.BroadcastShardOperationResponse;
+import org.elasticsearch.action.support.broadcast.BroadcastShardResponse;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -33,7 +33,7 @@ import java.util.List;
 
 import static org.elasticsearch.cluster.routing.ImmutableShardRouting.readShardRoutingEntry;
 
-public class ShardSegments extends BroadcastShardOperationResponse implements Iterable<Segment> {
+public class ShardSegments extends BroadcastShardResponse implements Iterable<Segment> {
 
     private ShardRouting shardRouting;
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/segments/TransportIndicesSegmentsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/segments/TransportIndicesSegmentsAction.java
@@ -23,8 +23,8 @@ import org.elasticsearch.action.ShardOperationFailedException;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.DefaultShardOperationFailedException;
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationFailedException;
-import org.elasticsearch.action.support.broadcast.BroadcastShardOperationRequest;
-import org.elasticsearch.action.support.broadcast.TransportBroadcastOperationAction;
+import org.elasticsearch.action.support.broadcast.BroadcastShardRequest;
+import org.elasticsearch.action.support.broadcast.TransportBroadcastAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
@@ -36,8 +36,8 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexService;
-import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -51,7 +51,7 @@ import static com.google.common.collect.Lists.newArrayList;
 /**
  *
  */
-public class TransportIndicesSegmentsAction extends TransportBroadcastOperationAction<IndicesSegmentsRequest, IndicesSegmentResponse, TransportIndicesSegmentsAction.IndexShardSegmentRequest, ShardSegments> {
+public class TransportIndicesSegmentsAction extends TransportBroadcastAction<IndicesSegmentsRequest, IndicesSegmentResponse, TransportIndicesSegmentsAction.IndexShardSegmentRequest, ShardSegments> {
 
     private final IndicesService indicesService;
 
@@ -122,7 +122,7 @@ public class TransportIndicesSegmentsAction extends TransportBroadcastOperationA
         return new ShardSegments(indexShard.routingEntry(), indexShard.engine().segments(request.verbose));
     }
 
-    static class IndexShardSegmentRequest extends BroadcastShardOperationRequest {
+    static class IndexShardSegmentRequest extends BroadcastShardRequest {
         boolean verbose;
         
         IndexShardSegmentRequest() {

--- a/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsRequest.java
@@ -19,12 +19,11 @@
 
 package org.elasticsearch.action.admin.indices.settings.get;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.ValidateActions;
 import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.action.support.master.MasterNodeReadOperationRequest;
+import org.elasticsearch.action.support.master.MasterNodeReadRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -33,7 +32,7 @@ import java.io.IOException;
 
 /**
  */
-public class GetSettingsRequest extends MasterNodeReadOperationRequest<GetSettingsRequest> implements IndicesRequest.Replaceable {
+public class GetSettingsRequest extends MasterNodeReadRequest<GetSettingsRequest> implements IndicesRequest.Replaceable {
 
     private String[] indices = Strings.EMPTY_ARRAY;
     private IndicesOptions indicesOptions = IndicesOptions.fromOptions(false, true, true, true);

--- a/src/main/java/org/elasticsearch/action/admin/indices/settings/get/TransportGetSettingsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/settings/get/TransportGetSettingsAction.java
@@ -21,7 +21,7 @@ package org.elasticsearch.action.admin.indices.settings.get;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.master.TransportMasterNodeReadOperationAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeReadAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
@@ -40,7 +40,7 @@ import java.util.Map;
 
 /**
  */
-public class TransportGetSettingsAction extends TransportMasterNodeReadOperationAction<GetSettingsRequest, GetSettingsResponse> {
+public class TransportGetSettingsAction extends TransportMasterNodeReadAction<GetSettingsRequest, GetSettingsResponse> {
 
     private final SettingsFilter settingsFilter;
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/settings/put/TransportUpdateSettingsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/settings/put/TransportUpdateSettingsAction.java
@@ -21,7 +21,7 @@ package org.elasticsearch.action.admin.indices.settings.put;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ack.ClusterStateUpdateResponse;
@@ -37,7 +37,7 @@ import org.elasticsearch.transport.TransportService;
 /**
  *
  */
-public class TransportUpdateSettingsAction extends TransportMasterNodeOperationAction<UpdateSettingsRequest, UpdateSettingsResponse> {
+public class TransportUpdateSettingsAction extends TransportMasterNodeAction<UpdateSettingsRequest, UpdateSettingsResponse> {
 
     private final MetaDataUpdateSettingsService updateSettingsService;
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsRequest.java
@@ -20,7 +20,7 @@
 package org.elasticsearch.action.admin.indices.stats;
 
 import org.elasticsearch.action.admin.indices.stats.CommonStatsFlags.Flag;
-import org.elasticsearch.action.support.broadcast.BroadcastOperationRequest;
+import org.elasticsearch.action.support.broadcast.BroadcastRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -34,7 +34,7 @@ import java.io.IOException;
  * <p>All the stats to be returned can be cleared using {@link #clear()}, at which point, specific
  * stats can be enabled.
  */
-public class IndicesStatsRequest extends BroadcastOperationRequest<IndicesStatsRequest> {
+public class IndicesStatsRequest extends BroadcastRequest<IndicesStatsRequest> {
 
     private CommonStatsFlags flags = new CommonStatsFlags();
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsResponse.java
@@ -24,7 +24,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.elasticsearch.action.ShardOperationFailedException;
-import org.elasticsearch.action.support.broadcast.BroadcastOperationResponse;
+import org.elasticsearch.action.support.broadcast.BroadcastResponse;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -41,7 +41,7 @@ import java.util.Set;
 
 /**
  */
-public class IndicesStatsResponse extends BroadcastOperationResponse implements ToXContent {
+public class IndicesStatsResponse extends BroadcastResponse implements ToXContent {
 
     private ShardStats[] shards;
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/stats/ShardStats.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/stats/ShardStats.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.action.admin.indices.stats;
 
-import org.elasticsearch.action.support.broadcast.BroadcastShardOperationResponse;
+import org.elasticsearch.action.support.broadcast.BroadcastShardResponse;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -36,7 +36,7 @@ import static org.elasticsearch.cluster.routing.ImmutableShardRouting.readShardR
 
 /**
  */
-public class ShardStats extends BroadcastShardOperationResponse implements ToXContent {
+public class ShardStats extends BroadcastShardResponse implements ToXContent {
 
     private ShardRouting shardRouting;
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/stats/TransportIndicesStatsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/stats/TransportIndicesStatsAction.java
@@ -24,8 +24,8 @@ import org.elasticsearch.action.ShardOperationFailedException;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.DefaultShardOperationFailedException;
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationFailedException;
-import org.elasticsearch.action.support.broadcast.BroadcastShardOperationRequest;
-import org.elasticsearch.action.support.broadcast.TransportBroadcastOperationAction;
+import org.elasticsearch.action.support.broadcast.BroadcastShardRequest;
+import org.elasticsearch.action.support.broadcast.TransportBroadcastAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
@@ -52,7 +52,7 @@ import static com.google.common.collect.Lists.newArrayList;
 
 /**
  */
-public class TransportIndicesStatsAction extends TransportBroadcastOperationAction<IndicesStatsRequest, IndicesStatsResponse, TransportIndicesStatsAction.IndexShardStatsRequest, ShardStats> {
+public class TransportIndicesStatsAction extends TransportBroadcastAction<IndicesStatsRequest, IndicesStatsResponse, TransportIndicesStatsAction.IndexShardStatsRequest, ShardStats> {
 
     private final IndicesService indicesService;
 
@@ -190,7 +190,7 @@ public class TransportIndicesStatsAction extends TransportBroadcastOperationActi
         return new ShardStats(indexShard, indexShard.routingEntry(), flags);
     }
 
-    static class IndexShardStatsRequest extends BroadcastShardOperationRequest {
+    static class IndexShardStatsRequest extends BroadcastShardRequest {
 
         // TODO if there are many indices, the request might hold a large indices array..., we don't really need to serialize it
         IndicesStatsRequest request;

--- a/src/main/java/org/elasticsearch/action/admin/indices/template/delete/DeleteIndexTemplateRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/template/delete/DeleteIndexTemplateRequest.java
@@ -19,7 +19,7 @@
 package org.elasticsearch.action.admin.indices.template.delete;
 
 import org.elasticsearch.action.ActionRequestValidationException;
-import org.elasticsearch.action.support.master.MasterNodeOperationRequest;
+import org.elasticsearch.action.support.master.MasterNodeRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -30,7 +30,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 /**
  * A request to delete an index template.
  */
-public class DeleteIndexTemplateRequest extends MasterNodeOperationRequest<DeleteIndexTemplateRequest> {
+public class DeleteIndexTemplateRequest extends MasterNodeRequest<DeleteIndexTemplateRequest> {
 
     private String name;
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/template/delete/TransportDeleteIndexTemplateAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/template/delete/TransportDeleteIndexTemplateAction.java
@@ -20,7 +20,7 @@ package org.elasticsearch.action.admin.indices.template.delete;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
@@ -34,7 +34,7 @@ import org.elasticsearch.transport.TransportService;
 /**
  * Delete index action.
  */
-public class TransportDeleteIndexTemplateAction extends TransportMasterNodeOperationAction<DeleteIndexTemplateRequest, DeleteIndexTemplateResponse> {
+public class TransportDeleteIndexTemplateAction extends TransportMasterNodeAction<DeleteIndexTemplateRequest, DeleteIndexTemplateResponse> {
 
     private final MetaDataIndexTemplateService indexTemplateService;
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetIndexTemplatesRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetIndexTemplatesRequest.java
@@ -18,9 +18,8 @@
  */
 package org.elasticsearch.action.admin.indices.template.get;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
-import org.elasticsearch.action.support.master.MasterNodeReadOperationRequest;
+import org.elasticsearch.action.support.master.MasterNodeReadRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -32,7 +31,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 /**
  * Request that allows to retrieve index templates
  */
-public class GetIndexTemplatesRequest extends MasterNodeReadOperationRequest<GetIndexTemplatesRequest> {
+public class GetIndexTemplatesRequest extends MasterNodeReadRequest<GetIndexTemplatesRequest> {
 
     private String[] names;
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/template/get/TransportGetIndexTemplatesAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/template/get/TransportGetIndexTemplatesAction.java
@@ -22,7 +22,7 @@ import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import com.google.common.collect.Lists;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.master.TransportMasterNodeReadOperationAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeReadAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
@@ -39,7 +39,7 @@ import java.util.List;
 /**
  *
  */
-public class TransportGetIndexTemplatesAction extends TransportMasterNodeReadOperationAction<GetIndexTemplatesRequest, GetIndexTemplatesResponse> {
+public class TransportGetIndexTemplatesAction extends TransportMasterNodeReadAction<GetIndexTemplatesRequest, GetIndexTemplatesResponse> {
 
     @Inject
     public TransportGetIndexTemplatesAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool, ActionFilters actionFilters) {

--- a/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequest.java
@@ -25,7 +25,7 @@ import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
 import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.action.support.master.MasterNodeOperationRequest;
+import org.elasticsearch.action.support.master.MasterNodeRequest;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -50,7 +50,7 @@ import static org.elasticsearch.common.settings.Settings.writeSettingsToStream;
 /**
  * A request to create an index template.
  */
-public class PutIndexTemplateRequest extends MasterNodeOperationRequest<PutIndexTemplateRequest> implements IndicesRequest {
+public class PutIndexTemplateRequest extends MasterNodeRequest<PutIndexTemplateRequest> implements IndicesRequest {
 
     private String name;
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/template/put/TransportPutIndexTemplateAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/template/put/TransportPutIndexTemplateAction.java
@@ -20,7 +20,7 @@ package org.elasticsearch.action.admin.indices.template.put;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
@@ -34,7 +34,7 @@ import org.elasticsearch.transport.TransportService;
 /**
  * Put index template action.
  */
-public class TransportPutIndexTemplateAction extends TransportMasterNodeOperationAction<PutIndexTemplateRequest, PutIndexTemplateResponse> {
+public class TransportPutIndexTemplateAction extends TransportMasterNodeAction<PutIndexTemplateRequest, PutIndexTemplateResponse> {
 
     private final MetaDataIndexTemplateService indexTemplateService;
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ShardValidateQueryRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ShardValidateQueryRequest.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.action.admin.indices.validate.query;
 
-import org.elasticsearch.action.support.broadcast.BroadcastShardOperationRequest;
+import org.elasticsearch.action.support.broadcast.BroadcastShardRequest;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -32,7 +32,7 @@ import java.io.IOException;
 /**
  * Internal validate request executed directly against a specific index shard.
  */
-class ShardValidateQueryRequest extends BroadcastShardOperationRequest {
+class ShardValidateQueryRequest extends BroadcastShardRequest {
 
     private BytesReference source;
     private String[] types = Strings.EMPTY_ARRAY;

--- a/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ShardValidateQueryResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ShardValidateQueryResponse.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.action.admin.indices.validate.query;
 
-import org.elasticsearch.action.support.broadcast.BroadcastShardOperationResponse;
+import org.elasticsearch.action.support.broadcast.BroadcastShardResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.shard.ShardId;
@@ -31,7 +31,7 @@ import java.io.IOException;
  *
  *
  */
-class ShardValidateQueryResponse extends BroadcastShardOperationResponse {
+class ShardValidateQueryResponse extends BroadcastShardResponse {
 
     private boolean valid;
     

--- a/src/main/java/org/elasticsearch/action/admin/indices/validate/query/TransportValidateQueryAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/validate/query/TransportValidateQueryAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.action.ShardOperationFailedException;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.DefaultShardOperationFailedException;
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationFailedException;
-import org.elasticsearch.action.support.broadcast.TransportBroadcastOperationAction;
+import org.elasticsearch.action.support.broadcast.TransportBroadcastAction;
 import org.elasticsearch.cache.recycler.PageCacheRecycler;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -63,7 +63,7 @@ import static com.google.common.collect.Lists.newArrayList;
 /**
  *
  */
-public class TransportValidateQueryAction extends TransportBroadcastOperationAction<ValidateQueryRequest, ValidateQueryResponse, ShardValidateQueryRequest, ShardValidateQueryResponse> {
+public class TransportValidateQueryAction extends TransportBroadcastAction<ValidateQueryRequest, ValidateQueryResponse, ShardValidateQueryRequest, ShardValidateQueryResponse> {
 
     private final IndicesService indicesService;
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryRequest.java
@@ -23,7 +23,7 @@ import org.elasticsearch.ElasticsearchGenerationException;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.QuerySourceBuilder;
-import org.elasticsearch.action.support.broadcast.BroadcastOperationRequest;
+import org.elasticsearch.action.support.broadcast.BroadcastRequest;
 import org.elasticsearch.client.Requests;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
@@ -44,7 +44,7 @@ import java.util.Map;
  * <p>The request requires the query source to be set either using {@link #source(QuerySourceBuilder)},
  * or {@link #source(byte[])}.
  */
-public class ValidateQueryRequest extends BroadcastOperationRequest<ValidateQueryRequest> {
+public class ValidateQueryRequest extends BroadcastRequest<ValidateQueryRequest> {
 
     private BytesReference source;
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryResponse.java
@@ -21,7 +21,7 @@ package org.elasticsearch.action.admin.indices.validate.query;
 
 import com.google.common.collect.ImmutableList;
 import org.elasticsearch.action.ShardOperationFailedException;
-import org.elasticsearch.action.support.broadcast.BroadcastOperationResponse;
+import org.elasticsearch.action.support.broadcast.BroadcastResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -36,7 +36,7 @@ import static org.elasticsearch.action.admin.indices.validate.query.QueryExplana
  *
  *
  */
-public class ValidateQueryResponse extends BroadcastOperationResponse {
+public class ValidateQueryResponse extends BroadcastResponse {
 
     private boolean valid;
     

--- a/src/main/java/org/elasticsearch/action/admin/indices/warmer/delete/TransportDeleteWarmerAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/warmer/delete/TransportDeleteWarmerAction.java
@@ -21,7 +21,7 @@ package org.elasticsearch.action.admin.indices.warmer.delete;
 import com.google.common.collect.Lists;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -47,7 +47,7 @@ import java.util.List;
  *
  * Note: this is an internal API and should not be used / called by any client code.
  */
-public class TransportDeleteWarmerAction extends TransportMasterNodeOperationAction<DeleteWarmerRequest, DeleteWarmerResponse> {
+public class TransportDeleteWarmerAction extends TransportMasterNodeAction<DeleteWarmerRequest, DeleteWarmerResponse> {
 
     @Inject
     public TransportDeleteWarmerAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool, ActionFilters actionFilters) {

--- a/src/main/java/org/elasticsearch/action/admin/indices/warmer/put/TransportPutWarmerAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/warmer/put/TransportPutWarmerAction.java
@@ -25,7 +25,7 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.TransportSearchAction;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -51,7 +51,7 @@ import java.util.List;
  *
  * Note: this is an internal API and should not be used / called by any client code.
  */
-public class TransportPutWarmerAction extends TransportMasterNodeOperationAction<PutWarmerRequest, PutWarmerResponse> {
+public class TransportPutWarmerAction extends TransportMasterNodeAction<PutWarmerRequest, PutWarmerResponse> {
 
     private final TransportSearchAction searchAction;
 

--- a/src/main/java/org/elasticsearch/action/count/CountRequest.java
+++ b/src/main/java/org/elasticsearch/action/count/CountRequest.java
@@ -22,7 +22,7 @@ package org.elasticsearch.action.count;
 import org.elasticsearch.ElasticsearchGenerationException;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.QuerySourceBuilder;
-import org.elasticsearch.action.support.broadcast.BroadcastOperationRequest;
+import org.elasticsearch.action.support.broadcast.BroadcastRequest;
 import org.elasticsearch.client.Requests;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
@@ -51,7 +51,7 @@ import static org.elasticsearch.search.internal.SearchContext.DEFAULT_TERMINATE_
  * @see org.elasticsearch.client.Client#count(CountRequest)
  * @see org.elasticsearch.client.Requests#countRequest(String...)
  */
-public class CountRequest extends BroadcastOperationRequest<CountRequest> {
+public class CountRequest extends BroadcastRequest<CountRequest> {
 
     public static final float DEFAULT_MIN_SCORE = -1f;
 

--- a/src/main/java/org/elasticsearch/action/count/CountResponse.java
+++ b/src/main/java/org/elasticsearch/action/count/CountResponse.java
@@ -19,18 +19,19 @@
 
 package org.elasticsearch.action.count;
 
-import java.io.IOException;
-import java.util.List;
 import org.elasticsearch.action.ShardOperationFailedException;
-import org.elasticsearch.action.support.broadcast.BroadcastOperationResponse;
+import org.elasticsearch.action.support.broadcast.BroadcastResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.rest.RestStatus;
 
+import java.io.IOException;
+import java.util.List;
+
 /**
  * The response of the count action.
  */
-public class CountResponse extends BroadcastOperationResponse {
+public class CountResponse extends BroadcastResponse {
 
     private boolean terminatedEarly;
     private long count;

--- a/src/main/java/org/elasticsearch/action/count/ShardCountRequest.java
+++ b/src/main/java/org/elasticsearch/action/count/ShardCountRequest.java
@@ -19,8 +19,7 @@
 
 package org.elasticsearch.action.count;
 
-import org.elasticsearch.Version;
-import org.elasticsearch.action.support.broadcast.BroadcastShardOperationRequest;
+import org.elasticsearch.action.support.broadcast.BroadcastShardRequest;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -30,12 +29,10 @@ import org.elasticsearch.index.shard.ShardId;
 
 import java.io.IOException;
 
-import static org.elasticsearch.search.internal.SearchContext.DEFAULT_TERMINATE_AFTER;
-
 /**
  * Internal count request executed directly against a specific index shard.
  */
-class ShardCountRequest extends BroadcastShardOperationRequest {
+class ShardCountRequest extends BroadcastShardRequest {
 
     private float minScore;
     private int terminateAfter;

--- a/src/main/java/org/elasticsearch/action/count/ShardCountResponse.java
+++ b/src/main/java/org/elasticsearch/action/count/ShardCountResponse.java
@@ -19,8 +19,7 @@
 
 package org.elasticsearch.action.count;
 
-import org.elasticsearch.Version;
-import org.elasticsearch.action.support.broadcast.BroadcastShardOperationResponse;
+import org.elasticsearch.action.support.broadcast.BroadcastShardResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.shard.ShardId;
@@ -32,7 +31,7 @@ import java.io.IOException;
  *
  *
  */
-class ShardCountResponse extends BroadcastShardOperationResponse {
+class ShardCountResponse extends BroadcastShardResponse {
 
     private long count;
     private boolean terminatedEarly;

--- a/src/main/java/org/elasticsearch/action/count/TransportCountAction.java
+++ b/src/main/java/org/elasticsearch/action/count/TransportCountAction.java
@@ -24,7 +24,7 @@ import org.elasticsearch.action.ShardOperationFailedException;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.DefaultShardOperationFailedException;
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationFailedException;
-import org.elasticsearch.action.support.broadcast.TransportBroadcastOperationAction;
+import org.elasticsearch.action.support.broadcast.TransportBroadcastAction;
 import org.elasticsearch.cache.recycler.PageCacheRecycler;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -37,8 +37,8 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.index.query.QueryParseContext;
 import org.elasticsearch.index.IndexService;
+import org.elasticsearch.index.query.QueryParseContext;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.script.ScriptService;
@@ -61,7 +61,7 @@ import static org.elasticsearch.search.internal.SearchContext.DEFAULT_TERMINATE_
 /**
  *
  */
-public class TransportCountAction extends TransportBroadcastOperationAction<CountRequest, CountResponse, ShardCountRequest, ShardCountResponse> {
+public class TransportCountAction extends TransportBroadcastAction<CountRequest, CountResponse, ShardCountRequest, ShardCountResponse> {
 
     private final IndicesService indicesService;
     private final ScriptService scriptService;

--- a/src/main/java/org/elasticsearch/action/exists/ExistsRequest.java
+++ b/src/main/java/org/elasticsearch/action/exists/ExistsRequest.java
@@ -22,7 +22,7 @@ package org.elasticsearch.action.exists;
 import org.elasticsearch.ElasticsearchGenerationException;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.QuerySourceBuilder;
-import org.elasticsearch.action.support.broadcast.BroadcastOperationRequest;
+import org.elasticsearch.action.support.broadcast.BroadcastRequest;
 import org.elasticsearch.client.Requests;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
@@ -38,7 +38,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Map;
 
-public class ExistsRequest extends BroadcastOperationRequest<ExistsRequest> {
+public class ExistsRequest extends BroadcastRequest<ExistsRequest> {
 
     public static final float DEFAULT_MIN_SCORE = -1f;
     private float minScore = DEFAULT_MIN_SCORE;

--- a/src/main/java/org/elasticsearch/action/exists/ExistsResponse.java
+++ b/src/main/java/org/elasticsearch/action/exists/ExistsResponse.java
@@ -20,14 +20,14 @@
 package org.elasticsearch.action.exists;
 
 import org.elasticsearch.action.ShardOperationFailedException;
-import org.elasticsearch.action.support.broadcast.BroadcastOperationResponse;
+import org.elasticsearch.action.support.broadcast.BroadcastResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
 import java.util.List;
 
-public class ExistsResponse extends BroadcastOperationResponse {
+public class ExistsResponse extends BroadcastResponse {
 
     private boolean exists = false;
 

--- a/src/main/java/org/elasticsearch/action/exists/ShardExistsRequest.java
+++ b/src/main/java/org/elasticsearch/action/exists/ShardExistsRequest.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.action.exists;
 
-import org.elasticsearch.action.support.broadcast.BroadcastShardOperationRequest;
+import org.elasticsearch.action.support.broadcast.BroadcastShardRequest;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -29,7 +29,7 @@ import org.elasticsearch.index.shard.ShardId;
 
 import java.io.IOException;
 
-class ShardExistsRequest extends BroadcastShardOperationRequest {
+class ShardExistsRequest extends BroadcastShardRequest {
 
     private float minScore;
 

--- a/src/main/java/org/elasticsearch/action/exists/ShardExistsResponse.java
+++ b/src/main/java/org/elasticsearch/action/exists/ShardExistsResponse.java
@@ -19,14 +19,14 @@
 
 package org.elasticsearch.action.exists;
 
-import org.elasticsearch.action.support.broadcast.BroadcastShardOperationResponse;
+import org.elasticsearch.action.support.broadcast.BroadcastShardResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.shard.ShardId;
 
 import java.io.IOException;
 
-class ShardExistsResponse extends BroadcastShardOperationResponse {
+class ShardExistsResponse extends BroadcastShardResponse {
 
     private boolean exists;
 

--- a/src/main/java/org/elasticsearch/action/exists/TransportExistsAction.java
+++ b/src/main/java/org/elasticsearch/action/exists/TransportExistsAction.java
@@ -25,7 +25,7 @@ import org.elasticsearch.action.ShardOperationFailedException;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.DefaultShardOperationFailedException;
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationFailedException;
-import org.elasticsearch.action.support.broadcast.TransportBroadcastOperationAction;
+import org.elasticsearch.action.support.broadcast.TransportBroadcastAction;
 import org.elasticsearch.cache.recycler.PageCacheRecycler;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -39,8 +39,8 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.index.query.QueryParseContext;
 import org.elasticsearch.index.IndexService;
+import org.elasticsearch.index.query.QueryParseContext;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.script.ScriptService;
@@ -61,7 +61,7 @@ import java.util.concurrent.atomic.AtomicReferenceArray;
 import static com.google.common.collect.Lists.newArrayList;
 import static org.elasticsearch.action.exists.ExistsRequest.DEFAULT_MIN_SCORE;
 
-public class TransportExistsAction extends TransportBroadcastOperationAction<ExistsRequest, ExistsResponse, ShardExistsRequest, ShardExistsResponse> {
+public class TransportExistsAction extends TransportBroadcastAction<ExistsRequest, ExistsResponse, ShardExistsRequest, ShardExistsResponse> {
 
     private final IndicesService indicesService;
     private final ScriptService scriptService;

--- a/src/main/java/org/elasticsearch/action/explain/ExplainRequest.java
+++ b/src/main/java/org/elasticsearch/action/explain/ExplainRequest.java
@@ -22,7 +22,7 @@ package org.elasticsearch.action.explain;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ValidateActions;
 import org.elasticsearch.action.support.QuerySourceBuilder;
-import org.elasticsearch.action.support.single.shard.SingleShardOperationRequest;
+import org.elasticsearch.action.support.single.shard.SingleShardRequest;
 import org.elasticsearch.client.Requests;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -35,7 +35,7 @@ import java.io.IOException;
 /**
  * Explain request encapsulating the explain query and document identifier to get an explanation for.
  */
-public class ExplainRequest extends SingleShardOperationRequest<ExplainRequest> {
+public class ExplainRequest extends SingleShardRequest<ExplainRequest> {
 
     private String type = "_all";
     private String id;

--- a/src/main/java/org/elasticsearch/action/explain/TransportExplainAction.java
+++ b/src/main/java/org/elasticsearch/action/explain/TransportExplainAction.java
@@ -25,7 +25,7 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.RoutingMissingException;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.single.shard.TransportShardSingleOperationAction;
+import org.elasticsearch.action.support.single.shard.TransportSingleShardAction;
 import org.elasticsearch.cache.recycler.PageCacheRecycler;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -33,13 +33,13 @@ import org.elasticsearch.cluster.routing.ShardIterator;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.get.GetResult;
 import org.elasticsearch.index.mapper.Uid;
 import org.elasticsearch.index.mapper.internal.UidFieldMapper;
-import org.elasticsearch.index.IndexService;
-import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.internal.DefaultSearchContext;
@@ -56,7 +56,7 @@ import java.io.IOException;
  * Explain transport action. Computes the explain on the targeted shard.
  */
 // TODO: AggregatedDfs. Currently the idf can be different then when executing a normal search with explain.
-public class TransportExplainAction extends TransportShardSingleOperationAction<ExplainRequest, ExplainResponse> {
+public class TransportExplainAction extends TransportSingleShardAction<ExplainRequest, ExplainResponse> {
 
     private final IndicesService indicesService;
 

--- a/src/main/java/org/elasticsearch/action/fieldstats/FieldStatsRequest.java
+++ b/src/main/java/org/elasticsearch/action/fieldstats/FieldStatsRequest.java
@@ -21,7 +21,7 @@ package org.elasticsearch.action.fieldstats;
 
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ValidateActions;
-import org.elasticsearch.action.support.broadcast.BroadcastOperationRequest;
+import org.elasticsearch.action.support.broadcast.BroadcastRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -29,7 +29,7 @@ import java.io.IOException;
 
 /**
  */
-public class FieldStatsRequest extends BroadcastOperationRequest<FieldStatsRequest> {
+public class FieldStatsRequest extends BroadcastRequest<FieldStatsRequest> {
 
     public final static String DEFAULT_LEVEL = "cluster";
 

--- a/src/main/java/org/elasticsearch/action/fieldstats/FieldStatsResponse.java
+++ b/src/main/java/org/elasticsearch/action/fieldstats/FieldStatsResponse.java
@@ -20,7 +20,7 @@
 package org.elasticsearch.action.fieldstats;
 
 import org.elasticsearch.action.ShardOperationFailedException;
-import org.elasticsearch.action.support.broadcast.BroadcastOperationResponse;
+import org.elasticsearch.action.support.broadcast.BroadcastResponse;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -32,7 +32,7 @@ import java.util.Map;
 
 /**
  */
-public class FieldStatsResponse extends BroadcastOperationResponse {
+public class FieldStatsResponse extends BroadcastResponse {
 
     private Map<String, Map<String, FieldStats>> indicesMergedFieldStats;
 

--- a/src/main/java/org/elasticsearch/action/fieldstats/FieldStatsShardRequest.java
+++ b/src/main/java/org/elasticsearch/action/fieldstats/FieldStatsShardRequest.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.action.fieldstats;
 
-import org.elasticsearch.action.support.broadcast.BroadcastShardOperationRequest;
+import org.elasticsearch.action.support.broadcast.BroadcastShardRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.shard.ShardId;
@@ -28,7 +28,7 @@ import java.io.IOException;
 
 /**
  */
-public class FieldStatsShardRequest extends BroadcastShardOperationRequest {
+public class FieldStatsShardRequest extends BroadcastShardRequest {
 
     private String[] fields;
 

--- a/src/main/java/org/elasticsearch/action/fieldstats/FieldStatsShardResponse.java
+++ b/src/main/java/org/elasticsearch/action/fieldstats/FieldStatsShardResponse.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.action.fieldstats;
 
-import org.elasticsearch.action.support.broadcast.BroadcastShardOperationResponse;
+import org.elasticsearch.action.support.broadcast.BroadcastShardResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.shard.ShardId;
@@ -30,7 +30,7 @@ import java.util.Map;
 
 /**
  */
-public class FieldStatsShardResponse extends BroadcastShardOperationResponse {
+public class FieldStatsShardResponse extends BroadcastShardResponse {
 
     private Map<String, FieldStats> fieldStats;
 

--- a/src/main/java/org/elasticsearch/action/fieldstats/TransportFieldStatsTransportAction.java
+++ b/src/main/java/org/elasticsearch/action/fieldstats/TransportFieldStatsTransportAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.action.ShardOperationFailedException;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.DefaultShardOperationFailedException;
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationFailedException;
-import org.elasticsearch.action.support.broadcast.TransportBroadcastOperationAction;
+import org.elasticsearch.action.support.broadcast.TransportBroadcastAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
@@ -47,10 +47,13 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 
-public class TransportFieldStatsTransportAction extends TransportBroadcastOperationAction<FieldStatsRequest, FieldStatsResponse, FieldStatsShardRequest, FieldStatsShardResponse> {
+public class TransportFieldStatsTransportAction extends TransportBroadcastAction<FieldStatsRequest, FieldStatsResponse, FieldStatsShardRequest, FieldStatsShardResponse> {
 
     private final IndicesService indicesService;
 

--- a/src/main/java/org/elasticsearch/action/get/GetRequest.java
+++ b/src/main/java/org/elasticsearch/action/get/GetRequest.java
@@ -22,7 +22,7 @@ package org.elasticsearch.action.get;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ValidateActions;
-import org.elasticsearch.action.support.single.shard.SingleShardOperationRequest;
+import org.elasticsearch.action.support.single.shard.SingleShardRequest;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -43,7 +43,7 @@ import java.io.IOException;
  * @see org.elasticsearch.client.Requests#getRequest(String)
  * @see org.elasticsearch.client.Client#get(GetRequest)
  */
-public class GetRequest extends SingleShardOperationRequest<GetRequest> {
+public class GetRequest extends SingleShardRequest<GetRequest> {
 
     private String type;
     private String id;

--- a/src/main/java/org/elasticsearch/action/get/MultiGetShardRequest.java
+++ b/src/main/java/org/elasticsearch/action/get/MultiGetShardRequest.java
@@ -20,19 +20,15 @@
 package org.elasticsearch.action.get;
 
 import com.carrotsearch.hppc.IntArrayList;
-import com.carrotsearch.hppc.LongArrayList;
-import org.elasticsearch.Version;
-import org.elasticsearch.action.support.single.shard.SingleShardOperationRequest;
+import org.elasticsearch.action.support.single.shard.SingleShardRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.index.VersionType;
-import org.elasticsearch.search.fetch.source.FetchSourceContext;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-public class MultiGetShardRequest extends SingleShardOperationRequest<MultiGetShardRequest> {
+public class MultiGetShardRequest extends SingleShardRequest<MultiGetShardRequest> {
 
     private int shardId;
     private String preference;

--- a/src/main/java/org/elasticsearch/action/get/TransportGetAction.java
+++ b/src/main/java/org/elasticsearch/action/get/TransportGetAction.java
@@ -21,7 +21,7 @@ package org.elasticsearch.action.get;
 
 import org.elasticsearch.action.RoutingMissingException;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.single.shard.TransportShardSingleOperationAction;
+import org.elasticsearch.action.support.single.shard.TransportSingleShardAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
@@ -40,7 +40,7 @@ import org.elasticsearch.transport.TransportService;
 /**
  * Performs the get operation.
  */
-public class TransportGetAction extends TransportShardSingleOperationAction<GetRequest, GetResponse> {
+public class TransportGetAction extends TransportSingleShardAction<GetRequest, GetResponse> {
 
     private final IndicesService indicesService;
     private final boolean realtime;

--- a/src/main/java/org/elasticsearch/action/get/TransportShardMultiGetAction.java
+++ b/src/main/java/org/elasticsearch/action/get/TransportShardMultiGetAction.java
@@ -23,21 +23,21 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.TransportActions;
-import org.elasticsearch.action.support.single.shard.TransportShardSingleOperationAction;
+import org.elasticsearch.action.support.single.shard.TransportSingleShardAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.routing.ShardIterator;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.index.get.GetResult;
 import org.elasticsearch.index.IndexService;
-import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.get.GetResult;
 import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
-public class TransportShardMultiGetAction extends TransportShardSingleOperationAction<MultiGetShardRequest, MultiGetShardResponse> {
+public class TransportShardMultiGetAction extends TransportSingleShardAction<MultiGetShardRequest, MultiGetShardResponse> {
 
     private static final String ACTION_NAME = MultiGetAction.NAME + "[shard]";
 

--- a/src/main/java/org/elasticsearch/action/percolate/PercolateRequest.java
+++ b/src/main/java/org/elasticsearch/action/percolate/PercolateRequest.java
@@ -24,7 +24,7 @@ import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.CompositeIndicesRequest;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.get.GetRequest;
-import org.elasticsearch.action.support.broadcast.BroadcastOperationRequest;
+import org.elasticsearch.action.support.broadcast.BroadcastRequest;
 import org.elasticsearch.client.Requests;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -43,7 +43,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 /**
  * A request to execute a percolate operation.
  */
-public class PercolateRequest extends BroadcastOperationRequest<PercolateRequest> implements CompositeIndicesRequest {
+public class PercolateRequest extends BroadcastRequest<PercolateRequest> implements CompositeIndicesRequest {
 
     private String documentType;
     private String routing;
@@ -55,7 +55,7 @@ public class PercolateRequest extends BroadcastOperationRequest<PercolateRequest
 
     private BytesReference docSource;
 
-    // Used internally in order to compute tookInMillis, TransportBroadcastOperationAction itself doesn't allow
+    // Used internally in order to compute tookInMillis, TransportBroadcastAction itself doesn't allow
     // to hold it temporarily in an easy way
     long startTime;
 

--- a/src/main/java/org/elasticsearch/action/percolate/PercolateResponse.java
+++ b/src/main/java/org/elasticsearch/action/percolate/PercolateResponse.java
@@ -19,7 +19,7 @@
 package org.elasticsearch.action.percolate;
 
 import org.elasticsearch.action.ShardOperationFailedException;
-import org.elasticsearch.action.support.broadcast.BroadcastOperationResponse;
+import org.elasticsearch.action.support.broadcast.BroadcastResponse;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -40,7 +40,7 @@ import java.util.*;
 /**
  * Encapsulates the response of a percolator request.
  */
-public class PercolateResponse extends BroadcastOperationResponse implements Iterable<PercolateResponse.Match>, ToXContent {
+public class PercolateResponse extends BroadcastResponse implements Iterable<PercolateResponse.Match>, ToXContent {
 
     public static final Match[] EMPTY = new Match[0];
 

--- a/src/main/java/org/elasticsearch/action/percolate/PercolateShardRequest.java
+++ b/src/main/java/org/elasticsearch/action/percolate/PercolateShardRequest.java
@@ -19,9 +19,8 @@
 
 package org.elasticsearch.action.percolate;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.OriginalIndices;
-import org.elasticsearch.action.support.broadcast.BroadcastShardOperationRequest;
+import org.elasticsearch.action.support.broadcast.BroadcastShardRequest;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -31,7 +30,7 @@ import java.io.IOException;
 
 /**
  */
-public class PercolateShardRequest extends BroadcastShardOperationRequest {
+public class PercolateShardRequest extends BroadcastShardRequest {
 
     private String documentType;
     private BytesReference source;

--- a/src/main/java/org/elasticsearch/action/percolate/PercolateShardResponse.java
+++ b/src/main/java/org/elasticsearch/action/percolate/PercolateShardResponse.java
@@ -19,9 +19,8 @@
 package org.elasticsearch.action.percolate;
 
 import com.google.common.collect.ImmutableList;
-
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.action.support.broadcast.BroadcastShardOperationResponse;
+import org.elasticsearch.action.support.broadcast.BroadcastShardResponse;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -42,7 +41,7 @@ import java.util.Map;
 
 /**
  */
-public class PercolateShardResponse extends BroadcastShardOperationResponse {
+public class PercolateShardResponse extends BroadcastShardResponse {
 
     private static final BytesRef[] EMPTY_MATCHES = new BytesRef[0];
     private static final float[] EMPTY_SCORES = new float[0];

--- a/src/main/java/org/elasticsearch/action/percolate/TransportPercolateAction.java
+++ b/src/main/java/org/elasticsearch/action/percolate/TransportPercolateAction.java
@@ -26,7 +26,7 @@ import org.elasticsearch.action.get.TransportGetAction;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.DefaultShardOperationFailedException;
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationFailedException;
-import org.elasticsearch.action.support.broadcast.TransportBroadcastOperationAction;
+import org.elasticsearch.action.support.broadcast.TransportBroadcastAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
@@ -52,7 +52,7 @@ import static com.google.common.collect.Lists.newArrayList;
 /**
  *
  */
-public class TransportPercolateAction extends TransportBroadcastOperationAction<PercolateRequest, PercolateResponse, PercolateShardRequest, PercolateShardResponse> {
+public class TransportPercolateAction extends TransportBroadcastAction<PercolateRequest, PercolateResponse, PercolateShardRequest, PercolateShardResponse> {
 
     private final PercolatorService percolatorService;
     private final TransportGetAction getAction;

--- a/src/main/java/org/elasticsearch/action/percolate/TransportShardMultiPercolateAction.java
+++ b/src/main/java/org/elasticsearch/action/percolate/TransportShardMultiPercolateAction.java
@@ -26,8 +26,8 @@ import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.OriginalIndices;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.TransportActions;
-import org.elasticsearch.action.support.single.shard.SingleShardOperationRequest;
-import org.elasticsearch.action.support.single.shard.TransportShardSingleOperationAction;
+import org.elasticsearch.action.support.single.shard.SingleShardRequest;
+import org.elasticsearch.action.support.single.shard.TransportSingleShardAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.routing.ShardIterator;
@@ -49,7 +49,7 @@ import java.util.List;
 
 /**
  */
-public class TransportShardMultiPercolateAction extends TransportShardSingleOperationAction<TransportShardMultiPercolateAction.Request, TransportShardMultiPercolateAction.Response> {
+public class TransportShardMultiPercolateAction extends TransportSingleShardAction<TransportShardMultiPercolateAction.Request, TransportShardMultiPercolateAction.Response> {
 
     private final PercolatorService percolatorService;
 
@@ -108,7 +108,7 @@ public class TransportShardMultiPercolateAction extends TransportShardSingleOper
     }
 
 
-    public static class Request extends SingleShardOperationRequest implements IndicesRequest {
+    public static class Request extends SingleShardRequest implements IndicesRequest {
 
         private int shardId;
         private String preference;

--- a/src/main/java/org/elasticsearch/action/suggest/ShardSuggestRequest.java
+++ b/src/main/java/org/elasticsearch/action/suggest/ShardSuggestRequest.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.action.suggest;
 
-import org.elasticsearch.action.support.broadcast.BroadcastShardOperationRequest;
+import org.elasticsearch.action.support.broadcast.BroadcastShardRequest;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -30,7 +30,7 @@ import java.io.IOException;
 /**
  * Internal suggest request executed directly against a specific index shard.
  */
-final class ShardSuggestRequest extends BroadcastShardOperationRequest {
+final class ShardSuggestRequest extends BroadcastShardRequest {
 
     private BytesReference suggestSource;
 

--- a/src/main/java/org/elasticsearch/action/suggest/ShardSuggestResponse.java
+++ b/src/main/java/org/elasticsearch/action/suggest/ShardSuggestResponse.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.action.suggest;
 
-import org.elasticsearch.action.support.broadcast.BroadcastShardOperationResponse;
+import org.elasticsearch.action.support.broadcast.BroadcastShardResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.shard.ShardId;
@@ -30,7 +30,7 @@ import java.io.IOException;
 /**
  * Internal suggest response of a shard suggest request executed directly against a specific shard.
  */
-class ShardSuggestResponse extends BroadcastShardOperationResponse {
+class ShardSuggestResponse extends BroadcastShardResponse {
 
     private final Suggest suggest;
 

--- a/src/main/java/org/elasticsearch/action/suggest/SuggestRequest.java
+++ b/src/main/java/org/elasticsearch/action/suggest/SuggestRequest.java
@@ -20,7 +20,7 @@
 package org.elasticsearch.action.suggest;
 
 import org.elasticsearch.action.ActionRequestValidationException;
-import org.elasticsearch.action.support.broadcast.BroadcastOperationRequest;
+import org.elasticsearch.action.support.broadcast.BroadcastRequest;
 import org.elasticsearch.client.Requests;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
@@ -48,7 +48,7 @@ import java.util.Arrays;
  * @see org.elasticsearch.client.Requests#suggestRequest(String...)
  * @see org.elasticsearch.search.suggest.SuggestBuilders
  */
-public final class SuggestRequest extends BroadcastOperationRequest<SuggestRequest> {
+public final class SuggestRequest extends BroadcastRequest<SuggestRequest> {
 
     @Nullable
     private String routing;

--- a/src/main/java/org/elasticsearch/action/suggest/SuggestResponse.java
+++ b/src/main/java/org/elasticsearch/action/suggest/SuggestResponse.java
@@ -20,7 +20,7 @@
 package org.elasticsearch.action.suggest;
 
 import org.elasticsearch.action.ShardOperationFailedException;
-import org.elasticsearch.action.support.broadcast.BroadcastOperationResponse;
+import org.elasticsearch.action.support.broadcast.BroadcastResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -35,7 +35,7 @@ import static org.elasticsearch.common.xcontent.ToXContent.EMPTY_PARAMS;
 /**
  * The response of the suggest action.
  */
-public final class SuggestResponse extends BroadcastOperationResponse {
+public final class SuggestResponse extends BroadcastResponse {
 
     private final Suggest suggest;
 

--- a/src/main/java/org/elasticsearch/action/suggest/TransportSuggestAction.java
+++ b/src/main/java/org/elasticsearch/action/suggest/TransportSuggestAction.java
@@ -24,7 +24,7 @@ import org.elasticsearch.action.ShardOperationFailedException;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.DefaultShardOperationFailedException;
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationFailedException;
-import org.elasticsearch.action.support.broadcast.TransportBroadcastOperationAction;
+import org.elasticsearch.action.support.broadcast.TransportBroadcastAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
@@ -36,8 +36,8 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.IndexService;
+import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.suggest.stats.ShardSuggestService;
 import org.elasticsearch.indices.IndicesService;
@@ -58,7 +58,7 @@ import static com.google.common.collect.Lists.newArrayList;
 /**
  * Defines the transport of a suggestion request across the cluster
  */
-public class TransportSuggestAction extends TransportBroadcastOperationAction<SuggestRequest, SuggestResponse, ShardSuggestRequest, ShardSuggestResponse> {
+public class TransportSuggestAction extends TransportBroadcastAction<SuggestRequest, SuggestResponse, ShardSuggestRequest, ShardSuggestResponse> {
 
     private final IndicesService indicesService;
     private final SuggestPhase suggestPhase;

--- a/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastOperationRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastOperationRequestBuilder.java
@@ -26,7 +26,7 @@ import org.elasticsearch.client.ElasticsearchClient;
 
 /**
  */
-public abstract class BroadcastOperationRequestBuilder<Request extends BroadcastOperationRequest<Request>, Response extends BroadcastOperationResponse, RequestBuilder extends BroadcastOperationRequestBuilder<Request, Response, RequestBuilder>>
+public abstract class BroadcastOperationRequestBuilder<Request extends BroadcastRequest<Request>, Response extends BroadcastResponse, RequestBuilder extends BroadcastOperationRequestBuilder<Request, Response, RequestBuilder>>
         extends ActionRequestBuilder<Request, Response, RequestBuilder> {
 
     protected BroadcastOperationRequestBuilder(ElasticsearchClient client, Action<Request, Response, RequestBuilder> action, Request request) {

--- a/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastRequest.java
+++ b/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastRequest.java
@@ -31,20 +31,20 @@ import java.io.IOException;
 /**
  *
  */
-public abstract class BroadcastOperationRequest<T extends BroadcastOperationRequest> extends ActionRequest<T> implements IndicesRequest.Replaceable {
+public abstract class BroadcastRequest<T extends BroadcastRequest> extends ActionRequest<T> implements IndicesRequest.Replaceable {
 
     protected String[] indices;
     private IndicesOptions indicesOptions = IndicesOptions.strictExpandOpenAndForbidClosed();
 
-    protected BroadcastOperationRequest() {
+    protected BroadcastRequest() {
 
     }
 
-    protected BroadcastOperationRequest(ActionRequest originalRequest) {
+    protected BroadcastRequest(ActionRequest originalRequest) {
         super(originalRequest);
     }
 
-    protected BroadcastOperationRequest(String[] indices) {
+    protected BroadcastRequest(String[] indices) {
         this.indices = indices;
     }
 

--- a/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastResponse.java
+++ b/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastResponse.java
@@ -19,30 +19,30 @@
 
 package org.elasticsearch.action.support.broadcast;
 
-import static org.elasticsearch.action.support.DefaultShardOperationFailedException.readShardOperationFailed;
-
-import java.io.IOException;
-import java.util.List;
-
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ShardOperationFailedException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
+import java.io.IOException;
+import java.util.List;
+
+import static org.elasticsearch.action.support.DefaultShardOperationFailedException.readShardOperationFailed;
+
 /**
  * Base class for all broadcast operation based responses.
  */
-public abstract class BroadcastOperationResponse extends ActionResponse {
+public abstract class BroadcastResponse extends ActionResponse {
     private static final ShardOperationFailedException[] EMPTY = new ShardOperationFailedException[0];
     private int totalShards;
     private int successfulShards;
     private int failedShards;
     private ShardOperationFailedException[] shardFailures = EMPTY;
 
-    protected BroadcastOperationResponse() {
+    protected BroadcastResponse() {
     }
 
-    protected BroadcastOperationResponse(int totalShards, int successfulShards, int failedShards, List<ShardOperationFailedException> shardFailures) {
+    protected BroadcastResponse(int totalShards, int successfulShards, int failedShards, List<ShardOperationFailedException> shardFailures) {
         this.totalShards = totalShards;
         this.successfulShards = successfulShards;
         this.failedShards = failedShards;

--- a/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastShardRequest.java
+++ b/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastShardRequest.java
@@ -32,22 +32,22 @@ import java.io.IOException;
 /**
  *
  */
-public abstract class BroadcastShardOperationRequest extends TransportRequest implements IndicesRequest {
+public abstract class BroadcastShardRequest extends TransportRequest implements IndicesRequest {
 
     private ShardId shardId;
 
     protected OriginalIndices originalIndices;
 
-    protected BroadcastShardOperationRequest() {
+    protected BroadcastShardRequest() {
     }
 
-    protected BroadcastShardOperationRequest(ShardId shardId, BroadcastOperationRequest request) {
+    protected BroadcastShardRequest(ShardId shardId, BroadcastRequest request) {
         super(request);
         this.shardId = shardId;
         this.originalIndices = new OriginalIndices(request);
     }
 
-    protected BroadcastShardOperationRequest(ShardId shardId, OriginalIndices originalIndices) {
+    protected BroadcastShardRequest(ShardId shardId, OriginalIndices originalIndices) {
         this.shardId = shardId;
         this.originalIndices = originalIndices;
     }

--- a/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastShardResponse.java
+++ b/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastShardResponse.java
@@ -29,15 +29,15 @@ import java.io.IOException;
 /**
  *
  */
-public abstract class BroadcastShardOperationResponse extends TransportResponse {
+public abstract class BroadcastShardResponse extends TransportResponse {
 
     ShardId shardId;
 
-    protected BroadcastShardOperationResponse() {
+    protected BroadcastShardResponse() {
 
     }
 
-    protected BroadcastShardOperationResponse(ShardId shardId) {
+    protected BroadcastShardResponse(ShardId shardId) {
         this.shardId = shardId;
     }
 

--- a/src/main/java/org/elasticsearch/action/support/broadcast/TransportBroadcastAction.java
+++ b/src/main/java/org/elasticsearch/action/support/broadcast/TransportBroadcastAction.java
@@ -43,7 +43,7 @@ import java.util.concurrent.atomic.AtomicReferenceArray;
 /**
  *
  */
-public abstract class TransportBroadcastOperationAction<Request extends BroadcastOperationRequest, Response extends BroadcastOperationResponse, ShardRequest extends BroadcastShardOperationRequest, ShardResponse extends BroadcastShardOperationResponse>
+public abstract class TransportBroadcastAction<Request extends BroadcastRequest, Response extends BroadcastResponse, ShardRequest extends BroadcastShardRequest, ShardResponse extends BroadcastShardResponse>
         extends HandledTransportAction<Request, Response> {
 
     protected final ThreadPool threadPool;
@@ -52,8 +52,8 @@ public abstract class TransportBroadcastOperationAction<Request extends Broadcas
 
     final String transportShardAction;
 
-    protected TransportBroadcastOperationAction(Settings settings, String actionName, ThreadPool threadPool, ClusterService clusterService, TransportService transportService, ActionFilters actionFilters,
-                                                Class<Request> request, Class<ShardRequest> shardRequest, String shardExecutor) {
+    protected TransportBroadcastAction(Settings settings, String actionName, ThreadPool threadPool, ClusterService clusterService, TransportService transportService, ActionFilters actionFilters,
+                                       Class<Request> request, Class<ShardRequest> shardRequest, String shardExecutor) {
         super(settings, actionName, threadPool, transportService, actionFilters, request);
         this.clusterService = clusterService;
         this.transportService = transportService;

--- a/src/main/java/org/elasticsearch/action/support/master/AcknowledgedRequest.java
+++ b/src/main/java/org/elasticsearch/action/support/master/AcknowledgedRequest.java
@@ -33,7 +33,7 @@ import static org.elasticsearch.common.unit.TimeValue.timeValueSeconds;
  * Abstract class that allows to mark action requests that support acknowledgements.
  * Facilitates consistency across different api.
  */
-public abstract class AcknowledgedRequest<T extends MasterNodeOperationRequest> extends MasterNodeOperationRequest<T> implements AckedRequest {
+public abstract class AcknowledgedRequest<T extends MasterNodeRequest> extends MasterNodeRequest<T> implements AckedRequest {
 
     public static final TimeValue DEFAULT_ACK_TIMEOUT = timeValueSeconds(30);
 

--- a/src/main/java/org/elasticsearch/action/support/master/MasterNodeOperationRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/support/master/MasterNodeOperationRequestBuilder.java
@@ -22,15 +22,13 @@ package org.elasticsearch.action.support.master;
 import org.elasticsearch.action.Action;
 import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.ActionResponse;
-import org.elasticsearch.client.ClusterAdminClient;
 import org.elasticsearch.client.ElasticsearchClient;
-import org.elasticsearch.client.IndicesAdminClient;
 import org.elasticsearch.common.unit.TimeValue;
 
 /**
  * Base request builder for master node operations
  */
-public abstract class MasterNodeOperationRequestBuilder<Request extends MasterNodeOperationRequest<Request>, Response extends ActionResponse, RequestBuilder extends MasterNodeOperationRequestBuilder<Request, Response, RequestBuilder>>
+public abstract class MasterNodeOperationRequestBuilder<Request extends MasterNodeRequest<Request>, Response extends ActionResponse, RequestBuilder extends MasterNodeOperationRequestBuilder<Request, Response, RequestBuilder>>
         extends ActionRequestBuilder<Request, Response, RequestBuilder> {
 
     protected MasterNodeOperationRequestBuilder(ElasticsearchClient client, Action<Request, Response, RequestBuilder> action, Request request) {

--- a/src/main/java/org/elasticsearch/action/support/master/MasterNodeReadOperationRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/support/master/MasterNodeReadOperationRequestBuilder.java
@@ -21,14 +21,12 @@ package org.elasticsearch.action.support.master;
 
 import org.elasticsearch.action.Action;
 import org.elasticsearch.action.ActionResponse;
-import org.elasticsearch.client.ClusterAdminClient;
 import org.elasticsearch.client.ElasticsearchClient;
-import org.elasticsearch.client.IndicesAdminClient;
 
 /**
  * Base request builder for master node read operations that can be executed on the local node as well
  */
-public abstract class MasterNodeReadOperationRequestBuilder<Request extends MasterNodeReadOperationRequest<Request>, Response extends ActionResponse, RequestBuilder extends MasterNodeReadOperationRequestBuilder<Request, Response, RequestBuilder>>
+public abstract class MasterNodeReadOperationRequestBuilder<Request extends MasterNodeReadRequest<Request>, Response extends ActionResponse, RequestBuilder extends MasterNodeReadOperationRequestBuilder<Request, Response, RequestBuilder>>
         extends MasterNodeOperationRequestBuilder<Request, Response, RequestBuilder> {
 
     protected MasterNodeReadOperationRequestBuilder(ElasticsearchClient client, Action<Request, Response, RequestBuilder> action, Request request) {

--- a/src/main/java/org/elasticsearch/action/support/master/MasterNodeReadRequest.java
+++ b/src/main/java/org/elasticsearch/action/support/master/MasterNodeReadRequest.java
@@ -17,39 +17,39 @@
  * under the License.
  */
 
-package org.elasticsearch.action.support.nodes;
+package org.elasticsearch.action.support.master;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.transport.TransportRequest;
 
 import java.io.IOException;
 
 /**
- *
+ * Base request for master based read operations that allows to read the cluster state from the local node if needed
  */
-public abstract class NodeOperationRequest extends TransportRequest {
+public abstract class MasterNodeReadRequest<T extends MasterNodeReadRequest> extends MasterNodeRequest<T> {
 
-    private String nodeId;
+    protected boolean local = false;
 
-    protected NodeOperationRequest() {
-
+    @SuppressWarnings("unchecked")
+    public final T local(boolean local) {
+        this.local = local;
+        return (T) this;
     }
 
-    protected NodeOperationRequest(NodesOperationRequest request, String nodeId) {
-        super(request);
-        this.nodeId = nodeId;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        nodeId = in.readString();
+    public final boolean local() {
+        return local;
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeString(nodeId);
+        out.writeBoolean(local);
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+        local = in.readBoolean();
     }
 }

--- a/src/main/java/org/elasticsearch/action/support/master/MasterNodeRequest.java
+++ b/src/main/java/org/elasticsearch/action/support/master/MasterNodeRequest.java
@@ -29,17 +29,17 @@ import java.io.IOException;
 /**
  * A based request for master based operation.
  */
-public abstract class MasterNodeOperationRequest<T extends MasterNodeOperationRequest> extends ActionRequest<T> {
+public abstract class MasterNodeRequest<T extends MasterNodeRequest> extends ActionRequest<T> {
 
     public static final TimeValue DEFAULT_MASTER_NODE_TIMEOUT = TimeValue.timeValueSeconds(30);
 
     protected TimeValue masterNodeTimeout = DEFAULT_MASTER_NODE_TIMEOUT;
 
-    protected MasterNodeOperationRequest() {
+    protected MasterNodeRequest() {
 
     }
 
-    protected MasterNodeOperationRequest(ActionRequest request) {
+    protected MasterNodeRequest(ActionRequest request) {
         super(request);
     }
 

--- a/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeAction.java
+++ b/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeAction.java
@@ -36,20 +36,23 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.discovery.MasterNotDiscoveredException;
 import org.elasticsearch.node.NodeClosedException;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.transport.*;
+import org.elasticsearch.transport.BaseTransportResponseHandler;
+import org.elasticsearch.transport.ConnectTransportException;
+import org.elasticsearch.transport.TransportException;
+import org.elasticsearch.transport.TransportService;
 
 /**
  * A base class for operations that needs to be performed on the master node.
  */
-public abstract class TransportMasterNodeOperationAction<Request extends MasterNodeOperationRequest, Response extends ActionResponse> extends HandledTransportAction<Request, Response> {
+public abstract class TransportMasterNodeAction<Request extends MasterNodeRequest, Response extends ActionResponse> extends HandledTransportAction<Request, Response> {
 
     protected final TransportService transportService;
     protected final ClusterService clusterService;
 
     final String executor;
 
-    protected TransportMasterNodeOperationAction(Settings settings, String actionName, TransportService transportService, ClusterService clusterService, ThreadPool threadPool, ActionFilters actionFilters,
-                                                 Class<Request> request) {
+    protected TransportMasterNodeAction(Settings settings, String actionName, TransportService transportService, ClusterService clusterService, ThreadPool threadPool, ActionFilters actionFilters,
+                                        Class<Request> request) {
         super(settings, actionName, threadPool, transportService, actionFilters, request);
         this.transportService = transportService;
         this.clusterService = clusterService;

--- a/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeReadAction.java
+++ b/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeReadAction.java
@@ -30,13 +30,13 @@ import org.elasticsearch.transport.TransportService;
  * A base class for read operations that needs to be performed on the master node.
  * Can also be executed on the local node if needed.
  */
-public abstract class TransportMasterNodeReadOperationAction<Request extends MasterNodeReadOperationRequest, Response extends ActionResponse> extends TransportMasterNodeOperationAction<Request, Response> {
+public abstract class TransportMasterNodeReadAction<Request extends MasterNodeReadRequest, Response extends ActionResponse> extends TransportMasterNodeAction<Request, Response> {
 
     public static final String FORCE_LOCAL_SETTING = "action.master.force_local";
 
     private Boolean forceLocal;
 
-    protected TransportMasterNodeReadOperationAction(Settings settings, String actionName, TransportService transportService, ClusterService clusterService, ThreadPool threadPool, ActionFilters actionFilters, Class<Request> request) {
+    protected TransportMasterNodeReadAction(Settings settings, String actionName, TransportService transportService, ClusterService clusterService, ThreadPool threadPool, ActionFilters actionFilters, Class<Request> request) {
         super(settings, actionName, transportService, clusterService, threadPool, actionFilters,request);
         this.forceLocal = settings.getAsBoolean(FORCE_LOCAL_SETTING, null);
     }

--- a/src/main/java/org/elasticsearch/action/support/master/info/ClusterInfoRequest.java
+++ b/src/main/java/org/elasticsearch/action/support/master/info/ClusterInfoRequest.java
@@ -21,7 +21,7 @@ package org.elasticsearch.action.support.master.info;
 
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.action.support.master.MasterNodeReadOperationRequest;
+import org.elasticsearch.action.support.master.MasterNodeReadRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -30,7 +30,7 @@ import java.io.IOException;
 
 /**
  */
-public abstract class ClusterInfoRequest<T extends ClusterInfoRequest> extends MasterNodeReadOperationRequest<T> implements IndicesRequest.Replaceable {
+public abstract class ClusterInfoRequest<T extends ClusterInfoRequest> extends MasterNodeReadRequest<T> implements IndicesRequest.Replaceable {
 
     private String[] indices = Strings.EMPTY_ARRAY;
     private String[] types = Strings.EMPTY_ARRAY;

--- a/src/main/java/org/elasticsearch/action/support/master/info/TransportClusterInfoAction.java
+++ b/src/main/java/org/elasticsearch/action/support/master/info/TransportClusterInfoAction.java
@@ -21,7 +21,7 @@ package org.elasticsearch.action.support.master.info;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.master.TransportMasterNodeReadOperationAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeReadAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.common.settings.Settings;
@@ -30,7 +30,7 @@ import org.elasticsearch.transport.TransportService;
 
 /**
  */
-public abstract class TransportClusterInfoAction<Request extends ClusterInfoRequest, Response extends ActionResponse> extends TransportMasterNodeReadOperationAction<Request, Response> {
+public abstract class TransportClusterInfoAction<Request extends ClusterInfoRequest, Response extends ActionResponse> extends TransportMasterNodeReadAction<Request, Response> {
 
     public TransportClusterInfoAction(Settings settings, String actionName, TransportService transportService, ClusterService clusterService, ThreadPool threadPool, ActionFilters actionFilters, Class<Request> request) {
         super(settings, actionName, transportService, clusterService, threadPool, actionFilters, request);

--- a/src/main/java/org/elasticsearch/action/support/nodes/BaseNodeRequest.java
+++ b/src/main/java/org/elasticsearch/action/support/nodes/BaseNodeRequest.java
@@ -17,40 +17,39 @@
  * under the License.
  */
 
-package org.elasticsearch.action.support.master;
+package org.elasticsearch.action.support.nodes;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.transport.TransportRequest;
 
 import java.io.IOException;
 
 /**
- * Base request for master based read operations that allows to read the cluster state from the local node if needed
+ *
  */
-public abstract class MasterNodeReadOperationRequest<T extends MasterNodeReadOperationRequest> extends MasterNodeOperationRequest<T> {
+public abstract class BaseNodeRequest extends TransportRequest {
 
-    protected boolean local = false;
+    private String nodeId;
 
-    @SuppressWarnings("unchecked")
-    public final T local(boolean local) {
-        this.local = local;
-        return (T) this;
+    protected BaseNodeRequest() {
+
     }
 
-    public final boolean local() {
-        return local;
-    }
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
-        out.writeBoolean(local);
+    protected BaseNodeRequest(BaseNodesRequest request, String nodeId) {
+        super(request);
+        this.nodeId = nodeId;
     }
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        local = in.readBoolean();
+        nodeId = in.readString();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(nodeId);
     }
 }

--- a/src/main/java/org/elasticsearch/action/support/nodes/BaseNodeResponse.java
+++ b/src/main/java/org/elasticsearch/action/support/nodes/BaseNodeResponse.java
@@ -29,14 +29,14 @@ import java.io.IOException;
 /**
  * A base class for node level operations.
  */
-public abstract class NodeOperationResponse extends TransportResponse {
+public abstract class BaseNodeResponse extends TransportResponse {
 
     private DiscoveryNode node;
 
-    protected NodeOperationResponse() {
+    protected BaseNodeResponse() {
     }
 
-    protected NodeOperationResponse(DiscoveryNode node) {
+    protected BaseNodeResponse(DiscoveryNode node) {
         assert node != null;
         this.node = node;
     }

--- a/src/main/java/org/elasticsearch/action/support/nodes/BaseNodesRequest.java
+++ b/src/main/java/org/elasticsearch/action/support/nodes/BaseNodesRequest.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 /**
  *
  */
-public abstract class NodesOperationRequest<T extends NodesOperationRequest> extends ActionRequest<T> {
+public abstract class BaseNodesRequest<T extends BaseNodesRequest> extends ActionRequest<T> {
 
     public static String[] ALL_NODES = Strings.EMPTY_ARRAY;
 
@@ -39,16 +39,16 @@ public abstract class NodesOperationRequest<T extends NodesOperationRequest> ext
 
     private TimeValue timeout;
 
-    protected NodesOperationRequest() {
+    protected BaseNodesRequest() {
 
     }
 
-    protected NodesOperationRequest(ActionRequest request, String... nodesIds) {
+    protected BaseNodesRequest(ActionRequest request, String... nodesIds) {
         super(request);
         this.nodesIds = nodesIds;
     }
 
-    protected NodesOperationRequest(String... nodesIds) {
+    protected BaseNodesRequest(String... nodesIds) {
         this.nodesIds = nodesIds;
     }
 

--- a/src/main/java/org/elasticsearch/action/support/nodes/BaseNodesResponse.java
+++ b/src/main/java/org/elasticsearch/action/support/nodes/BaseNodesResponse.java
@@ -34,16 +34,16 @@ import java.util.Map;
 /**
  *
  */
-public abstract class NodesOperationResponse<NodeResponse extends NodeOperationResponse> extends ActionResponse implements Iterable<NodeResponse> {
+public abstract class BaseNodesResponse<TNodeResponse extends BaseNodeResponse> extends ActionResponse implements Iterable<TNodeResponse> {
 
     private ClusterName clusterName;
-    protected NodeResponse[] nodes;
-    private Map<String, NodeResponse> nodesMap;
+    protected TNodeResponse[] nodes;
+    private Map<String, TNodeResponse> nodesMap;
 
-    protected NodesOperationResponse() {
+    protected BaseNodesResponse() {
     }
 
-    protected NodesOperationResponse(ClusterName clusterName, NodeResponse[] nodes) {
+    protected BaseNodesResponse(ClusterName clusterName, TNodeResponse[] nodes) {
         this.clusterName = clusterName;
         this.nodes = nodes;
     }
@@ -64,23 +64,23 @@ public abstract class NodesOperationResponse<NodeResponse extends NodeOperationR
         return this.clusterName.value();
     }
 
-    public NodeResponse[] getNodes() {
+    public TNodeResponse[] getNodes() {
         return nodes;
     }
 
-    public NodeResponse getAt(int position) {
+    public TNodeResponse getAt(int position) {
         return nodes[position];
     }
 
     @Override
-    public Iterator<NodeResponse> iterator() {
+    public Iterator<TNodeResponse> iterator() {
         return getNodesMap().values().iterator();
     }
 
-    public Map<String, NodeResponse> getNodesMap() {
+    public Map<String, TNodeResponse> getNodesMap() {
         if (nodesMap == null) {
             nodesMap = Maps.newHashMap();
-            for (NodeResponse nodeResponse : nodes) {
+            for (TNodeResponse nodeResponse : nodes) {
                 nodesMap.put(nodeResponse.getNode().id(), nodeResponse);
             }
         }

--- a/src/main/java/org/elasticsearch/action/support/nodes/NodesOperationRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/support/nodes/NodesOperationRequestBuilder.java
@@ -26,7 +26,7 @@ import org.elasticsearch.common.unit.TimeValue;
 
 /**
  */
-public abstract class NodesOperationRequestBuilder<Request extends NodesOperationRequest<Request>, Response extends NodesOperationResponse, RequestBuilder extends NodesOperationRequestBuilder<Request, Response, RequestBuilder>>
+public abstract class NodesOperationRequestBuilder<Request extends BaseNodesRequest<Request>, Response extends BaseNodesResponse, RequestBuilder extends NodesOperationRequestBuilder<Request, Response, RequestBuilder>>
         extends ActionRequestBuilder<Request, Response, RequestBuilder> {
 
     protected NodesOperationRequestBuilder(ElasticsearchClient client, Action<Request, Response, RequestBuilder> action, Request request) {

--- a/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesAction.java
+++ b/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesAction.java
@@ -39,7 +39,7 @@ import java.util.concurrent.atomic.AtomicReferenceArray;
 /**
  *
  */
-public abstract class TransportNodesOperationAction<Request extends NodesOperationRequest, Response extends NodesOperationResponse, NodeRequest extends NodeOperationRequest, NodeResponse extends NodeOperationResponse> extends HandledTransportAction<Request, Response> {
+public abstract class TransportNodesAction<NodesRequest extends BaseNodesRequest, NodesResponse extends BaseNodesResponse, NodeRequest extends BaseNodeRequest, NodeResponse extends BaseNodeResponse> extends HandledTransportAction<NodesRequest, NodesResponse> {
 
     protected final ClusterName clusterName;
     protected final ClusterService clusterService;
@@ -47,9 +47,9 @@ public abstract class TransportNodesOperationAction<Request extends NodesOperati
 
     final String transportNodeAction;
 
-    protected TransportNodesOperationAction(Settings settings, String actionName, ClusterName clusterName, ThreadPool threadPool,
-                                            ClusterService clusterService, TransportService transportService, ActionFilters actionFilters,
-                                            Class<Request> request, Class<NodeRequest> nodeRequest, String nodeExecutor) {
+    protected TransportNodesAction(Settings settings, String actionName, ClusterName clusterName, ThreadPool threadPool,
+                                   ClusterService clusterService, TransportService transportService, ActionFilters actionFilters,
+                                   Class<NodesRequest> request, Class<NodeRequest> nodeRequest, String nodeExecutor) {
         super(settings, actionName, threadPool, transportService, actionFilters, request);
         this.clusterName = clusterName;
         this.clusterService = clusterService;
@@ -61,7 +61,7 @@ public abstract class TransportNodesOperationAction<Request extends NodesOperati
     }
 
     @Override
-    protected void doExecute(Request request, ActionListener<Response> listener) {
+    protected void doExecute(NodesRequest request, ActionListener<NodesResponse> listener) {
         new AsyncAction(request, listener).start();
     }
 
@@ -69,9 +69,9 @@ public abstract class TransportNodesOperationAction<Request extends NodesOperati
         return false;
     }
 
-    protected abstract Response newResponse(Request request, AtomicReferenceArray nodesResponses);
+    protected abstract NodesResponse newResponse(NodesRequest request, AtomicReferenceArray nodesResponses);
 
-    protected abstract NodeRequest newNodeRequest(String nodeId, Request request);
+    protected abstract NodeRequest newNodeRequest(String nodeId, NodesRequest request);
 
     protected abstract NodeResponse newNodeResponse();
 
@@ -85,14 +85,14 @@ public abstract class TransportNodesOperationAction<Request extends NodesOperati
 
     private class AsyncAction {
 
-        private final Request request;
+        private final NodesRequest request;
         private final String[] nodesIds;
-        private final ActionListener<Response> listener;
+        private final ActionListener<NodesResponse> listener;
         private final ClusterState clusterState;
         private final AtomicReferenceArray<Object> responses;
         private final AtomicInteger counter = new AtomicInteger();
 
-        private AsyncAction(Request request, ActionListener<Response> listener) {
+        private AsyncAction(NodesRequest request, ActionListener<NodesResponse> listener) {
             this.request = request;
             this.listener = listener;
             clusterState = clusterService.state();
@@ -179,7 +179,7 @@ public abstract class TransportNodesOperationAction<Request extends NodesOperati
         }
 
         private void finishHim() {
-            Response finalResponse;
+            NodesResponse finalResponse;
             try {
                 finalResponse = newResponse(request, responses);
             } catch (Throwable t) {

--- a/src/main/java/org/elasticsearch/action/support/single/shard/SingleShardOperationRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/support/single/shard/SingleShardOperationRequestBuilder.java
@@ -22,12 +22,11 @@ package org.elasticsearch.action.support.single.shard;
 import org.elasticsearch.action.Action;
 import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.ActionResponse;
-import org.elasticsearch.client.Client;
 import org.elasticsearch.client.ElasticsearchClient;
 
 /**
  */
-public abstract class SingleShardOperationRequestBuilder<Request extends SingleShardOperationRequest<Request>, Response extends ActionResponse, RequestBuilder extends SingleShardOperationRequestBuilder<Request, Response, RequestBuilder>>
+public abstract class SingleShardOperationRequestBuilder<Request extends SingleShardRequest<Request>, Response extends ActionResponse, RequestBuilder extends SingleShardOperationRequestBuilder<Request, Response, RequestBuilder>>
         extends ActionRequestBuilder<Request, Response, RequestBuilder> {
 
     protected SingleShardOperationRequestBuilder(ElasticsearchClient client, Action<Request, Response, RequestBuilder> action, Request request) {

--- a/src/main/java/org/elasticsearch/action/support/single/shard/SingleShardRequest.java
+++ b/src/main/java/org/elasticsearch/action/support/single/shard/SingleShardRequest.java
@@ -33,7 +33,7 @@ import java.io.IOException;
 /**
  *
  */
-public abstract class SingleShardOperationRequest<T extends SingleShardOperationRequest> extends ActionRequest<T> implements IndicesRequest {
+public abstract class SingleShardRequest<T extends SingleShardRequest> extends ActionRequest<T> implements IndicesRequest {
 
     ShardId internalShardId;
 
@@ -41,18 +41,18 @@ public abstract class SingleShardOperationRequest<T extends SingleShardOperation
     public static final IndicesOptions INDICES_OPTIONS = IndicesOptions.strictSingleIndexNoExpandForbidClosed();
     private boolean threadedOperation = true;
 
-    protected SingleShardOperationRequest() {
+    protected SingleShardRequest() {
     }
 
-    protected SingleShardOperationRequest(String index) {
+    protected SingleShardRequest(String index) {
         this.index = index;
     }
 
-    protected SingleShardOperationRequest(ActionRequest request) {
+    protected SingleShardRequest(ActionRequest request) {
         super(request);
     }
 
-    protected SingleShardOperationRequest(ActionRequest request, String index) {
+    protected SingleShardRequest(ActionRequest request, String index) {
         super(request);
         this.index = index;
     }

--- a/src/main/java/org/elasticsearch/action/support/single/shard/TransportSingleShardAction.java
+++ b/src/main/java/org/elasticsearch/action/support/single/shard/TransportSingleShardAction.java
@@ -44,7 +44,7 @@ import static org.elasticsearch.action.support.TransportActions.isShardNotAvaila
 /**
  * A base class for single shard read operations.
  */
-public abstract class TransportShardSingleOperationAction<Request extends SingleShardOperationRequest, Response extends ActionResponse> extends TransportAction<Request, Response> {
+public abstract class TransportSingleShardAction<Request extends SingleShardRequest, Response extends ActionResponse> extends TransportAction<Request, Response> {
 
     protected final ClusterService clusterService;
 
@@ -53,8 +53,8 @@ public abstract class TransportShardSingleOperationAction<Request extends Single
     final String transportShardAction;
     final String executor;
 
-    protected TransportShardSingleOperationAction(Settings settings, String actionName, ThreadPool threadPool, ClusterService clusterService, TransportService transportService, ActionFilters actionFilters,
-                                                  Class<Request> request, String executor) {
+    protected TransportSingleShardAction(Settings settings, String actionName, ThreadPool threadPool, ClusterService clusterService, TransportService transportService, ActionFilters actionFilters,
+                                         Class<Request> request, String executor) {
         super(settings, actionName, threadPool, actionFilters);
         this.clusterService = clusterService;
         this.transportService = transportService;

--- a/src/main/java/org/elasticsearch/action/termvectors/MultiTermVectorsShardRequest.java
+++ b/src/main/java/org/elasticsearch/action/termvectors/MultiTermVectorsShardRequest.java
@@ -20,7 +20,7 @@
 package org.elasticsearch.action.termvectors;
 
 import com.carrotsearch.hppc.IntArrayList;
-import org.elasticsearch.action.support.single.shard.SingleShardOperationRequest;
+import org.elasticsearch.action.support.single.shard.SingleShardRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -28,7 +28,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-public class MultiTermVectorsShardRequest extends SingleShardOperationRequest<MultiTermVectorsShardRequest> {
+public class MultiTermVectorsShardRequest extends SingleShardRequest<MultiTermVectorsShardRequest> {
 
     private int shardId;
     private String preference;

--- a/src/main/java/org/elasticsearch/action/termvectors/TermVectorsRequest.java
+++ b/src/main/java/org/elasticsearch/action/termvectors/TermVectorsRequest.java
@@ -27,7 +27,7 @@ import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.DocumentRequest;
 import org.elasticsearch.action.ValidateActions;
 import org.elasticsearch.action.get.MultiGetRequest;
-import org.elasticsearch.action.support.single.shard.SingleShardOperationRequest;
+import org.elasticsearch.action.support.single.shard.SingleShardRequest;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -50,7 +50,7 @@ import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
  * Note, the {@link #index()}, {@link #type(String)} and {@link #id(String)} are
  * required.
  */
-public class TermVectorsRequest extends SingleShardOperationRequest<TermVectorsRequest> implements DocumentRequest<TermVectorsRequest> {
+public class TermVectorsRequest extends SingleShardRequest<TermVectorsRequest> implements DocumentRequest<TermVectorsRequest> {
 
     private String type;
 

--- a/src/main/java/org/elasticsearch/action/termvectors/TransportShardMultiTermsVectorAction.java
+++ b/src/main/java/org/elasticsearch/action/termvectors/TransportShardMultiTermsVectorAction.java
@@ -23,7 +23,7 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.TransportActions;
-import org.elasticsearch.action.support.single.shard.TransportShardSingleOperationAction;
+import org.elasticsearch.action.support.single.shard.TransportSingleShardAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.routing.ShardIterator;
@@ -36,7 +36,7 @@ import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
-public class TransportShardMultiTermsVectorAction extends TransportShardSingleOperationAction<MultiTermVectorsShardRequest, MultiTermVectorsShardResponse> {
+public class TransportShardMultiTermsVectorAction extends TransportSingleShardAction<MultiTermVectorsShardRequest, MultiTermVectorsShardResponse> {
 
     private final IndicesService indicesService;
 

--- a/src/main/java/org/elasticsearch/action/termvectors/TransportTermVectorsAction.java
+++ b/src/main/java/org/elasticsearch/action/termvectors/TransportTermVectorsAction.java
@@ -22,15 +22,15 @@ package org.elasticsearch.action.termvectors;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.RoutingMissingException;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.single.shard.TransportShardSingleOperationAction;
+import org.elasticsearch.action.support.single.shard.TransportSingleShardAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.routing.ShardIterator;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexService;
-import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -38,7 +38,7 @@ import org.elasticsearch.transport.TransportService;
 /**
  * Performs the get operation.
  */
-public class TransportTermVectorsAction extends TransportShardSingleOperationAction<TermVectorsRequest, TermVectorsResponse> {
+public class TransportTermVectorsAction extends TransportSingleShardAction<TermVectorsRequest, TermVectorsResponse> {
 
     private final IndicesService indicesService;
 

--- a/src/main/java/org/elasticsearch/action/termvectors/dfs/DfsOnlyRequest.java
+++ b/src/main/java/org/elasticsearch/action/termvectors/dfs/DfsOnlyRequest.java
@@ -24,7 +24,7 @@ import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.search.SearchRequest;
-import org.elasticsearch.action.support.broadcast.BroadcastOperationRequest;
+import org.elasticsearch.action.support.broadcast.BroadcastRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentHelper;
@@ -38,7 +38,7 @@ import java.util.Set;
 
 import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
 
-public class DfsOnlyRequest extends BroadcastOperationRequest<DfsOnlyRequest> {
+public class DfsOnlyRequest extends BroadcastRequest<DfsOnlyRequest> {
 
     private SearchRequest searchRequest = new SearchRequest();
 

--- a/src/main/java/org/elasticsearch/action/termvectors/dfs/DfsOnlyResponse.java
+++ b/src/main/java/org/elasticsearch/action/termvectors/dfs/DfsOnlyResponse.java
@@ -20,7 +20,7 @@
 package org.elasticsearch.action.termvectors.dfs;
 
 import org.elasticsearch.action.ShardOperationFailedException;
-import org.elasticsearch.action.support.broadcast.BroadcastOperationResponse;
+import org.elasticsearch.action.support.broadcast.BroadcastResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.unit.TimeValue;
@@ -32,7 +32,7 @@ import java.util.List;
 /**
  * A response of a dfs only request.
  */
-public class DfsOnlyResponse extends BroadcastOperationResponse {
+public class DfsOnlyResponse extends BroadcastResponse {
 
     private AggregatedDfs dfs;
     private long tookInMillis;

--- a/src/main/java/org/elasticsearch/action/termvectors/dfs/ShardDfsOnlyRequest.java
+++ b/src/main/java/org/elasticsearch/action/termvectors/dfs/ShardDfsOnlyRequest.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.action.termvectors.dfs;
 
-import org.elasticsearch.action.support.broadcast.BroadcastShardOperationRequest;
+import org.elasticsearch.action.support.broadcast.BroadcastShardRequest;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -29,7 +29,7 @@ import org.elasticsearch.search.internal.ShardSearchTransportRequest;
 
 import java.io.IOException;
 
-class ShardDfsOnlyRequest extends BroadcastShardOperationRequest {
+class ShardDfsOnlyRequest extends BroadcastShardRequest {
 
     private ShardSearchTransportRequest shardSearchRequest = new ShardSearchTransportRequest();
 

--- a/src/main/java/org/elasticsearch/action/termvectors/dfs/ShardDfsOnlyResponse.java
+++ b/src/main/java/org/elasticsearch/action/termvectors/dfs/ShardDfsOnlyResponse.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.action.termvectors.dfs;
 
-import org.elasticsearch.action.support.broadcast.BroadcastShardOperationResponse;
+import org.elasticsearch.action.support.broadcast.BroadcastShardResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.shard.ShardId;
@@ -30,7 +30,7 @@ import java.io.IOException;
 /**
  *
  */
-class ShardDfsOnlyResponse extends BroadcastShardOperationResponse {
+class ShardDfsOnlyResponse extends BroadcastShardResponse {
 
     private DfsSearchResult dfsSearchResult = new DfsSearchResult();
 

--- a/src/main/java/org/elasticsearch/action/termvectors/dfs/TransportDfsOnlyAction.java
+++ b/src/main/java/org/elasticsearch/action/termvectors/dfs/TransportDfsOnlyAction.java
@@ -24,7 +24,7 @@ import org.elasticsearch.action.ShardOperationFailedException;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.DefaultShardOperationFailedException;
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationFailedException;
-import org.elasticsearch.action.support.broadcast.TransportBroadcastOperationAction;
+import org.elasticsearch.action.support.broadcast.TransportBroadcastAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
@@ -51,7 +51,7 @@ import static com.google.common.collect.Lists.newArrayList;
 /**
  * Get the dfs only with no fetch phase. This is for internal use only.
  */
-public class TransportDfsOnlyAction extends TransportBroadcastOperationAction<DfsOnlyRequest, DfsOnlyResponse, ShardDfsOnlyRequest, ShardDfsOnlyResponse> {
+public class TransportDfsOnlyAction extends TransportBroadcastAction<DfsOnlyRequest, DfsOnlyResponse, ShardDfsOnlyRequest, ShardDfsOnlyResponse> {
 
     public static final String NAME = "internal:index/termvectors/dfs";
 

--- a/src/main/java/org/elasticsearch/cluster/metadata/MetaDataDeleteIndexService.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MetaDataDeleteIndexService.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.cluster.metadata;
 
-import org.elasticsearch.action.support.master.MasterNodeOperationRequest;
+import org.elasticsearch.action.support.master.MasterNodeRequest;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.TimeoutClusterStateUpdateTask;
@@ -223,7 +223,7 @@ public class MetaDataDeleteIndexService extends AbstractComponent {
         final String index;
 
         TimeValue timeout = TimeValue.timeValueSeconds(10);
-        TimeValue masterTimeout = MasterNodeOperationRequest.DEFAULT_MASTER_NODE_TIMEOUT;
+        TimeValue masterTimeout = MasterNodeRequest.DEFAULT_MASTER_NODE_TIMEOUT;
 
         public Request(String index) {
             this.index = index;

--- a/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexTemplateService.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexTemplateService.java
@@ -23,7 +23,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.elasticsearch.action.admin.indices.alias.Alias;
-import org.elasticsearch.action.support.master.MasterNodeOperationRequest;
+import org.elasticsearch.action.support.master.MasterNodeRequest;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.TimeoutClusterStateUpdateTask;
@@ -231,7 +231,7 @@ public class MetaDataIndexTemplateService extends AbstractComponent {
         List<Alias> aliases = Lists.newArrayList();
         Map<String, IndexMetaData.Custom> customs = Maps.newHashMap();
 
-        TimeValue masterTimeout = MasterNodeOperationRequest.DEFAULT_MASTER_NODE_TIMEOUT;
+        TimeValue masterTimeout = MasterNodeRequest.DEFAULT_MASTER_NODE_TIMEOUT;
 
         public PutRequest(String cause, String name) {
             this.cause = cause;
@@ -304,7 +304,7 @@ public class MetaDataIndexTemplateService extends AbstractComponent {
 
     public static class RemoveRequest {
         final String name;
-        TimeValue masterTimeout = MasterNodeOperationRequest.DEFAULT_MASTER_NODE_TIMEOUT;
+        TimeValue masterTimeout = MasterNodeRequest.DEFAULT_MASTER_NODE_TIMEOUT;
 
         public RemoveRequest(String name) {
             this.name = name;

--- a/src/main/java/org/elasticsearch/gateway/GatewayAllocator.java
+++ b/src/main/java/org/elasticsearch/gateway/GatewayAllocator.java
@@ -25,8 +25,8 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.apache.lucene.util.CollectionUtil;
-import org.elasticsearch.action.support.nodes.NodeOperationResponse;
-import org.elasticsearch.action.support.nodes.NodesOperationResponse;
+import org.elasticsearch.action.support.nodes.BaseNodeResponse;
+import org.elasticsearch.action.support.nodes.BaseNodesResponse;
 import org.elasticsearch.cluster.*;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
@@ -513,12 +513,12 @@ public class GatewayAllocator extends AbstractComponent {
         return changed;
     }
 
-    static class InternalAsyncFetch<T extends NodeOperationResponse> extends AsyncShardFetch<T> {
+    static class InternalAsyncFetch<T extends BaseNodeResponse> extends AsyncShardFetch<T> {
 
         private final ClusterService clusterService;
         private final AllocationService allocationService;
 
-        public InternalAsyncFetch(ESLogger logger, String type, ShardId shardId, List<? extends NodesOperationResponse<T>, T> action,
+        public InternalAsyncFetch(ESLogger logger, String type, ShardId shardId, List<? extends BaseNodesResponse<T>, T> action,
                                   ClusterService clusterService, AllocationService allocationService) {
             super(logger, type, shardId, action);
             this.clusterService = clusterService;

--- a/src/main/java/org/elasticsearch/gateway/TransportNodesListGatewayMetaState.java
+++ b/src/main/java/org/elasticsearch/gateway/TransportNodesListGatewayMetaState.java
@@ -45,7 +45,7 @@ import java.util.concurrent.atomic.AtomicReferenceArray;
 /**
  *
  */
-public class TransportNodesListGatewayMetaState extends TransportNodesOperationAction<TransportNodesListGatewayMetaState.Request, TransportNodesListGatewayMetaState.NodesGatewayMetaState, TransportNodesListGatewayMetaState.NodeRequest, TransportNodesListGatewayMetaState.NodeGatewayMetaState> {
+public class TransportNodesListGatewayMetaState extends TransportNodesAction<TransportNodesListGatewayMetaState.Request, TransportNodesListGatewayMetaState.NodesGatewayMetaState, TransportNodesListGatewayMetaState.NodeRequest, TransportNodesListGatewayMetaState.NodeGatewayMetaState> {
 
     public static final String ACTION_NAME = "internal:gateway/local/meta_state";
 
@@ -113,7 +113,7 @@ public class TransportNodesListGatewayMetaState extends TransportNodesOperationA
         return true;
     }
 
-    static class Request extends NodesOperationRequest<Request> {
+    static class Request extends BaseNodesRequest<Request> {
 
         public Request() {
         }
@@ -133,7 +133,7 @@ public class TransportNodesListGatewayMetaState extends TransportNodesOperationA
         }
     }
 
-    public static class NodesGatewayMetaState extends NodesOperationResponse<NodeGatewayMetaState> {
+    public static class NodesGatewayMetaState extends BaseNodesResponse<NodeGatewayMetaState> {
 
         private FailedNodeException[] failures;
 
@@ -170,7 +170,7 @@ public class TransportNodesListGatewayMetaState extends TransportNodesOperationA
     }
 
 
-    static class NodeRequest extends NodeOperationRequest {
+    static class NodeRequest extends BaseNodeRequest {
 
         NodeRequest() {
         }
@@ -190,7 +190,7 @@ public class TransportNodesListGatewayMetaState extends TransportNodesOperationA
         }
     }
 
-    public static class NodeGatewayMetaState extends NodeOperationResponse {
+    public static class NodeGatewayMetaState extends BaseNodeResponse {
 
         private MetaData metaData;
 

--- a/src/main/java/org/elasticsearch/gateway/TransportNodesListGatewayStartedShards.java
+++ b/src/main/java/org/elasticsearch/gateway/TransportNodesListGatewayStartedShards.java
@@ -50,7 +50,7 @@ import java.util.concurrent.atomic.AtomicReferenceArray;
  * We use this to find out which node holds the latest shard version and which of them used to be a primary in order to allocate
  * shards after node or cluster restarts.
  */
-public class TransportNodesListGatewayStartedShards extends TransportNodesOperationAction<TransportNodesListGatewayStartedShards.Request, TransportNodesListGatewayStartedShards.NodesGatewayStartedShards, TransportNodesListGatewayStartedShards.NodeRequest, TransportNodesListGatewayStartedShards.NodeGatewayStartedShards>
+public class TransportNodesListGatewayStartedShards extends TransportNodesAction<TransportNodesListGatewayStartedShards.Request, TransportNodesListGatewayStartedShards.NodesGatewayStartedShards, TransportNodesListGatewayStartedShards.NodeRequest, TransportNodesListGatewayStartedShards.NodeGatewayStartedShards>
         implements AsyncShardFetch.List<TransportNodesListGatewayStartedShards.NodesGatewayStartedShards, TransportNodesListGatewayStartedShards.NodeGatewayStartedShards> {
 
     public static final String ACTION_NAME = "internal:gateway/local/started_shards";
@@ -148,7 +148,7 @@ public class TransportNodesListGatewayStartedShards extends TransportNodesOperat
         return true;
     }
 
-    static class Request extends NodesOperationRequest<Request> {
+    static class Request extends BaseNodesRequest<Request> {
 
         private ShardId shardId;
         private String indexUUID;
@@ -186,7 +186,7 @@ public class TransportNodesListGatewayStartedShards extends TransportNodesOperat
         }
     }
 
-    public static class NodesGatewayStartedShards extends NodesOperationResponse<NodeGatewayStartedShards> {
+    public static class NodesGatewayStartedShards extends BaseNodesResponse<NodeGatewayStartedShards> {
 
         private FailedNodeException[] failures;
 
@@ -221,7 +221,7 @@ public class TransportNodesListGatewayStartedShards extends TransportNodesOperat
     }
 
 
-    static class NodeRequest extends NodeOperationRequest {
+    static class NodeRequest extends BaseNodeRequest {
 
         private ShardId shardId;
         private String indexUUID;
@@ -258,7 +258,7 @@ public class TransportNodesListGatewayStartedShards extends TransportNodesOperat
         }
     }
 
-    public static class NodeGatewayStartedShards extends NodeOperationResponse {
+    public static class NodeGatewayStartedShards extends BaseNodeResponse {
 
         private long version = -1;
 

--- a/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetaData.java
+++ b/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetaData.java
@@ -58,7 +58,7 @@ import java.util.concurrent.atomic.AtomicReferenceArray;
 /**
  *
  */
-public class TransportNodesListShardStoreMetaData extends TransportNodesOperationAction<TransportNodesListShardStoreMetaData.Request, TransportNodesListShardStoreMetaData.NodesStoreFilesMetaData, TransportNodesListShardStoreMetaData.NodeRequest, TransportNodesListShardStoreMetaData.NodeStoreFilesMetaData>
+public class TransportNodesListShardStoreMetaData extends TransportNodesAction<TransportNodesListShardStoreMetaData.Request, TransportNodesListShardStoreMetaData.NodesStoreFilesMetaData, TransportNodesListShardStoreMetaData.NodeRequest, TransportNodesListShardStoreMetaData.NodeStoreFilesMetaData>
         implements AsyncShardFetch.List<TransportNodesListShardStoreMetaData.NodesStoreFilesMetaData, TransportNodesListShardStoreMetaData.NodeStoreFilesMetaData> {
 
     public static final String ACTION_NAME = "internal:cluster/nodes/indices/shard/store";
@@ -241,7 +241,7 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesOperatio
     }
 
 
-    static class Request extends NodesOperationRequest<Request> {
+    static class Request extends BaseNodesRequest<Request> {
 
         private ShardId shardId;
 
@@ -277,7 +277,7 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesOperatio
         }
     }
 
-    public static class NodesStoreFilesMetaData extends NodesOperationResponse<NodeStoreFilesMetaData> {
+    public static class NodesStoreFilesMetaData extends BaseNodesResponse<NodeStoreFilesMetaData> {
 
         private FailedNodeException[] failures;
 
@@ -314,7 +314,7 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesOperatio
     }
 
 
-    static class NodeRequest extends NodeOperationRequest {
+    static class NodeRequest extends BaseNodeRequest {
 
         private ShardId shardId;
 
@@ -344,7 +344,7 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesOperatio
         }
     }
 
-    public static class NodeStoreFilesMetaData extends NodeOperationResponse {
+    public static class NodeStoreFilesMetaData extends BaseNodeResponse {
 
         private StoreFilesMetaData storeFilesMetaData;
 

--- a/src/main/java/org/elasticsearch/rest/action/support/RestActions.java
+++ b/src/main/java/org/elasticsearch/rest/action/support/RestActions.java
@@ -22,7 +22,7 @@ package org.elasticsearch.rest.action.support;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ShardOperationFailedException;
 import org.elasticsearch.action.support.QuerySourceBuilder;
-import org.elasticsearch.action.support.broadcast.BroadcastOperationResponse;
+import org.elasticsearch.action.support.broadcast.BroadcastResponse;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.lucene.uid.Versions;
@@ -62,7 +62,7 @@ public class RestActions {
         static final XContentBuilderString FAILURES = new XContentBuilderString("failures");
     }
 
-    public static void buildBroadcastShardsHeader(XContentBuilder builder, ToXContent.Params params, BroadcastOperationResponse response) throws IOException {
+    public static void buildBroadcastShardsHeader(XContentBuilder builder, ToXContent.Params params, BroadcastResponse response) throws IOException {
         buildBroadcastShardsHeader(builder, params, response.getTotalShards(), response.getSuccessfulShards(), response.getFailedShards(), response.getShardFailures());
     }
 

--- a/src/main/java/org/elasticsearch/tribe/TribeService.java
+++ b/src/main/java/org/elasticsearch/tribe/TribeService.java
@@ -23,7 +23,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.action.support.master.TransportMasterNodeReadOperationAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeReadAction;
 import org.elasticsearch.cluster.*;
 import org.elasticsearch.cluster.block.ClusterBlock;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
@@ -99,7 +99,7 @@ public class TribeService extends AbstractLifecycleComponent<TribeService> {
         if (sb.get("cluster.name") == null) {
             sb.put("cluster.name", "tribe_" + Strings.randomBase64UUID()); // make sure it won't join other tribe nodes in the same JVM
         }
-        sb.put(TransportMasterNodeReadOperationAction.FORCE_LOCAL_SETTING, true);
+        sb.put(TransportMasterNodeReadAction.FORCE_LOCAL_SETTING, true);
         return sb.build();
     }
 

--- a/src/test/java/org/elasticsearch/action/admin/HotThreadsTest.java
+++ b/src/test/java/org/elasticsearch/action/admin/HotThreadsTest.java
@@ -32,14 +32,9 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.elasticsearch.index.query.QueryBuilders.andQuery;
-import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
-import static org.elasticsearch.index.query.QueryBuilders.notQuery;
-import static org.elasticsearch.index.query.QueryBuilders.termQuery;
+import static org.elasticsearch.index.query.QueryBuilders.*;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.Matchers.lessThan;
 
 /**
@@ -90,7 +85,7 @@ public class HotThreadsTest extends ElasticsearchIntegrationTest {
                     boolean success = false;
                     try {
                         assertThat(nodeHotThreads, notNullValue());
-                        Map<String,NodeHotThreads> nodesMap = nodeHotThreads.getNodesMap();
+                        Map<String, NodeHotThreads> nodesMap = nodeHotThreads.getNodesMap();
                         assertThat(nodesMap.size(), equalTo(cluster().size()));
                         for (NodeHotThreads ht : nodeHotThreads) {
                             assertNotNull(ht.getHotThreads());

--- a/src/test/java/org/elasticsearch/gateway/AsyncShardFetchTests.java
+++ b/src/test/java/org/elasticsearch/gateway/AsyncShardFetchTests.java
@@ -22,7 +22,7 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableSet;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.FailedNodeException;
-import org.elasticsearch.action.support.nodes.NodeOperationResponse;
+import org.elasticsearch.action.support.nodes.BaseNodeResponse;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
@@ -314,7 +314,7 @@ public class AsyncShardFetchTests extends ElasticsearchTestCase {
     }
 
 
-    static class Response extends NodeOperationResponse {
+    static class Response extends BaseNodeResponse {
 
         public Response(DiscoveryNode node) {
             super(node);

--- a/src/test/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
+++ b/src/test/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
@@ -50,7 +50,7 @@ import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.ShardSearchFailure;
-import org.elasticsearch.action.support.broadcast.BroadcastOperationResponse;
+import org.elasticsearch.action.support.broadcast.BroadcastResponse;
 import org.elasticsearch.action.support.master.AcknowledgedRequestBuilder;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.cluster.block.ClusterBlock;
@@ -152,7 +152,7 @@ public class ElasticsearchAssertions {
         }
     }
 
-    public static String formatShardStatus(BroadcastOperationResponse response) {
+    public static String formatShardStatus(BroadcastResponse response) {
         String msg = " Total shards: " + response.getTotalShards() + " Successful shards: " + response.getSuccessfulShards() + " & "
                 + response.getFailedShards() + " shard failures:";
         for (ShardOperationFailedException failure : response.getShardFailures()) {
@@ -321,12 +321,12 @@ public class ElasticsearchAssertions {
         assertVersionSerializable(percolateResponse);
     }
 
-    public static void assertNoFailures(BroadcastOperationResponse response) {
+    public static void assertNoFailures(BroadcastResponse response) {
         assertThat("Unexpected ShardFailures: " + Arrays.toString(response.getShardFailures()), response.getFailedShards(), equalTo(0));
         assertVersionSerializable(response);
     }
 
-    public static void assertAllSuccessful(BroadcastOperationResponse response) {
+    public static void assertAllSuccessful(BroadcastResponse response) {
         assertNoFailures(response);
         assertThat("Expected all shards successful but got successful [" + response.getSuccessfulShards() + "] total [" + response.getTotalShards() + "]",
                 response.getTotalShards(), equalTo(response.getSuccessfulShards()));


### PR DESCRIPTION
As a follow up to #11332, this commit simplifies more class names by remove the superfluous Operation:

TransportBroadcastOperationAction -> TransportBroadcastAction
TransportMasterNodeOperationAction -> TransportMasterNodeAction
TransportMasterNodeReadOperationAction -> TransportMasterNodeReadAction
TransportShardSingleOperationAction -> TransportSingleShardAction
