### PR TITLE
Fix support for `_name` in some queries

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/FuzzyQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/FuzzyQueryBuilder.java
@@ -105,34 +105,30 @@ public class FuzzyQueryBuilder extends MultiTermQueryBuilder implements Boostabl
     @Override
     public void doXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(FuzzyQueryParser.NAME);
-        if (boost == -1 && fuzziness == null && prefixLength == null && queryName != null) {
-            builder.field(name, value);
-        } else {
-            builder.startObject(name);
-            builder.field("value", value);
-            if (boost != -1) {
-                builder.field("boost", boost);
-            }
-            if (transpositions != null) {
-                builder.field("transpositions", transpositions);
-            }
-            if (fuzziness != null) {
-                fuzziness.toXContent(builder, params);
-            }
-            if (prefixLength != null) {
-                builder.field("prefix_length", prefixLength);
-            }
-            if (maxExpansions != null) {
-                builder.field("max_expansions", maxExpansions);
-            }
-            if (rewrite != null) {
-                builder.field("rewrite", rewrite);
-            }
-            if (queryName != null) {
-                builder.field("_name", queryName);
-            }
-            builder.endObject();
+        builder.startObject(name);
+        builder.field("value", value);
+        if (boost != -1) {
+            builder.field("boost", boost);
         }
+        if (transpositions != null) {
+            builder.field("transpositions", transpositions);
+        }
+        if (fuzziness != null) {
+            fuzziness.toXContent(builder, params);
+        }
+        if (prefixLength != null) {
+            builder.field("prefix_length", prefixLength);
+        }
+        if (maxExpansions != null) {
+            builder.field("max_expansions", maxExpansions);
+        }
+        if (rewrite != null) {
+            builder.field("rewrite", rewrite);
+        }
+        if (queryName != null) {
+            builder.field("_name", queryName);
+        }
+        builder.endObject();
         builder.endObject();
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/PrefixQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/PrefixQueryBuilder.java
@@ -75,7 +75,7 @@ public class PrefixQueryBuilder extends MultiTermQueryBuilder implements Boostab
     @Override
     public void doXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(PrefixQueryParser.NAME);
-        if (boost == -1 && rewrite == null && queryName != null) {
+        if (boost == -1 && rewrite == null && queryName == null) {
             builder.field(name, prefix);
         } else {
             builder.startObject(name);

--- a/core/src/main/java/org/elasticsearch/index/query/RegexpQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/RegexpQueryBuilder.java
@@ -98,28 +98,24 @@ public class RegexpQueryBuilder extends MultiTermQueryBuilder implements Boostab
     @Override
     public void doXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(RegexpQueryParser.NAME);
-        if (boost == -1 && rewrite == null && queryName != null) {
-            builder.field(name, regexp);
-        } else {
-            builder.startObject(name);
-            builder.field("value", regexp);
-            if (flags != -1) {
-                builder.field("flags_value", flags);
-            }
-            if (maxDetermizedStatesSet) {
-                builder.field("max_determinized_states", maxDeterminizedStates);
-            }
-            if (boost != -1) {
-                builder.field("boost", boost);
-            }
-            if (rewrite != null) {
-                builder.field("rewrite", rewrite);
-            }
-            if (queryName != null) {
-                builder.field("name", queryName);
-            }
-            builder.endObject();
+        builder.startObject(name);
+        builder.field("value", regexp);
+        if (flags != -1) {
+            builder.field("flags_value", flags);
         }
+        if (maxDetermizedStatesSet) {
+            builder.field("max_determinized_states", maxDeterminizedStates);
+        }
+        if (boost != -1) {
+            builder.field("boost", boost);
+        }
+        if (rewrite != null) {
+            builder.field("rewrite", rewrite);
+        }
+        if (queryName != null) {
+            builder.field("_name", queryName);
+        }
+        builder.endObject();
         builder.endObject();
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/RegexpQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/RegexpQueryParser.java
@@ -27,7 +27,6 @@ import org.apache.lucene.util.automaton.Operations;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.query.support.QueryParsers;
 
@@ -87,6 +86,8 @@ public class RegexpQueryParser implements QueryParser {
                             maxDeterminizedStates = parser.intValue();
                         } else if ("flags_value".equals(currentFieldName)) {
                             flagsValue = parser.intValue();
+                        } else if ("_name".equals(currentFieldName)) {
+                            queryName = parser.text();
                         } else {
                             throw new QueryParsingException(parseContext, "[regexp] query does not support [" + currentFieldName + "]");
                         }

--- a/core/src/main/java/org/elasticsearch/index/query/SpanFirstQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanFirstQueryBuilder.java
@@ -62,7 +62,7 @@ public class SpanFirstQueryBuilder extends SpanQueryBuilder implements Boostable
             builder.field("boost", boost);
         }
         if (queryName != null) {
-            builder.field("name", queryName);
+            builder.field("_name", queryName);
         }
         builder.endObject();
     }

--- a/core/src/main/java/org/elasticsearch/index/query/WildcardQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/WildcardQueryBuilder.java
@@ -85,7 +85,7 @@ public class WildcardQueryBuilder extends MultiTermQueryBuilder implements Boost
     @Override
     public void doXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(WildcardQueryParser.NAME);
-        if (boost == -1 && rewrite == null && queryName != null) {
+        if (boost == -1 && rewrite == null && queryName == null) {
             builder.field(name, wildcard);
         } else {
             builder.startObject(name);


### PR DESCRIPTION
Some of our Java api builders had wrong logic when it comes to serializing the query in json format, resulting in missing fields like _name. Also, regexp parser was ignoring the _name field.
