### PR TITLE
Delayed allocation on node leave

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteRequestBuilder.java
@@ -23,6 +23,7 @@ import org.elasticsearch.action.support.master.AcknowledgedRequestBuilder;
 import org.elasticsearch.client.ElasticsearchClient;
 import org.elasticsearch.cluster.routing.allocation.command.AllocationCommand;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.unit.TimeValue;
 
 /**
  * Builder for a cluster reroute request
@@ -57,6 +58,15 @@ public class ClusterRerouteRequestBuilder extends AcknowledgedRequestBuilder<Clu
      */
     public ClusterRerouteRequestBuilder setExplain(boolean explain) {
         request.explain(explain);
+        return this;
+    }
+
+    /**
+     * Overrides the delayed duration setting, typically used to set "0" here to
+     * make sure delayed allocations are cleared.
+     */
+    public ClusterRerouteRequestBuilder setDelayedDuration(TimeValue delayedDuration) {
+        request.delayedDuration(delayedDuration);
         return this;
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/cluster/reroute/TransportClusterRerouteAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/reroute/TransportClusterRerouteAction.java
@@ -90,7 +90,7 @@ public class TransportClusterRerouteAction extends TransportMasterNodeAction<Clu
 
             @Override
             public ClusterState execute(ClusterState currentState) {
-                RoutingAllocation.Result routingResult = allocationService.reroute(currentState, request.commands, request.explain());
+                RoutingAllocation.Result routingResult = allocationService.reroute(currentState, request.commands, request.explain(), request.delayedDuration());
                 ClusterState newState = ClusterState.builder(currentState).routingResult(routingResult).build();
                 clusterStateToSend = newState;
                 explanations = routingResult.explanations();

--- a/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DelayUnassignedAllocation.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DelayUnassignedAllocation.java
@@ -1,0 +1,309 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.routing.allocation.allocator;
+
+import com.carrotsearch.hppc.cursors.ObjectCursor;
+import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.collect.Lists;
+import org.apache.lucene.util.ArrayUtil;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.routing.MutableShardRouting;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
+import org.elasticsearch.common.component.AbstractComponent;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
+
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * The delayed unassigned allocation allows to control delayed allocation of shards due to nodes leaving the
+ * cluster with the assumption that they might come back, and the opertunity to reduce cluster allocations if
+ * they do.
+ */
+public class DelayUnassignedAllocation extends AbstractComponent {
+
+    public static final String DELAY_ALLOCATION_DURATION = "cluster.routing.allocation.delay_unassigned_allocation.duration";
+    public static final String DELAY_ALLOCATION_NODE_KEY = "cluster.routing.allocation.delay_unassigned_allocation.node_key";
+
+    private final NodeKey nodeKey;
+    private volatile TimeValue duration;
+
+    private final Map<Object, DelayedAllocation> delayedAllocations = new HashMap<>();
+    private final Cache<String, DiscoveryNode> seenNodes = CacheBuilder.newBuilder().expireAfterWrite(5, TimeUnit.MINUTES).build();
+
+    public DelayUnassignedAllocation(Settings settings) {
+        super(settings);
+        this.duration = settings.getAsTime(DELAY_ALLOCATION_DURATION, TimeValue.timeValueMinutes(5));
+        this.nodeKey = NodeKey.valueOf(settings.get(DELAY_ALLOCATION_NODE_KEY, NodeKey.TRANSPORT_ADDRESS.toString()).toUpperCase(Locale.ROOT));
+        logger.debug("delayed allocation using duration [{}] and node_key [{}]", duration, nodeKey);
+    }
+
+    /**
+     * The duration to wait if a node leaves, a value below or equal to 0 means
+     * not taking node leaving into account at all (disabling delayed allocation).
+     */
+    public TimeValue getDuration() {
+        return this.duration;
+    }
+
+    /**
+     * The duration to wait if a node leaves, a value below or equal to 0 means
+     * not taking node leaving into account at all (disabling delayed allocation).
+     */
+    public void setDuration(TimeValue duration) {
+        this.duration = duration;
+    }
+
+    /**
+     * Clears that current delayed allocation.
+     */
+    public synchronized void clearDelayedAllocations() {
+        delayedAllocations.clear();
+    }
+
+    /**
+     * Returns the current set of delayed nodes.
+     */
+    public synchronized Set<DiscoveryNode> getDelayedNodes() {
+        Set<DiscoveryNode> nodes = new HashSet<>();
+        for (DelayedAllocation delayedAllocation : delayedAllocations.values()) {
+            nodes.add(delayedAllocation.node);
+        }
+        return nodes;
+    }
+
+    /**
+     * The number of delayed shards.
+     */
+    public synchronized int getNumberOfDelayedShards() {
+        int delayedShards = 0;
+        for (DelayedAllocation delayedAllocation : delayedAllocations.values()) {
+            delayedShards += delayedAllocation.shards.size();
+        }
+        return delayedShards;
+    }
+
+    /**
+     * Checks if, due to nodes leaving the cluster, any unassigned shards need to be delayed
+     * and not allocation (moved to ignoreUnassigned).
+     * <p/>
+     * Also times out (duration) when a node has not being around long enough to bring back
+     * those shards to the unassigned list to be allocated.
+     * <p/>
+     * Returns a Result, used to indicated if anything changed, as well as if a reroute is
+     * needed to be scheduled to act upon duration expiry.
+     */
+    public synchronized Result delayUnassignedAllocation(RoutingAllocation allocation) {
+        // refresh the seen nodes, we need the seen nodes since when a node leaves, it is no longer
+        // part of the DiscoveryNodes, yet we need its DiscoveryNode instance to properly process it
+        for (ObjectObjectCursor<String, DiscoveryNode> cursor : allocation.nodes().dataNodes()) {
+            seenNodes.put(cursor.value.getId(), cursor.value);
+        }
+
+        TimeValue duration = allocation.getDelayedDuration() == null ? this.duration : allocation.getDelayedDuration();
+
+        if (duration.millis() <= 0) {
+            delayedAllocations.clear();
+            return new Result(false, null);
+        }
+
+        long timestampInNanos = System.nanoTime();
+        boolean changed = false;
+        boolean scheduleReroute = false;
+
+        // go over all the existing failed shards and add them to the delayed allocations
+        for (Map.Entry<String, List<ShardRouting>> entry : allocation.getFailedShards().entrySet()) {
+            DiscoveryNode node = seenNodes.getIfPresent(entry.getKey());
+            // if we haven't seen this node, we can't do anything sadly...
+            if (node == null) {
+                continue;
+            }
+            List<ShardRouting> failed = entry.getValue();
+
+            // if the node still exists in the cluster state, nothing really to do
+            if (allocation.nodes().nodeExists(node.getId())) {
+                continue;
+            }
+
+            if (logger.isInfoEnabled()) {
+                StringBuilder sb = new StringBuilder("node ").append(node).append(" left the cluster, delaying allocation for [").append(duration).append("], shards: ");
+                for (ShardRouting shardRouting : failed) {
+                    sb.append(shardRouting.shardId()).append(" ");
+                }
+                logger.info(sb.toString());
+            }
+
+            delayedAllocations.put(nodeKey.getNodeKey(node), new DelayedAllocation(node, new ArrayList<>(failed), timestampInNanos));
+            scheduleReroute = true;
+            changed = true;
+        }
+
+        // remove any delayed allocations that have timed out, or shards that no longer have an index (deleted), or nodes that
+        // came back with the same node key
+        for (Iterator<DelayedAllocation> delayedAllocIt = delayedAllocations.values().iterator(); delayedAllocIt.hasNext(); ) {
+            DelayedAllocation delayedAllocation = delayedAllocIt.next();
+            if ((timestampInNanos - delayedAllocation.failedTimestampInNanos) > duration.getNanos()) {
+                logger.info("node {} delayed allocation expired after [{}], enabling allocation", delayedAllocation.node, duration);
+                delayedAllocIt.remove();
+                changed = true;
+            } else {
+                for (Iterator<ShardRouting> shardIt = delayedAllocation.shards.iterator(); shardIt.hasNext(); ) {
+                    ShardRouting shard = shardIt.next();
+                    if (allocation.metaData().hasConcreteIndex(shard.getIndex()) == false) {
+                        shardIt.remove();
+                        changed = true;
+                    }
+                }
+                if (delayedAllocation.shards.isEmpty() == true) {
+                    logger.info("node {} removed from delayed allocation, no more shards associated with it", delayedAllocation.node);
+                    delayedAllocIt.remove();
+                    changed = true;
+                } else {
+                    Object delayedAllocationNodeKey = nodeKey.getNodeKey(delayedAllocation.node);
+                    for (ObjectCursor<DiscoveryNode> cursor : allocation.nodes().dataNodes().values()) {
+                        if (delayedAllocationNodeKey.equals(nodeKey.getNodeKey(cursor.value))) {
+                            // we found a node key that has came back, remove it from the delayed allocations
+                            logger.info("node {} rejoined the cluster, removing delayed allocation", cursor.value);
+                            delayedAllocIt.remove();
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        if (delayedAllocations.isEmpty() == false) {
+            // create a list of shards, sorting them putting all the primaries at the end, so we
+            // will only delay those at the end
+            MutableShardRouting[] drained = allocation.routingNodes().unassigned().drain();
+            ArrayUtil.timSort(drained, new Comparator<MutableShardRouting>() {
+                @Override
+                public int compare(MutableShardRouting o1, MutableShardRouting o2) {
+                    return Boolean.compare(o1.primary(), o2.primary());
+                }
+            });
+            List<MutableShardRouting> unassigned = Lists.newArrayList(drained);
+            for (DelayedAllocation delayedAllocation : delayedAllocations.values()) {
+                for (ShardRouting shard : delayedAllocation.shards) {
+                    // see if we can find an unassigned shard with the same shard id, if so, just remove it
+                    // from the unassigned list and add it to ignored list
+                    for (Iterator<MutableShardRouting> it = unassigned.iterator(); it.hasNext(); ) {
+                        MutableShardRouting unassignedShard = it.next();
+                        if (unassignedShard.shardId().equals(shard.shardId())) {
+                            it.remove();
+                            allocation.routingNodes().ignoredUnassigned().add(unassignedShard);
+                            break;
+                        }
+                    }
+                }
+            }
+
+            allocation.routingNodes().unassigned().addAll(unassigned);
+        }
+
+        return new Result(changed, scheduleReroute ? duration : null);
+    }
+
+    /**
+     * Result of delayed allocation.
+     */
+    public static class Result {
+        private final boolean changed;
+        private final TimeValue rerouteSchedule;
+
+        public Result(boolean changed, TimeValue rerouteSchedule) {
+            this.changed = changed;
+            this.rerouteSchedule = rerouteSchedule;
+        }
+
+        /**
+         * Has anything changed in the allocation.
+         */
+        public boolean isChanged() {
+            return this.changed;
+        }
+
+        /**
+         * Is reroute needed in order to act upon node delayed duration expiry.
+         */
+        public boolean isRerouteRequired() {
+            return rerouteSchedule != null;
+        }
+
+        /**
+         * The reroute schedule to execute to act upon node delayed duration expiry.
+         */
+        public TimeValue getRerouteSchedule() {
+            return this.rerouteSchedule;
+        }
+    }
+
+    static class DelayedAllocation {
+
+        public final DiscoveryNode node;
+        public final List<ShardRouting> shards;
+        public final long failedTimestampInNanos;
+
+        public DelayedAllocation(DiscoveryNode node, List<ShardRouting> shards, long failedTimestampInNanos) {
+            this.node = node;
+            this.shards = shards;
+            this.failedTimestampInNanos = failedTimestampInNanos;
+        }
+    }
+
+    public enum NodeKey {
+        NAME() {
+            @Override
+            public Object getNodeKey(DiscoveryNode node) {
+                return node.getName();
+            }
+        },
+        ID() {
+            @Override
+            public Object getNodeKey(DiscoveryNode node) {
+                return node.getId();
+            }
+        },
+        HOST_ADDRESS() {
+            @Override
+            public Object getNodeKey(DiscoveryNode node) {
+                return node.getHostAddress();
+            }
+        },
+        HOST_NAME() {
+            @Override
+            public Object getNodeKey(DiscoveryNode node) {
+                return node.getHostName();
+            }
+        },
+        TRANSPORT_ADDRESS() {
+            @Override
+            public Object getNodeKey(DiscoveryNode node) {
+                return node.getAddress();
+            }
+        };
+
+        public abstract Object getNodeKey(DiscoveryNode node);
+    }
+}

--- a/src/main/java/org/elasticsearch/cluster/settings/ClusterDynamicSettingsModule.java
+++ b/src/main/java/org/elasticsearch/cluster/settings/ClusterDynamicSettingsModule.java
@@ -24,6 +24,7 @@ import org.elasticsearch.cluster.InternalClusterInfoService;
 import org.elasticsearch.cluster.action.index.MappingUpdatedAction;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllocator;
+import org.elasticsearch.cluster.routing.allocation.allocator.DelayUnassignedAllocation;
 import org.elasticsearch.cluster.routing.allocation.decider.*;
 import org.elasticsearch.cluster.service.InternalClusterService;
 import org.elasticsearch.common.inject.AbstractModule;
@@ -100,6 +101,7 @@ public class ClusterDynamicSettingsModule extends AbstractModule {
         clusterDynamicSettings.addDynamicSetting(HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_LIMIT_SETTING, Validator.MEMORY_SIZE);
         clusterDynamicSettings.addDynamicSetting(HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_OVERHEAD_SETTING, Validator.NON_NEGATIVE_DOUBLE);
         clusterDynamicSettings.addDynamicSetting(InternalClusterService.SETTING_CLUSTER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD, Validator.TIME_NON_NEGATIVE);
+        clusterDynamicSettings.addDynamicSetting(DelayUnassignedAllocation.DELAY_ALLOCATION_DURATION, Validator.TIME_NON_NEGATIVE);
     }
 
     public void addDynamicSettings(String... settings) {

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/reroute/RestClusterRerouteAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/reroute/RestClusterRerouteAction.java
@@ -56,6 +56,7 @@ public class RestClusterRerouteAction extends BaseRestHandler {
         final ClusterRerouteRequest clusterRerouteRequest = Requests.clusterRerouteRequest();
         clusterRerouteRequest.dryRun(request.paramAsBoolean("dry_run", clusterRerouteRequest.dryRun()));
         clusterRerouteRequest.explain(request.paramAsBoolean("explain", clusterRerouteRequest.explain()));
+        clusterRerouteRequest.delayedDuration(request.paramAsTime("delayed_duration", clusterRerouteRequest.delayedDuration()));
         clusterRerouteRequest.timeout(request.paramAsTime("timeout", clusterRerouteRequest.timeout()));
         clusterRerouteRequest.masterNodeTimeout(request.paramAsTime("master_timeout", clusterRerouteRequest.masterNodeTimeout()));
         if (request.hasContent()) {

--- a/src/test/java/org/elasticsearch/cluster/ClusterHealthResponsesTests.java
+++ b/src/test/java/org/elasticsearch/cluster/ClusterHealthResponsesTests.java
@@ -196,12 +196,14 @@ public class ClusterHealthResponsesTests extends ElasticsearchTestCase {
         ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT).metaData(metaData).routingTable(routingTable).build();
         int pendingTasks = randomIntBetween(0, 200);
         int inFlight = randomIntBetween(0, 200);
-        ClusterHealthResponse clusterHealth = new ClusterHealthResponse("bla", clusterState.metaData().concreteIndices(IndicesOptions.strictExpand(), (String[]) null), clusterState, pendingTasks, inFlight);
+        int delayedUnassigned = randomIntBetween(0, 200);
+        ClusterHealthResponse clusterHealth = new ClusterHealthResponse("bla", clusterState.metaData().concreteIndices(IndicesOptions.strictExpand(), (String[]) null), clusterState, pendingTasks, inFlight, delayedUnassigned);
         logger.info("cluster status: {}, expected {}", clusterHealth.getStatus(), counter.status());
         clusterHealth = maybeSerialize(clusterHealth);
         assertClusterHealth(clusterHealth, counter);
         assertThat(clusterHealth.getNumberOfPendingTasks(), Matchers.equalTo(pendingTasks));
         assertThat(clusterHealth.getNumberOfInFlightFetch(), Matchers.equalTo(inFlight));
+        assertThat(clusterHealth.getDelayedUnassignedShards(), Matchers.equalTo(delayedUnassigned));
     }
 
     ClusterHealthResponse maybeSerialize(ClusterHealthResponse clusterHealth) throws IOException {
@@ -229,7 +231,7 @@ public class ClusterHealthResponsesTests extends ElasticsearchTestCase {
         metaData.put(indexMetaData, true);
         routingTable.add(indexRoutingTable);
         ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT).metaData(metaData).routingTable(routingTable).build();
-        ClusterHealthResponse clusterHealth = new ClusterHealthResponse("bla", clusterState.metaData().concreteIndices(IndicesOptions.strictExpand(), (String[]) null), clusterState, 0, 0);
+        ClusterHealthResponse clusterHealth = new ClusterHealthResponse("bla", clusterState.metaData().concreteIndices(IndicesOptions.strictExpand(), (String[]) null), clusterState, 0, 0, 0);
         clusterHealth = maybeSerialize(clusterHealth);
         // currently we have no cluster level validation failures as index validation issues are reported per index.
         assertThat(clusterHealth.getValidationFailures(), Matchers.hasSize(0));

--- a/src/test/java/org/elasticsearch/cluster/routing/allocation/DelayUnassignedAllocationTests.java
+++ b/src/test/java/org/elasticsearch/cluster/routing/allocation/DelayUnassignedAllocationTests.java
@@ -1,0 +1,225 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.routing.allocation;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.routing.RoutingTable;
+import org.elasticsearch.cluster.routing.ShardRoutingState;
+import org.elasticsearch.cluster.routing.allocation.allocator.DelayUnassignedAllocation;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.gateway.GatewayAllocator;
+import org.elasticsearch.node.settings.NodeSettingsService;
+import org.elasticsearch.test.ElasticsearchAllocationTestCase;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ */
+public class DelayUnassignedAllocationTests extends ElasticsearchAllocationTestCase {
+
+    @Test
+    public void testDelayNodeComesBackWithinWindow() throws Exception {
+        TestDelayedAllocator allocator = new TestDelayedAllocator();
+        AllocationService allocationService = delayedAllocationService(allocator);
+
+        logger.info("build a 1/1 index with 2 node cluster");
+        MetaData metaData = MetaData.builder()
+                .put(IndexMetaData.builder("test").settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(1))
+                .build();
+        RoutingTable routingTable = RoutingTable.builder()
+                .addAsNew(metaData.index("test"))
+                .build();
+        ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT).metaData(metaData).routingTable(routingTable).build();
+        clusterState = ClusterState.builder(clusterState).nodes(DiscoveryNodes.builder().put(newNode("node1")).put(newNode("node2"))).build();
+
+        logger.info("reroute till all shards are started");
+        clusterState = ClusterState.builder(clusterState).routingResult(allocationService.reroute(clusterState)).build();
+        assertThat(allocator.lastResult.isRerouteRequired(), equalTo(false));
+        clusterState = ClusterState.builder(clusterState).routingResult(allocationService.applyStartedShards(clusterState, clusterState.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING))).build();
+        assertThat(allocator.lastResult.isRerouteRequired(), equalTo(false));
+        clusterState = ClusterState.builder(clusterState).routingResult(allocationService.applyStartedShards(clusterState, clusterState.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING))).build();
+        assertThat(allocator.lastResult.isRerouteRequired(), equalTo(false));
+        assertThat(clusterState.routingNodes().shardsWithState(ShardRoutingState.STARTED).size(), equalTo(2));
+        assertThat(allocator.allocation.getDelayedNodes().size(), equalTo(0));
+        assertThat(allocator.allocation.getNumberOfDelayedShards(), equalTo(0));
+
+        allocator.allocation.setDuration(TimeValue.timeValueHours(1));
+
+        logger.info("remove node2, verify allocation is delayed");
+        clusterState = ClusterState.builder(clusterState).nodes(DiscoveryNodes.builder(clusterState.nodes()).remove("node2")).build();
+
+        clusterState = ClusterState.builder(clusterState).routingResult(allocationService.reroute(clusterState)).build();
+        assertThat(clusterState.routingNodes().shardsWithState(ShardRoutingState.UNASSIGNED).size(), equalTo(1));
+        assertThat(allocator.allocation.getDelayedNodes().size(), equalTo(1));
+        assertThat(allocator.allocation.getNumberOfDelayedShards(), equalTo(1));
+        assertThat(allocator.lastResult.isRerouteRequired(), equalTo(true));
+        assertThat(allocator.lastResult.getRerouteSchedule(), equalTo(TimeValue.timeValueHours(1)));
+
+        logger.info("another reroute should not cause another scheduled reroute, once is enoguh");
+        clusterState = ClusterState.builder(clusterState).routingResult(allocationService.reroute(clusterState)).build();
+        assertThat(allocator.allocation.getDelayedNodes().size(), equalTo(1));
+        assertThat(allocator.allocation.getNumberOfDelayedShards(), equalTo(1));
+        assertThat(clusterState.routingNodes().shardsWithState(ShardRoutingState.UNASSIGNED).size(), equalTo(1));
+        assertThat(allocator.lastResult.isRerouteRequired(), equalTo(false));
+
+
+        logger.info("bring back node2, see that it gets allocated to");
+        clusterState = ClusterState.builder(clusterState).nodes(DiscoveryNodes.builder(clusterState.nodes()).put(newNode("node2"))).build();
+        clusterState = ClusterState.builder(clusterState).routingResult(allocationService.reroute(clusterState)).build();
+        assertThat(allocator.allocation.getDelayedNodes().size(), equalTo(0));
+        assertThat(allocator.allocation.getNumberOfDelayedShards(), equalTo(0));
+        assertThat(clusterState.routingNodes().shardsWithState(ShardRoutingState.UNASSIGNED).size(), equalTo(0));
+    }
+
+    @Test
+    public void testDelayNodeDoesntComeBackWithinWindow() throws Exception {
+        TestDelayedAllocator allocator = new TestDelayedAllocator();
+        AllocationService allocationService = delayedAllocationService(allocator);
+
+        logger.info("build a 1/1 index with 2 node cluster");
+        MetaData metaData = MetaData.builder()
+                .put(IndexMetaData.builder("test").settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(1))
+                .build();
+        RoutingTable routingTable = RoutingTable.builder()
+                .addAsNew(metaData.index("test"))
+                .build();
+        ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT).metaData(metaData).routingTable(routingTable).build();
+        clusterState = ClusterState.builder(clusterState).nodes(DiscoveryNodes.builder().put(newNode("node1")).put(newNode("node2"))).build();
+
+        logger.info("reroute till all shards are started");
+        clusterState = ClusterState.builder(clusterState).routingResult(allocationService.reroute(clusterState)).build();
+        assertThat(allocator.lastResult.isRerouteRequired(), equalTo(false));
+        clusterState = ClusterState.builder(clusterState).routingResult(allocationService.applyStartedShards(clusterState, clusterState.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING))).build();
+        assertThat(allocator.lastResult.isRerouteRequired(), equalTo(false));
+        clusterState = ClusterState.builder(clusterState).routingResult(allocationService.applyStartedShards(clusterState, clusterState.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING))).build();
+        assertThat(allocator.lastResult.isRerouteRequired(), equalTo(false));
+        assertThat(clusterState.routingNodes().shardsWithState(ShardRoutingState.STARTED).size(), equalTo(2));
+        assertThat(allocator.allocation.getDelayedNodes().size(), equalTo(0));
+        assertThat(allocator.allocation.getNumberOfDelayedShards(), equalTo(0));
+
+        allocator.allocation.setDuration(TimeValue.timeValueHours(1));
+
+        logger.info("remove node2, verify allocation is delayed");
+        clusterState = ClusterState.builder(clusterState).nodes(DiscoveryNodes.builder(clusterState.nodes()).remove("node2")).build();
+        clusterState = ClusterState.builder(clusterState).routingResult(allocationService.reroute(clusterState)).build();
+
+        assertThat(clusterState.routingNodes().shardsWithState(ShardRoutingState.UNASSIGNED).size(), equalTo(1));
+        assertThat(allocator.allocation.getDelayedNodes().size(), equalTo(1));
+        assertThat(allocator.allocation.getNumberOfDelayedShards(), equalTo(1));
+        assertThat(allocator.lastResult.isRerouteRequired(), equalTo(true));
+        assertThat(allocator.lastResult.getRerouteSchedule(), equalTo(TimeValue.timeValueHours(1)));
+
+        logger.info("reduce duration to 1ms, verify that nothing is assigned still, and no reroute is scheduled");
+        allocator.allocation.setDuration(TimeValue.timeValueMillis(1));
+        Thread.sleep(10);
+        clusterState = ClusterState.builder(clusterState).routingResult(allocationService.reroute(clusterState)).build();
+        assertThat(allocator.allocation.getDelayedNodes().size(), equalTo(0));
+        assertThat(allocator.allocation.getNumberOfDelayedShards(), equalTo(0));
+        assertThat(allocator.lastResult.isRerouteRequired(), equalTo(false));
+        assertThat(clusterState.routingNodes().shardsWithState(ShardRoutingState.UNASSIGNED).size(), equalTo(1));
+    }
+
+    @Test
+    public void testAllNodesGoAwayNodeHoldingReplicaComesBack() {
+        TestDelayedAllocator allocator = new TestDelayedAllocator();
+        AllocationService allocationService = delayedAllocationService(allocator);
+
+        logger.info("build a 1/1 index with 2 node cluster, verified primary exists on node1");
+        MetaData metaData = MetaData.builder()
+                .put(IndexMetaData.builder("test").settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(1))
+                .build();
+        RoutingTable routingTable = RoutingTable.builder()
+                .addAsNew(metaData.index("test"))
+                .build();
+        ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT).metaData(metaData).routingTable(routingTable).build();
+        clusterState = ClusterState.builder(clusterState).nodes(DiscoveryNodes.builder().put(newNode("node1"))).build();
+
+        clusterState = ClusterState.builder(clusterState).routingResult(allocationService.reroute(clusterState)).build();
+        clusterState = ClusterState.builder(clusterState).routingResult(allocationService.applyStartedShards(clusterState, clusterState.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING))).build();
+
+        clusterState = ClusterState.builder(clusterState).nodes(DiscoveryNodes.builder(clusterState.nodes()).put(newNode("node2"))).build();
+        clusterState = ClusterState.builder(clusterState).routingResult(allocationService.reroute(clusterState)).build();
+        clusterState = ClusterState.builder(clusterState).routingResult(allocationService.applyStartedShards(clusterState, clusterState.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING))).build();
+
+        assertThat(clusterState.routingNodes().shardsWithState(ShardRoutingState.STARTED).size(), equalTo(2));
+        assertThat(allocator.allocation.getDelayedNodes().size(), equalTo(0));
+        assertThat(allocator.allocation.getNumberOfDelayedShards(), equalTo(0));
+
+        logger.info("kill both nodes");
+        clusterState = ClusterState.builder(clusterState).nodes(DiscoveryNodes.builder(clusterState.nodes()).remove("node1").remove("node2")).build();
+        clusterState = ClusterState.builder(clusterState).routingResult(allocationService.reroute(clusterState)).build();
+        assertThat(clusterState.routingNodes().shardsWithState(ShardRoutingState.UNASSIGNED).size(), equalTo(2));
+        assertThat(allocator.allocation.getDelayedNodes().size(), equalTo(2));
+        assertThat(allocator.allocation.getNumberOfDelayedShards(), equalTo(2));
+
+        logger.info("bring back node2 holding the replica, verify primary is allocated");
+        clusterState = ClusterState.builder(clusterState).nodes(DiscoveryNodes.builder(clusterState.nodes()).put(newNode("node2"))).build();
+        clusterState = ClusterState.builder(clusterState).routingResult(allocationService.reroute(clusterState)).build();
+        assertThat(clusterState.routingNodes().shardsWithState(ShardRoutingState.UNASSIGNED).size(), equalTo(1));
+        assertThat(clusterState.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING).size(), equalTo(1));
+        assertThat(allocator.allocation.getDelayedNodes().size(), equalTo(1));
+        assertThat(allocator.allocation.getNumberOfDelayedShards(), equalTo(1));
+    }
+
+    private AllocationService delayedAllocationService(TestDelayedAllocator allocator) {
+        return createAllocationService(Settings.EMPTY, new NodeSettingsService(Settings.EMPTY), allocator, getRandom());
+    }
+
+    static class TestDelayedAllocator extends GatewayAllocator {
+
+        public final DelayUnassignedAllocation allocation;
+        public DelayUnassignedAllocation.Result lastResult;
+
+        public TestDelayedAllocator() {
+            this(Settings.EMPTY);
+        }
+
+        public TestDelayedAllocator(Settings settings) {
+            super(settings, null, new NodeSettingsService(Settings.EMPTY), null, null);
+            if (settings.get(DelayUnassignedAllocation.DELAY_ALLOCATION_NODE_KEY) == null) {
+                settings = Settings.builder().put(settings).put(DelayUnassignedAllocation.DELAY_ALLOCATION_NODE_KEY, DelayUnassignedAllocation.NodeKey.ID).build();
+            }
+            this.allocation = new DelayUnassignedAllocation(settings);
+        }
+
+        @Override
+        public void applyStartedShards(StartedRerouteAllocation allocation) {
+            // ignore
+        }
+
+        @Override
+        public void applyFailedShards(FailedRerouteAllocation allocation) {
+            // ignore
+        }
+
+        @Override
+        public boolean allocateUnassigned(RoutingAllocation allocation) {
+            this.lastResult = this.allocation.delayUnassignedAllocation(allocation);
+            return false;
+        }
+    }
+}

