### PR TITLE
[build] update maven-shade-plugin to 2.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -807,7 +807,7 @@
                     <!-- We just declare which plugin version to use. Each project can have then its own settings -->
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>2.3</version>
+                    <version>2.4</version>
                 </plugin>
                 <plugin>
                     <!-- We just declare which plugin version to use. Each project can have then its own settings -->


### PR DESCRIPTION
## Release Notes - Apache Maven Shade - Version 2.4

https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12317921&version=12331393
### Bugs:
- [MSHADE-155] - dependency-reduced-pom should use shadedArtifactId
- [MSHADE-169] - Typos in warning message
- [MSHADE-172] - "java.lang.ArithmeticException: / by zero" in MinijarFilter
- [MSHADE-174] - Unable to shade Java 8 jarfiles with static interface methods using minimizeJar
- [MSHADE-183] - Getting "Error creating shaded jar: java.util.jar.Attributes cannot be
               cast to java.lang.String" error when using ManifestResourceTransformer with Maven 3.2.5
- [MSHADE-185] - systemPath content is interpolated for system dependencies
### Improvements:
- [MSHADE-177] - MavenProject/MavenSession Injection as a paremeter instead as a component.
- [MSHADE-178] - Removing plexus-container-default dependency
- [MSHADE-179] - Fix RAT Report
- [MSHADE-180] - Upgrade plexus-utils to 3.0.18
- [MSHADE-188] - Upgrade maven-dependency-tree to 2.2
- [MSHADE-191] - Upgrade plexus-utils to 3.0.22
- [MSHADE-192] - Upgrade maven-invoker to 1.10
- [MSHADE-193] - Upgrade to fluido skin 1.4.0
