### PR TITLE
Fix mvn `exec:exec` target to work.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -378,6 +378,7 @@
             <configuration>
               <executable>${jvm.executable}</executable>
               <arguments>
+                <argument>-Des.path.home=.</argument>
                 <argument>-Des.security.manager.enabled=false</argument>
                 <argument>-classpath</argument>
                 <classpath/>


### PR DESCRIPTION
Currently this will not work, as it doesn't configure the ES home.
We should fix this build target, or remove it if its not needed.
