### PR TITLE
[maven] fix maven warnings when running assembly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,4 @@ eclipse-build
 nb-configuration.xml
 nbactions.xml
 
-/dependency-reduced-pom.xml
+dependency-reduced-pom.xml

--- a/src/main/assemblies/common-bin.xml
+++ b/src/main/assemblies/common-bin.xml
@@ -74,15 +74,15 @@
     <files>
         <file>
             <source>README.textile</source>
-            <outputDirectory>/</outputDirectory>
+            <outputDirectory></outputDirectory>
         </file>
         <file>
             <source>LICENSE.txt</source>
-            <outputDirectory>/</outputDirectory>
+            <outputDirectory></outputDirectory>
         </file>
         <file>
             <source>NOTICE.txt</source>
-            <outputDirectory>/</outputDirectory>
+            <outputDirectory></outputDirectory>
         </file>
     </files>
 </component>


### PR DESCRIPTION
- Ignore `dependency-reduced-pom.xml` even if used in submodules
- Fix maven assembly warning about using root dir …

It's a bad practice in Maven to define `/` as the output dir.
It's better to leave it empty.

See also http://stackoverflow.com/questions/28500401/maven-assembly-plugin-warning-the-assembly-descriptor-contains-a-filesystem-roo

@rmuir Wanna review it?
