### PR TITLE
Query refactoring: add utility methods to serialize/deserialize inner queries

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/QueryBuilderSerializer.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryBuilderSerializer.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query;
+
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.indices.query.IndicesQueriesRegistry;
+
+import java.io.IOException;
+
+/**
+ * Reads and writes a {@link QueryBuilder} when serialized over the wire based on its name which gets serialized
+ * before the the query itself and allows, when reading, to create the proper {@link QueryBuilder} subclass instance.
+ */
+public class QueryBuilderSerializer {
+
+    @Inject
+    static IndicesQueriesRegistry indicesQueriesRegistry;
+
+    /**
+     * Reads a {@link QueryBuilder} serialized over the wire.
+     * Depends on the {@link IndicesQueriesRegistry} being injected via guice, which happens only within nodes. The registry
+     * will be null within a transport client but that is fine given that it will only need to write queries, never read them.
+     */
+    public static QueryBuilder read(StreamInput in) throws IOException {
+        if (indicesQueriesRegistry == null) {
+            throw new IllegalStateException("unable to read query, the queries registry is null");
+        }
+        String queryId = in.readString();
+        QueryParser queryParser = indicesQueriesRegistry.queryParsers().get(queryId);
+        if (queryParser == null) {
+            throw new IllegalStateException("unable to read query, no query parser registered for [" + queryId + "]");
+        }
+        return queryParser.getBuilderPrototype().readFrom(in);
+    }
+
+    /**
+     * Writes a {@link QueryBuilder} to be serialized over the wire
+     */
+    public static void write(QueryBuilder queryBuilder, StreamOutput out) throws IOException {
+        out.writeString(queryBuilder.queryId());
+        queryBuilder.writeTo(out);
+    }
+}

