### PR TITLE
IdsQueryBuilder: Allow to add a list in addition to array

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -54,7 +55,22 @@ public class IdsQueryBuilder extends QueryBuilder implements BoostableQueryBuild
     /**
      * Adds ids to the filter.
      */
+    public IdsQueryBuilder addIds(Collection<String> ids) {
+        values.addAll(ids);
+        return this;
+    }
+
+    /**
+     * Adds ids to the filter.
+     */
     public IdsQueryBuilder ids(String... ids) {
+        return addIds(ids);
+    }
+
+    /**
+     * Adds ids to the filter.
+     */
+    public IdsQueryBuilder ids(Collection<String> ids) {
         return addIds(ids);
     }
 


### PR DESCRIPTION
In case a developer gets a `List<String>` of ids from another data source,
it does not make any sense, to convert it to an array first,
and then internally in `IdsQueryBuilder` a list is created a out of this again.

Closes #5089
