### PR TITLE
[TEST] expand testing of compound queries

### DIFF
--- a/core/src/test/java/org/elasticsearch/index/query/BaseQueryTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/query/BaseQueryTestCase.java
@@ -82,7 +82,7 @@ public abstract class BaseQueryTestCase<QB extends QueryBuilder<QB>> extends Ela
     protected static final String STRING_FIELD_NAME = "text";
     protected static final String DOUBLE_FIELD_NAME = "double";
     protected static final String BOOLEAN_FIELD_NAME = "boolean";
-    protected static final String[] mappedFieldNames = new String[] { DATE_FIELD_NAME, INT_FIELD_NAME, STRING_FIELD_NAME,
+    protected static final String[] MAPPED_FIELD_NAMES = new String[] { DATE_FIELD_NAME, INT_FIELD_NAME, STRING_FIELD_NAME,
             DOUBLE_FIELD_NAME, BOOLEAN_FIELD_NAME, OBJECT_FIELD_NAME };
 
     private static Injector injector;
@@ -195,10 +195,11 @@ public abstract class BaseQueryTestCase<QB extends QueryBuilder<QB>> extends Ela
         SearchContext.removeCurrent();
     }
 
-    /**
-     * Create the query that is being tested
-     */
-    protected abstract QB createTestQueryBuilder();
+    protected QB createTestQueryBuilder() {
+        return getRandomQueryBuilder().newQueryBuilder(random());
+    }
+
+    protected abstract RandomQueryBuilder<QB> getRandomQueryBuilder();
 
     /**
      * Generic test that creates new query from the test query and checks both for equality

--- a/core/src/test/java/org/elasticsearch/index/query/BaseTermQueryTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/query/BaseTermQueryTestCase.java
@@ -32,56 +32,6 @@ import static org.hamcrest.Matchers.is;
 
 @Ignore
 public abstract class BaseTermQueryTestCase<QB extends BaseTermQueryBuilder<QB>> extends BaseQueryTestCase<QB> {
-    
-    protected final QB createTestQueryBuilder() {
-        String fieldName = null;
-        Object value;
-        switch (randomIntBetween(0, 3)) {
-            case 0:
-                if (randomBoolean()) {
-                    fieldName = BOOLEAN_FIELD_NAME;
-                }
-                value = randomBoolean();
-                break;
-            case 1:
-                if (randomBoolean()) {
-                    fieldName = STRING_FIELD_NAME;
-                }
-                if (frequently()) {
-                    value = randomAsciiOfLengthBetween(1, 10);
-                } else {
-                    // generate unicode string in 10% of cases
-                    value = randomUnicodeOfLength(10);
-                }
-                break;
-            case 2:
-                if (randomBoolean()) {
-                    fieldName = INT_FIELD_NAME;
-                }
-                value = randomInt(10000);
-                break;
-            case 3:
-                if (randomBoolean()) {
-                    fieldName = DOUBLE_FIELD_NAME;
-                }
-                value = randomDouble();
-                break;
-            default:
-                throw new UnsupportedOperationException();
-        }
-
-        if (fieldName == null) {
-            fieldName = randomAsciiOfLengthBetween(1, 10);
-        }
-        QB query = createQueryBuilder(fieldName, value);
-        if (randomBoolean()) {
-            query.boost(2.0f / randomIntBetween(1, 20));
-        }
-        if (randomBoolean()) {
-            query.queryName(randomAsciiOfLengthBetween(1, 10));
-        }
-        return query;
-    }
 
     protected abstract QB createQueryBuilder(String fieldName, Object value);
 

--- a/core/src/test/java/org/elasticsearch/index/query/BoolQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/BoolQueryBuilderTest.java
@@ -47,43 +47,6 @@ public class BoolQueryBuilderTest extends BaseQueryTestCase<BoolQueryBuilder> {
     }
 
     @Override
-    protected BoolQueryBuilder createTestQueryBuilder() {
-        BoolQueryBuilder query = new BoolQueryBuilder();
-        if (randomBoolean()) {
-            query.boost(2.0f / randomIntBetween(1, 20));
-        }
-        if (randomBoolean()) {
-            query.adjustPureNegative(randomBoolean());
-        }
-        if (randomBoolean()) {
-            query.disableCoord(randomBoolean());
-        }
-        if (randomBoolean()) {
-            query.minimumNumberShouldMatch(randomIntBetween(1, 10));
-        }
-        int mustClauses = randomIntBetween(0, 3);
-        for (int i = 0; i < mustClauses; i++) {
-            query.must(RandomQueryBuilder.create(random()));
-        }
-        int mustNotClauses = randomIntBetween(0, 3);
-        for (int i = 0; i < mustNotClauses; i++) {
-            query.mustNot(RandomQueryBuilder.create(random()));
-        }
-        int shouldClauses = randomIntBetween(0, 3);
-        for (int i = 0; i < shouldClauses; i++) {
-            query.should(RandomQueryBuilder.create(random()));
-        }
-        int filterClauses = randomIntBetween(0, 3);
-        for (int i = 0; i < filterClauses; i++) {
-            query.filter(RandomQueryBuilder.create(random()));
-        }
-        if (randomBoolean()) {
-            query.queryName(randomUnicodeOfLengthBetween(3, 15));
-        }
-        return query;
-    }
-
-    @Override
     protected Query createExpectedQuery(BoolQueryBuilder queryBuilder, QueryParseContext context) throws IOException {
         if (!queryBuilder.hasClauses()) {
             return new MatchAllDocsQuery();
@@ -97,8 +60,7 @@ public class BoolQueryBuilderTest extends BaseQueryTestCase<BoolQueryBuilder> {
         addBooleanClauses(context, boolQuery, queryBuilder.filter(), BooleanClause.Occur.FILTER);
 
         Queries.applyMinimumShouldMatch(boolQuery, queryBuilder.minimumNumberShouldMatch());
-        Query returnedQuery = queryBuilder.adjustPureNegative() ? fixNegativeQueryIfNeeded(boolQuery) : boolQuery;
-        return returnedQuery;
+        return queryBuilder.adjustPureNegative() ? fixNegativeQueryIfNeeded(boolQuery) : boolQuery;
     }
 
     private static void addBooleanClauses(QueryParseContext parseContext, BooleanQuery booleanQuery, List<QueryBuilder> clauses, Occur occurs)
@@ -106,5 +68,10 @@ public class BoolQueryBuilderTest extends BaseQueryTestCase<BoolQueryBuilder> {
         for (QueryBuilder query : clauses) {
             booleanQuery.add(new BooleanClause(query.toQuery(parseContext), occurs));
         }
+    }
+
+    @Override
+    protected RandomQueryBuilder<BoolQueryBuilder> getRandomQueryBuilder() {
+        return new RandomBoolQueryBuilder();
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/query/ExistsQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/ExistsQueryBuilderTest.java
@@ -19,12 +19,7 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.search.BooleanClause;
-import org.apache.lucene.search.BooleanQuery;
-import org.apache.lucene.search.ConstantScoreQuery;
-import org.apache.lucene.search.Query;
-import org.apache.lucene.search.TermRangeQuery;
-import org.elasticsearch.cluster.metadata.MetaData;
+import org.apache.lucene.search.*;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.internal.FieldNamesFieldMapper;
@@ -57,7 +52,7 @@ public class ExistsQueryBuilderTest extends BaseQueryTestCase<ExistsQueryBuilder
 
         BooleanQuery boolFilter = new BooleanQuery();
         for (String field : fields) {
-            if (fieldNamesFieldType != null && fieldNamesFieldType.isEnabled()) {
+            if (fieldNamesFieldType.isEnabled()) {
                 boolFilter.add(fieldNamesFieldType.termQuery(field, context), BooleanClause.Occur.SHOULD);
             } else {
                 MappedFieldType fieldType = context.fieldMapper(field);
@@ -87,26 +82,7 @@ public class ExistsQueryBuilderTest extends BaseQueryTestCase<ExistsQueryBuilder
     }
 
     @Override
-    protected ExistsQueryBuilder createTestQueryBuilder() {
-        String fieldPattern;
-        if (randomBoolean()) {
-            fieldPattern = randomFrom(mappedFieldNames);
-        } else {
-            fieldPattern = randomAsciiOfLengthBetween(1, 10);
-        }
-        // also sometimes test wildcard patterns
-        if (randomBoolean()) {
-            if (randomBoolean()) {
-                fieldPattern = fieldPattern + "*";
-            } else {
-                fieldPattern = MetaData.ALL;
-            }
-        }
-        ExistsQueryBuilder query = new ExistsQueryBuilder(fieldPattern);
-
-        if (randomBoolean()) {
-            query.queryName(randomAsciiOfLengthBetween(1, 10));
-        }
-        return query;
+    protected RandomQueryBuilder<ExistsQueryBuilder> getRandomQueryBuilder() {
+        return new RandomExistsQueryBuilder();
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/query/IdsQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/IdsQueryBuilderTest.java
@@ -82,44 +82,7 @@ public class IdsQueryBuilderTest extends BaseQueryTestCase<IdsQueryBuilder> {
     }
 
     @Override
-    protected IdsQueryBuilder createTestQueryBuilder() {
-        String[] types;
-        if (getCurrentTypes().length > 0 && randomBoolean()) {
-            int numberOfTypes = randomIntBetween(1, getCurrentTypes().length);
-            types = new String[numberOfTypes];
-            for (int i = 0; i < numberOfTypes; i++) {
-                if (frequently()) {
-                    types[i] = randomFrom(getCurrentTypes());
-                } else {
-                    types[i] = randomAsciiOfLengthBetween(1, 10);
-                }
-            }
-        } else {
-            if (randomBoolean()) {
-                types = new String[]{MetaData.ALL};
-            } else {
-                types = new String[0];
-            }
-        }
-        int numberOfIds = randomIntBetween(0, 10);
-        String[] ids = new String[numberOfIds];
-        for (int i = 0; i < numberOfIds; i++) {
-            ids[i] = randomAsciiOfLengthBetween(1, 10);
-        }
-        IdsQueryBuilder query;
-        if (types.length > 0 || randomBoolean()) {
-            query = new IdsQueryBuilder(types);
-            query.addIds(ids);
-        } else {
-            query = new IdsQueryBuilder();
-            query.addIds(ids);
-        }
-        if (randomBoolean()) {
-            query.boost(2.0f / randomIntBetween(1, 20));
-        }
-        if (randomBoolean()) {
-            query.queryName(randomAsciiOfLengthBetween(1, 10));
-        }
-        return query;
+    protected RandomQueryBuilder<IdsQueryBuilder> getRandomQueryBuilder() {
+        return new RandomIdsQueryBuilder();
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/query/LimitQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/LimitQueryBuilderTest.java
@@ -30,13 +30,8 @@ public class LimitQueryBuilderTest extends BaseQueryTestCase<LimitQueryBuilder> 
         return Queries.newMatchAllQuery();
     }
 
-    /**
-     * @return a LimitQueryBuilder with random limit between 0 and 20
-     */
     @Override