--- a/src/test/java/org/elasticsearch/cluster/routing/allocation/DelayedUnassignedAllocationIntTests.java
+++ b/src/test/java/org/elasticsearch/cluster/routing/allocation/DelayedUnassignedAllocationIntTests.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.routing.allocation;
+
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.routing.MutableShardRouting;
+import org.elasticsearch.cluster.routing.ShardRoutingState;
+import org.elasticsearch.cluster.routing.allocation.allocator.DelayUnassignedAllocation;
+import org.elasticsearch.cluster.routing.allocation.decider.ConcurrentRebalanceAllocationDecider;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.InternalTestCluster;
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAllSuccessful;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+
+/**
+ */
+@ElasticsearchIntegrationTest.ClusterScope(scope = ElasticsearchIntegrationTest.Scope.TEST, numDataNodes = 0)
+public class DelayedUnassignedAllocationIntTests extends ElasticsearchIntegrationTest {
+
+    @Test
+    public void testDelayedAllocation() throws Exception {
+        // start a single master node
+        final String masterNode = internalCluster().startNodesAsync(1, Settings.builder().put("node.data", false)
+                .put(DelayUnassignedAllocation.DELAY_ALLOCATION_DURATION, "1h")
+                        // the test infra can maintain same node name when restarting a node
+                .put(DelayUnassignedAllocation.DELAY_ALLOCATION_NODE_KEY, DelayUnassignedAllocation.NodeKey.NAME)
+                .put(ConcurrentRebalanceAllocationDecider.CLUSTER_ROUTING_ALLOCATION_CLUSTER_CONCURRENT_REBALANCE, 0) // no rebalancing
+                .build()).get().get(0);
+        // and 4 data nodes
+        Settings settings = Settings.builder().put("node.master", false).build();
+        internalCluster().startNodesAsync(4, settings).get();
+
+        logger.info("create an index, and make sure the shard and replicas are sync'ed for fast recovery");
+        assertAcked(prepareCreate("test").setSettings(Settings.builder().put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)));
+        ensureGreen("test");
+        final int numDocs = randomIntBetween(10, 100);
+        for (int i = 0; i < numDocs; i++) {
+            client().prepareIndex("test", "doc", "" + i).setSource("foo", "bar").get();
+        }
+        assertAllSuccessful(client().admin().indices().prepareFlush().setForce(true).setWaitIfOngoing(true).execute().actionGet());
+        assertAcked(client().admin().indices().prepareUpdateSettings("test").setSettings(Settings.builder().put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, internalCluster().numDataNodes() - 2)));
+        ensureGreen("test");
+
+        final ClusterState fullClusterState = client().admin().cluster().prepareState().all().get().getState();
+        final Set<ShardId> shardsOnStartedNode = new HashSet<>();
+        final Set<ShardId> shardsOnClosedNode = new HashSet<>();
+        final AtomicReference<String> nodeNameRef = new AtomicReference<>();
+        internalCluster().restartRandomDataNode(new InternalTestCluster.RestartCallback() {
+            @Override
+            public Settings onNodeStopped(String nodeName) throws Exception {
+                nodeNameRef.set(nodeName);
+                List<MutableShardRouting> shardsOnRestartedNodeWhenStarted = fullClusterState.routingNodes().node(fullClusterState.nodes().resolveNode(nodeName).getId()).shardsWithState(ShardRoutingState.STARTED);
+                shardsOnStartedNode.addAll(toShardIds(shardsOnRestartedNodeWhenStarted));
+                List<MutableShardRouting> unassignedAfterClose = client(masterNode).admin().cluster().prepareState().all().get().getState().routingNodes().shardsWithState(ShardRoutingState.UNASSIGNED);
+                shardsOnClosedNode.addAll(toShardIds(unassignedAfterClose));
+                assertThat(client(masterNode).admin().cluster().prepareHealth().get().getDelayedUnassignedShards(), equalTo(shardsOnStartedNode.size()));
+                return null;
+            }
+        });
+
+        logger.info("making sure that during the restart operation, when the node restarted was closed, the node shards were unassigned");
+        assertThat(shardsOnStartedNode, equalTo(shardsOnClosedNode));
+        ensureGreen("test");
+        logger.info("verify that all the shards that were on the node are assigned to it again after it was restarted");
+        final ClusterState postRestartClusterState = client().admin().cluster().prepareState().all().get().getState();
+        List<MutableShardRouting> shardsOnRestartedNodeWhenStarted = postRestartClusterState.routingNodes().node(fullClusterState.nodes().resolveNode(nodeNameRef.get()).getId()).shardsWithState(ShardRoutingState.STARTED);
+        assertThat(toShardIds(shardsOnRestartedNodeWhenStarted), equalTo(shardsOnClosedNode));
+        assertThat(client(masterNode).admin().cluster().prepareHealth().get().getDelayedUnassignedShards(), equalTo(0));
+    }
+
+    @Test
+    public void testDurationExpiry() throws Exception {
+        // start a single master node
+        final String masterNode = internalCluster().startNodesAsync(1, Settings.builder().put("node.data", false)
+                .put(DelayUnassignedAllocation.DELAY_ALLOCATION_DURATION, "1h")
+                        // the test infra can maintain same node name when restarting a node
+                .put(DelayUnassignedAllocation.DELAY_ALLOCATION_NODE_KEY, DelayUnassignedAllocation.NodeKey.NAME)
+                .put(ConcurrentRebalanceAllocationDecider.CLUSTER_ROUTING_ALLOCATION_CLUSTER_CONCURRENT_REBALANCE, 0) // no rebalancing
+                .build()).get().get(0);
+        // and 4 data nodes
+        Settings settings = Settings.builder().put("node.master", false).build();
+        internalCluster().startNodesAsync(4, settings).get();
+
+        logger.info("create an index, and make sure the shard and replicas are sync'ed for fast recovery");
+        assertAcked(prepareCreate("test").setSettings(Settings.builder().put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)));
+        ensureGreen("test");
+        final int numDocs = randomIntBetween(10, 100);
+        for (int i = 0; i < numDocs; i++) {
+            client().prepareIndex("test", "doc", "" + i).setSource("foo", "bar").get();
+        }
+        assertAllSuccessful(client().admin().indices().prepareFlush().setForce(true).setWaitIfOngoing(true).execute().actionGet());
+        assertAcked(client().admin().indices().prepareUpdateSettings("test").setSettings(Settings.builder().put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, internalCluster().numDataNodes() - 2)));
+        ensureGreen("test");
+
+        internalCluster().stopRandomDataNode();
+        ensureYellow("test");
+        assertThat(client(masterNode).admin().cluster().prepareHealth().get().getDelayedUnassignedShards(), greaterThan(0));
+
+        if (randomBoolean()) {
+            logger.info("updating delay duration to 1ms, it should expire and allow to get to green");
+            assertAcked(client().admin().cluster().prepareUpdateSettings().setTransientSettings(Settings.builder().put(DelayUnassignedAllocation.DELAY_ALLOCATION_DURATION, "1ms")));
+        } else {
+            logger.info("executed reroute request with delayed duration of 1ms, should allow the cluster to get to green");
+            assertAcked(client().admin().cluster().prepareReroute().setDelayedDuration(TimeValue.timeValueMillis(1)));
+        }
+        ensureGreen("test");
+        assertThat(client(masterNode).admin().cluster().prepareHealth().get().getDelayedUnassignedShards(), equalTo(0));
+    }
+
+    private Set<ShardId> toShardIds(Iterable<MutableShardRouting> shards) {
+        Set<ShardId> ret = new HashSet<>();
+        for (MutableShardRouting shard : shards) {
+            ret.add(shard.shardId());
+        }
+        return ret;
+    }
+}

