### PR TITLE
GatewayAllocator: reset rerouting flag after error

### DIFF
--- a/src/main/java/org/elasticsearch/gateway/local/LocalGatewayAllocator.java
+++ b/src/main/java/org/elasticsearch/gateway/local/LocalGatewayAllocator.java
@@ -550,6 +550,7 @@ public class LocalGatewayAllocator extends AbstractComponent implements GatewayA
 
                 @Override
                 public void onFailure(String source, Throwable t) {
+                    rerouting.set(false);
                     logger.warn("failed to perform reroute post async fetch for {}", t, source);
                 }
             });

--- a/src/test/java/org/elasticsearch/cluster/MinimumMasterNodesTests.java
+++ b/src/test/java/org/elasticsearch/cluster/MinimumMasterNodesTests.java
@@ -167,7 +167,6 @@ public class MinimumMasterNodesTests extends ElasticsearchIntegrationTest {
 
     @Test @LuceneTestCase.Slow
     @TestLogging("cluster.routing.allocation.allocator:TRACE")
-    @LuceneTestCase.AwaitsFix(bugUrl = "boaz is looking into this")
     public void multipleNodesShutdownNonMasterNodes() throws Exception {
         Settings settings = settingsBuilder()
                 .put("discovery.type", "zen")


### PR DESCRIPTION
After asynchronously fetching shard information the gateway allocator issues a reroute via  a cluster state update task. #11421 introduced an optimization trying to avoid submitting unneeded reroutes when results for many shards come in together. This is done by having a rerouting flag, indicating a pending reroute is coming and thus any new incoming shard info doesn't need to issue a reroute. This flag wasn't reset upon an error in the reroute update task. Most notably - if a master node had to step during to a min_master_node violation, it could reject an ongoing reroute. Lacking to reset the flag causing it to skip any future reroute, when the node became master again.

Example failure: http://build-us-00.elastic.co/job/es_core_1x_metal/9122/testReport/junit/org.elasticsearch.cluster/MinimumMasterNodesTests/multipleNodesShutdownNonMasterNodes/
