### PR TITLE
Add script type and script name to error messages

### DIFF
--- a/core/src/main/java/org/elasticsearch/script/CompiledScript.java
+++ b/core/src/main/java/org/elasticsearch/script/CompiledScript.java
@@ -24,17 +24,39 @@ package org.elasticsearch.script;
  */
 public class CompiledScript {
 
+    private final ScriptService.ScriptType type;
+    private final String name;
     private final String lang;
     private final Object compiled;
 
     /**
      * Constructor for CompiledScript.
+     * @param type The type of script to be executed.
+     * @param name The name of the script to be executed.
      * @param lang The language of the script to be executed.
      * @param compiled The compiled script Object that is executable.
      */
-    public CompiledScript(String lang, Object compiled) {
-        this.lang = lang;
-        this.compiled = compiled;
+    public CompiledScript(ScriptService.ScriptType type, String name, String lang, Object compiled) {
+        this.type = type;
+        this.name = name;
+            this.lang = lang;
+            this.compiled = compiled;
+        }
+
+    /**
+     * Method to get the type of language.
+     * @return The type of language the script was compiled in.
+     */
+    public ScriptService.ScriptType type() {
+        return type;
+    }
+
+    /**
+     * Method to get the name of the script.
+     * @return The name of the script to be executed.
+     */
+    public String name() {
+        return name;
     }
 
     /**
@@ -51,5 +73,13 @@ public class CompiledScript {
      */
     public Object compiled() {
         return compiled;
+    }
+
+    /**
+     * @return A string composed of type, lang, and name to describe the CompiledScript.
+     */
+    @Override
+    public String toString() {
+        return type + " script [" + name + "] using lang [" + lang + "]";
     }
 }

--- a/core/src/main/java/org/elasticsearch/script/NativeScriptEngineService.java
+++ b/core/src/main/java/org/elasticsearch/script/NativeScriptEngineService.java
@@ -71,14 +71,14 @@ public class NativeScriptEngineService extends AbstractComponent implements Scri
     }
 
     @Override
