### PR TITLE
Add support for applying setting filters when displaying repository settings (Backport to 1.6)

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/ClusterState.java
+++ b/src/main/java/org/elasticsearch/cluster/ClusterState.java
@@ -451,7 +451,12 @@ public class ClusterState implements ToXContent {
 
             for (ObjectObjectCursor<String, MetaData.Custom> cursor : metaData.customs()) {
                 builder.startObject(cursor.key);
-                MetaData.lookupFactorySafe(cursor.key).toXContent(cursor.value, builder, params);
+                MetaData.Custom.Factory<MetaData.Custom> factory = MetaData.lookupFactorySafe(cursor.key);
+                if (factory instanceof MetaData.Custom.ToXFilteredContent) {
+                    ((MetaData.Custom.ToXFilteredContent)factory).toXContent(cursor.value, builder, params, settingsFilter);
+                } else {
+                    factory.toXContent(cursor.value, builder, params);
+                }
                 builder.endObject();
             }
 

--- a/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
@@ -38,6 +38,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.settings.SettingsFilter;
 import org.elasticsearch.common.settings.loader.SettingsLoader;
 import org.elasticsearch.common.xcontent.*;
 import org.elasticsearch.index.Index;
@@ -92,6 +93,10 @@ public class MetaData implements Iterable<IndexMetaData> {
             public EnumSet<XContentContext> context() {
                 return API_ONLY;
             }
+        }
+
+        interface ToXFilteredContent<T extends Custom> {
+            void toXContent(T customIndexMetaData, XContentBuilder builder, ToXContent.Params params, SettingsFilter settingsFilter) throws IOException;
         }
     }
 

