### PR TITLE
Added epoch date formats to configure parsing of unix dates

### DIFF
--- a/docs/reference/mapping/date-format.asciidoc
+++ b/docs/reference/mapping/date-format.asciidoc
@@ -198,6 +198,11 @@ year.
 
 |`year_month_day`|A formatter for a four digit year, two digit month of
 year, and two digit day of month.
+
+|`epoch_second`|A formatter for the number of seconds since the epoch.
+
+|`epoch_millis`|A formatter for the number of milliseconds since
+the epoch.
 |=======================================================================
 
 [float]

--- a/docs/reference/mapping/fields/timestamp-field.asciidoc
+++ b/docs/reference/mapping/fields/timestamp-field.asciidoc
@@ -79,7 +79,7 @@ format>> used to parse the provided timestamp value. For example:
 }
 --------------------------------------------------
 
-Note, the default format is `dateOptionalTime`. The timestamp value will
+Note, the default format is `epoch_millis||dateOptionalTime`. The timestamp value will
 first be parsed as a number and if it fails the format will be tried.
 
 [float]

--- a/docs/reference/mapping/types/core-types.asciidoc
+++ b/docs/reference/mapping/types/core-types.asciidoc
@@ -349,7 +349,7 @@ date type:
 Defaults to the property/field name.
 
 |`format` |The <<mapping-date-format,date
