### PR TITLE
Add -XX:+PrintGCDateStamps when using GC Logs

### DIFF
--- a/distribution/src/main/resources/bin/elasticsearch.in.bat
+++ b/distribution/src/main/resources/bin/elasticsearch.in.bat
@@ -64,6 +64,7 @@ if "%ES_GC_LOG_FILE%" == "" goto nogclog
 :gclog
 set JAVA_OPTS=%JAVA_OPTS% -XX:+PrintGCDetails
 set JAVA_OPTS=%JAVA_OPTS% -XX:+PrintGCTimeStamps
+set JAVA_OPTS=%JAVA_OPTS% -XX:+PrintGCDateStamps
 set JAVA_OPTS=%JAVA_OPTS% -XX:+PrintClassHistogram
 set JAVA_OPTS=%JAVA_OPTS% -XX:+PrintTenuringDistribution
 set JAVA_OPTS=%JAVA_OPTS% -XX:+PrintGCApplicationStoppedTime

--- a/distribution/src/main/resources/bin/elasticsearch.in.sh
+++ b/distribution/src/main/resources/bin/elasticsearch.in.sh
@@ -48,6 +48,7 @@ JAVA_OPTS="$JAVA_OPTS -XX:+UseCMSInitiatingOccupancyOnly"
 if [ -n "$ES_GC_LOG_FILE" ]; then
   JAVA_OPTS="$JAVA_OPTS -XX:+PrintGCDetails"
   JAVA_OPTS="$JAVA_OPTS -XX:+PrintGCTimeStamps"
+  JAVA_OPTS="$JAVA_OPTS -XX:+PrintGCDateStamps"
   JAVA_OPTS="$JAVA_OPTS -XX:+PrintClassHistogram"
   JAVA_OPTS="$JAVA_OPTS -XX:+PrintTenuringDistribution"
   JAVA_OPTS="$JAVA_OPTS -XX:+PrintGCApplicationStoppedTime"


### PR DESCRIPTION
Now that Elasticsearch requires Java 7 or later, it's safe to add `-XX:+PrintGCDateStamps` to get human readable times alongside JVM times.

Closes #11733
