### PR TITLE
Add option to `_cat/indices` to return index creation date #11524

### DIFF
--- a/core/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
@@ -42,6 +42,7 @@ import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.RestActionListener;
 import org.elasticsearch.rest.action.support.RestResponseListener;
 import org.elasticsearch.rest.action.support.RestTable;
+import org.joda.time.DateTime;
 
 import java.util.Locale;
 
@@ -111,6 +112,9 @@ public class RestIndicesAction extends AbstractCatAction {
         table.addCell("rep", "alias:r,shards.replica,shardsReplica;text-align:right;desc:number of replica shards");
         table.addCell("docs.count", "alias:dc,docsCount;text-align:right;desc:available docs");
         table.addCell("docs.deleted", "alias:dd,docsDeleted;text-align:right;desc:deleted docs");
+
+        table.addCell("creation.date", "alias:cd;default:false;desc:index creation date (millisecond value)");
+        table.addCell("creation.date.string", "alias:cds;default:false;desc:index creation date (as string)");        
 
         table.addCell("store.size", "sibling:pri;alias:ss,storeSize;text-align:right;desc:store size of primaries & replicas");
         table.addCell("pri.store.size", "text-align:right;desc:store size of primaries");
@@ -319,6 +323,9 @@ public class RestIndicesAction extends AbstractCatAction {
             table.addCell(indexHealth == null ? null : indexHealth.getNumberOfReplicas());
             table.addCell(indexStats == null ? null : indexStats.getPrimaries().getDocs().getCount());
             table.addCell(indexStats == null ? null : indexStats.getPrimaries().getDocs().getDeleted());
+
+            table.addCell(indexMetaData.creationDate());
+            table.addCell(new DateTime(indexMetaData.creationDate()));
 
             table.addCell(indexStats == null ? null : indexStats.getTotal().getStore().size());
             table.addCell(indexStats == null ? null : indexStats.getPrimaries().getStore().size());

--- a/core/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
@@ -43,6 +43,7 @@ import org.elasticsearch.rest.action.support.RestActionListener;
 import org.elasticsearch.rest.action.support.RestResponseListener;
 import org.elasticsearch.rest.action.support.RestTable;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 
 import java.util.Locale;
 
@@ -325,7 +326,7 @@ public class RestIndicesAction extends AbstractCatAction {
             table.addCell(indexStats == null ? null : indexStats.getPrimaries().getDocs().getDeleted());
 
             table.addCell(indexMetaData.creationDate());
-            table.addCell(new DateTime(indexMetaData.creationDate()));
+            table.addCell(new DateTime(indexMetaData.creationDate(), DateTimeZone.getDefault()));
 
             table.addCell(indexStats == null ? null : indexStats.getTotal().getStore().size());
             table.addCell(indexStats == null ? null : indexStats.getPrimaries().getStore().size());

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.indices/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.indices/10_basic.yaml
@@ -36,3 +36,18 @@
                   (\d+|\d+[.]\d+)(kb|b) \s*
                 )
                 $/
+                
+  - do:
+      cat.indices:
+        v: false
+        h: i,cd,cds,creation.date,creation.date.string
+  - match:
+      $body: |
+               /^(
+                  index1                                                    \s+
+                  (\d+)                                                     \s+
+                  (\d\d\d\d\-\d\d\-\d\d T\d\d:\d\d:\d\d.\d\d\d\+\d\d:\d\d)  \s+
+                  (\d+)                                                     \s+
+                  (\d\d\d\d\-\d\d\-\d\d T\d\d:\d\d:\d\d.\d\d\d\+\d\d:\d\d)  \s*
+                )
+                $/        

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.indices/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.indices/10_basic.yaml
@@ -46,8 +46,8 @@
                /^(
                   index1                                                    \s+
                   (\d+)                                                     \s+
-                  (\d\d\d\d\-\d\d\-\d\d T\d\d:\d\d:\d\d.\d\d\d\+\d\d:\d\d)  \s+
+                  (\d\d\d\d\-\d\d\-\d\dT\d\d:\d\d:\d\d.\d\d\d\+\d\d:\d\d)   \s+
                   (\d+)                                                     \s+
-                  (\d\d\d\d\-\d\d\-\d\d T\d\d:\d\d:\d\d.\d\d\d\+\d\d:\d\d)  \s*
+                  (\d\d\d\d\-\d\d\-\d\dT\d\d:\d\d:\d\d.\d\d\d\+\d\d:\d\d)   \s*
                 )
                 $/        

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.indices/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.indices/10_basic.yaml
@@ -36,7 +36,7 @@
                   (\d+|\d+[.]\d+)(kb|b) \s*
                 )
                 $/
-                
+
   - do:
       cat.indices:
         v: false
@@ -46,8 +46,8 @@
                /^(
                   index1                                                    \s+
                   (\d+)                                                     \s+
-                  (\d\d\d\d\-\d\d\-\d\dT\d\d:\d\d:\d\d.\d\d\d\+\d\d:\d\d)   \s+
+                  (\d\d\d\d\-\d\d\-\d\dT\d\d:\d\d:\d\d.\d\d\d[+-]\d\d:\d\d) \s+
                   (\d+)                                                     \s+
-                  (\d\d\d\d\-\d\d\-\d\dT\d\d:\d\d:\d\d.\d\d\d\+\d\d:\d\d)   \s*
+                  (\d\d\d\d\-\d\d\-\d\dT\d\d:\d\d:\d\d.\d\d\d[+-]\d\d:\d\d) \s*
                 )
-                $/        
+                $/


### PR DESCRIPTION
Returning index creation date, both as a numeric millisecond value and
as a string. This implements #11524
