### PR TITLE
Transport: allow to de-serialize arbitrary objects given their name

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/io/stream/FilterStreamInput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/FilterStreamInput.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.io.stream;
+
+import java.io.IOException;
+
+/**
+ * Wraps a {@link StreamInput} and associates it with a {@link NamedWriteableRegistry}
+ */
+public class FilterStreamInput extends StreamInput {
+
+    private final StreamInput delegate;
+
+    public FilterStreamInput(StreamInput delegate, NamedWriteableRegistry namedWriteableRegistry) {
+        super(namedWriteableRegistry);
+        this.delegate = delegate;
+    }
+
+    @Override
+    public byte readByte() throws IOException {
+        return delegate.readByte();
+    }
+
+    @Override
+    public void readBytes(byte[] b, int offset, int len) throws IOException {
+        delegate.readBytes(b, offset, len);
+    }
+
+    @Override
+    public void reset() throws IOException {
+        delegate.reset();
+    }
+
+    @Override
+    public int read() throws IOException {
+        return delegate.read();
+    }
+
+    @Override
+    public void close() throws IOException {
+        delegate.close();
+    }
+}

--- a/core/src/main/java/org/elasticsearch/common/io/stream/NamedWriteable.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/NamedWriteable.java
@@ -17,20 +17,17 @@
  * under the License.
  */
 
-package org.elasticsearch.transport.local;
+package org.elasticsearch.common.io.stream;
 
