### PR TITLE
Fix a typo in the documentation: six_hun -> "narrower"

### DIFF
--- a/docs/reference/search/request/sort.asciidoc
+++ b/docs/reference/search/request/sort.asciidoc
@@ -360,5 +360,5 @@ When sorting, the relevant sorted field values are loaded into memory.
 This means that per shard, there should be enough memory to contain
 them. For string based types, the field sorted on should not be analyzed
 / tokenized. For numeric types, if possible, it is recommended to
-explicitly set the type to six_hun types (like `short`, `integer` and
+explicitly set the type to narrower types (like `short`, `integer` and
 `float`).


### PR DESCRIPTION
This was introduced in https://github.com/elastic/elasticsearch.github.com/commit/defaf4f0, probably
as a search-and-replace mistake.
