### PR TITLE
Query Refactoring: ExistsQueryBuilder and Parser

### DIFF
--- a/core/src/main/java/org/apache/lucene/queryparser/classic/ExistsFieldQueryExtension.java
+++ b/core/src/main/java/org/apache/lucene/queryparser/classic/ExistsFieldQueryExtension.java
@@ -21,7 +21,7 @@ package org.apache.lucene.queryparser.classic;
 
 import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.Query;
-import org.elasticsearch.index.query.ExistsQueryParser;
+import org.elasticsearch.index.query.ExistsQueryBuilder;
 import org.elasticsearch.index.query.QueryParseContext;
 
 /**
@@ -33,6 +33,6 @@ public class ExistsFieldQueryExtension implements FieldQueryExtension {
 
     @Override
     public Query query(QueryParseContext parseContext, String queryText) {
-        return new ConstantScoreQuery(ExistsQueryParser.newFilter(parseContext, queryText, null));
+        return new ConstantScoreQuery(ExistsQueryBuilder.newFilter(parseContext, queryText, null));
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/ExistsQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/ExistsQueryBuilder.java
@@ -19,18 +19,31 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.ConstantScoreQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermRangeQuery;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.internal.FieldNamesFieldMapper;
 
 import java.io.IOException;
+import java.util.Collection;
+import java.util.Objects;
 
 /**
  * Constructs a query that only match on documents that the field has a value in them.
  */
