### PR TITLE
Return empty CommitID from ShadowEngine#flush

### DIFF
--- a/src/main/java/org/elasticsearch/indices/flush/SyncedFlushService.java
+++ b/src/main/java/org/elasticsearch/indices/flush/SyncedFlushService.java
@@ -543,6 +543,9 @@ public class SyncedFlushService extends AbstractComponent {
         }
 
         PreSyncedFlushResponse(Engine.CommitId commitId) {
+            if (commitId == null) {
+                throw new IllegalArgumentException("CommitID must not be null");
+            }
             this.commitId = commitId;
         }
 


### PR DESCRIPTION
this change removes CommitID reading for 1.x indices to prevent raceconditions on shared FS for shadow engines where null is returned if a race happens. We now simply return an empty commit ID which is not needed on shadow engines anyway.
