### PR TITLE
Update filter-aggregation.asciidoc

### DIFF
--- a/docs/reference/search/aggregations/bucket/filter-aggregation.asciidoc
+++ b/docs/reference/search/aggregations/bucket/filter-aggregation.asciidoc
@@ -9,8 +9,8 @@ Example:
 --------------------------------------------------
 {
     "aggs" : {
-        "in_stock_products" : {
-            "filter" : { "range" : { "stock" : { "gt" : 0 } } },
+        "red_products" : {
+            "filter" : { "term": { "color": "red" } },
             "aggs" : {
                 "avg_price" : { "avg" : { "field" : "price" } }
             }


### PR DESCRIPTION
Replace the previous example which leveraged a range filter, which causes unnecessary confusion about when to use a range filter to create a single bucket or a range aggregation with exactly one member in ranges.
