### PR TITLE
Test: filter out colons in test section names

### DIFF
--- a/src/test/java/org/elasticsearch/test/rest/ElasticsearchRestTestCase.java
+++ b/src/test/java/org/elasticsearch/test/rest/ElasticsearchRestTestCase.java
@@ -312,7 +312,7 @@ public abstract class ElasticsearchRestTestCase extends ElasticsearchIntegration
         //skip test if it matches one of the blacklist globs
         for (PathMatcher blacklistedPathMatcher : blacklistPathMatchers) {
             //we need to replace a few characters otherwise the test section name can't be parsed as a path on windows
-            String testSection = testCandidate.getTestSection().getName().replace("*", "").replace("\\", "/").replaceAll("\\s+/", "/").trim();
+            String testSection = testCandidate.getTestSection().getName().replace("*", "").replace("\\", "/").replaceAll("\\s+/", "/").replace(":", "").trim();
             String testPath = testCandidate.getSuitePath() + "/" + testSection;
             assumeFalse("[" + testCandidate.getTestPath() + "] skipped, reason: blacklisted", blacklistedPathMatcher.matches(PathUtils.get(testPath)));
         }


### PR DESCRIPTION
On Windows, colons ':' are illegal in file names and since we use a Path to
check if the test is blacklisted, tests with a colon in the test section name
will fail. This change simply removes the colon from the name when matching
against the blacklist.
