### PR TITLE
Deprecate addQuery methods that are going to be removed in 2.0

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/IndexQueryParserModule.java
+++ b/src/main/java/org/elasticsearch/index/query/IndexQueryParserModule.java
@@ -31,15 +31,14 @@ import org.elasticsearch.index.query.support.InnerHitsQueryParserHelper;
 import java.util.LinkedList;
 import java.util.Map;
 
-/**
- *
- */
 public class IndexQueryParserModule extends AbstractModule {
 
     /**
      * A custom processor that can be extended to process and bind custom implementations of
      * {@link QueryParserFactory}, and {@link FilterParser}.
+     * @deprecated query parsers should be registered globally via {@link org.elasticsearch.indices.query.IndicesQueriesModule#addQuery(Class)} instead
      */
+    @Deprecated
     public static class QueryParsersProcessor {
 
         /**
@@ -121,9 +120,12 @@ public class IndexQueryParserModule extends AbstractModule {
     /**
      * Adds a custom query parser.
      *
+     * @deprecated use {@link org.elasticsearch.indices.query.IndicesQueriesModule#addQuery(Class)} instead
+     *
      * @param name        The name of the query parser
      * @param queryParser the class of the query parser
      */
+    @Deprecated
     public void addQueryParser(String name, Class<? extends QueryParser> queryParser) {
         queries.put(name, queryParser);
     }
@@ -131,9 +133,12 @@ public class IndexQueryParserModule extends AbstractModule {
     /**
      * Adds a custom filter parser.
      *
+     * @deprecated use {@link org.elasticsearch.indices.query.IndicesQueriesModule#addFilter(Class)} instead
+     *
      * @param name         The name of the filter parser
      * @param filterParser the class of the filter parser
      */
+    @Deprecated
     public void addFilterParser(String name, Class<? extends FilterParser> filterParser) {
         filters.put(name, filterParser);
     }
@@ -149,7 +154,7 @@ public class IndexQueryParserModule extends AbstractModule {
         bind(IndexQueryParserService.class).asEagerSingleton();
         bind(InnerHitsQueryParserHelper.class).asEagerSingleton();
 
-        // handle XContenQueryParsers
+        // handle XContentQueryParsers
         MapBinder<String, QueryParserFactory> queryBinder
                 = MapBinder.newMapBinder(binder(), String.class, QueryParserFactory.class);
         Map<String, Settings> xContentQueryParserGroups = settings.getGroups(IndexQueryParserService.Defaults.QUERY_PREFIX);

--- a/src/main/java/org/elasticsearch/indices/query/IndicesQueriesModule.java
+++ b/src/main/java/org/elasticsearch/indices/query/IndicesQueriesModule.java
@@ -30,26 +30,42 @@ import java.util.Set;
 
 public class IndicesQueriesModule extends AbstractModule {
 
-    private Set<Class<QueryParser>> queryParsersClasses = Sets.newHashSet();
+    private Set<Class<? extends QueryParser>> queryParsersClasses = Sets.newHashSet();
     private Set<QueryParser> queryParsers = Sets.newHashSet();
-    private Set<Class<FilterParser>> filterParsersClasses = Sets.newHashSet();
+    private Set<Class<? extends FilterParser>> filterParsersClasses = Sets.newHashSet();
     private Set<FilterParser> filterParsers = Sets.newHashSet();
 
-    public synchronized IndicesQueriesModule addQuery(Class<QueryParser> queryParser) {
+    /**
+     * Registers a {@link QueryParser} given its class
+     */
+    public synchronized IndicesQueriesModule addQuery(Class<? extends QueryParser> queryParser) {
         queryParsersClasses.add(queryParser);
         return this;
     }
 
+    /**
+     * Registers a {@link QueryParser}
+     * @deprecated use {@link #addQuery(Class) instead}
+     */
+    @Deprecated
     public synchronized IndicesQueriesModule addQuery(QueryParser queryParser) {
         queryParsers.add(queryParser);
         return this;
     }
 
-    public synchronized IndicesQueriesModule addFilter(Class<FilterParser> filterParser) {
+    /**
+     * Registers a {@link FilterParser} given its class
+     */
+    public synchronized IndicesQueriesModule addFilter(Class<? extends FilterParser> filterParser) {
         filterParsersClasses.add(filterParser);
         return this;
     }
 
+    /**
+     * Registers a {@link FilterParser}
+     * @deprecated use {@link #addFilter(Class) instead}
+     */
+    @Deprecated
     public synchronized IndicesQueriesModule addFilter(FilterParser filterParser) {
         filterParsers.add(filterParser);
         return this;
@@ -60,7 +76,7 @@ public class IndicesQueriesModule extends AbstractModule {
         bind(IndicesQueriesRegistry.class).asEagerSingleton();
 
         Multibinder<QueryParser> qpBinders = Multibinder.newSetBinder(binder(), QueryParser.class);
-        for (Class<QueryParser> queryParser : queryParsersClasses) {
+        for (Class<? extends QueryParser> queryParser : queryParsersClasses) {
             qpBinders.addBinding().to(queryParser).asEagerSingleton();
         }
         for (QueryParser queryParser : queryParsers) {
@@ -110,7 +126,7 @@ public class IndicesQueriesModule extends AbstractModule {
         }
 
         Multibinder<FilterParser> fpBinders = Multibinder.newSetBinder(binder(), FilterParser.class);
-        for (Class<FilterParser> filterParser : filterParsersClasses) {
+        for (Class<? extends FilterParser> filterParser : filterParsersClasses) {
             fpBinders.addBinding().to(filterParser).asEagerSingleton();
         }
         for (FilterParser filterParser : filterParsers) {

--- a/src/main/java/org/elasticsearch/indices/query/IndicesQueriesRegistry.java
+++ b/src/main/java/org/elasticsearch/indices/query/IndicesQueriesRegistry.java
@@ -55,14 +55,21 @@ public class IndicesQueriesRegistry extends AbstractComponent {
     }
 
     /**
-     * Adds a global query parser.
+     * Registers a {@link QueryParser}
+     * @deprecated use {@link IndicesQueriesModule#addQuery(Class) instead}
      */
+    @Deprecated
     public synchronized void addQueryParser(QueryParser queryParser) {
         Map<String, QueryParser> queryParsers = Maps.newHashMap(this.queryParsers);
         addQueryParser(queryParsers, queryParser);
         this.queryParsers = ImmutableMap.copyOf(queryParsers);
     }
 
+    /**
+     * Registers a {@link FilterParser}
+     * @deprecated use {@link IndicesQueriesModule#addFilter(Class) instead}
+     */
+    @Deprecated
     public synchronized void addFilterParser(FilterParser filterParser) {
         Map<String, FilterParser> filterParsers = Maps.newHashMap(this.filterParsers);
         addFilterParser(filterParsers, filterParser);


### PR DESCRIPTION
Also fix the generics in `IndicesQueriesModule#addQuery(Class)` so that it can be used as the single way to register custom query parsers.

Relates to #11481
