### PR TITLE
Use task's class name if not a TimedPrioritizeRunnable

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/service/InternalClusterService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/service/InternalClusterService.java
@@ -318,7 +318,7 @@ public class InternalClusterService extends AbstractLifecycleComponent<ClusterSe
                 timeInQueue = runnable.timeSinceCreatedInMillis();
             } else {
                 assert false : "expected TimedPrioritizedRunnable got " + task.getClass();
-                source = "unknown";
+                source = "unknown [" + task.getClass() + "]";
                 timeInQueue = 0;
             }
 


### PR DESCRIPTION
This is helpful to track down the origin of pending_tasks that aren't
expected. In tests we catch this with an assert, but in production
asserts may not be enabled so we should at least add the class name.
