### PR TITLE
Shortcut `exists` and `missing` queries when no types/docs exist

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/ExistsQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/ExistsQueryParser.java
@@ -79,6 +79,10 @@ public class ExistsQueryParser implements QueryParser {
 
     public static Query newFilter(QueryParseContext parseContext, String fieldPattern, String queryName) {
         final FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType = (FieldNamesFieldMapper.FieldNamesFieldType)parseContext.mapperService().fullName(FieldNamesFieldMapper.NAME);
+        if (fieldNamesFieldType == null) {
+            // can only happen when no types exist, so no docs exist either
+            return Queries.newMatchNoDocsQuery();
+        }
 
         MapperService.SmartNameObjectMapper smartNameObjectMapper = parseContext.smartObjectMapper(fieldPattern);
         if (smartNameObjectMapper != null && smartNameObjectMapper.hasMapper()) {

--- a/core/src/main/java/org/elasticsearch/index/query/MissingQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MissingQueryParser.java
@@ -91,6 +91,11 @@ public class MissingQueryParser implements QueryParser {
         }
 
         final FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType = (FieldNamesFieldMapper.FieldNamesFieldType)parseContext.mapperService().fullName(FieldNamesFieldMapper.NAME);
+        if (fieldNamesFieldType == null) {
+            // can only happen when no types exist, so no docs exist either
+            return Queries.newMatchNoDocsQuery();
+        }
+
         MapperService.SmartNameObjectMapper smartNameObjectMapper = parseContext.smartObjectMapper(fieldPattern);
         if (smartNameObjectMapper != null && smartNameObjectMapper.hasMapper()) {
             // automatic make the object mapper pattern

--- a/core/src/test/java/org/elasticsearch/search/query/ExistsMissingTests.java
+++ b/core/src/test/java/org/elasticsearch/search/query/ExistsMissingTests.java
@@ -45,6 +45,16 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSear
 
 public class ExistsMissingTests extends ElasticsearchIntegrationTest {
 
+    // TODO: move this to a unit test somewhere...
+    public void testEmptyIndex() throws Exception {
+        createIndex("test");
+        ensureYellow("test");
+        SearchResponse resp = client().prepareSearch("test").setQuery(QueryBuilders.existsQuery("foo")).execute().actionGet();
+        assertSearchResponse(resp);
+        resp = client().prepareSearch("test").setQuery(QueryBuilders.missingQuery("foo")).execute().actionGet();
+        assertSearchResponse(resp);
+    }
+
     public void testExistsMissing() throws Exception {
         XContentBuilder mapping = XContentBuilder.builder(JsonXContent.jsonXContent)
             .startObject()


### PR DESCRIPTION
There used to be a null check for _field_names mapper not existing. This
was recently removed. However, there is a corner case when the mapper
may be missing: when no types or docs exist at all in the index.

This change adds back a null check and just returns no docs.
