### PR TITLE
Delete index api: reject when performed against filtered alias

### DIFF
--- a/docs/reference/migration/migrate_2_0.asciidoc
+++ b/docs/reference/migration/migrate_2_0.asciidoc
@@ -642,3 +642,10 @@ created on or after clusters with version 2.0:
 * The `type` option on the `_parent` field can only point to a parent type that doesn't exist yet,
   so this means that an existing type/mapping can no longer become a parent type.
 * The `has_child` and `has_parent` queries can no longer be use in alias filters.
+
+[float]
+=== Delete index api performed against a filtered alias
+
+Delete index api returns an error when trying to delete a filtered alias,
+rather than ignoring the filter completely and deleting the whole index.
+

--- a/src/main/java/org/elasticsearch/action/admin/indices/delete/TransportDeleteIndexAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/delete/TransportDeleteIndexAction.java
@@ -80,6 +80,13 @@ public class TransportDeleteIndexAction extends TransportMasterNodeAction<Delete
             listener.onResponse(new DeleteIndexResponse(true));
             return;
         }
+        for (String concreteIndex : concreteIndices) {
+            String[] filteringAliases = state.metaData().filteringAliases(concreteIndex, request.indices());
+            if (filteringAliases != null) {
+                throw new UnsupportedOperationException("delete index api doesn't support deleting a filtered alias.");
+            }
+        }
+
         // TODO: this API should be improved, currently, if one delete index failed, we send a failure, we should send a response array that includes all the indices that were deleted
         final CountDown count = new CountDown(concreteIndices.length);
         for (final String index : concreteIndices) {

--- a/src/test/java/org/elasticsearch/action/admin/indices/delete/DeleteIndexTests.java
+++ b/src/test/java/org/elasticsearch/action/admin/indices/delete/DeleteIndexTests.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.admin.indices.delete;
+
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.hamcrest.CoreMatchers.equalTo;
+
+public class DeleteIndexTests extends ElasticsearchIntegrationTest {
+
+    @Test
+    public void testFilteredAlias() {
+        assertAcked(prepareCreate("test1").addMapping("test", "field", "type=string"));
+        createIndex("test2");
+        assertAcked(client().admin().indices().prepareAliases()
+                .addAlias("test1", "alias1", QueryBuilders.termQuery("field", "value"))
+                .addAlias("test2", "alias2"));
+
+        try {
+            client().admin().indices().prepareDelete("alias1", "alias2").get();
+            fail("delete index should have failed");
+        } catch(UnsupportedOperationException e) {
+            //all good
+        }
+
+        assertThat(client().admin().cluster().prepareState().get().getState().metaData().indices().size(), equalTo(2));
+
+        assertAcked(client().admin().indices().prepareDelete("alias2"));
+        assertThat(client().admin().cluster().prepareState().get().getState().metaData().indices().size(), equalTo(1));
+    }
+}


### PR DESCRIPTION
Delete index api currently ignores the filter in case it's performed against a filtered alias, resulting in deleting the whole index rather than just the subset of documents that match the filter. Rejecting the request is a better behaviour, as a delete index cannot effectively be performed. Note that in case of a delete index against multiple indices, the whole request fails. This is because the delete index doesn't currently support returning a detailed response, per index.

Closes #2318
