### PR TITLE
Fixing edge case in RangeQueryBuilder when using time zone

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
@@ -304,6 +304,10 @@ public class RangeQueryBuilder extends MultiTermQueryBuilder<RangeQueryBuilder> 
         }
 
         if (query == null) {
+            if (this.timeZone != null) {
+                throw new QueryParsingException(parseContext, "[range] time_zone can not be applied to non date field ["
+                        + fieldName + "]");
+            }
             query = new TermRangeQuery(this.fieldName, BytesRefs.toBytesRef(from), BytesRefs.toBytesRef(to), includeLower, includeUpper);
         }
 


### PR DESCRIPTION
When specifying a time zone, RangeQueryBuilder currently throws an exeption when the field is not using DateFieldMapper, but if there are no mappers at all for that field it doesn't complain. 
To be more consistent we should also throw expection in this case.

PR goes agains query-refacoring feature branch.
