### PR TITLE
Serialization: Remove old version checks

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthResponse.java
@@ -21,7 +21,6 @@ package org.elasticsearch.action.admin.cluster.health;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
@@ -229,9 +228,7 @@ public class ClusterHealthResponse extends ActionResponse implements Iterable<Cl
             }
         }
 
-        if (in.getVersion().onOrAfter(Version.V_1_6_0)) {
-            numberOfInFlightFetch = in.readInt();
-        }
+        numberOfInFlightFetch = in.readInt();
     }
 
     @Override
@@ -258,9 +255,7 @@ public class ClusterHealthResponse extends ActionResponse implements Iterable<Cl
             out.writeString(failure);
         }
 
-        if (out.getVersion().onOrAfter(Version.V_1_6_0)) {
-            out.writeInt(numberOfInFlightFetch);
-        }
+        out.writeInt(numberOfInFlightFetch);
     }
 
 

--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/NodesHotThreadsRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/NodesHotThreadsRequest.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.admin.cluster.node.hotthreads;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.support.nodes.BaseNodesRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -100,12 +99,7 @@ public class NodesHotThreadsRequest extends BaseNodesRequest<NodesHotThreadsRequ
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
         threads = in.readInt();
-        if (in.getVersion().before(Version.V_1_5_0)) {
-            // Pre-1.5.0 did not filter hot threads, so we shouldn't:
-            ignoreIdleThreads = false;
-        } else {
-            ignoreIdleThreads = in.readBoolean();
-        }
+        ignoreIdleThreads = in.readBoolean();
         type = in.readString();
         interval = TimeValue.readTimeValue(in);
         snapshots = in.readInt();
@@ -115,9 +109,7 @@ public class NodesHotThreadsRequest extends BaseNodesRequest<NodesHotThreadsRequ
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeInt(threads);
-        if (out.getVersion().onOrAfter(Version.V_1_5_0)) {
-            out.writeBoolean(ignoreIdleThreads);
-        }
+        out.writeBoolean(ignoreIdleThreads);
         out.writeString(type);
         interval.writeTo(out);
         out.writeInt(snapshots);

--- a/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.action.admin.cluster.snapshots.restore;
 
 import org.elasticsearch.ElasticsearchGenerationException;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.MasterNodeRequest;
@@ -51,29 +50,17 @@ import static org.elasticsearch.common.xcontent.support.XContentMapValues.nodeBo
 public class RestoreSnapshotRequest extends MasterNodeRequest<RestoreSnapshotRequest> {
 
     private String snapshot;
-
     private String repository;
-
     private String[] indices = Strings.EMPTY_ARRAY;
-
     private IndicesOptions indicesOptions = IndicesOptions.strictExpandOpen();
-
     private String renamePattern;
-
     private String renameReplacement;
-
     private boolean waitForCompletion;
-
     private boolean includeGlobalState = true;
-
     private boolean partial = false;
-
     private boolean includeAliases = true;
-
     private Settings settings = EMPTY_SETTINGS;
-
     private Settings indexSettings = EMPTY_SETTINGS;
-
     private String[] ignoreIndexSettings = Strings.EMPTY_ARRAY;
 
     RestoreSnapshotRequest() {
@@ -638,10 +625,8 @@ public class RestoreSnapshotRequest extends MasterNodeRequest<RestoreSnapshotReq
         partial = in.readBoolean();
         includeAliases = in.readBoolean();
         settings = readSettingsFromStream(in);
-        if (in.getVersion().onOrAfter(Version.V_1_5_0)) {
-            indexSettings = readSettingsFromStream(in);
-            ignoreIndexSettings = in.readStringArray();
-        }
+        indexSettings = readSettingsFromStream(in);
+        ignoreIndexSettings = in.readStringArray();
     }
 
     @Override
@@ -658,9 +643,7 @@ public class RestoreSnapshotRequest extends MasterNodeRequest<RestoreSnapshotReq
         out.writeBoolean(partial);
         out.writeBoolean(includeAliases);
         writeSettingsToStream(settings, out);
-        if (out.getVersion().onOrAfter(Version.V_1_5_0)) {
-            writeSettingsToStream(indexSettings, out);
-            out.writeStringArray(ignoreIndexSettings);
-        }
+        writeSettingsToStream(indexSettings, out);
+        out.writeStringArray(ignoreIndexSettings);
     }
 }

