### PR TITLE
Query Refactoring: DisMaxQueryBuilder and Parser

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/BoolQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/BoolQueryBuilder.java
@@ -77,15 +77,6 @@ public class BoolQueryBuilder extends QueryBuilder<BoolQueryBuilder> implements 
     }
 
     /**
-     * Adds a list of queries that <b>must</b> appear in the matching documents and will
-     * contribute to scoring.
-     */
-    public BoolQueryBuilder must(List<QueryBuilder> queryBuilders) {
-        mustClauses.addAll(queryBuilders);
-        return this;
-    }
-
-    /**
      * Gets the queries that <b>must</b> appear in the matching documents.
      */
     public List<QueryBuilder> must() {
@@ -98,15 +89,6 @@ public class BoolQueryBuilder extends QueryBuilder<BoolQueryBuilder> implements 
      */
     public BoolQueryBuilder filter(QueryBuilder queryBuilder) {
         filterClauses.add(queryBuilder);
-        return this;
-    }
-
-    /**
-     * Adds a list of queries that <b>must</b> appear in the matching documents but will
-     * not contribute to scoring.
-     */
-    public BoolQueryBuilder filter(List<QueryBuilder> queryBuilders) {
-        filterClauses.addAll(queryBuilders);
         return this;
     }
 
@@ -126,14 +108,6 @@ public class BoolQueryBuilder extends QueryBuilder<BoolQueryBuilder> implements 
     }
 
     /**
-     * Adds a list of queries that <b>must not</b> appear in the matching documents.
-     */
-    public BoolQueryBuilder mustNot(List<QueryBuilder> queryBuilders) {
-        mustNotClauses.addAll(queryBuilders);
-        return this;
-    }
-
-    /**
      * Gets the queries that <b>must not</b> appear in the matching documents.
      */
     public List<QueryBuilder> mustNot() {
@@ -149,18 +123,6 @@ public class BoolQueryBuilder extends QueryBuilder<BoolQueryBuilder> implements 
      */
     public BoolQueryBuilder should(QueryBuilder queryBuilder) {
         shouldClauses.add(queryBuilder);
-        return this;
-    }
-
-    /**
-     * Adds a list of clauses that <i>should</i> be matched by the returned documents. For a boolean query with no
-     * <tt>MUST</tt> clauses one or more <code>SHOULD</code> clauses must match a document
-     * for the BooleanQuery to match.
-     *
-     * @see #minimumNumberShouldMatch(int)
-     */
-    public BoolQueryBuilder should(List<QueryBuilder> queryBuilders) {
-        shouldClauses.addAll(queryBuilders);
         return this;
     }
 
@@ -396,13 +358,13 @@ public class BoolQueryBuilder extends QueryBuilder<BoolQueryBuilder> implements 
     public BoolQueryBuilder readFrom(StreamInput in) throws IOException {
         BoolQueryBuilder boolQueryBuilder = new BoolQueryBuilder();
         List<QueryBuilder> queryBuilders = in.readNamedWritableList();
-        boolQueryBuilder.must(queryBuilders);
+        boolQueryBuilder.mustClauses.addAll(queryBuilders);
         queryBuilders = in.readNamedWritableList();
-        boolQueryBuilder.mustNot(queryBuilders);
+        boolQueryBuilder.mustNotClauses.addAll(queryBuilders);
         queryBuilders = in.readNamedWritableList();
-        boolQueryBuilder.should(queryBuilders);
+        boolQueryBuilder.shouldClauses.addAll(queryBuilders);
         queryBuilders = in.readNamedWritableList();
-        boolQueryBuilder.filter(queryBuilders);
+        boolQueryBuilder.filterClauses.addAll(queryBuilders);
         boolQueryBuilder.boost = in.readFloat();
         boolQueryBuilder.adjustPureNegative = in.readBoolean();
         boolQueryBuilder.disableCoord = in.readBoolean();

--- a/core/src/main/java/org/elasticsearch/index/query/BoolQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/BoolQueryParser.java
@@ -154,16 +154,23 @@ public class BoolQueryParser extends BaseQueryParser {
             }
         }
         BoolQueryBuilder boolQuery = new BoolQueryBuilder();
-        boolQuery.must(mustClauses);
-        boolQuery.mustNot(mustNotClauses);
-        boolQuery.should(shouldClauses);
-        boolQuery.filter(filterClauses);
+        for (QueryBuilder queryBuilder : mustClauses) {
+            boolQuery.must(queryBuilder);
+        }
+        for (QueryBuilder queryBuilder : mustNotClauses) {
+            boolQuery.mustNot(queryBuilder);
+        }
+        for (QueryBuilder queryBuilder : shouldClauses) {
+            boolQuery.should(queryBuilder);
+        }
+        for (QueryBuilder queryBuilder : filterClauses) {
+            boolQuery.filter(queryBuilder);
+        }
         boolQuery.boost(boost);
         boolQuery.disableCoord(disableCoord);
         boolQuery.adjustPureNegative(adjustPureNegative);
         boolQuery.minimumNumberShouldMatch(minimumShouldMatch);
         boolQuery.queryName(queryName);
-        boolQuery.validate();
         return boolQuery;
     }
 

