### PR TITLE
Fix the quotes in the explain message for a script score function without parameters

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/lucene/search/function/ScriptScoreFunction.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/search/function/ScriptScoreFunction.java
@@ -111,9 +111,9 @@ public class ScriptScoreFunction extends ScoreFunction {
                     exp = ((ExplainableSearchScript) leafScript).explain(subQueryScore);
                 } else {
                     double score = score(docId, subQueryScore.getValue());
-                    String explanation = "script score function, computed with script:\"" + sScript;
+                    String explanation = "script score function, computed with script:\"" + sScript + "\"";
                     if (sScript.getParams() != null) {
-                        explanation += "\" and parameters: \n" + sScript.getParams().toString();
+                        explanation += " and parameters: \n" + sScript.getParams().toString();
                     }
                     Explanation scoreExp = Explanation.match(
                             subQueryScore.getValue(), "_score: ",


### PR DESCRIPTION
…hout parameters
