### PR TITLE
Move in-progress snapshot and restore information from custom metadata to custom cluster state part

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/TransportCreateSnapshotAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/TransportCreateSnapshotAction.java
@@ -59,8 +59,8 @@ public class TransportCreateSnapshotAction extends TransportMasterNodeAction<Cre
 
     @Override
     protected ClusterBlockException checkBlock(CreateSnapshotRequest request, ClusterState state) {
-        // We are writing to the cluster metadata and reading from indices - so we need to check both blocks
-        ClusterBlockException clusterBlockException = state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
+        // We are reading the cluster metadata and indices - so we need to check both blocks
+        ClusterBlockException clusterBlockException = state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_READ);
         if (clusterBlockException != null) {
             return clusterBlockException;
         }

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/delete/TransportDeleteSnapshotAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/delete/TransportDeleteSnapshotAction.java
@@ -58,7 +58,8 @@ public class TransportDeleteSnapshotAction extends TransportMasterNodeAction<Del
 
     @Override
     protected ClusterBlockException checkBlock(DeleteSnapshotRequest request, ClusterState state) {
-        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
+        // Cluster is not affected but we look up repositories in metadata
+        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_READ);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotStatus.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotStatus.java
@@ -22,7 +22,7 @@ package org.elasticsearch.action.admin.cluster.snapshots.status;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.elasticsearch.cluster.metadata.SnapshotId;
-import org.elasticsearch.cluster.metadata.SnapshotMetaData.State;
+import org.elasticsearch.cluster.SnapshotsInProgress.State;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/state/ClusterStateRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/state/ClusterStateRequest.java
@@ -38,6 +38,7 @@ public class ClusterStateRequest extends MasterNodeReadRequest<ClusterStateReque
     private boolean nodes = true;
     private boolean metaData = true;
     private boolean blocks = true;
+    private boolean customs = true;
     private String[] indices = Strings.EMPTY_ARRAY;
     private IndicesOptions indicesOptions = IndicesOptions.lenientExpandOpen();
 
@@ -54,6 +55,7 @@ public class ClusterStateRequest extends MasterNodeReadRequest<ClusterStateReque
         nodes = true;
         metaData = true;
         blocks = true;
+        customs = true;
         indices = Strings.EMPTY_ARRAY;
         return this;
     }
@@ -63,6 +65,7 @@ public class ClusterStateRequest extends MasterNodeReadRequest<ClusterStateReque
         nodes = false;
         metaData = false;
         blocks = false;
+        customs = false;
         indices = Strings.EMPTY_ARRAY;
         return this;
     }
@@ -124,6 +127,15 @@ public class ClusterStateRequest extends MasterNodeReadRequest<ClusterStateReque
         return this;
     }
 
+    public ClusterStateRequest customs(boolean customs) {
+        this.customs = customs;
+        return this;
+    }
+
+    public boolean customs() {
+        return customs;
+    }
+
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
@@ -131,6 +143,7 @@ public class ClusterStateRequest extends MasterNodeReadRequest<ClusterStateReque
         nodes = in.readBoolean();
         metaData = in.readBoolean();
         blocks = in.readBoolean();
+        customs = in.readBoolean();
         indices = in.readStringArray();
         indicesOptions = IndicesOptions.readIndicesOptions(in);
     }
@@ -142,6 +155,7 @@ public class ClusterStateRequest extends MasterNodeReadRequest<ClusterStateReque
         out.writeBoolean(nodes);
         out.writeBoolean(metaData);
         out.writeBoolean(blocks);
+        out.writeBoolean(customs);
         out.writeStringArray(indices);
         indicesOptions.writeIndicesOptions(out);
     }

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateAction.java
@@ -123,6 +123,9 @@ public class TransportClusterStateAction extends TransportMasterNodeReadAction<C
 
             builder.metaData(mdBuilder);
         }