-format>>. Defaults to `dateOptionalTime`.
+format>>. Defaults to `epoch_millis||dateOptionalTime`.
 
 |`store` |Set to `true` to store actual field in the index, `false` to not
 store it. Defaults to `false` (note, the JSON document itself is stored,

--- a/docs/reference/mapping/types/root-object-type.asciidoc
+++ b/docs/reference/mapping/types/root-object-type.asciidoc
@@ -42,8 +42,8 @@ and will use the matching format as its format attribute. The date
 format itself is explained
 <<mapping-date-format,here>>.
 
-The default formats are: `dateOptionalTime` (ISO) and
-`yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z`.
+The default formats are: `dateOptionalTime` (ISO),
+`yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z` and `epoch_millis`.
 
 *Note:* `dynamic_date_formats` are used *only* for dynamically added
 date fields, not for `date` fields that you specify in your mapping.

--- a/src/main/java/org/elasticsearch/action/TimestampParsingException.java
+++ b/src/main/java/org/elasticsearch/action/TimestampParsingException.java
@@ -32,6 +32,11 @@ public class TimestampParsingException extends ElasticsearchException {
         this.timestamp = timestamp;
     }
 
+    public TimestampParsingException(String timestamp, Throwable cause) {
+        super("failed to parse timestamp [" + timestamp + "]", cause);
+        this.timestamp = timestamp;
+    }
+
     public String timestamp() {
         return timestamp;
     }

--- a/src/main/java/org/elasticsearch/cluster/metadata/MappingMetaData.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MappingMetaData.java
@@ -161,19 +161,11 @@ public class MappingMetaData extends AbstractDiffable<MappingMetaData> {
     public static class Timestamp {
 
         public static String parseStringTimestamp(String timestampAsString, FormatDateTimeFormatter dateTimeFormatter) throws TimestampParsingException {
-            long ts;
             try {
-                // if we manage to parse it, its a millisecond timestamp, just return the string as is
-                ts = Long.parseLong(timestampAsString);
-                return timestampAsString;
-            } catch (NumberFormatException e) {
-                try {
-                    ts = dateTimeFormatter.parser().parseMillis(timestampAsString);
-                } catch (RuntimeException e1) {
-                    throw new TimestampParsingException(timestampAsString);
-                }
+                return Long.toString(dateTimeFormatter.parser().parseMillis(timestampAsString));
+            } catch (RuntimeException e) {
+                throw new TimestampParsingException(timestampAsString, e);
             }
-            return Long.toString(ts);
         }
 
 

--- a/src/main/java/org/elasticsearch/common/joda/DateMathParser.java
+++ b/src/main/java/org/elasticsearch/common/joda/DateMathParser.java
@@ -19,14 +19,14 @@
 
 package org.elasticsearch.common.joda;
 
-import org.apache.commons.lang3.StringUtils;
 import org.elasticsearch.ElasticsearchParseException;
 import org.joda.time.DateTimeZone;
 import org.joda.time.MutableDateTime;
 import org.joda.time.format.DateTimeFormatter;
 
 import java.util.concurrent.Callable;
-import java.util.concurrent.TimeUnit;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * A parser for date/time formatted text with optional date math.
@@ -38,13 +38,10 @@ import java.util.concurrent.TimeUnit;
 public class DateMathParser {
 
     private final FormatDateTimeFormatter dateTimeFormatter;
-    private final TimeUnit timeUnit;
 
-    public DateMathParser(FormatDateTimeFormatter dateTimeFormatter, TimeUnit timeUnit) {
-        if (dateTimeFormatter == null) throw new NullPointerException();
-        if (timeUnit == null) throw new NullPointerException();
+    public DateMathParser(FormatDateTimeFormatter dateTimeFormatter) {
+        checkNotNull(dateTimeFormatter);
         this.dateTimeFormatter = dateTimeFormatter;
-        this.timeUnit = timeUnit;
     }
 
     public long parse(String text, Callable<Long> now) {
@@ -195,17 +192,6 @@ public class DateMathParser {
     }
 
     private long parseDateTime(String value, DateTimeZone timeZone) {
-        
-        // first check for timestamp
-        if (value.length() > 4 && StringUtils.isNumeric(value)) {
-            try {
-                long time = Long.parseLong(value);
-                return timeUnit.toMillis(time);
-            } catch (NumberFormatException e) {
-                throw new ElasticsearchParseException("failed to parse date field [" + value + "] as timestamp", e);
-            }
-        }
-        
         DateTimeFormatter parser = dateTimeFormatter.parser();
         if (timeZone != null) {
             parser = parser.withZone(timeZone);

--- a/src/main/java/org/elasticsearch/index/mapper/internal/TimestampFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/TimestampFieldMapper.java
@@ -58,7 +58,7 @@ public class TimestampFieldMapper extends DateFieldMapper implements RootMapper 
 
     public static final String NAME = "_timestamp";
     public static final String CONTENT_TYPE = "_timestamp";
-    public static final String DEFAULT_DATE_TIME_FORMAT = "dateOptionalTime";
+    public static final String DEFAULT_DATE_TIME_FORMAT = "epoch_millis||dateOptionalTime";
 
     public static class Defaults extends DateFieldMapper.Defaults {
         public static final String NAME = "_timestamp";

--- a/src/main/java/org/elasticsearch/index/query/RangeQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/RangeQueryParser.java
@@ -102,7 +102,7 @@ public class RangeQueryParser implements QueryParser {
                         } else if ("time_zone".equals(currentFieldName) || "timeZone".equals(currentFieldName)) {
                             timeZone = DateTimeZone.forID(parser.text());
                         } else if ("format".equals(currentFieldName)) {
-                            forcedDateParser = new DateMathParser(Joda.forPattern(parser.text()), DateFieldMapper.Defaults.TIME_UNIT);
+                            forcedDateParser = new DateMathParser(Joda.forPattern(parser.text()));
                         } else {
                             throw new QueryParsingException(parseContext, "[range] query does not support [" + currentFieldName + "]");
                         }
@@ -123,11 +123,6 @@ public class RangeQueryParser implements QueryParser {
         FieldMapper mapper = parseContext.fieldMapper(fieldName);
         if (mapper != null) {
             if (mapper instanceof DateFieldMapper) {
-                if ((from instanceof Number || to instanceof Number) && timeZone != null) {
-                    throw new QueryParsingException(parseContext,
-                            "[range] time_zone when using ms since epoch format as it's UTC based can not be applied to [" + fieldName
-                                    + "]");
-                }
                 query = ((DateFieldMapper) mapper).fieldType().rangeQuery(from, to, includeLower, includeUpper, timeZone, forcedDateParser, parseContext);
             } else  {
                 if (timeZone != null) {

--- a/src/main/java/org/elasticsearch/search/aggregations/support/format/ValueFormat.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/support/format/ValueFormat.java
@@ -68,7 +68,7 @@ public class ValueFormat {
         public static final DateTime DEFAULT = new DateTime(DateFieldMapper.Defaults.DATE_TIME_FORMATTER.format(), ValueFormatter.DateTime.DEFAULT, ValueParser.DateMath.DEFAULT);
 
         public static DateTime format(String format) {
-            return new DateTime(format, new ValueFormatter.DateTime(format), new ValueParser.DateMath(format, DateFieldMapper.Defaults.TIME_UNIT));
+            return new DateTime(format, new ValueFormatter.DateTime(format), new ValueParser.DateMath(format));
         }
 
         public static DateTime mapper(DateFieldMapper mapper) {

--- a/src/main/java/org/elasticsearch/search/aggregations/support/format/ValueParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/support/format/ValueParser.java
@@ -32,7 +32,6 @@ import java.text.NumberFormat;
 import java.text.ParseException;
 import java.util.Locale;
 import java.util.concurrent.Callable;
-import java.util.concurrent.TimeUnit;
 
 /**
  *
@@ -81,12 +80,12 @@ public interface ValueParser {
      */
     static class DateMath implements ValueParser {
 
-        public static final DateMath DEFAULT = new ValueParser.DateMath(new DateMathParser(DateFieldMapper.Defaults.DATE_TIME_FORMATTER, DateFieldMapper.Defaults.TIME_UNIT));
+        public static final DateMath DEFAULT = new ValueParser.DateMath(new DateMathParser(DateFieldMapper.Defaults.DATE_TIME_FORMATTER));
 
         private DateMathParser parser;
 
-        public DateMath(String format, TimeUnit timeUnit) {
-            this(new DateMathParser(Joda.forPattern(format), timeUnit));
+        public DateMath(String format) {
+            this(new DateMathParser(Joda.forPattern(format)));
         }
 
         public DateMath(DateMathParser parser) {
@@ -110,7 +109,7 @@ public interface ValueParser {
         }
 
         public static DateMath mapper(DateFieldMapper mapper) {
-            return new DateMath(new DateMathParser(mapper.fieldType().dateTimeFormatter(), DateFieldMapper.Defaults.TIME_UNIT));
+            return new DateMath(new DateMathParser(mapper.fieldType().dateTimeFormatter()));
         }
     }
 


### PR DESCRIPTION
This PR adds the support the new date formats, namely `epoch_second` and `epoch_second_millis`. By adding those, we can remove the internal logic to try and parse everything as a unix timestamp first and only then use our regular date format.

This PR tries to remain backwards compatible by using `epoch_second_millis||dateOptionalTime` where before only `dateOptionalTime` was used in combination with the parsing.

Some BWC occured, ie, a date like `10000` is now always a year without any other configuration instead of a unix timestamp.

Also, in the current implementation, the `RangeQueryParser` allows to configure a timezone for queries using `from`/`to` unix timestamps, even though the timezone is ignored in the query, as a timestamp is always UTC.

Closes #5328
Relates #10971