-public class ExistsQueryBuilder extends QueryBuilder {
+public class ExistsQueryBuilder extends QueryBuilder<ExistsQueryBuilder> {
 
     public static final String NAME = "exists";
 
-    private String name;
+    private final String name;
 
     private String queryName;
 
@@ -41,11 +54,25 @@ public class ExistsQueryBuilder extends QueryBuilder {
     }
 
     /**
+     * @return the field name that has to exist for this query to match
+     */
+    public String name() {
+        return this.name;
+    }
+
+    /**
      * Sets the query name for the query that can be used when searching for matched_queries per hit.
      */
     public ExistsQueryBuilder queryName(String queryName) {
         this.queryName = queryName;
         return this;
+    }
+
+    /**
+     * @return the query name for the query that can be used when searching for matched_queries per hit.
+     */
+    public String queryName() {
+        return this.queryName;
     }
 
     @Override
@@ -56,6 +83,91 @@ public class ExistsQueryBuilder extends QueryBuilder {
             builder.field("_name", queryName);
         }
         builder.endObject();
+    }
+
+
+    @Override
+    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
+        return newFilter(parseContext, name, queryName);
+    }
+
+    public static Query newFilter(QueryParseContext parseContext, String fieldPattern, String queryName) {
+        final FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType = (FieldNamesFieldMapper.FieldNamesFieldType)parseContext.mapperService().fullName(FieldNamesFieldMapper.NAME);
+        if (fieldNamesFieldType == null) {
+            // can only happen when no types exist, so no docs exist either
+            return Queries.newMatchNoDocsQuery();
+        }
+
+        MapperService.SmartNameObjectMapper smartNameObjectMapper = parseContext.smartObjectMapper(fieldPattern);
+        if (smartNameObjectMapper != null && smartNameObjectMapper.hasMapper()) {
+            // automatic make the object mapper pattern
+            fieldPattern = fieldPattern + ".*";
+        }
+
+        Collection<String> fields = parseContext.simpleMatchToIndexNames(fieldPattern);
+        if (fields.isEmpty()) {
+            // no fields exists, so we should not match anything
+            return Queries.newMatchNoDocsQuery();
+        }
+
+        BooleanQuery boolFilter = new BooleanQuery();
+        for (String field : fields) {
+            MappedFieldType fieldType = parseContext.fieldMapper(field);
+            Query filter = null;
+            if (fieldNamesFieldType.isEnabled()) {
+                final String f;
+                if (fieldType != null) {
+                    f = fieldType.names().indexName();
+                } else {
+                    f = field;
+                }
+                filter = fieldNamesFieldType.termQuery(f, parseContext);
+            }
+            // if _field_names are not indexed, we need to go the slow way
+            if (filter == null && fieldType != null) {
+                filter = fieldType.rangeQuery(null, null, true, true, parseContext);
+            }
+            if (filter == null) {
+                filter = new TermRangeQuery(field, null, null, true, true);
+            }
+            boolFilter.add(filter, BooleanClause.Occur.SHOULD);
+        }
+
+        if (queryName != null) {
+            parseContext.addNamedQuery(queryName, boolFilter);
+        }
+        return new ConstantScoreQuery(boolFilter);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, queryName);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        ExistsQueryBuilder other = (ExistsQueryBuilder) obj;
+        return Objects.equals(name, other.name) &&
+               Objects.equals(queryName, other.queryName);
+    }
+
+    @Override
+    public ExistsQueryBuilder readFrom(StreamInput in) throws IOException {
+        ExistsQueryBuilder newQuery = new ExistsQueryBuilder(in.readString());
+        newQuery.queryName = in.readOptionalString();
+        return newQuery;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(name);
+        out.writeOptionalString(queryName);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/ExistsQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/ExistsQueryParser.java
@@ -19,22 +19,15 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.search.*;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.mapper.FieldMapper;
-import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.mapper.MapperService;
-import org.elasticsearch.index.mapper.internal.FieldNamesFieldMapper;
 
 import java.io.IOException;
-import java.util.Collection;
 
 /**
  *
  */
-public class ExistsQueryParser extends BaseQueryParserTemp {
+public class ExistsQueryParser extends BaseQueryParser {
 
     @Inject
     public ExistsQueryParser() {
@@ -46,7 +39,7 @@ public class ExistsQueryParser extends BaseQueryParserTemp {
     }
 
     @Override
-    public Query parse(QueryParseContext parseContext) throws IOException, QueryParsingException {
+    public QueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
         XContentParser parser = parseContext.parser();
 
         String fieldPattern = null;
@@ -72,60 +65,14 @@ public class ExistsQueryParser extends BaseQueryParserTemp {
             throw new QueryParsingException(parseContext, "exists must be provided with a [field]");
         }
 
-        return newFilter(parseContext, fieldPattern, queryName);
-    }
-
-    public static Query newFilter(QueryParseContext parseContext, String fieldPattern, String queryName) {
-        final FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType = (FieldNamesFieldMapper.FieldNamesFieldType)parseContext.mapperService().fullName(FieldNamesFieldMapper.NAME);
-        if (fieldNamesFieldType == null) {
-            // can only happen when no types exist, so no docs exist either
-            return Queries.newMatchNoDocsQuery();
-        }
-
-        MapperService.SmartNameObjectMapper smartNameObjectMapper = parseContext.smartObjectMapper(fieldPattern);
-        if (smartNameObjectMapper != null && smartNameObjectMapper.hasMapper()) {
-            // automatic make the object mapper pattern
-            fieldPattern = fieldPattern + ".*";
-        }
-
-        Collection<String> fields = parseContext.simpleMatchToIndexNames(fieldPattern);
-        if (fields.isEmpty()) {
-            // no fields exists, so we should not match anything
-            return Queries.newMatchNoDocsQuery();
-        }
-
-        BooleanQuery boolFilter = new BooleanQuery();
-        for (String field : fields) {
-            MappedFieldType fieldType = parseContext.fieldMapper(field);
-            Query filter = null;
-            if (fieldNamesFieldType.isEnabled()) {
-                final String f;
-                if (fieldType != null) {
-                    f = fieldType.names().indexName();
-                } else {
-                    f = field;
-                }
-                filter = fieldNamesFieldType.termQuery(f, parseContext);
-            }
-            // if _field_names are not indexed, we need to go the slow way
-            if (filter == null && fieldType != null) {
-                filter = fieldType.rangeQuery(null, null, true, true, parseContext);
-            }
-            if (filter == null) {
-                filter = new TermRangeQuery(field, null, null, true, true);
-            }
-            boolFilter.add(filter, BooleanClause.Occur.SHOULD);
-        }
-
-        if (queryName != null) {
-            parseContext.addNamedQuery(queryName, boolFilter);
-        }
-        return new ConstantScoreQuery(boolFilter);
+        ExistsQueryBuilder builder = new ExistsQueryBuilder(fieldPattern);
+        builder.queryName(queryName);
+        builder.validate();
+        return builder;
     }
 
     @Override
     public ExistsQueryBuilder getBuilderPrototype() {
         return ExistsQueryBuilder.PROTOTYPE;
     }
-
 }

--- a/core/src/main/java/org/elasticsearch/index/query/GeoShapeQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoShapeQueryParser.java
@@ -158,7 +158,7 @@ public class GeoShapeQueryParser extends BaseQueryParserTemp {
             // this strategy doesn't support disjoint anymore: but it did before, including creating lucene fieldcache (!)
             // in this case, execute disjoint as exists && !intersects
             BooleanQuery bool = new BooleanQuery();
-            Query exists = ExistsQueryParser.newFilter(parseContext, fieldName, null);
+            Query exists = ExistsQueryBuilder.newFilter(parseContext, fieldName, null);
             Filter intersects = strategy.makeFilter(getArgs(shape, ShapeRelation.INTERSECTS));
             bool.add(exists, BooleanClause.Occur.MUST);
             bool.add(intersects, BooleanClause.Occur.MUST_NOT);

--- a/core/src/test/java/org/elasticsearch/index/query/BoolQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/BoolQueryBuilderTest.java
@@ -84,11 +84,6 @@ public class BoolQueryBuilderTest extends BaseQueryTestCase<BoolQueryBuilder> {
     }
 
     @Override
-    protected BoolQueryBuilder createEmptyQueryBuilder() {
-        return new BoolQueryBuilder();
-    }
-
-    @Override
     protected Query createExpectedQuery(BoolQueryBuilder queryBuilder, QueryParseContext context) throws IOException {
         if (!queryBuilder.hasClauses()) {
             return new MatchAllDocsQuery();

--- a/core/src/test/java/org/elasticsearch/index/query/ExistsQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/ExistsQueryBuilderTest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query;
+
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.ConstantScoreQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermRangeQuery;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.common.lucene.search.Queries;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.internal.FieldNamesFieldMapper;
+
+import java.io.IOException;
+import java.util.Collection;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class ExistsQueryBuilderTest extends BaseQueryTestCase<ExistsQueryBuilder> {
+
+    private Collection<String> getFieldNamePattern(String fieldName, QueryParseContext context) {
+        if (getCurrentTypes().length > 0 && fieldName.equals(BaseQueryTestCase.OBJECT_FIELD_NAME)) {
+            // "object" field has two inner fields (age, price), so if query hits that field, we
+            // extend field name with wildcard to match both nested fields. This is similar to what
+            // is done internally in ExistsQueryBuilder.toQuery()
+            fieldName = fieldName + ".*";
+        }
+        return context.simpleMatchToIndexNames(fieldName);
+    }
+
+    @Override
+    protected Query createExpectedQuery(ExistsQueryBuilder queryBuilder, QueryParseContext context) throws IOException {
+        final FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType = (FieldNamesFieldMapper.FieldNamesFieldType)context.mapperService().fullName(FieldNamesFieldMapper.NAME);
+        Collection<String> fields = getFieldNamePattern(queryBuilder.name(), context);
+
+        if (fields.isEmpty() || fieldNamesFieldType == null) {
+            return Queries.newMatchNoDocsQuery();
+        }
+
+        BooleanQuery boolFilter = new BooleanQuery();
+        for (String field : fields) {
+            if (fieldNamesFieldType != null && fieldNamesFieldType.isEnabled()) {
+                boolFilter.add(fieldNamesFieldType.termQuery(field, context), BooleanClause.Occur.SHOULD);
+            } else {
+                MappedFieldType fieldType = context.fieldMapper(field);
+                if (fieldType == null) {
+                    boolFilter.add(new TermRangeQuery(field, null, null, true, true), BooleanClause.Occur.SHOULD);
+                } else {
+                    boolFilter.add(fieldType.rangeQuery(null, null, true, true, context), BooleanClause.Occur.SHOULD);
+                }
+            }
+        }
+        return new ConstantScoreQuery(boolFilter);
+    }
+
+    @Override
+    protected void assertLuceneQuery(ExistsQueryBuilder queryBuilder, Query query, QueryParseContext context) {
+        if (queryBuilder.queryName() != null) {
+            Query namedQuery = context.copyNamedFilters().get(queryBuilder.queryName());
+            Collection<String> fields = getFieldNamePattern(queryBuilder.name(), context);
+
+            if (fields.isEmpty()) {
+                assertNull(namedQuery);
+            } else {
+                query = ((ConstantScoreQuery) query).getQuery();
+                assertThat(namedQuery, equalTo(query));
+            }
+        }
+    }
+
+    @Override
+    protected ExistsQueryBuilder createTestQueryBuilder() {
+        String fieldPattern;
+        if (randomBoolean()) {
+            fieldPattern = randomFrom(mappedFieldNames);
+        } else {
+            fieldPattern = randomAsciiOfLengthBetween(1, 10);
+        }
+        // also sometimes test wildcard patterns
+        if (randomBoolean()) {
+            if (randomBoolean()) {
+                fieldPattern = fieldPattern + "*";
+            } else {
+                fieldPattern = MetaData.ALL;
+            }
+        }
+        ExistsQueryBuilder query = new ExistsQueryBuilder(fieldPattern);
+
+        if (randomBoolean()) {
+            query.queryName(randomAsciiOfLengthBetween(1, 10));
+        }
+        return query;
+    }
+}

--- a/core/src/test/java/org/elasticsearch/index/query/IdsQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/IdsQueryBuilderTest.java
@@ -53,11 +53,6 @@ public class IdsQueryBuilderTest extends BaseQueryTestCase<IdsQueryBuilder> {
     }
 
     @Override
-    protected IdsQueryBuilder createEmptyQueryBuilder() {
-        return new IdsQueryBuilder();
-    }
-
-    @Override
     protected Query createExpectedQuery(IdsQueryBuilder queryBuilder, QueryParseContext context) throws IOException {
         Query expectedQuery;
         if (queryBuilder.ids().size() == 0) {

--- a/core/src/test/java/org/elasticsearch/index/query/LimitQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/LimitQueryBuilderTest.java
@@ -30,11 +30,6 @@ public class LimitQueryBuilderTest extends BaseQueryTestCase<LimitQueryBuilder> 
         return Queries.newMatchAllQuery();
     }
 
-    @Override
-    protected LimitQueryBuilder createEmptyQueryBuilder() {
-        return new LimitQueryBuilder(0);
-    }
-
     /**
      * @return a LimitQueryBuilder with random limit between 0 and 20
      */

--- a/core/src/test/java/org/elasticsearch/index/query/MatchAllQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/MatchAllQueryBuilderTest.java
@@ -31,11 +31,6 @@ public class MatchAllQueryBuilderTest extends BaseQueryTestCase<MatchAllQueryBui
         return matchAllDocsQuery;
     }
 
-    @Override
-    protected MatchAllQueryBuilder createEmptyQueryBuilder() {
-        return new MatchAllQueryBuilder();
-    }
-
     /**
      * @return a MatchAllQuery with random boost between 0.1f and 2.0f
      */

--- a/core/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTest.java
@@ -154,9 +154,4 @@ public class RangeQueryBuilderTest extends BaseQueryTestCase<RangeQueryBuilder> 
         query.from(1).to(10).timeZone("UTC");
         query.toQuery(createContext());
     }
-
-    @Override
-    protected RangeQueryBuilder createEmptyQueryBuilder() {
-        return new RangeQueryBuilder(null);
-    }
 }

--- a/core/src/test/java/org/elasticsearch/index/query/SpanTermQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanTermQueryBuilderTest.java
@@ -26,11 +26,6 @@ import org.apache.lucene.search.spans.SpanTermQuery;
 public class SpanTermQueryBuilderTest extends BaseTermQueryTestCase<SpanTermQueryBuilder> {
 
     @Override
-    protected SpanTermQueryBuilder createEmptyQueryBuilder() {
-        return new SpanTermQueryBuilder(null, null);
-    }
-    
-    @Override
     protected SpanTermQueryBuilder createQueryBuilder(String fieldName, Object value) {
         return new SpanTermQueryBuilder(fieldName, value);
     }

--- a/core/src/test/java/org/elasticsearch/index/query/TermQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/TermQueryBuilderTest.java
@@ -25,11 +25,6 @@ import org.apache.lucene.search.TermQuery;
 
 public class TermQueryBuilderTest extends BaseTermQueryTestCase<TermQueryBuilder> {
 
-    @Override
-    protected TermQueryBuilder createEmptyQueryBuilder() {
-        return new TermQueryBuilder(null, null);
-    }
-
     /**
      * @return a TermQuery with random field name and value, optional random boost and queryname
      */


### PR DESCRIPTION
Refactors ExistsQueryBuilder and Parser, splitting the parse() method into a parsing and a query building part. Also moving newFilter() uitlity method from parser to query builder.

Changes in the BaseQueryTestCase include introduction of randomized version to test disabled FieldNamesFieldMappers and also getting rid of the need for createEmptyBuilder() method by now using existing prototype constants.

Relates to #10217

PR goes agains query-refacoring feature branch.