--- a/src/main/java/org/elasticsearch/action/indexedscripts/get/GetIndexedScriptRequest.java
+++ b/src/main/java/org/elasticsearch/action/indexedscripts/get/GetIndexedScriptRequest.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.indexedscripts.get;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.IndicesRequest;
@@ -31,7 +30,6 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.lucene.uid.Versions;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.script.ScriptService;
-import org.elasticsearch.search.fetch.source.FetchSourceContext;
 
 import java.io.IOException;
 
@@ -147,47 +145,19 @@ public class GetIndexedScriptRequest extends ActionRequest<GetIndexedScriptReque
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        if (in.getVersion().before(Version.V_1_4_0_Beta1)) {
-            //the index was previously serialized although not needed
-            in.readString();
-        }
         scriptLang = in.readString();
         id = in.readString();
-        if (in.getVersion().before(Version.V_1_5_0)) {
-            in.readOptionalString(); //Preference
-            in.readBoolean(); //Refresh
-            in.readByte(); //Realtime
-        }
         this.versionType = VersionType.fromValue(in.readByte());
         this.version = in.readLong();
-
-        if (in.getVersion().before(Version.V_1_5_0)) {
-            FetchSourceContext.optionalReadFromStream(in);
-        }
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        if (out.getVersion().before(Version.V_1_4_0_Beta1)) {
-            //the index was previously serialized although not needed
-            out.writeString(ScriptService.SCRIPT_INDEX);
-        }
         out.writeString(scriptLang);
         out.writeString(id);
-        if (out.getVersion().before(Version.V_1_5_0)) {
-            out.writeOptionalString("_local"); //Preference
-            out.writeBoolean(true); //Refresh
-            out.writeByte((byte) -1); //Realtime
-        }
-
         out.writeByte(versionType.getValue());
         out.writeLong(version);
-
-        if (out.getVersion().before(Version.V_1_5_0)) {
-            FetchSourceContext.optionalWriteToStream(null, out);
-        }
-
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/cluster/metadata/MappingMetaData.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MappingMetaData.java
@@ -19,8 +19,6 @@
 
 package org.elasticsearch.cluster.metadata;
 
-import com.google.common.collect.Maps;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.TimestampParsingException;
 import org.elasticsearch.cluster.AbstractDiffable;
 import org.elasticsearch.common.Nullable;
@@ -40,10 +38,8 @@ import org.elasticsearch.index.mapper.internal.TimestampFieldMapper;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Map;
 