-    protected LimitQueryBuilder createTestQueryBuilder() {
-        LimitQueryBuilder query = new LimitQueryBuilder(randomIntBetween(0, 20));
-        return query;
+    protected RandomQueryBuilder<LimitQueryBuilder> getRandomQueryBuilder() {
+        return new RandomLimitQueryBuilder();
     }
-
 }

--- a/core/src/test/java/org/elasticsearch/index/query/MatchAllQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/MatchAllQueryBuilderTest.java
@@ -31,16 +31,8 @@ public class MatchAllQueryBuilderTest extends BaseQueryTestCase<MatchAllQueryBui
         return matchAllDocsQuery;
     }
 
-    /**
-     * @return a MatchAllQuery with random boost between 0.1f and 2.0f
-     */
     @Override
-    protected MatchAllQueryBuilder createTestQueryBuilder() {
-        MatchAllQueryBuilder query = new MatchAllQueryBuilder();
-        if (randomBoolean()) {
-            query.boost(2.0f / randomIntBetween(1, 20));
-        }
-        return query;
+    protected RandomQueryBuilder<MatchAllQueryBuilder> getRandomQueryBuilder() {
+        return new RandomMatchAllQueryBuilder();
     }
-
 }

--- a/core/src/test/java/org/elasticsearch/index/query/RandomBaseTermQueryBuilder.java
+++ b/core/src/test/java/org/elasticsearch/index/query/RandomBaseTermQueryBuilder.java
@@ -1,0 +1,62 @@
+package org.elasticsearch.index.query;
+
+import com.carrotsearch.randomizedtesting.generators.RandomInts;
+import com.carrotsearch.randomizedtesting.generators.RandomStrings;
+
+import java.util.Random;
+
+public abstract class RandomBaseTermQueryBuilder<QB extends BaseTermQueryBuilder> implements RandomQueryBuilder<QB> {
+
+    @Override
+    public final QB newQueryBuilder(Random random) {
+        String fieldName = null;
+        Object value;
+        switch (RandomInts.randomIntBetween(random, 0, 3)) {
+            case 0:
+                if (random.nextBoolean()) {
+                    fieldName = BaseQueryTestCase.BOOLEAN_FIELD_NAME;
+                }
+                value = random.nextBoolean();
+                break;
+            case 1:
+                if (random.nextBoolean()) {
+                    fieldName = BaseQueryTestCase.STRING_FIELD_NAME;
+                }
+                if (RandomInts.randomInt(random, 9) > 0) {
+                    value = RandomStrings.randomAsciiOfLengthBetween(random, 1, 10);
+                } else {
+                    // generate unicode string in 10% of cases
+                    value = RandomStrings.randomUnicodeOfLength(random, 10);
+                }
+                break;
+            case 2:
+                if (random.nextBoolean()) {
+                    fieldName = BaseQueryTestCase.INT_FIELD_NAME;
+                }
+                value = RandomInts.randomInt(random, 10000);
+                break;
+            case 3:
+                if (random.nextBoolean()) {
+                    fieldName = BaseQueryTestCase.DOUBLE_FIELD_NAME;
+                }
+                value = random.nextDouble();
+                break;
+            default:
+                throw new UnsupportedOperationException();
+        }
+
+        if (fieldName == null) {
+            fieldName = RandomStrings.randomAsciiOfLengthBetween(random, 1, 10);
+        }
+        QB query = createQueryBuilder(fieldName, value);
+        if (random.nextBoolean()) {
+            query.boost(2.0f / RandomInts.randomIntBetween(random, 1, 20));
+        }
+        if (random.nextBoolean()) {
+            query.queryName(RandomStrings.randomAsciiOfLengthBetween(random, 1, 10));
+        }
+        return query;
+    }
+
+    protected abstract QB createQueryBuilder(String fieldName, Object value);
+}

