### PR TITLE
Default to binding to loopback address

### DIFF
--- a/docs/reference/migration/migrate_2_0.asciidoc
+++ b/docs/reference/migration/migrate_2_0.asciidoc
@@ -4,6 +4,11 @@
 This section discusses the changes that you need to be aware of when migrating
 your application to Elasticsearch 2.0.
 
+=== Networking
+
+Elasticsearch now binds to the loopback interface by default (usually 127.0.0.1
+or ::1), the setting `network.host` can be specified to change this behavior.
+
 === Indices API
 
 The <<alias-retrieving, get alias api>> will, by default produce an error response

--- a/docs/reference/modules/network.asciidoc
+++ b/docs/reference/modules/network.asciidoc
@@ -8,15 +8,14 @@ configuration, for example, the
 network settings allows to set common settings that will be shared among
 all network based modules (unless explicitly overridden in each module).
 
-The `network.bind_host` setting allows to control the host different
-network components will bind on. By default, the bind host will be
-`anyLocalAddress` (typically `0.0.0.0` or `::0`).
+The `network.bind_host` setting allows to control the host different network
+components will bind on. By default, the bind host will be `anyLoopbackAddress`
+(typically `127.0.0.1` or `::1`).
 
-The `network.publish_host` setting allows to control the host the node
-will publish itself within the cluster so other nodes will be able to
-connect to it. Of course, this can't be the `anyLocalAddress`, and by
-default, it will be the first non loopback address (if possible), or the
-local address.
+The `network.publish_host` setting allows to control the host the node will
+publish itself within the cluster so other nodes will be able to connect to it.
+Of course, this can't be the `anyLocalAddress`, and by default, it will be the
+first loopback address (if possible), or the local address.
 
 The `network.host` setting is a simple setting to automatically set both
 `network.bind_host` and `network.publish_host` to the same host value.

--- a/src/main/java/org/elasticsearch/common/network/NetworkService.java
+++ b/src/main/java/org/elasticsearch/common/network/NetworkService.java
@@ -96,7 +96,7 @@ public class NetworkService extends AbstractComponent {
 
 
     public InetAddress resolveBindHostAddress(String bindHost) throws IOException {
-        return resolveBindHostAddress(bindHost, null);
+        return resolveBindHostAddress(bindHost, InetAddress.getLoopbackAddress().getHostAddress());
     }
 
     public InetAddress resolveBindHostAddress(String bindHost, String defaultValue2) throws IOException {
@@ -104,7 +104,8 @@ public class NetworkService extends AbstractComponent {
     }
 
     public InetAddress resolvePublishHostAddress(String publishHost) throws IOException {
-        InetAddress address = resolvePublishHostAddress(publishHost, null);
+        InetAddress address = resolvePublishHostAddress(publishHost,
+                InetAddress.getLoopbackAddress().getHostAddress());
         // verify that its not a local address
         if (address == null || address.isAnyLocalAddress()) {
             address = NetworkUtils.getFirstNonLoopbackAddress(NetworkUtils.StackType.IPv4);

--- a/src/main/java/org/elasticsearch/discovery/zen/ping/multicast/MulticastZenPing.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ping/multicast/MulticastZenPing.java
@@ -126,8 +126,12 @@ public class MulticastZenPing extends AbstractLifecycleComponent<ZenPing> implem
             // we know OSX has bugs in the JVM when creating multiple instances of multicast sockets
             // causing for "socket close" exceptions when receive and/or crashes
             boolean shared = settings.getAsBoolean("discovery.zen.ping.multicast.shared", Constants.MAC_OS_X);
+            // OSX does not correctly send multicasts FROM the right interface
+            boolean deferToInterface = settings.getAsBoolean("discovery.zen.ping.multicast.defer_group_to_set_interface", Constants.MAC_OS_X);
             multicastChannel = MulticastChannel.getChannel(nodeName(), shared,
-                    new MulticastChannel.Config(port, group, bufferSize, ttl, networkService.resolvePublishHostAddress(address)),
+                    new MulticastChannel.Config(port, group, bufferSize, ttl,
+                            networkService.resolvePublishHostAddress(address),
+                            deferToInterface),
                     new Receiver());
         } catch (Throwable t) {
             String msg = "multicast failed to start [{}], disabling. Consider using IPv4 only (by defining env. variable `ES_USE_IPV4`)";


### PR DESCRIPTION
Binds to the address returned by `InetAddress.getLoopbackAddress()`.

Closes #11300
Closes #7077
