### PR TITLE
Close ShardFilterCache after Store is closed

### DIFF
--- a/src/main/java/org/elasticsearch/index/cache/filter/ShardFilterCache.java
+++ b/src/main/java/org/elasticsearch/index/cache/filter/ShardFilterCache.java
@@ -28,17 +28,18 @@ import org.elasticsearch.indices.cache.filter.IndicesFilterCache;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
  */
-public class ShardFilterCache extends AbstractIndexShardComponent implements Closeable {
-
+public class ShardFilterCache  implements Closeable {
     final IndicesFilterCache cache;
+    final ShardId shardId;
 
-    @Inject
-    public ShardFilterCache(ShardId shardId, @IndexSettings Settings indexSettings, IndicesFilterCache cache) {
-        super(shardId, indexSettings);
+    public ShardFilterCache(ShardId shardId, IndicesFilterCache cache) {
         this.cache = cache;
+        this.shardId = shardId;
     }
 
     public FilterCacheStats stats() {

--- a/src/main/java/org/elasticsearch/index/cache/filter/ShardFilterCacheModule.java
+++ b/src/main/java/org/elasticsearch/index/cache/filter/ShardFilterCacheModule.java
@@ -25,8 +25,14 @@ import org.elasticsearch.common.inject.AbstractModule;
  */
 public class ShardFilterCacheModule extends AbstractModule {
 
+    private final ShardFilterCache shardFilterCache;
+
+    public ShardFilterCacheModule(ShardFilterCache shardFilterCache) {
+        this.shardFilterCache = shardFilterCache;
+    }
+
     @Override
     protected void configure() {
-        bind(ShardFilterCache.class).asEagerSingleton();
+        bind(ShardFilterCache.class).toInstance(shardFilterCache);
     }
 }

--- a/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -161,7 +161,6 @@ public class IndexShard extends AbstractIndexShardComponent {
     private final SnapshotDeletionPolicy deletionPolicy;
     private final SimilarityService similarityService;
     private final MergePolicyProvider mergePolicyProvider;
-    private final BigArrays bigArrays;
     private final EngineConfig engineConfig;
     private final TranslogConfig translogConfig;
 
@@ -212,7 +211,6 @@ public class IndexShard extends AbstractIndexShardComponent {
         this.deletionPolicy = deletionPolicy;
         this.similarityService = similarityService;
         this.mergePolicyProvider = mergePolicyProvider;
-        this.bigArrays = bigArrays;
         Preconditions.checkNotNull(store, "Store must be provided to the index shard");
         Preconditions.checkNotNull(deletionPolicy, "Snapshot deletion policy must be provided to the index shard");
         this.engineFactory = factory;
@@ -794,7 +792,7 @@ public class IndexShard extends AbstractIndexShardComponent {
                         engine.flushAndClose();
                     }
                 } finally { // playing safe here and close the engine even if the above succeeds - close can be called multiple times
-                    IOUtils.close(engine, shardFilterCache);
+                    IOUtils.close(engine);
                 }
             }
         }

--- a/src/test/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/src/test/java/org/elasticsearch/test/InternalTestCluster.java
@@ -801,12 +801,11 @@ public final class InternalTestCluster extends TestCluster {
         }
 
         void resetClient() throws IOException {
-            if (closed.get()) {
-                throw new RuntimeException("already closed");
+            if (closed.get() == false) {
+                Releasables.close(nodeClient, transportClient);
+                nodeClient = null;
+                transportClient = null;
             }
-            Releasables.close(nodeClient, transportClient);
-            nodeClient = null;
-            transportClient = null;
         }
 
         void closeNode() {


### PR DESCRIPTION
The ShardFilterCache relies on the fact that it's closed once the last reader on the shard is closed. This is only guaranteed once the Store and all its references are closed. This commit moves the closing into the internal callback mechanism we use for deleting shard data etc. to close the cache once we have all searchers released.
