### PR TITLE
Making bin/plugin compatible with Cygwin

### DIFF
--- a/distribution/src/main/resources/bin/plugin
+++ b/distribution/src/main/resources/bin/plugin
@@ -103,6 +103,13 @@ if [ -e "$CONF_FILE" ]; then
   esac
 fi
 
+# Special-case path variables.
+case `uname` in
+    CYGWIN*)
+        ES_HOME=`cygpath -p -w "$ES_HOME"`
+    ;;
+esac
+
 # full hostname passed through cut for portability on systems that do not support hostname -s
 # export on separate line for shells that do not support combining definition and export
 HOSTNAME=`hostname | cut -d. -f1`


### PR DESCRIPTION
Currently this script fails with the following error under Cygwin:

```
$ bin/plugin -install mobz/elasticsearch-head
Erreur : impossible de trouver ou charger la classe principale org.elasticsearch.plugins.PluginManager
```

In English:

```
Could not find the main class: org.elasticsearch.plugins.PluginManager
```
