### PR TITLE
Remove leftover sugar methods from FieldMapper

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/fieldvisitor/FieldsVisitor.java
+++ b/core/src/main/java/org/elasticsearch/index/fieldvisitor/FieldsVisitor.java
@@ -81,7 +81,7 @@ public abstract class FieldsVisitor extends StoredFieldVisitor {
             }
             List<Object> fieldValues = entry.getValue();
             for (int i = 0; i < fieldValues.size(); i++) {
-                fieldValues.set(i, fieldMapper.valueForSearch(fieldValues.get(i)));
+                fieldValues.set(i, fieldMapper.fieldType().valueForSearch(fieldValues.get(i)));
             }
         }
     }

--- a/core/src/main/java/org/elasticsearch/index/get/ShardGetService.java
+++ b/core/src/main/java/org/elasticsearch/index/get/ShardGetService.java
@@ -252,7 +252,7 @@ public class ShardGetService extends AbstractIndexShardComponent {
                                 List<Object> values = searchLookup.source().extractRawValues(field);
                                 if (!values.isEmpty()) {
                                     for (int i = 0; i < values.size(); i++) {
-                                        values.set(i, fieldMapper.valueForSearch(values.get(i)));
+                                        values.set(i, fieldMapper.fieldType().valueForSearch(values.get(i)));
                                     }
                                     value = values;
                                 }
@@ -379,7 +379,7 @@ public class ShardGetService extends AbstractIndexShardComponent {
                     List<Object> values = searchLookup.source().extractRawValues(field);
                     if (!values.isEmpty()) {
                         for (int i = 0; i < values.size(); i++) {
-                            values.set(i, fieldMapper.valueForSearch(values.get(i)));
+                            values.set(i, fieldMapper.fieldType().valueForSearch(values.get(i)));
                         }
                         value = values;
                     }

--- a/core/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
@@ -194,7 +194,7 @@ public class DocumentMapper implements ToXContent {
                 meta);
         this.documentParser = new DocumentParser(index, indexSettings, docMapperParser, this, new ReleasableLock(mappingLock.readLock()));
 
-        this.typeFilter = typeMapper().termQuery(type, null);
+        this.typeFilter = typeMapper().fieldType().termQuery(type, null);
         this.mappingWriteLock = new ReleasableLock(mappingLock.writeLock());
         this.mappingLock = mappingLock;
 

--- a/core/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -19,19 +19,9 @@
 
 package org.elasticsearch.index.mapper;
 
-import org.apache.lucene.index.Term;
-import org.apache.lucene.index.Terms;
-import org.apache.lucene.search.MultiTermQuery;
-import org.apache.lucene.search.Query;
-import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.action.fieldstats.FieldStats;
-import org.elasticsearch.common.Nullable;
-import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.index.mapper.core.AbstractFieldMapper;
-import org.elasticsearch.index.query.QueryParseContext;
 
 import java.io.IOException;
-import java.util.List;
 
 /**
  *
@@ -48,55 +38,6 @@ public interface FieldMapper extends Mapper {
     AbstractFieldMapper.CopyTo copyTo();
 
     /**
-     * Returns the actual value of the field.
-     */
-    Object value(Object value);
-
-    /**
-     * Returns the value that will be used as a result for search. Can be only of specific types... .
-     */
-    Object valueForSearch(Object value);
-
-    /**
-     * Returns the indexed value used to construct search "values".
-     */
-    BytesRef indexedValueForSearch(Object value);
-
-    /**
-     * Should the field query {@link #termQuery(Object, org.elasticsearch.index.query.QueryParseContext)}  be used when detecting this
-     * field in query string.
-     */
-    boolean useTermQueryWithQueryString();
-
-    Query termQuery(Object value, @Nullable QueryParseContext context);
-
-    Query termsQuery(List values, @Nullable QueryParseContext context);
-
-    Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, @Nullable QueryParseContext context);
-
-    Query fuzzyQuery(String value, Fuzziness fuzziness, int prefixLength, int maxExpansions, boolean transpositions);
-
-    Query prefixQuery(Object value, @Nullable MultiTermQuery.RewriteMethod method, @Nullable QueryParseContext context);
-
-    Query regexpQuery(Object value, int flags, int maxDeterminizedStates, @Nullable MultiTermQuery.RewriteMethod method, @Nullable QueryParseContext context);
-
-    /**
-     * A term query to use when parsing a query string. Can return <tt>null</tt>.
-     */
-    @Nullable
-    Query queryStringTermQuery(Term term);
-
-    /**
-     * Null value filter, returns <tt>null</tt> if there is no null value associated with the field.
-     */
-    @Nullable
-    Query nullValueFilter();
-
-    boolean isNumeric();
-
-    boolean isSortable();
-
-    /**
      * Fields might not be available before indexing, for example _all, token_count,...
      * When get is called and these fields are requested, this case needs special treatment.
      *
@@ -110,10 +51,5 @@ public interface FieldMapper extends Mapper {
      * mappings were not modified.
      */
     Mapper parse(ParseContext context) throws IOException;
-
-    /**
-     * @return a {@link FieldStats} instance that maps to the type of this field based on the provided {@link Terms} instance.
-     */
-    FieldStats stats(Terms terms, int maxDoc) throws IOException;
 
 }

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/AbstractFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/AbstractFieldMapper.java
@@ -28,18 +28,11 @@ import com.google.common.collect.Iterators;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.index.IndexOptions;
-import org.apache.lucene.index.Term;
-import org.apache.lucene.index.Terms;
-import org.apache.lucene.search.MultiTermQuery;
-import org.apache.lucene.search.Query;
-import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.Version;
-import org.elasticsearch.action.fieldstats.FieldStats;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.fielddata.FieldDataType;
@@ -52,7 +45,6 @@ import org.elasticsearch.index.mapper.MergeMappingException;
 import org.elasticsearch.index.mapper.MergeResult;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.internal.AllFieldMapper;
