### PR TITLE
Prevent changing the number of replicas on a closed index

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/metadata/MetaDataUpdateSettingsService.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MetaDataUpdateSettingsService.java
@@ -231,9 +231,15 @@ public class MetaDataUpdateSettingsService extends AbstractComponent implements 
                     }
                 }
 
+                if (closeIndices.size() > 0 && closeSettings.get(IndexMetaData.SETTING_NUMBER_OF_REPLICAS) != null) {
+                    throw new IllegalArgumentException(String.format(Locale.ROOT,
+                            "Can't update [%s] on closed indices [%s] - can leave index in an unopenable state", IndexMetaData.SETTING_NUMBER_OF_REPLICAS,
+                            closeIndices
+                    ));
+                }
                 if (!removedSettings.isEmpty() && !openIndices.isEmpty()) {
                     throw new IllegalArgumentException(String.format(Locale.ROOT,
-                            "Can't update non dynamic settings[%s] for open indices[%s]",
+                            "Can't update non dynamic settings[%s] for open indices [%s]",
                             removedSettings,
                             openIndices
                     ));

--- a/src/test/java/org/elasticsearch/indices/IndicesOptionsIntegrationTests.java
+++ b/src/test/java/org/elasticsearch/indices/IndicesOptionsIntegrationTests.java
@@ -773,7 +773,7 @@ public class IndicesOptionsIntegrationTests extends ElasticsearchIntegrationTest
         try {
             verify(client().admin().indices().prepareUpdateSettings("barbaz").setSettings(Settings.builder().put("e", "f")), false);
         } catch (IllegalArgumentException e) {
-            assertThat(e.getMessage(), equalTo("Can't update non dynamic settings[[index.e]] for open indices[[barbaz]]"));
+            assertThat(e.getMessage(), equalTo("Can't update non dynamic settings[[index.e]] for open indices [[barbaz]]"));
         }
         verify(client().admin().indices().prepareUpdateSettings("baz*").setSettings(Settings.builder().put("a", "b")), true);
     }

--- a/src/test/java/org/elasticsearch/indices/settings/UpdateSettingsTests.java
+++ b/src/test/java/org/elasticsearch/indices/settings/UpdateSettingsTests.java
@@ -92,6 +92,17 @@ public class UpdateSettingsTests extends ElasticsearchIntegrationTest {
 
         client().admin().indices().prepareClose("test").execute().actionGet();
 
+        try {
+            client().admin().indices().prepareUpdateSettings("test")
+                    .setSettings(Settings.settingsBuilder()
+                                    .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 1)
+                    )
+                    .execute().actionGet();
+            fail("can't change number of replicas on a closed index");
+        } catch (IllegalArgumentException ex) {
+            assertEquals(ex.getMessage(), "Can't update [index.number_of_replicas] on closed indices [[test]] - can leave index in an unopenable state");
+            // expected
+        }
         client().admin().indices().prepareUpdateSettings("test")
                 .setSettings(Settings.settingsBuilder()
                         .put("index.refresh_interval", "1s") // this one can change


### PR DESCRIPTION
Setting the number of replicas on a closed index can leave the index
in an unopenable state since we might not be able to recover a quorum.
This commit simply prevents updating this setting on a closed index.

Closes #9566
