### PR TITLE
Throw exception if no `elasticsearch.yml` file is found

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/settings/Settings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/Settings.java
@@ -25,7 +25,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-
 import org.elasticsearch.Version;
 import org.elasticsearch.common.Booleans;
 import org.elasticsearch.common.Classes;
@@ -33,8 +32,6 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.logging.ESLogger;
-import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.property.PropertyPlaceholder;
 import org.elasticsearch.common.settings.loader.SettingsLoader;
 import org.elasticsearch.common.settings.loader.SettingsLoaderFactory;
@@ -63,7 +60,6 @@ import static org.elasticsearch.common.unit.TimeValue.parseTimeValue;
  */
 public final class Settings implements ToXContent {
 
-    private static final ESLogger logger = Loggers.getLogger(Settings.class);
     public static final Settings EMPTY = new Builder().build();
     private static final Pattern ARRAY_PATTERN = Pattern.compile("(.*)\\.\\d+$");
 
@@ -1182,7 +1178,6 @@ public final class Settings implements ToXContent {
             }
             InputStream is = classLoader.getResourceAsStream(resourceName);
             if (is == null) {
-                logger.warn("Failed to load settings from [" + resourceName + "]");
                 return this;
             }
 

--- a/core/src/main/java/org/elasticsearch/common/settings/Settings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/Settings.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+
 import org.elasticsearch.Version;
 import org.elasticsearch.common.Booleans;
 import org.elasticsearch.common.Classes;
@@ -32,6 +33,8 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.property.PropertyPlaceholder;
 import org.elasticsearch.common.settings.loader.SettingsLoader;
 import org.elasticsearch.common.settings.loader.SettingsLoaderFactory;
@@ -60,6 +63,7 @@ import static org.elasticsearch.common.unit.TimeValue.parseTimeValue;
  */
 public final class Settings implements ToXContent {
 
+    private static final ESLogger logger = Loggers.getLogger(Settings.class);
     public static final Settings EMPTY = new Builder().build();
     private static final Pattern ARRAY_PATTERN = Pattern.compile("(.*)\\.\\d+$");
 
@@ -1178,6 +1182,7 @@ public final class Settings implements ToXContent {
             }
             InputStream is = classLoader.getResourceAsStream(resourceName);
             if (is == null) {
+                logger.warn("Failed to load settings from [" + resourceName + "]");
                 return this;
             }
 

--- a/core/src/main/java/org/elasticsearch/common/settings/Settings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/Settings.java
@@ -25,7 +25,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-
 import org.elasticsearch.Version;
 import org.elasticsearch.common.Booleans;
 import org.elasticsearch.common.Classes;
@@ -33,8 +32,6 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.logging.ESLogger;
-import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.property.PropertyPlaceholder;
 import org.elasticsearch.common.settings.loader.SettingsLoader;
 import org.elasticsearch.common.settings.loader.SettingsLoaderFactory;
@@ -63,7 +60,6 @@ import static org.elasticsearch.common.unit.TimeValue.parseTimeValue;
  */
 public final class Settings implements ToXContent {
 
-    private static final ESLogger logger = Loggers.getLogger(Settings.class);
     public static final Settings EMPTY = new Builder().build();
     private static final Pattern ARRAY_PATTERN = Pattern.compile("(.*)\\.\\d+$");
 
@@ -1183,7 +1179,7 @@ public final class Settings implements ToXContent {
             InputStream is = classLoader.getResourceAsStream(resourceName);
             if (is == null) {
                 logger.warn("Failed to load settings from [" + resourceName + "]");
-                return this;
+                throw new SettingsException("Failed to load settings from [" + resourceName + "]");
             }
 
             return loadFromStream(resourceName, is);

--- a/core/src/test/java/org/elasticsearch/common/settings/loader/YamlSettingsLoaderTests.java
+++ b/core/src/test/java/org/elasticsearch/common/settings/loader/YamlSettingsLoaderTests.java
@@ -19,11 +19,10 @@
 
 package org.elasticsearch.common.settings.loader;
 
-import org.apache.log4j.AppenderSkeleton;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
-import org.apache.log4j.spi.LoggingEvent;
+import com.sun.javafx.collections.SetAdapterChange;
+
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.settings.SettingsException;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.junit.Test;
 
@@ -38,9 +37,7 @@ public class YamlSettingsLoaderTests extends ElasticsearchTestCase {
 
     @Test
     public void testSimpleYamlSettings() throws Exception {
-        Settings settings = settingsBuilder()
-                .loadFromClasspath("org/elasticsearch/common/settings/loader/test-settings.yml")
-                .build();
+        Settings settings = settingsBuilder().loadFromClasspath("org/elasticsearch/common/settings/loader/test-settings.yml").build();
 
         assertThat(settings.get("test1.value1"), equalTo("value1"));
         assertThat(settings.get("test1.test2.value2"), equalTo("value2"));
@@ -53,46 +50,17 @@ public class YamlSettingsLoaderTests extends ElasticsearchTestCase {
         assertThat(settings.getAsArray("test1.test3")[0], equalTo("test3-1"));
         assertThat(settings.getAsArray("test1.test3")[1], equalTo("test3-2"));
     }
-    
+
     @Test
     public void testYamlSettingsNoFile() throws Exception {
         String invalidResourceName = "org/elasticsearch/common/settings/loader/no-test-settings.yml";
-        MockAppender mockAppender = new MockAppender();
-        Logger rootLogger = Logger.getRootLogger();
-        Level savedLevel = rootLogger.getLevel();
-        rootLogger.addAppender(mockAppender);
-        rootLogger.setLevel(Level.WARN);
-        rootLogger.addAppender(mockAppender);
         try {
-            Settings defaultSettings = settingsBuilder()
-                .loadFromClasspath(invalidResourceName)
-                .build();
-            assertTrue(mockAppender.sawLoadFailed);
-            assertFalse(defaultSettings == null);
-        } finally {
-            rootLogger.removeAppender(mockAppender);
-            rootLogger.setLevel(savedLevel);
+            Settings defaultSettings = settingsBuilder().loadFromClasspath(invalidResourceName).build();
+            fail("For a not exiting file an exception should be thrown.");
+        } catch (Exception e) {
+            assertTrue(e instanceof SettingsException);
+            assertThat(e.getMessage(), equalTo("Failed to load settings from [" + invalidResourceName + "]"));
         }
     }
-    
-    private static class MockAppender extends AppenderSkeleton {
-        public boolean sawLoadFailed = false;
 
-        @Override
-        protected void append(LoggingEvent event) {
-            String message = event.getMessage().toString();
-            if (event.getLevel() == Level.WARN && message.contains("Failed to load settings from [")) {
-                sawLoadFailed = true;
-            }
-        }
-
-        @Override
-        public boolean requiresLayout() {
-            return false;
-        }
-
-        @Override
-        public void close() {
-        }
-    }
 }

--- a/core/src/test/java/org/elasticsearch/common/settings/loader/YamlSettingsLoaderTests.java
+++ b/core/src/test/java/org/elasticsearch/common/settings/loader/YamlSettingsLoaderTests.java
@@ -19,6 +19,10 @@
 
 package org.elasticsearch.common.settings.loader;
 
+import org.apache.log4j.AppenderSkeleton;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.apache.log4j.spi.LoggingEvent;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.junit.Test;
@@ -48,5 +52,47 @@ public class YamlSettingsLoaderTests extends ElasticsearchTestCase {
         assertThat(settings.getAsArray("test1.test3").length, equalTo(2));
         assertThat(settings.getAsArray("test1.test3")[0], equalTo("test3-1"));
         assertThat(settings.getAsArray("test1.test3")[1], equalTo("test3-2"));
+    }
+    
+    @Test
+    public void testYamlSettingsNoFile() throws Exception {
+        String invalidResourceName = "org/elasticsearch/common/settings/loader/no-test-settings.yml";
+        MockAppender mockAppender = new MockAppender();
+        Logger rootLogger = Logger.getRootLogger();
+        Level savedLevel = rootLogger.getLevel();
+        rootLogger.addAppender(mockAppender);
+        rootLogger.setLevel(Level.WARN);
+        rootLogger.addAppender(mockAppender);
+        try {
+            Settings defaultSettings = settingsBuilder()
+                .loadFromClasspath(invalidResourceName)
+                .build();
+            assertTrue(mockAppender.sawLoadFailed);
+            assertFalse(defaultSettings == null);
+        } finally {
+            rootLogger.removeAppender(mockAppender);
+            rootLogger.setLevel(savedLevel);
+        }
+    }
+    
+    private static class MockAppender extends AppenderSkeleton {
+        public boolean sawLoadFailed = false;
+
+        @Override
+        protected void append(LoggingEvent event) {
+            String message = event.getMessage().toString();
+            if (event.getLevel() == Level.WARN && message.contains("Failed to load settings from [")) {
+                sawLoadFailed = true;
+            }
+        }
+
+        @Override
+        public boolean requiresLayout() {
+            return false;
+        }
+
+        @Override
+        public void close() {
+        }
     }
 }

--- a/core/src/test/java/org/elasticsearch/common/settings/loader/YamlSettingsLoaderTests.java
+++ b/core/src/test/java/org/elasticsearch/common/settings/loader/YamlSettingsLoaderTests.java
@@ -19,13 +19,8 @@
 
 package org.elasticsearch.common.settings.loader;
 
-import org.apache.log4j.AppenderSkeleton;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
-import org.apache.log4j.spi.LoggingEvent;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ElasticsearchTestCase;
-import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.junit.Test;
 
 import static org.elasticsearch.common.settings.Settings.settingsBuilder;
@@ -54,48 +49,4 @@ public class YamlSettingsLoaderTests extends ElasticsearchTestCase {
         assertThat(settings.getAsArray("test1.test3")[0], equalTo("test3-1"));
         assertThat(settings.getAsArray("test1.test3")[1], equalTo("test3-2"));
     }
-    
-    @Test
-    @TestLogging("loader:WARN") // To ensure that we log cluster state events on WARN level
-    public void testYamlSettingsNoFile() throws Exception {
-        String invalidResourceName = "org/elasticsearch/common/settings/loader/no-test-settings.yml";
-        MockAppender mockAppender = new MockAppender();
-        Logger rootLogger = Logger.getRootLogger();
-        Level savedLevel = rootLogger.getLevel();
-        rootLogger.addAppender(mockAppender);
-        rootLogger.setLevel(Level.WARN);
-        rootLogger.addAppender(mockAppender);
-        try {
-            Settings defaultSettings = settingsBuilder()
-                .loadFromClasspath(invalidResourceName)
-                .build();
-            assertTrue(mockAppender.sawLoadFailed);
-            assertFalse(defaultSettings == null);
-        } finally {
-            rootLogger.removeAppender(mockAppender);
-            rootLogger.setLevel(savedLevel);
-        }
-    }
-    
-    private static class MockAppender extends AppenderSkeleton {
-        public boolean sawLoadFailed = false;
-
-        @Override
-        protected void append(LoggingEvent event) {
-            String message = event.getMessage().toString();
-            if (event.getLevel() == Level.WARN && message.contains("Failed to load settings from [")) {
-                sawLoadFailed = true;
-            }
-        }
-
-        @Override
-        public boolean requiresLayout() {
-            return false;
-        }
-
-        @Override
-        public void close() {
-        }
-    }
-    
 }

--- a/core/src/test/java/org/elasticsearch/common/settings/loader/YamlSettingsLoaderTests.java
+++ b/core/src/test/java/org/elasticsearch/common/settings/loader/YamlSettingsLoaderTests.java
@@ -19,8 +19,13 @@
 
 package org.elasticsearch.common.settings.loader;
 
+import org.apache.log4j.AppenderSkeleton;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.apache.log4j.spi.LoggingEvent;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.junit.Test;
 
 import static org.elasticsearch.common.settings.Settings.settingsBuilder;
@@ -49,4 +54,48 @@ public class YamlSettingsLoaderTests extends ElasticsearchTestCase {
         assertThat(settings.getAsArray("test1.test3")[0], equalTo("test3-1"));
         assertThat(settings.getAsArray("test1.test3")[1], equalTo("test3-2"));
     }
+    
+    @Test
+    @TestLogging("loader:WARN") // To ensure that we log cluster state events on WARN level
+    public void testYamlSettingsNoFile() throws Exception {
+        String invalidResourceName = "org/elasticsearch/common/settings/loader/no-test-settings.yml";
+        MockAppender mockAppender = new MockAppender();
+        Logger rootLogger = Logger.getRootLogger();
+        Level savedLevel = rootLogger.getLevel();
+        rootLogger.addAppender(mockAppender);
+        rootLogger.setLevel(Level.WARN);
+        rootLogger.addAppender(mockAppender);
+        try {
+            Settings defaultSettings = settingsBuilder()
+                .loadFromClasspath(invalidResourceName)
+                .build();
+            assertTrue(mockAppender.sawLoadFailed);
+            assertFalse(defaultSettings == null);
+        } finally {
+            rootLogger.removeAppender(mockAppender);
+            rootLogger.setLevel(savedLevel);
+        }
+    }
+    
+    private static class MockAppender extends AppenderSkeleton {
+        public boolean sawLoadFailed = false;
+
+        @Override
+        protected void append(LoggingEvent event) {
+            String message = event.getMessage().toString();
+            if (event.getLevel() == Level.WARN && message.contains("Failed to load settings from [")) {
+                sawLoadFailed = true;
+            }
+        }
+
+        @Override
+        public boolean requiresLayout() {
+            return false;
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+    
 }


### PR DESCRIPTION
Log message to indicate that no `elasticsearch.yml` file was found

Added a warning despite other methods throw an exception to avoid breaking the former behaviour.
Closes https://github.com/elastic/elasticsearch/issues/11510 
