### PR TITLE
Fall back to reading SegmentInfos from Store if reading from commit fails

### DIFF
--- a/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -275,7 +275,7 @@ public class InternalEngine extends Engine {
             try {
                 final DirectoryReader directoryReader = ElasticsearchDirectoryReader.wrap(DirectoryReader.open(indexWriter, true), shardId);
                 searcherManager = new SearcherManager(directoryReader, searcherFactory);
-                lastCommittedSegmentInfos = readLastCommittedSegmentInfos(searcherManager);
+                lastCommittedSegmentInfos = readLastCommittedSegmentInfos(searcherManager, store);
                 success = true;
                 return searcherManager;
             } catch (IOException e) {

--- a/src/main/java/org/elasticsearch/index/engine/ShadowEngine.java
+++ b/src/main/java/org/elasticsearch/index/engine/ShadowEngine.java
@@ -79,7 +79,7 @@ public class ShadowEngine extends Engine {
                 if (Lucene.waitForIndex(store.directory(), nonexistentRetryTime)) {
                     reader = ElasticsearchDirectoryReader.wrap(DirectoryReader.open(store.directory()), shardId);
                     this.searcherManager = new SearcherManager(reader, searcherFactory);
-                    this.lastCommittedSegmentInfos = readLastCommittedSegmentInfos(searcherManager);
+                    this.lastCommittedSegmentInfos = readLastCommittedSegmentInfos(searcherManager, store);
                     success = true;
                 } else {
                     throw new IndexShardException(shardId, "failed to open a shadow engine after" +
@@ -148,7 +148,7 @@ public class ShadowEngine extends Engine {
         store.incRef();
         try (ReleasableLock lock = readLock.acquire()) {
             // reread the last committed segment infos
-            lastCommittedSegmentInfos = readLastCommittedSegmentInfos(searcherManager);
+            lastCommittedSegmentInfos = readLastCommittedSegmentInfos(searcherManager, store);
         } catch (Throwable e) {
             if (isClosed.get() == false) {
                 logger.warn("failed to read latest segment infos on flush", e);


### PR DESCRIPTION
In the event that reading from the latest commit fails, we should fall
back to reading from the `Store` using the traditional
`Directory.listAll()`

Related to #11361
