### PR TITLE
[build] mark elasticsearch as provided in plugins

### DIFF
--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -39,6 +39,7 @@
         <dependency>
             <groupId>org.elasticsearch</groupId>
             <artifactId>elasticsearch</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.elasticsearch</groupId>


### PR DESCRIPTION
When we build a plugin, we suppose it will be executed within elasticsearch server.
So we should mark it as `provided`.

If a java developer needs to embed the plugin and elasticsearch, it will make sense to declare both in its `pom.xml` file.