--- a/src/test/java/org/elasticsearch/test/ElasticsearchAllocationTestCase.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchAllocationTestCase.java
@@ -33,6 +33,7 @@ import org.elasticsearch.cluster.routing.allocation.decider.AllocationDecidersMo
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.DummyTransportAddress;
 import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.gateway.GatewayAllocator;
 import org.elasticsearch.test.gateway.NoopGatewayAllocator;
 import org.elasticsearch.node.settings.NodeSettingsService;
 
@@ -61,11 +62,14 @@ public abstract class ElasticsearchAllocationTestCase extends ElasticsearchTestC
     }
 
     public static AllocationService createAllocationService(Settings settings, NodeSettingsService nodeSettingsService, Random random) {
-        return new AllocationService(settings,
-                randomAllocationDeciders(settings, nodeSettingsService, random),
-                new ShardsAllocators(settings, NoopGatewayAllocator.INSTANCE), ClusterInfoService.EMPTY);
+        return createAllocationService(settings, nodeSettingsService, NoopGatewayAllocator.INSTANCE, random);
     }
 
+    public static AllocationService createAllocationService(Settings settings, NodeSettingsService nodeSettingsService, GatewayAllocator allocator, Random random) {
+        return new AllocationService(settings,
+                randomAllocationDeciders(settings, nodeSettingsService, random),
+                new ShardsAllocators(settings, allocator), ClusterInfoService.EMPTY);
+    }
 
     public static AllocationDeciders randomAllocationDeciders(Settings settings, NodeSettingsService nodeSettingsService, Random random) {
         final ImmutableSet<Class<? extends AllocationDecider>> defaultAllocationDeciders = AllocationDecidersModule.DEFAULT_ALLOCATION_DECIDERS;

--- a/src/test/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/src/test/java/org/elasticsearch/test/InternalTestCluster.java
@@ -48,6 +48,7 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.OperationRouting;
 import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.routing.allocation.allocator.DelayUnassignedAllocation;
 import org.elasticsearch.cluster.routing.allocation.decider.DiskThresholdDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.ThrottlingAllocationDecider;
 import org.elasticsearch.common.Nullable;
@@ -450,6 +451,8 @@ public final class InternalTestCluster extends TestCluster {
                 builder.put(TranslogConfig.INDEX_TRANSLOG_SYNC_INTERVAL, RandomInts.randomIntBetween(random, 100, 5000));
             }
         }
