### PR TITLE
Show human readable Elasticsearch version that created index and date when index was created

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexRequest.java
@@ -100,6 +100,7 @@ public class GetIndexRequest extends ClusterInfoRequest<GetIndexRequest> {
 
     private static final Feature[] DEFAULT_FEATURES = new Feature[] { Feature.ALIASES, Feature.MAPPINGS, Feature.SETTINGS, Feature.WARMERS };
     private Feature[] features = DEFAULT_FEATURES;
+    private boolean humanReadable = false;
 
     public GetIndexRequest features(Feature... features) {
         if (features == null) {
@@ -135,6 +136,15 @@ public class GetIndexRequest extends ClusterInfoRequest<GetIndexRequest> {
         return null;
     }
 
+    public GetIndexRequest humanReadable(boolean humanReadable) {
+        this.humanReadable = humanReadable;
+        return this;
+    }
+
+    public boolean humanReadable() {
+        return humanReadable;
+    }
+
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
@@ -143,6 +153,7 @@ public class GetIndexRequest extends ClusterInfoRequest<GetIndexRequest> {
         for (int i = 0; i < size; i++) {
             features[i] = Feature.fromId(in.readByte());
         }
+        humanReadable = in.readBoolean();
     }
 
     @Override
@@ -152,6 +163,7 @@ public class GetIndexRequest extends ClusterInfoRequest<GetIndexRequest> {
         for (Feature feature : features) {
             out.writeByte(feature.id);
         }
+        out.writeBoolean(humanReadable);
     }
 
 }

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/get/TransportGetIndexAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/get/TransportGetIndexAction.java
@@ -30,6 +30,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.AliasMetaData;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
@@ -102,7 +103,11 @@ public class TransportGetIndexAction extends TransportClusterInfoAction<GetIndex
                     if (!doneSettings) {
                         ImmutableOpenMap.Builder<String, Settings> settingsMapBuilder = ImmutableOpenMap.builder();
                         for (String index : concreteIndices) {
-                            settingsMapBuilder.put(index, state.metaData().index(index).getSettings());
+                            Settings indexSettings = state.metaData().index(index).getSettings();
+                            if (request.humanReadable()) {
+                                indexSettings = IndexMetaData.addHumanReadableSettings(indexSettings);
+                            }
+                            settingsMapBuilder.put(index, indexSettings);
                         }
                         settings = settingsMapBuilder.build();
                         doneSettings = true;

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsRequest.java
@@ -37,6 +37,7 @@ public class GetSettingsRequest extends MasterNodeReadRequest<GetSettingsRequest
     private String[] indices = Strings.EMPTY_ARRAY;
     private IndicesOptions indicesOptions = IndicesOptions.fromOptions(false, true, true, true);
     private String[] names = Strings.EMPTY_ARRAY;
+    private boolean humanReadable = false;
 
     @Override
     public GetSettingsRequest indices(String... indices) {
@@ -68,6 +69,15 @@ public class GetSettingsRequest extends MasterNodeReadRequest<GetSettingsRequest
         return this;
     }
 
+    public boolean humanReadable() {
+        return humanReadable;
+    }
+
+    public GetSettingsRequest humanReadable(boolean humanReadable) {
+        this.humanReadable = humanReadable;
+        return this;
+    }
+
     @Override
     public ActionRequestValidationException validate() {
         ActionRequestValidationException validationException = null;
@@ -83,6 +93,7 @@ public class GetSettingsRequest extends MasterNodeReadRequest<GetSettingsRequest
         indices = in.readStringArray();
         indicesOptions = IndicesOptions.readIndicesOptions(in);
         names = in.readStringArray();
+        humanReadable = in.readBoolean();
     }
 
     @Override
@@ -91,5 +102,6 @@ public class GetSettingsRequest extends MasterNodeReadRequest<GetSettingsRequest
         out.writeStringArray(indices);
         indicesOptions.writeIndicesOptions(out);
         out.writeStringArray(names);
+        out.writeBoolean(humanReadable);
     }
 }

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/settings/get/TransportGetSettingsAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/settings/get/TransportGetSettingsAction.java
@@ -79,6 +79,9 @@ public class TransportGetSettingsAction extends TransportMasterNodeReadAction<Ge
             }
 
             Settings settings = SettingsFilter.filterSettings(settingsFilter.getPatterns(), indexMetaData.settings());
