### PR TITLE
Replace Iterators#emptyIterator by JDK one

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/termvectors/TermVectorsResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/termvectors/TermVectorsResponse.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.termvectors;
 
-import com.google.common.collect.Iterators;
 import org.apache.lucene.index.Fields;
 import org.apache.lucene.index.PostingsEnum;
 import org.apache.lucene.index.Terms;
@@ -43,6 +42,7 @@ import org.elasticsearch.common.xcontent.XContentBuilderString;
 import org.elasticsearch.search.dfs.AggregatedDfs;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.Set;
@@ -154,7 +154,7 @@ public class TermVectorsResponse extends ActionResponse implements ToXContent {
             return new Fields() {
                 @Override
                 public Iterator<String> iterator() {
-                    return Iterators.emptyIterator();
+                    return Collections.emptyIterator();
                 }
 
                 @Override

--- a/core/src/main/java/org/elasticsearch/index/get/GetResult.java
+++ b/core/src/main/java/org/elasticsearch/index/get/GetResult.java
@@ -34,11 +34,11 @@ import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.search.lookup.SourceLookup;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import static com.google.common.collect.Iterators.emptyIterator;
 import static com.google.common.collect.Maps.newHashMapWithExpectedSize;
 import static org.elasticsearch.index.get.GetField.readGetField;
 
@@ -193,7 +193,7 @@ public class GetResult implements Streamable, Iterable<GetField>, ToXContent {
     @Override
     public Iterator<GetField> iterator() {
         if (fields == null) {
-            return emptyIterator();
+            return Collections.emptyIterator();
         }
         return fields.values().iterator();
     }


### PR DESCRIPTION
`com.google.common.collect.Iterators#emptyIterator()` is marked as deprecated and will be removed in May 2016. We should use JDK7 `Collections#emptyIterator()`
