### PR TITLE
Get api: reject get requests against a filtered alias

### DIFF
--- a/docs/reference/migration/migrate_2_0.asciidoc
+++ b/docs/reference/migration/migrate_2_0.asciidoc
@@ -642,3 +642,12 @@ created on or after clusters with version 2.0:
 * The `type` option on the `_parent` field can only point to a parent type that doesn't exist yet,
   so this means that an existing type/mapping can no longer become a parent type.
 * The `has_child` and `has_parent` queries can no longer be use in alias filters.
+
+[float]
+=== CRUD
+
+The get api doesn't support retrieving documents from a filtered alias anymore,
+as it could lead to returning documents that don't match the filter, in case
+the documents need to be retrieved from the transaction log. This change
+affects also other api that use the get api internally, like multi_get,
+ term_vector, multi_term_vector, explain and update.

--- a/src/main/java/org/elasticsearch/action/explain/TransportExplainAction.java
+++ b/src/main/java/org/elasticsearch/action/explain/TransportExplainAction.java
@@ -92,7 +92,13 @@ public class TransportExplainAction extends TransportSingleShardAction<ExplainRe
 
     @Override
     protected void resolveRequest(ClusterState state, InternalRequest request) {
-        request.request().filteringAlias(state.metaData().filteringAliases(request.concreteIndex(), request.request().index()));
+
+        if (request.concreteIndex().equals(request.request().index()) == false) {
+            String[] filteringAliases = state.metaData().filteringAliases(request.concreteIndex(), request.request().index());
+            if (filteringAliases != null) {
+                throw new UnsupportedOperationException("explain api doesn't support retrieving documents from a filtered alias, use the concrete index instead.");
+            }
+        }
         // Fail fast on the node that received the request.
         if (request.request().routing() == null && state.getMetaData().routingRequired(request.concreteIndex(), request.request().type())) {
             throw new RoutingMissingException(request.concreteIndex(), request.request().type(), request.request().id());

--- a/src/main/java/org/elasticsearch/action/get/TransportGetAction.java
+++ b/src/main/java/org/elasticsearch/action/get/TransportGetAction.java
@@ -71,6 +71,14 @@ public class TransportGetAction extends TransportSingleShardAction<GetRequest, G
         if (request.request().realtime == null) {
             request.request().realtime = this.realtime;
         }
+
+        if (request.concreteIndex().equals(request.request().index()) == false) {
+            String[] filteringAliases = state.metaData().filteringAliases(request.concreteIndex(), request.request().index());
+            if (filteringAliases != null) {
+                throw new UnsupportedOperationException("get api doesn't support retrieving documents from a filtered alias, use the concrete index instead.");
+            }
+        }
+
         IndexMetaData indexMeta = state.getMetaData().index(request.concreteIndex());
         if (request.request().realtime && // if the realtime flag is set
                 request.request().preference() == null && // the preference flag is not already set

--- a/src/main/java/org/elasticsearch/action/get/TransportShardMultiGetAction.java
+++ b/src/main/java/org/elasticsearch/action/get/TransportShardMultiGetAction.java
@@ -96,6 +96,12 @@ public class TransportShardMultiGetAction extends TransportSingleShardAction<Mul
         for (int i = 0; i < request.locations.size(); i++) {
             MultiGetRequest.Item item = request.items.get(i);
             try {
+                if (shardId.index().name().equals(item.index()) == false) {
+                    String[] filteringAliases = clusterService.state().metaData().filteringAliases(shardId.index().name(), item.index());
+                    if (filteringAliases != null) {
+                        throw new UnsupportedOperationException("multi_get api doesn't support retrieving documents from a filtered alias, use the concrete index instead.");
+                    }
+                }
                 GetResult getResult = indexShard.getService().get(item.type(), item.id(), item.fields(), request.realtime(), item.version(), item.versionType(), item.fetchSourceContext(), request.ignoreErrorsOnGeneratedFields());
                 response.add(request.locations.get(i), new GetResponse(getResult));
             } catch (Throwable t) {

--- a/src/main/java/org/elasticsearch/action/termvectors/TransportShardMultiTermsVectorAction.java
+++ b/src/main/java/org/elasticsearch/action/termvectors/TransportShardMultiTermsVectorAction.java
@@ -77,6 +77,12 @@ public class TransportShardMultiTermsVectorAction extends TransportSingleShardAc
         for (int i = 0; i < request.locations.size(); i++) {
             TermVectorsRequest termVectorsRequest = request.requests.get(i);
             try {
+                if (shardId.index().name().equals(termVectorsRequest.index()) == false) {
+                    String[] filteringAliases = clusterService.state().metaData().filteringAliases(shardId.index().name(), termVectorsRequest.index());
+                    if (filteringAliases != null) {
+                        throw new UnsupportedOperationException("multi_term_vector api doesn't support retrieving documents from a filtered alias, use the concrete index instead.");
+                    }
+                }
                 IndexService indexService = indicesService.indexServiceSafe(request.index());
                 IndexShard indexShard = indexService.shardSafe(shardId.id());
                 TermVectorsResponse termVectorsResponse = indexShard.termVectorsService().getTermVectors(termVectorsRequest, shardId.getIndex());

--- a/src/main/java/org/elasticsearch/action/termvectors/TransportTermVectorsAction.java
+++ b/src/main/java/org/elasticsearch/action/termvectors/TransportTermVectorsAction.java
@@ -69,6 +69,13 @@ public class TransportTermVectorsAction extends TransportSingleShardAction<TermV
 
     @Override
     protected void resolveRequest(ClusterState state, InternalRequest request) {
+        if (request.concreteIndex().equals(request.request().index()) == false) {
+            String[] filteringAliases = state.metaData().filteringAliases(request.concreteIndex(), request.request().index());
+            if (filteringAliases != null) {
+                throw new UnsupportedOperationException("term_vector api doesn't support retrieving term vectors from a filtered alias, use the concrete index instead.");
+            }
+        }
+
         // update the routing (request#index here is possibly an alias)
         request.request().routing(state.metaData().resolveIndexRouting(request.request().routing(), request.request().index()));
         // Fail fast on the node that received the request.

--- a/src/main/java/org/elasticsearch/action/update/TransportUpdateAction.java
+++ b/src/main/java/org/elasticsearch/action/update/TransportUpdateAction.java
@@ -100,6 +100,12 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
 
     @Override
     protected boolean resolveRequest(ClusterState state, InternalRequest request, ActionListener<UpdateResponse> listener) {
+        if (request.concreteIndex().equals(request.request().index()) == false) {
+            String[] filteringAliases = state.metaData().filteringAliases(request.concreteIndex(), request.request().index());
+            if (filteringAliases != null) {
+                throw new UnsupportedOperationException("update api doesn't support updating documents retrieved from a filtered alias, use the concrete index instead.");
+            }
+        }
         request.request().routing((state.metaData().resolveIndexRouting(request.request().routing(), request.request().index())));
         // Fail fast on the node that received the request, rather than failing when translating on the index or delete request.
         if (request.request().routing() == null && state.getMetaData().routingRequired(request.concreteIndex(), request.request().type())) {


### PR DESCRIPTION
Documents that don't belong to the filtered alias might get returned as the filter cannot be taken into account when the document is retrieved from the transaction log, we simply reject the request given that we cannot answer it properly.
This change affects also apis that use the get api internally, like: multi_get, term_vector, multi_term_vector, explain and update. Percolator is not affected as it already knows how to execute alias filters against the lucene index in non real-time when needed.

I looked into supporting get against a filtered alias when the realtime flag is set to false, but it doesn't seem that straight-forward to be honest, as it would require executing a filter rather than a lookup in the terms enum for the proper uid. I am not sure we want to make the get api more complicated than it currently is, the right answer could just be to use the search api instead.

Closes #3861