--- a/core/src/test/java/org/elasticsearch/index/query/RandomBoolQueryBuilder.java
+++ b/core/src/test/java/org/elasticsearch/index/query/RandomBoolQueryBuilder.java
@@ -1,0 +1,46 @@
+package org.elasticsearch.index.query;
+
+import com.carrotsearch.randomizedtesting.generators.RandomInts;
+import com.carrotsearch.randomizedtesting.generators.RandomStrings;
+
+import java.util.Random;
+
+public class RandomBoolQueryBuilder implements RandomQueryBuilder<BoolQueryBuilder> {
+
+    @Override
+    public BoolQueryBuilder newQueryBuilder(Random random) {
+        BoolQueryBuilder query = new BoolQueryBuilder();
+        if (random.nextBoolean()) {
+            query.boost(2.0f / RandomInts.randomIntBetween(random, 1, 20));
+        }
+        if (random.nextBoolean()) {
+            query.adjustPureNegative(random.nextBoolean());
+        }
+        if (random.nextBoolean()) {
+            query.disableCoord(random.nextBoolean());
+        }
+        if (random.nextBoolean()) {
+            query.minimumNumberShouldMatch(RandomInts.randomIntBetween(random, 1, 10));
+        }
+        int mustClauses = RandomInts.randomIntBetween(random, 0, 3);
+        for (int i = 0; i < mustClauses; i++) {
+            query.must(RandomQueriesRegistry.createRandomQuery(random));
+        }
+        int mustNotClauses = RandomInts.randomIntBetween(random, 0, 3);
+        for (int i = 0; i < mustNotClauses; i++) {
+            query.mustNot(RandomQueriesRegistry.createRandomQuery(random));
+        }
+        int shouldClauses = RandomInts.randomIntBetween(random, 0, 3);
+        for (int i = 0; i < shouldClauses; i++) {
+            query.should(RandomQueriesRegistry.createRandomQuery(random));
+        }
+        int filterClauses = RandomInts.randomIntBetween(random, 0, 3);
+        for (int i = 0; i < filterClauses; i++) {
+            query.filter(RandomQueriesRegistry.createRandomQuery(random));
+        }
+        if (random.nextBoolean()) {
+            query.queryName(RandomStrings.randomUnicodeOfLengthBetween(random, 3, 15));
+        }
+        return query;
+    }
+}

