### PR TITLE
Fix MapperException detection during translog ops replay

### DIFF
--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
@@ -306,7 +306,8 @@ public class RecoveryTarget extends AbstractComponent {
                 try {
                     recoveryStatus.indexShard().performBatchRecovery(request.operations());
                 } catch (TranslogRecoveryPerformer.BatchOperationException exception) {
-                    if (ExceptionsHelper.unwrapCause(exception) instanceof MapperException == false) {
+                    MapperException mapperException = (MapperException) ExceptionsHelper.unwrap(exception, MapperException.class);
+                    if (mapperException == null) {
                         throw exception;
                     }
                     // in very rare cases a translog replay from primary is processed before a mapping update on this node


### PR DESCRIPTION
The current ExceptionsHelper.unwrapCause(exception) requires the incoming exception to support ElasticsearchWrapperException , which TranslogRecoveryPerformer.BatchOperationException doesn't implement. I opted for a more generic solution

Example failure: http://build-us-00.elastic.co/job/es_g1gc_master_metal/8534/testReport/junit/org.elasticsearch.recovery/RelocationTests/testRelocationWhileRefreshing/

See #11363