+        if (request.customs()) {
+            builder.customs(currentState.customs());
+        }
         listener.onResponse(new ClusterStateResponse(clusterName, builder.build()));
     }
 

--- a/core/src/main/java/org/elasticsearch/cluster/ClusterState.java
+++ b/core/src/main/java/org/elasticsearch/cluster/ClusterState.java
@@ -117,6 +117,12 @@ public class ClusterState implements ToXContent, Diffable<ClusterState> {
         customPrototypes.put(type, proto);
     }
 
+    static {
+        // register non plugin custom parts
+        registerPrototype(SnapshotsInProgress.TYPE, SnapshotsInProgress.PROTO);
+        registerPrototype(RestoreInProgress.TYPE, RestoreInProgress.PROTO);
+    }
+
     @Nullable
     public static <T extends Custom> T lookupPrototype(String type) {
         //noinspection unchecked
@@ -247,6 +253,10 @@ public class ClusterState implements ToXContent, Diffable<ClusterState> {
 
     public ImmutableOpenMap<String, Custom> getCustoms() {
         return this.customs;
+    }
+
+    public <T extends Custom> T custom(String type) {
+        return (T) customs.get(type);
     }
 
     public ClusterName getClusterName() {

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
@@ -97,8 +97,6 @@ public class MetaData implements Iterable<IndexMetaData>, Diffable<MetaData> {
     static {
         // register non plugin custom metadata
         registerPrototype(RepositoriesMetaData.TYPE, RepositoriesMetaData.PROTO);
-        registerPrototype(SnapshotMetaData.TYPE, SnapshotMetaData.PROTO);
-        registerPrototype(RestoreMetaData.TYPE, RestoreMetaData.PROTO);
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
@@ -28,6 +28,7 @@ import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.index.shard.ShardId;
 
 import java.util.*;
@@ -56,6 +57,8 @@ public class RoutingNodes implements Iterable<RoutingNode> {
 
     private final Map<ShardId, List<MutableShardRouting>> assignedShards = newHashMap();
 
+    private final ImmutableOpenMap<String, ClusterState.Custom> customs;
+
     private int inactivePrimaryCount = 0;
 
     private int inactiveShardCount = 0;
@@ -70,6 +73,7 @@ public class RoutingNodes implements Iterable<RoutingNode> {
         this.metaData = clusterState.metaData();
         this.blocks = clusterState.blocks();
         this.routingTable = clusterState.routingTable();
+        this.customs = clusterState.customs();
 
         Map<String, List<MutableShardRouting>> nodesToShards = newHashMap();
         // fill in the nodeToShards with the "live" nodes
@@ -155,6 +159,14 @@ public class RoutingNodes implements Iterable<RoutingNode> {
 
     public ClusterBlocks getBlocks() {
         return this.blocks;
+    }
+
+    public ImmutableOpenMap<String, ClusterState.Custom> customs() {
+        return this.customs;
+    }
+
+    public <T extends ClusterState.Custom> T custom(String type) {
+        return (T) customs.get(type);
     }
 
     public int requiredAverageNumberOfShardsPerNode() {

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/SnapshotInProgressAllocationDecider.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/SnapshotInProgressAllocationDecider.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.cluster.routing.allocation.decider;
 
-import org.elasticsearch.cluster.metadata.SnapshotMetaData;
+import org.elasticsearch.cluster.SnapshotsInProgress;
 import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
@@ -99,14 +99,14 @@ public class SnapshotInProgressAllocationDecider extends AllocationDecider {
         if (!enableRelocation && shardRouting.primary()) {
             // Only primary shards are snapshotted
 
-            SnapshotMetaData snapshotMetaData = allocation.metaData().custom(SnapshotMetaData.TYPE);
-            if (snapshotMetaData == null) {
+            SnapshotsInProgress snapshotsInProgress = allocation.routingNodes().custom(SnapshotsInProgress.TYPE);
+            if (snapshotsInProgress == null) {
                 // Snapshots are not running
                 return allocation.decision(Decision.YES, NAME, "no snapshots are currently running");
             }
 
-            for (SnapshotMetaData.Entry snapshot : snapshotMetaData.entries()) {
-                SnapshotMetaData.ShardSnapshotStatus shardSnapshotStatus = snapshot.shards().get(shardRouting.shardId());
+            for (SnapshotsInProgress.Entry snapshot : snapshotsInProgress.entries()) {
+                SnapshotsInProgress.ShardSnapshotStatus shardSnapshotStatus = snapshot.shards().get(shardRouting.shardId());
                 if (shardSnapshotStatus != null && !shardSnapshotStatus.state().completed() && shardSnapshotStatus.nodeId() != null && shardSnapshotStatus.nodeId().equals(shardRouting.currentNodeId())) {
                     logger.trace("Preventing snapshotted shard [{}] to be moved from node [{}]", shardRouting.shardId(), shardSnapshotStatus.nodeId());
                     return allocation.decision(Decision.NO, NAME, "snapshot for shard [%s] is currently running on node [%s]",

--- a/core/src/main/java/org/elasticsearch/rest/action/admin/cluster/state/RestClusterStateAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/cluster/state/RestClusterStateAction.java
@@ -75,6 +75,7 @@ public class RestClusterStateAction extends BaseRestHandler {
             clusterStateRequest.routingTable(metrics.contains(ClusterState.Metric.ROUTING_TABLE) || metrics.contains(ClusterState.Metric.ROUTING_NODES));
             clusterStateRequest.metaData(metrics.contains(ClusterState.Metric.METADATA));
             clusterStateRequest.blocks(metrics.contains(ClusterState.Metric.BLOCKS));
+            clusterStateRequest.customs(metrics.contains(ClusterState.Metric.CUSTOMS));
         }
         settingsFilter.addFilterSettingParams(request);
 

--- a/core/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/SnapshotBlocksTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/SnapshotBlocksTests.java
@@ -88,16 +88,16 @@ public class SnapshotBlocksTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testCreateSnapshotWithBlocks() {
-        logger.info("-->  creating a snapshot is blocked when the cluster is read only");
+        logger.info("-->  creating a snapshot is allowed when the cluster is read only");
         try {
             setClusterReadOnly(true);
-            assertBlocked(client().admin().cluster().prepareCreateSnapshot(REPOSITORY_NAME, "snapshot-1"), MetaData.CLUSTER_READ_ONLY_BLOCK);
+            assertThat(client().admin().cluster().prepareCreateSnapshot(REPOSITORY_NAME, "snapshot-1").setWaitForCompletion(true).get().status(), equalTo(RestStatus.OK));
         } finally {
             setClusterReadOnly(false);
         }
 
         logger.info("-->  creating a snapshot is allowed when the cluster is not read only");
-        CreateSnapshotResponse response = client().admin().cluster().prepareCreateSnapshot(REPOSITORY_NAME, "snapshot-1")
+        CreateSnapshotResponse response = client().admin().cluster().prepareCreateSnapshot(REPOSITORY_NAME, "snapshot-2")
                 .setWaitForCompletion(true)
                 .execute().actionGet();
         assertThat(response.status(), equalTo(RestStatus.OK));
@@ -126,17 +126,13 @@ public class SnapshotBlocksTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testDeleteSnapshotWithBlocks() {
-        logger.info("-->  deleting a snapshot is blocked when the cluster is read only");
+        logger.info("-->  deleting a snapshot is allowed when the cluster is read only");
         try {
             setClusterReadOnly(true);
-            assertBlocked(client().admin().cluster().prepareDeleteSnapshot(REPOSITORY_NAME, SNAPSHOT_NAME), MetaData.CLUSTER_READ_ONLY_BLOCK);
+            assertTrue(client().admin().cluster().prepareDeleteSnapshot(REPOSITORY_NAME, SNAPSHOT_NAME).get().isAcknowledged());
         } finally {
             setClusterReadOnly(false);
         }
-
-        logger.info("-->  deleting a snapshot is allowed when the cluster is not read only");
-        DeleteSnapshotResponse response = client().admin().cluster().prepareDeleteSnapshot(REPOSITORY_NAME, SNAPSHOT_NAME).execute().actionGet();
-        assertThat(response.isAcknowledged(), equalTo(true));
     }
 
     @Test

--- a/core/src/test/java/org/elasticsearch/snapshots/AbstractSnapshotTests.java
+++ b/core/src/test/java/org/elasticsearch/snapshots/AbstractSnapshotTests.java
@@ -19,13 +19,12 @@
 package org.elasticsearch.snapshots;
 
 import com.google.common.base.Predicate;
-import com.google.common.collect.ImmutableList;
 
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.action.admin.cluster.tasks.PendingClusterTasksResponse;
 import org.elasticsearch.cluster.*;
 import org.elasticsearch.cluster.metadata.SnapshotId;
-import org.elasticsearch.cluster.metadata.SnapshotMetaData;
+import org.elasticsearch.cluster.SnapshotsInProgress;
 import org.elasticsearch.cluster.service.PendingClusterTask;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.settings.Settings;
@@ -106,8 +105,8 @@ public abstract class AbstractSnapshotTests extends ElasticsearchIntegrationTest
             if (snapshotInfos.get(0).state().completed()) {
                 // Make sure that snapshot clean up operations are finished
                 ClusterStateResponse stateResponse = client().admin().cluster().prepareState().get();
-                SnapshotMetaData snapshotMetaData = stateResponse.getState().getMetaData().custom(SnapshotMetaData.TYPE);
-                if (snapshotMetaData == null || snapshotMetaData.snapshot(snapshotId) == null) {
+                SnapshotsInProgress snapshotsInProgress = stateResponse.getState().custom(SnapshotsInProgress.TYPE);
+                if (snapshotsInProgress == null || snapshotsInProgress.snapshot(snapshotId) == null) {
                     return snapshotInfos.get(0);
                 }
             }

--- a/core/src/test/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreTests.java
+++ b/core/src/test/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreTests.java
@@ -68,7 +68,6 @@ import org.elasticsearch.rest.action.admin.cluster.state.RestClusterStateAction;
 import org.elasticsearch.snapshots.mockstore.MockRepositoryModule;
 import org.elasticsearch.snapshots.mockstore.MockRepositoryPlugin;
 import org.elasticsearch.test.InternalTestCluster;
-import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.test.rest.FakeRestRequest;
 import org.junit.Ignore;
 import org.junit.Test;

--- a/core/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreTests.java
+++ b/core/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreTests.java
@@ -33,7 +33,6 @@ import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsResponse
 import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotResponse;
 import org.elasticsearch.action.admin.cluster.snapshots.status.*;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
-import org.elasticsearch.action.admin.cluster.tasks.PendingClusterTasksResponse;
 import org.elasticsearch.action.admin.indices.flush.FlushResponse;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
 import org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesResponse;
@@ -42,11 +41,10 @@ import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.*;
 import org.elasticsearch.cluster.metadata.*;
-import org.elasticsearch.cluster.metadata.SnapshotMetaData.Entry;
-import org.elasticsearch.cluster.metadata.SnapshotMetaData.ShardSnapshotStatus;
-import org.elasticsearch.cluster.metadata.SnapshotMetaData.State;
+import org.elasticsearch.cluster.SnapshotsInProgress.Entry;
+import org.elasticsearch.cluster.SnapshotsInProgress.ShardSnapshotStatus;
+import org.elasticsearch.cluster.SnapshotsInProgress.State;
 import org.elasticsearch.cluster.routing.allocation.decider.FilterAllocationDecider;
-import org.elasticsearch.cluster.service.PendingClusterTask;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.Settings;
@@ -1390,7 +1388,7 @@ public class SharedClusterSnapshotRestoreTests extends AbstractSnapshotTests {
         SnapshotsStatusResponse response = client.admin().cluster().prepareSnapshotStatus("test-repo").execute().actionGet();
         assertThat(response.getSnapshots().size(), equalTo(1));
         SnapshotStatus snapshotStatus = response.getSnapshots().get(0);
-        assertThat(snapshotStatus.getState(), equalTo(SnapshotMetaData.State.STARTED));
+        assertThat(snapshotStatus.getState(), equalTo(SnapshotsInProgress.State.STARTED));
         // We blocked the node during data write operation, so at least one shard snapshot should be in STARTED stage
         assertThat(snapshotStatus.getShardsStats().getStartedShards(), greaterThan(0));
         for (SnapshotIndexShardStatus shardStatus : snapshotStatus.getIndices().get("test-idx")) {
@@ -1403,7 +1401,7 @@ public class SharedClusterSnapshotRestoreTests extends AbstractSnapshotTests {
         response = client.admin().cluster().prepareSnapshotStatus().execute().actionGet();
         assertThat(response.getSnapshots().size(), equalTo(1));
         snapshotStatus = response.getSnapshots().get(0);
-        assertThat(snapshotStatus.getState(), equalTo(SnapshotMetaData.State.STARTED));
+        assertThat(snapshotStatus.getState(), equalTo(SnapshotsInProgress.State.STARTED));
         // We blocked the node during data write operation, so at least one shard snapshot should be in STARTED stage
         assertThat(snapshotStatus.getShardsStats().getStartedShards(), greaterThan(0));
         for (SnapshotIndexShardStatus shardStatus : snapshotStatus.getIndices().get("test-idx")) {
@@ -1769,9 +1767,7 @@ public class SharedClusterSnapshotRestoreTests extends AbstractSnapshotTests {
                 shards.put(new ShardId("test-idx", 2), new ShardSnapshotStatus("unknown-node", State.ABORTED));
                 ImmutableList.Builder<Entry> entries = ImmutableList.builder();
                 entries.add(new Entry(new SnapshotId("test-repo", "test-snap"), true, State.ABORTED, ImmutableList.of("test-idx"), System.currentTimeMillis(), shards.build()));
-                MetaData.Builder mdBuilder = MetaData.builder(currentState.metaData());
-                mdBuilder.putCustom(SnapshotMetaData.TYPE, new SnapshotMetaData(entries.build()));
-                return ClusterState.builder(currentState).metaData(mdBuilder).build();
+                return ClusterState.builder(currentState).putCustom(SnapshotsInProgress.TYPE, new SnapshotsInProgress(entries.build())).build();
             }
 
             @Override

--- a/docs/reference/modules/snapshots.asciidoc
+++ b/docs/reference/modules/snapshots.asciidoc
@@ -426,4 +426,13 @@ The restore operation uses the standard shard recovery mechanism. Therefore, any
 be canceled by deleting indices that are being restored. Please note that data for all deleted indices will be removed
 from the cluster as a result of this operation.
 
+[float]
+=== Effect of cluster blocks on snapshot and restore operations
+Many snapshot and restore operations are affected by cluster and index blocks. For example, registering and unregistering
+repositories require write global metadata access. The snapshot operation requires that all indices and their metadata as
+well as the global metadata were readable. The restore operation requires the global metadata to be writable, however
+the index level blocks are ignored during restore because indices are essentially recreated during restore.
+Please note that a repository content is not part of the cluster and therefore cluster blocks don't affect internal
+repository operations such as listing or deleting snapshots from an already registered repository.
+
 


### PR DESCRIPTION
Information about in-progress snapshot and restore processes is not really metadata and should be represented as a part of the cluster state similar to discovery nodes, routing table, and cluster blocks. Since in-progress snapshot and restore information is no longer part of metadata, this refactoring also enables us to handle cluster blocks in more consistent manner and allow creation of snapshots of a read-only cluster.

Closes #8102