--- a/core/src/test/java/org/elasticsearch/index/query/RandomExistsQueryBuilder.java
+++ b/core/src/test/java/org/elasticsearch/index/query/RandomExistsQueryBuilder.java
@@ -1,0 +1,34 @@
+package org.elasticsearch.index.query;
+
+import com.carrotsearch.randomizedtesting.generators.RandomPicks;
+import com.carrotsearch.randomizedtesting.generators.RandomStrings;
+import org.elasticsearch.cluster.metadata.MetaData;
+
+import java.util.Random;
+
+public class RandomExistsQueryBuilder implements RandomQueryBuilder<ExistsQueryBuilder> {
+
+    @Override
+    public ExistsQueryBuilder newQueryBuilder(Random random) {
+        String fieldPattern;
+        if (random.nextBoolean()) {
+            fieldPattern = RandomPicks.randomFrom(random, BaseQueryTestCase.MAPPED_FIELD_NAMES);
+        } else {
+            fieldPattern = RandomStrings.randomAsciiOfLengthBetween(random, 1, 10);
+        }
+        // also sometimes test wildcard patterns
+        if (random.nextBoolean()) {
+            if (random.nextBoolean()) {
+                fieldPattern = fieldPattern + "*";
+            } else {
+                fieldPattern = MetaData.ALL;
+            }
+        }
+        ExistsQueryBuilder query = new ExistsQueryBuilder(fieldPattern);
+
+        if (random.nextBoolean()) {
+            query.queryName(RandomStrings.randomAsciiOfLengthBetween(random, 1, 10));
+        }
+        return query;
+    }
+}

