### PR TITLE
Wildcard field names in highlighting should only return fields that can be highlighted

### DIFF
--- a/src/main/java/org/elasticsearch/search/highlight/FastVectorHighlighter.java
+++ b/src/main/java/org/elasticsearch/search/highlight/FastVectorHighlighter.java
@@ -63,7 +63,7 @@ public class FastVectorHighlighter implements Highlighter {
         FetchSubPhase.HitContext hitContext = highlighterContext.hitContext;
         FieldMapper mapper = highlighterContext.mapper;
 
-        if (!(mapper.fieldType().storeTermVectors() && mapper.fieldType().storeTermVectorOffsets() && mapper.fieldType().storeTermVectorPositions())) {
+        if (canHighlight(mapper) == false) {
             throw new IllegalArgumentException("the field [" + highlighterContext.fieldName + "] should be indexed with term vector with position offsets to be used with fast vector highlighter");
         }
 
@@ -175,6 +175,11 @@ public class FastVectorHighlighter implements Highlighter {
         } catch (Exception e) {
             throw new FetchPhaseExecutionException(context, "Failed to highlight field [" + highlighterContext.fieldName + "]", e);
         }
+    }
+
+    @Override
+    public boolean canHighlight(FieldMapper fieldMapper) {
+        return fieldMapper.fieldType().storeTermVectors() && fieldMapper.fieldType().storeTermVectorOffsets() && fieldMapper.fieldType().storeTermVectorPositions();
     }
 
     private class MapperHighlightEntry {

--- a/src/main/java/org/elasticsearch/search/highlight/HighlightPhase.java
+++ b/src/main/java/org/elasticsearch/search/highlight/HighlightPhase.java
@@ -21,7 +21,6 @@ package org.elasticsearch.search.highlight;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.inject.Inject;
@@ -44,6 +43,8 @@ import static com.google.common.collect.Maps.newHashMap;
  *
  */
 public class HighlightPhase extends AbstractComponent implements FetchSubPhase {
+
+    private static final ImmutableList<String> STANDARD_HIGHLIGHTERS_BY_PRECEDENCE = ImmutableList.of("fvh", "postings", "plain");
 
     private final Highlighters highlighters;
 
@@ -91,6 +92,7 @@ public class HighlightPhase extends AbstractComponent implements FetchSubPhase {
                 }
             }
 
+            boolean fieldNameContainsWildcards = field.field().contains("*");
             for (String fieldName : fieldNamesToHighlight) {
                 FieldMapper fieldMapper = getMapperForField(fieldName, context, hitContext);
                 if (fieldMapper == null) {
@@ -99,16 +101,14 @@ public class HighlightPhase extends AbstractComponent implements FetchSubPhase {
 
                 String highlighterType = field.fieldOptions().highlighterType();
                 if (highlighterType == null) {
-                    boolean useFastVectorHighlighter = fieldMapper.fieldType().storeTermVectors() && fieldMapper.fieldType().storeTermVectorOffsets() && fieldMapper.fieldType().storeTermVectorPositions();
-                    if (useFastVectorHighlighter) {
-                        highlighterType = "fvh";
-                    } else if (fieldMapper.fieldType().indexOptions() == IndexOptions.DOCS_AND_FREQS_AND_POSITIONS_AND_OFFSETS) {
-                        highlighterType = "postings";
-                    } else {
-                        highlighterType = "plain";
+                    for(String highlighterCandidate : STANDARD_HIGHLIGHTERS_BY_PRECEDENCE) {
+                        if (highlighters.get(highlighterCandidate).canHighlight(fieldMapper)) {
+                            highlighterType = highlighterCandidate;
+                            break;
+                        }
                     }
+                    assert highlighterType != null;
                 }
-
                 Highlighter highlighter = highlighters.get(highlighterType);
                 if (highlighter == null) {
                     throw new IllegalArgumentException("unknown highlighter type [" + highlighterType + "] for the field [" + fieldName + "]");
@@ -116,13 +116,17 @@ public class HighlightPhase extends AbstractComponent implements FetchSubPhase {
 
                 Query highlightQuery = field.fieldOptions().highlightQuery() == null ? context.parsedQuery().query() : field.fieldOptions().highlightQuery();
                 HighlighterContext highlighterContext = new HighlighterContext(fieldName, field, fieldMapper, context, hitContext, highlightQuery);
+
+                if ((highlighter.canHighlight(fieldMapper) == false) && fieldNameContainsWildcards) {
+                    // if several fieldnames matched the wildcard then we want to skip those that we cannot highlight
+                    continue;
+                }
                 HighlightField highlightField = highlighter.highlight(highlighterContext);
                 if (highlightField != null) {
                     highlightFields.put(highlightField.name(), highlightField);
                 }
             }
         }
-
         hitContext.hit().highlightFields(highlightFields);
     }
 

--- a/src/main/java/org/elasticsearch/search/highlight/Highlighter.java
+++ b/src/main/java/org/elasticsearch/search/highlight/Highlighter.java
@@ -18,6 +18,8 @@
  */
 package org.elasticsearch.search.highlight;
 
+import org.elasticsearch.index.mapper.FieldMapper;
+
 /**
  *
  */
@@ -26,4 +28,6 @@ public interface Highlighter {
     String[] names();
 
     HighlightField highlight(HighlighterContext highlighterContext);
+
+    boolean canHighlight(FieldMapper fieldMapper);
 }

--- a/src/main/java/org/elasticsearch/search/highlight/PostingsHighlighter.java
+++ b/src/main/java/org/elasticsearch/search/highlight/PostingsHighlighter.java
@@ -50,7 +50,7 @@ public class PostingsHighlighter implements Highlighter {
 
         FieldMapper fieldMapper = highlighterContext.mapper;
         SearchContextHighlight.Field field = highlighterContext.field;
-        if (fieldMapper.fieldType().indexOptions() != IndexOptions.DOCS_AND_FREQS_AND_POSITIONS_AND_OFFSETS) {
+        if (canHighlight(fieldMapper) == false) {
             throw new IllegalArgumentException("the field [" + highlighterContext.fieldName + "] should be indexed with positions and offsets in the postings list to be used with postings highlighter");
         }
 
@@ -124,6 +124,11 @@ public class PostingsHighlighter implements Highlighter {
         }
 
         return null;
+    }
+
+    @Override
+    public boolean canHighlight(FieldMapper fieldMapper) {
+        return fieldMapper.fieldType().indexOptions() == IndexOptions.DOCS_AND_FREQS_AND_POSITIONS_AND_OFFSETS;
     }
 
     private static String mergeFieldValues(List<Object> fieldValues, char valuesSeparator) {

--- a/src/test/java/org/elasticsearch/search/highlight/CustomHighlighter.java
+++ b/src/test/java/org/elasticsearch/search/highlight/CustomHighlighter.java
@@ -21,6 +21,7 @@ package org.elasticsearch.search.highlight;
 import com.google.common.collect.Lists;
 import org.elasticsearch.common.text.StringText;
 import org.elasticsearch.common.text.Text;
+import org.elasticsearch.index.mapper.FieldMapper;
 
 import java.util.List;
 import java.util.Locale;
@@ -66,6 +67,11 @@ public class CustomHighlighter implements Highlighter {
         }
 
         return new HighlightField(highlighterContext.fieldName, responses.toArray(new Text[]{}));
+    }
+
+    @Override
+    public boolean canHighlight(FieldMapper fieldMapper) {
+        return true;
     }
 
     private static class CacheEntry {


### PR DESCRIPTION
When we highlight on fields using wildcards then fields might match that cannot
be highlighted by the specified highlighter. The whole search request then
failed. Instead, check that the field can be highlighted and ignore the field
if it can't.

In addition ignore the exception thrown by plain highlighter if a field conatins
terms larger than 32766. 

closes #9881
