### PR TITLE
Fix check for locations in a repository path

### DIFF
--- a/src/main/java/org/elasticsearch/env/Environment.java
+++ b/src/main/java/org/elasticsearch/env/Environment.java
@@ -30,7 +30,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.nio.file.FileSystem;
+import java.nio.file.Path;
 
 import static org.elasticsearch.common.Strings.cleanPath;
 import static org.elasticsearch.common.settings.ImmutableSettings.Builder.EMPTY_SETTINGS;
@@ -249,19 +249,10 @@ public class Environment {
      */
     public static File resolve(File[] roots, String path) {
         for (File root : roots) {
-            File file = new File(path);
-            final File normalizedPath;
-            try {
-                if (file.isAbsolute()) {
-                    normalizedPath = file.getCanonicalFile();
-                } else {
-                    normalizedPath = new File(root, path).getCanonicalFile();
-                }
-            } catch (IOException ex) {
-                continue;
-            }
-            if(normalizedPath.getAbsolutePath().startsWith(root.getAbsolutePath())) {
-                return normalizedPath;
+            Path rootPath = root.toPath().normalize();
+            Path normalizedPath = rootPath.resolve(path).normalize();
+            if(normalizedPath.startsWith(rootPath)) {
+                return normalizedPath.toFile();
             }
         }
         return null;

--- a/src/test/java/org/elasticsearch/env/EnvironmentTests.java
+++ b/src/test/java/org/elasticsearch/env/EnvironmentTests.java
@@ -57,4 +57,13 @@ public class EnvironmentTests extends ElasticsearchTestCase {
         assertThat(environment.resolveRepoFile("/test/repos/../repos/repo1"), notNullValue());
         assertThat(environment.resolveRepoFile("/somethingeles/repos/repo1"), nullValue());
     }
+
+    @Test
+    public void testRepositoryResolutionWithActualFile() throws IOException {
+        File tempDir = newTempDir();
+        Environment environment = newEnvironment(settingsBuilder().putArray("path.repo", tempDir.getAbsolutePath()).build());
+        assertThat(environment.resolveRepoFile(tempDir.getAbsolutePath()), notNullValue());
+        assertThat(environment.resolveRepoFile(new File(tempDir, "repo").getAbsolutePath()), notNullValue());
+        assertThat(environment.resolveRepoFile("/test/somewhere"), nullValue());
+    }
 }


### PR DESCRIPTION
Currently, when trying to determine if a location is within one of the configured repository
paths, we compare a canonical path against an absolute path. These are not always
equivalent and this check will fail even when the same directory is used. This changes
the logic to to follow that of the http server, where we use normalized absolute path
comparisons. A test has been added that failed with the old code and now passes with the
updated method.

This only targets the 1.x branch as the code for handling this is different on master.
