### PR TITLE
Bugfix: ignore_above uses string length, not utf-8

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/core/StringFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/StringFieldMapper.java
@@ -41,6 +41,7 @@ import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.internal.AllFieldMapper;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -280,7 +281,7 @@ public class StringFieldMapper extends AbstractFieldMapper implements AllFieldMa
         if (valueAndBoost.value() == null) {
             return;
         }
-        if (ignoreAbove > 0 && valueAndBoost.value().length() > ignoreAbove) {
+        if (ignoreAbove > 0 && lengthInBytes(valueAndBoost.value()) > ignoreAbove) {
             return;
         }
         if (context.includeInAll(includeInAll, this)) {
@@ -297,6 +298,14 @@ public class StringFieldMapper extends AbstractFieldMapper implements AllFieldMa
         }
         if (fields.isEmpty()) {
             context.ignoredValue(fieldType.names().indexName(), valueAndBoost.value());
+        }
+    }
+
+    private int lengthInBytes(final String str) {
+        try {
+            return str.getBytes("UTF-8").length;
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException("Missing the UTF-8 encoding, unexpectedly.", e);
         }
     }
 


### PR DESCRIPTION
ignore_above is intended to guard against the lucene limitation
that a term cannot exceed 32766 bytes.

However, the implementation just used the character count, which
doesn't take into account the fact that some characters have
multi-byte utf-8 encodings.

This commit causes the string field mapper to use the byte length
of the UTF-8 encoding instead, which should correctly filter out
terms whose lengths exceed the limit in bytes.
