### PR TITLE
Allow dynamic template deletion by defining an empty template

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/object/DynamicTemplate.java
+++ b/src/main/java/org/elasticsearch/index/mapper/object/DynamicTemplate.java
@@ -27,7 +27,6 @@ import org.elasticsearch.index.mapper.ContentPath;
 import org.elasticsearch.index.mapper.MapperParsingException;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -105,20 +104,17 @@ public class DynamicTemplate {
     private final String matchMappingType;
 
     private final Map<String, Object> mapping;
-    
-    private final boolean empty;
 
     public DynamicTemplate(String name, Map<String, Object> conf, String pathMatch, String pathUnmatch, String match, String unmatch, String matchMappingType, MatchType matchType, Map<String, Object> mapping) {
         this.name = name;
-        this.conf = (conf == null) ? Collections.<String, Object>emptyMap() : new TreeMap<>(conf);
+        this.conf = new TreeMap<>(conf);
         this.pathMatch = pathMatch;
         this.pathUnmatch = pathUnmatch;
         this.match = match;
         this.unmatch = unmatch;
         this.matchType = matchType;
         this.matchMappingType = matchMappingType;
-        this.mapping = (mapping == null) ? Collections.<String, Object>emptyMap() : mapping;
-        this.empty = (this.mapping.isEmpty()) || (this.mapping.isEmpty());
+        this.mapping = mapping;
     }
 
     public String name() {
@@ -202,11 +198,6 @@ public class DynamicTemplate {
             processedList.add(value);
         }
         return processedList;
-    }
-
-
-    public boolean isEmpty() {
-        return empty;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/mapper/object/DynamicTemplate.java
+++ b/src/main/java/org/elasticsearch/index/mapper/object/DynamicTemplate.java
@@ -27,6 +27,7 @@ import org.elasticsearch.index.mapper.ContentPath;
 import org.elasticsearch.index.mapper.MapperParsingException;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -104,17 +105,20 @@ public class DynamicTemplate {
     private final String matchMappingType;
 
     private final Map<String, Object> mapping;
+    
+    private final boolean empty;
 
     public DynamicTemplate(String name, Map<String, Object> conf, String pathMatch, String pathUnmatch, String match, String unmatch, String matchMappingType, MatchType matchType, Map<String, Object> mapping) {
         this.name = name;
-        this.conf = new TreeMap<>(conf);
+        this.conf = (conf == null) ? Collections.<String, Object>emptyMap() : new TreeMap<>(conf);
         this.pathMatch = pathMatch;
         this.pathUnmatch = pathUnmatch;
         this.match = match;
         this.unmatch = unmatch;
         this.matchType = matchType;
         this.matchMappingType = matchMappingType;
-        this.mapping = mapping;
+        this.mapping = (mapping == null) ? Collections.<String, Object>emptyMap() : mapping;
+        this.empty = (this.mapping.isEmpty()) || (this.mapping.isEmpty());
     }
 
     public String name() {
@@ -198,6 +202,11 @@ public class DynamicTemplate {
             processedList.add(value);
         }
         return processedList;
+    }
+
+
+    public boolean isEmpty() {
+        return empty;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/mapper/object/RootObjectMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/object/RootObjectMapper.java
@@ -311,9 +311,6 @@ public class RootObjectMapper extends ObjectMapper {
             if (nonEmptyTemplatePresent) {
                 builder.startArray("dynamic_templates");
                 for (DynamicTemplate dynamicTemplate : dynamicTemplates) {
-                    if(dynamicTemplate.conf().isEmpty()) {
-                        continue;
-                    }
                     builder.startObject();
                     builder.field(dynamicTemplate.name());
                     builder.map(dynamicTemplate.conf());

--- a/src/main/java/org/elasticsearch/index/mapper/object/RootObjectMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/object/RootObjectMapper.java
@@ -179,7 +179,7 @@ public class RootObjectMapper extends ObjectMapper {
                     if(entry.getValue() != null && !((Map<String, Object>) entry.getValue()).isEmpty()) {
                         ((Builder) builder).add(DynamicTemplate.parse(entry.getKey(), (Map<String, Object>) entry.getValue()));
                     } else {
-                        ((Builder) builder).add(new DynamicTemplate(entry.getKey(), null, null, null, null, null, null, null, null));
+                        ((Builder) builder).add(new DynamicTemplate(entry.getKey(), Collections.EMPTY_MAP, null, null, null, null, null, null, Collections.EMPTY_MAP));
                     }
                 }
                 return true;
@@ -242,7 +242,7 @@ public class RootObjectMapper extends ObjectMapper {
 
     public DynamicTemplate findTemplate(ContentPath path, String name, String matchType) {
         for (DynamicTemplate dynamicTemplate : dynamicTemplates) {
-            if (!dynamicTemplate.isEmpty() && dynamicTemplate.match(path, name, matchType)) {
+            if (!dynamicTemplate.conf().isEmpty() && dynamicTemplate.match(path, name, matchType)) {
                 return dynamicTemplate;
             }
         }
@@ -265,14 +265,14 @@ public class RootObjectMapper extends ObjectMapper {
                 DynamicTemplate currentTemplate = it.next();
                 for (DynamicTemplate toMergeTemplate : mergeWithObject.dynamicTemplates) {
                     if (toMergeTemplate.name().equals(currentTemplate.name())
-                            && toMergeTemplate.isEmpty()) {
+                            && toMergeTemplate.conf().isEmpty()) {
                         it.remove();
                         break;
                     }
                 }
             }
             for (DynamicTemplate template : mergeWithObject.dynamicTemplates) {
-                if(template.isEmpty()) {
+                if(template.conf().isEmpty()) {
                     continue;
                 }
                 boolean replaced = false;
@@ -305,13 +305,13 @@ public class RootObjectMapper extends ObjectMapper {
         if (dynamicTemplates != null && !dynamicTemplates.isEmpty()) {
             boolean nonEmptyTemplatePresent = false;
             for (DynamicTemplate dynamicTemplate : dynamicTemplates) {
-                nonEmptyTemplatePresent = !dynamicTemplate.isEmpty();
+                nonEmptyTemplatePresent = !dynamicTemplate.conf().isEmpty();
             }
             
             if (nonEmptyTemplatePresent) {
                 builder.startArray("dynamic_templates");
                 for (DynamicTemplate dynamicTemplate : dynamicTemplates) {
-                    if(dynamicTemplate.isEmpty()) {
+                    if(dynamicTemplate.conf().isEmpty()) {
                         continue;
                     }
                     builder.startObject();

--- a/src/test/java/org/elasticsearch/index/mapper/dynamictemplate/simple/test-data-2.json
+++ b/src/test/java/org/elasticsearch/index/mapper/dynamictemplate/simple/test-data-2.json
@@ -1,0 +1,7 @@
+{
+    "_id":"2",
+    "name_2":"some other name",
+    "age_2":2,
+    "multi3":"multi 3",
+    "multi4":"multi 4"
+}

--- a/src/test/java/org/elasticsearch/index/mapper/dynamictemplate/simple/test-mapping-remove.json
+++ b/src/test/java/org/elasticsearch/index/mapper/dynamictemplate/simple/test-mapping-remove.json
@@ -1,0 +1,9 @@
+{
+    "person":{
+        "dynamic_templates":[
+            {
+                "template_2":{}
+            }
+        ]
+    }
+}

--- a/src/test/java/org/elasticsearch/index/mapper/dynamictemplate/simple/test-mapping.json
+++ b/src/test/java/org/elasticsearch/index/mapper/dynamictemplate/simple/test-mapping.json
@@ -2,7 +2,7 @@
     "person":{
         "dynamic_templates":[
             {
-                "tempalte_1":{
+                "template_1":{
                     "match":"multi*",
                     "mapping":{
                         "type":"{dynamic_type}",


### PR DESCRIPTION
Currently is not possible to delete a dynamic template once added to a type mapping.
This PR aims to add this functionality.

See Issue https://github.com/elastic/elasticsearch/issues/11627

As proposed by @peschlowp here https://github.com/elastic/elasticsearch/issues/11627#issuecomment-111598151 you can delete a dynamic template by setting the "value" of the template to empty.

```
"name_of_template_to_delete": {}
```