-import static com.google.common.collect.Maps.newHashMap;
 import static org.elasticsearch.common.xcontent.support.XContentMapValues.nodeBooleanValue;
 
 /**
@@ -571,10 +567,7 @@ public class MappingMetaData extends AbstractDiffable<MappingMetaData> {
         out.writeOptionalString(timestamp().path());
         out.writeString(timestamp().format());
         out.writeOptionalString(timestamp().defaultTimestamp());
-        // TODO Remove the test in elasticsearch 2.0.0
-        if (out.getVersion().onOrAfter(Version.V_1_5_0)) {
-            out.writeOptionalBoolean(timestamp().ignoreMissing());
-        }
+        out.writeOptionalBoolean(timestamp().ignoreMissing());
         out.writeBoolean(hasParentField());
     }
 
@@ -619,10 +612,7 @@ public class MappingMetaData extends AbstractDiffable<MappingMetaData> {
         String defaultTimestamp = in.readOptionalString();
         Boolean ignoreMissing = null;
 
-        // TODO Remove the test in elasticsearch 2.0.0
-        if (in.getVersion().onOrAfter(Version.V_1_5_0)) {
-            ignoreMissing = in.readOptionalBoolean();
-        }
+        ignoreMissing = in.readOptionalBoolean();
 
         final Timestamp timestamp = new Timestamp(enabled, path, format, defaultTimestamp, ignoreMissing);
         final boolean hasParentField = in.readBoolean();

--- a/src/main/java/org/elasticsearch/common/Priority.java
+++ b/src/main/java/org/elasticsearch/common/Priority.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.common;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -35,9 +34,6 @@ public final class Priority implements Comparable<Priority> {
 
     public static void writeTo(Priority priority, StreamOutput output) throws IOException {
         byte b = priority.value;
-        if (output.getVersion().before(Version.V_1_1_0)) {
-            b = (byte) Math.max(URGENT.value, b);
-        }
         output.writeByte(b);
     }
 

--- a/src/main/java/org/elasticsearch/discovery/zen/fd/MasterFaultDetection.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/fd/MasterFaultDetection.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.discovery.zen.fd;
 
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -428,19 +427,11 @@ public class MasterFaultDetection extends FaultDetection {
         @Override
         public void readFrom(StreamInput in) throws IOException {
             super.readFrom(in);
-            if (in.getVersion().onOrBefore(Version.V_1_4_0_Beta1)) {
-                // old listedOnMaster
-                in.readBoolean();
-            }
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
-            if (out.getVersion().onOrBefore(Version.V_1_4_0_Beta1)) {
-                // old listedOnMaster
-                out.writeBoolean(true);
-            }
         }
     }
 }

--- a/src/main/java/org/elasticsearch/index/percolator/stats/PercolateStats.java
+++ b/src/main/java/org/elasticsearch/index/percolator/stats/PercolateStats.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.index.percolator.stats;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
@@ -152,11 +151,6 @@ public class PercolateStats implements Streamable, ToXContent {
         percolateCount = in.readVLong();
         percolateTimeInMillis = in.readVLong();
         current = in.readVLong();
-        if (in.getVersion().before(Version.V_1_1_0)) {
-            in.readVLong();
-        } else {
-            in.readLong();
-        }
         numQueries = in.readVLong();
     }
 
@@ -165,11 +159,6 @@ public class PercolateStats implements Streamable, ToXContent {
         out.writeVLong(percolateCount);
         out.writeVLong(percolateTimeInMillis);
         out.writeVLong(current);
-        if (out.getVersion().before(Version.V_1_1_0)) {
-            out.writeVLong(0);
-        } else {
-            out.writeLong(-1);
-        }
         out.writeVLong(numQueries);
     }
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/AbstractInternalPercentiles.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/AbstractInternalPercentiles.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.search.aggregations.metrics.percentiles;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.inject.internal.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -79,12 +78,6 @@ abstract class AbstractInternalPercentiles extends InternalNumericMetricsAggrega
     @Override
     protected void doReadFrom(StreamInput in) throws IOException {
         valueFormatter = ValueFormatterStreams.readOptional(in);
-        if (in.getVersion().before(Version.V_1_2_0)) {
-            final byte id = in.readByte();
-            if (id != 0) {
-                throw new IllegalArgumentException("Unexpected percentiles aggregator id [" + id + "]");
-            }
-        }
         keys = new double[in.readInt()];
         for (int i = 0; i < keys.length; ++i) {
             keys[i] = in.readDouble();
@@ -96,9 +89,6 @@ abstract class AbstractInternalPercentiles extends InternalNumericMetricsAggrega
     @Override
     protected void doWriteTo(StreamOutput out) throws IOException {
         ValueFormatterStreams.writeOptional(valueFormatter, out);
-        if (out.getVersion().before(Version.V_1_2_0)) {
-            out.writeByte((byte) 0);
-        }
         out.writeInt(keys.length);
         for (int i = 0 ; i < keys.length; ++i) {
             out.writeDouble(keys[i]);


### PR DESCRIPTION
As the 2.x release does not need to be backwards compatible in terms of
serialization, we can remove a fair share of the serialization checks.

TODO: Unsure about the `MetaData` and the `Priority` version check removal. Just want to make sure, we dont persist any of those (snapshot/restore maybe?) - maybe someone can clarify.
