### PR TITLE
Add support for query boost to SimpleQueryStringBuilder.

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
@@ -39,7 +39,7 @@ public class SimpleQueryStringBuilder extends QueryBuilder implements BoostableQ
     private String queryName;
     private String minimumShouldMatch;
     private int flags = -1;
-    private float boost = 1.0f;
+    private float boost = -1.0f;
     private Boolean lowercaseExpandedTerms;
     private Boolean lenient;
     private Boolean analyzeWildcard;
@@ -210,7 +210,7 @@ public class SimpleQueryStringBuilder extends QueryBuilder implements BoostableQ
             builder.field("minimum_should_match", minimumShouldMatch);
         }
         
-        if (boost != 1.0f) {
+        if (boost != -1.0f) {
             builder.field("boost", boost);
         }
 

--- a/core/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.query;
 
+import org.elasticsearch.common.xcontent.ToXContent.Params;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -30,7 +31,7 @@ import java.util.Map;
  * SimpleQuery is a query parser that acts similar to a query_string
  * query, but won't throw exceptions for any weird string syntax.
  */
-public class SimpleQueryStringBuilder extends QueryBuilder {
+public class SimpleQueryStringBuilder extends QueryBuilder implements BoostableQueryBuilder<SimpleQueryStringBuilder> {
     private Map<String, Float> fields = new HashMap<>();
     private String analyzer;
     private Operator operator;
@@ -38,6 +39,7 @@ public class SimpleQueryStringBuilder extends QueryBuilder {
     private String queryName;
     private String minimumShouldMatch;
     private int flags = -1;
+    private float boost = 1.0f;
     private Boolean lowercaseExpandedTerms;
     private Boolean lenient;
     private Boolean analyzeWildcard;
@@ -56,6 +58,18 @@ public class SimpleQueryStringBuilder extends QueryBuilder {
      */
     public SimpleQueryStringBuilder(String text) {
         this.queryText = text;
+    }
+
+    /** Set the boost of this query. */
+    @Override
+    public SimpleQueryStringBuilder boost(float boost) {
+        this.boost = boost;
+        return this;
+    }
+    
+    /** Returns the boost of this query. */
+    public float boost() {
+        return this.boost;
     }
 
     /**
@@ -195,7 +209,12 @@ public class SimpleQueryStringBuilder extends QueryBuilder {
         if (minimumShouldMatch != null) {
             builder.field("minimum_should_match", minimumShouldMatch);
         }
+        
+        if (boost != 1.0f) {
+            builder.field("boost", boost);
+        }
 
         builder.endObject();
     }
+
 }

--- a/core/src/main/java/org/elasticsearch/index/query/SimpleQueryStringParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SimpleQueryStringParser.java
@@ -234,8 +234,11 @@ public class SimpleQueryStringParser implements QueryParser {
         if (minimumShouldMatch != null && query instanceof BooleanQuery) {
             Queries.applyMinimumShouldMatch((BooleanQuery) query, minimumShouldMatch);
         }
-        
-        query.setBoost(boost);
+
+        if (query != null) {
+            query.setBoost(boost);
+        }
+
         return query;
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/SimpleQueryStringParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SimpleQueryStringParser.java
@@ -90,6 +90,7 @@ public class SimpleQueryStringParser implements QueryParser {
 
         String currentFieldName = null;
         String queryBody = null;
+        float boost = 1.0f; 
         String queryName = null;
         String field = null;
         String minimumShouldMatch = null;
@@ -147,6 +148,8 @@ public class SimpleQueryStringParser implements QueryParser {
             } else if (token.isValue()) {
                 if ("query".equals(currentFieldName)) {
                     queryBody = parser.text();
+                } else if ("boost".equals(currentFieldName)) {
+                    boost = parser.floatValue();
                 } else if ("analyzer".equals(currentFieldName)) {
                     analyzer = parseContext.analysisService().analyzer(parser.text());
                     if (analyzer == null) {
@@ -198,7 +201,7 @@ public class SimpleQueryStringParser implements QueryParser {
         if (queryBody == null) {
             throw new QueryParsingException(parseContext, "[" + NAME + "] query text missing");
         }
-
+        
         // Support specifying only a field instead of a map
         if (field == null) {
             field = currentFieldName;
@@ -231,6 +234,8 @@ public class SimpleQueryStringParser implements QueryParser {
         if (minimumShouldMatch != null && query instanceof BooleanQuery) {
             Queries.applyMinimumShouldMatch((BooleanQuery) query, minimumShouldMatch);
         }
+        
+        query.setBoost(boost);
         return query;
     }
 }

--- a/core/src/test/java/org/elasticsearch/search/query/SimpleQueryStringTests.java
+++ b/core/src/test/java/org/elasticsearch/search/query/SimpleQueryStringTests.java
@@ -36,6 +36,7 @@ import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
 import static org.elasticsearch.index.query.QueryBuilders.queryStringQuery;
 import static org.elasticsearch.index.query.QueryBuilders.simpleQueryStringQuery;
+import static org.elasticsearch.index.query.QueryBuilders.termQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.*;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -58,6 +59,13 @@ public class SimpleQueryStringTests extends ElasticsearchIntegrationTest {
         SearchResponse searchResponse = client().prepareSearch().setQuery(simpleQueryStringQuery("foo bar")).get();
         assertHitCount(searchResponse, 3l);
         assertSearchHits(searchResponse, "1", "2", "3");
+
+        searchResponse = client().prepareSearch().setQuery(
+                boolQuery()
+                    .should(simpleQueryStringQuery("foo").boost(-10.0f))
+                    .should(termQuery("body", "eggplant"))).get();
+        assertHitCount(searchResponse, 3l);
+        assertFirstHit(searchResponse, hasId("4"));
 
         searchResponse = client().prepareSearch().setQuery(
                 simpleQueryStringQuery("foo bar").defaultOperator(SimpleQueryStringBuilder.Operator.AND)).get();

--- a/core/src/test/java/org/elasticsearch/search/query/SimpleQueryStringTests.java
+++ b/core/src/test/java/org/elasticsearch/search/query/SimpleQueryStringTests.java
@@ -60,12 +60,14 @@ public class SimpleQueryStringTests extends ElasticsearchIntegrationTest {
         assertHitCount(searchResponse, 3l);
         assertSearchHits(searchResponse, "1", "2", "3");
 
+        // Tests boost value setting. In this case doc 1 should always be ranked above the other
+        // two matches.
         searchResponse = client().prepareSearch().setQuery(
                 boolQuery()
-                    .should(simpleQueryStringQuery("foo").boost(-10.0f))
+                    .should(simpleQueryStringQuery("\"foo bar\"").boost(10.0f))
                     .should(termQuery("body", "eggplant"))).get();
-        assertHitCount(searchResponse, 3l);
-        assertFirstHit(searchResponse, hasId("4"));
+        assertHitCount(searchResponse, 2l);
+        assertFirstHit(searchResponse, hasId("3"));
 
         searchResponse = client().prepareSearch().setQuery(
                 simpleQueryStringQuery("foo bar").defaultOperator(SimpleQueryStringBuilder.Operator.AND)).get();


### PR DESCRIPTION
As per discussion in #11274 this adds support for query boosting to the SimpleQueryStringQuery.

In the process of refactoring SimpleQueryStringQueryBuilder/-Parser we noticed that this is one of the few queries that doesn't support query level boosting, although it in theory it could. Adding this support here.

@dakrone @javanna @cbuescher can either of you check the PR please?
