### PR TITLE
Rewrite fields with `just_name` option to their actual index names in MLT

### DIFF
--- a/src/main/java/org/elasticsearch/common/lucene/search/XMoreLikeThis.java
+++ b/src/main/java/org/elasticsearch/common/lucene/search/XMoreLikeThis.java
@@ -39,10 +39,7 @@ import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.*;
-import org.apache.lucene.search.BooleanClause;
-import org.apache.lucene.search.BooleanQuery;
-import org.apache.lucene.search.Query;
-import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.*;
 import org.apache.lucene.search.similarities.DefaultSimilarity;
 import org.apache.lucene.search.similarities.TFIDFSimilarity;
 import org.apache.lucene.util.BytesRef;
@@ -827,9 +824,11 @@ public final class XMoreLikeThis {
                 continue;
             }
 
-            DocsEnum docs = termsEnum.docs(null, null);
-            final int freq = docs.freq();
-
+            final DocsEnum docs = termsEnum.docs(null, null);
+            int freq = 0;
+            while(docs != null && docs.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
+                freq += docs.freq();
+            }
             // increment frequency
             Int cnt = termFreqMap.get(term);
             if (cnt == null) {


### PR DESCRIPTION
Closes #11573