+            if (request.humanReadable()) {
+                settings = IndexMetaData.addHumanReadableSettings(settings);
+            }
             if (!CollectionUtils.isEmpty(request.names())) {
                 Settings.Builder settingsBuilder = Settings.builder();
                 for (Map.Entry<String, String> entry : settings.getAsMap().entrySet()) {

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
@@ -47,6 +47,7 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.warmer.IndexWarmersMetaData;
+import org.joda.time.DateTime;
 
 import java.io.IOException;
 import java.text.ParseException;
@@ -160,9 +161,12 @@ public class IndexMetaData implements Diffable<IndexMetaData> {
     public static final String SETTING_BLOCKS_WRITE = "index.blocks.write";
     public static final String SETTING_BLOCKS_METADATA = "index.blocks.metadata";
     public static final String SETTING_VERSION_CREATED = "index.version.created";
+    public static final String SETTING_VERSION_CREATED_STRING = "index.version.created_string";
     public static final String SETTING_VERSION_UPGRADED = "index.version.upgraded";
+    public static final String SETTING_VERSION_UPGRADED_STRING = "index.version.upgraded_string";
     public static final String SETTING_VERSION_MINIMUM_COMPATIBLE = "index.version.minimum_compatible";
     public static final String SETTING_CREATION_DATE = "index.creation_date";
+    public static final String SETTING_CREATION_DATE_STRING = "index.creation_date_string";
     public static final String SETTING_UUID = "index.uuid";
     public static final String SETTING_LEGACY_ROUTING_HASH_FUNCTION = "index.legacy.routing.hash.type";
     public static final String SETTING_LEGACY_ROUTING_USE_TYPE = "index.legacy.routing.use_type";
@@ -918,6 +922,28 @@ public class IndexMetaData implements Diffable<IndexMetaData> {
      */
     public static boolean isIndexUsingShadowReplicas(Settings settings) {
         return settings.getAsBoolean(SETTING_SHADOW_REPLICAS, false);
+    }
+
+    /**
+     * Adds human readable version and creation date settings.
+     * This method is used to display the settings in a human readable format in REST API
+     */
+    public static Settings addHumanReadableSettings(Settings settings) {
+        Settings.Builder builder = Settings.builder().put(settings);
+        Version version = settings.getAsVersion(SETTING_VERSION_CREATED, null);
+        if (version != null) {
+            builder.put(SETTING_VERSION_CREATED_STRING, version.toString());
+        }
+        Version versionUpgraded = settings.getAsVersion(SETTING_VERSION_UPGRADED, null);
+        if (versionUpgraded != null) {
+            builder.put(SETTING_VERSION_UPGRADED_STRING, versionUpgraded.toString());
+        }
+        Long creationDate = settings.getAsLong(SETTING_CREATION_DATE, null);
+        if (creationDate != null) {
+            DateTime creationDateTime = new DateTime(creationDate);
+            builder.put(SETTING_CREATION_DATE_STRING, creationDateTime.toString());
+        }
+        return builder.build();
     }
 
 }

--- a/core/src/main/java/org/elasticsearch/rest/action/admin/indices/get/RestGetIndicesAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/indices/get/RestGetIndicesAction.java
@@ -27,6 +27,7 @@ import org.elasticsearch.action.admin.indices.get.GetIndexResponse;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.metadata.AliasMetaData;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
@@ -78,6 +79,7 @@ public class RestGetIndicesAction extends BaseRestHandler {
         }
         getIndexRequest.indicesOptions(IndicesOptions.fromRequest(request, getIndexRequest.indicesOptions()));
         getIndexRequest.local(request.paramAsBoolean("local", getIndexRequest.local()));
+        getIndexRequest.humanReadable(request.paramAsBoolean("human", false));
         client.admin().indices().getIndex(getIndexRequest, new RestBuilderListener<GetIndexResponse>(channel) {
 
             @Override

--- a/core/src/main/java/org/elasticsearch/rest/action/admin/indices/settings/RestGetSettingsAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/indices/settings/RestGetSettingsAction.java
@@ -51,6 +51,7 @@ public class RestGetSettingsAction extends BaseRestHandler {
         GetSettingsRequest getSettingsRequest = new GetSettingsRequest()
                 .indices(Strings.splitStringByCommaToArray(request.param("index")))
                 .indicesOptions(IndicesOptions.fromRequest(request, IndicesOptions.strictExpandOpen()))
+                .humanReadable(request.hasParam("human"))
                 .names(names);
         getSettingsRequest.local(request.paramAsBoolean("local", getSettingsRequest.local()));
 

--- a/core/src/test/java/org/elasticsearch/cluster/metadata/HumanReadableIndexSettingsTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/metadata/HumanReadableIndexSettingsTests.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.metadata;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.joda.time.DateTime;
+import org.junit.Test;
+
+import static com.google.common.collect.Sets.newHashSet;
+import static org.elasticsearch.test.VersionUtils.randomVersion;
+
+public class HumanReadableIndexSettingsTests extends ElasticsearchTestCase {
+
+    @Test
+    public void testHumanReadableSettings() {
+        Version versionCreated = randomVersion(random());
+        Version versionUpgraded = randomVersion(random());
+        long created = System.currentTimeMillis();
+        Settings testSettings = Settings.builder()
+                .put(IndexMetaData.SETTING_VERSION_CREATED, versionCreated)
+                .put(IndexMetaData.SETTING_VERSION_UPGRADED, versionUpgraded)
+                .put(IndexMetaData.SETTING_CREATION_DATE, created)
+                .build();
+
+        Settings humanSettings = IndexMetaData.addHumanReadableSettings(testSettings);
+
+        assertEquals(versionCreated.toString(), humanSettings.get(IndexMetaData.SETTING_VERSION_CREATED_STRING, null));
+        assertEquals(versionUpgraded.toString(), humanSettings.get(IndexMetaData.SETTING_VERSION_UPGRADED_STRING, null));
+        assertEquals(new DateTime(created).toString(), humanSettings.get(IndexMetaData.SETTING_CREATION_DATE_STRING, null));
+    }
+}

--- a/rest-api-spec/api/indices.get.json
+++ b/rest-api-spec/api/indices.get.json
@@ -34,6 +34,15 @@
           "options" : ["open","closed","none","all"],
           "default" : "open",
           "description":"Whether wildcard expressions should get expanded to open or closed indices (default: open)"
+        },
+        "flat_settings": {
+          "type": "boolean",
+          "description": "Return settings in flat format (default: false)"
+        },
+        "human": {
+          "type": "boolean",
+          "description": "Whether to return version and creation date values in human-readable format.",
+          "default": false
         }
       }
     },

--- a/rest-api-spec/api/indices.get_settings.json
+++ b/rest-api-spec/api/indices.get_settings.json
@@ -37,6 +37,11 @@
         "local": {
           "type": "boolean",
           "description": "Return local information, do not retrieve the state from master node (default: false)"
+        },
+        "human": {
+          "type": "boolean",
+          "description": "Whether to return version and creation date values in human-readable format.",
+          "default": false
         }
       }
     },

--- a/rest-api-spec/test/indices.get/10_basic.yaml
+++ b/rest-api-spec/test/indices.get/10_basic.yaml
@@ -116,6 +116,29 @@ setup:
   - is_false: test_index.warmers
 
 ---
+"Get index infos with human settings should return index creation date and version in readable format":
+
+  - do:
+      indices.get:
+        index: test_index
+        feature: _settings
+        human: true
+
+  - is_true: test_index.settings.index.creation_date_string
+  - is_true: test_index.settings.index.version.created_string
+
+---
+"Get index infos by default shouldn't return index creation date and version in readable format":
+
+  - do:
+      indices.get:
+        index: test_index
+        feature: _settings
+
+  - is_false: test_index.settings.index.creation_date_string
+  - is_false: test_index.settings.index.version.created_string
+
+---
 "Missing index should throw an Error":
 
   - do:


### PR DESCRIPTION
By setting human parameter to true, it's now possible to see human readable versions of Elasticsearch that created and updated the index as well as the date when the index was created.

Closes #11484