--- a/core/src/test/java/org/elasticsearch/index/query/RandomIdsQueryBuilder.java
+++ b/core/src/test/java/org/elasticsearch/index/query/RandomIdsQueryBuilder.java
@@ -1,0 +1,53 @@
+package org.elasticsearch.index.query;
+
+import com.carrotsearch.randomizedtesting.generators.RandomInts;
+import com.carrotsearch.randomizedtesting.generators.RandomPicks;
+import com.carrotsearch.randomizedtesting.generators.RandomStrings;
+import org.elasticsearch.cluster.metadata.MetaData;
+
+import java.util.Random;
+
+public class RandomIdsQueryBuilder implements RandomQueryBuilder<IdsQueryBuilder> {
+
+    @Override
+    public IdsQueryBuilder newQueryBuilder(Random random) {
+        String[] types;
+        if (BaseQueryTestCase.getCurrentTypes().length > 0 && random.nextBoolean()) {
+            int numberOfTypes = RandomInts.randomIntBetween(random, 1, BaseQueryTestCase.getCurrentTypes().length);
+            types = new String[numberOfTypes];
+            for (int i = 0; i < numberOfTypes; i++) {
+                if (RandomInts.randomInt(random, 9) > 0) {
+                    types[i] = RandomPicks.randomFrom(random, BaseQueryTestCase.getCurrentTypes());
+                } else {
+                    types[i] = RandomStrings.randomAsciiOfLengthBetween(random, 1, 10);
+                }
+            }
+        } else {
+            if (random.nextBoolean()) {
+                types = new String[]{MetaData.ALL};
+            } else {
+                types = new String[0];
+            }
+        }
+        int numberOfIds = RandomInts.randomIntBetween(random, 0, 10);
+        String[] ids = new String[numberOfIds];
+        for (int i = 0; i < numberOfIds; i++) {
+            ids[i] = RandomStrings.randomAsciiOfLengthBetween(random, 1, 10);
+        }
+        IdsQueryBuilder query;
+        if (types.length > 0 || random.nextBoolean()) {
+            query = new IdsQueryBuilder(types);
+            query.addIds(ids);
+        } else {
+            query = new IdsQueryBuilder();
+            query.addIds(ids);
+        }
+        if (random.nextBoolean()) {
+            query.boost(2.0f / RandomInts.randomIntBetween(random, 1, 20));
+        }
+        if (random.nextBoolean()) {
+            query.queryName(RandomStrings.randomAsciiOfLengthBetween(random, 1, 10));
+        }
+        return query;
+    }
+}

--- a/core/src/test/java/org/elasticsearch/index/query/RandomLimitQueryBuilder.java
+++ b/core/src/test/java/org/elasticsearch/index/query/RandomLimitQueryBuilder.java
@@ -1,0 +1,13 @@
+package org.elasticsearch.index.query;
+
+import com.carrotsearch.randomizedtesting.generators.RandomInts;
+
+import java.util.Random;
+
+public class RandomLimitQueryBuilder implements RandomQueryBuilder<LimitQueryBuilder> {
+
+    @Override
+    public LimitQueryBuilder newQueryBuilder(Random random) {
+        return new LimitQueryBuilder(RandomInts.randomIntBetween(random, 0, 20));
+    }
+}

