### PR TITLE
Categorize index by size and make ClusterInfo available to all nodes

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/ClusterInfo.java
+++ b/core/src/main/java/org/elasticsearch/cluster/ClusterInfo.java
@@ -20,30 +20,184 @@
 package org.elasticsearch.cluster;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.shard.ShardId;
 
+import java.io.IOException;
 import java.util.Map;
 
 /**
- * ClusterInfo is an object representing a map of nodes to {@link DiskUsage}
- * and a map of shard ids to shard sizes, see
- * <code>InternalClusterInfoService.shardIdentifierFromRouting(String)</code>
- * for the key used in the shardSizes map
+ * ClusterInfo is an object representing information about nodes and shards in
+ * the cluster. This includes a map of nodes to disk usage, primary shards to
+ * shard size, and classifications for the relative sizes of indices in the
+ * cluster.
+ *
+ * It is a custom cluster state object. This means it is sent to all nodes in
+ * the cluster via the cluster state, however, it is not written to disk since
+ * it is dynamically generated.
  */
-public class ClusterInfo {
+public class ClusterInfo extends AbstractDiffable<ClusterState.Custom> implements ClusterState.Custom {
 
+    public static final String TYPE = "cluster_info";
+    public static final ClusterInfo PROTO = new ClusterInfo();
+    
     private final ImmutableMap<String, DiskUsage> usages;
-    private final ImmutableMap<String, Long> shardSizes;
+    private final ImmutableMap<ShardId, Long> shardSizes;
+    private final IndexClassification indexClassification;
 
-    public ClusterInfo(ImmutableMap<String, DiskUsage> usages, ImmutableMap<String, Long> shardSizes) {
-        this.usages = usages;
-        this.shardSizes = shardSizes;
+    public ClusterInfo() {
+        this.usages = ImmutableMap.of();
+        this.shardSizes = ImmutableMap.of();
+        this.indexClassification = new IndexClassification(ImmutableMap.<String, IndexSize>of());
     }
 
+    public ClusterInfo(Map<String, DiskUsage> usages, Map<ShardId, Long> shardSizes,
+                       IndexClassification indexClassification) {
+        this.usages = ImmutableMap.copyOf(usages);
+        this.shardSizes = ImmutableMap.copyOf(shardSizes);
+        this.indexClassification = indexClassification;
+    }
+
+    public ClusterInfo(Map<String, DiskUsage> usages, Map<ShardId, Long> shardSizes,
+                       Map<String, IndexSize> indexClassifications) {
+        this(usages, shardSizes, new IndexClassification(indexClassifications));
+    }
+
+    /**
+     * Return a map of node ids to disk usage
+     */
     public Map<String, DiskUsage> getNodeDiskUsages() {
         return this.usages;
     }
 
-    public Map<String, Long> getShardSizes() {
+    /**
+     * Return a map of shard id to shard size. Note this is the size of the
+     * primary shard.
+     */
+    public Map<ShardId, Long> getShardSizes() {
         return this.shardSizes;
+    }
+
+    /**
+     * Return a map of index name to index size classification.
+     */
+    public Map<String, IndexSize> getIndexClassification() {
+        return this.indexClassification.getIndexClassifications();
+    }
+
+    public String type() {
+        return TYPE;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject("node_disk_usage");
+        for (Map.Entry<String, DiskUsage> entry : usages.entrySet()) {
+            builder.startObject(entry.getKey());
+            builder.field("free_bytes");
+            builder.value(entry.getValue().getFreeBytes());
+            builder.field("used_bytes");
+            builder.value(entry.getValue().getUsedBytes());
+            builder.endObject();
+        }
+        builder.endObject();
+        builder.startObject("shard_size");
+        for (Map.Entry<ShardId, Long> entry : shardSizes.entrySet()) {
+            builder.field(entry.getKey().toString());
+            builder.value(entry.getValue());
+        }
+        builder.endObject();
+        indexClassification.toXContent(builder, params);
+        return builder;
+    }
+
+    @Override
+    public ClusterInfo readFrom(StreamInput in) throws IOException {
+        long mapSize = in.readVLong();
+        Map<String, DiskUsage> newUsages = Maps.newHashMap();
+        for (int i = 0; i < mapSize; i++) {
+            String index = in.readString();
+            String nodeId = in.readString();
+            String nodeName = in.readString();
+            long totalBytes = in.readLong();
+            long freeBytes = in.readLong();
+            DiskUsage usage = new DiskUsage(nodeId, nodeName, totalBytes, freeBytes);
+            newUsages.put(index, usage);
+        }
+
+        mapSize = in.readVLong();
+        Map<ShardId, Long> newSizes = Maps.newHashMap();
+        for (int i = 0; i < mapSize; i++) {
+            String idx = in.readString();
+            int id = in.readVInt();
+            long size = in.readLong();
+            newSizes.put(new ShardId(idx, id), size);
+        }
+
+        IndexClassification newClassifications = new IndexClassification();
+        newClassifications.readFrom(in);
+        return new ClusterInfo(newUsages, newSizes, newClassifications);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVLong(usages.size());
+        for (Map.Entry<String, DiskUsage> entry : usages.entrySet()) {
+            String index = entry.getKey();
+            DiskUsage usage = entry.getValue();
+            out.writeString(index);
+            out.writeString(usage.getNodeId());
+            out.writeString(usage.getNodeName());
+            out.writeLong(usage.getTotalBytes());
+            out.writeLong(usage.getFreeBytes());
+        }
+
+        out.writeVLong(shardSizes.size());
+        for (Map.Entry<ShardId, Long> entry : shardSizes.entrySet()) {
+            out.writeString(entry.getKey().getIndex());
+            out.writeVInt(entry.getKey().getId());
+            out.writeLong(entry.getValue());
+        }
+
+        indexClassification.writeTo(out);
+    }
+
+    @Override
+    public int hashCode() {
+        return usages.hashCode() ^
+                31 * shardSizes.hashCode() ^
+                31 * indexClassification.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (obj instanceof ClusterInfo) {
+            ClusterInfo other = (ClusterInfo) obj;
+            return usages.equals(other.usages) &&
+                    shardSizes.equals(other.shardSizes) &&
+                    indexClassification.equals(other.indexClassification);
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * An Enumeration representing the classification for the size of an index.
+     * {@code SMALLEST} corresponds to the smallest index and {@code LARGEST}
+     * corresponds to the largest, with the other sizes falling equidistantly
+     * between them.
+     */
+    public enum IndexSize {
+        SMALLEST,
+        SMALL,
+        MEDIUM,
+        LARGE,
+        LARGEST
     }
 }

--- a/core/src/main/java/org/elasticsearch/cluster/ClusterState.java
+++ b/core/src/main/java/org/elasticsearch/cluster/ClusterState.java
@@ -121,6 +121,7 @@ public class ClusterState implements ToXContent, Diffable<ClusterState> {
         // register non plugin custom parts
         registerPrototype(SnapshotsInProgress.TYPE, SnapshotsInProgress.PROTO);
         registerPrototype(RestoreInProgress.TYPE, RestoreInProgress.PROTO);
+        registerPrototype(ClusterInfo.TYPE, ClusterInfo.PROTO);
     }
 
     @Nullable
@@ -289,6 +290,12 @@ public class ClusterState implements ToXContent, Diffable<ClusterState> {
         sb.append(nodes().prettyPrint());
         sb.append(routingTable().prettyPrint());
         sb.append(readOnlyRoutingNodes().prettyPrint());
+        sb.append("custom:").append("\n");
+        for (ObjectObjectCursor<String, Custom> cursor : customs) {
+            sb.append(cursor.key).append(":\n");
+            sb.append(cursor.value.toString()).append("\n");
+        }
+        sb.append("\n");
         return sb.toString();
     }
 

--- a/core/src/main/java/org/elasticsearch/cluster/DiskUsage.java
+++ b/core/src/main/java/org/elasticsearch/cluster/DiskUsage.java
@@ -76,8 +76,32 @@ public class DiskUsage {
     }
 
     @Override
+    public int hashCode() {
+        return nodeId.hashCode() ^
+                31 * nodeName.hashCode() ^
+                31 * Long.hashCode(freeBytes) ^
+                31 * Long.hashCode(totalBytes);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (obj instanceof DiskUsage) {
+            DiskUsage other = (DiskUsage) obj;
+            return nodeId.equals(other.nodeId) &&
+                    nodeName.equals(other.nodeName) &&
+                    freeBytes == other.freeBytes &&
+                    totalBytes == other.totalBytes;
+        } else {
+            return false;
+        }
+    }
+
+    @Override
     public String toString() {
-        return "[" + nodeId + "][" + nodeName + "] free: " + new ByteSizeValue(getFreeBytes()) +
-                "[" + Strings.format1Decimals(getFreeDiskAsPercentage(), "%") + "]";
+        return "[" + nodeId + "][" + nodeName + "] used: " + new ByteSizeValue(getUsedBytes()) +
+                "[" + Strings.format1Decimals(getUsedDiskAsPercentage(), "%") + "]";
     }
 }

--- a/core/src/main/java/org/elasticsearch/cluster/EmptyClusterInfoService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/EmptyClusterInfoService.java
@@ -35,7 +35,7 @@ public class EmptyClusterInfoService extends AbstractComponent implements Cluste
 
     private EmptyClusterInfoService() {
         super(Settings.EMPTY);
-        emptyClusterInfo = new ClusterInfo(ImmutableMap.<String, DiskUsage>of(), ImmutableMap.<String, Long>of());
+        emptyClusterInfo = new ClusterInfo();
     }
 
     public static EmptyClusterInfoService getInstance() {

--- a/core/src/main/java/org/elasticsearch/cluster/IndexClassification.java
+++ b/core/src/main/java/org/elasticsearch/cluster/IndexClassification.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * IndexClassification is used to classify indices by size into different
+ * {@code ClusterInfo.IndexSize} categories.
+ */
+public class IndexClassification implements Streamable, ToXContent {
+
+    private volatile ImmutableMap<String, ClusterInfo.IndexSize> indexClassifications;
+
+    public IndexClassification(Map<String, ClusterInfo.IndexSize> indexClassifications) {
+        this.indexClassifications = ImmutableMap.copyOf(indexClassifications);
+    }
+
+    // Used for serialization in ClusterInfo
+    IndexClassification() {
+    }
+
+    public static IndexClassification classifyIndices(final Map<String, Long> indexSizes,
+            ESLogger logger) {
+        long maxSize = 0;
+        long minSize = Long.MAX_VALUE;
+        for (Map.Entry<String, Long> idx : indexSizes.entrySet()) {
+            maxSize = Math.max(maxSize, idx.getValue());
+            minSize = Math.min(minSize, idx.getValue());
+        }
+        Map<String, ClusterInfo.IndexSize> newIndexClassifications = new HashMap<>(indexSizes.size());
+
+        long TINY = minSize;
+        long HUGE = maxSize;
+        long MEDIUM = HUGE - ((HUGE - TINY) / 2);
+        long SMALL = MEDIUM - ((MEDIUM - TINY) / 2);
+        long LARGE = HUGE - ((HUGE - MEDIUM) / 2);
+
+        if (logger.isDebugEnabled()) {
+            logger.debug("SMALLEST: [{}], SMALL: [{}], MEDIUM: [{}], LARGE: [{}], LARGEST: [{}]",
+                    new ByteSizeValue(TINY),
+                    new ByteSizeValue(SMALL),
+                    new ByteSizeValue(MEDIUM),
+                    new ByteSizeValue(LARGE),
+                    new ByteSizeValue(HUGE));
+        }
+
+        for (Map.Entry<String, Long> idx : indexSizes.entrySet()) {
+            if (TINY == HUGE) {
+                // This means they're all the same size, or there is only one
+                // index, so short-circuit to MEDIUM
+                logger.debug("index [{}] is [{}]", idx.getKey(), ClusterInfo.IndexSize.MEDIUM);
+                newIndexClassifications.put(idx.getKey(), ClusterInfo.IndexSize.MEDIUM);
+                continue;
+            }
+            long size = idx.getValue();
+            logger.debug("index size for [{}] is [{}]", idx.getKey(), new ByteSizeValue(size));
+            ClusterInfo.IndexSize sizeEnum;
+            // split the search set in half
+            if (size <= MEDIUM) {
+                // less than or equal to medium
+                if (size > SMALL) {
+                    // between SMALL and MEDIUM
+                    if ((size - SMALL) < (MEDIUM - size)) {
+                        sizeEnum = ClusterInfo.IndexSize.SMALL;
+                    } else {
+                        sizeEnum = ClusterInfo.IndexSize.MEDIUM;
+                    }
+                } else {
+                    // between SMALLEST and SMALL
+                    if ((size - TINY) < (SMALL - size)) {
+                        sizeEnum = ClusterInfo.IndexSize.SMALLEST;
+                    } else {
+                        sizeEnum = ClusterInfo.IndexSize.SMALL;
+                    }
+                }
+            } else {
+                // greater than MEDIUM
+                if (size > LARGE) {
+                    // between LARGE and LARGEST
+                    if ((size - LARGE) < (HUGE - size)) {
+                        sizeEnum = ClusterInfo.IndexSize.LARGE;
+                    } else {
+                        sizeEnum = ClusterInfo.IndexSize.LARGEST;
+                    }
+                } else {
+                    // between MEDIUM and LARGE
+                    if ((size - MEDIUM) < (LARGE - size)) {
+                        sizeEnum = ClusterInfo.IndexSize.MEDIUM;
+                    } else {
+                        sizeEnum = ClusterInfo.IndexSize.LARGE;
+                    }
+                }
+            }
+            logger.debug("index [{}] is [{}]", idx.getKey(), sizeEnum);
+            newIndexClassifications.put(idx.getKey(), sizeEnum);
+        }
+
+        return new IndexClassification(newIndexClassifications);
+    }
+
+    public Map<String, ClusterInfo.IndexSize> getIndexClassifications() {
+        return this.indexClassifications;
+    }
+    
+    @Override
+    public int hashCode() {
+        return this.indexClassifications.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null) {
+            return false;
+        }
+        if (o instanceof IndexClassification) {
+            IndexClassification other = (IndexClassification) o;
+            // Just compare the maps
+            return this.indexClassifications.equals(other.getIndexClassifications());
+        } else {
+            return false;
+        }
+    }
+    
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        for (Map.Entry<String, ClusterInfo.IndexSize> entry : indexClassifications.entrySet()) {
+            sb.append(entry.getKey()).append(": ");
+            sb.append(entry.getValue());
+            sb.append("\n");
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject("classifications");
+        for (Map.Entry<String, ClusterInfo.IndexSize> entry : indexClassifications.entrySet()) {
+            builder.field(entry.getKey());
+            builder.value(entry.getValue());
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        long mapSize = in.readVLong();
+        Map<String, ClusterInfo.IndexSize> sizes = Maps.newHashMap();
+        for (int i = 0; i < mapSize; i++) {
+            String index = in.readString();
+            String sizeStr = in.readString();
+            ClusterInfo.IndexSize size = ClusterInfo.IndexSize.valueOf(sizeStr);
+            sizes.put(index, size);
+        }
+        this.indexClassifications = ImmutableMap.copyOf(sizes);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVLong(indexClassifications.size());
+        for (Map.Entry<String, ClusterInfo.IndexSize> entry : indexClassifications.entrySet()) {
+            String index = entry.getKey();
+            ClusterInfo.IndexSize size = entry.getValue();
+            out.writeString(index);
+            out.writeString(size.toString());
+        }
+    }
+}

--- a/core/src/test/java/org/elasticsearch/cluster/ClusterStateDiffTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/ClusterStateDiffTests.java
@@ -44,7 +44,9 @@ import org.elasticsearch.search.warmer.IndexWarmersMetaData;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.junit.Test;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.elasticsearch.cluster.metadata.AliasMetaData.newAliasMetaDataBuilder;
 import static org.elasticsearch.test.XContentTestUtils.convertToMap;
@@ -630,7 +632,7 @@ public class ClusterStateDiffTests extends ElasticsearchIntegrationTest {
 
             @Override
             public ClusterState.Custom randomCreate(String name) {
-                switch (randomIntBetween(0, 1)) {
+                switch (randomIntBetween(0, 2)) {
                     case 0:
                         return new SnapshotsInProgress(new SnapshotsInProgress.Entry(
                                 new SnapshotId(randomName("repo"), randomName("snap")),
@@ -645,6 +647,14 @@ public class ClusterStateDiffTests extends ElasticsearchIntegrationTest {
                                 RestoreInProgress.State.fromValue((byte) randomIntBetween(0, 3)),
                                 ImmutableList.<String>of(),
                                 ImmutableMap.<ShardId, RestoreInProgress.ShardRestoreStatus>of()));
+                    case 2:
+                        Map<String, DiskUsage> usages = new HashMap<>();
+                        Map<ShardId, Long> sizes = new HashMap<>();
+                        Map<String, ClusterInfo.IndexSize> classifications = new HashMap<>();
+                        usages.put("node1", new DiskUsage("nodeid", "node1", 100, 50));
+                        sizes.put(new ShardId("test", 0), 100L);
+                        classifications.put("test", ClusterInfo.IndexSize.MEDIUM);
+                        return new ClusterInfo(usages, sizes, classifications);
                     default:
                         throw new IllegalArgumentException("Shouldn't be here");
                 }

--- a/core/src/test/java/org/elasticsearch/cluster/IndexClassificationTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/IndexClassificationTests.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster;
+
+import org.elasticsearch.common.io.stream.ByteBufferStreamInput;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.test.ElasticsearchTestCase;
+
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
+
+public class IndexClassificationTests extends ElasticsearchTestCase {
+
+    @Test
+    public void testIndexSizeClassification() throws Exception {
+        testSequence(1, 2, 3, 4, 5);
+        testSequence(1, 5, 10, 15, 20);
+        testSequence(1, 17, 27, 45, 55);
+
+        Map<String, Long> indexSizes = new HashMap<>(2);
+
+        indexSizes.put("single", 1L);
+        Map<String, ClusterInfo.IndexSize> c = IndexClassification.classifyIndices(indexSizes, logger).getIndexClassifications();
+        assertTrue(c.get("single") == ClusterInfo.IndexSize.MEDIUM);
+
+        indexSizes.clear();
+
+        indexSizes.put("foo", 3L);
+        indexSizes.put("bar", 3L);
+        c = IndexClassification.classifyIndices(indexSizes, logger).getIndexClassifications();
+        assertTrue(c.get("foo") == ClusterInfo.IndexSize.MEDIUM);
+        assertTrue(c.get("bar") == ClusterInfo.IndexSize.MEDIUM);
+    }
+
+    @Test
+    public void testIndexSizeStreaming() throws Exception {
+        Map<String, Long> indexSizes = new HashMap<>(2);
+
+        indexSizes.put("foo", 1L);
+        indexSizes.put("bar", 100L);
+        IndexClassification ic = IndexClassification.classifyIndices(indexSizes, logger);
+        assertTrue(ic.getIndexClassifications().get("foo") == ClusterInfo.IndexSize.SMALLEST);
+        assertTrue(ic.getIndexClassifications().get("bar") == ClusterInfo.IndexSize.LARGEST);
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        ic.writeTo(out);
+        out.flush();
+        ByteBufferStreamInput in = new ByteBufferStreamInput(ByteBuffer.wrap(out.bytes().toBytes()));
+        IndexClassification ic2 = new IndexClassification();
+        ic2.readFrom(in);
+
+        assertTrue(ic.getIndexClassifications().get("foo") == ClusterInfo.IndexSize.SMALLEST);
+        assertTrue(ic.getIndexClassifications().get("bar") == ClusterInfo.IndexSize.LARGEST);
+
+        assertEquals(ic.hashCode(), ic2.hashCode());
+        assertEquals(ic, ic2);
+    }
+
+    private void testSequence(long tiny, long small, long medium, long large, long huge) {
+        Map<String, Long> indexSizes = new HashMap<>(5);
+
+        indexSizes.put("tiny", tiny);
+        indexSizes.put("small", small);
+        indexSizes.put("medium", medium);
+        indexSizes.put("large", large);
+        indexSizes.put("huge", huge);
+        Map<String, ClusterInfo.IndexSize> c = IndexClassification.classifyIndices(indexSizes, logger).getIndexClassifications();
+
+        assertTrue("should be SMALLEST:" + c.get("tiny"),
+                c.get("tiny") == ClusterInfo.IndexSize.SMALLEST);
+        assertTrue("should be SMALL:" + c.get("small"),
+                c.get("small") == ClusterInfo.IndexSize.SMALL);
+        assertTrue("should be MEDIUM:" + c.get("medium"),
+                c.get("medium") == ClusterInfo.IndexSize.MEDIUM);
+        assertTrue("should be LARGE:" + c.get("large"),
+                c.get("large") == ClusterInfo.IndexSize.LARGE);
+        assertTrue("should be LARGEST:" + c.get("huge"),
+                c.get("huge") == ClusterInfo.IndexSize.LARGEST);
+    }
+}

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderTests.java
@@ -74,10 +74,11 @@ public class DiskThresholdDeciderTests extends ElasticsearchAllocationTestCase {
         usages.put("node3", new DiskUsage("node3", "node3", 100, 60)); // 40% used
         usages.put("node4", new DiskUsage("node4", "node4", 100, 80)); // 20% used
 
-        Map<String, Long> shardSizes = new HashMap<>();
-        shardSizes.put("[test][0][p]", 10L); // 10 bytes
-        shardSizes.put("[test][0][r]", 10L);
-        final ClusterInfo clusterInfo = new ClusterInfo(ImmutableMap.copyOf(usages), ImmutableMap.copyOf(shardSizes));
+        Map<ShardId, Long> shardSizes = new HashMap<>();
+        shardSizes.put(new ShardId("test", 0), 10L); // 10 bytes
+        final ClusterInfo clusterInfo = new ClusterInfo(ImmutableMap.copyOf(usages),
+                ImmutableMap.copyOf(shardSizes),
+                ImmutableMap.<String, ClusterInfo.IndexSize>of());
 
         AllocationDeciders deciders = new AllocationDeciders(Settings.EMPTY,
                 new HashSet<>(Arrays.asList(
@@ -269,10 +270,11 @@ public class DiskThresholdDeciderTests extends ElasticsearchAllocationTestCase {
         usages.put("node4", new DiskUsage("node4", "n4", 100, 80)); // 20% used
         usages.put("node5", new DiskUsage("node5", "n5", 100, 85)); // 15% used
 
-        Map<String, Long> shardSizes = new HashMap<>();
-        shardSizes.put("[test][0][p]", 10L); // 10 bytes
-        shardSizes.put("[test][0][r]", 10L);
-        final ClusterInfo clusterInfo = new ClusterInfo(ImmutableMap.copyOf(usages), ImmutableMap.copyOf(shardSizes));
+        Map<ShardId, Long> shardSizes = new HashMap<>();
+        shardSizes.put(new ShardId("test", 0), 10L); // 10 bytes
+        final ClusterInfo clusterInfo = new ClusterInfo(ImmutableMap.copyOf(usages),
+                ImmutableMap.copyOf(shardSizes),
+                ImmutableMap.<String, ClusterInfo.IndexSize>of());
 
         AllocationDeciders deciders = new AllocationDeciders(Settings.EMPTY,
                 new HashSet<>(Arrays.asList(
@@ -334,7 +336,9 @@ public class DiskThresholdDeciderTests extends ElasticsearchAllocationTestCase {
 
         // Make node without the primary now habitable to replicas
         usages.put(nodeWithoutPrimary, new DiskUsage(nodeWithoutPrimary, "", 100, 35)); // 65% used
-        final ClusterInfo clusterInfo2 = new ClusterInfo(ImmutableMap.copyOf(usages), ImmutableMap.copyOf(shardSizes));
+        final ClusterInfo clusterInfo2 = new ClusterInfo(ImmutableMap.copyOf(usages),
+                ImmutableMap.copyOf(shardSizes),
+                ImmutableMap.<String, ClusterInfo.IndexSize>of());
         cis = new ClusterInfoService() {
             @Override
             public ClusterInfo getClusterInfo() {
@@ -531,9 +535,11 @@ public class DiskThresholdDeciderTests extends ElasticsearchAllocationTestCase {
         usages.put("node1", new DiskUsage("node1", "n1", 100, 31)); // 69% used
         usages.put("node2", new DiskUsage("node2", "n2", 100, 1));  // 99% used
 
-        Map<String, Long> shardSizes = new HashMap<>();
-        shardSizes.put("[test][0][p]", 10L); // 10 bytes
-        final ClusterInfo clusterInfo = new ClusterInfo(ImmutableMap.copyOf(usages), ImmutableMap.copyOf(shardSizes));
+        Map<ShardId, Long> shardSizes = new HashMap<>();
+        shardSizes.put(new ShardId("test", 0), 10L); // 10 bytes
+        final ClusterInfo clusterInfo = new ClusterInfo(ImmutableMap.copyOf(usages),
+                ImmutableMap.copyOf(shardSizes),
+                ImmutableMap.<String, ClusterInfo.IndexSize>of());
 
         AllocationDeciders deciders = new AllocationDeciders(Settings.EMPTY,
                 new HashSet<>(Arrays.asList(
@@ -597,10 +603,11 @@ public class DiskThresholdDeciderTests extends ElasticsearchAllocationTestCase {
         usages.put("node2", new DiskUsage("node2", "node2", 100, 50)); // 50% used
         usages.put("node3", new DiskUsage("node3", "node3", 100, 0));  // 100% used
 
-        Map<String, Long> shardSizes = new HashMap<>();
-        shardSizes.put("[test][0][p]", 10L); // 10 bytes
-        shardSizes.put("[test][0][r]", 10L); // 10 bytes
-        final ClusterInfo clusterInfo = new ClusterInfo(ImmutableMap.copyOf(usages), ImmutableMap.copyOf(shardSizes));
+        Map<ShardId, Long> shardSizes = new HashMap<>();
+        shardSizes.put(new ShardId("test", 0), 10L); // 10 bytes
+        final ClusterInfo clusterInfo = new ClusterInfo(ImmutableMap.copyOf(usages),
+                ImmutableMap.copyOf(shardSizes),
+                ImmutableMap.<String, ClusterInfo.IndexSize>of());
 
         AllocationDeciders deciders = new AllocationDeciders(Settings.EMPTY,
                 new HashSet<>(Arrays.asList(
@@ -699,12 +706,12 @@ public class DiskThresholdDeciderTests extends ElasticsearchAllocationTestCase {
         usages.put("node2", new DiskUsage("node2", "n2", 100, 40)); // 60% used
         usages.put("node2", new DiskUsage("node3", "n3", 100, 40)); // 60% used
 
-        Map<String, Long> shardSizes = new HashMap<>();
-        shardSizes.put("[test][0][p]", 14L); // 14 bytes
-        shardSizes.put("[test][0][r]", 14L);
-        shardSizes.put("[test2][0][p]", 1L); // 1 bytes
-        shardSizes.put("[test2][0][r]", 1L);
-        final ClusterInfo clusterInfo = new ClusterInfo(ImmutableMap.copyOf(usages), ImmutableMap.copyOf(shardSizes));
+        Map<ShardId, Long> shardSizes = new HashMap<>();
+        shardSizes.put(new ShardId("test", 0), 14L); // 14 bytes
+        shardSizes.put(new ShardId("test2", 0), 1L); // 1 bytes
+        final ClusterInfo clusterInfo = new ClusterInfo(ImmutableMap.copyOf(usages),
+                ImmutableMap.copyOf(shardSizes),
+                ImmutableMap.<String, ClusterInfo.IndexSize>of());
 
         AllocationDeciders deciders = new AllocationDeciders(Settings.EMPTY,
                 new HashSet<>(Arrays.asList(
@@ -804,10 +811,12 @@ public class DiskThresholdDeciderTests extends ElasticsearchAllocationTestCase {
         usages.put("node1", new DiskUsage("node1", "n1", 100, 20)); // 80% used
         usages.put("node2", new DiskUsage("node2", "n2", 100, 100)); // 0% used
 
-        Map<String, Long> shardSizes = new HashMap<>();
-        shardSizes.put("[test][0][p]", 40L);
-        shardSizes.put("[test][1][p]", 40L);
-        final ClusterInfo clusterInfo = new ClusterInfo(ImmutableMap.copyOf(usages), ImmutableMap.copyOf(shardSizes));
+        Map<ShardId, Long> shardSizes = new HashMap<>();
+        shardSizes.put(new ShardId("test", 0), 40L);
+        shardSizes.put(new ShardId("test", 1), 40L);
+        final ClusterInfo clusterInfo = new ClusterInfo(ImmutableMap.copyOf(usages),
+                ImmutableMap.copyOf(shardSizes),
+                ImmutableMap.<String, ClusterInfo.IndexSize>of());
 
         DiskThresholdDecider diskThresholdDecider = new DiskThresholdDecider(diskSettings);
         MetaData metaData = MetaData.builder()

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderUnitTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderUnitTests.java
@@ -47,9 +47,7 @@ public class DiskThresholdDeciderUnitTests extends ElasticsearchTestCase {
         ClusterInfoService cis = new ClusterInfoService() {
             @Override
             public ClusterInfo getClusterInfo() {
-                Map<String, DiskUsage> usages = new HashMap<>();
-                Map<String, Long> shardSizes = new HashMap<>();
-                return new ClusterInfo(ImmutableMap.copyOf(usages), ImmutableMap.copyOf(shardSizes));
+                return new ClusterInfo();
             }
 
             @Override

--- a/core/src/test/java/org/elasticsearch/discovery/zen/ZenDiscoveryTests.java
+++ b/core/src/test/java/org/elasticsearch/discovery/zen/ZenDiscoveryTests.java
@@ -24,10 +24,7 @@ import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.indices.recovery.RecoveryResponse;
-import org.elasticsearch.cluster.ClusterChangedEvent;
-import org.elasticsearch.cluster.ClusterService;
-import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateListener;
+import org.elasticsearch.cluster.*;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.Priority;
@@ -128,6 +125,7 @@ public class ZenDiscoveryTests extends ElasticsearchIntegrationTest {
         Settings defaultSettings = Settings.builder()
                 .put(FaultDetection.SETTING_PING_TIMEOUT, "1s")
                 .put(FaultDetection.SETTING_PING_RETRIES, "1")
+                .put(InternalClusterInfoService.INTERNAL_CLUSTER_INFO_ENABLED, false)
                 .put("discovery.type", "zen")
                 .build();
 

--- a/core/src/test/java/org/elasticsearch/indices/state/RareClusterStateTests.java
+++ b/core/src/test/java/org/elasticsearch/indices/state/RareClusterStateTests.java
@@ -92,7 +92,7 @@ public class RareClusterStateTests extends ElasticsearchIntegrationTest {
                         .nodes(DiscoveryNodes.EMPTY_NODES)
                         .build()
         );
-        ClusterInfo clusterInfo = new ClusterInfo(ImmutableMap.<String, DiskUsage>of(), ImmutableMap.<String, Long>of());
+        ClusterInfo clusterInfo = new ClusterInfo();
 
         RoutingAllocation routingAllocation = new RoutingAllocation(allocationDeciders, routingNodes, current.nodes(), clusterInfo);
         allocator.allocateUnassigned(routingAllocation);


### PR DESCRIPTION
This commit makes the `ClusterInfo` object available to all nodes via a
custom ClusterState object. The cluster info contains the following
information:
1. Disk usage information about each node in the cluster.
2. Shard sizes for all primary shards in the cluster.
3. Relative classifications for the size of each index.

Each index is classified from SMALLEST to LARGEST based on its size,
with SMALL, MEDIUM, and LARGE falling equidistantly between smallest and
largest.

This information can be used in the future for determining the best data
path for a particular shard, enhancing the `DiskThresholdDecider`, or
making routing decidings for a shard based on its relative size in the
cluster. It can be accessed by using something like:

``` java
ClusterInfo info = clusterService.state().custom(ClusterInfo.TYPE);
Map<String, DiskUsage> nodeDiskUsage = info.getNodeDiskUsages();
Map<ShardId, Long> shardSizes = info.getShardSizes();
IndexClassification classification = info.getIndexClassification();
```

The `ClusterInfo` object is also available to inspect from the cluster
state HTTP endpoint, which returns a response like:

``` json
{
  ... other cluster state ...
  "cluster_info" : {
    "node_disk_usage" : {
      "nFlT3nFzQRyvixcYv6Yfuw" : {
        "free_bytes" : 37556461568,
        "used_bytes" : 23225233408
      }
    },
    "shard_size" : {
      "[test][4]" : 156,
      "[test][2]" : 156,
      "[test][3]" : 3007,
      "[foo][0]" : 127,
      "[wiki][0]" : 12728802,
      "[test2][4]" : 156,
      "[test2][3]" : 2904,
      "[wiki2][1]" : 23338909,
      "[test2][2]" : 156,
      "[test2][1]" : 156,
      "[test2][0]" : 156,
      "[test][0]" : 156,
      "[test][1]" : 156
    },
    "classifications" : {
      "test2" : "SMALLEST",
      "test" : "SMALLEST",
      "wiki2" : "LARGEST",
      "foo" : "SMALLEST",
      "wiki" : "MEDIUM"
    }
  }
}
```

Relates to work on #11185
