### PR TITLE
Always normalize root paths during resolution of paths

### DIFF
--- a/src/main/java/org/elasticsearch/common/io/PathUtils.java
+++ b/src/main/java/org/elasticsearch/common/io/PathUtils.java
@@ -83,8 +83,9 @@ public final class PathUtils {
      */
     public static Path get(Path[] roots, String path) {
         for (Path root : roots) {
-            Path normalizedPath = root.resolve(path).normalize();
-            if(normalizedPath.startsWith(root)) {
+            Path normalizedRoot = root.normalize();
+            Path normalizedPath = normalizedRoot.resolve(path).normalize();
+            if(normalizedPath.startsWith(normalizedRoot)) {
                 return normalizedPath;
             }
         }

--- a/src/test/java/org/elasticsearch/env/EnvironmentTests.java
+++ b/src/test/java/org/elasticsearch/env/EnvironmentTests.java
@@ -77,13 +77,14 @@ public class EnvironmentTests extends ElasticsearchTestCase {
         Environment environment = newEnvironment();
         assertThat(environment.resolveRepoFile("/test/repos/repo1"), nullValue());
         assertThat(environment.resolveRepoFile("test/repos/repo1"), nullValue());
-        environment = newEnvironment(settingsBuilder().putArray("path.repo", "/test/repos", "/another/repos").build());
+        environment = newEnvironment(settingsBuilder().putArray("path.repo", "/test/repos", "/another/repos", "/test/repos/../other").build());
         assertThat(environment.resolveRepoFile("/test/repos/repo1"), notNullValue());
         assertThat(environment.resolveRepoFile("test/repos/repo1"), notNullValue());
         assertThat(environment.resolveRepoFile("/another/repos/repo1"), notNullValue());
         assertThat(environment.resolveRepoFile("/test/repos/../repo1"), nullValue());
         assertThat(environment.resolveRepoFile("/test/repos/../repos/repo1"), notNullValue());
         assertThat(environment.resolveRepoFile("/somethingeles/repos/repo1"), nullValue());
+        assertThat(environment.resolveRepoFile("/test/other/repo"), notNullValue());
     }
 
 }


### PR DESCRIPTION
Currently, when trying to determine if a location is within one of the configured repository
paths, we compare the root path against a normalized path but the root path is never
normalized so the check may incorrectly fail. This change normalizes the root path and
compares it to the other normalized path.

Relates to #11426