--- a/core/src/test/java/org/elasticsearch/index/query/RandomMatchAllQueryBuilder.java
+++ b/core/src/test/java/org/elasticsearch/index/query/RandomMatchAllQueryBuilder.java
@@ -1,0 +1,17 @@
+package org.elasticsearch.index.query;
+
+import com.carrotsearch.randomizedtesting.generators.RandomInts;
+
+import java.util.Random;
+
+public class RandomMatchAllQueryBuilder implements RandomQueryBuilder<MatchAllQueryBuilder> {
+
+    @Override
+    public MatchAllQueryBuilder newQueryBuilder(Random random) {
+        MatchAllQueryBuilder query = new MatchAllQueryBuilder();
+        if (random.nextBoolean()) {
+            query.boost(2.0f / RandomInts.randomIntBetween(random, 1, 20));
+        }
+        return query;
+    }
+}

--- a/core/src/test/java/org/elasticsearch/index/query/RandomQueriesRegistry.java
+++ b/core/src/test/java/org/elasticsearch/index/query/RandomQueriesRegistry.java
@@ -1,0 +1,30 @@
+package org.elasticsearch.index.query;
+
+import com.carrotsearch.randomizedtesting.generators.RandomPicks;
+
+import java.util.Map;
+import java.util.Random;
+import java.util.TreeMap;
+
+public class RandomQueriesRegistry {
+
+    private final static Map<String, RandomQueryBuilder> registry;
+
+    static {
+        //order matters here for repeatable tests
+        registry = new TreeMap<>();
+        registry.put(MatchAllQueryBuilder.NAME, new RandomMatchAllQueryBuilder());
+        registry.put(TermQueryBuilder.NAME, new RandomTermQueryBuilder());
+        //span_term cannot go anywhere, only within span queries
+        //registry.put(SpanTermQueryBuilder.NAME, new RandomSpanTermQueryBuilder());
+        registry.put(RangeQueryBuilder.NAME, new RandomRangeQueryBuilder());
+        registry.put(IdsQueryBuilder.NAME, new RandomIdsQueryBuilder());
+        registry.put(LimitQueryBuilder.NAME, new RandomLimitQueryBuilder());
+        registry.put(ExistsQueryBuilder.NAME, new RandomExistsQueryBuilder());
+        registry.put(BoolQueryBuilder.NAME, new RandomBoolQueryBuilder());
+    }
+
+    public static QueryBuilder createRandomQuery(Random random) {
+        return RandomPicks.randomFrom(random, registry.values()).newQueryBuilder(random);
+    }
+}

--- a/core/src/test/java/org/elasticsearch/index/query/RandomQueryBuilder.java
+++ b/core/src/test/java/org/elasticsearch/index/query/RandomQueryBuilder.java
@@ -19,31 +19,9 @@
 
 package org.elasticsearch.index.query;
 
-import com.carrotsearch.randomizedtesting.generators.RandomInts;
-
 import java.util.Random;
 
