### PR TITLE
Deduplicate field names returned by simpleMatchToFullName & simpleMatchToIndexNames in FieldMappersLookup

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/DocumentFieldMappers.java
+++ b/src/main/java/org/elasticsearch/index/mapper/DocumentFieldMappers.java
@@ -28,7 +28,6 @@ import org.elasticsearch.index.analysis.FieldNameAnalyzer;
 
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -98,11 +97,11 @@ public final class DocumentFieldMappers implements Iterable<FieldMapper> {
         return fieldMappers.get(field);
     }
 
-    List<String> simpleMatchToIndexNames(String pattern) {
+    Collection<String> simpleMatchToIndexNames(String pattern) {
         return fieldMappers.simpleMatchToIndexNames(pattern);
     }
 
-    public List<String> simpleMatchToFullName(String pattern) {
+    public Collection<String> simpleMatchToFullName(String pattern) {
         return fieldMappers.simpleMatchToFullName(pattern);
     }
 

--- a/src/main/java/org/elasticsearch/index/mapper/FieldMappersLookup.java
+++ b/src/main/java/org/elasticsearch/index/mapper/FieldMappersLookup.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.index.mapper;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.collect.CopyOnWriteHashMap;
 import org.elasticsearch.common.regex.Regex;
@@ -27,7 +27,7 @@ import org.elasticsearch.common.regex.Regex;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
-import java.util.List;
+import java.util.Set;
 
 /**
  * A class that holds a map of field mappers from name, index name, and full name.
@@ -114,8 +114,8 @@ class FieldMappersLookup implements Iterable<FieldMapper> {
     /**
      * Returns a list of the index names of a simple match regex like pattern against full name and index name.
      */
-    public List<String> simpleMatchToIndexNames(String pattern) {
-        List<String> fields = Lists.newArrayList();
+    public Collection<String> simpleMatchToIndexNames(String pattern) {
+        Set<String> fields = Sets.newHashSet();
         for (FieldMapper fieldMapper : this) {
             if (Regex.simpleMatch(pattern, fieldMapper.names().fullName())) {
                 fields.add(fieldMapper.names().indexName());
@@ -129,8 +129,8 @@ class FieldMappersLookup implements Iterable<FieldMapper> {
     /**
      * Returns a list of the full names of a simple match regex like pattern against full name and index name.
      */
-    public List<String> simpleMatchToFullName(String pattern) {
-        List<String> fields = Lists.newArrayList();
+    public Collection<String> simpleMatchToFullName(String pattern) {
+        Set<String> fields = Sets.newHashSet();
         for (FieldMapper fieldMapper : this) {
             if (Regex.simpleMatch(pattern, fieldMapper.names().fullName())) {
                 fields.add(fieldMapper.names().fullName());

--- a/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -481,14 +481,14 @@ public class MapperService extends AbstractIndexComponent  {
      * Returns all the fields that match the given pattern. If the pattern is prefixed with a type
      * then the fields will be returned with a type prefix.
      */
-    public List<String> simpleMatchToIndexNames(String pattern) {
+    public Collection<String> simpleMatchToIndexNames(String pattern) {
         return simpleMatchToIndexNames(pattern, null);
     }
     /**
      * Returns all the fields that match the given pattern, with an optional narrowing
      * based on a list of types.
      */
-    public List<String> simpleMatchToIndexNames(String pattern, @Nullable String[] types) {
+    public Collection<String> simpleMatchToIndexNames(String pattern, @Nullable String[] types) {
         if (Regex.isSimpleMatchPattern(pattern) == false) {
             // no wildcards
             return ImmutableList.of(pattern);

--- a/src/main/java/org/elasticsearch/index/query/ExistsQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/ExistsQueryParser.java
@@ -19,11 +19,7 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.search.BooleanClause;
-import org.apache.lucene.search.BooleanQuery;
-import org.apache.lucene.search.ConstantScoreQuery;
-import org.apache.lucene.search.Query;
-import org.apache.lucene.search.TermRangeQuery;
+import org.apache.lucene.search.*;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -32,7 +28,7 @@ import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.internal.FieldNamesFieldMapper;
 
 import java.io.IOException;
-import java.util.List;
+import java.util.Collection;
 
 /**
  *
@@ -89,7 +85,7 @@ public class ExistsQueryParser implements QueryParser {
             fieldPattern = fieldPattern + ".*";
         }
 
-        List<String> fields = parseContext.simpleMatchToIndexNames(fieldPattern);
+        Collection<String> fields = parseContext.simpleMatchToIndexNames(fieldPattern);
         if (fields.isEmpty()) {
             // no fields exists, so we should not match anything
             return Queries.newMatchNoDocsQuery();

--- a/src/main/java/org/elasticsearch/index/query/MissingQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MissingQueryParser.java
@@ -19,11 +19,7 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.search.BooleanClause;
-import org.apache.lucene.search.BooleanQuery;
-import org.apache.lucene.search.ConstantScoreQuery;
-import org.apache.lucene.search.Query;
-import org.apache.lucene.search.TermRangeQuery;
+import org.apache.lucene.search.*;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -32,7 +28,7 @@ import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.internal.FieldNamesFieldMapper;
 
 import java.io.IOException;
-import java.util.List;
+import java.util.Collection;
 
 /**
  *
@@ -100,7 +96,7 @@ public class MissingQueryParser implements QueryParser {
             fieldPattern = fieldPattern + ".*";
         }
 
-        List<String> fields = parseContext.simpleMatchToIndexNames(fieldPattern);
+        Collection<String> fields = parseContext.simpleMatchToIndexNames(fieldPattern);
         if (fields.isEmpty()) {
             if (existence) {
                 // if we ask for existence of fields, and we found none, then we should match on all

--- a/src/main/java/org/elasticsearch/index/query/QueryParseContext.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryParseContext.java
@@ -21,7 +21,6 @@ package org.elasticsearch.index.query;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
-
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.queryparser.classic.MapperQueryParser;
 import org.apache.lucene.queryparser.classic.QueryParserSettings;
@@ -38,11 +37,7 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.analysis.AnalysisService;
 import org.elasticsearch.index.fielddata.IndexFieldData;
-import org.elasticsearch.index.mapper.ContentPath;
-import org.elasticsearch.index.mapper.FieldMapper;
-import org.elasticsearch.index.mapper.Mapper;
-import org.elasticsearch.index.mapper.MapperBuilders;
-import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.*;
 import org.elasticsearch.index.mapper.core.StringFieldMapper;
 import org.elasticsearch.index.query.support.NestedScope;
 import org.elasticsearch.index.similarity.SimilarityService;
@@ -52,12 +47,7 @@ import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.lookup.SearchLookup;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  *
@@ -281,7 +271,7 @@ public class QueryParseContext {
         }
     }
 
-    public List<String> simpleMatchToIndexNames(String pattern) {
+    public Collection<String> simpleMatchToIndexNames(String pattern) {
         return indexQueryParser.mapperService.simpleMatchToIndexNames(pattern, getTypes());
     }
 

--- a/src/main/java/org/elasticsearch/search/highlight/HighlightPhase.java
+++ b/src/main/java/org/elasticsearch/search/highlight/HighlightPhase.java
@@ -34,7 +34,7 @@ import org.elasticsearch.search.fetch.FetchSubPhase;
 import org.elasticsearch.search.internal.InternalSearchHit;
 import org.elasticsearch.search.internal.SearchContext;
 
-import java.util.List;
+import java.util.Collection;
 import java.util.Map;
 
 import static com.google.common.collect.Maps.newHashMap;
@@ -77,7 +77,7 @@ public class HighlightPhase extends AbstractComponent implements FetchSubPhase {
     public void hitExecute(SearchContext context, HitContext hitContext) {
         Map<String, HighlightField> highlightFields = newHashMap();
         for (SearchContextHighlight.Field field : context.highlight().fields()) {
-            List<String> fieldNamesToHighlight;
+            Collection<String> fieldNamesToHighlight;
             if (Regex.isSimpleMatchPattern(field.field())) {
                 DocumentMapper documentMapper = context.mapperService().documentMapper(hitContext.hit().type());
                 fieldNamesToHighlight = documentMapper.mappers().simpleMatchToFullName(field.field());

--- a/src/test/java/org/elasticsearch/index/mapper/FieldMappersLookupTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/FieldMappersLookupTests.java
@@ -30,6 +30,7 @@ import org.elasticsearch.index.mapper.core.AbstractFieldMapper;
 import org.elasticsearch.test.ElasticsearchTestCase;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 
@@ -39,7 +40,7 @@ public class FieldMappersLookupTests extends ElasticsearchTestCase {
         FieldMappersLookup lookup = new FieldMappersLookup();
         assertNull(lookup.fullName("foo"));
         assertNull(lookup.indexName("foo"));
-        List<String> names = lookup.simpleMatchToFullName("foo");
+        Collection<String> names = lookup.simpleMatchToFullName("foo");
         assertNotNull(names);
         assertTrue(names.isEmpty());
         names = lookup.simpleMatchToFullName("foo");
@@ -105,7 +106,7 @@ public class FieldMappersLookupTests extends ElasticsearchTestCase {
         FakeFieldMapper f2 = new FakeFieldMapper("bar", "boo");
         FieldMappersLookup lookup = new FieldMappersLookup();
         lookup = lookup.copyAndAddAll(newList(f1, f2));
-        List<String> names = lookup.simpleMatchToIndexNames("b*");
+        Collection<String> names = lookup.simpleMatchToIndexNames("b*");
         assertTrue(names.contains("baz"));
         assertTrue(names.contains("boo"));
     }
@@ -115,7 +116,7 @@ public class FieldMappersLookupTests extends ElasticsearchTestCase {
         FakeFieldMapper f2 = new FakeFieldMapper("bar", "boo");
         FieldMappersLookup lookup = new FieldMappersLookup();
         lookup = lookup.copyAndAddAll(newList(f1, f2));
-        List<String> names = lookup.simpleMatchToFullName("b*");
+        Collection<String> names = lookup.simpleMatchToFullName("b*");
         assertTrue(names.contains("foo"));
         assertTrue(names.contains("bar"));
     }

--- a/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
@@ -145,15 +145,7 @@ import java.net.InetSocketAddress;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.IdentityHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
@@ -906,7 +898,7 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
                     DocumentMapper documentMapper = indexService.mapperService().documentMapper(type);
                     assertThat("document mapper doesn't exists on " + node, documentMapper, notNullValue());
                     for (String fieldName : fieldNames) {
-                        List<String> matches = documentMapper.mappers().simpleMatchToFullName(fieldName);
+                        Collection<String> matches = documentMapper.mappers().simpleMatchToFullName(fieldName);
                         assertThat("field " + fieldName + " doesn't exists on " + node, matches, Matchers.not(emptyIterable()));
                     }
                 }


### PR DESCRIPTION
Relates to #10916
