### PR TITLE
Cluster Health: Add wait time for pending task and recovery percentage

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/ClusterService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/ClusterService.java
@@ -120,4 +120,10 @@ public interface ClusterService extends LifecycleComponent<ClusterService> {
      */
     int numberOfPendingTasks();
 
+    /**
+     * Returns the maximum wait time for tasks in the queue
+     *
+     * @returns A zero time value if the queue is empty, otherwise the time value oldest task waiting in the queue
+     */
+    TimeValue getMaxTaskWaitTime();
 }

--- a/core/src/main/java/org/elasticsearch/common/util/concurrent/EsThreadPoolExecutor.java
+++ b/core/src/main/java/org/elasticsearch/common/util/concurrent/EsThreadPoolExecutor.java
@@ -20,7 +20,10 @@
 package org.elasticsearch.common.util.concurrent;
 
 
-import java.util.concurrent.*;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 /**
  * An extension to thread pool executor, allowing (in the future) to add specific additional stats to it.
@@ -67,8 +70,8 @@ public class EsThreadPoolExecutor extends ThreadPoolExecutor {
         }
     }
 
-    public static interface ShutdownListener {
-        public void onTerminated();
+    public interface ShutdownListener {
+        void onTerminated();
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/common/util/concurrent/PrioritizedRunnable.java
+++ b/core/src/main/java/org/elasticsearch/common/util/concurrent/PrioritizedRunnable.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.common.util.concurrent;
 
 import org.elasticsearch.common.Priority;
+import org.elasticsearch.common.unit.TimeValue;
 
 /**
  *
@@ -26,6 +27,7 @@ import org.elasticsearch.common.Priority;
 public abstract class PrioritizedRunnable implements Runnable, Comparable<PrioritizedRunnable> {
 
     private final Priority priority;
+    private final long creationDate;
 
     public static PrioritizedRunnable wrap(Runnable runnable, Priority priority) {
         return new Wrapped(runnable, priority);
@@ -33,6 +35,15 @@ public abstract class PrioritizedRunnable implements Runnable, Comparable<Priori
 
     protected PrioritizedRunnable(Priority priority) {
         this.priority = priority;
+        creationDate = System.nanoTime();
+    }
+
+    public long getCreationDateInNanos() {
+        return creationDate;
+    }
+
+    public long getAgeInMillis() {
+        return Math.max(0, (System.nanoTime() - creationDate) / 1000);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/common/xcontent/XContentBuilder.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/XContentBuilder.java
@@ -43,6 +43,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -954,6 +955,14 @@ public final class XContentBuilder implements BytesStream, Releasable {
             field(readableFieldName, new ByteSizeValue(rawSize).toString());
         }
         field(rawFieldName, rawSize);
+        return this;
+    }
+
+    public XContentBuilder percentageField(XContentBuilderString rawFieldName, XContentBuilderString readableFieldName, double percentage) throws IOException {
+        if (humanReadable) {
+            field(readableFieldName, String.format(Locale.ROOT, "%1.1f%%", percentage));
+        }
+        field(rawFieldName, percentage);
         return this;
     }
 

--- a/core/src/main/java/org/elasticsearch/rest/action/cat/RestHealthAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/cat/RestHealthAction.java
@@ -80,6 +80,8 @@ public class RestHealthAction extends AbstractCatAction {
         t.addCell("init", "alias:i,shards.initializing,shardsInitializing;text-align:right;desc:number of initializing nodes");
         t.addCell("unassign", "alias:u,shards.unassigned,shardsUnassigned;text-align:right;desc:number of unassigned shards");
         t.addCell("pending_tasks", "alias:pt,pendingTasks;text-align:right;desc:number of pending tasks");
+        t.addCell("max_task_wait_time", "alias:mtwt,maxTaskWaitTime;text-align:right;desc:wait time of longest task pending");
+        t.addCell("active_shards_percent", "alias:asp,activeShardsPercent;text-align:right;desc:active number of shards in percent");
         t.endHeaders();
 
         return t;
@@ -103,6 +105,8 @@ public class RestHealthAction extends AbstractCatAction {
         t.addCell(health.getInitializingShards());
         t.addCell(health.getUnassignedShards());
         t.addCell(health.getNumberOfPendingTasks());
+        t.addCell(health.getTaskMaxWaitingTime().millis() == 0 ? "-" : health.getTaskMaxWaitingTime());
+        t.addCell(String.format(Locale.ROOT, "%1.1f%%", health.getActiveShardsPercent()));
         t.endRow();
         return t;
     }

--- a/core/src/test/java/org/elasticsearch/cluster/ClusterHealthResponsesTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/ClusterHealthResponsesTests.java
@@ -31,6 +31,7 @@ import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.routing.*;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.hamcrest.Matchers;
@@ -38,8 +39,9 @@ import org.junit.Test;
 
 import java.io.IOException;
 
+import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.*;
 
 public class ClusterHealthResponsesTests extends ElasticsearchTestCase {
 
@@ -193,13 +195,16 @@ public class ClusterHealthResponsesTests extends ElasticsearchTestCase {
         int pendingTasks = randomIntBetween(0, 200);
         int inFlight = randomIntBetween(0, 200);
         int delayedUnassigned = randomIntBetween(0, 200);
-        ClusterHealthResponse clusterHealth = new ClusterHealthResponse("bla", clusterState.metaData().concreteIndices(IndicesOptions.strictExpand(), (String[]) null), clusterState, pendingTasks, inFlight, delayedUnassigned);
+        TimeValue pendingTaskInQueueTime = TimeValue.timeValueMillis(randomIntBetween(1000, 100000));
+        ClusterHealthResponse clusterHealth = new ClusterHealthResponse("bla", clusterState.metaData().concreteIndices(IndicesOptions.strictExpand(), (String[]) null), clusterState, pendingTasks, inFlight, delayedUnassigned, pendingTaskInQueueTime);
         logger.info("cluster status: {}, expected {}", clusterHealth.getStatus(), counter.status());
         clusterHealth = maybeSerialize(clusterHealth);
         assertClusterHealth(clusterHealth, counter);
         assertThat(clusterHealth.getNumberOfPendingTasks(), Matchers.equalTo(pendingTasks));
         assertThat(clusterHealth.getNumberOfInFlightFetch(), Matchers.equalTo(inFlight));
         assertThat(clusterHealth.getDelayedUnassignedShards(), Matchers.equalTo(delayedUnassigned));
+        assertThat(clusterHealth.getTaskMaxWaitingTime().millis(), is(pendingTaskInQueueTime.millis()));
+        assertThat(clusterHealth.getActiveShardsPercent(), is(allOf(greaterThanOrEqualTo(0.0), lessThanOrEqualTo(100.0))));
     }
 
     ClusterHealthResponse maybeSerialize(ClusterHealthResponse clusterHealth) throws IOException {
@@ -227,7 +232,7 @@ public class ClusterHealthResponsesTests extends ElasticsearchTestCase {
         metaData.put(indexMetaData, true);
         routingTable.add(indexRoutingTable);
         ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT).metaData(metaData).routingTable(routingTable).build();
-        ClusterHealthResponse clusterHealth = new ClusterHealthResponse("bla", clusterState.metaData().concreteIndices(IndicesOptions.strictExpand(), (String[]) null), clusterState, 0, 0, 0);
+        ClusterHealthResponse clusterHealth = new ClusterHealthResponse("bla", clusterState.metaData().concreteIndices(IndicesOptions.strictExpand(), (String[]) null), clusterState, 0, 0, 0, TimeValue.timeValueMillis(0));
         clusterHealth = maybeSerialize(clusterHealth);
         // currently we have no cluster level validation failures as index validation issues are reported per index.
         assertThat(clusterHealth.getValidationFailures(), Matchers.hasSize(0));

--- a/core/src/test/java/org/elasticsearch/test/cluster/NoopClusterService.java
+++ b/core/src/test/java/org/elasticsearch/test/cluster/NoopClusterService.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.test.cluster;
 
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.*;
 import org.elasticsearch.cluster.block.ClusterBlock;
@@ -133,6 +132,11 @@ public class NoopClusterService implements ClusterService {
     @Override
     public int numberOfPendingTasks() {
         return 0;
+    }
+
+    @Override
+    public TimeValue getMaxTaskWaitTime() {
+        return TimeValue.timeValueMillis(0);
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/test/cluster/TestClusterService.java
+++ b/core/src/test/java/org/elasticsearch/test/cluster/TestClusterService.java
@@ -193,6 +193,11 @@ public class TestClusterService implements ClusterService {
     }
 
     @Override
+    public TimeValue getMaxTaskWaitTime() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public Lifecycle.State lifecycleState() {
         throw new UnsupportedOperationException();
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.health/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.health/10_basic.yaml
@@ -18,6 +18,8 @@
                    init          .+ \n
                    unassign      .+ \n
                    pending_tasks .+ \n
+                   max_task_wait_time .+ \n
+                   active_shards_percent .+ \n
 
                $/
 
@@ -44,6 +46,8 @@
                 \d+            \s+ # init
                 \d+            \s+ # unassign
                 \d+            \s+ # pending_tasks
+                (-|\d+[.]\d+ms|s) \s+ # max task waiting time
+                \d+\.\d+%      \s+ # active shards percent
                 \n
               )+
             $/


### PR DESCRIPTION
In order to get a quick overview using by simply checking the cluster state
and its corresponding cat API, the following two attributes have been added
to the cluster health response:
- pending_task_time_in_queue, the time value of the first task of the
  queue and how long it has been waiting
- recovery percent: The percentage of the number of shards that are in
  initializing state

This makes the cluster health API handy to check, when a fully restarted
cluster is back up and running.

In addition a small serialization fix has been added, which removes version
checks for the this branch in the ClusterHealthResponse.

Closes #10805