-/**
- * Utility class for creating random QueryBuilders.
- * So far only leaf queries like {@link MatchAllQueryBuilder}, {@link TermQueryBuilder} or
- * {@link IdsQueryBuilder} are returned.
- */
-public class RandomQueryBuilder {
+public interface RandomQueryBuilder<QB extends QueryBuilder> {
 
-    /**
-     * @param r random seed
-     * @return a random {@link QueryBuilder}
-     */
-    public static QueryBuilder create(Random r) {
-        QueryBuilder query = null;
-        switch (RandomInts.randomIntBetween(r, 0, 2)) {
-        case 0:
-            return new MatchAllQueryBuilderTest().createTestQueryBuilder();
-        case 1:
-            return new TermQueryBuilderTest().createTestQueryBuilder();
-        case 2:
-            return new IdsQueryBuilderTest().createTestQueryBuilder();
-        }
-        return query;
-    }
+    QB newQueryBuilder(Random random);
 }

--- a/core/src/test/java/org/elasticsearch/index/query/RandomRangeQueryBuilder.java
+++ b/core/src/test/java/org/elasticsearch/index/query/RandomRangeQueryBuilder.java
@@ -1,0 +1,60 @@
+package org.elasticsearch.index.query;
+
+import com.carrotsearch.randomizedtesting.generators.RandomInts;
+import com.carrotsearch.randomizedtesting.generators.RandomStrings;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+public class RandomRangeQueryBuilder implements RandomQueryBuilder<RangeQueryBuilder> {
+
+    private static final List<String> TIMEZONE_IDS = new ArrayList<>(DateTimeZone.getAvailableIDs());
+
+    @Override
+    public RangeQueryBuilder newQueryBuilder(Random random) {
+        RangeQueryBuilder query;
+        // switch between numeric and date ranges
+        if (random.nextBoolean()) {
+            if (random.nextBoolean()) {
+                // use mapped integer field for numeric range queries
+                query = new RangeQueryBuilder(BaseQueryTestCase.INT_FIELD_NAME);
+                query.from(RandomInts.randomIntBetween(random, 1, 100));
+                query.to(RandomInts.randomIntBetween(random, 101, 200));
+            } else {
+                // use unmapped field for numeric range queries
+                query = new RangeQueryBuilder(RandomStrings.randomAsciiOfLengthBetween(random, 1, 10));
+                query.from(0.0 - random.nextDouble());
+                query.to(random.nextDouble());
+            }
+        } else {
+            // use mapped date field, using date string representation
+            query = new RangeQueryBuilder(BaseQueryTestCase.DATE_FIELD_NAME);
+            query.from(new DateTime(System.currentTimeMillis() - RandomInts.randomIntBetween(random, 0, 1000000)).toString());
+            query.to(new DateTime(System.currentTimeMillis() + RandomInts.randomIntBetween(random, 0, 1000000)).toString());
+            if (random.nextBoolean()) {
+                query.timeZone(TIMEZONE_IDS.get(RandomInts.randomIntBetween(random, 0, TIMEZONE_IDS.size() - 1)));
+            }
+            if (random.nextBoolean()) {
+                query.format("yyyy-MM-dd'T'HH:mm:ss.SSSZZ");
+            }
+        }
+        query.includeLower(random.nextBoolean()).includeUpper(random.nextBoolean());
+        if (random.nextBoolean()) {
+            query.boost(2.0f / RandomInts.randomIntBetween(random, 1, 20));
+        }
+        if (random.nextBoolean()) {
+            query.queryName(RandomStrings.randomAsciiOfLengthBetween(random, 1, 10));
+        }
+
+        if (random.nextBoolean()) {
+            query.from(null);
+        }
+        if (random.nextBoolean()) {
+            query.to(null);
+        }
+        return query;
+    }
+}

--- a/core/src/test/java/org/elasticsearch/index/query/RandomSpanTermQueryBuilder.java
+++ b/core/src/test/java/org/elasticsearch/index/query/RandomSpanTermQueryBuilder.java
@@ -1,0 +1,9 @@
+package org.elasticsearch.index.query;
+
+public class RandomSpanTermQueryBuilder extends RandomBaseTermQueryBuilder<SpanTermQueryBuilder> {
+
+    @Override
+    protected SpanTermQueryBuilder createQueryBuilder(String fieldName, Object value) {
+        return new SpanTermQueryBuilder(fieldName, value);
+    }
+}

--- a/core/src/test/java/org/elasticsearch/index/query/RandomTermQueryBuilder.java
+++ b/core/src/test/java/org/elasticsearch/index/query/RandomTermQueryBuilder.java
@@ -1,0 +1,9 @@
+package org.elasticsearch.index.query;
+
+public class RandomTermQueryBuilder extends RandomBaseTermQueryBuilder<TermQueryBuilder> {
+
+    @Override
+    protected TermQueryBuilder createQueryBuilder(String fieldName, Object value) {
+        return new TermQueryBuilder(fieldName, value);
+    }
+}

--- a/core/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTest.java
@@ -27,65 +27,15 @@ import org.elasticsearch.common.joda.Joda;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.core.DateFieldMapper;
-import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 public class RangeQueryBuilderTest extends BaseQueryTestCase<RangeQueryBuilder> {
-
-    private static final List<String> TIMEZONE_IDS = new ArrayList<>(DateTimeZone.getAvailableIDs());
-
-    @Override
-    protected RangeQueryBuilder createTestQueryBuilder() {
-        RangeQueryBuilder query;
-        // switch between numeric and date ranges
-        if (randomBoolean()) {
-            if (randomBoolean()) {
-                // use mapped integer field for numeric range queries
-                query = new RangeQueryBuilder(INT_FIELD_NAME);
-                query.from(randomIntBetween(1, 100));
-                query.to(randomIntBetween(101, 200));
-            } else {
-                // use unmapped field for numeric range queries
-                query = new RangeQueryBuilder(randomAsciiOfLengthBetween(1, 10));
-                query.from(0.0-randomDouble());
-                query.to(randomDouble());
-            }
-        } else {
-            // use mapped date field, using date string representation
-            query = new RangeQueryBuilder(DATE_FIELD_NAME);
-            query.from(new DateTime(System.currentTimeMillis() - randomIntBetween(0, 1000000)).toString());
-            query.to(new DateTime(System.currentTimeMillis() + randomIntBetween(0, 1000000)).toString());
-            if (randomBoolean()) {
-                query.timeZone(TIMEZONE_IDS.get(randomIntBetween(0, TIMEZONE_IDS.size()-1)));
-            }
-            if (randomBoolean()) {
-                query.format("yyyy-MM-dd'T'HH:mm:ss.SSSZZ");
-            }
-        }
-        query.includeLower(randomBoolean()).includeUpper(randomBoolean());
-        if (randomBoolean()) {
-            query.boost(2.0f / randomIntBetween(1, 20));
-        }
-        if (randomBoolean()) {
-            query.queryName(randomAsciiOfLengthBetween(1, 10));
-        }
-
-        if (randomBoolean()) {
-            query.from(null);
-        }
-        if (randomBoolean()) {
-            query.to(null);
-        }
-        return query;
-    }
 
     @Override
     protected Query createExpectedQuery(RangeQueryBuilder queryBuilder, QueryParseContext context) throws IOException {
@@ -153,5 +103,10 @@ public class RangeQueryBuilderTest extends BaseQueryTestCase<RangeQueryBuilder> 
         RangeQueryBuilder query = new RangeQueryBuilder(INT_FIELD_NAME);
         query.from(1).to(10).timeZone("UTC");
         query.toQuery(createContext());
+    }
+
+    @Override
+    protected RandomQueryBuilder<RangeQueryBuilder> getRandomQueryBuilder() {
+        return new RandomRangeQueryBuilder();
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/query/SpanTermQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanTermQueryBuilderTest.java
@@ -34,4 +34,9 @@ public class SpanTermQueryBuilderTest extends BaseTermQueryTestCase<SpanTermQuer
     protected Query createLuceneTermQuery(Term term) {
         return new SpanTermQuery(term);
     }
+
+    @Override
+    protected RandomQueryBuilder<SpanTermQueryBuilder> getRandomQueryBuilder() {
+        return new RandomSpanTermQueryBuilder();
+    }
 }

--- a/core/src/test/java/org/elasticsearch/index/query/TermQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/TermQueryBuilderTest.java
@@ -25,9 +25,6 @@ import org.apache.lucene.search.TermQuery;
 
 public class TermQueryBuilderTest extends BaseTermQueryTestCase<TermQueryBuilder> {
 
-    /**
-     * @return a TermQuery with random field name and value, optional random boost and queryname
-     */
     @Override
     protected TermQueryBuilder createQueryBuilder(String fieldName, Object value) {
         return new TermQueryBuilder(fieldName, value);
@@ -36,5 +33,10 @@ public class TermQueryBuilderTest extends BaseTermQueryTestCase<TermQueryBuilder
     @Override
     protected Query createLuceneTermQuery(Term term) {
         return new TermQuery(term);
+    }
+
+    @Override
+    protected RandomQueryBuilder<TermQueryBuilder> getRandomQueryBuilder() {
+        return new RandomTermQueryBuilder();
     }
 }


### PR DESCRIPTION
Extracted random query creation code from tests and created one class per query. This is a bit verbose but allows us to avoid having to create a new instance of a test class in order to create a random instance of a specific query. Also, we can reuse the same code to add random queries to compound queries for more coverage and deeper testing. In the end this is a way to share code between different tests through intermediate classes.

I want to open this up for discussion, this solution is not perfect but it improve things a bit, although it might be seen as making our query test infra even more complicated, let's discuss it here.

This PR goes against the feature/query-refactoring branch.