-    public ExecutableScript executable(Object compiledScript, @Nullable Map<String, Object> vars) {
-        NativeScriptFactory scriptFactory = (NativeScriptFactory) compiledScript;
+    public ExecutableScript executable(CompiledScript compiledScript, @Nullable Map<String, Object> vars) {
+        NativeScriptFactory scriptFactory = (NativeScriptFactory) compiledScript.compiled();
         return scriptFactory.newScript(vars);
     }
 
     @Override
-    public SearchScript search(Object compiledScript, final SearchLookup lookup, @Nullable final Map<String, Object> vars) {
-        final NativeScriptFactory scriptFactory = (NativeScriptFactory) compiledScript;
+    public SearchScript search(CompiledScript compiledScript, final SearchLookup lookup, @Nullable final Map<String, Object> vars) {
+        final NativeScriptFactory scriptFactory = (NativeScriptFactory) compiledScript.compiled();
         return new SearchScript() {
             @Override
             public LeafSearchScript getLeafSearchScript(LeafReaderContext context) throws IOException {
@@ -90,7 +90,7 @@ public class NativeScriptEngineService extends AbstractComponent implements Scri
     }
 
     @Override
-    public Object execute(Object compiledScript, Map<String, Object> vars) {
+    public Object execute(CompiledScript compiledScript, Map<String, Object> vars) {
         return executable(compiledScript, vars).run();
     }
 

--- a/core/src/main/java/org/elasticsearch/script/ScriptEngineService.java
+++ b/core/src/main/java/org/elasticsearch/script/ScriptEngineService.java
@@ -38,11 +38,11 @@ public interface ScriptEngineService extends Closeable {
 
     Object compile(String script);
 
-    ExecutableScript executable(Object compiledScript, @Nullable Map<String, Object> vars);
+    ExecutableScript executable(CompiledScript compiledScript, @Nullable Map<String, Object> vars);
 
-    SearchScript search(Object compiledScript, SearchLookup lookup, @Nullable Map<String, Object> vars);
+    SearchScript search(CompiledScript compiledScript, SearchLookup lookup, @Nullable Map<String, Object> vars);
 
-    Object execute(Object compiledScript, Map<String, Object> vars);
+    Object execute(CompiledScript compiledScript, Map<String, Object> vars);
 
     Object unwrap(Object value);
 

--- a/core/src/main/java/org/elasticsearch/script/ScriptService.java
+++ b/core/src/main/java/org/elasticsearch/script/ScriptService.java
@@ -249,50 +249,67 @@ public class ScriptService extends AbstractComponent implements Closeable {
     }
 
     /**
-     * Compiles a script straight-away, or returns the previously compiled and cached script, without checking if it can be executed based on settings.
+     * Compiles a script straight-away, or returns the previously compiled and cached script,
+     * without checking if it can be executed based on settings.
      */
     public CompiledScript compileInternal(Script script) {
         if (script == null) {
             throw new IllegalArgumentException("The parameter script (Script) must not be null.");
         }
 
-        String lang = script.getLang();
+        String lang = script.getLang() == null ? defaultLang : script.getLang();
+        ScriptType type = script.getType();
+        //script.getScript() could return either a name or code for a script,
+        //but we check for a file script name first and an indexed script name second
+        String name = script.getScript();
 
-        if (lang == null) {
-            lang = defaultLang;
-        }
         if (logger.isTraceEnabled()) {
-            logger.trace("Compiling lang: [{}] type: [{}] script: {}", lang, script.getType(), script.getScript());
+            logger.trace("Compiling lang: [{}] type: [{}] script: {}", lang, type, name);
         }
 
         ScriptEngineService scriptEngineService = getScriptEngineServiceForLang(lang);
-        String cacheKey = getCacheKey(scriptEngineService, script.getScript());
 
-        if (script.getType() == ScriptType.FILE) {
-            CompiledScript compiled = staticCache.get(cacheKey); //On disk scripts will be loaded into the staticCache by the listener
-            if (compiled == null) {
-                throw new IllegalArgumentException("Unable to find on disk script " + script.getScript());
+        if (type == ScriptType.FILE) {
+            String cacheKey = getCacheKey(scriptEngineService, name, null);
+            //On disk scripts will be loaded into the staticCache by the listener
+            CompiledScript compiledScript = staticCache.get(cacheKey);
+
+            if (compiledScript == null) {
+                throw new IllegalArgumentException("Unable to find on disk file script [" + name + "] using lang [" + lang + "]");
             }
-            return compiled;
+
+            return compiledScript;
         }
 
+        //script.getScript() will be code if the script type is inline
         String code = script.getScript();
 
-        if (script.getType() == ScriptType.INDEXED) {
-            final IndexedScript indexedScript = new IndexedScript(lang, script.getScript());
+        if (type == ScriptType.INDEXED) {
+            //The look up for an indexed script must be done every time in case
+            //the script has been updated in the index since the last look up.
+            final IndexedScript indexedScript = new IndexedScript(lang, name);
+            name = indexedScript.id;
             code = getScriptFromIndex(indexedScript.lang, indexedScript.id);
-            cacheKey = getCacheKey(scriptEngineService, code);
         }
 
-        CompiledScript compiled = cache.getIfPresent(cacheKey);
-        if (compiled == null) {
-            //Either an un-cached inline script or an indexed script
-            compiled = new CompiledScript(lang, scriptEngineService.compile(code));
+        //if the script type is inline the name will be the same as the code for identification in exceptions
+        String cacheKey = getCacheKey(scriptEngineService, type == ScriptType.INLINE ? null : name, code);
+        CompiledScript compiledScript = cache.getIfPresent(cacheKey);
+
+        if (compiledScript == null) {
+            //Either an un-cached inline script or indexed script
+            try {
+                compiledScript = new CompiledScript(type, name, lang, scriptEngineService.compile(code));
+            } catch (Exception exception) {
+                throw new ScriptException("Failed to compile " + type + " script [" + name + "] using lang [" + lang + "]", exception);
+            }
+
             //Since the cache key is the script content itself we don't need to
             //invalidate/check the cache if an indexed script changes.
-            cache.put(cacheKey, compiled);
+            cache.put(cacheKey, compiledScript);
         }
-        return compiled;
+
+        return compiledScript;
     }
 
     public void queryScriptIndex(GetIndexedScriptRequest request, final ActionListener<GetResponse> listener) {
@@ -334,13 +351,13 @@ public class ScriptService extends AbstractComponent implements Closeable {
             Template template = TemplateQueryParser.parse(scriptLang, parser, parseFieldMatcher, "params", "script", "template");
             if (Strings.hasLength(template.getScript())) {
                 //Just try and compile it
-                //This will have the benefit of also adding the script to the cache if it compiles
                 try {
+                    ScriptEngineService scriptEngineService = getScriptEngineServiceForLang(scriptLang);
                     //we don't know yet what the script will be used for, but if all of the operations for this lang with
-                    //indexed scripts are disabled, it makes no sense to even compile it and cache it.
-                    if (isAnyScriptContextEnabled(scriptLang, getScriptEngineServiceForLang(scriptLang), ScriptType.INDEXED)) {
-                        CompiledScript compiledScript = compileInternal(template);
-                        if (compiledScript == null) {
+                    //indexed scripts are disabled, it makes no sense to even compile it.
+                    if (isAnyScriptContextEnabled(scriptLang, scriptEngineService, ScriptType.INDEXED)) {
+                        Object compiled = scriptEngineService.compile(template.getScript());
+                        if (compiled == null) {
                             throw new IllegalArgumentException("Unable to parse [" + template.getScript() +
                                     "] lang [" + scriptLang + "] (ScriptService.compile returned null)");
                         }
@@ -419,7 +436,7 @@ public class ScriptService extends AbstractComponent implements Closeable {
      * Executes a previously compiled script provided as an argument
      */
     public ExecutableScript executable(CompiledScript compiledScript, Map<String, Object> vars) {
-        return getScriptEngineServiceForLang(compiledScript.lang()).executable(compiledScript.compiled(), vars);
+        return getScriptEngineServiceForLang(compiledScript.lang()).executable(compiledScript, vars);
     }
 
     /**
@@ -427,7 +444,7 @@ public class ScriptService extends AbstractComponent implements Closeable {
      */
     public SearchScript search(SearchLookup lookup, Script script, ScriptContext scriptContext) {
         CompiledScript compiledScript = compile(script, scriptContext);
-        return getScriptEngineServiceForLang(compiledScript.lang()).search(compiledScript.compiled(), lookup, script.getParams());
+        return getScriptEngineServiceForLang(compiledScript.lang()).search(compiledScript, lookup, script.getParams());
     }
 
     private boolean isAnyScriptContextEnabled(String lang, ScriptEngineService scriptEngineService, ScriptType scriptType) {
@@ -513,8 +530,8 @@ public class ScriptService extends AbstractComponent implements Closeable {
                             logger.info("compiling script file [{}]", file.toAbsolutePath());
                             try(InputStreamReader reader = new InputStreamReader(Files.newInputStream(file), Charsets.UTF_8)) {
                                 String script = Streams.copyToString(reader);
-                                String cacheKey = getCacheKey(engineService, scriptNameExt.v1());
-                                staticCache.put(cacheKey, new CompiledScript(engineService.types()[0], engineService.compile(script)));
+                                String cacheKey = getCacheKey(engineService, scriptNameExt.v1(), null);
+                                staticCache.put(cacheKey, new CompiledScript(ScriptType.FILE, scriptNameExt.v1(), engineService.types()[0], engineService.compile(script)));
                             }
                         } else {
                             logger.warn("skipping compile of script file [{}] as all scripted operations are disabled for file scripts", file.toAbsolutePath());
@@ -538,7 +555,7 @@ public class ScriptService extends AbstractComponent implements Closeable {
                 ScriptEngineService engineService = getScriptEngineServiceForFileExt(scriptNameExt.v2());
                 assert engineService != null;
                 logger.info("removing script file [{}]", file.toAbsolutePath());
-                staticCache.remove(getCacheKey(engineService, scriptNameExt.v1()));
+                staticCache.remove(getCacheKey(engineService, scriptNameExt.v1(), null));
             }
         }
 
@@ -598,9 +615,9 @@ public class ScriptService extends AbstractComponent implements Closeable {
         }
     }
 
-    private static String getCacheKey(ScriptEngineService scriptEngineService, String script) {
+    private static String getCacheKey(ScriptEngineService scriptEngineService, String name, String code) {
         String lang = scriptEngineService.types()[0];
-        return lang + ":" + script;
+        return lang + ":" + (name != null ? ":" + name : "") + (code != null ? ":" + code : "");
     }
 
     private static class IndexedScript {

--- a/core/src/test/java/org/elasticsearch/script/ScriptModesTests.java
+++ b/core/src/test/java/org/elasticsearch/script/ScriptModesTests.java
@@ -287,17 +287,17 @@ public class ScriptModesTests extends ElasticsearchTestCase {
         }
 
         @Override
-        public ExecutableScript executable(Object compiledScript, @Nullable Map<String, Object> vars) {
+        public ExecutableScript executable(CompiledScript compiledScript, @Nullable Map<String, Object> vars) {
             return null;
         }
 
         @Override
-        public SearchScript search(Object compiledScript, SearchLookup lookup, @Nullable Map<String, Object> vars) {
+        public SearchScript search(CompiledScript compiledScript, SearchLookup lookup, @Nullable Map<String, Object> vars) {
             return null;
         }
 
         @Override
-        public Object execute(Object compiledScript, Map<String, Object> vars) {
+        public Object execute(CompiledScript compiledScript, Map<String, Object> vars) {
             return null;
         }
 

--- a/core/src/test/java/org/elasticsearch/script/ScriptServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/script/ScriptServiceTests.java
@@ -148,7 +148,7 @@ public class ScriptServiceTests extends ElasticsearchTestCase {
             scriptService.compile(new Script("test_script", ScriptType.FILE, "test", null), ScriptContext.Standard.SEARCH);
             fail("the script test_script should no longer exist");
         } catch (IllegalArgumentException ex) {
-            assertThat(ex.getMessage(), containsString("Unable to find on disk script test_script"));
+            assertThat(ex.getMessage(), containsString("Unable to find on disk file script [test_script] using lang [test]"));
         }
     }
 
@@ -171,7 +171,7 @@ public class ScriptServiceTests extends ElasticsearchTestCase {
                 randomFrom(scriptContexts));
         CompiledScript compiledScript2 = scriptService.compile(new Script("1+1", ScriptType.INLINE, "test", null),
                 randomFrom(scriptContexts));
-        assertThat(compiledScript1, sameInstance(compiledScript2));
+        assertThat(compiledScript1.compiled(), sameInstance(compiledScript2.compiled()));
     }
 
     @Test
@@ -181,7 +181,7 @@ public class ScriptServiceTests extends ElasticsearchTestCase {
                 randomFrom(scriptContexts));
         CompiledScript compiledScript2 = scriptService.compile(new Script("script", ScriptType.INLINE, "test2", null),
                 randomFrom(scriptContexts));
-        assertThat(compiledScript1, sameInstance(compiledScript2));
+        assertThat(compiledScript1.compiled(), sameInstance(compiledScript2.compiled()));
     }
 
     @Test
@@ -192,7 +192,7 @@ public class ScriptServiceTests extends ElasticsearchTestCase {
                 randomFrom(scriptContexts));
         CompiledScript compiledScript2 = scriptService.compile(new Script("file_script", ScriptType.FILE, "test2", null),
                 randomFrom(scriptContexts));
-        assertThat(compiledScript1, sameInstance(compiledScript2));
+        assertThat(compiledScript1.compiled(), sameInstance(compiledScript2.compiled()));
     }
 
     @Test
@@ -431,17 +431,17 @@ public class ScriptServiceTests extends ElasticsearchTestCase {
         }
 
         @Override
-        public ExecutableScript executable(final Object compiledScript, @Nullable Map<String, Object> vars) {
+        public ExecutableScript executable(final CompiledScript compiledScript, @Nullable Map<String, Object> vars) {
             return null;
         }
 
         @Override
-        public SearchScript search(Object compiledScript, SearchLookup lookup, @Nullable Map<String, Object> vars) {
+        public SearchScript search(CompiledScript compiledScript, SearchLookup lookup, @Nullable Map<String, Object> vars) {
             return null;
         }
 
         @Override
-        public Object execute(Object compiledScript, Map<String, Object> vars) {
+        public Object execute(CompiledScript compiledScript, Map<String, Object> vars) {
             return null;
         }
 

--- a/core/src/test/java/org/elasticsearch/script/expression/ExpressionScriptTests.java
+++ b/core/src/test/java/org/elasticsearch/script/expression/ExpressionScriptTests.java
@@ -29,9 +29,11 @@ import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.action.update.UpdateRequestBuilder;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilder;
 import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilders;
+import org.elasticsearch.script.CompiledScript;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptException;
 import org.elasticsearch.script.ScriptService.ScriptType;
@@ -414,8 +416,9 @@ public class ExpressionScriptTests extends ElasticsearchIntegrationTest {
         vars.put("xyz", -1);
 
         Expression expr = JavascriptCompiler.compile("a+b+xyz");
+        CompiledScript compiledScript = new CompiledScript(ScriptType.INLINE, "", "expression", expr);
 
-        ExpressionExecutableScript ees = new ExpressionExecutableScript(expr, vars);
+        ExpressionExecutableScript ees = new ExpressionExecutableScript(compiledScript, vars);
         assertEquals((Double) ees.run(), 4.5, 0.001);
 
         ees.setNextVar("b", -2.5);
@@ -431,7 +434,7 @@ public class ExpressionScriptTests extends ElasticsearchIntegrationTest {
         try {
             vars = new HashMap<>();
             vars.put("a", 1);
-            ees = new ExpressionExecutableScript(expr, vars);
+            ees = new ExpressionExecutableScript(compiledScript, vars);
             ees.run();
             fail("An incorrect number of variables were allowed to be used in an expression.");
         } catch (ScriptException se) {
@@ -444,7 +447,7 @@ public class ExpressionScriptTests extends ElasticsearchIntegrationTest {
             vars.put("a", 1);
             vars.put("b", 3);
             vars.put("c", -1);
-            ees = new ExpressionExecutableScript(expr, vars);
+            ees = new ExpressionExecutableScript(compiledScript, vars);
             ees.run();
             fail("A variable was allowed to be set that does not exist in the expression.");
         } catch (ScriptException se) {
@@ -457,7 +460,7 @@ public class ExpressionScriptTests extends ElasticsearchIntegrationTest {
             vars.put("a", 1);
             vars.put("b", 3);
             vars.put("xyz", "hello");
-            ees = new ExpressionExecutableScript(expr, vars);
+            ees = new ExpressionExecutableScript(compiledScript, vars);
             ees.run();
             fail("A non-number was allowed to be use in the expression.");
         } catch (ScriptException se) {

--- a/core/src/test/java/org/elasticsearch/script/mustache/MustacheScriptEngineTest.java
+++ b/core/src/test/java/org/elasticsearch/script/mustache/MustacheScriptEngineTest.java
@@ -20,6 +20,8 @@ package org.elasticsearch.script.mustache;
 
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.script.CompiledScript;
+import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.junit.Before;
 import org.junit.Test;
@@ -52,7 +54,7 @@ public class MustacheScriptEngineTest extends ElasticsearchTestCase {
                     + "\"negative\": {\"term\": {\"body\": {\"value\": \"solr\"}" + "}}, \"negative_boost\": {{boost_val}} } }}";
             Map<String, Object> vars = new HashMap<>();
             vars.put("boost_val", "0.3");
-            BytesReference o = (BytesReference) qe.execute(qe.compile(template), vars);
+            BytesReference o = (BytesReference) qe.execute(new CompiledScript(ScriptService.ScriptType.INLINE, "", "mustache", qe.compile(template)), vars);
             assertEquals("GET _search {\"query\": {\"boosting\": {\"positive\": {\"match\": {\"body\": \"gift\"}},"
                     + "\"negative\": {\"term\": {\"body\": {\"value\": \"solr\"}}}, \"negative_boost\": 0.3 } }}",
                     new String(o.toBytes(), Charset.forName("UTF-8")));
@@ -63,7 +65,7 @@ public class MustacheScriptEngineTest extends ElasticsearchTestCase {
             Map<String, Object> vars = new HashMap<>();
             vars.put("boost_val", "0.3");
             vars.put("body_val", "\"quick brown\"");
-            BytesReference o = (BytesReference) qe.execute(qe.compile(template), vars);
+            BytesReference o = (BytesReference) qe.execute(new CompiledScript(ScriptService.ScriptType.INLINE, "", "mustache", qe.compile(template)), vars);
             assertEquals("GET _search {\"query\": {\"boosting\": {\"positive\": {\"match\": {\"body\": \"gift\"}},"
                     + "\"negative\": {\"term\": {\"body\": {\"value\": \"\\\"quick brown\\\"\"}}}, \"negative_boost\": 0.3 } }}",
                     new String(o.toBytes(), Charset.forName("UTF-8")));

--- a/plugins/lang-javascript/src/main/java/org/elasticsearch/script/javascript/JavaScriptScriptEngineService.java
+++ b/plugins/lang-javascript/src/main/java/org/elasticsearch/script/javascript/JavaScriptScriptEngineService.java
@@ -105,7 +105,7 @@ public class JavaScriptScriptEngineService extends AbstractComponent implements 
     }
 
     @Override
-    public ExecutableScript executable(Object compiledScript, Map<String, Object> vars) {
+    public ExecutableScript executable(CompiledScript compiledScript, Map<String, Object> vars) {
         Context ctx = Context.enter();
         try {
             ctx.setWrapFactory(wrapFactory);
@@ -117,14 +117,14 @@ public class JavaScriptScriptEngineService extends AbstractComponent implements 
                 ScriptableObject.putProperty(scope, entry.getKey(), entry.getValue());
             }
 
-            return new JavaScriptExecutableScript((Script) compiledScript, scope);
+            return new JavaScriptExecutableScript((Script) compiledScript.compiled(), scope);
         } finally {
             Context.exit();
         }
     }
 
     @Override
-    public SearchScript search(final Object compiledScript, final SearchLookup lookup, @Nullable final Map<String, Object> vars) {
+    public SearchScript search(final CompiledScript compiledScript, final SearchLookup lookup, @Nullable final Map<String, Object> vars) {
         Context ctx = Context.enter();
         try {
             ctx.setWrapFactory(wrapFactory);
@@ -148,7 +148,7 @@ public class JavaScriptScriptEngineService extends AbstractComponent implements 
                     }
                 }
 
-                return new JavaScriptSearchScript((Script) compiledScript, scope, leafLookup);
+                return new JavaScriptSearchScript((Script) compiledScript.compiled(), scope, leafLookup);
               }
             };
         } finally {
@@ -157,11 +157,11 @@ public class JavaScriptScriptEngineService extends AbstractComponent implements 
     }
 
     @Override
-    public Object execute(Object compiledScript, Map<String, Object> vars) {
+    public Object execute(CompiledScript compiledScript, Map<String, Object> vars) {
         Context ctx = Context.enter();
         ctx.setWrapFactory(wrapFactory);
         try {
-            Script script = (Script) compiledScript;
+            Script script = (Script) compiledScript.compiled();
             Scriptable scope = ctx.newObject(globalScope);
             scope.setPrototype(globalScope);
             scope.setParentScope(null);

--- a/plugins/lang-javascript/src/test/java/org/elasticsearch/script/javascript/JavaScriptScriptMultiThreadedTest.java
+++ b/plugins/lang-javascript/src/test/java/org/elasticsearch/script/javascript/JavaScriptScriptMultiThreadedTest.java
@@ -20,7 +20,9 @@
 package org.elasticsearch.script.javascript;
 
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.script.CompiledScript;
 import org.elasticsearch.script.ExecutableScript;
+import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.junit.Test;
 
@@ -59,7 +61,7 @@ public class JavaScriptScriptMultiThreadedTest extends ElasticsearchTestCase {
                         Map<String, Object> vars = new HashMap<String, Object>();
                         vars.put("x", x);
                         vars.put("y", y);
-                        ExecutableScript script = se.executable(compiled, vars);
+                        ExecutableScript script = se.executable(new CompiledScript(ScriptService.ScriptType.INLINE, "testExecutableNoRuntimeParams", "js", compiled), vars);
                         for (int i = 0; i < 100000; i++) {
                             long result = ((Number) script.run()).longValue();
                             assertThat(result, equalTo(addition));
@@ -100,7 +102,7 @@ public class JavaScriptScriptMultiThreadedTest extends ElasticsearchTestCase {
                         long x = ThreadLocalRandom.current().nextInt();
                         Map<String, Object> vars = new HashMap<String, Object>();
                         vars.put("x", x);
-                        ExecutableScript script = se.executable(compiled, vars);
+                        ExecutableScript script = se.executable(new CompiledScript(ScriptService.ScriptType.INLINE, "testExecutableNoRuntimeParams", "js", compiled), vars);
                         for (int i = 0; i < 100000; i++) {
                             long y = ThreadLocalRandom.current().nextInt();
                             long addition = x + y;
@@ -147,7 +149,7 @@ public class JavaScriptScriptMultiThreadedTest extends ElasticsearchTestCase {
                             long addition = x + y;
                             runtimeVars.put("x", x);
                             runtimeVars.put("y", y);
-                            long result = ((Number) se.execute(compiled, runtimeVars)).longValue();
+                            long result = ((Number) se.execute(new CompiledScript(ScriptService.ScriptType.INLINE, "testExecutableNoRuntimeParams", "js", compiled), runtimeVars)).longValue();
                             assertThat(result, equalTo(addition));
                         }
                     } catch (Throwable t) {

--- a/plugins/lang-python/src/main/java/org/elasticsearch/script/python/PythonScriptEngineService.java
+++ b/plugins/lang-python/src/main/java/org/elasticsearch/script/python/PythonScriptEngineService.java
@@ -78,26 +78,26 @@ public class PythonScriptEngineService extends AbstractComponent implements Scri
     }
 
     @Override
-    public ExecutableScript executable(Object compiledScript, Map<String, Object> vars) {
-        return new PythonExecutableScript((PyCode) compiledScript, vars);
+    public ExecutableScript executable(CompiledScript compiledScript, Map<String, Object> vars) {
+        return new PythonExecutableScript((PyCode) compiledScript.compiled(), vars);
     }
 
     @Override
-    public SearchScript search(final Object compiledScript, final SearchLookup lookup, @Nullable final Map<String, Object> vars) {
+    public SearchScript search(final CompiledScript compiledScript, final SearchLookup lookup, @Nullable final Map<String, Object> vars) {
         return new SearchScript() {
             @Override
             public LeafSearchScript getLeafSearchScript(LeafReaderContext context) throws IOException {
                 final LeafSearchLookup leafLookup = lookup.getLeafSearchLookup(context);
-                return new PythonSearchScript((PyCode) compiledScript, vars, leafLookup);
+                return new PythonSearchScript((PyCode) compiledScript.compiled(), vars, leafLookup);
             }
         };
     }
 
     @Override
-    public Object execute(Object compiledScript, Map<String, Object> vars) {
+    public Object execute(CompiledScript compiledScript, Map<String, Object> vars) {
         PyObject pyVars = Py.java2py(vars);
         interp.setLocals(pyVars);
-        PyObject ret = interp.eval((PyCode) compiledScript);
+        PyObject ret = interp.eval((PyCode) compiledScript.compiled());
         if (ret == null) {
             return null;
         }

--- a/plugins/lang-python/src/test/java/org/elasticsearch/script/python/PythonScriptMultiThreadedTest.java
+++ b/plugins/lang-python/src/test/java/org/elasticsearch/script/python/PythonScriptMultiThreadedTest.java
@@ -20,7 +20,9 @@
 package org.elasticsearch.script.python;
 
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.script.CompiledScript;
 import org.elasticsearch.script.ExecutableScript;
+import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.junit.After;
 import org.junit.Test;
@@ -50,6 +52,7 @@ public class PythonScriptMultiThreadedTest extends ElasticsearchTestCase {
     public void testExecutableNoRuntimeParams() throws Exception {
         final PythonScriptEngineService se = new PythonScriptEngineService(Settings.Builder.EMPTY_SETTINGS);
         final Object compiled = se.compile("x + y");
+        final CompiledScript compiledScript = new CompiledScript(ScriptService.ScriptType.INLINE, "testExecutableNoRuntimeParams", "python", compiled);
         final AtomicBoolean failed = new AtomicBoolean();
 
         Thread[] threads = new Thread[4];
@@ -67,7 +70,7 @@ public class PythonScriptMultiThreadedTest extends ElasticsearchTestCase {
                         Map<String, Object> vars = new HashMap<String, Object>();
                         vars.put("x", x);
                         vars.put("y", y);
-                        ExecutableScript script = se.executable(compiled, vars);
+                        ExecutableScript script = se.executable(compiledScript, vars);
                         for (int i = 0; i < 10000; i++) {
                             long result = ((Number) script.run()).longValue();
                             assertThat(result, equalTo(addition));
@@ -136,6 +139,7 @@ public class PythonScriptMultiThreadedTest extends ElasticsearchTestCase {
     public void testExecute() throws Exception {
         final PythonScriptEngineService se = new PythonScriptEngineService(Settings.Builder.EMPTY_SETTINGS);
         final Object compiled = se.compile("x + y");
+        final CompiledScript compiledScript = new CompiledScript(ScriptService.ScriptType.INLINE, "testExecute", "python", compiled);
         final AtomicBoolean failed = new AtomicBoolean();
 
         Thread[] threads = new Thread[4];
@@ -154,7 +158,7 @@ public class PythonScriptMultiThreadedTest extends ElasticsearchTestCase {
                             long addition = x + y;
                             runtimeVars.put("x", x);
                             runtimeVars.put("y", y);
-                            long result = ((Number) se.execute(compiled, runtimeVars)).longValue();
+                            long result = ((Number) se.execute(compiledScript, runtimeVars)).longValue();
                             assertThat(result, equalTo(addition));
                         }
                     } catch (Throwable t) {

--- a/plugins/lang-python/src/test/java/org/elasticsearch/script/python/SimpleBench.java
+++ b/plugins/lang-python/src/test/java/org/elasticsearch/script/python/SimpleBench.java
@@ -21,7 +21,9 @@ package org.elasticsearch.script.python;
 
 import org.elasticsearch.common.StopWatch;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.script.CompiledScript;
 import org.elasticsearch.script.ExecutableScript;
+import org.elasticsearch.script.ScriptService;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -34,32 +36,34 @@ public class SimpleBench {
     public static void main(String[] args) {
         PythonScriptEngineService se = new PythonScriptEngineService(Settings.Builder.EMPTY_SETTINGS);
         Object compiled = se.compile("x + y");
+        CompiledScript compiledScript = new CompiledScript(ScriptService.ScriptType.INLINE, "SimpleBench", "python", compiled);
+
 
         Map<String, Object> vars = new HashMap<String, Object>();
         // warm up
         for (int i = 0; i < 1000; i++) {
             vars.put("x", i);
             vars.put("y", i + 1);
-            se.execute(compiled, vars);
+            se.execute(compiledScript, vars);
         }
 
         final long ITER = 100000;
 
         StopWatch stopWatch = new StopWatch().start();
         for (long i = 0; i < ITER; i++) {
-            se.execute(compiled, vars);
+            se.execute(compiledScript, vars);
         }
         System.out.println("Execute Took: " + stopWatch.stop().lastTaskTime());
 
         stopWatch = new StopWatch().start();
-        ExecutableScript executableScript = se.executable(compiled, vars);
+        ExecutableScript executableScript = se.executable(compiledScript, vars);
         for (long i = 0; i < ITER; i++) {
             executableScript.run();
         }
         System.out.println("Executable Took: " + stopWatch.stop().lastTaskTime());
 
         stopWatch = new StopWatch().start();
-        executableScript = se.executable(compiled, vars);
+        executableScript = se.executable(compiledScript, vars);
         for (long i = 0; i < ITER; i++) {
             for (Map.Entry<String, Object> entry : vars.entrySet()) {
                 executableScript.setNextVar(entry.getKey(), entry.getValue());


### PR DESCRIPTION
Modified ScriptEngineService to pass in a CompiledScript object
to several methods with newly added name and type member variables.
This can in turn be used to give better scripting error messages
with the type of script used and the name of the script.

Required slight modifications to the caching mechanism.

Note that this does not enforce good behavior in that plugins will
have to write exceptions that also output the name of the script
in order to be effective.  There was no way to wrap the script
methods in a try/catch block properly further up the chain because
many have script-like objects passed back that can be run at a
later time.

fixes #6653
