### PR TITLE
`ignore_above` uses string length, not utf-8

### DIFF
--- a/docs/reference/mapping/types/core-types.asciidoc
+++ b/docs/reference/mapping/types/core-types.asciidoc
@@ -143,6 +143,11 @@ defaults to `true` or to the parent `object` type setting.
 |`ignore_above` |The analyzer will ignore strings larger than this size.
 Useful for generic `not_analyzed` fields that should ignore long text.
 
+This option is also useful for protecting against lucene's term byte-length limit of 32766.
+Note: the value for `ignore_above` is the _character count_, but lucene counts bytes, so 
+if you have UTF-8 text, you may want to set the limit to `32766 / 3 = 10922` 
+(since UTF-8 characters may occupy at most 3 bytes).
+
 |`position_offset_gap` |Position increment gap between field instances
 with the same field name. Defaults to 0.
 |=======================================================================


### PR DESCRIPTION
ignore_above is intended to guard against the lucene limitation
that a term cannot exceed 32766 bytes.

However, the implementation just used the character count, which
doesn't take into account the fact that some characters have
multi-byte utf-8 encodings.

This commit causes the string field mapper to use the byte length
of the UTF-8 encoding instead, which should correctly filter out
terms whose lengths exceed the limit in bytes.
