### PR TITLE
ResourceWatcher: Rename settings to prevent watcher clash

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/component/AbstractComponent.java
+++ b/core/src/main/java/org/elasticsearch/common/component/AbstractComponent.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.common.component;
 
+import com.google.common.base.Strings;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
@@ -50,5 +51,23 @@ public abstract class AbstractComponent {
      */
     public final String nodeName() {
         return settings.get("name", "");
+    }
+
+    /**
+     * Checks for a deprecated setting and logs the correct alternative
+     */
+    protected void logDeprecatedSetting(String settingName, String alternativeName) {
+        if (!Strings.isNullOrEmpty(settings.get(settingName))) {
+            deprecationLogger.deprecated("Setting [{}] is deprecated, use [{}] instead", settingName, alternativeName);
+        }
+    }
+
+    /**
+     * Checks for a removed setting and logs the correct alternative
+     */
+    protected void logRemovedSetting(String settingName, String alternativeName) {
+        if (!Strings.isNullOrEmpty(settings.get(settingName))) {
+            deprecationLogger.deprecated("Setting [{}] has been removed, use [{}] instead", settingName, alternativeName);
+        }
     }
 }

--- a/core/src/main/java/org/elasticsearch/watcher/ResourceWatcherService.java
+++ b/core/src/main/java/org/elasticsearch/watcher/ResourceWatcherService.java
@@ -35,12 +35,12 @@ import java.util.concurrent.ScheduledFuture;
  *
  * Other elasticsearch services can register their resource watchers with this service using {@link #add(ResourceWatcher)}
  * method. This service will call {@link org.elasticsearch.watcher.ResourceWatcher#checkAndNotify()} method of all
- * registered watcher periodically. The frequency of checks can be specified using {@code watcher.interval} setting, which
- * defaults to {@code 60s}. The service can be disabled by setting {@code watcher.enabled} setting to {@code false}.
+ * registered watcher periodically. The frequency of checks can be specified using {@code resource.reload.interval} setting, which
+ * defaults to {@code 60s}. The service can be disabled by setting {@code resource.reload.enabled} setting to {@code false}.
  */
 public class ResourceWatcherService extends AbstractLifecycleComponent<ResourceWatcherService> {
 
-    public static enum Frequency {
+    public enum Frequency {
 
         /**
          * Defaults to 5 seconds
@@ -59,7 +59,7 @@ public class ResourceWatcherService extends AbstractLifecycleComponent<ResourceW
 
         final TimeValue interval;
 
-        private Frequency(TimeValue interval) {
+        Frequency(TimeValue interval) {
             this.interval = interval;
         }
     }
@@ -78,15 +78,21 @@ public class ResourceWatcherService extends AbstractLifecycleComponent<ResourceW
     @Inject
     public ResourceWatcherService(Settings settings, ThreadPool threadPool) {
         super(settings);
-        this.enabled = settings.getAsBoolean("watcher.enabled", true);
+        this.enabled = settings.getAsBoolean("resource.reload.enabled", true);
         this.threadPool = threadPool;
 
-        TimeValue interval = settings.getAsTime("watcher.interval.low", Frequency.LOW.interval);
+        TimeValue interval = settings.getAsTime("resource.reload.interval.low", Frequency.LOW.interval);
         lowMonitor = new ResourceMonitor(interval, Frequency.LOW);
-        interval = settings.getAsTime("watcher.interval.medium", settings.getAsTime("watcher.interval", Frequency.MEDIUM.interval));
+        interval = settings.getAsTime("resource.reload.interval.medium", settings.getAsTime("resource.reload.interval", Frequency.MEDIUM.interval));
         mediumMonitor = new ResourceMonitor(interval, Frequency.MEDIUM);
-        interval = settings.getAsTime("watcher.interval.high", Frequency.HIGH.interval);
+        interval = settings.getAsTime("resource.reload.interval.high", Frequency.HIGH.interval);
         highMonitor = new ResourceMonitor(interval, Frequency.HIGH);
+
+        logRemovedSetting("watcher.enabled", "resource.reload.enabled");
+        logRemovedSetting("watcher.interval", "resource.reload.interval");
+        logRemovedSetting("watcher.interval.low", "resource.reload.interval.low");
+        logRemovedSetting("watcher.interval.medium", "resource.reload.interval.medium");
+        logRemovedSetting("watcher.interval.high", "resource.reload.interval.high");
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/watcher/ResourceWatcherServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/watcher/ResourceWatcherServiceTests.java
@@ -45,7 +45,7 @@ public class ResourceWatcherServiceTests extends ElasticsearchTestCase {
 
         // checking bwc
         settings = Settings.builder()
-                .put("watcher.interval", "40s") // only applies to medium
+                .put("resource.reload.interval", "40s") // only applies to medium
                 .build();
         service = new ResourceWatcherService(settings, threadPool);
         assertThat(service.highMonitor.interval.millis(), is(timeValueSeconds(5).millis()));
@@ -54,9 +54,9 @@ public class ResourceWatcherServiceTests extends ElasticsearchTestCase {
 
         // checking custom
         settings = Settings.builder()
-                .put("watcher.interval.high", "10s")
-                .put("watcher.interval.medium", "20s")
-                .put("watcher.interval.low", "30s")
+                .put("resource.reload.interval.high", "10s")
+                .put("resource.reload.interval.medium", "20s")
+                .put("resource.reload.interval.low", "30s")
                 .build();
         service = new ResourceWatcherService(settings, threadPool);
         assertThat(service.highMonitor.interval.millis(), is(timeValueSeconds(10).millis()));

--- a/docs/reference/migration/migrate_2_0.asciidoc
+++ b/docs/reference/migration/migrate_2_0.asciidoc
@@ -685,3 +685,14 @@ curl -XGET 'localhost:9200/test/_search?fields=_timestamp,foo'
    }
 }
 ---------------
+
+=== Settings for resource watcher have been renamed
+
+The setting names for configuring the resource watcher have been renamed
+to prevent clashes with the watcher plugin
+
+* `watcher.enabled` is now `resource.reload.enabled`
+* `watcher.interval` is now `resource.reload.interval`
+* `watcher.interval.low` is now `resource.reload.interval.low`
+* `watcher.interval.medium` is now `resource.reload.interval.medium`
+* `watcher.interval.high` is now `resource.reload.interval.high`

--- a/docs/reference/modules/scripting.asciidoc
+++ b/docs/reference/modules/scripting.asciidoc
@@ -342,7 +342,7 @@ appropriate language.
 The `config/scripts` directory is scanned periodically for changes.
 New and changed scripts are reloaded and deleted script are removed
 from preloaded scripts cache. The reload frequency can be specified
-using `watcher.interval` setting, which defaults to `60s`.
+using `resource.reload.interval` setting, which defaults to `60s`.
 To disable script reloading completely set `script.auto_reload_enabled`
 to `false`.
 


### PR DESCRIPTION
The ResourceWatcher used settings prefixed `watcher.`, which
potentially could clash with the watcher plugin.

In order to prevent confusion, the settings have been renamed to
`resource.reload` prefixes.

This also uses the deprecation logging infrastructure introduced
in #11033 to log deprecated settings and their alternative at
startup.

Closes #11175
