### PR TITLE
Export hostname as environment variable for plugin manager

### DIFF
--- a/bin/plugin
+++ b/bin/plugin
@@ -103,4 +103,6 @@ if [ -e "$CONF_FILE" ]; then
   esac
 fi
 
+export HOSTNAME=`hostname -s`
+
 exec "$JAVA" $JAVA_OPTS $ES_JAVA_OPTS -Xmx64m -Xms16m -Delasticsearch -Des.path.home="$ES_HOME" $properties -cp "$ES_HOME/lib/*" org.elasticsearch.plugins.PluginManager $args

--- a/bin/plugin.bat
+++ b/bin/plugin.bat
@@ -9,6 +9,8 @@ for %%I in ("%SCRIPT_DIR%..") do set ES_HOME=%%~dpfI
 
 TITLE Elasticsearch Plugin Manager ${project.version}
 
+SET HOSTNAME=%COMPUTERNAME%
+
 "%JAVA_HOME%\bin\java" %JAVA_OPTS% %ES_JAVA_OPTS% -Xmx64m -Xms16m -Des.path.home="%ES_HOME%" -cp "%ES_HOME%/lib/*;" "org.elasticsearch.plugins.PluginManager" %*
 goto finally
 


### PR DESCRIPTION
In #9474, we exported the hostname in the bin/elasticsearch scripts so that it
could be used as a variable in the elasticsearch.yml file but did not do the same
for plugin manager. When using the hostname variable in elasticsearch.yml and
trying to use the plugin manager, initialization will fail because the property could
not be resolved. This change will allow the hostname to be resolved in the same
manner as the service scripts.

Closes #10902
