### PR TITLE
Allow executable expression scripts for aggregations

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.mapper;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 
 import org.apache.lucene.document.Field;

--- a/core/src/main/java/org/elasticsearch/script/expression/ExpressionExecutableScript.java
+++ b/core/src/main/java/org/elasticsearch/script/expression/ExpressionExecutableScript.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.script.expression;
+
+import org.apache.lucene.expressions.Expression;
+import org.elasticsearch.script.ExecutableScript;
+import org.elasticsearch.script.ScriptException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A bridge to evaluate an {@link Expression} against a map of variables in the context
+ * of an {@link ExecutableScript}.
+ */
+public class ExpressionExecutableScript implements ExecutableScript {
+
+    private final int NO_DOCUMENT = -1;
+
+    public final Expression expression;
+    public final Map<String, ReplaceableConstFunctionValues> functionValuesMap;
+    public final ReplaceableConstFunctionValues[] functionValuesArray;
+
+    public ExpressionExecutableScript(Object compiledScript, Map<String, Object> vars) {
+        expression = (Expression)compiledScript;
+        int functionValuesLength = expression.variables.length;
+
+        if (vars.size() != functionValuesLength) {
+            throw new ScriptException("The number of variables in an executable expression script [" +
+                    functionValuesLength + "] must match the number of variables in the variable map" +
+                    " [" + vars.size() + "].");
+        }
+
+        functionValuesArray = new ReplaceableConstFunctionValues[functionValuesLength];
+        functionValuesMap = new HashMap<>();
+
+        for (int functionValuesIndex = 0; functionValuesIndex < functionValuesLength; ++functionValuesIndex) {
+            String variableName = expression.variables[functionValuesIndex];
+            functionValuesArray[functionValuesIndex] = new ReplaceableConstFunctionValues();
+            functionValuesMap.put(variableName, functionValuesArray[functionValuesIndex]);
+        }
+
+        for (String varsName : vars.keySet()) {
+            setNextVar(varsName, vars.get(varsName));
+        }
+    }
+
+    @Override
+    public void setNextVar(String name, Object value) {
+        if (functionValuesMap.containsKey(name)) {
+            if (value instanceof Number) {
+                double doubleValue = ((Number)value).doubleValue();
+                functionValuesMap.get(name).setValue(doubleValue);
+            } else {
+                throw new ScriptException("Executable expressions scripts can only process numbers." +
+                        "  The variable [" + name + "] is not a number.");
+            }
+        } else {
+            throw new ScriptException("The variable [" + name + "] does not exist in the executable expressions script.");
+        }
+    }
+
+    @Override
+    public Object run() {
+        return expression.evaluate(NO_DOCUMENT, functionValuesArray);
+    }
+
+    @Override
+    public Object unwrap(Object value) {
+        return value;
+    }
+}

--- a/core/src/main/java/org/elasticsearch/script/expression/ExpressionScriptEngineService.java
+++ b/core/src/main/java/org/elasticsearch/script/expression/ExpressionScriptEngineService.java
@@ -31,7 +31,6 @@ import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.fielddata.IndexFieldData;
-import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.core.DateFieldMapper;
@@ -172,7 +171,7 @@ public class ExpressionScriptEngineService extends AbstractComponent implements 
             }
         }
 
-        return new ExpressionScript((Expression)compiledScript, bindings, specialValue);
+        return new ExpressionSearchScript((Expression)compiledScript, bindings, specialValue);
     }
 
     protected ValueSource getMethodValueSource(MappedFieldType fieldType, IndexFieldData<?> fieldData, String fieldName, String methodName) {
@@ -215,13 +214,14 @@ public class ExpressionScriptEngineService extends AbstractComponent implements 
     }
 
     @Override
