### PR TITLE
`fielddata_fields` query string parameter was ignored.

### DIFF
--- a/rest-api-spec/test/search/10_source_filtering.yaml
+++ b/rest-api-spec/test/search/10_source_filtering.yaml
@@ -89,4 +89,10 @@
             query: { match_all: {} }
   - match: { hits.hits.0.fields: { include.field2 : [v2] }}
   - is_true:  hits.hits.0._source
+  
+  
+  - do:
+      search:
+        fielddata_fields: ["count"]
+  - match: { hits.hits.0.fields.count: [1] }  
 

--- a/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
@@ -195,6 +195,20 @@ public class RestSearchAction extends BaseRestHandler {
                 }
             }
         }
+        String sFieldDataFields = request.param("fielddata_fields");
+        if (sFieldDataFields != null) {
+            if (searchSourceBuilder == null) {
+                searchSourceBuilder = new SearchSourceBuilder();
+            }
+            if (Strings.hasText(sFieldDataFields)) {
+                String[] sFields = Strings.splitStringByCommaToArray(sFieldDataFields);
+                if (sFields != null) {
+                    for (String field : sFields) {
+                        searchSourceBuilder.fieldDataField(field);
+                    }
+                }
+            }
+        }
         FetchSourceContext fetchSourceContext = FetchSourceContext.parseFromRestRequest(request);
         if (fetchSourceContext != null) {
             if (searchSourceBuilder == null) {


### PR DESCRIPTION
The RestSearchAction did not parse the fielddata_fields parameter. Added test case and missing parser code.

Closes #11025