--- a/src/main/java/org/elasticsearch/common/settings/SettingsFilter.java
+++ b/src/main/java/org/elasticsearch/common/settings/SettingsFilter.java
@@ -28,7 +28,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
  */
 public class SettingsFilter extends AbstractComponent {
 
-    public static interface Filter {
+    public interface Filter {
 
         void filter(ImmutableSettings.Builder settings);
     }

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/repositories/get/RestGetRepositoriesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/repositories/get/RestGetRepositoriesAction.java
@@ -27,6 +27,7 @@ import org.elasticsearch.cluster.metadata.RepositoryMetaData;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.settings.SettingsFilter;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.RestBuilderListener;
@@ -40,11 +41,14 @@ import static org.elasticsearch.rest.RestStatus.OK;
  */
 public class RestGetRepositoriesAction extends BaseRestHandler {
 
+    private final SettingsFilter settingsFilter;
+
     @Inject
-    public RestGetRepositoriesAction(Settings settings, RestController controller, Client client) {
+    public RestGetRepositoriesAction(Settings settings, RestController controller, Client client, SettingsFilter settingsFilter) {
         super(settings, controller, client);
         controller.registerHandler(GET, "/_snapshot", this);
         controller.registerHandler(GET, "/_snapshot/{repository}", this);
+        this.settingsFilter = settingsFilter;
     }
 
     @Override
@@ -58,7 +62,7 @@ public class RestGetRepositoriesAction extends BaseRestHandler {
             public RestResponse buildResponse(GetRepositoriesResponse response, XContentBuilder builder) throws Exception {
                 builder.startObject();
                 for (RepositoryMetaData repositoryMetaData : response.repositories()) {
-                    RepositoriesMetaData.FACTORY.toXContent(repositoryMetaData, builder, request);
+                    RepositoriesMetaData.FACTORY.toXContent(repositoryMetaData, builder, request, settingsFilter);
                 }
                 builder.endObject();
 

--- a/src/test/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreTests.java
+++ b/src/test/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreTests.java
@@ -55,9 +55,15 @@ import org.elasticsearch.discovery.zen.elect.ElectMasterService;
 import org.elasticsearch.index.store.support.AbstractIndexStore;
 import org.elasticsearch.indices.ttl.IndicesTTLService;
 import org.elasticsearch.repositories.RepositoryMissingException;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.RestResponse;
+import org.elasticsearch.rest.action.admin.cluster.repositories.get.RestGetRepositoriesAction;
+import org.elasticsearch.rest.action.admin.cluster.state.RestClusterStateAction;
 import org.elasticsearch.snapshots.mockstore.MockRepositoryModule;
 import org.elasticsearch.snapshots.mockstore.MockRepositoryPlugin;
 import org.elasticsearch.test.InternalTestCluster;
+import org.elasticsearch.test.rest.FakeRestRequest;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -69,6 +75,7 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
@@ -611,6 +618,66 @@ public class DedicatedClusterSnapshotRestoreTests extends AbstractSnapshotTests 
                 .setType("fs").setSettings(ImmutableSettings.settingsBuilder()
                 .put("location", randomRepoPath())).get();
 
+    }
+
+    @Test
+    public void testThatSensitiveRepositorySettingsAreNotExposed() throws Exception {
+        Settings nodeSettings = settingsBuilder().put("plugin.types", MockRepositoryPlugin.class.getName()).build();
+        logger.info("--> start two nodes");
+        internalCluster().startNodesAsync(2, nodeSettings);
+        logger.info("--> waiting for nodes to join");
+        assertFalse(client().admin().cluster().prepareHealth().setWaitForNodes("2").get().isTimedOut());
+        // Register mock repositories
+        client().admin().cluster().preparePutRepository("test-repo")
+                .setType("mock").setSettings(ImmutableSettings.settingsBuilder()
+                        .put("location", randomRepoPath())
+                        .put("secret.mock.username", "notsecretusername")
+                        .put("secret.mock.password", "verysecretpassword")
+        ).get();
+
+        RestGetRepositoriesAction getRepoAction = internalCluster().getInstance(RestGetRepositoriesAction.class);
+        RestRequest getRepoRequest = new FakeRestRequest();
+        getRepoRequest.params().put("repository", "test-repo");
+        final CountDownLatch getRepoLatch = new CountDownLatch(1);
+        final AtomicReference<AssertionError> getRepoError = new AtomicReference<>();
+        getRepoAction.handleRequest(getRepoRequest, new RestChannel(getRepoRequest, true) {
+            @Override
+            public void sendResponse(RestResponse response) {
+                try {
+                    assertThat(response.content().toUtf8(), containsString("notsecretusername"));
+                    assertThat(response.content().toUtf8(), not(containsString("verysecretpassword")));
+                } catch (AssertionError ex) {
+                    getRepoError.set(ex);
+                }
+                getRepoLatch.countDown();
+            }
+        });
+        assertTrue(getRepoLatch.await(1, TimeUnit.SECONDS));
+        if (getRepoError.get() != null) {
+            throw getRepoError.get();
+        }
+
+        RestClusterStateAction clusterStateAction = internalCluster().getInstance(RestClusterStateAction.class);
+        RestRequest clusterStateRequest = new FakeRestRequest();
+        final CountDownLatch clusterStateLatch = new CountDownLatch(1);
+        final AtomicReference<AssertionError> clusterStateError = new AtomicReference<>();
+        clusterStateAction.handleRequest(clusterStateRequest, new RestChannel(clusterStateRequest, true) {
+            @Override
+            public void sendResponse(RestResponse response) {
+                try {
+                    assertThat(response.content().toUtf8(), containsString("notsecretusername"));
+                    assertThat(response.content().toUtf8(), not(containsString("verysecretpassword")));
+                } catch (AssertionError ex) {
+                    clusterStateError.set(ex);
+                }
+                clusterStateLatch.countDown();
+            }
+        });
+        assertTrue(clusterStateLatch.await(1, TimeUnit.SECONDS));
+        if (clusterStateError.get() != null) {
+            throw clusterStateError.get();
+        }
+        
     }
 
     @Test

--- a/src/test/java/org/elasticsearch/snapshots/mockstore/MockRepositoryPlugin.java
+++ b/src/test/java/org/elasticsearch/snapshots/mockstore/MockRepositoryPlugin.java
@@ -19,8 +19,17 @@
 
 package org.elasticsearch.snapshots.mockstore;
 
+import org.elasticsearch.common.inject.AbstractModule;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Module;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.SettingsFilter;
 import org.elasticsearch.plugins.AbstractPlugin;
 import org.elasticsearch.repositories.RepositoriesModule;
+
+import java.util.Collection;
+
+import static com.google.common.collect.Lists.newArrayList;
 
 public class MockRepositoryPlugin extends AbstractPlugin {
 
@@ -37,4 +46,32 @@ public class MockRepositoryPlugin extends AbstractPlugin {
     public void onModule(RepositoriesModule repositoriesModule) {
         repositoriesModule.registerRepository("mock", MockRepositoryModule.class);
     }
+
+    @Override
+    public Collection<Class<? extends Module>> modules() {
+        Collection<Class<? extends Module>> modules = newArrayList();
+        modules.add(SettingsFilteringModule.class);
+        return modules;
+    }
+
+    public static class SettingsFilteringModule extends AbstractModule {
+
+        @Override
+        protected void configure() {
+            bind(SettingsFilteringService.class).asEagerSingleton();
+        }
+    }
+
+    public static class SettingsFilteringService {
+        @Inject
+        public SettingsFilteringService(SettingsFilter settingsFilter) {
+            settingsFilter.addFilter(new SettingsFilter.Filter() {
+                @Override
+                public void filter(ImmutableSettings.Builder settings) {
+                    settings.remove("secret.mock.password");
+                }
+            });
+        }
+    }
+
 }


### PR DESCRIPTION
Currently all settings that were specified during repository creation are displayed. This commit enables  plugins such as cloud-aws to filter out sensitive settings from the repository.

Closes #11265
