### PR TITLE
Deprecate filter option in PhraseSuggester collate

### DIFF
--- a/docs/reference/search/suggesters/phrase-suggest.asciidoc
+++ b/docs/reference/search/suggesters/phrase-suggest.asciidoc
@@ -162,19 +162,20 @@ can contain misspellings (See parameter descriptions below).
     is wrapped rather than each token.
 
 `collate`::
-    Checks each suggestion against the specified `query` or `filter` to
-    prune suggestions for which no matching docs exist in the index.
-    The collate query for a suggestion is run only on the local shard from which
-    the suggestion has been generated from. Either a `query` or a `filter` must
-    be specified, and it is run as a <<query-dsl-template-query,`template` query>>.
-    The current suggestion is automatically made available as the `{{suggestion}}`
-    variable, which should be used in your query/filter.  You can still specify
-    your own template `params` -- the `suggestion` value will be added to the
-    variables you specify. Additionally, you can specify a `prune` to control
-    if all phrase suggestions will be returned, when set to `true` the suggestions
-    will have an additional option `collate_match`, which will be `true` if
-    matching documents for the phrase was found, `false` otherwise.
-    The default value for `prune` is `false`.
+    Checks each suggestion against a specified `query` to prune suggestions
+    for which no matching docs exist in the index. The collate query for a
+    suggestion is run only on the local shard from which the suggestion has
+    been generated from. A `query` must be specified, and it is run as a
+    <<query-dsl-template-query,`template` query>>. The current suggestion is
+    automatically made available as the `{{suggestion}}` variable, which
+    should be used in your query.  You can still specify your own template
+    `params` -- the `suggestion` value will be added to the variables you specify.
+    Additionally, you can specify a `prune` to control if all phrase suggestions
+    will be returned, when set to `true` the suggestions will have an additional
+    option `collate_match`, which will be `true` if matching documents for the
+    phrase was found, `false` otherwise. The default value for `prune` is `false`.
+    The option of specifying a `filter` has been deprecated in v1.6.0 and will be
+    removed in v2.0.0.
 
 [source,js]
 --------------------------------------------------

--- a/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilder.java
+++ b/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilder.java
@@ -182,16 +182,9 @@ public final class PhraseSuggestionBuilder extends SuggestionBuilder<PhraseSugge
     /**
      * Sets a filter used for filtering out suggested phrases (collation).
      */
+    @Deprecated
     public PhraseSuggestionBuilder collateFilter(String collateFilter) {
         this.collateFilter = collateFilter;
-        return this;
-    }
-
-    /**
-     * Sets routing preferences for executing filter query (collation).
-     */
-    public PhraseSuggestionBuilder collatePreference(String collatePreference) {
-        this.collatePreference = collatePreference;
         return this;
     }
 


### PR DESCRIPTION
Collate filter option is removed in v2.0.0, use collate query for
collation in PhraseSuggester.

see #11195
