### PR TITLE
Upgrade to Lucene 5.2.1.

### DIFF
--- a/core/src/main/java/org/elasticsearch/Version.java
+++ b/core/src/main/java/org/elasticsearch/Version.java
@@ -245,7 +245,7 @@ public class Version {
     public static final int V_1_7_0_ID = 1070099;
     public static final Version V_1_7_0 = new Version(V_1_7_0_ID, true, org.apache.lucene.util.Version.LUCENE_4_10_4);
     public static final int V_2_0_0_ID = 2000099;
-    public static final Version V_2_0_0 = new Version(V_2_0_0_ID, true, org.apache.lucene.util.Version.LUCENE_5_2_0);
+    public static final Version V_2_0_0 = new Version(V_2_0_0_ID, true, org.apache.lucene.util.Version.LUCENE_5_2_1);
 
     public static final Version CURRENT = V_2_0_0;
 

--- a/core/src/main/java/org/elasticsearch/common/lucene/all/AllTermQuery.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/all/AllTermQuery.java
@@ -58,13 +58,13 @@ public final class AllTermQuery extends PayloadTermQuery {
     public SpanWeight createWeight(IndexSearcher searcher, boolean needsScores) throws IOException {
         // TODO: needsScores
         // we should be able to just return a regular SpanTermWeight, at most here if needsScores == false?
-        return new AllTermWeight(this, searcher);
+        return new AllTermWeight(this, searcher, needsScores);
     }
 
     class AllTermWeight extends PayloadTermWeight {
 
-        AllTermWeight(AllTermQuery query, IndexSearcher searcher) throws IOException {
-            super(query, searcher);
+        AllTermWeight(AllTermQuery query, IndexSearcher searcher, boolean needsScores) throws IOException {
+            super(query, searcher, needsScores);
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/index/search/child/ChildrenConstantScoreQuery.java
+++ b/core/src/main/java/org/elasticsearch/index/search/child/ChildrenConstantScoreQuery.java
@@ -104,7 +104,7 @@ public class ChildrenConstantScoreQuery extends IndexCacheableQuery {
         }
 
         IndexSearcher indexSearcher = new IndexSearcher(searcher.getIndexReader());
-        indexSearcher.setSimilarity(searcher.getSimilarity());
+        indexSearcher.setSimilarity(searcher.getSimilarity(true));
         indexSearcher.setQueryCache(null);
         ParentOrdCollector collector = new ParentOrdCollector(globalIfd, valueCount, parentType);
         indexSearcher.search(childQuery, collector);

--- a/core/src/main/java/org/elasticsearch/index/search/child/ChildrenQuery.java
+++ b/core/src/main/java/org/elasticsearch/index/search/child/ChildrenQuery.java
@@ -153,7 +153,7 @@ public final class ChildrenQuery extends IndexCacheableQuery {
             return new BooleanQuery().createWeight(searcher, needsScores);
         }
         IndexSearcher indexSearcher = new IndexSearcher(searcher.getIndexReader());
-        indexSearcher.setSimilarity(searcher.getSimilarity());
+        indexSearcher.setSimilarity(searcher.getSimilarity(true));
         indexSearcher.setQueryCache(null);
 
         boolean abort = true;

--- a/core/src/main/java/org/elasticsearch/index/search/child/ParentConstantScoreQuery.java
+++ b/core/src/main/java/org/elasticsearch/index/search/child/ParentConstantScoreQuery.java
@@ -93,7 +93,7 @@ public class ParentConstantScoreQuery extends IndexCacheableQuery {
 
         ParentOrdsCollector collector = new ParentOrdsCollector(globalIfd, maxOrd, parentType);
         IndexSearcher indexSearcher = new IndexSearcher(searcher.getIndexReader());
-        indexSearcher.setSimilarity(searcher.getSimilarity());
+        indexSearcher.setSimilarity(searcher.getSimilarity(true));
         indexSearcher.setQueryCache(null);
         indexSearcher.search(parentQuery, collector);
 

--- a/core/src/main/java/org/elasticsearch/index/search/child/ParentQuery.java
+++ b/core/src/main/java/org/elasticsearch/index/search/child/ParentQuery.java
@@ -130,7 +130,7 @@ public class ParentQuery extends IndexCacheableQuery {
         try {
             collector = new ParentOrdAndScoreCollector(sc, globalIfd, parentType);
             IndexSearcher indexSearcher = new IndexSearcher(sc.searcher().getIndexReader());
-            indexSearcher.setSimilarity(searcher.getSimilarity());
+            indexSearcher.setSimilarity(searcher.getSimilarity(true));
             indexSearcher.setQueryCache(null);
             indexSearcher.search(parentQuery, collector);
             if (collector.parentCount() == 0) {

--- a/core/src/main/java/org/elasticsearch/search/internal/ContextIndexSearcher.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/ContextIndexSearcher.java
@@ -70,7 +70,7 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
         super(searcher.reader());
         in = searcher.searcher();
         this.searchContext = searchContext;
-        setSimilarity(searcher.searcher().getSimilarity());
+        setSimilarity(searcher.searcher().getSimilarity(true));
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/common/lucene/IndexCacheableQueryTests.java
+++ b/core/src/test/java/org/elasticsearch/common/lucene/IndexCacheableQueryTests.java
@@ -106,7 +106,7 @@ public class IndexCacheableQueryTests extends ElasticsearchTestCase {
         IndexReader reader = writer.getReader();
         // IndexReader wrapping is disabled because of LUCENE-6500.
         // Add it back when we are on 5.3
-        assert Version.LATEST == Version.LUCENE_5_2_0;
+        assert Version.LATEST == Version.LUCENE_5_2_1;
         IndexSearcher searcher = newSearcher(reader, false);
         reader = searcher.getIndexReader(); // reader might be wrapped
         searcher.setQueryCache(cache);
@@ -125,7 +125,7 @@ public class IndexCacheableQueryTests extends ElasticsearchTestCase {
         IndexReader reader2 = writer.getReader();
         // IndexReader wrapping is disabled because of LUCENE-6500.
         // Add it back when we are on 5.3
-        assert Version.LATEST == Version.LUCENE_5_2_0;
+        assert Version.LATEST == Version.LUCENE_5_2_1;
         searcher = newSearcher(reader2, false);
         reader2 = searcher.getIndexReader(); // reader might be wrapped
         searcher.setQueryCache(cache);

--- a/core/src/test/java/org/elasticsearch/deps/lucene/SimpleLuceneTests.java
+++ b/core/src/test/java/org/elasticsearch/deps/lucene/SimpleLuceneTests.java
@@ -62,29 +62,6 @@ public class SimpleLuceneTests extends ElasticsearchTestCase {
     }
 
     @Test
-    public void testAddDocAfterPrepareCommit() throws Exception {
-        Directory dir = new RAMDirectory();
-        IndexWriter indexWriter = new IndexWriter(dir, new IndexWriterConfig(Lucene.STANDARD_ANALYZER));
-        Document document = new Document();
-        document.add(new TextField("_id", "1", Field.Store.YES));
-        indexWriter.addDocument(document);
-        DirectoryReader reader = DirectoryReader.open(indexWriter, true);
-        assertThat(reader.numDocs(), equalTo(1));
-
-        indexWriter.prepareCommit();
-        // Returns null b/c no changes.
-        // nocommit: this fails
-        assertThat(DirectoryReader.openIfChanged(reader), equalTo(null));
-
-        document = new Document();
-        document.add(new TextField("_id", "2", Field.Store.YES));
-        indexWriter.addDocument(document);
-        indexWriter.commit();
-        reader = DirectoryReader.openIfChanged(reader);
-        assertThat(reader.numDocs(), equalTo(2));
-    }
-
-    @Test
     public void testSimpleNumericOps() throws Exception {
         Directory dir = new RAMDirectory();
         IndexWriter indexWriter = new IndexWriter(dir, new IndexWriterConfig(Lucene.STANDARD_ANALYZER));

--- a/core/src/test/java/org/elasticsearch/deps/lucene/SimpleLuceneTests.java
+++ b/core/src/test/java/org/elasticsearch/deps/lucene/SimpleLuceneTests.java
@@ -73,6 +73,7 @@ public class SimpleLuceneTests extends ElasticsearchTestCase {
 
         indexWriter.prepareCommit();
         // Returns null b/c no changes.
+        // nocommit: this fails
         assertThat(DirectoryReader.openIfChanged(reader), equalTo(null));
 
         document = new Document();

--- a/core/src/test/java/org/elasticsearch/test/IBMJ9HackThreadFilters.java
+++ b/core/src/test/java/org/elasticsearch/test/IBMJ9HackThreadFilters.java
@@ -30,7 +30,7 @@ public class IBMJ9HackThreadFilters implements ThreadFilter {
     static final boolean isJ9;
     
     static {
-        assert Version.LATEST.equals(Version.LUCENE_5_2_0) : "please remove this entire class for 5.3";
+        assert Version.LATEST.equals(Version.LUCENE_5_2_1) : "please remove this entire class for 5.3";
         isJ9 = Constants.JAVA_VENDOR.startsWith("IBM");
     }
     

--- a/core/src/test/java/org/elasticsearch/test/engine/MockEngineSupport.java
+++ b/core/src/test/java/org/elasticsearch/test/engine/MockEngineSupport.java
@@ -128,7 +128,7 @@ public final class MockEngineSupport {
         }
         // this executes basic query checks and asserts that weights are normalized only once etc.
         final AssertingIndexSearcher assertingIndexSearcher = new AssertingIndexSearcher(mockContext.random, wrappedReader);
-        assertingIndexSearcher.setSimilarity(searcher.getSimilarity());
+        assertingIndexSearcher.setSimilarity(searcher.getSimilarity(true));
         assertingIndexSearcher.setQueryCache(filterCache);
         assertingIndexSearcher.setQueryCachingPolicy(filterCachingPolicy);
         return assertingIndexSearcher;
@@ -180,7 +180,7 @@ public final class MockEngineSupport {
 
     public Engine.Searcher wrapSearcher(String source, Engine.Searcher engineSearcher, IndexSearcher searcher, SearcherManager manager) {
         final AssertingIndexSearcher assertingIndexSearcher = newSearcher(source, searcher, manager);
-        assertingIndexSearcher.setSimilarity(searcher.getSimilarity());
+        assertingIndexSearcher.setSimilarity(searcher.getSimilarity(true));
         // pass the original searcher to the super.newSearcher() method to make sure this is the searcher that will
         // be released later on. If we wrap an index reader here must not pass the wrapped version to the manager
         // on release otherwise the reader will be closed too early. - good news, stuff will fail all over the place if we don't get this right here

--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,8 @@
         <maven.compiler.target>1.7</maven.compiler.target>
 
         <!-- libraries -->
-        <lucene.version>5.2.0</lucene.version>
-        <lucene.maven.version>5.2.0</lucene.maven.version>
+        <lucene.version>5.2.1</lucene.version>
+        <lucene.maven.version>5.2.1</lucene.maven.version>
         <testframework.version>2.1.14</testframework.version>
         <jackson.version>2.5.3</jackson.version>
         <slf4j.version>1.6.2</slf4j.version>


### PR DESCRIPTION
I have one remaining nocommit to fix in SimpleLuceneTests because of DirectoryReader.openIfChanged returning a non-null reader after IndexWriter.prepareCommit has been called. I'll dig.