-import org.elasticsearch.index.query.QueryParseContext;
 import org.elasticsearch.index.similarity.SimilarityLookupService;
 import org.elasticsearch.index.similarity.SimilarityProvider;
 
@@ -389,67 +381,6 @@ public abstract class AbstractFieldMapper implements FieldMapper {
     }
 
     @Override
-    public final Object value(Object value) {
-        return fieldType().value(value);
-    }
-
-    @Override
-    public final Object valueForSearch(Object value) {
-        return fieldType().valueForSearch(value);
-    }
-
-    // TODO: this is not final so ParentFieldMapper can have custom behavior, per type...
-    @Override
-    public BytesRef indexedValueForSearch(Object value) {
-        return fieldType().indexedValueForSearch(value);
-    }
-
-    @Override
-    public final Query queryStringTermQuery(Term term) {
-        return fieldType().queryStringTermQuery(term);
-    }
-
-    @Override
-    public final boolean useTermQueryWithQueryString() {
-        return fieldType().useTermQueryWithQueryString();
-    }
-
-    @Override
-    public final Query termQuery(Object value, @Nullable QueryParseContext context) {
-        return fieldType().termQuery(value, context);
-    }
-
-    @Override
-    public final Query termsQuery(List values, @Nullable QueryParseContext context) {
-        return fieldType().termsQuery(values, context);
-    }
-
-    @Override
-    public final Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, @Nullable QueryParseContext context) {
-        return fieldType().rangeQuery(lowerTerm, upperTerm, includeLower, includeUpper, context);
-    }
-
-    @Override
-    public final Query fuzzyQuery(String value, Fuzziness fuzziness, int prefixLength, int maxExpansions, boolean transpositions) {
-        return fieldType().fuzzyQuery(value, fuzziness, prefixLength, maxExpansions, transpositions);
-    }
-
-    @Override
-    public final Query prefixQuery(Object value, @Nullable MultiTermQuery.RewriteMethod method, @Nullable QueryParseContext context) {
-        return fieldType().prefixQuery(value, method, context);
-    }
-
-    @Override
-    public final Query regexpQuery(Object value, int flags, int maxDeterminizedStates, @Nullable MultiTermQuery.RewriteMethod method, @Nullable QueryParseContext context) {
-        return fieldType().regexpQuery(value, flags, maxDeterminizedStates, method, context);
-    }
-
-    @Override
-    public final Query nullValueFilter() {
-        return fieldType().nullValueQuery();
-    }
-
-    @Override
     public void merge(Mapper mergeWith, MergeResult mergeResult) throws MergeMappingException {
         if (!this.getClass().equals(mergeWith.getClass())) {
             String mergedType = mergeWith.getClass().getSimpleName();
@@ -684,16 +615,6 @@ public abstract class AbstractFieldMapper implements FieldMapper {
         multiFields.close();
     }
 
-    @Override
-    public final boolean isNumeric() {
-        return fieldType().isNumeric();
-    }
-
-    @Override
-    public final boolean isSortable() {
-        return fieldType().isSortable();
-    }
-
     public static class MultiFields {
 
         public static MultiFields empty() {
@@ -902,10 +823,5 @@ public abstract class AbstractFieldMapper implements FieldMapper {
     @Override
     public boolean isGenerated() {
         return false;
-    }
-
-    @Override
-    public final FieldStats stats(Terms terms, int maxDoc) throws IOException {
-        return fieldType().stats(terms, maxDoc);
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/RoutingFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/RoutingFieldMapper.java
@@ -185,7 +185,7 @@ public class RoutingFieldMapper extends AbstractFieldMapper implements RootMappe
 
     public String value(Document document) {
         Field field = (Field) document.getField(fieldType.names().indexName());
-        return field == null ? null : (String)value(field);
+        return field == null ? null : (String)fieldType().value(field);
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/index/mapper/all/SimpleAllMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/all/SimpleAllMapperTests.java
@@ -85,7 +85,7 @@ public class SimpleAllMapperTests extends ElasticsearchSingleNodeTest {
         assertThat(allEntries.fields().contains("simple1"), equalTo(true));
         AllFieldMapper mapper = docMapper.allFieldMapper();
         assertThat(field.fieldType().omitNorms(), equalTo(true));
-        assertThat(mapper.queryStringTermQuery(new Term("_all", "foobar")), Matchers.instanceOf(AllTermQuery.class));
+        assertThat(mapper.fieldType().queryStringTermQuery(new Term("_all", "foobar")), Matchers.instanceOf(AllTermQuery.class));
     }
 
     public void testAllMappersNoBoost() throws Exception {
@@ -116,7 +116,7 @@ public class SimpleAllMapperTests extends ElasticsearchSingleNodeTest {
         assertThat(allEntries.fields().contains("simple1"), equalTo(true));
         AllFieldMapper mapper = docMapper.allFieldMapper();
         assertThat(field.fieldType().omitNorms(), equalTo(false));
-        assertThat(mapper.queryStringTermQuery(new Term("_all", "foobar")), Matchers.instanceOf(AllTermQuery.class));
+        assertThat(mapper.fieldType().queryStringTermQuery(new Term("_all", "foobar")), Matchers.instanceOf(AllTermQuery.class));
 
     }
 
@@ -136,7 +136,7 @@ public class SimpleAllMapperTests extends ElasticsearchSingleNodeTest {
         assertThat(allEntries.fields().contains("simple1"), equalTo(true));
         AllFieldMapper mapper = docMapper.allFieldMapper();
         assertThat(field.fieldType().omitNorms(), equalTo(false));
-        assertThat(mapper.queryStringTermQuery(new Term("_all", "foobar")), Matchers.instanceOf(AllTermQuery.class));
+        assertThat(mapper.fieldType().queryStringTermQuery(new Term("_all", "foobar")), Matchers.instanceOf(AllTermQuery.class));
     }
 
     // #6187: if _all doesn't index positions then we never use AllTokenStream, even if some fields have boost
@@ -443,7 +443,7 @@ public class SimpleAllMapperTests extends ElasticsearchSingleNodeTest {
             IndexService indexService = createIndex(index, client().admin().indices().prepareCreate(index).addMapping("type", "foo", "type=string" + (boost ? ",boost=2" : "")));
             client().prepareIndex(index, "type").setSource("foo", "bar").get();
             client().admin().indices().prepareRefresh(index).get();
-            Query query = indexService.mapperService().documentMapper("type").allFieldMapper().termQuery("bar", null);
+            Query query = indexService.mapperService().documentMapper("type").allFieldMapper().fieldType().termQuery("bar", null);
             try (Searcher searcher = indexService.shard(0).acquireSearcher("tests")) {
                 query = searcher.searcher().rewrite(query);
                 final Class<?> expected = boost ? AllTermQuery.class : TermQuery.class;

--- a/core/src/test/java/org/elasticsearch/index/mapper/binary/BinaryMappingTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/binary/BinaryMappingTests.java
@@ -89,7 +89,7 @@ public class BinaryMappingTests extends ElasticsearchSingleNodeTest {
             BytesRef indexedValue = doc.rootDoc().getBinaryValue("field");
             assertEquals(new BytesRef(value), indexedValue);
             FieldMapper fieldMapper = mapper.mappers().smartNameFieldMapper("field");
-            Object originalValue = fieldMapper.valueForSearch(indexedValue);
+            Object originalValue = fieldMapper.fieldType().valueForSearch(indexedValue);
             assertEquals(new BytesArray(value), originalValue);
         }
     }
@@ -120,7 +120,7 @@ public class BinaryMappingTests extends ElasticsearchSingleNodeTest {
         BytesRef indexedValue = doc.rootDoc().getBinaryValue("field");
         assertEquals(new BytesRef(binaryValue), indexedValue);
         FieldMapper fieldMapper = mapper.mappers().smartNameFieldMapper("field");
-        Object originalValue = fieldMapper.valueForSearch(indexedValue);
+        Object originalValue = fieldMapper.fieldType().valueForSearch(indexedValue);
         assertEquals(new BytesArray(original), originalValue);
     }
 

--- a/core/src/test/java/org/elasticsearch/index/mapper/date/SimpleDateMappingTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/date/SimpleDateMappingTests.java
@@ -228,7 +228,7 @@ public class SimpleDateMappingTests extends ElasticsearchSingleNodeTest {
         NumericRangeQuery<Long> rangeQuery;
         try {
             SearchContext.setCurrent(new TestSearchContext());
-            rangeQuery = (NumericRangeQuery<Long>) defaultMapper.mappers().smartNameFieldMapper("date_field").rangeQuery("10:00:00", "11:00:00", true, true, null);
+            rangeQuery = (NumericRangeQuery<Long>) defaultMapper.mappers().smartNameFieldMapper("date_field").fieldType().rangeQuery("10:00:00", "11:00:00", true, true, null);
         } finally {
             SearchContext.removeCurrent();
         }
@@ -254,7 +254,7 @@ public class SimpleDateMappingTests extends ElasticsearchSingleNodeTest {
         NumericRangeQuery<Long> rangeQuery;
         try {
             SearchContext.setCurrent(new TestSearchContext());
-            rangeQuery = (NumericRangeQuery<Long>) defaultMapper.mappers().smartNameFieldMapper("date_field").rangeQuery("Jan 02 10:00:00", "Jan 02 11:00:00", true, true, null);
+            rangeQuery = (NumericRangeQuery<Long>) defaultMapper.mappers().smartNameFieldMapper("date_field").fieldType().rangeQuery("Jan 02 10:00:00", "Jan 02 11:00:00", true, true, null);
         } finally {
             SearchContext.removeCurrent();
         }

--- a/core/src/test/java/org/elasticsearch/index/mapper/lucene/DoubleIndexingDocTest.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/lucene/DoubleIndexingDocTest.java
@@ -71,25 +71,25 @@ public class DoubleIndexingDocTest extends ElasticsearchSingleNodeTest {
         IndexReader reader = DirectoryReader.open(writer, true);
         IndexSearcher searcher = new IndexSearcher(reader);
 
-        TopDocs topDocs = searcher.search(mapper.mappers().smartNameFieldMapper("field1").termQuery("value1", null), 10);
+        TopDocs topDocs = searcher.search(mapper.mappers().smartNameFieldMapper("field1").fieldType().termQuery("value1", null), 10);
         assertThat(topDocs.totalHits, equalTo(2));
 
-        topDocs = searcher.search(mapper.mappers().smartNameFieldMapper("field2").termQuery("1", null), 10);
+        topDocs = searcher.search(mapper.mappers().smartNameFieldMapper("field2").fieldType().termQuery("1", null), 10);
         assertThat(topDocs.totalHits, equalTo(2));
 
-        topDocs = searcher.search(mapper.mappers().smartNameFieldMapper("field3").termQuery("1.1", null), 10);
+        topDocs = searcher.search(mapper.mappers().smartNameFieldMapper("field3").fieldType().termQuery("1.1", null), 10);
         assertThat(topDocs.totalHits, equalTo(2));
 
-        topDocs = searcher.search(mapper.mappers().smartNameFieldMapper("field4").termQuery("2010-01-01", null), 10);
+        topDocs = searcher.search(mapper.mappers().smartNameFieldMapper("field4").fieldType().termQuery("2010-01-01", null), 10);
         assertThat(topDocs.totalHits, equalTo(2));
 
-        topDocs = searcher.search(mapper.mappers().smartNameFieldMapper("field5").termQuery("1", null), 10);
+        topDocs = searcher.search(mapper.mappers().smartNameFieldMapper("field5").fieldType().termQuery("1", null), 10);
         assertThat(topDocs.totalHits, equalTo(2));
 
-        topDocs = searcher.search(mapper.mappers().smartNameFieldMapper("field5").termQuery("2", null), 10);
+        topDocs = searcher.search(mapper.mappers().smartNameFieldMapper("field5").fieldType().termQuery("2", null), 10);
         assertThat(topDocs.totalHits, equalTo(2));
 
-        topDocs = searcher.search(mapper.mappers().smartNameFieldMapper("field5").termQuery("3", null), 10);
+        topDocs = searcher.search(mapper.mappers().smartNameFieldMapper("field5").fieldType().termQuery("3", null), 10);
         assertThat(topDocs.totalHits, equalTo(2));
         writer.close();
         reader.close();


### PR DESCRIPTION
These methods are now all in MappedFieldType. This removes the remaining
callers of the methods on FieldMapper, and cuts down the FieldMapper
API to no longer include them.
