### PR TITLE
[TEST] make filter_path a default parameter in java rest runner

### DIFF
--- a/rest-api-spec/api/nodes.stats.json
+++ b/rest-api-spec/api/nodes.stats.json
@@ -56,10 +56,6 @@
           "options" : ["node", "indices", "shards"],
           "default" : "node"
         },
-        "filter_path": {
-          "type" : "list",
-          "description" : "A comma-separated list of fields to include in the returned response"
-        },
         "types" : {
           "type" : "list",
           "description" : "A comma-separated list of document types for the `indexing` index metric"

--- a/rest-api-spec/api/search.json
+++ b/rest-api-spec/api/search.json
@@ -72,10 +72,6 @@
           "type" : "boolean",
           "description" : "Specify whether query terms should be lowercased"
         },
-        "filter_path": {
-          "type" : "list",
-          "description" : "A comma-separated list of fields to include in the returned response"
-        },
         "preference": {
           "type" : "string",
           "description" : "Specify the node or shard the operation should be performed on (default: random)"


### PR DESCRIPTION
The query string `filter_path` parameter should be supported by all apis, we shouldn't need to declare it in the rest spec. Removed its declaration and made sure that the java runner still works, as it validates the params used in tests based on the ones declared in the rest spec.

I wonder how we can better test that this param is really supported across the board, as up until now we test it only in search and nodes stats.