+
+        builder.put(DelayUnassignedAllocation.DELAY_ALLOCATION_DURATION, TimeValue.timeValueMillis(RandomInts.randomIntBetween(random, 0, 100)));
 
         return builder.build();
     }

--- a/src/test/java/org/elasticsearch/test/gateway/NoopGatewayAllocator.java
+++ b/src/test/java/org/elasticsearch/test/gateway/NoopGatewayAllocator.java
@@ -24,6 +24,7 @@ import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
 import org.elasticsearch.cluster.routing.allocation.StartedRerouteAllocation;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.gateway.GatewayAllocator;
+import org.elasticsearch.node.settings.NodeSettingsService;
 
 /**
  * An allocator used for tests that doesn't do anything
@@ -33,7 +34,7 @@ public class NoopGatewayAllocator extends GatewayAllocator {
     public static final NoopGatewayAllocator INSTANCE = new NoopGatewayAllocator();
 
     private NoopGatewayAllocator() {
-        super(Settings.EMPTY, null, null);
+        super(Settings.EMPTY, null, new NodeSettingsService(Settings.EMPTY), null, null);
     }
 
     @Override


### PR DESCRIPTION
Delay allocation of unassigned shards when node leaves for a specific period (defaults to 5m) to give it a chance to come back and not cause excessive allocations.

This new behavior, specifically with the default value, means that when a node leaves the cluster now, the shards assigned to it will only be allocated back to the rest of the cluster after the specified duration.

The number of delayed unassigned shards can be retrieved using the cluster health API.

The setting to control the duration is `cluster.routing.allocation.delay_unassigned_allocation.duration`, and its dynamically updatable using the cluster update settings API (only applicable to master nodes).

The reroute cluster command now also accepts an optional `delayed_duration` parameter, when set, it will override the duration for this reroute operation. This can be handy, for example, to set it to 0 and get the current delayed shards to be assigned.

The concept of a node key is also introduced, allowing to specify what represents a node in a "cross restart" manner. The potential values for the setting `cluster.routing.allocation.delay_unassigned_allocation.node_key` are `name` (node name), `id` (node id, note, randomly generated on node startup), `host_address` (the host ip address)
, `host_name` (the host name), `transport_addresss` (the transport address, ip + port of the node). Defaults to `transport_address`.

Closes https://github.com/elastic/elasticsearch/issues/7288
