### PR TITLE
Reduce the size of the XContent parsing exception

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/xcontent/XContentFactory.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/XContentFactory.java
@@ -177,7 +177,7 @@ public class XContentFactory {
     public static XContent xContent(CharSequence content) {
         XContentType type = xContentType(content);
         if (type == null) {
-            throw new ElasticsearchParseException("Failed to derive xcontent from " + content);
+            throw new ElasticsearchParseException("Failed to derive xcontent");
         }
         return xContent(type);
     }
@@ -195,7 +195,7 @@ public class XContentFactory {
     public static XContent xContent(byte[] data, int offset, int length) {
         XContentType type = xContentType(data, offset, length);
         if (type == null) {
-            throw new ElasticsearchParseException("Failed to derive xcontent from (offset=" + offset + ", length=" + length + "): " + Arrays.toString(data));
+            throw new ElasticsearchParseException("Failed to derive xcontent");
         }
         return xContent(type);
     }
@@ -290,7 +290,7 @@ public class XContentFactory {
     public static XContent xContent(BytesReference bytes) {
         XContentType type = xContentType(bytes);
         if (type == null) {
-            throw new ElasticsearchParseException("Failed to derive xcontent from " + bytes);
+            throw new ElasticsearchParseException("Failed to derive xcontent");
         }
         return xContent(type);
     }

--- a/core/src/test/java/org/elasticsearch/percolator/MultiPercolatorTests.java
+++ b/core/src/test/java/org/elasticsearch/percolator/MultiPercolatorTests.java
@@ -311,7 +311,7 @@ public class MultiPercolatorTests extends ElasticsearchIntegrationTest {
             assertThat(item.getResponse().getSuccessfulShards(), equalTo(0));
             assertThat(item.getResponse().getShardFailures().length, equalTo(test.numPrimaries));
             for (ShardOperationFailedException shardFailure : item.getResponse().getShardFailures()) {
-                assertThat(shardFailure.reason(), containsString("Failed to derive xcontent from"));
+                assertThat(shardFailure.reason(), containsString("Failed to derive xcontent"));
                 assertThat(shardFailure.status().getStatus(), equalTo(500));
             }
         }


### PR DESCRIPTION
The content that caused the exception can be potentially very big and in most cases it's not very useful for debugging.
