### PR TITLE
Use the smallest version rather than the default version

### DIFF
--- a/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -756,13 +756,13 @@ public class IndexShard extends AbstractIndexShardComponent {
     }
 
     public org.apache.lucene.util.Version minimumCompatibleVersion() {
-        org.apache.lucene.util.Version luceneVersion = org.apache.lucene.util.Version.LUCENE_3_6;
+        org.apache.lucene.util.Version luceneVersion = null;
         for(Segment segment : engine().segments()) {
-            if (luceneVersion.onOrAfter(segment.getVersion())) {
+            if (luceneVersion == null || luceneVersion.onOrAfter(segment.getVersion())) {
                 luceneVersion = segment.getVersion();
             }
         }
-        return luceneVersion;
+        return luceneVersion == null ?  Version.indexCreated(indexSettings).luceneVersion : luceneVersion;
     }
 
     public SnapshotIndexCommit snapshotIndex() throws EngineException {

--- a/src/test/java/org/elasticsearch/rest/action/admin/indices/upgrade/UpgradeReallyOldIndexTest.java
+++ b/src/test/java/org/elasticsearch/rest/action/admin/indices/upgrade/UpgradeReallyOldIndexTest.java
@@ -19,7 +19,11 @@
 
 package org.elasticsearch.rest.action.admin.indices.upgrade;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.bwcompat.StaticIndexBackwardCompatibilityTest;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.index.IndexService;
+import org.elasticsearch.indices.IndicesService;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 
@@ -28,7 +32,7 @@ public class UpgradeReallyOldIndexTest extends StaticIndexBackwardCompatibilityT
     public void testUpgrade_0_20() throws Exception {
         String indexName = "test";
         loadIndex("index-0.20.zip", indexName);
-
+        assertMinVersion(indexName, org.apache.lucene.util.Version.parse("3.6.2"));
         assertTrue(UpgradeTest.hasAncientSegments(client(), indexName));
         UpgradeTest.assertNotUpgraded(client(), indexName);
         assertNoFailures(client().admin().indices().prepareUpgrade(indexName).setUpgradeOnlyAncientSegments(true).get());
@@ -36,12 +40,15 @@ public class UpgradeReallyOldIndexTest extends StaticIndexBackwardCompatibilityT
 
         // This index has entirely ancient segments so the whole index should now be upgraded:
         UpgradeTest.assertUpgraded(client(), indexName);
+        assertEquals(Version.CURRENT.luceneVersion.toString(), client().admin().indices().prepareGetSettings(indexName).get().getSetting(indexName, IndexMetaData.SETTING_VERSION_MINIMUM_COMPATIBLE));
+        assertMinVersion(indexName, Version.CURRENT.luceneVersion);
+
     }
 
     public void testUpgradeMixed_0_20_6_and_0_90_6() throws Exception {
         String indexName = "index-0.20.6-and-0.90.6";
         loadIndex(indexName + ".zip", indexName);
-
+        assertMinVersion(indexName, org.apache.lucene.util.Version.parse("3.6.2"));
         // Has ancient segments?:
         assertTrue(UpgradeTest.hasAncientSegments(client(), indexName));
 
@@ -59,5 +66,18 @@ public class UpgradeReallyOldIndexTest extends StaticIndexBackwardCompatibilityT
 
         // We succeeded in upgrading only the ancient segments but leaving the "merely old" ones untouched:
         assertTrue(UpgradeTest.hasOldButNotAncientSegments(client(), indexName));
+        assertEquals(org.apache.lucene.util.Version.LUCENE_4_5_1.toString(), client().admin().indices().prepareGetSettings(indexName).get().getSetting(indexName, IndexMetaData.SETTING_VERSION_MINIMUM_COMPATIBLE));
+        assertMinVersion(indexName, org.apache.lucene.util.Version.LUCENE_4_5_1);
+
+    }
+
+    private void assertMinVersion(String index, org.apache.lucene.util.Version version) {
+        for (IndicesService services : internalCluster().getInstances(IndicesService.class)) {
+            IndexService indexService = services.indexService(index);
+            if (indexService != null) {
+                assertEquals(version, indexService.shard(0).minimumCompatibleVersion());
+            }
+        }
+
     }
 }


### PR DESCRIPTION
The minimum version comparison was always using the default version
sicne the comparison was flipped.

Closes #11474
