### PR TITLE
Fix missing dependencies for RPM/DEB packages

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -713,7 +713,7 @@
                                 </data>
                                 <data>
                                     <src>${project.build.directory}/lib</src>
-                                    <includes>lucene*, *log4j*, jna*, spatial4j*, jts*, groovy*, antlr-runtime*, asm*</includes>
+                                    <excludes>${project.build.finalName}-shaded.jar,${project.build.finalName}-sources.jar,${project.build.finalName}-tests.jar,${project.build.finalName}-test-sources.jar,slf4j-api-*.jar,sigar-*.jar</excludes>
                                     <type>directory</type>
                                     <mapper>
                                         <type>perm</type>
@@ -880,16 +880,14 @@
                             <sources>
                                 <source>
                                     <location>target/lib/</location>
-                                    <includes>
-                                        <include>lucene*</include>
-                                        <include>*log4j*</include>
-                                        <include>jna*</include>
-                                        <include>spatial4j*</include>
-                                        <include>jts*</include>
-                                        <include>groovy*</include>
-                                        <include>antlr-runtime*</include>
-                                        <include>asm*</include>
-                                    </includes>
+                                    <excludes>
+                                        <exclude>${project.build.finalName}-shaded.jar</exclude>
+                                        <exclude>${project.build.finalName}-sources.jar</exclude>
+                                        <exclude>${project.build.finalName}-tests.jar</exclude>
+                                        <exclude>${project.build.finalName}-test-sources.jar</exclude>
+                                        <exclude>slf4j-api-*.jar</exclude>
+                                        <exclude>sigar-*.jar</exclude>
+                                    </excludes>
                                 </source>
                                 <source>
                                     <location>${project.build.directory}/</location>


### PR DESCRIPTION
Since elasticsearch doesn't shade artifacts anymore (see #11522), the dependencies list for RPM/DEB must be updated. In this commit, we package all maven libs by default except the generated -shaded/-tests/-test-cours JARs and slf4j-api (marked as optionnal).
