### PR TITLE
Execute Scripting Engine before searching for inner templates in template query

### DIFF
--- a/core/src/test/java/org/elasticsearch/index/query/TemplateQueryParserTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/TemplateQueryParserTest.java
@@ -119,6 +119,35 @@ public class TemplateQueryParserTest extends ElasticsearchTestCase {
     }
 
     @Test
+    public void testParseTemplateAsSingleStringWithConditionalClause() throws IOException {
+        String templateString = "{" + "  \"inline\" : \"{ \\\"match_{{#use_it}}{{template}}{{/use_it}}\\\":{} }\"," + "  \"params\":{"
+                + "    \"template\":\"all\"," + "    \"use_it\": true" + "  }" + "}";
+        XContentParser templateSourceParser = XContentFactory.xContent(templateString).createParser(templateString);
+        context.reset(templateSourceParser);
+
+        TemplateQueryParser parser = injector.getInstance(TemplateQueryParser.class);
+        Query query = parser.parse(context);
+        assertTrue("Parsing template query failed.", query instanceof MatchAllDocsQuery);
+    }
+
+    /**
+     * Test that the template query parser can parse and evaluate template
+     * expressed as a single string but still it expects only the query
+     * specification (thus this test should fail with specific exception).
+     */
+    @Test(expected = QueryParsingException.class)
+    public void testParseTemplateFailsToParseCompleteQueryAsSingleString() throws IOException {
+        String templateString = "{" + "  \"inline\" : \"{ \\\"size\\\": \\\"{{size}}\\\", \\\"query\\\":{\\\"match_all\\\":{}}}\","
+                + "  \"params\":{" + "    \"size\":2" + "  }\n" + "}";
+
+        XContentParser templateSourceParser = XContentFactory.xContent(templateString).createParser(templateString);
+        context.reset(templateSourceParser);
+
+        TemplateQueryParser parser = injector.getInstance(TemplateQueryParser.class);
+        parser.parse(context);
+    }
+
+    @Test
     public void testParserCanExtractTemplateNames() throws Exception {
         String templateString = "{ \"file\": \"storedTemplate\" ,\"params\":{\"template\":\"all\" } } ";
 


### PR DESCRIPTION
The search template and template query did not run the template through the script engine before searching for an inner template. This meant that parsing for the inner template failed because the template was not always valid JSON (if it contained mustache code) when it was parsed to find the inner template. This has been fixed and Tests added to check for the failing behaviour

Tests are from https://github.com/elastic/elasticsearch/pull/8393