--- a/src/main/java/org/elasticsearch/indices/query/IndicesQueriesModule.java
+++ b/src/main/java/org/elasticsearch/indices/query/IndicesQueriesModule.java
@@ -46,6 +46,7 @@ public class IndicesQueriesModule extends AbstractModule {
     @Override
     protected void configure() {
         bind(IndicesQueriesRegistry.class).asEagerSingleton();
+        requestStaticInjection(QueryBuilderSerializer.class);
 
         Multibinder<QueryParser> qpBinders = Multibinder.newSetBinder(binder(), QueryParser.class);
         for (Class<QueryParser> queryParser : queryParsersClasses) {

--- a/src/test/java/org/elasticsearch/index/query/QueryBuilderSerializerTests.java
+++ b/src/test/java/org/elasticsearch/index/query/QueryBuilderSerializerTests.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.common.inject.AbstractModule;
+import org.elasticsearch.common.inject.ModulesBuilder;
+import org.elasticsearch.common.inject.util.Providers;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.settings.SettingsModule;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.env.EnvironmentModule;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexNameModule;
+import org.elasticsearch.index.analysis.AnalysisModule;
+import org.elasticsearch.index.cache.IndexCacheModule;
+import org.elasticsearch.index.query.functionscore.FunctionScoreModule;
+import org.elasticsearch.index.settings.IndexSettingsModule;
+import org.elasticsearch.index.similarity.SimilarityModule;
+import org.elasticsearch.indices.breaker.CircuitBreakerService;
+import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
+import org.elasticsearch.indices.query.IndicesQueriesModule;
+import org.elasticsearch.script.ScriptModule;
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.test.VersionUtils;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.threadpool.ThreadPoolModule;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.Matchers.greaterThan;
+
+public class QueryBuilderSerializerTests extends ElasticsearchTestCase {
+
+    private ThreadPool threadPool;
+
+    @Before
+    public void setup() {
+        Settings settings = Settings.builder()
+                .put("name", "testQueryBuilderSerializerStaticInjection")
+                .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
+                .put("path.home", createTempDir()).build();
+        Index index = new Index("test");
+        new ModulesBuilder().add(
+                new EnvironmentModule(new Environment(settings)),
+                new SettingsModule(settings),
+                new ThreadPoolModule(threadPool = new ThreadPool(getClass().getName())),
+                new IndicesQueriesModule(),
+                new ScriptModule(settings),
+                new IndexSettingsModule(index, settings),
+                new IndexCacheModule(settings),
+                new AnalysisModule(settings),
+                new SimilarityModule(settings),
+                new IndexQueryParserModule(settings),
+                new IndexNameModule(index),
+                new FunctionScoreModule(),
+                new AbstractModule() {
+                    @Override
+                    protected void configure() {
+                        bind(ClusterService.class).toProvider(Providers.of((ClusterService) null));
+                        bind(CircuitBreakerService.class).to(NoneCircuitBreakerService.class);
+                    }
+                }
+        ).createInjector();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        terminate(threadPool);
+    }
+
+    @Test
+    public void testQueryBuilderSerializerStaticInjection() throws Exception {
+        assertThat(QueryBuilderSerializer.indicesQueriesRegistry, notNullValue());
+        assertThat(QueryBuilderSerializer.indicesQueriesRegistry.queryParsers().size(), greaterThan(0));
+    }
+
+    @Test
+    public void testQueryBuilderSerialization() throws IOException {
+        TermQueryBuilder termQueryBuilder = new TermQueryBuilder(randomAsciiOfLengthBetween(1, 10), randomAsciiOfLengthBetween(1, 10));
+        if (randomBoolean()) {
+            termQueryBuilder.boost(2.0f / randomIntBetween(1, 20));
+        }
+        if (randomBoolean()) {
+            termQueryBuilder.queryName(randomAsciiOfLengthBetween(1, 10));
+        }
+
+        Version version = VersionUtils.randomVersion(random());
+        BytesStreamOutput out = new BytesStreamOutput();
+        out.setVersion(version);
+        QueryBuilderSerializer.write(termQueryBuilder, out);
+        StreamInput in = StreamInput.wrap(out.bytes());
+        in.setVersion(version);
+        QueryBuilder queryBuilder = QueryBuilderSerializer.read(in);
+        assertThat(queryBuilder, equalTo((QueryBuilder)termQueryBuilder));
+    }
+}

--- a/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
+++ b/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
@@ -162,12 +162,9 @@ public class SimpleIndexQueryParserTests extends ElasticsearchSingleNodeTest {
         public String toString(String field) {
             return getClass().getSimpleName();
         }
-
     }
 
     public static class DummyQueryParser extends AbstractIndexComponent implements QueryParser {
-
-
 
         @Inject
         public DummyQueryParser(Index index, Settings indexSettings) {
@@ -182,7 +179,6 @@ public class SimpleIndexQueryParserTests extends ElasticsearchSingleNodeTest {
         @Override
         public Query parse(QueryParseContext parseContext) throws IOException, QueryParsingException {
             return fromXContent(parseContext).toQuery(parseContext);
-
         }
 
         @Override


### PR DESCRIPTION
`QueryBuilder`s can be serialized being them `Writeable`. Given that we support different types of queries, which can be nested into one another, we also have to make sure  that we read and write the name of the query before the actual query fields so that we know which instance of query we have to create when de-serializing. That is why serializing a query builder will be done by calling `QueryBuilderSerializer#write`, which will serialize the name of the query before the query itself, and reading only by calling `QueryBuilderSerializer#read`, which will lookup the query in the parsers registry, retrieve its corresponding empty builder from it (`getPrototypeBuilder`) and call `readFrom` against it, which will return a new query builder containing all the de-serialized fields. Compound queries will then have to use these methods to read and write their inner queries.

The registration of custom queries via plugin doesn't change, only the parser needs to be registered still, but it has now to implement the `getPrototypeBuilder` method too introduced with #11344, which returns an empy builder instance that can be used to de-serialize the query.

The way this was done is probably not the most elegant one, through a static injection and static `read` and `write` methods. Let's discuss if there are better ways to do it.
