### PR TITLE
Clarify Java requirements

### DIFF
--- a/docs/reference/getting-started.asciidoc
+++ b/docs/reference/getting-started.asciidoc
@@ -96,7 +96,7 @@ With that out of the way, let's get started with the fun part...
 
 == Installation
 
-Elasticsearch requires Java 7. Specifically as of this writing, it is recommended that you use the Oracle JDK version {jdk}. Java installation varies from platform to platform so we won't go into those details here. Suffice to say, before you install Elasticsearch, please check your Java version first by running (and then install/upgrade accordingly if needed):
+Elasticsearch requires at least Java 7. Specifically as of this writing, it is recommended that you use the Oracle JDK version {jdk}. Java installation varies from platform to platform so we won't go into those details here. Suffice to say, before you install Elasticsearch, please check your Java version first by running (and then install/upgrade accordingly if needed):
 
 [source,sh]
 --------------------------------------------------


### PR DESCRIPTION
Looks like the getting started and setup pages have slightly different wording about the Java requirements, which might cause some confusion (e.g. as reported on [Gentoo bug 551880](https://bugs.gentoo.org/show_bug.cgi?id=551880#c0)). I believe this small commit helps clarifying the situation.
