### PR TITLE
Add back support for deprectated percent_terms_to_match REST parameter

### DIFF
--- a/src/main/java/org/elasticsearch/rest/action/mlt/RestMoreLikeThisAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/mlt/RestMoreLikeThisAction.java
@@ -57,6 +57,11 @@ public class RestMoreLikeThisAction extends BaseRestHandler {
         //needs some work if it is to be used in a REST context like this too
         // See the MoreLikeThisQueryParser constants that hold the valid syntax
         mltRequest.fields(request.paramAsStringArray("mlt_fields", null));
+        if (request.hasParam("percent_terms_to_match") && request.hasParam("minimum_should_match") == false) {
+            // percent_terms_to_match is deprecated!!!
+            // only set if it's really set AND the new parameter is not present (prefer non-deprecated
+            mltRequest.percentTermsToMatch(request.paramAsFloat("percent_terms_to_match", 0));
+        }
         mltRequest.minimumShouldMatch(request.param("minimum_should_match", "0"));
         mltRequest.minTermFreq(request.paramAsInt("min_term_freq", -1));
         mltRequest.maxQueryTerms(request.paramAsInt("max_query_terms", -1));


### PR DESCRIPTION
This was removed in 1.5 but should still be supported until the next major release.

Closes #11572
