### PR TITLE
Only load term statistics if required

### DIFF
--- a/src/main/java/org/elasticsearch/action/termvector/TermVectorWriter.java
+++ b/src/main/java/org/elasticsearch/action/termvector/TermVectorWriter.java
@@ -79,9 +79,9 @@ final class TermVectorWriter {
                 // current field
                 // get the doc frequency
                 BytesRef term = iterator.term();
-                boolean foundTerm = topLevelIterator.seekExact(term);
                 startTerm(term);
                 if (flags.contains(Flag.TermStatistics)) {
+                    boolean foundTerm = topLevelIterator.seekExact(term);
                     if (foundTerm) {
                         writeTermStatistics(topLevelIterator);
                     } else {


### PR DESCRIPTION
Current code loads term statistics even if not requested.  This slows down term vector requests markedly (typical figures for stored term vectors on 3k-character field on 4-core machine: 2ms per vector with current code; 0.3ms with this fix).
