### PR TITLE
Fix typed parameters in IndexRequestBuilder and CreateIndexRequestBuilder

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequest.java
@@ -377,9 +377,9 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
      * Sets the settings and mappings as a single source.
      */
     @SuppressWarnings("unchecked")
-    public CreateIndexRequest source(Map<String, Object> source) {
+    public CreateIndexRequest source(Map<String, ?> source) {
         boolean found = false;
-        for (Map.Entry<String, Object> entry : source.entrySet()) {
+        for (Map.Entry<String, ?> entry : source.entrySet()) {
             String name = entry.getKey();
             if (name.equals("settings")) {
                 found = true;

--- a/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequestBuilder.java
@@ -93,7 +93,7 @@ public class CreateIndexRequestBuilder extends AcknowledgedRequestBuilder<Create
     /**
      * The settings to create the index with (either json/yaml/properties format)
      */
-    public CreateIndexRequestBuilder setSettings(Map<String, Object> source) {
+    public CreateIndexRequestBuilder setSettings(Map<String, ?> source) {
         request.settings(source);
         return this;
     }
@@ -223,7 +223,7 @@ public class CreateIndexRequestBuilder extends AcknowledgedRequestBuilder<Create
     /**
      * Sets the settings and mappings as a single source.
      */
-    public CreateIndexRequestBuilder setSource(Map<String, Object> source) {
+    public CreateIndexRequestBuilder setSource(Map<String, ?> source) {
         request.source(source);
         return this;
     }

--- a/src/main/java/org/elasticsearch/action/index/IndexRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/index/IndexRequestBuilder.java
@@ -90,7 +90,7 @@ public class IndexRequestBuilder extends ReplicationRequestBuilder<IndexRequest,
      *
      * @param source The map to index
      */
-    public IndexRequestBuilder setSource(Map<String, Object> source) {
+    public IndexRequestBuilder setSource(Map<String, ?> source) {
         request.source(source);
         return this;
     }
@@ -100,7 +100,7 @@ public class IndexRequestBuilder extends ReplicationRequestBuilder<IndexRequest,
      *
      * @param source The map to index
      */
-    public IndexRequestBuilder setSource(Map<String, Object> source, XContentType contentType) {
+    public IndexRequestBuilder setSource(Map<String, ?> source, XContentType contentType) {
         request.source(source, contentType);
         return this;
     }

--- a/src/test/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequestBuilderTest.java
+++ b/src/test/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequestBuilderTest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.admin.indices.create;
+
+import org.elasticsearch.action.index.IndexRequestBuilderTest;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.rest.NoOpClient;
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class CreateIndexRequestBuilderTest extends ElasticsearchTestCase {
+
+    private static final String KEY = "my.settings.key";
+    private static final String VALUE = "my.settings.value";
+    private NoOpClient testClient;
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        this.testClient = new NoOpClient(getTestName());
+    }
+
+    @Override
+    @After
+    public void tearDown() throws Exception {
+        this.testClient.close();
+        super.tearDown();
+    }
+
+    /**
+     * test setting the source with available setters
+     */
+    @Test
+    public void testSetSource() throws IOException {
+        CreateIndexRequestBuilder builder = new CreateIndexRequestBuilder(this.testClient, CreateIndexAction.INSTANCE);
+        builder.setSource("{\""+KEY+"\" : \""+VALUE+"\"}");
+        assertEquals(VALUE, builder.request().settings().get(KEY));
+
+        XContentBuilder xContent = XContentFactory.jsonBuilder().startObject().field(KEY, VALUE).endObject();
+        xContent.close();
+        builder.setSource(xContent);
+        assertEquals(VALUE, builder.request().settings().get(KEY));
+
+        ByteArrayOutputStream docOut = new ByteArrayOutputStream();
+        XContentBuilder doc = XContentFactory.jsonBuilder(docOut).startObject().field(KEY, VALUE).endObject();
+        doc.close();
+        builder.setSource(docOut.toByteArray());
+        assertEquals(VALUE, builder.request().settings().get(KEY));
+
+        Map<String, String> settingsMap = new HashMap<>();
+        settingsMap.put(KEY, VALUE);
+        builder.setSettings(settingsMap);
+        assertEquals(VALUE, builder.request().settings().get(KEY));
+    }
+
+    /**
+     * test setting the settings with available setters
+     */
+    @Test
+    public void testSetSettings() throws IOException {
+        CreateIndexRequestBuilder builder = new CreateIndexRequestBuilder(this.testClient, CreateIndexAction.INSTANCE);
+        builder.setSettings(KEY, VALUE);
+        assertEquals(VALUE, builder.request().settings().get(KEY));
+
+        builder.setSettings("{\""+KEY+"\" : \""+VALUE+"\"}");
+        assertEquals(VALUE, builder.request().settings().get(KEY));
+
+        builder.setSettings(Settings.builder().put(KEY, VALUE));
+        assertEquals(VALUE, builder.request().settings().get(KEY));
+
+        builder.setSettings(Settings.builder().put(KEY, VALUE).build());
+        assertEquals(VALUE, builder.request().settings().get(KEY));
+
+        Map<String, String> settingsMap = new HashMap<>();
+        settingsMap.put(KEY, VALUE);
+        builder.setSettings(settingsMap);
+        assertEquals(VALUE, builder.request().settings().get(KEY));
+
+        XContentBuilder xContent = XContentFactory.jsonBuilder().startObject().field(KEY, VALUE).endObject();
+        xContent.close();
+        builder.setSettings(xContent);
+        assertEquals(VALUE, builder.request().settings().get(KEY));
+    }
+
+}

--- a/src/test/java/org/elasticsearch/action/index/IndexRequestBuilderTest.java
+++ b/src/test/java/org/elasticsearch/action/index/IndexRequestBuilderTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.index;
+
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.rest.NoOpClient;
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+public class IndexRequestBuilderTest extends ElasticsearchTestCase {
+
+    private static final String EXPECTED_SOURCE = "{\"SomeKey\":\"SomeValue\"}";
+    private NoOpClient testClient;
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        this.testClient = new NoOpClient(getTestName());
+    }
+
+    @Override
+    @After
+    public void tearDown() throws Exception {
+        this.testClient.close();
+        super.tearDown();
+    }
+
+    /**
+     * test setting the source for the request with different available setters
+     */
+    @Test
+    public void testSetSource() throws Exception {
+        IndexRequestBuilder indexRequestBuilder = new IndexRequestBuilder(this.testClient, IndexAction.INSTANCE);
+        Map<String, String> source = new HashMap<>();
+        source.put("SomeKey", "SomeValue");
+        indexRequestBuilder.setSource(source);
+        assertEquals(EXPECTED_SOURCE, XContentHelper.convertToJson(indexRequestBuilder.request().source(), true));
+
+        indexRequestBuilder.setSource(source, XContentType.JSON);
+        assertEquals(EXPECTED_SOURCE, XContentHelper.convertToJson(indexRequestBuilder.request().source(), true));
+
+        indexRequestBuilder.setSource("SomeKey", "SomeValue");
+        assertEquals(EXPECTED_SOURCE, XContentHelper.convertToJson(indexRequestBuilder.request().source(), true));
+
+        // force the Object... setter
+        indexRequestBuilder.setSource((Object) "SomeKey", "SomeValue");
+        assertEquals(EXPECTED_SOURCE, XContentHelper.convertToJson(indexRequestBuilder.request().source(), true));
+
+        ByteArrayOutputStream docOut = new ByteArrayOutputStream();
+        XContentBuilder doc = XContentFactory.jsonBuilder(docOut).startObject().field("SomeKey", "SomeValue").endObject();
+        doc.close();
+        indexRequestBuilder.setSource(docOut.toByteArray());
+        assertEquals(EXPECTED_SOURCE, XContentHelper.convertToJson(indexRequestBuilder.request().source(), true));
+
+        doc = XContentFactory.jsonBuilder().startObject().field("SomeKey", "SomeValue").endObject();
+        doc.close();
+        indexRequestBuilder.setSource(doc);
+        assertEquals(EXPECTED_SOURCE, XContentHelper.convertToJson(indexRequestBuilder.request().source(), true));
+    }
+}

--- a/src/test/java/org/elasticsearch/rest/NoOpClient.java
+++ b/src/test/java/org/elasticsearch/rest/NoOpClient.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.rest;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.Action;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionRequestBuilder;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.client.support.AbstractClient;
+import org.elasticsearch.client.support.Headers;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import java.util.concurrent.TimeUnit;
+
+public class NoOpClient extends AbstractClient {
+
+    public NoOpClient(String testName) {
+        super(Settings.EMPTY, new ThreadPool(testName), Headers.EMPTY);
+    }
+
+    @Override
+    protected <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder>> void doExecute(Action<Request, Response, RequestBuilder> action, Request request, ActionListener<Response> listener) {
+        listener.onResponse(null);
+    }
+
+    @Override
+    public void close() {
+        try {
+            ThreadPool.terminate(threadPool(), 10, TimeUnit.SECONDS);
+        } catch (Throwable t) {
+            throw new ElasticsearchException(t.getMessage(), t);
+        }
+    }
+}


### PR DESCRIPTION
IndexRequestBuilder#setSource as well as CreateIndexRequestBuilder#setSettings and CreateIndexRequestBuilder#setSouce will not work with `Map<String, String>` argument although the API looks like it should. This PR fixes the problem introducing correct wildcard parameters and adds tests.

Closes #10825
