### PR TITLE
[maven] update maven-assembly-plugin to 2.5.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -507,7 +507,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
-                    <version>2.5.4</version>
+                    <version>2.5.5</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
``` xml
<plugin>
 <groupId>org.apache.maven.plugins</groupId>
 <artifactId>maven-assembly-plugin</artifactId>
 <version>2.5.5</version>
</plugin>
```
## Release Notes - Maven Assembly Plugin - Version 2.5.5
- Bug
  - [MASSEMBLY-767] - Schema missing from the web site
  - [MASSEMBLY-768] - JarInputStream unable to find  manifest
    created by version 2.5.4
  - [MASSEMBLY-769] - ZIP fileMode permissions not properly set with
    dependencySet and unpackOptions
