### PR TITLE
Allow to opt-out of loading packaged REST tests

### DIFF
--- a/core/src/test/java/org/elasticsearch/test/rest/ElasticsearchRestTestCase.java
+++ b/core/src/test/java/org/elasticsearch/test/rest/ElasticsearchRestTestCase.java
@@ -120,6 +120,8 @@ public abstract class ElasticsearchRestTestCase extends ElasticsearchIntegration
      */
     public static final String REST_TESTS_SPEC = "tests.rest.spec";
 
+    public static final String REST_LOAD_PACKAGED_TESTS = "tests.rest.load_packaged";
+
     private static final String DEFAULT_TESTS_PATH = "/rest-api-spec/test";
     private static final String DEFAULT_SPEC_PATH = "/rest-api-spec/api";
 
@@ -239,8 +241,8 @@ public abstract class ElasticsearchRestTestCase extends ElasticsearchIntegration
         // REST suite handling is currently complicated, with lots of filtering and so on
         // For now, to work embedded in a jar, return a ZipFileSystem over the jar contents. 
         URL codeLocation = FileUtils.class.getProtectionDomain().getCodeSource().getLocation();
-
-        if (codeLocation.getFile().endsWith(".jar")) {
+        boolean loadPackaged = RandomizedTest.systemPropertyAsBoolean(REST_LOAD_PACKAGED_TESTS, true);
+        if (codeLocation.getFile().endsWith(".jar") && loadPackaged) {
             try {
                 // hack around a bug in the zipfilesystem implementation before java 9,
                 // its checkWritable was incorrect and it won't work without write permissions. 

--- a/plugins/delete-by-query/pom.xml
+++ b/plugins/delete-by-query/pom.xml
@@ -31,6 +31,7 @@ governing permissions and limitations under the License. -->
     <properties>
         <tests.ifNoTests>warn</tests.ifNoTests>
         <tests.rest.suite>delete_by_query</tests.rest.suite>
+        <tests.rest.load_packaged>false</tests.rest.load_packaged>
     </properties>
 
     <build>

--- a/plugins/delete-by-query/src/test/java/org/elasticsearch/plugin/deletebyquery/test/rest/DeleteByQueryRestTests.java
+++ b/plugins/delete-by-query/src/test/java/org/elasticsearch/plugin/deletebyquery/test/rest/DeleteByQueryRestTests.java
@@ -36,8 +36,6 @@ import static org.elasticsearch.test.ElasticsearchIntegrationTest.Scope.SUITE;
 
 @Rest
 @ClusterScope(scope = SUITE, randomDynamicTemplates = false)
-@Ignore
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/11721")
 public class DeleteByQueryRestTests extends ElasticsearchRestTestCase {
 
     public DeleteByQueryRestTests(@Name("yaml") RestTestCandidate testCandidate) {

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,7 @@
         <tests.network></tests.network>
         <tests.cluster></tests.cluster>
         <tests.filter></tests.filter>
+        <tests.rest.load_packaged></tests.rest.load_packaged>
         <env.ES_TEST_LOCAL></env.ES_TEST_LOCAL>
         <tests.security.manager>true</tests.security.manager>
         <tests.compatibility></tests.compatibility>
@@ -660,6 +661,7 @@
                                     <tests.filter>${tests.filter}</tests.filter>
                                     <tests.version>${elasticsearch.version}</tests.version>
                                     <tests.locale>${tests.locale}</tests.locale>
+                                    <tests.rest.load_packaged>${tests.rest.load_packaged}</tests.rest.load_packaged>
                                     <tests.timezone>${tests.timezone}</tests.timezone>
                                     <project.basedir>${project.basedir}</project.basedir>
                                     <m2.repository>${settings.localRepository}</m2.repository>


### PR DESCRIPTION
this is really just a workaround for plugins to run their own
REST tests instead of the core ones. It opts out of the rest test
loading from the core jar file and tries to load from the classpath instead.
Eventually we need to fix this infrastrucutre to move away from parameterized
tests such that subclasses can override behavior.

Closes #11721