--- a/core/src/main/java/org/elasticsearch/index/query/QueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryBuilder.java
@@ -30,6 +30,9 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentType;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 /**
  * Base class for all classes producing lucene queries.
@@ -111,6 +114,27 @@ public abstract class QueryBuilder<QB extends QueryBuilder> extends ToXContentTo
             return ((BytesRef) obj).utf8ToString();
         }
         return obj;
+    }
+
+    /**
+     * Helper method to convert collection of {@link QueryBuilder} instances to lucene
+     * {@link Query} instances. {@link QueryBuilder} that return <tt>null</tt> calling
+     * their {@link QueryBuilder#toQuery(QueryParseContext)} method are not added to the
+     * resulting collection.
+     *
+     * @throws IOException
+     * @throws QueryParsingException
+     */
+    protected static Collection<Query> toQueries(Collection<QueryBuilder> queryBuilders, QueryParseContext parseContext) throws QueryParsingException,
+            IOException {
+        List<Query> queries = new ArrayList<>(queryBuilders.size());
+        for (QueryBuilder queryBuilder : queryBuilders) {
+            Query query = queryBuilder.toQuery(parseContext);
+            if (query != null) {
+                queries.add(query);
+            }
+        }
+        return queries;
     }
 
     //norelease remove this once all builders implement readFrom themselves

--- a/core/src/test/java/org/elasticsearch/index/query/DisMaxQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/DisMaxQueryBuilderTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query;
+
+import org.apache.lucene.search.DisjunctionMaxQuery;
+import org.apache.lucene.search.Query;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class DisMaxQueryBuilderTest extends BaseQueryTestCase<DisMaxQueryBuilder> {
+
+    @Override
+    protected Query createExpectedQuery(DisMaxQueryBuilder testBuilder, QueryParseContext context) throws QueryParsingException, IOException {
+        Query query = new DisjunctionMaxQuery(QueryBuilder.toQueries(testBuilder.queries(), context), testBuilder.tieBreaker());
+        query.setBoost(testBuilder.boost());
+        if (testBuilder.queryName() != null) {
+            context.addNamedQuery(testBuilder.queryName(), query);
+        }
+        return query;
+    }
+
+    /**
+     * @return a {@link DisMaxQueryBuilder} with random inner queries
+     */
+    @Override
+    protected DisMaxQueryBuilder createTestQueryBuilder() {
+        DisMaxQueryBuilder dismax = new DisMaxQueryBuilder();
+        int clauses = randomIntBetween(1, 5);
+        for (int i = 0; i < clauses; i++) {
+            dismax.add(RandomQueryBuilder.create(random()));
+        }
+        if (randomBoolean()) {
+            dismax.boost(2.0f / randomIntBetween(1, 20));
+        }
+        if (randomBoolean()) {
+            dismax.tieBreaker(2.0f / randomIntBetween(1, 20));
+        }
+        if (randomBoolean()) {
+            dismax.queryName(randomUnicodeOfLengthBetween(3, 15));
+        }
+        return dismax;
+    }
+
+    /**
+     * test `null`return value for missing inner queries
+     * @throws IOException
+     * @throws QueryParsingException
+     */
+    @Test
+    public void testNoInnerQueries() throws QueryParsingException, IOException {
+        DisMaxQueryBuilder disMaxBuilder = new DisMaxQueryBuilder();
+        assertNull(disMaxBuilder.toQuery(createContext()));
+        assertNull(disMaxBuilder.validate());
+    }
+
+    /**
+     * Test inner query parsing to null. Current DSL allows inner filter element to parse to <tt>null</tt>.
+     * Those should be ignored upstream. To test this, we use inner {@link ConstantScoreQueryBuilder}
+     * with empty inner filter.
+     */
+    @Test
+    public void testInnerQueryReturnsNull() throws IOException {
+        QueryParseContext context = createContext();
+        String queryId = ConstantScoreQueryBuilder.PROTOTYPE.queryId();
+        String queryString = "{ \""+queryId+"\" : { \"filter\" : { } }";
+        XContentParser parser = XContentFactory.xContent(queryString).createParser(queryString);
+        context.reset(parser);
+        assertQueryHeader(parser, queryId);
+        ConstantScoreQueryBuilder innerQueryBuilder = (ConstantScoreQueryBuilder) context.indexQueryParserService()
+                .queryParser(queryId).fromXContent(context);
+
+        DisMaxQueryBuilder disMaxBuilder = new DisMaxQueryBuilder().add(innerQueryBuilder);
+        assertNull(disMaxBuilder.toQuery(context));
+    }
+}


### PR DESCRIPTION
Moving the query building functionality from the parser to the builders
new toQuery() method analogous to other recent query refactorings.

Relates to #10217

PR goes agains query-refactoring feature branch.
