### PR TITLE
[BUILD] Don't shade core artifacts

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -18,8 +18,6 @@
 
 
     <properties>
-        <!-- testing is currently done unshaded :( -->
-        <elasticsearch.thirdparty.config>unshaded</elasticsearch.thirdparty.config>
         <!-- Properties used for building RPM & DEB packages (see common/packaging.properties) -->
         <packaging.elasticsearch.home.dir>/usr/share/elasticsearch</packaging.elasticsearch.home.dir>
         <packaging.elasticsearch.bin.dir>/usr/share/elasticsearch/bin</packaging.elasticsearch.bin.dir>
@@ -415,9 +413,12 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <shadeTestJar>true</shadeTestJar>
+                    <shadedArtifactAttached>true</shadedArtifactAttached>
+                    <shadedClassifierName>shaded</shadedClassifierName>
+                    <shadeTestJar>false</shadeTestJar>
                     <minimizeJar>true</minimizeJar>
                     <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+                    <createDependencyReducedPom>false</createDependencyReducedPom>
                     <artifactSet>
                         <includes>
                             <include>com.google.guava:guava</include>

--- a/core/src/main/assemblies/common-bin.xml
+++ b/core/src/main/assemblies/common-bin.xml
@@ -11,6 +11,20 @@
                 <include>com.spatial4j:spatial4j</include>
                 <include>com.vividsolutions:jts</include>
                 <include>org.codehaus.groovy:groovy-all</include>
+                <include>com.google.guava:guava</include>
+                <include>com.carrotsearch:hppc</include>
+                <include>com.fasterxml.jackson.core:jackson-core</include>
+                <include>com.fasterxml.jackson.dataformat:jackson-dataformat-smile</include>
+                <include>com.fasterxml.jackson.dataformat:jackson-dataformat-yaml</include>
+                <include>com.fasterxml.jackson.dataformat:jackson-dataformat-cbor</include>
+                <include>joda-time:joda-time</include>
+                <include>org.joda:joda-convert</include>
+                <include>io.netty:netty</include>
+                <include>com.ning:compress-lzf</include>
+                <include>com.github.spullara.mustache.java:compiler</include>
+                <include>com.tdunning:t-digest</include>
+                <include>org.apache.commons:commons-lang3</include>
+                <include>commons-cli:commons-cli</include>
             </includes>
         </dependencySet>
         <dependencySet>

--- a/pom.xml
+++ b/pom.xml
@@ -760,8 +760,6 @@
                                      <internalRuntimeForbidden>true</internalRuntimeForbidden>
                                      <!-- if the used Java version is too new, don't fail, just do nothing: -->
                                      <failOnUnsupportedJava>false</failOnUnsupportedJava>
-                                     <!-- Temporary until we stabilize builds -->
-                                     <failOnUnresolvableSignatures>false</failOnUnresolvableSignatures>
                                      <excludes>
                                          <exclude>jsr166e/**</exclude>
                                      </excludes>
@@ -792,8 +790,6 @@
                                  <internalRuntimeForbidden>true</internalRuntimeForbidden>
                                  <!-- if the used Java version is too new, don't fail, just do nothing: -->
                                  <failOnUnsupportedJava>false</failOnUnsupportedJava>
-                                 <!-- Temporary until we stabilize builds -->
-                                 <failOnUnresolvableSignatures>false</failOnUnresolvableSignatures>
                                  <bundledSignatures>
                                      <!-- This will automatically choose the right signatures based on 'targetVersion': -->
                                      <bundledSignature>jdk-unsafe</bundledSignature>


### PR DESCRIPTION
This commit adds an additioal jar that is shaded and keeps all the
artifacts that are used by default on the server-side unshaded. Users
that need a shaded jar can now use the `shaded` classifyer to pull
the shaded minimized jar in instead. Including the shaded jar in a
downstream project looks like this:

``` XML
<dependency>
  <groupId>org.elasticsearch</groupId>
  <artifactId>elasticsearch</artifactId>
  <classifier>shaded</classifier>
</dependency>
```
