### PR TITLE
Removing top-level filter parameter from search API.

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/query/QueryPhase.java
+++ b/core/src/main/java/org/elasticsearch/search/query/QueryPhase.java
@@ -65,7 +65,6 @@ public class QueryPhase implements SearchPhase {
                 .put("query", new QueryParseElement())
                 .put("queryBinary", new QueryBinaryParseElement())
                 .put("query_binary", new QueryBinaryParseElement())
-                .put("filter", new PostFilterParseElement()) // For bw comp reason, should be removed in version 1.1
                 .put("post_filter", new PostFilterParseElement())
                 .put("postFilter", new PostFilterParseElement())
                 .put("filterBinary", new FilterBinaryParseElement())


### PR DESCRIPTION
Closes #8862.
