### PR TITLE
Make index level mapping apis use MappedFieldType

### DIFF
--- a/core/src/main/java/org/apache/lucene/queries/ExtendedCommonTermsQuery.java
+++ b/core/src/main/java/org/apache/lucene/queries/ExtendedCommonTermsQuery.java
@@ -19,15 +19,12 @@
 
 package org.apache.lucene.queries;
 
-import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.index.TermContext;
-import org.apache.lucene.search.*;
 import org.apache.lucene.search.BooleanClause.Occur;
+import org.apache.lucene.search.Query;
 import org.elasticsearch.common.lucene.search.Queries;
-import org.elasticsearch.index.mapper.FieldMapper;
-
-import java.io.IOException;
+import org.elasticsearch.index.mapper.MappedFieldType;
 
 /**
  * Extended version of {@link CommonTermsQuery} that allows to pass in a
@@ -36,11 +33,11 @@ import java.io.IOException;
  */
 public class ExtendedCommonTermsQuery extends CommonTermsQuery {
 
-    private final FieldMapper mapper;
+    private final MappedFieldType fieldType;
 
-    public ExtendedCommonTermsQuery(Occur highFreqOccur, Occur lowFreqOccur, float maxTermFrequency, boolean disableCoord, FieldMapper mapper) {
+    public ExtendedCommonTermsQuery(Occur highFreqOccur, Occur lowFreqOccur, float maxTermFrequency, boolean disableCoord, MappedFieldType fieldType) {
         super(highFreqOccur, lowFreqOccur, maxTermFrequency, disableCoord);
-        this.mapper = mapper;
+        this.fieldType = fieldType;
     }
 
     private String lowFreqMinNumShouldMatchSpec;
@@ -81,10 +78,10 @@ public class ExtendedCommonTermsQuery extends CommonTermsQuery {
 
     @Override
     protected Query newTermQuery(Term term, TermContext context) {
-        if (mapper == null) {
+        if (fieldType == null) {
             return super.newTermQuery(term, context);
         }
-        final Query query = mapper.queryStringTermQuery(term);
+        final Query query = fieldType.queryStringTermQuery(term);
         if (query == null) {
             return super.newTermQuery(term, context);
         } else {

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/analyze/TransportAnalyzeAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/analyze/TransportAnalyzeAction.java
@@ -39,6 +39,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.analysis.*;
 import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.internal.AllFieldMapper;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.shard.ShardId;
@@ -108,13 +109,13 @@ public class TransportAnalyzeAction extends TransportSingleCustomOperationAction
             if (indexService == null) {
                 throw new IllegalArgumentException("No index provided, and trying to analyzer based on a specific field which requires the index parameter");
             }
-            FieldMapper fieldMapper = indexService.mapperService().smartNameFieldMapper(request.field());
-            if (fieldMapper != null) {
-                if (fieldMapper.isNumeric()) {
+            MappedFieldType fieldType = indexService.mapperService().smartNameFieldType(request.field());
+            if (fieldType != null) {
+                if (fieldType.isNumeric()) {
                     throw new IllegalArgumentException("Can't process field [" + request.field() + "], Analysis requests are not supported on numeric fields");
                 }
-                analyzer = fieldMapper.fieldType().indexAnalyzer();
-                field = fieldMapper.fieldType().names().indexName();
+                analyzer = fieldType.indexAnalyzer();
+                field = fieldType.names().indexName();
                 
             }
         }

--- a/core/src/main/java/org/elasticsearch/action/fieldstats/TransportFieldStatsTransportAction.java
+++ b/core/src/main/java/org/elasticsearch/action/fieldstats/TransportFieldStatsTransportAction.java
@@ -39,6 +39,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardId;
@@ -135,12 +136,12 @@ public class TransportFieldStatsTransportAction extends TransportBroadcastAction
         shard.readAllowed();
         try (Engine.Searcher searcher = shard.acquireSearcher("fieldstats")) {
             for (String field : request.getFields()) {
-                FieldMapper fieldMapper = mapperService.fullName(field);
-                if (fieldMapper != null) {
+                MappedFieldType fieldType = mapperService.fullName(field);
+                if (fieldType != null) {
                     IndexReader reader = searcher.reader();
                     Terms terms = MultiFields.getTerms(reader, field);
                     if (terms != null) {
-                        fieldStats.put(field, fieldMapper.stats(terms, reader.maxDoc()));
+                        fieldStats.put(field, fieldType.stats(terms, reader.maxDoc()));
                     }
                 } else {
                     throw new IllegalArgumentException("field [" + field + "] doesn't exist");

--- a/core/src/main/java/org/elasticsearch/index/codec/PerFieldMappingPostingFormatCodec.java
+++ b/core/src/main/java/org/elasticsearch/index/codec/PerFieldMappingPostingFormatCodec.java
@@ -26,6 +26,7 @@ import org.apache.lucene.codecs.lucene50.Lucene50StoredFieldsFormat;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.core.CompletionFieldMapper;
 
@@ -54,14 +55,14 @@ public class PerFieldMappingPostingFormatCodec extends Lucene50Codec {
 
     @Override
     public PostingsFormat getPostingsFormatForField(String field) {
-        final FieldMapper indexName = mapperService.indexName(field);
+        final MappedFieldType indexName = mapperService.indexName(field);
         if (indexName == null) {
             logger.warn("no index mapper found for field: [{}] returning default postings format", field);
-        } else if (indexName instanceof CompletionFieldMapper) {
+        } else if (indexName instanceof CompletionFieldMapper.CompletionFieldType) {
             // CompletionFieldMapper needs a special postings format
-            final CompletionFieldMapper mapper = (CompletionFieldMapper) indexName;
+            final CompletionFieldMapper.CompletionFieldType fieldType = (CompletionFieldMapper.CompletionFieldType) indexName;
             final PostingsFormat defaultFormat = super.getPostingsFormatForField(field);
-            return mapper.postingsFormat(defaultFormat);
+            return fieldType.postingsFormat(defaultFormat);
         }
         return super.getPostingsFormatForField(field);
     }

--- a/core/src/main/java/org/elasticsearch/index/fielddata/IndexFieldData.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/IndexFieldData.java
@@ -229,7 +229,7 @@ public interface IndexFieldData<FD extends AtomicFieldData> extends IndexCompone
 
     interface Builder {
 
-        IndexFieldData<?> build(Index index, @IndexSettings Settings indexSettings, FieldMapper mapper, IndexFieldDataCache cache,
+        IndexFieldData<?> build(Index index, @IndexSettings Settings indexSettings, MappedFieldType fieldType, IndexFieldDataCache cache,
                              CircuitBreakerService breakerService, MapperService mapperService);
     }
 

--- a/core/src/main/java/org/elasticsearch/index/fielddata/IndexFieldDataService.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/IndexFieldDataService.java
@@ -228,13 +228,13 @@ public class IndexFieldDataService extends AbstractIndexComponent {
     }
 
     @SuppressWarnings("unchecked")
-    public <IFD extends IndexFieldData<?>> IFD getForField(FieldMapper mapper) {
-        final Names fieldNames = mapper.fieldType().names();
-        final FieldDataType type = mapper.fieldType().fieldDataType();
+    public <IFD extends IndexFieldData<?>> IFD getForField(MappedFieldType fieldType) {
+        final Names fieldNames = fieldType.names();
+        final FieldDataType type = fieldType.fieldDataType();
         if (type == null) {
             throw new IllegalArgumentException("found no fielddata type for field [" + fieldNames.fullName() + "]");
         }
-        final boolean docValues = mapper.fieldType().hasDocValues();
+        final boolean docValues = fieldType.hasDocValues();
         final String key = fieldNames.indexName();
         IndexFieldData<?> fieldData = loadedFieldData.get(key);
         if (fieldData == null) {
@@ -279,7 +279,7 @@ public class IndexFieldDataService extends AbstractIndexComponent {
                         fieldDataCaches.put(fieldNames.indexName(), cache);
                     }
 
-                    fieldData = builder.build(index, indexSettings, mapper, cache, circuitBreakerService, indexService.mapperService());
+                    fieldData = builder.build(index, indexSettings, fieldType, cache, circuitBreakerService, indexService.mapperService());
                     loadedFieldData.put(fieldNames.indexName(), fieldData);
                 }
             } finally {

--- a/core/src/main/java/org/elasticsearch/index/fielddata/plain/BytesBinaryDVIndexFieldData.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/plain/BytesBinaryDVIndexFieldData.java
@@ -29,6 +29,7 @@ import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource.Nested;
 import org.elasticsearch.index.fielddata.IndexFieldDataCache;
 import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MappedFieldType.Names;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
@@ -64,11 +65,11 @@ public class BytesBinaryDVIndexFieldData extends DocValuesIndexFieldData impleme
     public static class Builder implements IndexFieldData.Builder {
 
         @Override
-        public IndexFieldData<?> build(Index index, Settings indexSettings, FieldMapper mapper, IndexFieldDataCache cache,
+        public IndexFieldData<?> build(Index index, Settings indexSettings, MappedFieldType fieldType, IndexFieldDataCache cache,
                                        CircuitBreakerService breakerService, MapperService mapperService) {
             // Ignore breaker
-            final Names fieldNames = mapper.fieldType().names();
-            return new BytesBinaryDVIndexFieldData(index, fieldNames, mapper.fieldType().fieldDataType());
+            final Names fieldNames = fieldType.names();
+            return new BytesBinaryDVIndexFieldData(index, fieldNames, fieldType.fieldDataType());
         }
 
     }

--- a/core/src/main/java/org/elasticsearch/index/fielddata/plain/DisabledIndexFieldData.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/plain/DisabledIndexFieldData.java
@@ -25,6 +25,7 @@ import org.elasticsearch.index.Index;
 import org.elasticsearch.index.fielddata.*;
 import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource.Nested;
 import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MappedFieldType.Names;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.settings.IndexSettings;
@@ -39,10 +40,10 @@ public final class DisabledIndexFieldData extends AbstractIndexFieldData<AtomicF
 
     public static class Builder implements IndexFieldData.Builder {
         @Override
-        public IndexFieldData<AtomicFieldData> build(Index index, @IndexSettings Settings indexSettings, FieldMapper mapper,
+        public IndexFieldData<AtomicFieldData> build(Index index, @IndexSettings Settings indexSettings, MappedFieldType fieldType,
                                                         IndexFieldDataCache cache, CircuitBreakerService breakerService, MapperService mapperService) {
             // Ignore Circuit Breaker
-            return new DisabledIndexFieldData(index, indexSettings, mapper.fieldType().names(), mapper.fieldType().fieldDataType(), cache);
+            return new DisabledIndexFieldData(index, indexSettings, fieldType.names(), fieldType.fieldDataType(), cache);
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/index/fielddata/plain/DocValuesIndexFieldData.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/plain/DocValuesIndexFieldData.java
@@ -91,11 +91,11 @@ public abstract class DocValuesIndexFieldData {
         }
 
         @Override
-        public IndexFieldData<?> build(Index index, Settings indexSettings, FieldMapper mapper, IndexFieldDataCache cache,
+        public IndexFieldData<?> build(Index index, Settings indexSettings, MappedFieldType fieldType, IndexFieldDataCache cache,
                                        CircuitBreakerService breakerService, MapperService mapperService) {
             // Ignore Circuit Breaker
-            final Names fieldNames = mapper.fieldType().names();
-            final Settings fdSettings = mapper.fieldType().fieldDataType().getSettings();
+            final Names fieldNames = fieldType.names();
+            final Settings fdSettings = fieldType.fieldDataType().getSettings();
             final Map<String, Settings> filter = fdSettings.getGroups("filter");
             if (filter != null && !filter.isEmpty()) {
                 throw new IllegalArgumentException("Doc values field data doesn't support filters [" + fieldNames.fullName() + "]");
@@ -103,19 +103,19 @@ public abstract class DocValuesIndexFieldData {
 
             if (BINARY_INDEX_FIELD_NAMES.contains(fieldNames.indexName())) {
                 assert numericType == null;
-                return new BinaryDVIndexFieldData(index, fieldNames, mapper.fieldType().fieldDataType());
+                return new BinaryDVIndexFieldData(index, fieldNames, fieldType.fieldDataType());
             } else if (NUMERIC_INDEX_FIELD_NAMES.contains(fieldNames.indexName())) {
                 assert !numericType.isFloatingPoint();
-                return new NumericDVIndexFieldData(index, fieldNames, mapper.fieldType().fieldDataType());
+                return new NumericDVIndexFieldData(index, fieldNames, fieldType.fieldDataType());
             } else if (numericType != null) {
                 if (Version.indexCreated(indexSettings).onOrAfter(Version.V_1_4_0_Beta1)) {
-                    return new SortedNumericDVIndexFieldData(index, fieldNames, numericType, mapper.fieldType().fieldDataType());
+                    return new SortedNumericDVIndexFieldData(index, fieldNames, numericType, fieldType.fieldDataType());
                 } else {
                     // prior to ES 1.4: multi-valued numerics were boxed inside a byte[] as BINARY
-                    return new BinaryDVNumericIndexFieldData(index, fieldNames, numericType, mapper.fieldType().fieldDataType());
+                    return new BinaryDVNumericIndexFieldData(index, fieldNames, numericType, fieldType.fieldDataType());
                 }
             } else {
-                return new SortedSetDVOrdinalsIndexFieldData(index, cache, indexSettings, fieldNames, breakerService, mapper.fieldType().fieldDataType());
+                return new SortedSetDVOrdinalsIndexFieldData(index, cache, indexSettings, fieldNames, breakerService, fieldType.fieldDataType());
             }
         }
 

--- a/core/src/main/java/org/elasticsearch/index/fielddata/plain/DoubleArrayIndexFieldData.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/plain/DoubleArrayIndexFieldData.java
@@ -73,9 +73,9 @@ public class DoubleArrayIndexFieldData extends AbstractIndexFieldData<AtomicNume
     public static class Builder implements IndexFieldData.Builder {
 
         @Override
-        public IndexFieldData<?> build(Index index, @IndexSettings Settings indexSettings, FieldMapper mapper, IndexFieldDataCache cache,
+        public IndexFieldData<?> build(Index index, @IndexSettings Settings indexSettings, MappedFieldType fieldType, IndexFieldDataCache cache,
                                        CircuitBreakerService breakerService, MapperService mapperService) {
-            return new DoubleArrayIndexFieldData(index, indexSettings, mapper.fieldType().names(), mapper.fieldType().fieldDataType(), cache, breakerService);
+            return new DoubleArrayIndexFieldData(index, indexSettings, fieldType.names(), fieldType.fieldDataType(), cache, breakerService);
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/index/fielddata/plain/FSTBytesIndexFieldData.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/plain/FSTBytesIndexFieldData.java
@@ -47,9 +47,9 @@ public class FSTBytesIndexFieldData extends AbstractIndexOrdinalsFieldData {
     public static class Builder implements IndexFieldData.Builder {
 
         @Override
-        public IndexOrdinalsFieldData build(Index index, @IndexSettings Settings indexSettings, FieldMapper mapper,
+        public IndexOrdinalsFieldData build(Index index, @IndexSettings Settings indexSettings, MappedFieldType fieldType,
                                                              IndexFieldDataCache cache, CircuitBreakerService breakerService, MapperService mapperService) {
-            return new FSTBytesIndexFieldData(index, indexSettings, mapper.fieldType().names(), mapper.fieldType().fieldDataType(), cache, breakerService);
+            return new FSTBytesIndexFieldData(index, indexSettings, fieldType.names(), fieldType.fieldDataType(), cache, breakerService);
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/index/fielddata/plain/FloatArrayIndexFieldData.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/plain/FloatArrayIndexFieldData.java
@@ -72,9 +72,9 @@ public class FloatArrayIndexFieldData extends AbstractIndexFieldData<AtomicNumer
     public static class Builder implements IndexFieldData.Builder {
 
         @Override
-        public IndexFieldData<?> build(Index index, @IndexSettings Settings indexSettings, FieldMapper mapper, IndexFieldDataCache cache,
+        public IndexFieldData<?> build(Index index, @IndexSettings Settings indexSettings, MappedFieldType fieldType, IndexFieldDataCache cache,
                                        CircuitBreakerService breakerService, MapperService mapperService) {
-            return new FloatArrayIndexFieldData(index, indexSettings, mapper.fieldType().names(), mapper.fieldType().fieldDataType(), cache, breakerService);
+            return new FloatArrayIndexFieldData(index, indexSettings, fieldType.names(), fieldType.fieldDataType(), cache, breakerService);
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointBinaryDVIndexFieldData.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointBinaryDVIndexFieldData.java
@@ -63,11 +63,11 @@ public class GeoPointBinaryDVIndexFieldData extends DocValuesIndexFieldData impl
     public static class Builder implements IndexFieldData.Builder {
 
         @Override
-        public IndexFieldData<?> build(Index index, Settings indexSettings, FieldMapper mapper, IndexFieldDataCache cache,
+        public IndexFieldData<?> build(Index index, Settings indexSettings, MappedFieldType fieldType, IndexFieldDataCache cache,
                                        CircuitBreakerService breakerService, MapperService mapperService) {
             // Ignore breaker
-            final Names fieldNames = mapper.fieldType().names();
-            return new GeoPointBinaryDVIndexFieldData(index, fieldNames, mapper.fieldType().fieldDataType());
+            final Names fieldNames = fieldType.names();
+            return new GeoPointBinaryDVIndexFieldData(index, fieldNames, fieldType.fieldDataType());
         }
 
     }

--- a/core/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointCompressedIndexFieldData.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointCompressedIndexFieldData.java
@@ -53,9 +53,9 @@ public class GeoPointCompressedIndexFieldData extends AbstractIndexGeoPointField
     public static class Builder implements IndexFieldData.Builder {
 
         @Override
-        public IndexFieldData<?> build(Index index, @IndexSettings Settings indexSettings, FieldMapper mapper, IndexFieldDataCache cache,
+        public IndexFieldData<?> build(Index index, @IndexSettings Settings indexSettings, MappedFieldType fieldType, IndexFieldDataCache cache,
                                        CircuitBreakerService breakerService, MapperService mapperService) {
-            FieldDataType type = mapper.fieldType().fieldDataType();
+            FieldDataType type = fieldType.fieldDataType();
             final String precisionAsString = type.getSettings().get(PRECISION_KEY);
             final Distance precision;
             if (precisionAsString != null) {
@@ -63,7 +63,7 @@ public class GeoPointCompressedIndexFieldData extends AbstractIndexGeoPointField
             } else {
                 precision = DEFAULT_PRECISION_VALUE;
             }
-            return new GeoPointCompressedIndexFieldData(index, indexSettings, mapper.fieldType().names(), mapper.fieldType().fieldDataType(), cache, precision, breakerService);
+            return new GeoPointCompressedIndexFieldData(index, indexSettings, fieldType.names(), fieldType.fieldDataType(), cache, precision, breakerService);
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointDoubleArrayIndexFieldData.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointDoubleArrayIndexFieldData.java
@@ -47,9 +47,9 @@ public class GeoPointDoubleArrayIndexFieldData extends AbstractIndexGeoPointFiel
     public static class Builder implements IndexFieldData.Builder {
 
         @Override
-        public IndexFieldData<?> build(Index index, @IndexSettings Settings indexSettings, FieldMapper mapper, IndexFieldDataCache cache,
+        public IndexFieldData<?> build(Index index, @IndexSettings Settings indexSettings, MappedFieldType fieldType, IndexFieldDataCache cache,
                                        CircuitBreakerService breakerService, MapperService mapperService) {
-            return new GeoPointDoubleArrayIndexFieldData(index, indexSettings, mapper.fieldType().names(), mapper.fieldType().fieldDataType(), cache, breakerService);
+            return new GeoPointDoubleArrayIndexFieldData(index, indexSettings, fieldType.names(), fieldType.fieldDataType(), cache, breakerService);
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/index/fielddata/plain/IndexIndexFieldData.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/plain/IndexIndexFieldData.java
@@ -46,9 +46,9 @@ public class IndexIndexFieldData extends AbstractIndexOrdinalsFieldData {
     public static class Builder implements IndexFieldData.Builder {
 
         @Override
-        public IndexFieldData<?> build(Index index, Settings indexSettings, FieldMapper mapper, IndexFieldDataCache cache,
+        public IndexFieldData<?> build(Index index, Settings indexSettings, MappedFieldType fieldType, IndexFieldDataCache cache,
                 CircuitBreakerService breakerService, MapperService mapperService) {
-            return new IndexIndexFieldData(index, mapper.fieldType().names());
+            return new IndexIndexFieldData(index, fieldType.names());
         }
 
     }

--- a/core/src/main/java/org/elasticsearch/index/fielddata/plain/PackedArrayIndexFieldData.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/plain/PackedArrayIndexFieldData.java
@@ -85,9 +85,9 @@ public class PackedArrayIndexFieldData extends AbstractIndexFieldData<AtomicNume
         }
 
         @Override
-        public IndexFieldData<AtomicNumericFieldData> build(Index index, @IndexSettings Settings indexSettings, FieldMapper mapper,
+        public IndexFieldData<AtomicNumericFieldData> build(Index index, @IndexSettings Settings indexSettings, MappedFieldType fieldType,
                                                             IndexFieldDataCache cache, CircuitBreakerService breakerService, MapperService mapperService) {
-            return new PackedArrayIndexFieldData(index, indexSettings, mapper.fieldType().names(), mapper.fieldType().fieldDataType(), cache, numericType, breakerService);
+            return new PackedArrayIndexFieldData(index, indexSettings, fieldType.names(), fieldType.fieldDataType(), cache, numericType, breakerService);
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/index/fielddata/plain/PagedBytesIndexFieldData.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/plain/PagedBytesIndexFieldData.java
@@ -48,9 +48,9 @@ public class PagedBytesIndexFieldData extends AbstractIndexOrdinalsFieldData {
     public static class Builder implements IndexFieldData.Builder {
 
         @Override
-        public IndexOrdinalsFieldData build(Index index, @IndexSettings Settings indexSettings, FieldMapper mapper,
+        public IndexOrdinalsFieldData build(Index index, @IndexSettings Settings indexSettings, MappedFieldType fieldType,
                                                                IndexFieldDataCache cache, CircuitBreakerService breakerService, MapperService mapperService) {
-            return new PagedBytesIndexFieldData(index, indexSettings, mapper.fieldType().names(), mapper.fieldType().fieldDataType(), cache, breakerService);
+            return new PagedBytesIndexFieldData(index, indexSettings, fieldType.names(), fieldType.fieldDataType(), cache, breakerService);
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/index/fielddata/plain/ParentChildIndexFieldData.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/plain/ParentChildIndexFieldData.java
@@ -250,10 +250,10 @@ public class ParentChildIndexFieldData extends AbstractIndexFieldData<AtomicPare
     public static class Builder implements IndexFieldData.Builder {
 
         @Override
-        public IndexFieldData<?> build(Index index, @IndexSettings Settings indexSettings, FieldMapper mapper,
+        public IndexFieldData<?> build(Index index, @IndexSettings Settings indexSettings, MappedFieldType fieldType,
                                        IndexFieldDataCache cache, CircuitBreakerService breakerService,
                                        MapperService mapperService) {
-            return new ParentChildIndexFieldData(index, indexSettings, mapper.fieldType().names(), mapper.fieldType().fieldDataType(), cache,
+            return new ParentChildIndexFieldData(index, indexSettings, fieldType.names(), fieldType.fieldDataType(), cache,
                 mapperService, breakerService);
         }
     }

--- a/core/src/main/java/org/elasticsearch/index/fieldvisitor/FieldsVisitor.java
+++ b/core/src/main/java/org/elasticsearch/index/fieldvisitor/FieldsVisitor.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.FieldMappers;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.Uid;
 import org.elasticsearch.index.mapper.internal.SourceFieldMapper;
@@ -61,13 +62,13 @@ public abstract class FieldsVisitor extends StoredFieldVisitor {
         }
         // can't derive exact mapping type
         for (Map.Entry<String, List<Object>> entry : fields().entrySet()) {
-            FieldMapper fieldMappers = mapperService.indexName(entry.getKey());
-            if (fieldMappers == null) {
+            MappedFieldType fieldType = mapperService.indexName(entry.getKey());
+            if (fieldType == null) {
                 continue;
             }
             List<Object> fieldValues = entry.getValue();
             for (int i = 0; i < fieldValues.size(); i++) {
-                fieldValues.set(i, fieldMappers.valueForSearch(fieldValues.get(i)));
+                fieldValues.set(i, fieldType.valueForSearch(fieldValues.get(i)));
             }
         }
     }

--- a/core/src/main/java/org/elasticsearch/index/fieldvisitor/SingleFieldsVisitor.java
+++ b/core/src/main/java/org/elasticsearch/index/fieldvisitor/SingleFieldsVisitor.java
@@ -20,6 +20,7 @@ package org.elasticsearch.index.fieldvisitor;
 
 import org.apache.lucene.index.FieldInfo;
 import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.internal.IdFieldMapper;
 import org.elasticsearch.index.mapper.internal.TypeFieldMapper;
 import org.elasticsearch.index.mapper.internal.UidFieldMapper;
@@ -55,7 +56,7 @@ public class SingleFieldsVisitor extends FieldsVisitor {
         super.reset();
     }
 
-    public void postProcess(FieldMapper mapper) {
+    public void postProcess(MappedFieldType fieldType) {
         if (uid != null) {
             switch (field) {
                 case UidFieldMapper.NAME: addValue(field, uid.toString());
@@ -67,12 +68,12 @@ public class SingleFieldsVisitor extends FieldsVisitor {
         if (fieldsValues == null) {
             return;
         }
-        List<Object> fieldValues = fieldsValues.get(mapper.fieldType().names().indexName());
+        List<Object> fieldValues = fieldsValues.get(fieldType.names().indexName());
         if (fieldValues == null) {
             return;
         }
         for (int i = 0; i < fieldValues.size(); i++) {
-            fieldValues.set(i, mapper.valueForSearch(fieldValues.get(i)));
+            fieldValues.set(i, fieldType.valueForSearch(fieldValues.get(i)));
         }
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -113,7 +113,7 @@ public class MapperService extends AbstractIndexComponent  {
 
     private final List<DocumentTypeListener> typeListeners = new CopyOnWriteArrayList<>();
 
-    private volatile ImmutableMap<String, FieldMapper> unmappedFieldMappers = ImmutableMap.of();
+    private volatile ImmutableMap<String, MappedFieldType> unmappedFieldTypes = ImmutableMap.of();
 
     private volatile ImmutableSet<String> parentTypes = ImmutableSet.of();
 
@@ -474,31 +474,29 @@ public class MapperService extends AbstractIndexComponent  {
     }
 
     /**
-     * Returns an {@link FieldMapper} which has the given index name.
+     * Returns an {@link MappedFieldType} which has the given index name.
      *
      * If multiple types have fields with the same index name, the first is returned.
      */
-    public FieldMapper indexName(String indexName) {
+    public MappedFieldType indexName(String indexName) {
         FieldMappers mappers = fieldMappers.indexName(indexName);
         if (mappers == null) {
             return null;
         }
-        return mappers.mapper();
+        return mappers.mapper().fieldType();
     }
 
     /**
-     * Returns the {@link FieldMappers} of all the {@link FieldMapper}s that are
-     * registered under the give fullName across all the different {@link DocumentMapper} types.
+     * Returns the {@link MappedFieldType} for the give fullName.
      *
-     * @param fullName The full name
-     * @return All teh {@link FieldMappers} across all the {@link DocumentMapper}s for the given fullName.
+     * If multiple types have fields with the same full name, the first is returned.
      */
-    public FieldMapper fullName(String fullName) {
+    public MappedFieldType fullName(String fullName) {
         FieldMappers mappers = fieldMappers.fullName(fullName);
         if (mappers == null) {
             return null;
         }
-        return mappers.mapper();
+        return mappers.mapper().fieldType();
     }
 
     /**
@@ -563,17 +561,17 @@ public class MapperService extends AbstractIndexComponent  {
         return null;
     }
 
-    public FieldMapper smartNameFieldMapper(String smartName) {
-        FieldMapper mapper = fullName(smartName);
-        if (mapper != null) {
-            return mapper;
+    public MappedFieldType smartNameFieldType(String smartName) {
+        MappedFieldType fieldType = fullName(smartName);
+        if (fieldType != null) {
+            return fieldType;
         }
         return indexName(smartName);
     }
 
-    public FieldMapper smartNameFieldMapper(String smartName, @Nullable String[] types) {
+    public MappedFieldType smartNameFieldType(String smartName, @Nullable String[] types) {
         if (types == null || types.length == 0 || types.length == 1 && types[0].equals("_all")) {
-            return smartNameFieldMapper(smartName);
+            return smartNameFieldType(smartName);
         }
         for (String type : types) {
             DocumentMapper documentMapper = mappers.get(type);
@@ -582,7 +580,7 @@ public class MapperService extends AbstractIndexComponent  {
                 // see if we find a field for it
                 FieldMappers mappers = documentMapper.mappers().smartName(smartName);
                 if (mappers != null) {
-                    return mappers.mapper();
+                    return mappers.mapper().fieldType();
                 }
             }
         }
@@ -592,10 +590,10 @@ public class MapperService extends AbstractIndexComponent  {
     /**
      * Given a type (eg. long, string, ...), return an anonymous field mapper that can be used for search operations.
      */
-    public FieldMapper unmappedFieldMapper(String type) {
-        final ImmutableMap<String, FieldMapper> unmappedFieldMappers = this.unmappedFieldMappers;
-        FieldMapper mapper = unmappedFieldMappers.get(type);
-        if (mapper == null) {
+    public MappedFieldType unmappedFieldType(String type) {
+        final ImmutableMap<String, MappedFieldType> unmappedFieldMappers = this.unmappedFieldTypes;
+        MappedFieldType fieldType = unmappedFieldMappers.get(type);
+        if (fieldType == null) {
             final Mapper.TypeParser.ParserContext parserContext = documentMapperParser().parserContext();
             Mapper.TypeParser typeParser = parserContext.typeParser(type);
             if (typeParser == null) {
@@ -603,16 +601,16 @@ public class MapperService extends AbstractIndexComponent  {
             }
             final Mapper.Builder<?, ?> builder = typeParser.parse("__anonymous_" + type, ImmutableMap.<String, Object>of(), parserContext);
             final BuilderContext builderContext = new BuilderContext(indexSettings, new ContentPath(1));
-            mapper = (FieldMapper) builder.build(builderContext);
+            fieldType = ((FieldMapper)builder.build(builderContext)).fieldType();
 
             // There is no need to synchronize writes here. In the case of concurrent access, we could just
             // compute some mappers several times, which is not a big deal
-            this.unmappedFieldMappers = ImmutableMap.<String, FieldMapper>builder()
+            this.unmappedFieldTypes = ImmutableMap.<String, MappedFieldType>builder()
                     .putAll(unmappedFieldMappers)
-                    .put(type, mapper)
+                    .put(type, fieldType)
                     .build();
         }
-        return mapper;
+        return fieldType;
     }
 
     public Analyzer searchAnalyzer() {
@@ -702,9 +700,9 @@ public class MapperService extends AbstractIndexComponent  {
 
         @Override
         protected Analyzer getWrappedAnalyzer(String fieldName) {
-            FieldMapper mapper = smartNameFieldMapper(fieldName);
-            if (mapper != null && mapper.fieldType().searchAnalyzer() != null) {
-                return mapper.fieldType().searchAnalyzer();
+            MappedFieldType fieldType = smartNameFieldType(fieldName);
+            if (fieldType != null && fieldType.searchAnalyzer() != null) {
+                return fieldType.searchAnalyzer();
             }
             return defaultAnalyzer;
         }
@@ -721,9 +719,9 @@ public class MapperService extends AbstractIndexComponent  {
 
         @Override
         protected Analyzer getWrappedAnalyzer(String fieldName) {
-            FieldMapper mapper = smartNameFieldMapper(fieldName);
-            if (mapper != null && mapper.fieldType().searchQuoteAnalyzer() != null) {
-                return mapper.fieldType().searchQuoteAnalyzer();
+            MappedFieldType fieldType = smartNameFieldType(fieldName);
+            if (fieldType != null && fieldType.searchQuoteAnalyzer() != null) {
+                return fieldType.searchQuoteAnalyzer();
             }
             return defaultAnalyzer;
         }

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/BooleanFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/BooleanFieldMapper.java
@@ -116,7 +116,7 @@ public class BooleanFieldMapper extends AbstractFieldMapper {
         }
     }
 
-    static final class BooleanFieldType extends MappedFieldType {
+    public static final class BooleanFieldType extends MappedFieldType {
 
         public BooleanFieldType() {
             super(AbstractFieldMapper.Defaults.FIELD_TYPE);

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/CompletionFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/CompletionFieldMapper.java
@@ -45,7 +45,6 @@ import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.MergeMappingException;
 import org.elasticsearch.index.mapper.MergeResult;
 import org.elasticsearch.index.mapper.ParseContext;
-import org.elasticsearch.index.similarity.SimilarityProvider;
 import org.elasticsearch.search.suggest.completion.AnalyzingCompletionLookupProvider;
 import org.elasticsearch.search.suggest.completion.Completion090PostingsFormat;
 import org.elasticsearch.search.suggest.completion.CompletionTokenStream;
@@ -72,7 +71,7 @@ public class CompletionFieldMapper extends AbstractFieldMapper {
     public static final String CONTENT_TYPE = "completion";
 
     public static class Defaults extends AbstractFieldMapper.Defaults {
-        public static final MappedFieldType FIELD_TYPE = new CompletionFieldType();
+        public static final CompletionFieldType FIELD_TYPE = new CompletionFieldType();
 
         static {
             FIELD_TYPE.setOmitNorms(true);
@@ -149,8 +148,10 @@ public class CompletionFieldMapper extends AbstractFieldMapper {
         @Override
         public CompletionFieldMapper build(Mapper.BuilderContext context) {
             setupFieldType(context);
-            return new CompletionFieldMapper(fieldType, null, payloads,
-                    preserveSeparators, preservePositionIncrements, maxInputLength, context.indexSettings(), multiFieldsBuilder.build(this, context), copyTo, this.contextMapping);
+            CompletionFieldType completionFieldType = (CompletionFieldType)fieldType;
+            completionFieldType.setProvider(new AnalyzingCompletionLookupProvider(preserveSeparators, false, preservePositionIncrements, payloads));
+            completionFieldType.setContextMapping(contextMapping);
+            return new CompletionFieldMapper(fieldType, maxInputLength, context.indexSettings(), multiFieldsBuilder.build(this, context), copyTo);
         }
 
     }
@@ -220,7 +221,10 @@ public class CompletionFieldMapper extends AbstractFieldMapper {
         }
     }
 
-    static final class CompletionFieldType extends MappedFieldType {
+    public static final class CompletionFieldType extends MappedFieldType {
+        private PostingsFormat postingsFormat;
+        private AnalyzingCompletionLookupProvider analyzingSuggestLookupProvider;
+        private SortedMap<String, ContextMapping> contextMapping = ContextMapping.EMPTY_MAPPING;
 
         public CompletionFieldType() {
             super(AbstractFieldMapper.Defaults.FIELD_TYPE);
@@ -228,11 +232,44 @@ public class CompletionFieldMapper extends AbstractFieldMapper {
 
         protected CompletionFieldType(CompletionFieldType ref) {
             super(ref);
+            this.postingsFormat = ref.postingsFormat;
+            this.analyzingSuggestLookupProvider = ref.analyzingSuggestLookupProvider;
+            this.contextMapping = ref.contextMapping;
         }
 
         @Override
-        public MappedFieldType clone() {
+        public CompletionFieldType clone() {
             return new CompletionFieldType(this);
+        }
+
+        public void setProvider(AnalyzingCompletionLookupProvider provider) {
+            checkIfFrozen();
+            this.analyzingSuggestLookupProvider = provider;
+        }
+
+        public synchronized PostingsFormat postingsFormat(PostingsFormat in) {
+            if (in instanceof Completion090PostingsFormat) {
+                throw new IllegalStateException("Double wrapping of " + Completion090PostingsFormat.class);
+            }
+            if (postingsFormat == null) {
+                postingsFormat = new Completion090PostingsFormat(in, analyzingSuggestLookupProvider);
+            }
+            return postingsFormat;
+        }
+
+        public void setContextMapping(SortedMap<String, ContextMapping> contextMapping) {
+            checkIfFrozen();
+            this.contextMapping = contextMapping;
+        }
+
+        /** Get the context mapping associated with this completion field */
+        public SortedMap<String, ContextMapping> getContextMapping() {
+            return contextMapping;
+        }
+
+        /** @return true if a context mapping has been defined */
+        public boolean requiresContext() {
+            return contextMapping.isEmpty() == false;
         }
 
         @Override
@@ -251,46 +288,16 @@ public class CompletionFieldMapper extends AbstractFieldMapper {
 
     private static final BytesRef EMPTY = new BytesRef();
 
-    private PostingsFormat postingsFormat;
-    private final AnalyzingCompletionLookupProvider analyzingSuggestLookupProvider;
-    private final boolean payloads;
-    private final boolean preservePositionIncrements;
-    private final boolean preserveSeparators;
     private int maxInputLength;
-    private final SortedMap<String, ContextMapping> contextMapping;
 
-    /**
-     * 
-     * @param contextMappings Configuration of context type. If none should be used set {@link ContextMapping.EMPTY_MAPPING}
-     * @param wrappedPostingsFormat the postings format to wrap, or {@code null} to wrap the codec's default postings format
-     */
-    // Custom postings formats are deprecated but we still accept a postings format here to be able to test backward compatibility
-    // with older postings formats such as Elasticsearch090
-    public CompletionFieldMapper(MappedFieldType fieldType, PostingsFormat wrappedPostingsFormat, boolean payloads,
-                                 boolean preserveSeparators, boolean preservePositionIncrements, int maxInputLength, Settings indexSettings, MultiFields multiFields, CopyTo copyTo, SortedMap<String, ContextMapping> contextMappings) {
+    public CompletionFieldMapper(MappedFieldType fieldType, int maxInputLength, Settings indexSettings, MultiFields multiFields, CopyTo copyTo) {
         super(fieldType, false, null, indexSettings, multiFields, copyTo);
-        analyzingSuggestLookupProvider = new AnalyzingCompletionLookupProvider(preserveSeparators, false, preservePositionIncrements, payloads);
-        if (wrappedPostingsFormat == null) {
-            // delayed until postingsFormat() is called
-            this.postingsFormat = null;
-        } else {
-            this.postingsFormat = new Completion090PostingsFormat(wrappedPostingsFormat, analyzingSuggestLookupProvider);
-        }
-        this.preserveSeparators = preserveSeparators;
-        this.payloads = payloads;
-        this.preservePositionIncrements = preservePositionIncrements;
         this.maxInputLength = maxInputLength;
-        this.contextMapping = contextMappings;
     }
 
-    public synchronized PostingsFormat postingsFormat(PostingsFormat in) {
-        if (in instanceof Completion090PostingsFormat) {
-            throw new IllegalStateException("Double wrapping of " + Completion090PostingsFormat.class);
-        }
-        if (postingsFormat == null) {
-            postingsFormat = new Completion090PostingsFormat(in, analyzingSuggestLookupProvider);
-        }
-        return postingsFormat;
+    @Override
+    public CompletionFieldType fieldType() {
+        return (CompletionFieldType)fieldType;
     }
 
     @Override
@@ -325,7 +332,7 @@ public class CompletionFieldMapper extends AbstractFieldMapper {
                     if (token == Token.START_OBJECT) {
                         while ((token = parser.nextToken()) != Token.END_OBJECT) {
                             String name = parser.text();
-                            ContextMapping mapping = contextMapping.get(name);
+                            ContextMapping mapping = fieldType().getContextMapping().get(name);
                             if (mapping == null) {
                                 throw new ElasticsearchParseException("context [" + name + "] is not defined");
                             } else {
@@ -334,7 +341,7 @@ public class CompletionFieldMapper extends AbstractFieldMapper {
                             }
                         }
                         contextConfig = Maps.newTreeMap();
-                        for (ContextMapping mapping : contextMapping.values()) {
+                        for (ContextMapping mapping : fieldType().getContextMapping().values()) {
                             ContextConfig config = configs.get(mapping.name());
                             contextConfig.put(mapping.name(), config==null ? mapping.defaultConfig() : config);
                         }
@@ -392,7 +399,7 @@ public class CompletionFieldMapper extends AbstractFieldMapper {
 
         if(contextConfig == null) {
             contextConfig = Maps.newTreeMap();
-            for (ContextMapping mapping : contextMapping.values()) {
+            for (ContextMapping mapping : fieldType().getContextMapping().values()) {
                 contextConfig.put(mapping.name(), mapping.defaultConfig());
             }
         }
@@ -405,13 +412,13 @@ public class CompletionFieldMapper extends AbstractFieldMapper {
                 if (input.length() == 0) {
                     continue;
                 }
-                BytesRef suggestPayload = analyzingSuggestLookupProvider.buildPayload(new BytesRef(
-                        input), weight, payload);
+                BytesRef suggestPayload = fieldType().analyzingSuggestLookupProvider.buildPayload(new BytesRef(
+                    input), weight, payload);
                 context.doc().add(getCompletionField(ctx, input, suggestPayload));
             }
         } else {
-            BytesRef suggestPayload = analyzingSuggestLookupProvider.buildPayload(new BytesRef(
-                    surfaceForm), weight, payload);
+            BytesRef suggestPayload = fieldType().analyzingSuggestLookupProvider.buildPayload(new BytesRef(
+                surfaceForm), weight, payload);
             for (String input : inputs) {
                 if (input.length() == 0) {
                     continue;
@@ -428,22 +435,6 @@ public class CompletionFieldMapper extends AbstractFieldMapper {
         }
     }
 
-    /**
-     * Get the context mapping associated with this completion field.
-     */
-    public SortedMap<String, ContextMapping> getContextMapping() {
-        return contextMapping;
-    }
-
-    /** @return true if a context mapping has been defined */
-    public boolean requiresContext() {
-        return !contextMapping.isEmpty();
-    }
-
-    public Field getCompletionField(String input, BytesRef payload) {
-        return getCompletionField(ContextMapping.EMPTY_CONTEXT, input, payload);
-    }
-
     public Field getCompletionField(ContextMapping.Context ctx, String input, BytesRef payload) {
         final String originalInput = input;
         if (input.length() > maxInputLength) {
@@ -457,7 +448,7 @@ public class CompletionFieldMapper extends AbstractFieldMapper {
                         + "] at position " + i + " is a reserved character");
             }
         }
-        return new SuggestField(fieldType.names().indexName(), ctx, input, this.fieldType, payload, analyzingSuggestLookupProvider);
+        return new SuggestField(fieldType.names().indexName(), ctx, input, this.fieldType, payload, fieldType().analyzingSuggestLookupProvider);
     }
 
     public static int correctSubStringLen(String input, int len) {
@@ -469,8 +460,7 @@ public class CompletionFieldMapper extends AbstractFieldMapper {
     }
 
     public BytesRef buildPayload(BytesRef surfaceForm, long weight, BytesRef payload) throws IOException {
-        return analyzingSuggestLookupProvider.buildPayload(
-                surfaceForm, weight, payload);
+        return fieldType().analyzingSuggestLookupProvider.buildPayload(surfaceForm, weight, payload);
     }
 
     private static final class SuggestField extends Field {
@@ -501,15 +491,15 @@ public class CompletionFieldMapper extends AbstractFieldMapper {
         if (fieldType.indexAnalyzer().name().equals(fieldType.searchAnalyzer().name()) == false) {
             builder.field(Fields.SEARCH_ANALYZER.getPreferredName(), fieldType.searchAnalyzer().name());
         }
-        builder.field(Fields.PAYLOADS, this.payloads);
-        builder.field(Fields.PRESERVE_SEPARATORS.getPreferredName(), this.preserveSeparators);
-        builder.field(Fields.PRESERVE_POSITION_INCREMENTS.getPreferredName(), this.preservePositionIncrements);
+        builder.field(Fields.PAYLOADS, fieldType().analyzingSuggestLookupProvider.hasPayloads());
+        builder.field(Fields.PRESERVE_SEPARATORS.getPreferredName(), fieldType().analyzingSuggestLookupProvider.getPreserveSep());
+        builder.field(Fields.PRESERVE_POSITION_INCREMENTS.getPreferredName(), fieldType().analyzingSuggestLookupProvider.getPreservePositionsIncrements());
         builder.field(Fields.MAX_INPUT_LENGTH.getPreferredName(), this.maxInputLength);
         multiFields.toXContent(builder, params);
 
-        if(!contextMapping.isEmpty()) {
+        if(fieldType().requiresContext()) {
             builder.startObject(Fields.CONTEXT);
-            for (ContextMapping mapping : contextMapping.values()) {
+            for (ContextMapping mapping : fieldType().getContextMapping().values()) {
                 builder.value(mapping);
             }
             builder.endObject();
@@ -538,23 +528,23 @@ public class CompletionFieldMapper extends AbstractFieldMapper {
     }
 
     public boolean isStoringPayloads() {
-        return payloads;
+        return fieldType().analyzingSuggestLookupProvider.hasPayloads();
     }
 
     @Override
     public void merge(Mapper mergeWith, MergeResult mergeResult) throws MergeMappingException {
         super.merge(mergeWith, mergeResult);
         CompletionFieldMapper fieldMergeWith = (CompletionFieldMapper) mergeWith;
-        if (payloads != fieldMergeWith.payloads) {
+        if (fieldType().analyzingSuggestLookupProvider.hasPayloads() != fieldMergeWith.fieldType().analyzingSuggestLookupProvider.hasPayloads()) {
             mergeResult.addConflict("mapper [" + fieldType.names().fullName() + "] has different payload values");
         }
-        if (preservePositionIncrements != fieldMergeWith.preservePositionIncrements) {
+        if (fieldType().analyzingSuggestLookupProvider.getPreservePositionsIncrements() != fieldMergeWith.fieldType().analyzingSuggestLookupProvider.getPreservePositionsIncrements()) {
             mergeResult.addConflict("mapper [" + fieldType.names().fullName() + "] has different 'preserve_position_increments' values");
         }
-        if (preserveSeparators != fieldMergeWith.preserveSeparators) {
+        if (fieldType().analyzingSuggestLookupProvider.getPreserveSep() != fieldMergeWith.fieldType().analyzingSuggestLookupProvider.getPreserveSep()) {
             mergeResult.addConflict("mapper [" + fieldType.names().fullName() + "] has different 'preserve_separators' values");
         }
-        if(!ContextMapping.mappingsAreEqual(getContextMapping(), fieldMergeWith.getContextMapping())) {
+        if(!ContextMapping.mappingsAreEqual(fieldType().getContextMapping(), fieldMergeWith.fieldType().getContextMapping())) {
             mergeResult.addConflict("mapper [" + fieldType.names().fullName() + "] has different 'context_mapping' values");
         }
         if (!mergeResult.simulate()) {

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/Murmur3FieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/Murmur3FieldMapper.java
@@ -47,6 +47,7 @@ public class Murmur3FieldMapper extends LongFieldMapper {
     public static final String CONTENT_TYPE = "murmur3";
 
     public static class Defaults extends LongFieldMapper.Defaults {
+        public static final MappedFieldType FIELD_TYPE = new Murmur3FieldType();
     }
 
     public static class Builder extends NumberFieldMapper.Builder<Builder, Murmur3FieldMapper> {
@@ -101,6 +102,20 @@ public class Murmur3FieldMapper extends LongFieldMapper {
             // determine whether the JSON is the original JSON from the user or if its the serialised cluster state being passed between nodes.
 //            node.remove("null_value");
             return builder;
+        }
+    }
+
+    // this only exists so a check can be done to match the field type to using murmur3 hashing...
+    public static class Murmur3FieldType extends LongFieldMapper.LongFieldType {
+        public Murmur3FieldType() {}
+
+        protected Murmur3FieldType(Murmur3FieldType ref) {
+            super(ref);
+        }
+
+        @Override
+        public Murmur3FieldType clone() {
+            return new Murmur3FieldType(this);
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/StringFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/StringFieldMapper.java
@@ -184,7 +184,7 @@ public class StringFieldMapper extends AbstractFieldMapper implements AllFieldMa
         }
     }
 
-    static final class StringFieldType extends MappedFieldType {
+    public static final class StringFieldType extends MappedFieldType {
 
         public StringFieldType() {
             super(AbstractFieldMapper.Defaults.FIELD_TYPE);

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/FieldNamesFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/FieldNamesFieldMapper.java
@@ -66,7 +66,7 @@ public class FieldNamesFieldMapper extends AbstractFieldMapper implements RootMa
     public static class Defaults extends AbstractFieldMapper.Defaults {
         public static final String NAME = FieldNamesFieldMapper.NAME;
         
-        public static final EnabledAttributeMapper ENABLED_STATE = EnabledAttributeMapper.UNSET_ENABLED;
+        public static final boolean ENABLED = true;
         public static final MappedFieldType FIELD_TYPE = new FieldNamesFieldType();
 
         static {
@@ -82,7 +82,7 @@ public class FieldNamesFieldMapper extends AbstractFieldMapper implements RootMa
     }
 
     public static class Builder extends AbstractFieldMapper.Builder<Builder, FieldNamesFieldMapper> {
-        private EnabledAttributeMapper enabledState = Defaults.ENABLED_STATE;
+        private boolean enabled = Defaults.ENABLED;
 
         public Builder() {
             super(Defaults.NAME, Defaults.FIELD_TYPE);
@@ -97,14 +97,16 @@ public class FieldNamesFieldMapper extends AbstractFieldMapper implements RootMa
         }
         
         public Builder enabled(boolean enabled) {
-            this.enabledState = enabled ? EnabledAttributeMapper.ENABLED : EnabledAttributeMapper.DISABLED;
+            this.enabled = enabled;
             return this;
         }
 
         @Override
         public FieldNamesFieldMapper build(BuilderContext context) {
-            fieldType.setNames(new MappedFieldType.Names(name, indexName, indexName, name));
-            return new FieldNamesFieldMapper(fieldType, enabledState, fieldDataSettings, context.indexSettings());
+            setupFieldType(context);
+            FieldNamesFieldType fieldNamesFieldType = (FieldNamesFieldType)fieldType;
+            fieldNamesFieldType.setEnabled(enabled);
+            return new FieldNamesFieldMapper(fieldType, fieldDataSettings, context.indexSettings());
         }
     }
 
@@ -133,7 +135,9 @@ public class FieldNamesFieldMapper extends AbstractFieldMapper implements RootMa
         }
     }
 
-    static final class FieldNamesFieldType extends MappedFieldType {
+    public static final class FieldNamesFieldType extends MappedFieldType {
+
+        private boolean enabled = Defaults.ENABLED;
 
         public FieldNamesFieldType() {
             super(AbstractFieldMapper.Defaults.FIELD_TYPE);
@@ -141,10 +145,20 @@ public class FieldNamesFieldMapper extends AbstractFieldMapper implements RootMa
 
         protected FieldNamesFieldType(FieldNamesFieldType ref) {
             super(ref);
+            this.enabled = ref.enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            checkIfFrozen();
+            this.enabled = enabled;
+        }
+
+        public boolean isEnabled() {
+            return enabled;
         }
 
         @Override
-        public MappedFieldType clone() {
+        public FieldNamesFieldType clone() {
             return new FieldNamesFieldType(this);
         }
 
@@ -163,22 +177,25 @@ public class FieldNamesFieldMapper extends AbstractFieldMapper implements RootMa
     }
 
     private final MappedFieldType defaultFieldType;
-    private EnabledAttributeMapper enabledState;
     private final boolean pre13Index; // if the index was created before 1.3, _field_names is always disabled
 
     public FieldNamesFieldMapper(Settings indexSettings) {
-        this(Defaults.FIELD_TYPE.clone(), Defaults.ENABLED_STATE, null, indexSettings);
+        this(Defaults.FIELD_TYPE.clone(), null, indexSettings);
     }
 
-    public FieldNamesFieldMapper(MappedFieldType fieldType, EnabledAttributeMapper enabledState, @Nullable Settings fieldDataSettings, Settings indexSettings) {
+    public FieldNamesFieldMapper(MappedFieldType fieldType, @Nullable Settings fieldDataSettings, Settings indexSettings) {
         super(fieldType, false, fieldDataSettings, indexSettings);
         this.defaultFieldType = Defaults.FIELD_TYPE;
         this.pre13Index = Version.indexCreated(indexSettings).before(Version.V_1_3_0);
-        this.enabledState = enabledState;
+    }
+
+    @Override
+    public FieldNamesFieldType fieldType() {
+        return (FieldNamesFieldType)fieldType;
     }
 
     public boolean enabled() {
-        return pre13Index == false && enabledState.enabled;
+        return pre13Index == false && fieldType().isEnabled();
     }
 
     @Override
@@ -240,7 +257,7 @@ public class FieldNamesFieldMapper extends AbstractFieldMapper implements RootMa
 
     @Override
     protected void parseCreateField(ParseContext context, List<Field> fields) throws IOException {
-        if (enabledState.enabled == false) {
+        if (fieldType().isEnabled() == false) {
             return;
         }
         for (ParseContext.Document document : context.docs()) {
@@ -270,13 +287,13 @@ public class FieldNamesFieldMapper extends AbstractFieldMapper implements RootMa
         }
         boolean includeDefaults = params.paramAsBoolean("include_defaults", false);
 
-        if (includeDefaults == false && fieldType().equals(Defaults.FIELD_TYPE) && enabledState == Defaults.ENABLED_STATE) {
+        if (includeDefaults == false && fieldType().equals(Defaults.FIELD_TYPE) && fieldType().isEnabled() == Defaults.ENABLED) {
             return builder;
         }
         
         builder.startObject(NAME);
-        if (includeDefaults || enabledState != Defaults.ENABLED_STATE) {
-            builder.field("enabled", enabledState.enabled);
+        if (includeDefaults || fieldType().isEnabled() != Defaults.ENABLED) {
+            builder.field("enabled", fieldType().isEnabled());
         }
         if (indexCreatedBefore2x && (includeDefaults || fieldType().equals(Defaults.FIELD_TYPE) == false)) {
             super.doXContentBody(builder, includeDefaults, params);
@@ -290,8 +307,10 @@ public class FieldNamesFieldMapper extends AbstractFieldMapper implements RootMa
     public void merge(Mapper mergeWith, MergeResult mergeResult) throws MergeMappingException {
         FieldNamesFieldMapper fieldNamesMapperMergeWith = (FieldNamesFieldMapper)mergeWith;
         if (!mergeResult.simulate()) {
-            if (fieldNamesMapperMergeWith.enabledState != enabledState && !fieldNamesMapperMergeWith.enabledState.unset()) {
-                this.enabledState = fieldNamesMapperMergeWith.enabledState;
+            if (fieldNamesMapperMergeWith.fieldType().isEnabled() != fieldType().isEnabled()) {
+                this.fieldType = fieldType().clone();
+                fieldType().setEnabled(fieldNamesMapperMergeWith.fieldType().isEnabled());
+                fieldType().freeze();
             }
         }
     }

--- a/core/src/main/java/org/elasticsearch/index/mapper/ip/IpFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/ip/IpFieldMapper.java
@@ -157,7 +157,7 @@ public class IpFieldMapper extends NumberFieldMapper {
         }
     }
 
-    static final class IpFieldType extends NumberFieldType {
+    public static final class IpFieldType extends NumberFieldType {
 
         public IpFieldType() {}
 

--- a/core/src/main/java/org/elasticsearch/index/percolator/QueriesLoaderCollector.java
+++ b/core/src/main/java/org/elasticsearch/index/percolator/QueriesLoaderCollector.java
@@ -31,6 +31,7 @@ import org.elasticsearch.index.fielddata.IndexFieldDataService;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.index.fieldvisitor.JustSourceFieldsVisitor;
 import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.Uid;
 import org.elasticsearch.index.mapper.internal.UidFieldMapper;
@@ -54,7 +55,7 @@ final class QueriesLoaderCollector extends SimpleCollector {
     QueriesLoaderCollector(PercolatorQueriesRegistry percolator, ESLogger logger, MapperService mapperService, IndexFieldDataService indexFieldDataService) {
         this.percolator = percolator;
         this.logger = logger;
-        final FieldMapper uidMapper = mapperService.smartNameFieldMapper(UidFieldMapper.NAME);
+        final MappedFieldType uidMapper = mapperService.smartNameFieldType(UidFieldMapper.NAME);
         this.uidFieldData = indexFieldDataService.getForField(uidMapper);
     }
 

--- a/core/src/main/java/org/elasticsearch/index/query/CommonTermsQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/CommonTermsQueryParser.java
@@ -30,7 +30,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRefBuilder;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 
 import java.io.IOException;
 
@@ -163,20 +163,20 @@ public class CommonTermsQueryParser implements QueryParser {
             throw new QueryParsingException(parseContext, "No text specified for text query");
         }
         String field;
-        FieldMapper mapper = parseContext.fieldMapper(fieldName);
-        if (mapper != null) {
-            field = mapper.fieldType().names().indexName();
+        MappedFieldType fieldType = parseContext.fieldMapper(fieldName);
+        if (fieldType != null) {
+            field = fieldType.names().indexName();
         } else {
             field = fieldName;
         }
 
         Analyzer analyzer = null;
         if (queryAnalyzer == null) {
-            if (mapper != null) {
-                analyzer = mapper.fieldType().searchAnalyzer();
+            if (fieldType != null) {
+                analyzer = fieldType.searchAnalyzer();
             }
-            if (analyzer == null && mapper != null) {
-                analyzer = parseContext.getSearchAnalyzer(mapper);
+            if (analyzer == null && fieldType != null) {
+                analyzer = parseContext.getSearchAnalyzer(fieldType);
             }
             if (analyzer == null) {
                 analyzer = parseContext.mapperService().searchAnalyzer();
@@ -188,7 +188,7 @@ public class CommonTermsQueryParser implements QueryParser {
             }
         }
 
-        ExtendedCommonTermsQuery commonsQuery = new ExtendedCommonTermsQuery(highFreqOccur, lowFreqOccur, maxTermFrequency, disableCoords, mapper);
+        ExtendedCommonTermsQuery commonsQuery = new ExtendedCommonTermsQuery(highFreqOccur, lowFreqOccur, maxTermFrequency, disableCoords, fieldType);
         commonsQuery.setBoost(boost);
         Query query = parseQueryString(commonsQuery, value.toString(), field, parseContext, analyzer, lowFreqMinimumShouldMatch, highFreqMinimumShouldMatch);
         if (queryName != null) {

--- a/core/src/main/java/org/elasticsearch/index/query/ExistsQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/ExistsQueryParser.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.internal.FieldNamesFieldMapper;
 
@@ -77,7 +78,7 @@ public class ExistsQueryParser implements QueryParser {
     }
 
     public static Query newFilter(QueryParseContext parseContext, String fieldPattern, String queryName) {
-        final FieldNamesFieldMapper fieldNamesMapper = (FieldNamesFieldMapper)parseContext.mapperService().fullName(FieldNamesFieldMapper.NAME);
+        final FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType = (FieldNamesFieldMapper.FieldNamesFieldType)parseContext.mapperService().fullName(FieldNamesFieldMapper.NAME);
 
         MapperService.SmartNameObjectMapper smartNameObjectMapper = parseContext.smartObjectMapper(fieldPattern);
         if (smartNameObjectMapper != null && smartNameObjectMapper.hasMapper()) {
@@ -93,20 +94,20 @@ public class ExistsQueryParser implements QueryParser {
 
         BooleanQuery boolFilter = new BooleanQuery();
         for (String field : fields) {
-            FieldMapper mapper = parseContext.fieldMapper(field);
+            MappedFieldType fieldType = parseContext.fieldMapper(field);
             Query filter = null;
-            if (fieldNamesMapper!= null && fieldNamesMapper.enabled()) {
+            if (fieldNamesFieldType.isEnabled()) {
                 final String f;
-                if (mapper != null) {
-                    f = mapper.fieldType().names().indexName();
+                if (fieldType != null) {
+                    f = fieldType.names().indexName();
                 } else {
                     f = field;
                 }
-                filter = fieldNamesMapper.termQuery(f, parseContext);
+                filter = fieldNamesFieldType.termQuery(f, parseContext);
             }
             // if _field_names are not indexed, we need to go the slow way
-            if (filter == null && mapper != null) {
-                filter = mapper.rangeQuery(null, null, true, true, parseContext);
+            if (filter == null && fieldType != null) {
+                filter = fieldType.rangeQuery(null, null, true, true, parseContext);
             }
             if (filter == null) {
                 filter = new TermRangeQuery(field, null, null, true, true);

--- a/core/src/main/java/org/elasticsearch/index/query/FieldMaskingSpanQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/FieldMaskingSpanQueryParser.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 
 import java.io.IOException;
 
@@ -90,9 +91,9 @@ public class FieldMaskingSpanQueryParser implements QueryParser {
             throw new QueryParsingException(parseContext, "field_masking_span must have [field] set for it");
         }
 
-        FieldMapper mapper = parseContext.fieldMapper(field);
-        if (mapper != null) {
-            field = mapper.fieldType().names().indexName();
+        MappedFieldType fieldType = parseContext.fieldMapper(field);
+        if (fieldType != null) {
+            field = fieldType.names().indexName();
         }
 
         FieldMaskingSpanQuery query = new FieldMaskingSpanQuery(inner, field);

--- a/core/src/main/java/org/elasticsearch/index/query/FuzzyQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/FuzzyQueryParser.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.query.support.QueryParsers;
 
 import java.io.IOException;
@@ -114,9 +115,9 @@ public class FuzzyQueryParser implements QueryParser {
         }
 
         Query query = null;
-        FieldMapper mapper = parseContext.fieldMapper(fieldName);
-        if (mapper != null) {
-            query = mapper.fuzzyQuery(value, fuzziness, prefixLength, maxExpansions, transpositions);
+        MappedFieldType fieldType = parseContext.fieldMapper(fieldName);
+        if (fieldType != null) {
+            query = fieldType.fuzzyQuery(value, fuzziness, prefixLength, maxExpansions, transpositions);
         }
         if (query == null) {
             query = new FuzzyQuery(new Term(fieldName, value), fuzziness.asDistance(value), prefixLength, maxExpansions, transpositions);

--- a/core/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxQueryParser.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.fielddata.IndexGeoPointFieldData;
 import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.geo.GeoPointFieldMapper;
 import org.elasticsearch.index.search.geo.InMemoryGeoBoundingBoxQuery;
 import org.elasticsearch.index.search.geo.IndexedGeoBoundingBoxQuery;
@@ -160,20 +161,20 @@ public class GeoBoundingBoxQueryParser implements QueryParser {
             }
         }
 
-        FieldMapper mapper = parseContext.fieldMapper(fieldName);
-        if (mapper == null) {
+        MappedFieldType fieldType = parseContext.fieldMapper(fieldName);
+        if (fieldType == null) {
             throw new QueryParsingException(parseContext, "failed to find geo_point field [" + fieldName + "]");
         }
-        if (!(mapper instanceof GeoPointFieldMapper)) {
+        if (!(fieldType instanceof GeoPointFieldMapper.GeoPointFieldType)) {
             throw new QueryParsingException(parseContext, "field [" + fieldName + "] is not a geo_point field");
         }
-        GeoPointFieldMapper geoMapper = ((GeoPointFieldMapper) mapper);
+        GeoPointFieldMapper.GeoPointFieldType geoFieldType = ((GeoPointFieldMapper.GeoPointFieldType) fieldType);
 
         Query filter;
         if ("indexed".equals(type)) {
-            filter = IndexedGeoBoundingBoxQuery.create(topLeft, bottomRight, geoMapper);
+            filter = IndexedGeoBoundingBoxQuery.create(topLeft, bottomRight, geoFieldType);
         } else if ("memory".equals(type)) {
-            IndexGeoPointFieldData indexFieldData = parseContext.getForField(mapper);
+            IndexGeoPointFieldData indexFieldData = parseContext.getForField(fieldType);
             filter = new InMemoryGeoBoundingBoxQuery(topLeft, bottomRight, indexFieldData);
         } else {
             throw new QueryParsingException(parseContext, "geo bounding box type [" + type

--- a/core/src/main/java/org/elasticsearch/index/query/GeoDistanceQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoDistanceQueryParser.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.fielddata.IndexGeoPointFieldData;
 import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.geo.GeoPointFieldMapper;
 import org.elasticsearch.index.search.geo.GeoDistanceRangeQuery;
 
@@ -147,18 +148,18 @@ public class GeoDistanceQueryParser implements QueryParser {
             GeoUtils.normalizePoint(point, normalizeLat, normalizeLon);
         }
 
-        FieldMapper mapper = parseContext.fieldMapper(fieldName);
-        if (mapper == null) {
+        MappedFieldType fieldType = parseContext.fieldMapper(fieldName);
+        if (fieldType == null) {
             throw new QueryParsingException(parseContext, "failed to find geo_point field [" + fieldName + "]");
         }
-        if (!(mapper instanceof GeoPointFieldMapper)) {
+        if (!(fieldType instanceof GeoPointFieldMapper.GeoPointFieldType)) {
             throw new QueryParsingException(parseContext, "field [" + fieldName + "] is not a geo_point field");
         }
-        GeoPointFieldMapper geoMapper = ((GeoPointFieldMapper) mapper);
+        GeoPointFieldMapper.GeoPointFieldType geoFieldType = ((GeoPointFieldMapper.GeoPointFieldType) fieldType);
 
 
-        IndexGeoPointFieldData indexFieldData = parseContext.getForField(mapper);
-        Query query = new GeoDistanceRangeQuery(point, null, distance, true, false, geoDistance, geoMapper, indexFieldData, optimizeBbox);
+        IndexGeoPointFieldData indexFieldData = parseContext.getForField(fieldType);
+        Query query = new GeoDistanceRangeQuery(point, null, distance, true, false, geoDistance, geoFieldType, indexFieldData, optimizeBbox);
         if (queryName != null) {
             parseContext.addNamedQuery(queryName, query);
         }

--- a/core/src/main/java/org/elasticsearch/index/query/GeoDistanceRangeQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoDistanceRangeQueryParser.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.fielddata.IndexGeoPointFieldData;
 import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.geo.GeoPointFieldMapper;
 import org.elasticsearch.index.search.geo.GeoDistanceRangeQuery;
 
@@ -187,17 +188,17 @@ public class GeoDistanceRangeQueryParser implements QueryParser {
             GeoUtils.normalizePoint(point, normalizeLat, normalizeLon);
         }
 
-        FieldMapper mapper = parseContext.fieldMapper(fieldName);
-        if (mapper == null) {
+        MappedFieldType fieldType = parseContext.fieldMapper(fieldName);
+        if (fieldType == null) {
             throw new QueryParsingException(parseContext, "failed to find geo_point field [" + fieldName + "]");
         }
-        if (!(mapper instanceof GeoPointFieldMapper)) {
+        if (!(fieldType instanceof GeoPointFieldMapper.GeoPointFieldType)) {
             throw new QueryParsingException(parseContext, "field [" + fieldName + "] is not a geo_point field");
         }
-        GeoPointFieldMapper geoMapper = ((GeoPointFieldMapper) mapper);
+        GeoPointFieldMapper.GeoPointFieldType geoFieldType = ((GeoPointFieldMapper.GeoPointFieldType) fieldType);
 
-        IndexGeoPointFieldData indexFieldData = parseContext.getForField(mapper);
-        Query query = new GeoDistanceRangeQuery(point, from, to, includeLower, includeUpper, geoDistance, geoMapper, indexFieldData, optimizeBbox);
+        IndexGeoPointFieldData indexFieldData = parseContext.getForField(fieldType);
+        Query query = new GeoDistanceRangeQuery(point, from, to, includeLower, includeUpper, geoDistance, geoFieldType, indexFieldData, optimizeBbox);
         if (queryName != null) {
             parseContext.addNamedQuery(queryName, query);
         }

--- a/core/src/main/java/org/elasticsearch/index/query/GeoPolygonQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoPolygonQueryParser.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentParser.Token;
 import org.elasticsearch.index.fielddata.IndexGeoPointFieldData;
 import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.geo.GeoPointFieldMapper;
 import org.elasticsearch.index.search.geo.GeoPolygonQuery;
 
@@ -136,15 +137,15 @@ public class GeoPolygonQueryParser implements QueryParser {
             }
         }
 
-        FieldMapper mapper = parseContext.fieldMapper(fieldName);
-        if (mapper == null) {
+        MappedFieldType fieldType = parseContext.fieldMapper(fieldName);
+        if (fieldType == null) {
             throw new QueryParsingException(parseContext, "failed to find geo_point field [" + fieldName + "]");
         }
-        if (!(mapper instanceof GeoPointFieldMapper)) {
+        if (!(fieldType instanceof GeoPointFieldMapper.GeoPointFieldType)) {
             throw new QueryParsingException(parseContext, "field [" + fieldName + "] is not a geo_point field");
         }
 
-        IndexGeoPointFieldData indexFieldData = parseContext.getForField(mapper);
+        IndexGeoPointFieldData indexFieldData = parseContext.getForField(fieldType);
         Query query = new GeoPolygonQuery(indexFieldData, shell.toArray(new GeoPoint[shell.size()]));
         if (queryName != null) {
             parseContext.addNamedQuery(queryName, query);

--- a/core/src/main/java/org/elasticsearch/index/query/GeoShapeQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoShapeQueryParser.java
@@ -32,6 +32,7 @@ import org.elasticsearch.common.geo.builders.ShapeBuilder;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.geo.GeoShapeFieldMapper;
 import org.elasticsearch.index.search.shape.ShapeFetchService;
 import org.elasticsearch.search.internal.SearchContext;
@@ -138,21 +139,21 @@ public class GeoShapeQueryParser implements QueryParser {
             throw new QueryParsingException(parseContext, "No Shape Relation defined");
         }
 
-        FieldMapper fieldMapper = parseContext.fieldMapper(fieldName);
-        if (fieldMapper == null) {
+        MappedFieldType fieldType = parseContext.fieldMapper(fieldName);
+        if (fieldType == null) {
             throw new QueryParsingException(parseContext, "Failed to find geo_shape field [" + fieldName + "]");
         }
 
         // TODO: This isn't the nicest way to check this
-        if (!(fieldMapper instanceof GeoShapeFieldMapper)) {
+        if (!(fieldType instanceof GeoShapeFieldMapper.GeoShapeFieldType)) {
             throw new QueryParsingException(parseContext, "Field [" + fieldName + "] is not a geo_shape");
         }
 
-        GeoShapeFieldMapper shapeFieldMapper = (GeoShapeFieldMapper) fieldMapper;
+        GeoShapeFieldMapper.GeoShapeFieldType shapeFieldType = (GeoShapeFieldMapper.GeoShapeFieldType) fieldType;
 
-        PrefixTreeStrategy strategy = shapeFieldMapper.fieldType().defaultStrategy();
+        PrefixTreeStrategy strategy = shapeFieldType.defaultStrategy();
         if (strategyName != null) {
-            strategy = shapeFieldMapper.fieldType().resolveStrategy(strategyName);
+            strategy = shapeFieldType.resolveStrategy(strategyName);
         }
         Query query;
         if (strategy instanceof RecursivePrefixTreeStrategy && shapeRelation == ShapeRelation.DISJOINT) {

--- a/core/src/main/java/org/elasticsearch/index/query/GeohashCellQuery.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeohashCellQuery.java
@@ -66,13 +66,13 @@ public class GeohashCellQuery {
      * returns a boolean filter combining the geohashes OR-wise.
      *
      * @param context     Context of the filter
-     * @param fieldMapper field mapper for geopoints
+     * @param fieldType field mapper for geopoints
      * @param geohash     mandatory geohash
      * @param geohashes   optional array of additional geohashes
      * @return a new GeoBoundinboxfilter
      */
-    public static Query create(QueryParseContext context, GeoPointFieldMapper fieldMapper, String geohash, @Nullable List<CharSequence> geohashes) {
-        MappedFieldType geoHashMapper = fieldMapper.fieldType().geohashFieldType();
+    public static Query create(QueryParseContext context, GeoPointFieldMapper.GeoPointFieldType fieldType, String geohash, @Nullable List<CharSequence> geohashes) {
+        MappedFieldType geoHashMapper = fieldType.geohashFieldType();
         if (geoHashMapper == null) {
             throw new IllegalArgumentException("geohash filter needs geohash_prefix to be enabled");
         }
@@ -237,17 +237,17 @@ public class GeohashCellQuery {
                 throw new QueryParsingException(parseContext, "no geohash value provided to geohash_cell filter");
             }
 
-            FieldMapper mapper = parseContext.fieldMapper(fieldName);
-            if (mapper == null) {
+            MappedFieldType fieldType = parseContext.fieldMapper(fieldName);
+            if (fieldType == null) {
                 throw new QueryParsingException(parseContext, "failed to find geo_point field [" + fieldName + "]");
             }
 
-            if (!(mapper instanceof GeoPointFieldMapper)) {
+            if (!(fieldType instanceof GeoPointFieldMapper.GeoPointFieldType)) {
                 throw new QueryParsingException(parseContext, "field [" + fieldName + "] is not a geo_point field");
             }
 
-            GeoPointFieldMapper geoMapper = ((GeoPointFieldMapper) mapper);
-            if (!geoMapper.fieldType().isGeohashPrefixEnabled()) {
+            GeoPointFieldMapper.GeoPointFieldType geoFieldType = ((GeoPointFieldMapper.GeoPointFieldType) fieldType);
+            if (!geoFieldType.isGeohashPrefixEnabled()) {
                 throw new QueryParsingException(parseContext, "can't execute geohash_cell on field [" + fieldName
                         + "], geohash_prefix is not enabled");
             }
@@ -259,9 +259,9 @@ public class GeohashCellQuery {
 
             Query filter;
             if (neighbors) {
-                filter = create(parseContext, geoMapper, geohash, GeoHashUtils.addNeighbors(geohash, new ArrayList<CharSequence>(8)));
+                filter = create(parseContext, geoFieldType, geohash, GeoHashUtils.addNeighbors(geohash, new ArrayList<CharSequence>(8)));
             } else {
-                filter = create(parseContext, geoMapper, geohash, null);
+                filter = create(parseContext, geoFieldType, geohash, null);
             }
 
             return filter;

--- a/core/src/main/java/org/elasticsearch/index/query/HasChildQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/HasChildQueryParser.java
@@ -176,7 +176,7 @@ public class HasChildQueryParser implements QueryParser {
         innerQuery = Queries.filtered(innerQuery, childDocMapper.typeFilter());
 
         final Query query;
-        final ParentChildIndexFieldData parentChildIndexFieldData = parseContext.getForField(parentFieldMapper);
+        final ParentChildIndexFieldData parentChildIndexFieldData = parseContext.getForField(parentFieldMapper.fieldType());
         if (parseContext.indexVersionCreated().onOrAfter(Version.V_2_0_0)) {
             query = joinUtilHelper(parentType, parentChildIndexFieldData, parentDocMapper.typeFilter(), scoreType, innerQuery, minChildren, maxChildren);
         } else {

--- a/core/src/main/java/org/elasticsearch/index/query/HasParentQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/HasParentQueryParser.java
@@ -166,7 +166,7 @@ public class HasParentQueryParser implements QueryParser {
             ParentFieldMapper parentFieldMapper = documentMapper.parentFieldMapper();
             if (parentFieldMapper.active()) {
                 DocumentMapper parentTypeDocumentMapper = parseContext.mapperService().documentMapper(parentFieldMapper.type());
-                parentChildIndexFieldData = parseContext.getForField(parentFieldMapper);
+                parentChildIndexFieldData = parseContext.getForField(parentFieldMapper.fieldType());
                 if (parentTypeDocumentMapper == null) {
                     // Only add this, if this parentFieldMapper (also a parent)  isn't a child of another parent.
                     parentTypes.add(parentFieldMapper.type());

--- a/core/src/main/java/org/elasticsearch/index/query/MissingQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MissingQueryParser.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.internal.FieldNamesFieldMapper;
 
@@ -89,7 +90,7 @@ public class MissingQueryParser implements QueryParser {
             throw new QueryParsingException(parseContext, "missing must have either existence, or null_value, or both set to true");
         }
 
-        final FieldNamesFieldMapper fieldNamesMapper = (FieldNamesFieldMapper)parseContext.mapperService().fullName(FieldNamesFieldMapper.NAME);
+        final FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType = (FieldNamesFieldMapper.FieldNamesFieldType)parseContext.mapperService().fullName(FieldNamesFieldMapper.NAME);
         MapperService.SmartNameObjectMapper smartNameObjectMapper = parseContext.smartObjectMapper(fieldPattern);
         if (smartNameObjectMapper != null && smartNameObjectMapper.hasMapper()) {
             // automatic make the object mapper pattern
@@ -111,20 +112,20 @@ public class MissingQueryParser implements QueryParser {
         if (existence) {
             BooleanQuery boolFilter = new BooleanQuery();
             for (String field : fields) {
-                FieldMapper mapper = parseContext.fieldMapper(field);
+                MappedFieldType fieldType = parseContext.fieldMapper(field);
                 Query filter = null;
-                if (fieldNamesMapper != null && fieldNamesMapper.enabled()) {
+                if (fieldNamesFieldType.isEnabled()) {
                     final String f;
-                    if (mapper != null) {
-                        f = mapper.fieldType().names().indexName();
+                    if (fieldType != null) {
+                        f = fieldType.names().indexName();
                     } else {
                         f = field;
                     }
-                    filter = fieldNamesMapper.termQuery(f, parseContext);
+                    filter = fieldNamesFieldType.termQuery(f, parseContext);
                 }
                 // if _field_names are not indexed, we need to go the slow way
-                if (filter == null && mapper != null) {
-                    filter = mapper.rangeQuery(null, null, true, true, parseContext);
+                if (filter == null && fieldType != null) {
+                    filter = fieldType.rangeQuery(null, null, true, true, parseContext);
                 }
                 if (filter == null) {
                     filter = new TermRangeQuery(field, null, null, true, true);
@@ -138,9 +139,9 @@ public class MissingQueryParser implements QueryParser {
 
         if (nullValue) {
             for (String field : fields) {
-                FieldMapper mapper = parseContext.fieldMapper(field);
-                if (mapper != null) {
-                    nullFilter = mapper.nullValueFilter();
+                MappedFieldType fieldType = parseContext.fieldMapper(field);
+                if (fieldType != null) {
+                    nullFilter = fieldType.nullValueQuery();
                 }
             }
         }

--- a/core/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryParser.java
@@ -37,7 +37,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.lucene.search.MoreLikeThisQuery;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.analysis.Analysis;
-import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.internal.UidFieldMapper;
 import org.elasticsearch.index.search.morelikethis.MoreLikeThisFetchService;
 import org.elasticsearch.search.internal.SearchContext;
@@ -166,8 +166,8 @@ public class MoreLikeThisQueryParser implements QueryParser {
                     moreLikeFields = Lists.newLinkedList();
                     while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                         String field = parser.text();
-                        FieldMapper mapper = parseContext.fieldMapper(field);
-                        moreLikeFields.add(mapper == null ? field : mapper.fieldType().names().indexName());
+                        MappedFieldType fieldType = parseContext.fieldMapper(field);
+                        moreLikeFields.add(fieldType == null ? field : fieldType.names().indexName());
                     }
                 } else if (Fields.DOCUMENT_IDS.match(currentFieldName, parseContext.parseFlags())) {
                     while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {

--- a/core/src/main/java/org/elasticsearch/index/query/PrefixQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/PrefixQueryParser.java
@@ -26,7 +26,7 @@ import org.apache.lucene.search.Query;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.query.support.QueryParsers;
 
 import java.io.IOException;
@@ -100,9 +100,9 @@ public class PrefixQueryParser implements QueryParser {
         MultiTermQuery.RewriteMethod method = QueryParsers.parseRewriteMethod(rewriteMethod, null);
 
         Query query = null;
-        FieldMapper mapper = parseContext.fieldMapper(fieldName);
-        if (mapper != null) {
-            query = mapper.prefixQuery(value, method, parseContext);
+        MappedFieldType fieldType = parseContext.fieldMapper(fieldName);
+        if (fieldType != null) {
+            query = fieldType.prefixQuery(value, method, parseContext);
         }
         if (query == null) {
             PrefixQuery prefixQuery = new PrefixQuery(new Term(fieldName, BytesRefs.toBytesRef(value)));

--- a/core/src/main/java/org/elasticsearch/index/query/RangeQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/RangeQueryParser.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.joda.Joda;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.core.DateFieldMapper;
 import org.joda.time.DateTimeZone;
 
@@ -120,10 +121,10 @@ public class RangeQueryParser implements QueryParser {
         }
 
         Query query = null;
-        FieldMapper mapper = parseContext.fieldMapper(fieldName);
+        MappedFieldType mapper = parseContext.fieldMapper(fieldName);
         if (mapper != null) {
-            if (mapper instanceof DateFieldMapper) {
-                query = ((DateFieldMapper) mapper).fieldType().rangeQuery(from, to, includeLower, includeUpper, timeZone, forcedDateParser, parseContext);
+            if (mapper instanceof DateFieldMapper.DateFieldType) {
+                query = ((DateFieldMapper.DateFieldType) mapper).rangeQuery(from, to, includeLower, includeUpper, timeZone, forcedDateParser, parseContext);
             } else  {
                 if (timeZone != null) {
                     throw new QueryParsingException(parseContext, "[range] time_zone can not be applied to non date field ["

--- a/core/src/main/java/org/elasticsearch/index/query/RegexpQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/RegexpQueryParser.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.query.support.QueryParsers;
 
 import java.io.IOException;
@@ -108,9 +109,9 @@ public class RegexpQueryParser implements QueryParser {
         MultiTermQuery.RewriteMethod method = QueryParsers.parseRewriteMethod(rewriteMethod, null);
 
         Query query = null;
-        FieldMapper mapper = parseContext.fieldMapper(fieldName);
-        if (mapper != null) {
-            query = mapper.regexpQuery(value, flagsValue, maxDeterminizedStates, method, parseContext);
+        MappedFieldType fieldType = parseContext.fieldMapper(fieldName);
+        if (fieldType != null) {
+            query = fieldType.regexpQuery(value, flagsValue, maxDeterminizedStates, method, parseContext);
         }
         if (query == null) {
             RegexpQuery regexpQuery = new RegexpQuery(new Term(fieldName, BytesRefs.toBytesRef(value)), flagsValue, maxDeterminizedStates);

--- a/core/src/main/java/org/elasticsearch/index/query/SimpleQueryStringParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SimpleQueryStringParser.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.LocaleUtils;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -130,9 +131,9 @@ public class SimpleQueryStringParser implements QueryParser {
                                 fieldsAndWeights.put(fieldName, fBoost);
                             }
                         } else {
-                            FieldMapper mapper = parseContext.fieldMapper(fField);
-                            if (mapper != null) {
-                                fieldsAndWeights.put(mapper.fieldType().names().indexName(), fBoost);
+                            MappedFieldType fieldType = parseContext.fieldMapper(fField);
+                            if (fieldType != null) {
+                                fieldsAndWeights.put(fieldType.names().indexName(), fBoost);
                             } else {
                                 fieldsAndWeights.put(fField, fBoost);
                             }

--- a/core/src/main/java/org/elasticsearch/index/query/SpanTermQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanTermQueryParser.java
@@ -26,7 +26,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 
 import java.io.IOException;
 
@@ -93,10 +93,10 @@ public class SpanTermQueryParser implements QueryParser {
         }
 
         BytesRef valueBytes = null;
-        FieldMapper mapper = parseContext.fieldMapper(fieldName);
-        if (mapper != null) {
-            fieldName = mapper.fieldType().names().indexName();
-            valueBytes = mapper.indexedValueForSearch(value);
+        MappedFieldType fieldType = parseContext.fieldMapper(fieldName);
+        if (fieldType != null) {
+            fieldName = fieldType.names().indexName();
+            valueBytes = fieldType.indexedValueForSearch(value);
         }
         if (valueBytes == null) {
             valueBytes = new BytesRef(value);

--- a/core/src/main/java/org/elasticsearch/index/query/TermQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/TermQueryParser.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 
 import java.io.IOException;
 
@@ -99,9 +100,9 @@ public class TermQueryParser implements QueryParser {
         }
 
         Query query = null;
-        FieldMapper mapper = parseContext.fieldMapper(fieldName);
-        if (mapper != null) {
-            query = mapper.termQuery(value, parseContext);
+        MappedFieldType fieldType = parseContext.fieldMapper(fieldName);
+        if (fieldType != null) {
+            query = fieldType.termQuery(value, parseContext);
         }
         if (query == null) {
             query = new TermQuery(new Term(fieldName, BytesRefs.toBytesRef(value)));

--- a/core/src/main/java/org/elasticsearch/index/query/TermsQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/TermsQueryParser.java
@@ -37,6 +37,7 @@ import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.indices.cache.filter.terms.TermsLookup;
 import org.elasticsearch.search.internal.SearchContext;
 
@@ -158,9 +159,9 @@ public class TermsQueryParser implements QueryParser {
             throw new QueryParsingException(parseContext, "terms query requires a field name, followed by array of terms");
         }
 
-        FieldMapper fieldMapper = parseContext.fieldMapper(fieldName);
-        if (fieldMapper != null) {
-            fieldName = fieldMapper.fieldType().names().indexName();
+        MappedFieldType fieldType = parseContext.fieldMapper(fieldName);
+        if (fieldType != null) {
+            fieldName = fieldType.names().indexName();
         }
 
         if (lookupId != null) {
@@ -180,8 +181,8 @@ public class TermsQueryParser implements QueryParser {
 
         Query query;
         if (parseContext.isFilter()) {
-            if (fieldMapper != null) {
-                query = fieldMapper.termsQuery(terms, parseContext);
+            if (fieldType != null) {
+                query = fieldType.termsQuery(terms, parseContext);
             } else {
                 BytesRef[] filterValues = new BytesRef[terms.size()];
                 for (int i = 0; i < filterValues.length; i++) {
@@ -192,8 +193,8 @@ public class TermsQueryParser implements QueryParser {
         } else {
             BooleanQuery bq = new BooleanQuery();
             for (Object term : terms) {
-                if (fieldMapper != null) {
-                    bq.add(fieldMapper.termQuery(term, parseContext), Occur.SHOULD);
+                if (fieldType != null) {
+                    bq.add(fieldType.termQuery(term, parseContext), Occur.SHOULD);
                 } else {
                     bq.add(new TermQuery(new Term(fieldName, BytesRefs.toBytesRef(term))), Occur.SHOULD);
                 }

--- a/core/src/main/java/org/elasticsearch/index/query/WildcardQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/WildcardQueryParser.java
@@ -26,6 +26,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.query.support.QueryParsers;
 
 import java.io.IOException;
@@ -93,10 +94,10 @@ public class WildcardQueryParser implements QueryParser {
         }
 
         BytesRef valueBytes;
-        FieldMapper mapper = parseContext.fieldMapper(fieldName);
-        if (mapper != null) {
-            fieldName = mapper.fieldType().names().indexName();
-            valueBytes = mapper.indexedValueForSearch(value);
+        MappedFieldType fieldType = parseContext.fieldMapper(fieldName);
+        if (fieldType != null) {
+            fieldName = fieldType.names().indexName();
+            valueBytes = fieldType.indexedValueForSearch(value);
         } else {
             valueBytes = new BytesRef(value);
         }

--- a/core/src/main/java/org/elasticsearch/index/query/functionscore/fieldvaluefactor/FieldValueFactorFunctionParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/functionscore/fieldvaluefactor/FieldValueFactorFunctionParser.java
@@ -25,6 +25,7 @@ import org.elasticsearch.common.lucene.search.function.ScoreFunction;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData;
 import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.query.QueryParseContext;
 import org.elasticsearch.index.query.QueryParsingException;
 import org.elasticsearch.index.query.functionscore.ScoreFunctionParser;
@@ -84,12 +85,12 @@ public class FieldValueFactorFunctionParser implements ScoreFunctionParser {
         }
 
         SearchContext searchContext = SearchContext.current();
-        FieldMapper mapper = searchContext.mapperService().smartNameFieldMapper(field);
-        if (mapper == null) {
+        MappedFieldType fieldType = searchContext.mapperService().smartNameFieldType(field);
+        if (fieldType == null) {
             throw new ElasticsearchException("Unable to find a field mapper for field [" + field + "]");
         }
         return new FieldValueFactorFunction(field, boostFactor, modifier, missing,
-                (IndexNumericFieldData)searchContext.fieldData().getForField(mapper));
+                (IndexNumericFieldData)searchContext.fieldData().getForField(fieldType));
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/functionscore/random/RandomScoreFunctionParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/functionscore/random/RandomScoreFunctionParser.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.lucene.search.function.ScoreFunction;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.query.QueryParseContext;
 import org.elasticsearch.index.query.QueryParsingException;
 import org.elasticsearch.index.query.functionscore.ScoreFunctionParser;
@@ -82,8 +83,8 @@ public class RandomScoreFunctionParser implements ScoreFunctionParser {
             }
         }
 
-        final FieldMapper mapper = SearchContext.current().mapperService().smartNameFieldMapper("_uid");
-        if (mapper == null) {
+        final MappedFieldType fieldType = SearchContext.current().mapperService().smartNameFieldType("_uid");
+        if (fieldType == null) {
             // mapper could be null if we are on a shard with no docs yet, so this won't actually be used
             return new RandomScoreFunction();
         }
@@ -93,7 +94,7 @@ public class RandomScoreFunctionParser implements ScoreFunctionParser {
         }
         final ShardId shardId = SearchContext.current().indexShard().shardId();
         final int salt = (shardId.index().name().hashCode() << 10) | shardId.id();
-        final IndexFieldData<?> uidFieldData = SearchContext.current().fieldData().getForField(mapper);
+        final IndexFieldData<?> uidFieldData = SearchContext.current().fieldData().getForField(fieldType);
 
         return new RandomScoreFunction(seed, salt, uidFieldData);
     }

--- a/core/src/main/java/org/elasticsearch/index/search/geo/GeoDistanceRangeQuery.java
+++ b/core/src/main/java/org/elasticsearch/index/search/geo/GeoDistanceRangeQuery.java
@@ -58,7 +58,7 @@ public class GeoDistanceRangeQuery extends Query {
 
     private final IndexGeoPointFieldData indexFieldData;
 
-    public GeoDistanceRangeQuery(GeoPoint point, Double lowerVal, Double upperVal, boolean includeLower, boolean includeUpper, GeoDistance geoDistance, GeoPointFieldMapper mapper, IndexGeoPointFieldData indexFieldData,
+    public GeoDistanceRangeQuery(GeoPoint point, Double lowerVal, Double upperVal, boolean includeLower, boolean includeUpper, GeoDistance geoDistance, GeoPointFieldMapper.GeoPointFieldType fieldType, IndexGeoPointFieldData indexFieldData,
                                   String optimizeBbox) {
         this.lat = point.lat();
         this.lon = point.lon();
@@ -91,7 +91,7 @@ public class GeoDistanceRangeQuery extends Query {
             if ("memory".equals(optimizeBbox)) {
                 boundingBoxFilter = null;
             } else if ("indexed".equals(optimizeBbox)) {
-                boundingBoxFilter = IndexedGeoBoundingBoxQuery.create(distanceBoundingCheck.topLeft(), distanceBoundingCheck.bottomRight(), mapper);
+                boundingBoxFilter = IndexedGeoBoundingBoxQuery.create(distanceBoundingCheck.topLeft(), distanceBoundingCheck.bottomRight(), fieldType);
                 distanceBoundingCheck = GeoDistance.ALWAYS_INSTANCE; // fine, we do the bounding box check using the filter
             } else {
                 throw new IllegalArgumentException("type [" + optimizeBbox + "] for bounding box optimization not supported");

--- a/core/src/main/java/org/elasticsearch/index/search/geo/IndexedGeoBoundingBoxQuery.java
+++ b/core/src/main/java/org/elasticsearch/index/search/geo/IndexedGeoBoundingBoxQuery.java
@@ -30,31 +30,31 @@ import org.elasticsearch.index.mapper.geo.GeoPointFieldMapper;
  */
 public class IndexedGeoBoundingBoxQuery {
 
-    public static Query create(GeoPoint topLeft, GeoPoint bottomRight, GeoPointFieldMapper fieldMapper) {
-        if (!fieldMapper.fieldType().isLatLonEnabled()) {
-            throw new IllegalArgumentException("lat/lon is not enabled (indexed) for field [" + fieldMapper.name() + "], can't use indexed filter on it");
+    public static Query create(GeoPoint topLeft, GeoPoint bottomRight, GeoPointFieldMapper.GeoPointFieldType fieldType) {
+        if (!fieldType.isLatLonEnabled()) {
+            throw new IllegalArgumentException("lat/lon is not enabled (indexed) for field [" + fieldType.names().fullName() + "], can't use indexed filter on it");
         }
         //checks to see if bounding box crosses 180 degrees
         if (topLeft.lon() > bottomRight.lon()) {
-            return westGeoBoundingBoxFilter(topLeft, bottomRight, fieldMapper);
+            return westGeoBoundingBoxFilter(topLeft, bottomRight, fieldType);
         } else {
-            return eastGeoBoundingBoxFilter(topLeft, bottomRight, fieldMapper);
+            return eastGeoBoundingBoxFilter(topLeft, bottomRight, fieldType);
         }
     }
 
-    private static Query westGeoBoundingBoxFilter(GeoPoint topLeft, GeoPoint bottomRight, GeoPointFieldMapper fieldMapper) {
+    private static Query westGeoBoundingBoxFilter(GeoPoint topLeft, GeoPoint bottomRight, GeoPointFieldMapper.GeoPointFieldType fieldType) {
         BooleanQuery filter = new BooleanQuery();
         filter.setMinimumNumberShouldMatch(1);
-        filter.add(fieldMapper.fieldType().lonFieldType().rangeQuery(null, bottomRight.lon(), true, true, null), Occur.SHOULD);
-        filter.add(fieldMapper.fieldType().lonFieldType().rangeQuery(topLeft.lon(), null, true, true, null), Occur.SHOULD);
-        filter.add(fieldMapper.fieldType().latFieldType().rangeQuery(bottomRight.lat(), topLeft.lat(), true, true, null), Occur.MUST);
+        filter.add(fieldType.lonFieldType().rangeQuery(null, bottomRight.lon(), true, true, null), Occur.SHOULD);
+        filter.add(fieldType.lonFieldType().rangeQuery(topLeft.lon(), null, true, true, null), Occur.SHOULD);
+        filter.add(fieldType.latFieldType().rangeQuery(bottomRight.lat(), topLeft.lat(), true, true, null), Occur.MUST);
         return new ConstantScoreQuery(filter);
     }
 
-    private static Query eastGeoBoundingBoxFilter(GeoPoint topLeft, GeoPoint bottomRight, GeoPointFieldMapper fieldMapper) {
+    private static Query eastGeoBoundingBoxFilter(GeoPoint topLeft, GeoPoint bottomRight, GeoPointFieldMapper.GeoPointFieldType fieldType) {
         BooleanQuery filter = new BooleanQuery();
-        filter.add(fieldMapper.fieldType().lonFieldType().rangeQuery(topLeft.lon(), bottomRight.lon(), true, true, null), Occur.MUST);
-        filter.add(fieldMapper.fieldType().latFieldType().rangeQuery(bottomRight.lat(), topLeft.lat(), true, true, null), Occur.MUST);
+        filter.add(fieldType.lonFieldType().rangeQuery(topLeft.lon(), bottomRight.lon(), true, true, null), Occur.MUST);
+        filter.add(fieldType.latFieldType().rangeQuery(bottomRight.lat(), topLeft.lat(), true, true, null), Occur.MUST);
         return new ConstantScoreQuery(filter);
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/similarity/SimilarityService.java
+++ b/core/src/main/java/org/elasticsearch/index/similarity/SimilarityService.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.AbstractIndexComponent;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.settings.IndexSettings;
 
@@ -99,8 +100,8 @@ public class SimilarityService extends AbstractIndexComponent {
 
         @Override
         public Similarity get(String name) {
-            FieldMapper mapper = mapperService.smartNameFieldMapper(name);
-            return (mapper != null && mapper.fieldType().similarity() != null) ? mapper.fieldType().similarity().get() : defaultSimilarity;
+            MappedFieldType fieldType = mapperService.smartNameFieldType(name);
+            return (fieldType != null && fieldType.similarity() != null) ? fieldType.similarity().get() : defaultSimilarity;
         }
     }
 }

--- a/core/src/main/java/org/elasticsearch/indices/ttl/IndicesTTLService.java
+++ b/core/src/main/java/org/elasticsearch/indices/ttl/IndicesTTLService.java
@@ -196,7 +196,7 @@ public class IndicesTTLService extends AbstractLifecycleComponent<IndicesTTLServ
 
     private void purgeShards(List<IndexShard> shardsToPurge) {
         for (IndexShard shardToPurge : shardsToPurge) {
-            Query query = shardToPurge.indexService().mapperService().smartNameFieldMapper(TTLFieldMapper.NAME).rangeQuery(null, System.currentTimeMillis(), false, true, null);
+            Query query = shardToPurge.indexService().mapperService().smartNameFieldType(TTLFieldMapper.NAME).rangeQuery(null, System.currentTimeMillis(), false, true, null);
             Engine.Searcher searcher = shardToPurge.acquireSearcher("indices_ttl");
             try {
                 logger.debug("[{}][{}] purging shard", shardToPurge.routingEntry().index(), shardToPurge.routingEntry().id());

--- a/core/src/main/java/org/elasticsearch/percolator/PercolateContext.java
+++ b/core/src/main/java/org/elasticsearch/percolator/PercolateContext.java
@@ -45,6 +45,7 @@ import org.elasticsearch.index.cache.bitset.BitsetFilterCache;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.fielddata.IndexFieldDataService;
 import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.index.query.IndexQueryParserService;
@@ -651,13 +652,13 @@ public class PercolateContext extends SearchContext {
     }
 
     @Override
-    public FieldMapper smartNameFieldMapper(String name) {
-        return mapperService().smartNameFieldMapper(name, types);
+    public MappedFieldType smartNameFieldType(String name) {
+        return mapperService().smartNameFieldType(name, types);
     }
 
     @Override
-    public FieldMapper smartNameFieldMapperFromAnyType(String name) {
-        return mapperService().smartNameFieldMapper(name);
+    public MappedFieldType smartNameFieldTypeFromAnyType(String name) {
+        return mapperService().smartNameFieldType(name);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/percolator/PercolatorService.java
+++ b/core/src/main/java/org/elasticsearch/percolator/PercolatorService.java
@@ -66,6 +66,7 @@ import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.Mapping;
 import org.elasticsearch.index.mapper.ParsedDocument;
@@ -752,7 +753,7 @@ public class PercolatorService extends AbstractComponent {
                     hls = new ArrayList<>(topDocs.scoreDocs.length);
                 }
 
-                final FieldMapper uidMapper = context.mapperService().smartNameFieldMapper(UidFieldMapper.NAME);
+                final MappedFieldType uidMapper = context.mapperService().smartNameFieldType(UidFieldMapper.NAME);
                 final IndexFieldData<?> uidFieldData = context.fieldData().getForField(uidMapper);
                 int i = 0;
                 for (ScoreDoc scoreDoc : topDocs.scoreDocs) {

--- a/core/src/main/java/org/elasticsearch/percolator/QueryCollector.java
+++ b/core/src/main/java/org/elasticsearch/percolator/QueryCollector.java
@@ -35,6 +35,7 @@ import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Uid;
 import org.elasticsearch.index.mapper.internal.UidFieldMapper;
 import org.elasticsearch.index.query.ParsedQuery;
@@ -73,7 +74,7 @@ abstract class QueryCollector extends SimpleCollector {
         this.logger = logger;
         this.queries = context.percolateQueries();
         this.searcher = context.docSearcher();
-        final FieldMapper uidMapper = context.mapperService().smartNameFieldMapper(UidFieldMapper.NAME);
+        final MappedFieldType uidMapper = context.mapperService().smartNameFieldType(UidFieldMapper.NAME);
         this.uidFieldData = context.fieldData().getForField(uidMapper);
         this.isNestedDoc = isNestedDoc;
 

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/children/ChildrenParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/children/ChildrenParser.java
@@ -88,8 +88,8 @@ public class ChildrenParser implements Aggregator.Parser {
                 // TODO: use the query API
                 parentFilter = new QueryWrapperFilter(parentDocMapper.typeFilter());
                 childFilter = new QueryWrapperFilter(childDocMapper.typeFilter());
-                ParentChildIndexFieldData parentChildIndexFieldData = context.fieldData().getForField(parentFieldMapper);
-                config.fieldContext(new FieldContext(parentFieldMapper.fieldType().names().indexName(), parentChildIndexFieldData, parentFieldMapper));
+                ParentChildIndexFieldData parentChildIndexFieldData = context.fieldData().getForField(parentFieldMapper.fieldType());
+                config.fieldContext(new FieldContext(parentFieldMapper.fieldType().names().indexName(), parentChildIndexFieldData, parentFieldMapper.fieldType()));
             } else {
                 config.unmapped(true);
             }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsAggregatorFactory.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsAggregatorFactory.java
@@ -28,7 +28,7 @@ import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.lucene.index.FilterableTermsEnum;
 import org.elasticsearch.common.lucene.index.FreqTermsEnum;
-import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.search.aggregations.AggregationExecutionException;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
@@ -131,7 +131,7 @@ public class SignificantTermsAggregatorFactory extends ValuesSourceAggregatorFac
     private final IncludeExclude includeExclude;
     private final String executionHint;
     private String indexedFieldName;
-    private FieldMapper mapper;
+    private MappedFieldType fieldType;
     private FilterableTermsEnum termsEnum;
     private int numberOfAggregatorsCreated = 0;
     private final Query filter;
@@ -152,7 +152,7 @@ public class SignificantTermsAggregatorFactory extends ValuesSourceAggregatorFac
         this.significanceHeuristic = significanceHeuristic;
         if (!valueSourceConfig.unmapped()) {
             this.indexedFieldName = config.fieldContext().field();
-            mapper = SearchContext.current().smartNameFieldMapper(indexedFieldName);
+            fieldType = SearchContext.current().smartNameFieldType(indexedFieldName);
         }
         this.filter = filter;
     }
@@ -266,7 +266,7 @@ public class SignificantTermsAggregatorFactory extends ValuesSourceAggregatorFac
 
 
     public long getBackgroundFrequency(long term) {
-        BytesRef indexedVal = mapper.indexedValueForSearch(term);
+        BytesRef indexedVal = fieldType.indexedValueForSearch(term);
         return getBackgroundFrequency(indexedVal);
     }
 

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/CardinalityParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/CardinalityParser.java
@@ -72,7 +72,7 @@ public class CardinalityParser implements Aggregator.Parser {
 
         ValuesSourceConfig<?> config = vsParser.config();
 
-        if (rehash == null && config.fieldContext() != null && config.fieldContext().mapper() instanceof Murmur3FieldMapper) {
+        if (rehash == null && config.fieldContext() != null && config.fieldContext().fieldType() instanceof Murmur3FieldMapper.Murmur3FieldType) {
             rehash = false;
         } else if (rehash == null) {
             rehash = true;

--- a/core/src/main/java/org/elasticsearch/search/aggregations/support/AggregationContext.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/support/AggregationContext.java
@@ -35,7 +35,6 @@ import org.elasticsearch.search.aggregations.AggregationExecutionException;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.Date;
 
 /**
  *
@@ -102,10 +101,10 @@ public class AggregationContext {
             if (config.missing instanceof Number) {
                 missing = (Number) config.missing;
             } else {
-                if (config.fieldContext != null && config.fieldContext.mapper() instanceof DateFieldMapper) {
-                    final DateFieldMapper mapper = (DateFieldMapper) config.fieldContext.mapper();
+                if (config.fieldContext != null && config.fieldContext.fieldType() instanceof DateFieldMapper.DateFieldType) {
+                    final DateFieldMapper.DateFieldType fieldType = (DateFieldMapper.DateFieldType) config.fieldContext.fieldType();
                     try {
-                        missing = mapper.fieldType().dateTimeFormatter().parser().parseDateTime(config.missing.toString()).getMillis();
+                        missing = fieldType.dateTimeFormatter().parser().parseDateTime(config.missing.toString()).getMillis();
                     } catch (IllegalArgumentException e) {
                         throw new SearchParseException(context, "Expected a date value in [missing] but got [" + config.missing + "]", null, e);
                     }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/support/FieldContext.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/support/FieldContext.java
@@ -20,6 +20,7 @@ package org.elasticsearch.search.aggregations.support;
 
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 
 /**
  * Used by all field data based aggregators. This determine the context of the field data the aggregators are operating
@@ -29,7 +30,7 @@ public class FieldContext {
 
     private final String field;
     private final IndexFieldData<?> indexFieldData;
-    private final FieldMapper mapper;
+    private final MappedFieldType fieldType;
 
     /**
      * Constructs a field data context for the given field and its index field data
@@ -37,10 +38,10 @@ public class FieldContext {
      * @param field             The name of the field
      * @param indexFieldData    The index field data of the field
      */
-    public FieldContext(String field, IndexFieldData<?> indexFieldData, FieldMapper mapper) {
+    public FieldContext(String field, IndexFieldData<?> indexFieldData, MappedFieldType fieldType) {
         this.field = field;
         this.indexFieldData = indexFieldData;
-        this.mapper = mapper;
+        this.fieldType = fieldType;
     }
 
     public String field() {
@@ -54,8 +55,8 @@ public class FieldContext {
         return indexFieldData;
     }
 
-    public FieldMapper mapper() {
-        return mapper;
+    public MappedFieldType fieldType() {
+        return fieldType;
     }
 
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/support/format/ValueFormat.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/support/format/ValueFormat.java
@@ -71,8 +71,8 @@ public class ValueFormat {
             return new DateTime(format, new ValueFormatter.DateTime(format), new ValueParser.DateMath(format));
         }
 
-        public static DateTime mapper(DateFieldMapper mapper) {
-            return new DateTime(mapper.fieldType().dateTimeFormatter().format(), ValueFormatter.DateTime.mapper(mapper), ValueParser.DateMath.mapper(mapper));
+        public static DateTime mapper(DateFieldMapper.DateFieldType fieldType) {
+            return new DateTime(fieldType.dateTimeFormatter().format(), ValueFormatter.DateTime.mapper(fieldType), ValueParser.DateMath.mapper(fieldType));
         }
 
         public DateTime(String pattern, ValueFormatter formatter, ValueParser parser) {

--- a/core/src/main/java/org/elasticsearch/search/aggregations/support/format/ValueFormatter.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/support/format/ValueFormatter.java
@@ -104,8 +104,8 @@ public interface ValueFormatter extends Streamable {
         public static final ValueFormatter DEFAULT = new ValueFormatter.DateTime(DateFieldMapper.Defaults.DATE_TIME_FORMATTER);
         private DateTimeZone timeZone = DateTimeZone.UTC;
 
-        public static DateTime mapper(DateFieldMapper mapper) {
-            return new DateTime(mapper.fieldType().dateTimeFormatter());
+        public static DateTime mapper(DateFieldMapper.DateFieldType fieldType) {
+            return new DateTime(fieldType.dateTimeFormatter());
         }
 
         static final byte ID = 2;

--- a/core/src/main/java/org/elasticsearch/search/aggregations/support/format/ValueParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/support/format/ValueParser.java
@@ -108,8 +108,8 @@ public interface ValueParser {
             return parseLong(value, searchContext);
         }
 
-        public static DateMath mapper(DateFieldMapper mapper) {
-            return new DateMath(new DateMathParser(mapper.fieldType().dateTimeFormatter()));
+        public static DateMath mapper(DateFieldMapper.DateFieldType fieldType) {
+            return new DateMath(new DateMathParser(fieldType.dateTimeFormatter()));
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
@@ -45,7 +45,7 @@ import org.elasticsearch.index.fieldvisitor.JustUidFieldsVisitor;
 import org.elasticsearch.index.fieldvisitor.UidAndSourceFieldsVisitor;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.FieldMapper;
-import org.elasticsearch.index.mapper.FieldMappers;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.internal.SourceFieldMapper;
 import org.elasticsearch.index.mapper.object.ObjectMapper;
 import org.elasticsearch.search.SearchHit;
@@ -142,17 +142,17 @@ public class FetchPhase implements SearchPhase {
                     }
                     continue;
                 }
-                FieldMapper mapper = context.smartNameFieldMapper(fieldName);
-                if (mapper == null) {
+                MappedFieldType fieldType = context.smartNameFieldType(fieldName);
+                if (fieldType == null) {
                     // Only fail if we know it is a object field, missing paths / fields shouldn't fail.
                     if (context.smartNameObjectMapper(fieldName) != null) {
                         throw new IllegalArgumentException("field [" + fieldName + "] isn't a leaf field");
                     }
-                } else if (mapper.fieldType().stored()) {
+                } else if (fieldType.stored()) {
                     if (fieldNames == null) {
                         fieldNames = new HashSet<>();
                     }
-                    fieldNames.add(mapper.fieldType().names().indexName());
+                    fieldNames.add(fieldType.names().indexName());
                 } else {
                     if (extractFieldNames == null) {
                         extractFieldNames = newArrayList();

--- a/core/src/main/java/org/elasticsearch/search/fetch/fielddata/FieldDataFieldsFetchSubPhase.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/fielddata/FieldDataFieldsFetchSubPhase.java
@@ -19,11 +19,11 @@
 package org.elasticsearch.search.fetch.fielddata;
 
 import com.google.common.collect.ImmutableMap;
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.index.fielddata.AtomicFieldData;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.search.SearchHitField;
 import org.elasticsearch.search.SearchParseElement;
 import org.elasticsearch.search.fetch.FetchSubPhase;
@@ -80,9 +80,9 @@ public class FieldDataFieldsFetchSubPhase implements FetchSubPhase {
                 hitField = new InternalSearchHitField(field.name(), new ArrayList<>(2));
                 hitContext.hit().fields().put(field.name(), hitField);
             }
-            FieldMapper mapper = context.mapperService().smartNameFieldMapper(field.name());
-            if (mapper != null) {
-                AtomicFieldData data = context.fieldData().getForField(mapper).load(hitContext.readerContext());
+            MappedFieldType fieldType = context.mapperService().smartNameFieldType(field.name());
+            if (fieldType != null) {
+                AtomicFieldData data = context.fieldData().getForField(fieldType).load(hitContext.readerContext());
                 ScriptDocValues values = data.getScriptValues();
                 values.setNextDocId(hitContext.docId());
                 hitField.values().addAll(values.getValues());

--- a/core/src/main/java/org/elasticsearch/search/internal/DefaultSearchContext.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/DefaultSearchContext.java
@@ -50,7 +50,7 @@ import org.elasticsearch.index.cache.bitset.BitsetFilterCache;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.fielddata.IndexFieldDataService;
 import org.elasticsearch.index.mapper.FieldMapper;
-import org.elasticsearch.index.mapper.FieldMappers;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.IndexQueryParserService;
 import org.elasticsearch.index.query.ParsedQuery;
@@ -713,13 +713,13 @@ public class DefaultSearchContext extends SearchContext {
     }
 
     @Override
-    public FieldMapper smartNameFieldMapper(String name) {
-        return mapperService().smartNameFieldMapper(name, request.types());
+    public MappedFieldType smartNameFieldType(String name) {
+        return mapperService().smartNameFieldType(name, request.types());
     }
 
     @Override
-    public FieldMapper smartNameFieldMapperFromAnyType(String name) {
-        return mapperService().smartNameFieldMapper(name);
+    public MappedFieldType smartNameFieldTypeFromAnyType(String name) {
+        return mapperService().smartNameFieldType(name);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/search/internal/FilteredSearchContext.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/FilteredSearchContext.java
@@ -35,7 +35,7 @@ import org.elasticsearch.index.analysis.AnalysisService;
 import org.elasticsearch.index.cache.bitset.BitsetFilterCache;
 import org.elasticsearch.index.fielddata.IndexFieldDataService;
 import org.elasticsearch.index.mapper.FieldMapper;
-import org.elasticsearch.index.mapper.FieldMappers;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.IndexQueryParserService;
 import org.elasticsearch.index.query.ParsedQuery;
@@ -532,13 +532,13 @@ public abstract class FilteredSearchContext extends SearchContext {
     }
 
     @Override
-    public FieldMapper smartNameFieldMapper(String name) {
-        return in.smartNameFieldMapper(name);
+    public MappedFieldType smartNameFieldType(String name) {
+        return in.smartNameFieldType(name);
     }
 
     @Override
-    public FieldMapper smartNameFieldMapperFromAnyType(String name) {
-        return in.smartNameFieldMapperFromAnyType(name);
+    public MappedFieldType smartNameFieldTypeFromAnyType(String name) {
+        return in.smartNameFieldTypeFromAnyType(name);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/search/internal/SearchContext.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/SearchContext.java
@@ -21,16 +21,13 @@ package org.elasticsearch.search.internal;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.MultimapBuilder;
-
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.util.Counter;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.cache.recycler.PageCacheRecycler;
-import org.elasticsearch.common.HasContext;
 import org.elasticsearch.common.HasContextAndHeaders;
-import org.elasticsearch.common.HasHeaders;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.lease.Releasables;
@@ -38,8 +35,7 @@ import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.index.analysis.AnalysisService;
 import org.elasticsearch.index.cache.bitset.BitsetFilterCache;
 import org.elasticsearch.index.fielddata.IndexFieldDataService;
-import org.elasticsearch.index.mapper.FieldMapper;
-import org.elasticsearch.index.mapper.FieldMappers;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.IndexQueryParserService;
 import org.elasticsearch.index.query.ParsedQuery;
@@ -343,12 +339,12 @@ public abstract class SearchContext implements Releasable, HasContextAndHeaders 
 
     public abstract ScanContext scanContext();
 
-    public abstract FieldMapper smartNameFieldMapper(String name);
+    public abstract MappedFieldType smartNameFieldType(String name);
 
     /**
      * Looks up the given field, but does not restrict to fields in the types set on this context.
      */
-    public abstract FieldMapper smartNameFieldMapperFromAnyType(String name);
+    public abstract MappedFieldType smartNameFieldTypeFromAnyType(String name);
 
     public abstract MapperService.SmartNameObjectMapper smartNameObjectMapper(String name);
 

--- a/core/src/main/java/org/elasticsearch/search/lookup/FieldLookup.java
+++ b/core/src/main/java/org/elasticsearch/search/lookup/FieldLookup.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.search.lookup;
 
 import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -29,8 +30,8 @@ import java.util.Map;
  */
 public class FieldLookup {
 
-    // we can cached mapper completely per name, since its on an index/shard level (the lookup, and it does not change within the scope of a search request)
-    private final FieldMapper mapper;
+    // we can cached fieldType completely per name, since its on an index/shard level (the lookup, and it does not change within the scope of a search request)
+    private final MappedFieldType fieldType;
 
     private Map<String, List<Object>> fields;
 
@@ -42,12 +43,12 @@ public class FieldLookup {
 
     private boolean valuesLoaded = false;
 
-    FieldLookup(FieldMapper mapper) {
-        this.mapper = mapper;
+    FieldLookup(MappedFieldType fieldType) {
+        this.fieldType = fieldType;
     }
 
-    public FieldMapper mapper() {
-        return mapper;
+    public MappedFieldType fieldType() {
+        return fieldType;
     }
 
     public Map<String, List<Object>> fields() {
@@ -85,7 +86,7 @@ public class FieldLookup {
         }
         valueLoaded = true;
         value = null;
-        List<Object> values = fields.get(mapper.fieldType().names().indexName());
+        List<Object> values = fields.get(fieldType.names().indexName());
         return values != null ? value = values.get(0) : null;
     }
 
@@ -95,6 +96,6 @@ public class FieldLookup {
         }
         valuesLoaded = true;
         values.clear();
-        return values = fields().get(mapper.fieldType().names().indexName());
+        return values = fields().get(fieldType.names().indexName());
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/lookup/LeafDocLookup.java
+++ b/core/src/main/java/org/elasticsearch/search/lookup/LeafDocLookup.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.index.fielddata.IndexFieldDataService;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.apache.lucene.index.LeafReaderContext;
 
@@ -76,8 +77,8 @@ public class LeafDocLookup implements Map {
         String fieldName = key.toString();
         ScriptDocValues scriptValues = localCacheFieldData.get(fieldName);
         if (scriptValues == null) {
-            final FieldMapper mapper = mapperService.smartNameFieldMapper(fieldName, types);
-            if (mapper == null) {
+            final MappedFieldType fieldType = mapperService.smartNameFieldType(fieldName, types);
+            if (fieldType == null) {
                 throw new IllegalArgumentException("No field found for [" + fieldName + "] in mapping with types " + Arrays.toString(types) + "");
             }
             // load fielddata on behalf of the script: otherwise it would need additional permissions
@@ -85,7 +86,7 @@ public class LeafDocLookup implements Map {
             scriptValues = AccessController.doPrivileged(new PrivilegedAction<ScriptDocValues>() {
                 @Override
                 public ScriptDocValues run() {
-                    return fieldDataService.getForField(mapper).load(reader).getScriptValues();
+                    return fieldDataService.getForField(fieldType).load(reader).getScriptValues();
                 }
             });
             localCacheFieldData.put(fieldName, scriptValues);
@@ -100,8 +101,8 @@ public class LeafDocLookup implements Map {
         String fieldName = key.toString();
         ScriptDocValues scriptValues = localCacheFieldData.get(fieldName);
         if (scriptValues == null) {
-            FieldMapper mapper = mapperService.smartNameFieldMapper(fieldName, types);
-            if (mapper == null) {
+            MappedFieldType fieldType = mapperService.smartNameFieldType(fieldName, types);
+            if (fieldType == null) {
                 return false;
             }
         }

--- a/core/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortParser.java
+++ b/core/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortParser.java
@@ -43,6 +43,7 @@ import org.elasticsearch.index.fielddata.MultiGeoPointValues;
 import org.elasticsearch.index.fielddata.NumericDoubleValues;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.object.ObjectMapper;
 import org.elasticsearch.index.query.support.NestedInnerQueryParseSupport;
 import org.elasticsearch.search.MultiValueMode;
@@ -139,12 +140,12 @@ public class GeoDistanceSortParser implements SortParser {
             throw new IllegalArgumentException("sort_mode [sum] isn't supported for sorting by geo distance");
         }
 
-        FieldMapper mapper = context.smartNameFieldMapper(fieldName);
-        if (mapper == null) {
+        MappedFieldType fieldType = context.smartNameFieldType(fieldName);
+        if (fieldType == null) {
             throw new IllegalArgumentException("failed to find mapper for [" + fieldName + "] for geo distance based sort");
         }
         final MultiValueMode finalSortMode = sortMode; // final reference for use in the anonymous class
-        final IndexGeoPointFieldData geoIndexFieldData = context.fieldData().getForField(mapper);
+        final IndexGeoPointFieldData geoIndexFieldData = context.fieldData().getForField(fieldType);
         final FixedSourceDistance[] distances = new FixedSourceDistance[geoPoints.size()];
         for (int i = 0; i< geoPoints.size(); i++) {
             distances[i] = geoDistance.fixedSourceDistance(geoPoints.get(i).lat(), geoPoints.get(i).lon(), unit);

--- a/core/src/main/java/org/elasticsearch/search/suggest/completion/Completion090PostingsFormat.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/completion/Completion090PostingsFormat.java
@@ -20,7 +20,6 @@ package org.elasticsearch.search.suggest.completion;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMap.Builder;
-
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.codecs.FieldsConsumer;
 import org.apache.lucene.codecs.FieldsProducer;
@@ -46,6 +45,7 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.core.CompletionFieldMapper;
 import org.elasticsearch.search.suggest.completion.CompletionTokenStream.ToFiniteStrings;
 
@@ -260,7 +260,7 @@ public class Completion090PostingsFormat extends PostingsFormat {
             this.lookup = lookup;
         }
 
-        public Lookup getLookup(CompletionFieldMapper mapper, CompletionSuggestionContext suggestionContext) {
+        public Lookup getLookup(CompletionFieldMapper.CompletionFieldType mapper, CompletionSuggestionContext suggestionContext) {
             return lookup.getLookup(mapper, suggestionContext);
         }
 
@@ -340,8 +340,8 @@ public class Completion090PostingsFormat extends PostingsFormat {
     }
 
     public static abstract class LookupFactory implements Accountable {
-        public abstract Lookup getLookup(CompletionFieldMapper mapper, CompletionSuggestionContext suggestionContext);
+        public abstract Lookup getLookup(CompletionFieldMapper.CompletionFieldType fieldType, CompletionSuggestionContext suggestionContext);
         public abstract CompletionStats stats(String ... fields);
-        abstract AnalyzingCompletionLookupProvider.AnalyzingSuggestHolder getAnalyzingSuggestHolder(CompletionFieldMapper mapper);
+        abstract AnalyzingCompletionLookupProvider.AnalyzingSuggestHolder getAnalyzingSuggestHolder(MappedFieldType fieldType);
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestParser.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestParser.java
@@ -100,16 +100,16 @@ public class CompletionSuggestParser implements SuggestContextParser {
             }
         }
         
-        suggestion.mapper((CompletionFieldMapper)mapperService.smartNameFieldMapper(suggestion.getField()));
+        suggestion.fieldType((CompletionFieldMapper.CompletionFieldType) mapperService.smartNameFieldType(suggestion.getField()));
 
-        CompletionFieldMapper mapper = suggestion.mapper();
-        if (mapper != null) {
-            if (mapper.requiresContext()) {
+        CompletionFieldMapper.CompletionFieldType fieldType = suggestion.fieldType();
+        if (fieldType != null) {
+            if (fieldType.requiresContext()) {
                 if (contextParser == null) {
                     throw new IllegalArgumentException("suggester [completion] requires context to be setup");
                 } else {
                     contextParser.nextToken();
-                    List<ContextQuery> contextQueries = ContextQuery.parseQueries(mapper.getContextMapping(), contextParser);
+                    List<ContextQuery> contextQueries = ContextQuery.parseQueries(fieldType.getContextMapping(), contextParser);
                     suggestion.setContextQuery(contextQueries);
                 }
             } else if (contextParser != null) {

--- a/core/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggester.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggester.java
@@ -50,7 +50,7 @@ public class CompletionSuggester extends Suggester<CompletionSuggestionContext> 
     @Override
     protected Suggest.Suggestion<? extends Suggest.Suggestion.Entry<? extends Suggest.Suggestion.Entry.Option>> innerExecute(String name,
             CompletionSuggestionContext suggestionContext, IndexSearcher searcher, CharsRefBuilder spare) throws IOException {
-        if (suggestionContext.mapper() == null || !(suggestionContext.mapper() instanceof CompletionFieldMapper)) {
+        if (suggestionContext.fieldType() == null) {
             throw new ElasticsearchException("Field [" + suggestionContext.getField() + "] is not a completion suggest field");
         }
         final IndexReader indexReader = searcher.getIndexReader();
@@ -67,7 +67,7 @@ public class CompletionSuggester extends Suggester<CompletionSuggestionContext> 
             Terms terms = atomicReader.fields().terms(fieldName);
             if (terms instanceof Completion090PostingsFormat.CompletionTerms) {
                 final Completion090PostingsFormat.CompletionTerms lookupTerms = (Completion090PostingsFormat.CompletionTerms) terms;
-                final Lookup lookup = lookupTerms.getLookup(suggestionContext.mapper(), suggestionContext);
+                final Lookup lookup = lookupTerms.getLookup(suggestionContext.fieldType(), suggestionContext);
                 if (lookup == null) {
                     // we don't have a lookup for this segment.. this might be possible if a merge dropped all
                     // docs from the segment that had a value in this segment.

--- a/core/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestionContext.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestionContext.java
@@ -32,7 +32,7 @@ import java.util.List;
  */
 public class CompletionSuggestionContext extends SuggestionSearchContext.SuggestionContext {
 
-    private CompletionFieldMapper mapper;
+    private CompletionFieldMapper.CompletionFieldType fieldType;
     private int fuzzyEditDistance = XFuzzySuggester.DEFAULT_MAX_EDITS;
     private boolean fuzzyTranspositions = XFuzzySuggester.DEFAULT_TRANSPOSITIONS;
     private int fuzzyMinLength = XFuzzySuggester.DEFAULT_MIN_FUZZY_LENGTH;
@@ -45,12 +45,12 @@ public class CompletionSuggestionContext extends SuggestionSearchContext.Suggest
         super(suggester);
     }
 
-    public CompletionFieldMapper mapper() {
-        return this.mapper;
+    public CompletionFieldMapper.CompletionFieldType fieldType() {
+        return this.fieldType;
     }
 
-    public void mapper(CompletionFieldMapper mapper) {
-        this.mapper = mapper;
+    public void fieldType(CompletionFieldMapper.CompletionFieldType fieldType) {
+        this.fieldType = fieldType;
     }
 
     public void setFuzzyEditDistance(int fuzzyEditDistance) {

--- a/core/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestParser.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestParser.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentParser.Token;
 import org.elasticsearch.index.analysis.ShingleTokenFilterFactory;
 import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.IndexQueryParserService;
 import org.elasticsearch.script.CompiledScript;
@@ -166,15 +167,15 @@ public final class PhraseSuggestParser implements SuggestContextParser {
             throw new IllegalArgumentException("The required field option is missing");
         }
 
-        FieldMapper fieldMapper = mapperService.smartNameFieldMapper(suggestion.getField());
-        if (fieldMapper == null) {
+        MappedFieldType fieldType = mapperService.smartNameFieldType(suggestion.getField());
+        if (fieldType == null) {
             throw new IllegalArgumentException("No mapping found for field [" + suggestion.getField() + "]");
         } else if (suggestion.getAnalyzer() == null) {
             // no analyzer name passed in, so try the field's analyzer, or the default analyzer
-            if (fieldMapper.fieldType().searchAnalyzer() == null) {
+            if (fieldType.searchAnalyzer() == null) {
                 suggestion.setAnalyzer(mapperService.searchAnalyzer());
             } else {
-                suggestion.setAnalyzer(fieldMapper.fieldType().searchAnalyzer());
+                suggestion.setAnalyzer(fieldType.searchAnalyzer());
             }
         }
         
@@ -324,7 +325,7 @@ public final class PhraseSuggestParser implements SuggestContextParser {
         if (!SuggestUtils.parseDirectSpellcheckerSettings(parser, fieldName, generator)) {
             if ("field".equals(fieldName)) {
                 generator.setField(parser.text());
-                if (mapperService.smartNameFieldMapper(generator.field()) == null) {
+                if (mapperService.smartNameFieldType(generator.field()) == null) {
                     throw new IllegalArgumentException("No mapping found for field [" + generator.field() + "]");
                 }
             } else if ("size".equals(fieldName)) {

--- a/core/src/test/java/org/elasticsearch/index/fielddata/AbstractFieldDataTests.java
+++ b/core/src/test/java/org/elasticsearch/index/fielddata/AbstractFieldDataTests.java
@@ -29,6 +29,7 @@ import org.apache.lucene.store.RAMDirectory;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.mapper.ContentPath;
 import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper.BuilderContext;
 import org.elasticsearch.index.mapper.MapperBuilders;
 import org.elasticsearch.index.mapper.MapperService;
@@ -65,32 +66,32 @@ public abstract class AbstractFieldDataTests extends ElasticsearchSingleNodeTest
     }
 
     public <IFD extends IndexFieldData<?>> IFD getForField(FieldDataType type, String fieldName, boolean docValues) {
-        final FieldMapper mapper;
+        final MappedFieldType fieldType;
         final BuilderContext context = new BuilderContext(indexService.settingsService().getSettings(), new ContentPath(1));
         if (type.getType().equals("string")) {
-            mapper = MapperBuilders.stringField(fieldName).tokenized(false).docValues(docValues).fieldDataSettings(type.getSettings()).build(context);
+            fieldType = MapperBuilders.stringField(fieldName).tokenized(false).docValues(docValues).fieldDataSettings(type.getSettings()).build(context).fieldType();
         } else if (type.getType().equals("float")) {
-            mapper = MapperBuilders.floatField(fieldName).docValues(docValues).fieldDataSettings(type.getSettings()).build(context);
+            fieldType = MapperBuilders.floatField(fieldName).docValues(docValues).fieldDataSettings(type.getSettings()).build(context).fieldType();
         } else if (type.getType().equals("double")) {
-            mapper = MapperBuilders.doubleField(fieldName).docValues(docValues).fieldDataSettings(type.getSettings()).build(context);
+            fieldType = MapperBuilders.doubleField(fieldName).docValues(docValues).fieldDataSettings(type.getSettings()).build(context).fieldType();
         } else if (type.getType().equals("long")) {
-            mapper = MapperBuilders.longField(fieldName).docValues(docValues).fieldDataSettings(type.getSettings()).build(context);
+            fieldType = MapperBuilders.longField(fieldName).docValues(docValues).fieldDataSettings(type.getSettings()).build(context).fieldType();
         } else if (type.getType().equals("int")) {
-            mapper = MapperBuilders.integerField(fieldName).docValues(docValues).fieldDataSettings(type.getSettings()).build(context);
+            fieldType = MapperBuilders.integerField(fieldName).docValues(docValues).fieldDataSettings(type.getSettings()).build(context).fieldType();
         } else if (type.getType().equals("short")) {
-            mapper = MapperBuilders.shortField(fieldName).docValues(docValues).fieldDataSettings(type.getSettings()).build(context);
+            fieldType = MapperBuilders.shortField(fieldName).docValues(docValues).fieldDataSettings(type.getSettings()).build(context).fieldType();
         } else if (type.getType().equals("byte")) {
-            mapper = MapperBuilders.byteField(fieldName).docValues(docValues).fieldDataSettings(type.getSettings()).build(context);
+            fieldType = MapperBuilders.byteField(fieldName).docValues(docValues).fieldDataSettings(type.getSettings()).build(context).fieldType();
         } else if (type.getType().equals("geo_point")) {
-            mapper = MapperBuilders.geoPointField(fieldName).docValues(docValues).fieldDataSettings(type.getSettings()).build(context);
+            fieldType = MapperBuilders.geoPointField(fieldName).docValues(docValues).fieldDataSettings(type.getSettings()).build(context).fieldType();
         } else if (type.getType().equals("_parent")) {
-            mapper = MapperBuilders.parent().type(fieldName).build(context);
+            fieldType = MapperBuilders.parent().type(fieldName).build(context).fieldType();
         } else if (type.getType().equals("binary")) {
-            mapper = MapperBuilders.binaryField(fieldName).docValues(docValues).fieldDataSettings(type.getSettings()).build(context);
+            fieldType = MapperBuilders.binaryField(fieldName).docValues(docValues).fieldDataSettings(type.getSettings()).build(context).fieldType();
         } else {
             throw new UnsupportedOperationException(type.getType());
         }
-        return ifdService.getForField(mapper);
+        return ifdService.getForField(fieldType);
     }
 
     @Before

--- a/core/src/test/java/org/elasticsearch/index/fielddata/IndexFieldDataServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/index/fielddata/IndexFieldDataServiceTests.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.fielddata.plain.*;
 import org.elasticsearch.index.mapper.ContentPath;
 import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper.BuilderContext;
 import org.elasticsearch.index.mapper.MapperBuilders;
 import org.elasticsearch.index.mapper.core.*;
@@ -51,7 +52,7 @@ public class IndexFieldDataServiceTests extends ElasticsearchSingleNodeTest {
         final IndexFieldDataService ifdService = indexService.fieldData();
         for (boolean docValues : Arrays.asList(true, false)) {
             final BuilderContext ctx = new BuilderContext(indexService.settingsService().getSettings(), new ContentPath(1));
-            final StringFieldMapper stringMapper = new StringFieldMapper.Builder("string").tokenized(false).docValues(docValues).build(ctx);
+            final MappedFieldType stringMapper = new StringFieldMapper.Builder("string").tokenized(false).docValues(docValues).build(ctx).fieldType();
             ifdService.clear();
             IndexFieldData<?> fd = ifdService.getForField(stringMapper);
             if (docValues) {
@@ -60,11 +61,11 @@ public class IndexFieldDataServiceTests extends ElasticsearchSingleNodeTest {
                 assertTrue(fd instanceof PagedBytesIndexFieldData);
             }
 
-            for (FieldMapper mapper : Arrays.asList(
-                    new ByteFieldMapper.Builder("int").docValues(docValues).build(ctx),
-                    new ShortFieldMapper.Builder("int").docValues(docValues).build(ctx),
-                    new IntegerFieldMapper.Builder("int").docValues(docValues).build(ctx),
-                    new LongFieldMapper.Builder("long").docValues(docValues).build(ctx)
+            for (MappedFieldType mapper : Arrays.asList(
+                    new ByteFieldMapper.Builder("int").docValues(docValues).build(ctx).fieldType(),
+                    new ShortFieldMapper.Builder("int").docValues(docValues).build(ctx).fieldType(),
+                    new IntegerFieldMapper.Builder("int").docValues(docValues).build(ctx).fieldType(),
+                    new LongFieldMapper.Builder("long").docValues(docValues).build(ctx).fieldType()
                     )) {
                 ifdService.clear();
                 fd = ifdService.getForField(mapper);
@@ -75,7 +76,7 @@ public class IndexFieldDataServiceTests extends ElasticsearchSingleNodeTest {
                 }
             }
 
-            final FloatFieldMapper floatMapper = new FloatFieldMapper.Builder("float").docValues(docValues).build(ctx);
+            final MappedFieldType floatMapper = new FloatFieldMapper.Builder("float").docValues(docValues).build(ctx).fieldType();
             ifdService.clear();
             fd = ifdService.getForField(floatMapper);
             if (docValues) {
@@ -84,7 +85,7 @@ public class IndexFieldDataServiceTests extends ElasticsearchSingleNodeTest {
                 assertTrue(fd instanceof FloatArrayIndexFieldData);
             }
 
-            final DoubleFieldMapper doubleMapper = new DoubleFieldMapper.Builder("double").docValues(docValues).build(ctx);
+            final MappedFieldType doubleMapper = new DoubleFieldMapper.Builder("double").docValues(docValues).build(ctx).fieldType();
             ifdService.clear();
             fd = ifdService.getForField(doubleMapper);
             if (docValues) {
@@ -100,29 +101,29 @@ public class IndexFieldDataServiceTests extends ElasticsearchSingleNodeTest {
         final IndexService indexService = createIndex("test");
         final IndexFieldDataService ifdService = indexService.fieldData();
         final BuilderContext ctx = new BuilderContext(indexService.settingsService().getSettings(), new ContentPath(1));
-        final StringFieldMapper stringMapper = MapperBuilders.stringField("string").tokenized(false).fieldDataSettings(DOC_VALUES_SETTINGS).fieldDataSettings(Settings.builder().put("format", "fst").build()).build(ctx);
+        final MappedFieldType stringMapper = MapperBuilders.stringField("string").tokenized(false).fieldDataSettings(DOC_VALUES_SETTINGS).fieldDataSettings(Settings.builder().put("format", "fst").build()).build(ctx).fieldType();
         ifdService.clear();
         IndexFieldData<?> fd = ifdService.getForField(stringMapper);
         assertTrue(fd instanceof FSTBytesIndexFieldData);
 
         final Settings fdSettings = Settings.builder().put("format", "array").build();
-        for (FieldMapper mapper : Arrays.asList(
-                new ByteFieldMapper.Builder("int").fieldDataSettings(DOC_VALUES_SETTINGS).fieldDataSettings(fdSettings).build(ctx),
-                new ShortFieldMapper.Builder("int").fieldDataSettings(DOC_VALUES_SETTINGS).fieldDataSettings(fdSettings).build(ctx),
-                new IntegerFieldMapper.Builder("int").fieldDataSettings(DOC_VALUES_SETTINGS).fieldDataSettings(fdSettings).build(ctx),
-                new LongFieldMapper.Builder("long").fieldDataSettings(DOC_VALUES_SETTINGS).fieldDataSettings(fdSettings).build(ctx)
+        for (MappedFieldType mapper : Arrays.asList(
+                new ByteFieldMapper.Builder("int").fieldDataSettings(DOC_VALUES_SETTINGS).fieldDataSettings(fdSettings).build(ctx).fieldType(),
+                new ShortFieldMapper.Builder("int").fieldDataSettings(DOC_VALUES_SETTINGS).fieldDataSettings(fdSettings).build(ctx).fieldType(),
+                new IntegerFieldMapper.Builder("int").fieldDataSettings(DOC_VALUES_SETTINGS).fieldDataSettings(fdSettings).build(ctx).fieldType(),
+                new LongFieldMapper.Builder("long").fieldDataSettings(DOC_VALUES_SETTINGS).fieldDataSettings(fdSettings).build(ctx).fieldType()
                 )) {
             ifdService.clear();
             fd = ifdService.getForField(mapper);
             assertTrue(fd instanceof PackedArrayIndexFieldData);
         }
 
-        final FloatFieldMapper floatMapper = MapperBuilders.floatField("float").fieldDataSettings(DOC_VALUES_SETTINGS).fieldDataSettings(fdSettings).build(ctx);
+        final MappedFieldType floatMapper = MapperBuilders.floatField("float").fieldDataSettings(DOC_VALUES_SETTINGS).fieldDataSettings(fdSettings).build(ctx).fieldType();
         ifdService.clear();
         fd = ifdService.getForField(floatMapper);
         assertTrue(fd instanceof FloatArrayIndexFieldData);
 
-        final DoubleFieldMapper doubleMapper = MapperBuilders.doubleField("double").fieldDataSettings(DOC_VALUES_SETTINGS).fieldDataSettings(fdSettings).build(ctx);
+        final MappedFieldType doubleMapper = MapperBuilders.doubleField("double").fieldDataSettings(DOC_VALUES_SETTINGS).fieldDataSettings(fdSettings).build(ctx).fieldType();
         ifdService.clear();
         fd = ifdService.getForField(doubleMapper);
         assertTrue(fd instanceof DoubleArrayIndexFieldData);
@@ -132,7 +133,7 @@ public class IndexFieldDataServiceTests extends ElasticsearchSingleNodeTest {
         final IndexService indexService = createIndex("test");
         final IndexFieldDataService ifdService = indexService.fieldData();
         final BuilderContext ctx = new BuilderContext(indexService.settingsService().getSettings(), new ContentPath(1));
-        final StringFieldMapper mapper1 = MapperBuilders.stringField("s").tokenized(false).fieldDataSettings(Settings.builder().put(FieldDataType.FORMAT_KEY, "paged_bytes").build()).build(ctx);
+        final MappedFieldType mapper1 = MapperBuilders.stringField("s").tokenized(false).fieldDataSettings(Settings.builder().put(FieldDataType.FORMAT_KEY, "paged_bytes").build()).build(ctx).fieldType();
         final IndexWriter writer = new IndexWriter(new RAMDirectory(), new IndexWriterConfig(new KeywordAnalyzer()));
         Document doc = new Document();
         doc.add(new StringField("s", "thisisastring", Store.NO));
@@ -149,7 +150,7 @@ public class IndexFieldDataServiceTests extends ElasticsearchSingleNodeTest {
         // write new segment
         writer.addDocument(doc);
         final IndexReader reader2 = DirectoryReader.open(writer, true);
-        final StringFieldMapper mapper2 = MapperBuilders.stringField("s").tokenized(false).fieldDataSettings(Settings.builder().put(FieldDataType.FORMAT_KEY, "fst").build()).build(ctx);
+        final MappedFieldType mapper2 = MapperBuilders.stringField("s").tokenized(false).fieldDataSettings(Settings.builder().put(FieldDataType.FORMAT_KEY, "fst").build()).build(ctx).fieldType();
         ifdService.onMappingUpdate();
         ifd = ifdService.getForField(mapper2);
         assertThat(ifd, instanceOf(FSTBytesIndexFieldData.class));

--- a/core/src/test/java/org/elasticsearch/index/mapper/DynamicMappingTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/DynamicMappingTests.java
@@ -165,8 +165,8 @@ public class DynamicMappingTests extends ElasticsearchSingleNodeTest {
     public void testDynamicMappingOnEmptyString() throws Exception {
         IndexService service = createIndex("test");
         client().prepareIndex("test", "type").setSource("empty_field", "").get();
-        FieldMapper mapper = service.mapperService().fullName("empty_field");
-        assertNotNull(mapper);
+        MappedFieldType fieldType = service.mapperService().fullName("empty_field");
+        assertNotNull(fieldType);
     }
 
     public void testTypeNotCreatedOnIndexFailure() throws IOException, InterruptedException {

--- a/core/src/test/java/org/elasticsearch/index/search/child/ChildrenConstantScoreQueryTests.java
+++ b/core/src/test/java/org/elasticsearch/index/search/child/ChildrenConstantScoreQueryTests.java
@@ -90,7 +90,7 @@ public class ChildrenConstantScoreQueryTests extends AbstractChildTests {
     public void testBasicQuerySanities() {
         Query childQuery = new TermQuery(new Term("field", "value"));
         ParentFieldMapper parentFieldMapper = SearchContext.current().mapperService().documentMapper("child").parentFieldMapper();
-        ParentChildIndexFieldData parentChildIndexFieldData = SearchContext.current().fieldData().getForField(parentFieldMapper);
+        ParentChildIndexFieldData parentChildIndexFieldData = SearchContext.current().fieldData().getForField(parentFieldMapper.fieldType());
         BitDocIdSetFilter parentFilter = wrapWithBitSetFilter(new QueryWrapperFilter(new TermQuery(new Term(TypeFieldMapper.NAME, "parent"))));
         Query query = new ChildrenConstantScoreQuery(parentChildIndexFieldData, childQuery, "parent", "child", parentFilter, 12, wrapWithBitSetFilter(Queries.newNonNestedFilter()));
         QueryUtils.check(query);
@@ -127,7 +127,7 @@ public class ChildrenConstantScoreQueryTests extends AbstractChildTests {
         BitDocIdSetFilter parentFilter = wrapWithBitSetFilter(new QueryWrapperFilter(new TermQuery(new Term(TypeFieldMapper.NAME, "parent"))));
         int shortCircuitParentDocSet = random().nextInt(5);
         ParentFieldMapper parentFieldMapper = SearchContext.current().mapperService().documentMapper("child").parentFieldMapper();
-        ParentChildIndexFieldData parentChildIndexFieldData = SearchContext.current().fieldData().getForField(parentFieldMapper);
+        ParentChildIndexFieldData parentChildIndexFieldData = SearchContext.current().fieldData().getForField(parentFieldMapper.fieldType());
         ChildrenConstantScoreQuery query = new ChildrenConstantScoreQuery(parentChildIndexFieldData, childQuery, "parent", "child", parentFilter, shortCircuitParentDocSet, null);
 
         BitSetCollector collector = new BitSetCollector(indexReader.maxDoc());

--- a/core/src/test/java/org/elasticsearch/index/search/child/ChildrenQueryTests.java
+++ b/core/src/test/java/org/elasticsearch/index/search/child/ChildrenQueryTests.java
@@ -108,7 +108,7 @@ public class ChildrenQueryTests extends AbstractChildTests {
         Query childQuery = new TermQuery(new Term("field", "value"));
         ScoreType scoreType = ScoreType.values()[random().nextInt(ScoreType.values().length)];
         ParentFieldMapper parentFieldMapper = SearchContext.current().mapperService().documentMapper("child").parentFieldMapper();
-        ParentChildIndexFieldData parentChildIndexFieldData = SearchContext.current().fieldData().getForField(parentFieldMapper);
+        ParentChildIndexFieldData parentChildIndexFieldData = SearchContext.current().fieldData().getForField(parentFieldMapper.fieldType());
         BitDocIdSetFilter parentFilter = wrapWithBitSetFilter(new QueryWrapperFilter(new TermQuery(new Term(TypeFieldMapper.NAME, "parent"))));
         int minChildren = random().nextInt(10);
         int maxChildren = scaledRandomIntBetween(minChildren, 10);

--- a/core/src/test/java/org/elasticsearch/index/search/child/ParentConstantScoreQueryTests.java
+++ b/core/src/test/java/org/elasticsearch/index/search/child/ParentConstantScoreQueryTests.java
@@ -90,7 +90,7 @@ public class ParentConstantScoreQueryTests extends AbstractChildTests {
     public void testBasicQuerySanities() {
         Query parentQuery = new TermQuery(new Term("field", "value"));
         ParentFieldMapper parentFieldMapper = SearchContext.current().mapperService().documentMapper("child").parentFieldMapper();
-        ParentChildIndexFieldData parentChildIndexFieldData = SearchContext.current().fieldData().getForField(parentFieldMapper);
+        ParentChildIndexFieldData parentChildIndexFieldData = SearchContext.current().fieldData().getForField(parentFieldMapper.fieldType());
         BitDocIdSetFilter childrenFilter = wrapWithBitSetFilter(new QueryWrapperFilter(new TermQuery(new Term(TypeFieldMapper.NAME, "child"))));
         Query query = new ParentConstantScoreQuery(parentChildIndexFieldData, parentQuery, "parent", childrenFilter);
         QueryUtils.check(query);

--- a/core/src/test/java/org/elasticsearch/index/search/child/ParentQueryTests.java
+++ b/core/src/test/java/org/elasticsearch/index/search/child/ParentQueryTests.java
@@ -94,7 +94,7 @@ public class ParentQueryTests extends AbstractChildTests {
     public void testBasicQuerySanities() {
         Query parentQuery = new TermQuery(new Term("field", "value"));
         ParentFieldMapper parentFieldMapper = SearchContext.current().mapperService().documentMapper("child").parentFieldMapper();
-        ParentChildIndexFieldData parentChildIndexFieldData = SearchContext.current().fieldData().getForField(parentFieldMapper);
+        ParentChildIndexFieldData parentChildIndexFieldData = SearchContext.current().fieldData().getForField(parentFieldMapper.fieldType());
         BitDocIdSetFilter childrenFilter = wrapWithBitSetFilter(new QueryWrapperFilter(new TermQuery(new Term(TypeFieldMapper.NAME, "child"))));
         Query query = new ParentQuery(parentChildIndexFieldData, parentQuery, "parent", childrenFilter);
         QueryUtils.check(query);

--- a/core/src/test/java/org/elasticsearch/search/geo/GeoShapeIntegrationTests.java
+++ b/core/src/test/java/org/elasticsearch/search/geo/GeoShapeIntegrationTests.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.geo.GeoShapeFieldMapper;
 import org.elasticsearch.index.query.GeoShapeQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -457,11 +458,11 @@ public class GeoShapeIntegrationTests extends ElasticsearchIntegrationTest {
         // left orientation test
         IndicesService indicesService = internalCluster().getInstance(IndicesService.class, findNodeName(idxName));
         IndexService indexService = indicesService.indexService(idxName);
-        FieldMapper fieldMapper = indexService.mapperService().smartNameFieldMapper("location");
-        assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
+        MappedFieldType fieldType = indexService.mapperService().smartNameFieldType("location");
+        assertThat(fieldType, instanceOf(GeoShapeFieldMapper.GeoShapeFieldType.class));
 
-        GeoShapeFieldMapper gsfm = (GeoShapeFieldMapper)fieldMapper;
-        ShapeBuilder.Orientation orientation = gsfm.fieldType().orientation();
+        GeoShapeFieldMapper.GeoShapeFieldType gsfm = (GeoShapeFieldMapper.GeoShapeFieldType)fieldType;
+        ShapeBuilder.Orientation orientation = gsfm.orientation();
         assertThat(orientation, equalTo(ShapeBuilder.Orientation.CLOCKWISE));
         assertThat(orientation, equalTo(ShapeBuilder.Orientation.LEFT));
         assertThat(orientation, equalTo(ShapeBuilder.Orientation.CW));
@@ -469,11 +470,11 @@ public class GeoShapeIntegrationTests extends ElasticsearchIntegrationTest {
         // right orientation test
         indicesService = internalCluster().getInstance(IndicesService.class, findNodeName(idxName+"2"));
         indexService = indicesService.indexService(idxName+"2");
-        fieldMapper = indexService.mapperService().smartNameFieldMapper("location");
-        assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
+        fieldType = indexService.mapperService().smartNameFieldType("location");
+        assertThat(fieldType, instanceOf(GeoShapeFieldMapper.GeoShapeFieldType.class));
 
-        gsfm = (GeoShapeFieldMapper)fieldMapper;
-        orientation = gsfm.fieldType().orientation();
+        gsfm = (GeoShapeFieldMapper.GeoShapeFieldType)fieldType;
+        orientation = gsfm.orientation();
         assertThat(orientation, equalTo(ShapeBuilder.Orientation.COUNTER_CLOCKWISE));
         assertThat(orientation, equalTo(ShapeBuilder.Orientation.RIGHT));
         assertThat(orientation, equalTo(ShapeBuilder.Orientation.CCW));

--- a/core/src/test/java/org/elasticsearch/test/TestSearchContext.java
+++ b/core/src/test/java/org/elasticsearch/test/TestSearchContext.java
@@ -36,8 +36,7 @@ import org.elasticsearch.index.analysis.AnalysisService;
 import org.elasticsearch.index.cache.bitset.BitsetFilterCache;
 import org.elasticsearch.index.cache.filter.FilterCache;
 import org.elasticsearch.index.fielddata.IndexFieldDataService;
-import org.elasticsearch.index.mapper.FieldMapper;
-import org.elasticsearch.index.mapper.FieldMappers;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.IndexQueryParserService;
 import org.elasticsearch.index.query.ParsedQuery;
@@ -552,17 +551,17 @@ public class TestSearchContext extends SearchContext {
     }
 
     @Override
-    public FieldMapper smartNameFieldMapper(String name) {
+    public MappedFieldType smartNameFieldType(String name) {
         if (mapperService() != null) {
-            return mapperService().smartNameFieldMapper(name, types());
+            return mapperService().smartNameFieldType(name, types());
         }
         return null;
     }
 
     @Override
-    public FieldMapper smartNameFieldMapperFromAnyType(String name) {
+    public MappedFieldType smartNameFieldTypeFromAnyType(String name) {
         if (mapperService() != null) {
-            return mapperService().smartNameFieldMapper(name);
+            return mapperService().smartNameFieldType(name);
         }
         return null;
     }


### PR DESCRIPTION
The MapperService is the "index wide view" of mappings. Methods on it
are used at query time to lookup how to query a field. This
change reduces the exposed api so that any information returned
is limited to that api exposed by MappedFieldType. In the future,
MappedFieldType will be guaranteed to be the same across all
document types for a given field.

Note CompletionFieldType needed some more settings moved to it. Other
than that, this change is almost purely cosmetic.