-    public ExecutableScript executable(Object compiledScript, @Nullable Map<String, Object> vars) {
-        throw new UnsupportedOperationException("Cannot use expressions for updates");
+    public ExecutableScript executable(Object compiledScript, Map<String, Object> vars) {
+        return new ExpressionExecutableScript(compiledScript, vars);
     }
 
     @Override
     public Object execute(Object compiledScript, Map<String, Object> vars) {
-        throw new UnsupportedOperationException("Cannot use expressions for updates");
+        ExpressionExecutableScript expressionExecutableScript = new ExpressionExecutableScript(compiledScript, vars);
+        return expressionExecutableScript.run();
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/script/expression/ExpressionSearchScript.java
+++ b/core/src/main/java/org/elasticsearch/script/expression/ExpressionSearchScript.java
@@ -38,7 +38,7 @@ import java.util.Map;
  * A bridge to evaluate an {@link Expression} against {@link Bindings} in the context
  * of a {@link SearchScript}.
  */
-class ExpressionScript implements SearchScript {
+class ExpressionSearchScript implements SearchScript {
 
     final Expression expression;
     final SimpleBindings bindings;
@@ -47,7 +47,7 @@ class ExpressionScript implements SearchScript {
     Scorer scorer;
     int docid;
 
-    ExpressionScript(Expression e, SimpleBindings b, ReplaceableConstValueSource v) {
+    ExpressionSearchScript(Expression e, SimpleBindings b, ReplaceableConstValueSource v) {
         expression = e;
         bindings = b;
         source = expression.getValueSource(bindings);

--- a/core/src/main/java/org/elasticsearch/script/expression/ReplaceableConstFunctionValues.java
+++ b/core/src/main/java/org/elasticsearch/script/expression/ReplaceableConstFunctionValues.java
@@ -19,44 +19,26 @@
 
 package org.elasticsearch.script.expression;
 
-import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.queries.function.FunctionValues;
-import org.apache.lucene.queries.function.ValueSource;
-
-import java.io.IOException;
-import java.util.Map;
 
 /**
- * A {@link ValueSource} which has a stub {@link FunctionValues} that holds a dynamically replaceable constant double.
+ * A support class for an executable expression script that allows the double returned
+ * by a {@link FunctionValues} to be modified.
  */
-class ReplaceableConstValueSource extends ValueSource {
-    final ReplaceableConstFunctionValues fv;
+public class ReplaceableConstFunctionValues extends FunctionValues {
+    private double value = 0;
 
-    public ReplaceableConstValueSource() {
-        fv = new ReplaceableConstFunctionValues();
+    public void setValue(double value) {
+        this.value = value;
     }
 
     @Override
-    public FunctionValues getValues(Map map, LeafReaderContext atomicReaderContext) throws IOException {
-        return fv;
+    public double doubleVal(int doc) {
+        return value;
     }
 
     @Override
-    public boolean equals(Object o) {
-        return o == this;
-    }
-
-    @Override
-    public int hashCode() {
-        return System.identityHashCode(this);
-    }
-
-    @Override
-    public String description() {
-        return "replaceableConstDouble";
-    }
-
-    public void setValue(double v) {
-        fv.setValue(v);
+    public String toString(int i) {
+        return "ReplaceableConstFunctionValues: " + value;
     }
 }

--- a/core/src/test/java/org/elasticsearch/script/CustomScriptContextTests.java
+++ b/core/src/test/java/org/elasticsearch/script/CustomScriptContextTests.java
@@ -72,7 +72,7 @@ public class CustomScriptContextTests extends ElasticsearchIntegrationTest {
         }
 
         CompiledScript compiledScript = scriptService.compile(new Script("1", ScriptService.ScriptType.INLINE, "expression", null),
-                randomFrom(ScriptContext.Standard.values()));
+                randomFrom(new ScriptContext[] {ScriptContext.Standard.AGGS, ScriptContext.Standard.SEARCH}));
         assertThat(compiledScript, notNullValue());
 
         compiledScript = scriptService.compile(new Script("1", ScriptService.ScriptType.INLINE, "mustache", null),

--- a/core/src/test/java/org/elasticsearch/script/IndexedScriptTests.java
+++ b/core/src/test/java/org/elasticsearch/script/IndexedScriptTests.java
@@ -162,7 +162,7 @@ public class IndexedScriptTests extends ElasticsearchIntegrationTest {
             fail("update script should have been rejected");
         } catch(Exception e) {
             assertThat(e.getMessage(), containsString("failed to execute script"));
-            assertThat(e.getCause().toString(), containsString("scripts of type [indexed], operation [update] and lang [expression] are disabled"));
+            assertThat(e.getCause().getMessage(), containsString("scripts of type [indexed], operation [update] and lang [expression] are disabled"));
         }
         try {
             String query = "{ \"script_fields\" : { \"test1\" : { \"script_id\" : \"script1\", \"lang\":\"expression\" }}}";

--- a/core/src/test/java/org/elasticsearch/script/OnDiskScriptTests.java
+++ b/core/src/test/java/org/elasticsearch/script/OnDiskScriptTests.java
@@ -142,8 +142,7 @@ public class OnDiskScriptTests extends ElasticsearchIntegrationTest {
             fail("update script should have been rejected");
         } catch (Exception e) {
             assertThat(e.getMessage(), containsString("failed to execute script"));
-            assertThat(e.getCause().toString(),
-                    containsString("scripts of type [file], operation [update] and lang [mustache] are disabled"));
+            assertThat(e.getCause().getMessage(), containsString("scripts of type [file], operation [update] and lang [mustache] are disabled"));
         }
     }
 


### PR DESCRIPTION
Added several classes to support expressions being used for numerical
calculations in aggregations.  Expressions will still not compile
when used with mapping and update script contexts.

Closes #11596
