### PR TITLE
Revert "Removing top-level filter parameter from search API."

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/query/QueryPhase.java
+++ b/core/src/main/java/org/elasticsearch/search/query/QueryPhase.java
@@ -65,6 +65,7 @@ public class QueryPhase implements SearchPhase {
                 .put("query", new QueryParseElement())
                 .put("queryBinary", new QueryBinaryParseElement())
                 .put("query_binary", new QueryBinaryParseElement())
+                .put("filter", new PostFilterParseElement()) // For bw comp reason, should be removed in version 1.1
                 .put("post_filter", new PostFilterParseElement())
                 .put("postFilter", new PostFilterParseElement())
                 .put("filterBinary", new FilterBinaryParseElement())


### PR DESCRIPTION
Reverts elastic/elasticsearch#11600

Tests are failing so reverting PR for now. Need to re-run tests with `-Dtests.slow=true`
