### PR TITLE
Make explicit the requirement for intervals to be integers

### DIFF
--- a/docs/reference/search/aggregations/bucket/histogram-aggregation.asciidoc
+++ b/docs/reference/search/aggregations/bucket/histogram-aggregation.asciidoc
@@ -18,6 +18,8 @@ if (rem < 0) {
 bucket_key = value - rem
 --------------------------------------------------
 
+From the rounding function above it can be seen that the intervals themsevles **must** be integers.
+
 The following snippet "buckets" the products based on their `price` by interval of `50`:
 
 [source,js]


### PR DESCRIPTION
The rounding function implies this, but this has still caught some people out.
https://github.com/elastic/elasticsearch/issues/4847
