### PR TITLE
Fix exception for plain highlighter and huge terms for Lucene 4.x

### DIFF
--- a/src/main/java/org/elasticsearch/search/highlight/PlainHighlighter.java
+++ b/src/main/java/org/elasticsearch/search/highlight/PlainHighlighter.java
@@ -28,6 +28,7 @@ import org.apache.lucene.search.highlight.*;
 import org.apache.lucene.util.BytesRefHash;
 import org.apache.lucene.util.CollectionUtil;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.text.StringText;
 import org.elasticsearch.common.text.Text;
 import org.elasticsearch.index.mapper.FieldMapper;
@@ -124,7 +125,7 @@ public class PlainHighlighter implements Highlighter {
                 }
             }
         } catch (Exception e) {
-            if (e instanceof BytesRefHash.MaxBytesLengthExceededException) {
+            if (ExceptionsHelper.unwrap(e, BytesRefHash.MaxBytesLengthExceededException.class) != null) {
                 // this can happen if for example a field is not_analyzed and ignore_above option is set.
                 // the field will be ignored when indexing but the huge term is still in the source and
                 // the plain highlighter will parse the source and try to analyze it.

--- a/src/test/java/org/elasticsearch/search/highlight/HighlighterSearchTests.java
+++ b/src/test/java/org/elasticsearch/search/highlight/HighlighterSearchTests.java
@@ -132,6 +132,10 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
         search = client().prepareSearch().setQuery(constantScoreQuery(matchQuery("text", "text"))).addHighlightedField(new Field("long_text").highlighterType(highlighter)).get();
         assertNoFailures(search);
         assertThat(search.getHits().getAt(0).getHighlightFields().size(), equalTo(0));
+
+        search = client().prepareSearch().setQuery(prefixQuery("text", "te")).addHighlightedField(new Field("long_text").highlighterType(highlighter)).get();
+        assertNoFailures(search);
+        assertThat(search.getHits().getAt(0).getHighlightFields().size(), equalTo(0));
     }
 
     @Test


### PR DESCRIPTION
In Lucene 5x the exception thrown when highlighter encounters a huge term
is a BytesRefHash.MaxBytesLengthExceededException but in Lucene 4x it is
wrapped in a RuntimeException. We have to catch that as well.

closes #11599
