### PR TITLE
Fold ShardGetService creation away from Guice  into IndexShard

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -22,7 +22,7 @@ package org.elasticsearch.index.shard;
 import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
 import org.apache.lucene.codecs.PostingsFormat;
-import org.apache.lucene.index.*;
+import org.apache.lucene.index.CheckIndex;
 import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.ThreadInterruptedException;
@@ -192,7 +192,7 @@ public class IndexShard extends AbstractIndexShardComponent {
 
     @Inject
     public IndexShard(ShardId shardId, IndexSettingsService indexSettingsService, IndicesLifecycle indicesLifecycle, Store store,
-                      ThreadPool threadPool, MapperService mapperService, IndexQueryParserService queryParserService, IndexCache indexCache, IndexAliasesService indexAliasesService, ShardIndexingService indexingService, ShardGetService getService, ShardSearchService searchService, ShardIndexWarmerService shardWarmerService,
+                      ThreadPool threadPool, MapperService mapperService, IndexQueryParserService queryParserService, IndexCache indexCache, IndexAliasesService indexAliasesService, ShardIndexingService indexingService, ShardSearchService searchService, ShardIndexWarmerService shardWarmerService,
                       ShardFilterCache shardFilterCache, ShardFieldData shardFieldData, PercolatorQueriesRegistry percolatorQueriesRegistry, ShardPercolateService shardPercolateService, CodecService codecService,
                       ShardTermVectorsService termVectorsService, IndexFieldDataService indexFieldDataService, IndexService indexService, ShardSuggestService shardSuggestService,
                       ShardQueryCache shardQueryCache, ShardBitsetFilterCache shardBitsetFilterCache,
@@ -216,7 +216,7 @@ public class IndexShard extends AbstractIndexShardComponent {
         this.indexCache = indexCache;
         this.indexAliasesService = indexAliasesService;
         this.indexingService = indexingService;
-        this.getService = getService.setIndexShard(this);
+        this.getService = new ShardGetService(this, mapperService);
         this.termVectorsService = termVectorsService.setIndexShard(this);
         this.searchService = searchService;
         this.shardWarmerService = shardWarmerService;

--- a/core/src/main/java/org/elasticsearch/index/shard/IndexShardModule.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/IndexShardModule.java
@@ -30,7 +30,6 @@ import org.elasticsearch.index.engine.InternalEngineFactory;
 import org.elasticsearch.index.fielddata.ShardFieldData;
 import org.elasticsearch.index.gateway.IndexShardGateway;
 import org.elasticsearch.index.gateway.IndexShardGatewayService;
-import org.elasticsearch.index.get.ShardGetService;
 import org.elasticsearch.index.indexing.ShardIndexingService;
 import org.elasticsearch.index.indexing.slowlog.ShardSlowLogIndexingService;
 import org.elasticsearch.index.percolator.PercolatorQueriesRegistry;
@@ -92,7 +91,6 @@ public class IndexShardModule extends AbstractModule {
         bind(ShardSlowLogIndexingService.class).asEagerSingleton();
         bind(ShardSearchService.class).asEagerSingleton();
         bind(ShardSlowLogSearchService.class).asEagerSingleton();
-        bind(ShardGetService.class).asEagerSingleton();
         bind(ShardFilterCache.class).toInstance(shardFilterCache);
         bind(ShardQueryCache.class).asEagerSingleton();
         bind(ShardBitsetFilterCache.class).asEagerSingleton();

--- a/core/src/main/java/org/elasticsearch/index/shard/ShadowIndexShard.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/ShadowIndexShard.java
@@ -37,7 +37,6 @@ import org.elasticsearch.index.engine.EngineConfig;
 import org.elasticsearch.index.engine.EngineFactory;
 import org.elasticsearch.index.fielddata.IndexFieldDataService;
 import org.elasticsearch.index.fielddata.ShardFieldData;
-import org.elasticsearch.index.get.ShardGetService;
 import org.elasticsearch.index.indexing.ShardIndexingService;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.merge.MergeStats;
@@ -71,7 +70,7 @@ public final class ShadowIndexShard extends IndexShard {
                             ThreadPool threadPool, MapperService mapperService,
                             IndexQueryParserService queryParserService, IndexCache indexCache,
                             IndexAliasesService indexAliasesService, ShardIndexingService indexingService,
-                            ShardGetService getService, ShardSearchService searchService,
+                            ShardSearchService searchService,
                             ShardIndexWarmerService shardWarmerService, ShardFilterCache shardFilterCache,
                             ShardFieldData shardFieldData, PercolatorQueriesRegistry percolatorQueriesRegistry,
                             ShardPercolateService shardPercolateService, CodecService codecService,
@@ -83,7 +82,7 @@ public final class ShadowIndexShard extends IndexShard {
                             NodeEnvironment nodeEnv, ShardPath path, BigArrays bigArrays) throws IOException {
         super(shardId, indexSettingsService, indicesLifecycle, store,
                 threadPool, mapperService, queryParserService, indexCache, indexAliasesService,
-                indexingService, getService, searchService, shardWarmerService, shardFilterCache,
+                indexingService, searchService, shardWarmerService, shardFilterCache,
                 shardFieldData, percolatorQueriesRegistry, shardPercolateService, codecService,
                 termVectorsService, indexFieldDataService, indexService, shardSuggestService,
                 shardQueryCache, shardBitsetFilterCache, warmer, deletionPolicy, similarityService,


### PR DESCRIPTION
it's always acccessed via IndexShard and has crazy circular dependencies or
rather had. It just makes IndexShard ctor bigger for no reason.