-import org.elasticsearch.Version;
-import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.test.transport.MockTransportService;
-import org.elasticsearch.transport.AbstractSimpleTransportTests;
+/**
+ * A {@link Writeable} object identified by its name.
+ * To be used for arbitrary serializable objects (e.g. queries); when reading them, their name tells
+ * which specific object needs to be created.
+ */
+public interface NamedWriteable<T> extends Writeable<T> {
 
-public class SimpleLocalTransportTests extends AbstractSimpleTransportTests {
-
-    @Override
-    protected MockTransportService build(Settings settings, Version version, NamedWriteableRegistry namedWriteableRegistry) {
-        MockTransportService transportService = new MockTransportService(Settings.EMPTY, new LocalTransport(settings, threadPool, version, namedWriteableRegistry), threadPool);
-        transportService.start();
-        return transportService;
-    }
+    /**
+     * Returns the name of the writeable object
+     */
+    String getName();
 }

--- a/core/src/main/java/org/elasticsearch/common/io/stream/NamedWriteableRegistry.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/NamedWriteableRegistry.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.io.stream;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Registry for {@link NamedWriteable} objects. Allows to register and retrieve prototype instances of writeable objects
+ * given their name.
+ */
+public class NamedWriteableRegistry {
+
+    private Map<String, NamedWriteable> registry = new HashMap<>();
+
+    /**
+     * Registers a {@link NamedWriteable} prototype
+     */
+    public synchronized void registerPrototype(NamedWriteable<?> namedWriteable) {
+        if (registry.containsKey(namedWriteable.getName())) {
+            throw new IllegalArgumentException("named writeable of type [" + namedWriteable.getClass().getName() + "] with name [" + namedWriteable.getName() + "] " +
+                    "is already registered by type [" + registry.get(namedWriteable.getName()).getClass().getName() + "]");
+        }
+        registry.put(namedWriteable.getName(), namedWriteable);
+    }
+
+    /**
+     * Returns a prototype of the {@link NamedWriteable} object identified by the name provided as argument
+     */
+    public <C> NamedWriteable<C> getPrototype(String name) {
+        @SuppressWarnings("unchecked")
+        NamedWriteable<C> namedWriteable = (NamedWriteable<C>)registry.get(name);
+        if (namedWriteable == null) {
+            throw new IllegalArgumentException("unknown named writeable with name [" + name + "]");
+        }
+        return namedWriteable;
+    }
+}

--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -359,6 +359,7 @@ public abstract class StreamOutput extends OutputStream {
             } else {
                 writeByte((byte) 10);
             }
+            @SuppressWarnings("unchecked")
             Map<String, Object> map = (Map<String, Object>) value;
             writeVInt(map.size());
             for (Map.Entry<String, Object> entry : map.entrySet()) {
@@ -403,31 +404,31 @@ public abstract class StreamOutput extends OutputStream {
         }
     }
 
-    public void writeIntArray(int[] value) throws IOException {
-        writeVInt(value.length);
-        for (int i=0; i<value.length; i++) {
-            writeInt(value[i]);
+    public void writeIntArray(int[] values) throws IOException {
+        writeVInt(values.length);
+        for (int value : values) {
+            writeInt(value);
         }
     }
 
-    public void writeLongArray(long[] value) throws IOException {
-        writeVInt(value.length);
-        for (int i=0; i<value.length; i++) {
-            writeLong(value[i]);
+    public void writeLongArray(long[] values) throws IOException {
+        writeVInt(values.length);
+        for (long value : values) {
+            writeLong(value);
         }
     }
 
-    public void writeFloatArray(float[] value) throws IOException {
-        writeVInt(value.length);
-        for (int i=0; i<value.length; i++) {
-            writeFloat(value[i]);
+    public void writeFloatArray(float[] values) throws IOException {
+        writeVInt(values.length);
+        for (float value : values) {
+            writeFloat(value);
         }
     }
 
-    public void writeDoubleArray(double[] value) throws IOException {
-        writeVInt(value.length);
-        for (int i=0; i<value.length; i++) {
-            writeDouble(value[i]);
+    public void writeDoubleArray(double[] values) throws IOException {
+        writeVInt(values.length);
+        for (double value : values) {
+            writeDouble(value);
         }
     }
 
@@ -447,5 +448,13 @@ public abstract class StreamOutput extends OutputStream {
         ObjectOutputStream out = new ObjectOutputStream(this);
         out.writeObject(throwable);
         out.flush();
+    }
+
+    /**
+     * Writes a {@link NamedWriteable} to the current stream, by first writing its name and then the object itself
+     */
+    public void writeNamedWriteable(NamedWriteable namedWriteable) throws IOException {
+        writeString(namedWriteable.getName());
+        namedWriteable.writeTo(this);
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/FQueryFilterBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/FQueryFilterBuilder.java
@@ -24,57 +24,30 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import java.io.IOException;
 
 /**
- * A filter that simply wraps a query.
+ * A filter that simply wraps a query. Same as the {@link QueryFilterBuilder} except that it allows also to
+ * associate a name with the query filter.
  * @deprecated Useless now that queries and filters are merged: pass the
  *             query as a filter directly.
  */
 @Deprecated
-public class QueryFilterBuilder extends QueryBuilder {
+public class FQueryFilterBuilder extends QueryFilterBuilder {
 
-    public static final String NAME = "query";
+    public static final String NAME = "fquery";
 
-    private final QueryBuilder queryBuilder;
-
-    private String queryName;
-
-    static final QueryFilterBuilder PROTOTYPE = new QueryFilterBuilder(null);
+    static final FQueryFilterBuilder PROTOTYPE = new FQueryFilterBuilder(null);
 
     /**
      * A filter that simply wraps a query.
      *
      * @param queryBuilder The query to wrap as a filter
      */
-    public QueryFilterBuilder(QueryBuilder queryBuilder) {
-        this.queryBuilder = queryBuilder;
-    }
-
-    /**
-     * Sets the query name for the filter that can be used when searching for matched_filters per hit.
-     */
-    public QueryFilterBuilder queryName(String queryName) {
-        this.queryName = queryName;
-        return this;
+    public FQueryFilterBuilder(QueryBuilder queryBuilder) {
+        super(queryBuilder);
     }
 
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
-        if (queryName == null) {
-            builder.field(NAME);
-            queryBuilder.toXContent(builder, params);
-        } else {
-            //fallback fo fquery when needed, for bw comp
-            buildFQuery(builder, params);
-        }
-    }
-
-    protected void buildFQuery(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(FQueryFilterBuilder.NAME);
-        builder.field("query");
-        queryBuilder.toXContent(builder, params);
-        if (queryName != null) {
-            builder.field("_name", queryName);
-        }
-        builder.endObject();
+        buildFQuery(builder, params);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/FQueryFilterParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/FQueryFilterParser.java
@@ -39,7 +39,7 @@ public class FQueryFilterParser extends BaseQueryParserTemp {
 
     @Override
     public String[] names() {
-        return new String[]{QueryFilterBuilder.FQUERY_NAME};
+        return new String[]{FQueryFilterBuilder.NAME};
     }
 
     @Override
@@ -86,7 +86,7 @@ public class FQueryFilterParser extends BaseQueryParserTemp {
     }
 
     @Override
-    public QueryFilterBuilder getBuilderPrototype() {
-        return QueryFilterBuilder.PROTOTYPE;
+    public FQueryFilterBuilder getBuilderPrototype() {
+        return FQueryFilterBuilder.PROTOTYPE;
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/QueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryBuilder.java
@@ -20,12 +20,12 @@
 package org.elasticsearch.index.query;
 
 import org.apache.lucene.search.Query;
-import org.elasticsearch.action.support.ToXContentToBytes;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.lucene.BytesRefs;
+import org.elasticsearch.action.support.ToXContentToBytes;
+import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentType;
 
@@ -35,7 +35,7 @@ import java.io.IOException;
  * Base class for all classes producing lucene queries.
  * Supports conversion to BytesReference and creation of lucene Query objects.
  */
-public abstract class QueryBuilder<QB extends QueryBuilder> extends ToXContentToBytes implements Writeable<QB> {
+public abstract class QueryBuilder<QB extends QueryBuilder> extends ToXContentToBytes implements NamedWriteable<QB> {
 
     protected QueryBuilder() {
         super(XContentType.JSON);
@@ -53,6 +53,11 @@ public abstract class QueryBuilder<QB extends QueryBuilder> extends ToXContentTo
      * @return a unique name this query is identified with
      */
     public abstract String queryId();
+
+    @Override
+    public final String getName() {
+        return queryId();
+    }
 
     /**
      * Converts this QueryBuilder to a lucene {@link Query}

--- a/core/src/main/java/org/elasticsearch/indices/query/IndicesQueriesModule.java
+++ b/core/src/main/java/org/elasticsearch/indices/query/IndicesQueriesModule.java
@@ -32,6 +32,9 @@ public class IndicesQueriesModule extends AbstractModule {
 
     private Set<Class<? extends QueryParser>> queryParsersClasses = Sets.newHashSet();
 
+    /**
+     * Registers a {@link QueryParser} given its class
+     */
     public synchronized IndicesQueriesModule addQuery(Class<? extends QueryParser> queryParser) {
         queryParsersClasses.add(queryParser);
         return this;
@@ -83,7 +86,6 @@ public class IndicesQueriesModule extends AbstractModule {
         qpBinders.addBinding().to(TemplateQueryParser.class).asEagerSingleton();
         qpBinders.addBinding().to(TypeQueryParser.class).asEagerSingleton();
         qpBinders.addBinding().to(LimitQueryParser.class).asEagerSingleton();
-        qpBinders.addBinding().to(TermsQueryParser.class).asEagerSingleton();
         qpBinders.addBinding().to(ScriptQueryParser.class).asEagerSingleton();
         qpBinders.addBinding().to(GeoDistanceQueryParser.class).asEagerSingleton();
         qpBinders.addBinding().to(GeoDistanceRangeQueryParser.class).asEagerSingleton();

--- a/core/src/main/java/org/elasticsearch/indices/query/IndicesQueriesRegistry.java
+++ b/core/src/main/java/org/elasticsearch/indices/query/IndicesQueriesRegistry.java
@@ -24,6 +24,7 @@ import com.google.common.collect.Maps;
 
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.query.QueryParser;
 
@@ -35,13 +36,14 @@ public class IndicesQueriesRegistry extends AbstractComponent {
     private ImmutableMap<String, QueryParser> queryParsers;
 
     @Inject
-    public IndicesQueriesRegistry(Settings settings, Set<QueryParser> injectedQueryParsers) {
+    public IndicesQueriesRegistry(Settings settings, Set<QueryParser> injectedQueryParsers, NamedWriteableRegistry namedWriteableRegistry) {
         super(settings);
         Map<String, QueryParser> queryParsers = Maps.newHashMap();
         for (QueryParser queryParser : injectedQueryParsers) {
             for (String name : queryParser.names()) {
                 queryParsers.put(name, queryParser);
             }
+            namedWriteableRegistry.registerPrototype(queryParser.getBuilderPrototype());
         }
         this.queryParsers = ImmutableMap.copyOf(queryParsers);
     }

--- a/core/src/main/java/org/elasticsearch/transport/TransportModule.java
+++ b/core/src/main/java/org/elasticsearch/transport/TransportModule.java
@@ -22,6 +22,7 @@ package org.elasticsearch.transport;
 import com.google.common.base.Preconditions;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.inject.AbstractModule;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
@@ -63,6 +64,8 @@ public class TransportModule extends AbstractModule {
                 bind(TransportService.class).asEagerSingleton();
             }
         }
+
+        bind(NamedWriteableRegistry.class).asEagerSingleton();
 
         if (configuredTransport != null) {
             logger.info("Using [{}] as transport, overridden by [{}]", configuredTransport.getName(), configuredTransportSource);

--- a/core/src/main/java/org/elasticsearch/transport/netty/MessageChannelHandler.java
+++ b/core/src/main/java/org/elasticsearch/transport/netty/MessageChannelHandler.java
@@ -25,6 +25,8 @@ import org.elasticsearch.common.compress.Compressor;
 import org.elasticsearch.common.compress.CompressorFactory;
 import org.elasticsearch.common.compress.NotCompressedException;
 import org.elasticsearch.common.io.ThrowableObjectInputStream;
+import org.elasticsearch.common.io.stream.FilterStreamInput;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
@@ -49,13 +51,19 @@ public class MessageChannelHandler extends SimpleChannelUpstreamHandler {
     protected final TransportServiceAdapter transportServiceAdapter;
     protected final NettyTransport transport;
     protected final String profileName;
+    private final NamedWriteableRegistry namedWriteableRegistry;
 
     public MessageChannelHandler(NettyTransport transport, ESLogger logger, String profileName) {
+        this(transport, logger, profileName, new NamedWriteableRegistry());
+    }
+
+    public MessageChannelHandler(NettyTransport transport, ESLogger logger, String profileName, NamedWriteableRegistry namedWriteableRegistry) {
         this.threadPool = transport.threadPool();
         this.transportServiceAdapter = transport.transportServiceAdapter();
         this.transport = transport;
         this.logger = logger;
         this.profileName = profileName;
+        this.namedWriteableRegistry = namedWriteableRegistry;
     }
 
     @Override
@@ -109,6 +117,7 @@ public class MessageChannelHandler extends SimpleChannelUpstreamHandler {
         } else {
             wrappedStream = streamIn;
         }
+        wrappedStream = new FilterStreamInput(wrappedStream, namedWriteableRegistry);
         wrappedStream.setVersion(version);
 
         if (TransportStatus.isRequest(status)) {

--- a/core/src/test/java/org/elasticsearch/benchmark/transport/BenchmarkNettyLargeMessages.java
+++ b/core/src/test/java/org/elasticsearch/benchmark/transport/BenchmarkNettyLargeMessages.java
@@ -23,6 +23,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.settings.DynamicSettings;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
@@ -59,10 +60,10 @@ public class BenchmarkNettyLargeMessages {
 
         final ThreadPool threadPool = new ThreadPool("BenchmarkNettyLargeMessages");
         final TransportService transportServiceServer = new TransportService(
-                new NettyTransport(settings, threadPool, networkService, BigArrays.NON_RECYCLING_INSTANCE, Version.CURRENT), threadPool
+                new NettyTransport(settings, threadPool, networkService, BigArrays.NON_RECYCLING_INSTANCE, Version.CURRENT, new NamedWriteableRegistry()), threadPool
         ).start();
         final TransportService transportServiceClient = new TransportService(
-                new NettyTransport(settings, threadPool, networkService, BigArrays.NON_RECYCLING_INSTANCE, Version.CURRENT), threadPool
+                new NettyTransport(settings, threadPool, networkService, BigArrays.NON_RECYCLING_INSTANCE, Version.CURRENT, new NamedWriteableRegistry()), threadPool
         ).start();
 
         final DiscoveryNode bigNode = new DiscoveryNode("big", new InetSocketTransportAddress("localhost", 9300), Version.CURRENT);

--- a/core/src/test/java/org/elasticsearch/benchmark/transport/TransportBenchmark.java
+++ b/core/src/test/java/org/elasticsearch/benchmark/transport/TransportBenchmark.java
@@ -22,6 +22,7 @@ package org.elasticsearch.benchmark.transport;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.StopWatch;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
@@ -44,13 +45,13 @@ public class TransportBenchmark {
         LOCAL {
             @Override
             public Transport newTransport(Settings settings, ThreadPool threadPool) {
-                return new LocalTransport(settings, threadPool, Version.CURRENT);
+                return new LocalTransport(settings, threadPool, Version.CURRENT, new NamedWriteableRegistry());
             }
         },
         NETTY {
             @Override
             public Transport newTransport(Settings settings, ThreadPool threadPool) {
-                return new NettyTransport(settings, threadPool, new NetworkService(Settings.EMPTY), BigArrays.NON_RECYCLING_INSTANCE, Version.CURRENT);
+                return new NettyTransport(settings, threadPool, new NetworkService(Settings.EMPTY), BigArrays.NON_RECYCLING_INSTANCE, Version.CURRENT, new NamedWriteableRegistry());
             }
         };
 

--- a/core/src/test/java/org/elasticsearch/cluster/ClusterStateDiffPublishingTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/ClusterStateDiffPublishingTests.java
@@ -29,6 +29,7 @@ import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.discovery.Discovery;
@@ -168,7 +169,7 @@ public class ClusterStateDiffPublishingTests extends ElasticsearchTestCase {
     }
 
     protected MockTransportService buildTransportService(Settings settings, Version version) {
-        MockTransportService transportService = new MockTransportService(settings, new LocalTransport(settings, threadPool, version), threadPool);
+        MockTransportService transportService = new MockTransportService(settings, new LocalTransport(settings, threadPool, version, new NamedWriteableRegistry()), threadPool);
         transportService.start();
         return transportService;
     }

--- a/core/src/test/java/org/elasticsearch/discovery/ZenFaultDetectionTests.java
+++ b/core/src/test/java/org/elasticsearch/discovery/ZenFaultDetectionTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.discovery.zen.fd.FaultDetection;
 import org.elasticsearch.discovery.zen.fd.MasterFaultDetection;
@@ -105,7 +106,7 @@ public class ZenFaultDetectionTests extends ElasticsearchTestCase {
     }
 
     protected MockTransportService build(Settings settings, Version version) {
-        MockTransportService transportService = new MockTransportService(Settings.EMPTY, new LocalTransport(settings, threadPool, version), threadPool);
+        MockTransportService transportService = new MockTransportService(Settings.EMPTY, new LocalTransport(settings, threadPool, version, new NamedWriteableRegistry()), threadPool);
         transportService.start();
         return transportService;
     }

--- a/core/src/test/java/org/elasticsearch/discovery/zen/ping/multicast/MulticastZenPingTests.java
+++ b/core/src/test/java/org/elasticsearch/discovery/zen/ping/multicast/MulticastZenPingTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
@@ -65,10 +66,10 @@ public class MulticastZenPingTests extends ElasticsearchTestCase {
 
         ThreadPool threadPool = new ThreadPool("testSimplePings");
         final ClusterName clusterName = new ClusterName("test");
-        final TransportService transportServiceA = new TransportService(new LocalTransport(settings, threadPool, Version.CURRENT), threadPool).start();
+        final TransportService transportServiceA = new TransportService(new LocalTransport(settings, threadPool, Version.CURRENT, new NamedWriteableRegistry()), threadPool).start();
         final DiscoveryNode nodeA = new DiscoveryNode("A", transportServiceA.boundAddress().publishAddress(), Version.CURRENT);
 
-        final TransportService transportServiceB = new TransportService(new LocalTransport(settings, threadPool, Version.CURRENT), threadPool).start();
+        final TransportService transportServiceB = new TransportService(new LocalTransport(settings, threadPool, Version.CURRENT, new NamedWriteableRegistry()), threadPool).start();
         final DiscoveryNode nodeB = new DiscoveryNode("B", transportServiceB.boundAddress().publishAddress(), Version.CURRENT);
 
         MulticastZenPing zenPingA = new MulticastZenPing(threadPool, transportServiceA, clusterName, Version.CURRENT);
@@ -138,7 +139,7 @@ public class MulticastZenPingTests extends ElasticsearchTestCase {
 
         final ThreadPool threadPool = new ThreadPool("testExternalPing");
         final ClusterName clusterName = new ClusterName("test");
-        final TransportService transportServiceA = new TransportService(new LocalTransport(settings, threadPool, Version.CURRENT), threadPool).start();
+        final TransportService transportServiceA = new TransportService(new LocalTransport(settings, threadPool, Version.CURRENT, new NamedWriteableRegistry()), threadPool).start();
         final DiscoveryNode nodeA = new DiscoveryNode("A", transportServiceA.boundAddress().publishAddress(), Version.CURRENT);
 
         MulticastZenPing zenPingA = new MulticastZenPing(threadPool, transportServiceA, clusterName, Version.CURRENT);

--- a/core/src/test/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPingTests.java
+++ b/core/src/test/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPingTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
@@ -59,13 +60,13 @@ public class UnicastZenPingTests extends ElasticsearchTestCase {
         NetworkService networkService = new NetworkService(settings);
         ElectMasterService electMasterService = new ElectMasterService(settings);
 
-        NettyTransport transportA = new NettyTransport(settings, threadPool, networkService, BigArrays.NON_RECYCLING_INSTANCE, Version.CURRENT);
+        NettyTransport transportA = new NettyTransport(settings, threadPool, networkService, BigArrays.NON_RECYCLING_INSTANCE, Version.CURRENT, new NamedWriteableRegistry());
         final TransportService transportServiceA = new TransportService(transportA, threadPool).start();
         final DiscoveryNode nodeA = new DiscoveryNode("UZP_A", transportServiceA.boundAddress().publishAddress(), Version.CURRENT);
 
         InetSocketTransportAddress addressA = (InetSocketTransportAddress) transportA.boundAddress().publishAddress();
 
-        NettyTransport transportB = new NettyTransport(settings, threadPool, networkService, BigArrays.NON_RECYCLING_INSTANCE, Version.CURRENT);
+        NettyTransport transportB = new NettyTransport(settings, threadPool, networkService, BigArrays.NON_RECYCLING_INSTANCE, Version.CURRENT, new NamedWriteableRegistry());
         final TransportService transportServiceB = new TransportService(transportB, threadPool).start();
         final DiscoveryNode nodeB = new DiscoveryNode("UZP_B", transportServiceA.boundAddress().publishAddress(), Version.CURRENT);
 

--- a/core/src/test/java/org/elasticsearch/plugins/PluggableTransportModuleTests.java
+++ b/core/src/test/java/org/elasticsearch/plugins/PluggableTransportModuleTests.java
@@ -21,6 +21,7 @@ package org.elasticsearch.plugins;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.elasticsearch.test.transport.AssertingLocalTransport;
@@ -91,8 +92,8 @@ public class PluggableTransportModuleTests extends ElasticsearchIntegrationTest 
     public static final class CountingAssertingLocalTransport extends AssertingLocalTransport {
 
         @Inject
-        public CountingAssertingLocalTransport(Settings settings, ThreadPool threadPool, Version version) {
-            super(settings, threadPool, version);
+        public CountingAssertingLocalTransport(Settings settings, ThreadPool threadPool, Version version, NamedWriteableRegistry namedWriteableRegistry) {
+            super(settings, threadPool, version, namedWriteableRegistry);
         }
 
         @Override

--- a/core/src/test/java/org/elasticsearch/test/transport/AssertingLocalTransport.java
+++ b/core/src/test/java/org/elasticsearch/test/transport/AssertingLocalTransport.java
@@ -22,6 +22,7 @@ package org.elasticsearch.test.transport;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.elasticsearch.test.VersionUtils;
@@ -45,8 +46,8 @@ public class AssertingLocalTransport extends LocalTransport {
     private final Version maxVersion;
 
     @Inject
-    public AssertingLocalTransport(Settings settings, ThreadPool threadPool, Version version) {
-        super(settings, threadPool, version);
+    public AssertingLocalTransport(Settings settings, ThreadPool threadPool, Version version, NamedWriteableRegistry namedWriteableRegistry) {
+        super(settings, threadPool, version, namedWriteableRegistry);
         final long seed = settings.getAsLong(ElasticsearchIntegrationTest.SETTING_INDEX_SEED, 0l);
         random = new Random(seed);
         minVersion = settings.getAsVersion(ASSERTING_TRANSPORT_MIN_VERSION_KEY, Version.V_0_18_0);

--- a/core/src/test/java/org/elasticsearch/transport/AbstractSimpleTransportTests.java
+++ b/core/src/test/java/org/elasticsearch/transport/AbstractSimpleTransportTests.java
@@ -22,6 +22,7 @@ package org.elasticsearch.transport;
 import com.google.common.collect.ImmutableMap;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
@@ -51,6 +52,7 @@ public abstract class AbstractSimpleTransportTests extends ElasticsearchTestCase
 
     protected ThreadPool threadPool;
 
+    protected static final NamedWriteableRegistry namedWriteableRegistry = new NamedWriteableRegistry();
     protected static final Version version0 = Version.fromId(/*0*/99);
     protected DiscoveryNode nodeA;
     protected MockTransportService serviceA;
@@ -59,7 +61,7 @@ public abstract class AbstractSimpleTransportTests extends ElasticsearchTestCase
     protected DiscoveryNode nodeB;
     protected MockTransportService serviceB;
 
-    protected abstract MockTransportService build(Settings settings, Version version);
+    protected abstract MockTransportService build(Settings settings, Version version, NamedWriteableRegistry namedWriteableRegistry);
 
     @Override
     @Before
@@ -68,12 +70,14 @@ public abstract class AbstractSimpleTransportTests extends ElasticsearchTestCase
         threadPool = new ThreadPool(getClass().getName());
         serviceA = build(
                 Settings.builder().put("name", "TS_A", TransportService.SETTING_TRACE_LOG_INCLUDE, "", TransportService.SETTING_TRACE_LOG_EXCLUDE, "NOTHING").build(),
-                version0
+                version0,
+                namedWriteableRegistry
         );
         nodeA = new DiscoveryNode("TS_A", "TS_A", serviceA.boundAddress().publishAddress(), ImmutableMap.<String, String>of(), version0);
         serviceB = build(
                 Settings.builder().put("name", "TS_B", TransportService.SETTING_TRACE_LOG_INCLUDE, "", TransportService.SETTING_TRACE_LOG_EXCLUDE, "NOTHING").build(),
-                version1
+                version1,
+                namedWriteableRegistry
         );
         nodeB = new DiscoveryNode("TS_B", "TS_B", serviceB.boundAddress().publishAddress(), ImmutableMap.<String, String>of(), version1);
 

--- a/core/src/test/java/org/elasticsearch/transport/NettySizeHeaderFrameDecoderTests.java
+++ b/core/src/test/java/org/elasticsearch/transport/NettySizeHeaderFrameDecoderTests.java
@@ -21,6 +21,7 @@ package org.elasticsearch.transport;
 
 import com.google.common.base.Charsets;
 import org.elasticsearch.Version;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
@@ -62,7 +63,7 @@ public class NettySizeHeaderFrameDecoderTests extends ElasticsearchTestCase {
         threadPool.setNodeSettingsService(new NodeSettingsService(settings));
         NetworkService networkService = new NetworkService(settings);
         BigArrays bigArrays = new MockBigArrays(new MockPageCacheRecycler(settings, threadPool), new NoneCircuitBreakerService());
-        nettyTransport = new NettyTransport(settings, threadPool, networkService, bigArrays, Version.CURRENT);
+        nettyTransport = new NettyTransport(settings, threadPool, networkService, bigArrays, Version.CURRENT, new NamedWriteableRegistry());
         nettyTransport.start();
         TransportService transportService = new TransportService(nettyTransport, threadPool);
         nettyTransport.transportServiceAdapter(transportService.createAdapter());

--- a/core/src/test/java/org/elasticsearch/transport/netty/NettyScheduledPingTests.java
+++ b/core/src/test/java/org/elasticsearch/transport/netty/NettyScheduledPingTests.java
@@ -21,6 +21,7 @@ package org.elasticsearch.transport.netty;
 import com.google.common.collect.ImmutableMap;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.settings.Settings;
@@ -48,11 +49,11 @@ public class NettyScheduledPingTests extends ElasticsearchTestCase {
         int endPort = startPort + 10;
         Settings settings = Settings.builder().put(NettyTransport.PING_SCHEDULE, "5ms").put("transport.tcp.port", startPort + "-" + endPort).build();
 
-        final NettyTransport nettyA = new NettyTransport(settings, threadPool, new NetworkService(settings), BigArrays.NON_RECYCLING_INSTANCE, Version.CURRENT);
+        final NettyTransport nettyA = new NettyTransport(settings, threadPool, new NetworkService(settings), BigArrays.NON_RECYCLING_INSTANCE, Version.CURRENT, new NamedWriteableRegistry());
         MockTransportService serviceA = new MockTransportService(settings, nettyA, threadPool);
         serviceA.start();
 
-        final NettyTransport nettyB = new NettyTransport(settings, threadPool, new NetworkService(settings), BigArrays.NON_RECYCLING_INSTANCE, Version.CURRENT);
+        final NettyTransport nettyB = new NettyTransport(settings, threadPool, new NetworkService(settings), BigArrays.NON_RECYCLING_INSTANCE, Version.CURRENT, new NamedWriteableRegistry());
         MockTransportService serviceB = new MockTransportService(settings, nettyB, threadPool);
         serviceB.start();
 

--- a/core/src/test/java/org/elasticsearch/transport/netty/NettyTransportMultiPortTests.java
+++ b/core/src/test/java/org/elasticsearch/transport/netty/NettyTransportMultiPortTests.java
@@ -23,6 +23,7 @@ import com.google.common.base.Charsets;
 import org.elasticsearch.Version;
 import org.elasticsearch.cache.recycler.PageCacheRecycler;
 import org.elasticsearch.common.component.Lifecycle;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.network.NetworkUtils;
 import org.elasticsearch.common.settings.Settings;
@@ -195,7 +196,7 @@ public class NettyTransportMultiPortTests extends ElasticsearchTestCase {
     private NettyTransport startNettyTransport(Settings settings, ThreadPool threadPool) {
         BigArrays bigArrays = new MockBigArrays(new PageCacheRecycler(settings, threadPool), new NoneCircuitBreakerService());
 
-        NettyTransport nettyTransport = new NettyTransport(settings, threadPool, new NetworkService(settings), bigArrays, Version.CURRENT);
+        NettyTransport nettyTransport = new NettyTransport(settings, threadPool, new NetworkService(settings), bigArrays, Version.CURRENT, new NamedWriteableRegistry());
         nettyTransport.start();
 
         assertThat(nettyTransport.lifecycleState(), is(Lifecycle.State.STARTED));

--- a/core/src/test/java/org/elasticsearch/transport/netty/NettyTransportTests.java
+++ b/core/src/test/java/org/elasticsearch/transport/netty/NettyTransportTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.action.admin.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.component.Lifecycle;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.network.NetworkService;
@@ -83,21 +84,21 @@ public class NettyTransportTests extends ElasticsearchIntegrationTest {
     public static final class ExceptionThrowingNettyTransport extends NettyTransport {
 
         @Inject
-        public ExceptionThrowingNettyTransport(Settings settings, ThreadPool threadPool, NetworkService networkService, BigArrays bigArrays, Version version) {
-            super(settings, threadPool, networkService, bigArrays, version);
+        public ExceptionThrowingNettyTransport(Settings settings, ThreadPool threadPool, NetworkService networkService, BigArrays bigArrays, Version version, NamedWriteableRegistry namedWriteableRegistry) {
+            super(settings, threadPool, networkService, bigArrays, version, namedWriteableRegistry);
         }
 
         @Override
         public ChannelPipelineFactory configureServerChannelPipelineFactory(String name, Settings groupSettings) {
-            return new ErrorPipelineFactory(this, name, groupSettings);
+            return new ErrorPipelineFactory(this, name, groupSettings, namedWriteableRegistry);
         }
 
         private static class ErrorPipelineFactory extends ServerChannelPipelineFactory {
 
             private final ESLogger logger;
 
-            public ErrorPipelineFactory(ExceptionThrowingNettyTransport exceptionThrowingNettyTransport, String name, Settings groupSettings) {
-                super(exceptionThrowingNettyTransport, name, groupSettings);
+            public ErrorPipelineFactory(ExceptionThrowingNettyTransport exceptionThrowingNettyTransport, String name, Settings groupSettings, NamedWriteableRegistry namedWriteableRegistry) {
+                super(exceptionThrowingNettyTransport, name, groupSettings, namedWriteableRegistry);
                 this.logger = exceptionThrowingNettyTransport.logger;
             }
 

--- a/core/src/test/java/org/elasticsearch/transport/netty/SimpleNettyTransportTests.java
+++ b/core/src/test/java/org/elasticsearch/transport/netty/SimpleNettyTransportTests.java
@@ -22,6 +22,7 @@ package org.elasticsearch.transport.netty;
 import org.apache.lucene.util.LuceneTestCase.Slow;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
@@ -35,11 +36,11 @@ import org.junit.Test;
 public class SimpleNettyTransportTests extends AbstractSimpleTransportTests {
 
     @Override
-    protected MockTransportService build(Settings settings, Version version) {
+    protected MockTransportService build(Settings settings, Version version, NamedWriteableRegistry namedWriteableRegistry) {
         int startPort = 11000 + randomIntBetween(0, 255);
         int endPort = startPort + 10;
         settings = Settings.builder().put(settings).put("transport.tcp.port", startPort + "-" + endPort).build();
-        MockTransportService transportService = new MockTransportService(settings, new NettyTransport(settings, threadPool, new NetworkService(settings), BigArrays.NON_RECYCLING_INSTANCE, version), threadPool);
+        MockTransportService transportService = new MockTransportService(settings, new NettyTransport(settings, threadPool, new NetworkService(settings), BigArrays.NON_RECYCLING_INSTANCE, version, namedWriteableRegistry), threadPool);
         transportService.start();
         return transportService;
     }


### PR DESCRIPTION
As part of the query refactoring, we want to be able to serialize queries by having them extend Writeable, rather than serializing their json. When reading them though, we need to be able to identify which query we have to create, based on its name.

For this purpose we introduce a new abstraction called NamedWriteable, which is supported by StreamOutput and StreamInput through writeNamedWriteable and readNamedWriteable methods. A new NamedWriteableRegistry is introduced also where named writeable prototypes need to be registered so that we are able to retrieve the proper instance of query given its name and then de-serialize it calling readFrom against it.

This PR replaces #11355 and goes against the feature/query-refactoring branch.
