### PR TITLE
Improve exception message when shard has a partial commit (segments_N file) due to prior disk full

### DIFF
--- a/src/test/java/org/elasticsearch/common/lucene/LuceneTest.java
+++ b/src/test/java/org/elasticsearch/common/lucene/LuceneTest.java
@@ -330,14 +330,7 @@ public class LuceneTest extends ElasticsearchLuceneTestCase {
                         assertTrue(Lucene.indexNeeds3xUpgrading(dir));
                     }
 
-                    for (int i = 0; i < 2; i++) {
-                        boolean upgraded = Lucene.upgradeLucene3xSegmentsMetadata(dir);
-                        if (i == 0) {
-                            assertTrue(upgraded);
-                        } else {
-                            assertFalse(upgraded);
-                        }
-                    }
+                    Lucene.upgradeLucene3xSegmentsMetadata(dir);
 
                     for (int i = 0; i < 2; i++) {
                         assertFalse(Lucene.indexNeeds3xUpgrading(dir));


### PR DESCRIPTION
ES checks the latest segments_N file to see if it was written by Lucene 3.x and upgrade if so, but if that file is truncated (e.g. 0 bytes) due prior disk full, we now give a confusing "failed to upgrade 3x segments" exception when you likely don't have 3.x segments_N nor segments.

This change just breaks apart the exception handling so we do a better job separating "I could not read the latest segments_N file" from "I did read it and it was ancient (Lucene 3.x) and then when I tried to upgrade it, bad things happened".

Closed #11249
