### PR TITLE
Remove SmartNameObjectMapper

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -532,30 +532,21 @@ public class MapperService extends AbstractIndexComponent  {
         return fields;
     }
 
-    public SmartNameObjectMapper smartNameObjectMapper(String smartName, @Nullable String[] types) {
+    public ObjectMapper getObjectMapper(String name, @Nullable String[] types) {
         if (types == null || types.length == 0 || types.length == 1 && types[0].equals("_all")) {
-            ObjectMappers mappers = fullPathObjectMappers.get(smartName);
+            ObjectMappers mappers = fullPathObjectMappers.get(name);
             if (mappers != null) {
-                return new SmartNameObjectMapper(mappers.mapper(), guessDocMapper(smartName));
+                return mappers.mapper();
             }
             return null;
         }
         for (String type : types) {
             DocumentMapper possibleDocMapper = mappers.get(type);
             if (possibleDocMapper != null) {
-                ObjectMapper mapper = possibleDocMapper.objectMappers().get(smartName);
+                ObjectMapper mapper = possibleDocMapper.objectMappers().get(name);
                 if (mapper != null) {
-                    return new SmartNameObjectMapper(mapper, possibleDocMapper);
+                    return mapper;
                 }
-            }
-        }
-        return null;
-    }
-
-    private DocumentMapper guessDocMapper(String path) {
-        for (DocumentMapper documentMapper : docMappers(false)) {
-            if (documentMapper.objectMappers().containsKey(path)) {
-                return documentMapper;
             }
         }
         return null;
@@ -661,32 +652,6 @@ public class MapperService extends AbstractIndexComponent  {
      */
     public static boolean isMetadataField(String fieldName) {
         return META_FIELDS.contains(fieldName);
-    }
-
-    public static class SmartNameObjectMapper {
-        private final ObjectMapper mapper;
-        private final DocumentMapper docMapper;
-
-        public SmartNameObjectMapper(ObjectMapper mapper, @Nullable DocumentMapper docMapper) {
-            this.mapper = mapper;
-            this.docMapper = docMapper;
-        }
-
-        public boolean hasMapper() {
-            return mapper != null;
-        }
-
-        public ObjectMapper mapper() {
-            return mapper;
-        }
-
-        public boolean hasDocMapper() {
-            return docMapper != null;
-        }
-
-        public DocumentMapper docMapper() {
-            return docMapper;
-        }
     }
 
     final class SmartIndexNameSearchAnalyzer extends DelegatingAnalyzerWrapper {

--- a/core/src/main/java/org/elasticsearch/index/query/ExistsQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/ExistsQueryParser.java
@@ -23,10 +23,10 @@ import org.apache.lucene.search.*;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.internal.FieldNamesFieldMapper;
+import org.elasticsearch.index.mapper.object.ObjectMapper;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -84,8 +84,8 @@ public class ExistsQueryParser implements QueryParser {
             return Queries.newMatchNoDocsQuery();
         }
 
-        MapperService.SmartNameObjectMapper smartNameObjectMapper = parseContext.smartObjectMapper(fieldPattern);
-        if (smartNameObjectMapper != null && smartNameObjectMapper.hasMapper()) {
+        ObjectMapper objectMapper = parseContext.getObjectMapper(fieldPattern);
+        if (objectMapper != null) {
             // automatic make the object mapper pattern
             fieldPattern = fieldPattern + ".*";
         }

--- a/core/src/main/java/org/elasticsearch/index/query/MissingQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MissingQueryParser.java
@@ -19,14 +19,17 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.search.*;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.ConstantScoreQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermRangeQuery;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.internal.FieldNamesFieldMapper;
+import org.elasticsearch.index.mapper.object.ObjectMapper;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -96,8 +99,8 @@ public class MissingQueryParser implements QueryParser {
             return Queries.newMatchNoDocsQuery();
         }
 
-        MapperService.SmartNameObjectMapper smartNameObjectMapper = parseContext.smartObjectMapper(fieldPattern);
-        if (smartNameObjectMapper != null && smartNameObjectMapper.hasMapper()) {
+        ObjectMapper objectMapper = parseContext.getObjectMapper(fieldPattern);
+        if (objectMapper != null) {
             // automatic make the object mapper pattern
             fieldPattern = fieldPattern + ".*";
         }

--- a/core/src/main/java/org/elasticsearch/index/query/QueryParseContext.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryParseContext.java
@@ -40,6 +40,7 @@ import org.elasticsearch.index.analysis.AnalysisService;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.mapper.*;
 import org.elasticsearch.index.mapper.core.StringFieldMapper;
+import org.elasticsearch.index.mapper.object.ObjectMapper;
 import org.elasticsearch.index.query.support.NestedScope;
 import org.elasticsearch.index.similarity.SimilarityService;
 import org.elasticsearch.script.ScriptService;
@@ -283,8 +284,8 @@ public class QueryParseContext {
         return failIfFieldMappingNotFound(name, indexQueryParser.mapperService.smartNameFieldType(name, getTypes()));
     }
 
-    public MapperService.SmartNameObjectMapper smartObjectMapper(String name) {
-        return indexQueryParser.mapperService.smartNameObjectMapper(name, getTypes());
+    public ObjectMapper getObjectMapper(String name) {
+        return indexQueryParser.mapperService.getObjectMapper(name, getTypes());
     }
 
     /** Gets the search analyzer for the given field, or the default if there is none present for the field

--- a/core/src/main/java/org/elasticsearch/index/query/support/NestedInnerQueryParseSupport.java
+++ b/core/src/main/java/org/elasticsearch/index/query/support/NestedInnerQueryParseSupport.java
@@ -26,7 +26,6 @@ import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.object.ObjectMapper;
 import org.elasticsearch.index.query.QueryParseContext;
@@ -57,7 +56,6 @@ public class NestedInnerQueryParseSupport {
     protected BitDocIdSetFilter parentFilter;
     protected BitDocIdSetFilter childFilter;
 
-    protected DocumentMapper childDocumentMapper;
     protected ObjectMapper nestedObjectMapper;
     private ObjectMapper parentObjectMapper;
 
@@ -157,12 +155,7 @@ public class NestedInnerQueryParseSupport {
 
     public void setPath(String path) {
         this.path = path;
-        MapperService.SmartNameObjectMapper smart = parseContext.smartObjectMapper(path);
-        if (smart == null) {
-            throw new QueryParsingException(parseContext, "[nested] failed to find nested object under path [" + path + "]");
-        }
-        childDocumentMapper = smart.docMapper();
-        nestedObjectMapper = smart.mapper();
+        nestedObjectMapper = parseContext.getObjectMapper(path);
         if (nestedObjectMapper == null) {
             throw new QueryParsingException(parseContext, "[nested] failed to find nested object under path [" + path + "]");
         }

--- a/core/src/main/java/org/elasticsearch/percolator/PercolateContext.java
+++ b/core/src/main/java/org/elasticsearch/percolator/PercolateContext.java
@@ -44,10 +44,10 @@ import org.elasticsearch.index.analysis.AnalysisService;
 import org.elasticsearch.index.cache.bitset.BitsetFilterCache;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.fielddata.IndexFieldDataService;
-import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.ParsedDocument;
+import org.elasticsearch.index.mapper.object.ObjectMapper;
 import org.elasticsearch.index.query.IndexQueryParserService;
 import org.elasticsearch.index.query.ParsedQuery;
 import org.elasticsearch.index.shard.IndexShard;
@@ -65,7 +65,11 @@ import org.elasticsearch.search.fetch.innerhits.InnerHitsContext;
 import org.elasticsearch.search.fetch.script.ScriptFieldsContext;
 import org.elasticsearch.search.fetch.source.FetchSourceContext;
 import org.elasticsearch.search.highlight.SearchContextHighlight;
-import org.elasticsearch.search.internal.*;
+import org.elasticsearch.search.internal.ContextIndexSearcher;
+import org.elasticsearch.search.internal.InternalSearchHit;
+import org.elasticsearch.search.internal.InternalSearchHitField;
+import org.elasticsearch.search.internal.SearchContext;
+import org.elasticsearch.search.internal.ShardSearchRequest;
 import org.elasticsearch.search.lookup.LeafSearchLookup;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.search.query.QuerySearchResult;
@@ -73,7 +77,11 @@ import org.elasticsearch.search.rescore.RescoreSearchContext;
 import org.elasticsearch.search.scan.ScanContext;
 import org.elasticsearch.search.suggest.SuggestionSearchContext;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 
 /**
@@ -662,7 +670,7 @@ public class PercolateContext extends SearchContext {
     }
 
     @Override
-    public MapperService.SmartNameObjectMapper smartNameObjectMapper(String name) {
+    public ObjectMapper getObjectMapper(String name) {
         throw new UnsupportedOperationException();
     }
 

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregator.java
@@ -156,11 +156,7 @@ public class NestedAggregator extends SingleBucketAggregator {
             if (collectsFromSingleBucket == false) {
                 return asMultiBucketAggregator(this, context, parent);
             }
-            MapperService.SmartNameObjectMapper mapper = context.searchContext().smartNameObjectMapper(path);
-            if (mapper == null) {
-                return new Unmapped(name, context, parent, pipelineAggregators, metaData);
-            }
-            ObjectMapper objectMapper = mapper.mapper();
+            ObjectMapper objectMapper = context.searchContext().getObjectMapper(path);
             if (objectMapper == null) {
                 return new Unmapped(name, context, parent, pipelineAggregators, metaData);
             }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/ReverseNestedAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/ReverseNestedAggregator.java
@@ -145,11 +145,7 @@ public class ReverseNestedAggregator extends SingleBucketAggregator {
 
             final ObjectMapper objectMapper;
             if (path != null) {
-                MapperService.SmartNameObjectMapper mapper = context.searchContext().smartNameObjectMapper(path);
-                if (mapper == null) {
-                    return new Unmapped(name, context, parent, pipelineAggregators, metaData);
-                }
-                objectMapper = mapper.mapper();
+                objectMapper = context.searchContext().getObjectMapper(path);
                 if (objectMapper == null) {
                     return new Unmapped(name, context, parent, pipelineAggregators, metaData);
                 }

--- a/core/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
@@ -44,7 +44,6 @@ import org.elasticsearch.index.fieldvisitor.FieldsVisitor;
 import org.elasticsearch.index.fieldvisitor.JustUidFieldsVisitor;
 import org.elasticsearch.index.fieldvisitor.UidAndSourceFieldsVisitor;
 import org.elasticsearch.index.mapper.DocumentMapper;
-import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.internal.SourceFieldMapper;
 import org.elasticsearch.index.mapper.object.ObjectMapper;
@@ -145,7 +144,7 @@ public class FetchPhase implements SearchPhase {
                 MappedFieldType fieldType = context.smartNameFieldType(fieldName);
                 if (fieldType == null) {
                     // Only fail if we know it is a object field, missing paths / fields shouldn't fail.
-                    if (context.smartNameObjectMapper(fieldName) != null) {
+                    if (context.getObjectMapper(fieldName) != null) {
                         throw new IllegalArgumentException("field [" + fieldName + "] isn't a leaf field");
                     }
                 } else if (fieldType.stored()) {

--- a/core/src/main/java/org/elasticsearch/search/fetch/innerhits/InnerHitsParseElement.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/innerhits/InnerHitsParseElement.java
@@ -158,7 +158,7 @@ public class InnerHitsParseElement implements SearchParseElement {
         if (objectMapper == null) {
             throw new IllegalArgumentException("path [" + nestedPath +"] doesn't exist");
         }
-        if (!objectMapper.nested().isNested()) {
+        if (objectMapper.nested().isNested() == false) {
             throw new IllegalArgumentException("path [" + nestedPath +"] isn't nested");
         }
         ObjectMapper parentObjectMapper = parseContext.nestedScope().nextLevel(objectMapper);

--- a/core/src/main/java/org/elasticsearch/search/fetch/innerhits/InnerHitsParseElement.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/innerhits/InnerHitsParseElement.java
@@ -154,19 +154,18 @@ public class InnerHitsParseElement implements SearchParseElement {
     }
 
     private InnerHitsContext.NestedInnerHits parseNested(XContentParser parser, QueryParseContext parseContext, SearchContext searchContext, String nestedPath) throws Exception {
-        MapperService.SmartNameObjectMapper smartNameObjectMapper = searchContext.smartNameObjectMapper(nestedPath);
-        if (smartNameObjectMapper == null || !smartNameObjectMapper.hasMapper()) {
+        ObjectMapper objectMapper = searchContext.getObjectMapper(nestedPath);
+        if (objectMapper == null) {
             throw new IllegalArgumentException("path [" + nestedPath +"] doesn't exist");
         }
-        ObjectMapper childObjectMapper = smartNameObjectMapper.mapper();
-        if (!childObjectMapper.nested().isNested()) {
+        if (!objectMapper.nested().isNested()) {
             throw new IllegalArgumentException("path [" + nestedPath +"] isn't nested");
         }
-        ObjectMapper parentObjectMapper = parseContext.nestedScope().nextLevel(childObjectMapper);
+        ObjectMapper parentObjectMapper = parseContext.nestedScope().nextLevel(objectMapper);
         ParseResult parseResult = parseSubSearchContext(searchContext, parseContext, parser);
         parseContext.nestedScope().previousLevel();
 
-        return new InnerHitsContext.NestedInnerHits(parseResult.context(), parseResult.query(), parseResult.childInnerHits(), parentObjectMapper, childObjectMapper);
+        return new InnerHitsContext.NestedInnerHits(parseResult.context(), parseResult.query(), parseResult.childInnerHits(), parentObjectMapper, objectMapper);
     }
 
     private ParseResult parseSubSearchContext(SearchContext searchContext, QueryParseContext parseContext, XContentParser parser) throws Exception {

--- a/core/src/main/java/org/elasticsearch/search/internal/DefaultSearchContext.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/DefaultSearchContext.java
@@ -49,9 +49,9 @@ import org.elasticsearch.index.analysis.AnalysisService;
 import org.elasticsearch.index.cache.bitset.BitsetFilterCache;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.fielddata.IndexFieldDataService;
-import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.object.ObjectMapper;
 import org.elasticsearch.index.query.IndexQueryParserService;
 import org.elasticsearch.index.query.ParsedQuery;
 import org.elasticsearch.index.shard.IndexShard;
@@ -723,8 +723,8 @@ public class DefaultSearchContext extends SearchContext {
     }
 
     @Override
-    public MapperService.SmartNameObjectMapper smartNameObjectMapper(String name) {
-        return mapperService().smartNameObjectMapper(name, request.types());
+    public ObjectMapper getObjectMapper(String name) {
+        return mapperService().getObjectMapper(name, request.types());
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/search/internal/FilteredSearchContext.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/FilteredSearchContext.java
@@ -34,9 +34,9 @@ import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.index.analysis.AnalysisService;
 import org.elasticsearch.index.cache.bitset.BitsetFilterCache;
 import org.elasticsearch.index.fielddata.IndexFieldDataService;
-import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.object.ObjectMapper;
 import org.elasticsearch.index.query.IndexQueryParserService;
 import org.elasticsearch.index.query.ParsedQuery;
 import org.elasticsearch.index.shard.IndexShard;
@@ -542,8 +542,8 @@ public abstract class FilteredSearchContext extends SearchContext {
     }
 
     @Override
-    public MapperService.SmartNameObjectMapper smartNameObjectMapper(String name) {
-        return in.smartNameObjectMapper(name);
+    public ObjectMapper getObjectMapper(String name) {
+        return in.getObjectMapper(name);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/search/internal/SearchContext.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/SearchContext.java
@@ -37,6 +37,7 @@ import org.elasticsearch.index.cache.bitset.BitsetFilterCache;
 import org.elasticsearch.index.fielddata.IndexFieldDataService;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.object.ObjectMapper;
 import org.elasticsearch.index.query.IndexQueryParserService;
 import org.elasticsearch.index.query.ParsedQuery;
 import org.elasticsearch.index.query.QueryParseContext;
@@ -346,7 +347,7 @@ public abstract class SearchContext implements Releasable, HasContextAndHeaders 
      */
     public abstract MappedFieldType smartNameFieldTypeFromAnyType(String name);
 
-    public abstract MapperService.SmartNameObjectMapper smartNameObjectMapper(String name);
+    public abstract ObjectMapper getObjectMapper(String name);
 
     public abstract Counter timeEstimateCounter();
 

--- a/core/src/test/java/org/elasticsearch/test/TestSearchContext.java
+++ b/core/src/test/java/org/elasticsearch/test/TestSearchContext.java
@@ -38,6 +38,7 @@ import org.elasticsearch.index.cache.filter.FilterCache;
 import org.elasticsearch.index.fielddata.IndexFieldDataService;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.object.ObjectMapper;
 import org.elasticsearch.index.query.IndexQueryParserService;
 import org.elasticsearch.index.query.ParsedQuery;
 import org.elasticsearch.index.shard.IndexShard;
@@ -567,9 +568,9 @@ public class TestSearchContext extends SearchContext {
     }
 
     @Override
-    public MapperService.SmartNameObjectMapper smartNameObjectMapper(String name) {
+    public ObjectMapper getObjectMapper(String name) {
         if (mapperService() != null) {
-            return mapperService().smartNameObjectMapper(name, types);
+            return mapperService().getObjectMapper(name, types);
         }
         return null;
     }


### PR DESCRIPTION
This was previously a container for an ObjectMapper, along with the
DocumentMapper that ObjectMapper came from. However, there was
only one use of needing the associated DocumentMapper, and that
wasn't actually used.
