### PR TITLE
[TEST] remove redundant tests and move to different suite

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/ClusterChangedEvent.java
+++ b/core/src/main/java/org/elasticsearch/cluster/ClusterChangedEvent.java
@@ -110,8 +110,11 @@ public class ClusterChangedEvent {
         // is actually supposed to be deleted or imported as dangling instead. for example a new master might not have
         // the index in its cluster state because it was started with an empty data folder and in this case we want to
         // import as dangling. we check here for new master too to be on the safe side in this case.
-        // norelease because we are not sure this is actually a good solution
-        // See discussion on https://github.com/elastic/elasticsearch/pull/9952
+        // This means that under certain conditions deleted indices might be reimported if a master fails while the deletion
+        // request is issued and a node receives the cluster state that would trigger the deletion from the new master.
+        // See test MetaDataWriteDataNodesTests.testIndicesDeleted()
+        // See discussion on https://github.com/elastic/elasticsearch/pull/9952 and
+        // https://github.com/elastic/elasticsearch/issues/11665
         if (hasNewMaster() || previousState == null) {
             return ImmutableList.of();
         }

--- a/core/src/test/java/org/elasticsearch/gateway/GatewayMetaStateTests.java
+++ b/core/src/test/java/org/elasticsearch/gateway/GatewayMetaStateTests.java
@@ -174,9 +174,9 @@ public class GatewayMetaStateTests extends ElasticsearchAllocationTestCase {
         if (stateInMemory) {
             inMemoryMetaData = event.previousState().metaData();
             ImmutableSet.Builder<String> relevantIndices = ImmutableSet.builder();
-            oldIndicesList = relevantIndices.addAll(GatewayMetaState.getRelevantIndices(event.previousState(), oldIndicesList)).build();
+            oldIndicesList = relevantIndices.addAll(GatewayMetaState.getRelevantIndices(event.previousState(), event.previousState(), oldIndicesList)).build();
         }
-        Set<String> newIndicesList = GatewayMetaState.getRelevantIndices(event.state(), oldIndicesList);
+        Set<String> newIndicesList = GatewayMetaState.getRelevantIndices(event.state(),event.previousState(), oldIndicesList);
         // third, get the actual write info
         Iterator<GatewayMetaState.IndexMetaWriteInfo> indices = GatewayMetaState.resolveStatesToBeWritten(oldIndicesList, newIndicesList, inMemoryMetaData, event.state().metaData()).iterator();
 


### PR DESCRIPTION
Some of the test for meta data are redundant. Also, since they
somewhat test service disruptions (start master with empty
data folder) we might move them to DiscoveryWithServiceDisruptionsTests.
Also, this commit adds a test for
https://github.com/elastic/elasticsearch/issues/11665
