### PR TITLE
Query refactoring: refactored LimitQueryBuilder and Parser and added test

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/LimitQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/LimitQueryBuilder.java
@@ -19,7 +19,11 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.search.Query;
 import org.elasticsearch.action.search.SearchRequestBuilder;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -28,7 +32,7 @@ import java.io.IOException;
  * @deprecated Use {@link SearchRequestBuilder#setTerminateAfter(int)} instead.
  */
 @Deprecated
-public class LimitQueryBuilder extends QueryBuilder {
+public class LimitQueryBuilder extends QueryBuilder<LimitQueryBuilder> {
 
     public static final String NAME = "limit";
     private final int limit;
@@ -43,6 +47,40 @@ public class LimitQueryBuilder extends QueryBuilder {
         builder.startObject(NAME);
         builder.field("value", limit);
         builder.endObject();
+    }
+
+    @Override
+    public Query toQuery(QueryParseContext parseContext) {
+        // this filter is deprecated and parses to a filter that matches everything
+        return Queries.newMatchAllQuery();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        LimitQueryBuilder that = (LimitQueryBuilder) o;
+        return Integer.compare(that.limit, limit) == 0;
+    }
+
+    @Override
+    public int hashCode() {
+        return Integer.hashCode(limit);
+    }
+
+    @Override
+    public LimitQueryBuilder readFrom(StreamInput in) throws IOException {
+        LimitQueryBuilder limitQueryBuilder = new LimitQueryBuilder(in.readInt());
+        return limitQueryBuilder;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeInt(this.limit);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/LimitQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/LimitQueryParser.java
@@ -19,15 +19,13 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.search.Query;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
 
 @Deprecated
-public class LimitQueryParser extends BaseQueryParserTemp {
+public class LimitQueryParser extends BaseQueryParser {
 
     @Inject
     public LimitQueryParser() {
@@ -39,7 +37,7 @@ public class LimitQueryParser extends BaseQueryParserTemp {
     }
 
     @Override
-    public Query parse(QueryParseContext parseContext) throws IOException, QueryParsingException {
+    public QueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
         XContentParser parser = parseContext.parser();
 
         int limit = -1;
@@ -61,8 +59,7 @@ public class LimitQueryParser extends BaseQueryParserTemp {
             throw new QueryParsingException(parseContext, "No value specified for limit query");
         }
 
-        // this filter is deprecated and parses to a filter that matches everything
-        return Queries.newMatchAllQuery();
+        return new LimitQueryBuilder(limit);
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/index/query/LimitQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/LimitQueryBuilderTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query;
+
+import org.apache.lucene.search.Query;
+import org.elasticsearch.common.lucene.search.Queries;
+
+public class LimitQueryBuilderTest extends BaseQueryTestCase<LimitQueryBuilder> {
+
+    @Override
+    protected Query createExpectedQuery(LimitQueryBuilder queryBuilder, QueryParseContext context) {
+        // this filter is deprecated and parses to a filter that matches everything
+        return Queries.newMatchAllQuery();
+    }
+
+    @Override
+    protected LimitQueryBuilder createEmptyQueryBuilder() {
+        return new LimitQueryBuilder(0);
+    }
+
+    /**
+     * @return a LimitQueryBuilder with random limit between 0 and 20
+     */
+    @Override
+    protected LimitQueryBuilder createTestQueryBuilder() {
+        LimitQueryBuilder query = new LimitQueryBuilder(randomIntBetween(0, 20));
+        return query;
+    }
+
+}


### PR DESCRIPTION
Split the parse method into a parsing and a query building part, adding serialization and hashCode(), equals() for better testing.
Add basic unit test for Builder and Parser.

PR goes agains query-refacoring feature branch.
