### PR TITLE
Add DateTime ctors without timezone to forbidden APIs

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.text.StringAndBytesText;
 import org.elasticsearch.common.text.Text;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -398,7 +399,8 @@ public abstract class StreamInput extends InputStream {
             case 12:
                 return new Date(readLong());
             case 13:
-                return new DateTime(readLong());
+                final String timeZoneId = readString();
+                return new DateTime(readLong(), DateTimeZone.forID(timeZoneId));
             case 14:
                 return readBytesReference();
             case 15:

--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -373,6 +373,7 @@ public abstract class StreamOutput extends OutputStream {
             writeLong(((Date) value).getTime());
         } else if (value instanceof ReadableInstant) {
             writeByte((byte) 13);
+            writeString(((ReadableInstant) value).getZone().getID());
             writeLong(((ReadableInstant) value).getMillis());
         } else if (value instanceof BytesReference) {
             writeByte((byte) 14);

--- a/core/src/test/java/org/elasticsearch/benchmark/scripts/score/BasicScriptBenchmark.java
+++ b/core/src/test/java/org/elasticsearch/benchmark/scripts/score/BasicScriptBenchmark.java
@@ -35,6 +35,7 @@ import org.elasticsearch.index.query.functionscore.script.ScriptScoreFunctionBui
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptService.ScriptType;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 
 import java.io.BufferedWriter;
 import java.io.IOException;
@@ -172,7 +173,7 @@ public class BasicScriptBenchmark {
             out.write("\n\n\n\n");
             out.write("######################################\n");
             out.write("# Octave script for plotting results\n");
-            String filename = "scriptScoreBenchmark" + new DateTime().toString();
+            String filename = "scriptScoreBenchmark" + new DateTime(DateTimeZone.UTC).toString();
             out.write("#Call '" + args[0] + "' from the command line. The plot is then in " + filename + "\n\n");
 
             out.write("handleArray = [];\n tagArray = [];\n plot([]);\n hold on;\n");

--- a/core/src/test/java/org/elasticsearch/index/mapper/date/SimpleDateMappingTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/date/SimpleDateMappingTests.java
@@ -232,8 +232,8 @@ public class SimpleDateMappingTests extends ElasticsearchSingleNodeTest {
         } finally {
             SearchContext.removeCurrent();
         }
-        assertThat(rangeQuery.getMax(), equalTo(new DateTime(TimeValue.timeValueHours(11).millis()).getMillis()));
-        assertThat(rangeQuery.getMin(), equalTo(new DateTime(TimeValue.timeValueHours(10).millis()).getMillis()));
+        assertThat(rangeQuery.getMax(), equalTo(new DateTime(TimeValue.timeValueHours(11).millis(), DateTimeZone.UTC).getMillis()));
+        assertThat(rangeQuery.getMin(), equalTo(new DateTime(TimeValue.timeValueHours(10).millis(), DateTimeZone.UTC).getMillis()));
     }
     
     public void testDayWithoutYearFormat() throws Exception {
@@ -258,8 +258,8 @@ public class SimpleDateMappingTests extends ElasticsearchSingleNodeTest {
         } finally {
             SearchContext.removeCurrent();
         }
-        assertThat(rangeQuery.getMax(), equalTo(new DateTime(TimeValue.timeValueHours(35).millis()).getMillis()));
-        assertThat(rangeQuery.getMin(), equalTo(new DateTime(TimeValue.timeValueHours(34).millis()).getMillis()));
+        assertThat(rangeQuery.getMax(), equalTo(new DateTime(TimeValue.timeValueHours(35).millis(), DateTimeZone.UTC).getMillis()));
+        assertThat(rangeQuery.getMin(), equalTo(new DateTime(TimeValue.timeValueHours(34).millis(), DateTimeZone.UTC).getMillis()));
     }
     
     public void testIgnoreMalformedOption() throws Exception {

--- a/core/src/test/java/org/elasticsearch/index/query/IndexQueryParserFilterDateRangeTimezoneTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/IndexQueryParserFilterDateRangeTimezoneTests.java
@@ -32,6 +32,7 @@ import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.test.ElasticsearchSingleNodeTest;
 import org.elasticsearch.test.TestSearchContext;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -107,7 +108,7 @@ public class IndexQueryParserFilterDateRangeTimezoneTests extends ElasticsearchS
         // Min value was 2012-01-01 (UTC) so we need to remove one hour
         DateTime min = DateTime.parse("2012-01-01T00:00:00.000+01:00");
         // Max value is when we started the test. So it should be some ms from now
-        DateTime max = new DateTime(startDate);
+        DateTime max = new DateTime(startDate, DateTimeZone.UTC);
 
         assertThat(((NumericRangeQuery) parsedQuery).getMin().longValue(), is(min.getMillis()));
 

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/MinDocCountTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/MinDocCountTests.java
@@ -35,6 +35,7 @@ import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsBuilder;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.joda.time.format.DateTimeFormat;
 
 import java.util.ArrayList;
@@ -78,7 +79,7 @@ public class MinDocCountTests extends AbstractTermsTests {
                 longTerm = randomInt(cardinality * 2);
             } while (!longTerms.add(longTerm));
             double doubleTerm = longTerm * Math.PI;
-            String dateTerm = DateTimeFormat.forPattern("yyyy-MM-dd").print(new DateTime(2014, 1, ((int) longTerm % 20) + 1, 0, 0));
+            String dateTerm = DateTimeFormat.forPattern("yyyy-MM-dd").print(new DateTime(2014, 1, ((int) longTerm % 20) + 1, 0, 0, DateTimeZone.UTC));
             final int frequency = randomBoolean() ? 1 : randomIntBetween(2, 20);
             for (int j = 0; j < frequency; ++j) {
                 indexRequests.add(client().prepareIndex("idx", "type").setSource(jsonBuilder()

--- a/core/src/test/java/org/elasticsearch/search/functionscore/DecayFunctionScoreTests.java
+++ b/core/src/test/java/org/elasticsearch/search/functionscore/DecayFunctionScoreTests.java
@@ -35,6 +35,7 @@ import org.elasticsearch.index.query.functionscore.gauss.GaussDecayFunctionBuild
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -532,7 +533,7 @@ public class DecayFunctionScoreTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testDateWithoutOrigin() throws Exception {
-        DateTime dt = new DateTime();
+        DateTime dt = new DateTime(DateTimeZone.UTC);
 
         assertAcked(prepareCreate("test").addMapping(
                 "type1",

--- a/dev-tools/src/main/resources/forbidden/all-signatures.txt
+++ b/dev-tools/src/main/resources/forbidden/all-signatures.txt
@@ -45,3 +45,11 @@ java.nio.file.FileSystems#getDefault() @ use PathUtils.getDefault instead.
 @defaultMessage Specify a location for the temp file/directory instead.
 java.nio.file.Files#createTempDirectory(java.lang.String,java.nio.file.attribute.FileAttribute[])
 java.nio.file.Files#createTempFile(java.lang.String,java.lang.String,java.nio.file.attribute.FileAttribute[])
+
+@defaultMessage Constructing a DateTime without a time zone is dangerous - use DateTime(DateTimeZone.getDefault()) if you really want the default timezone
+org.joda.time.DateTime#<init>()
+org.joda.time.DateTime#<init>(long)
+org.joda.time.DateTime#<init>(int, int, int, int, int)
+org.joda.time.DateTime#<init>(int, int, int, int, int, int)
+org.joda.time.DateTime#<init>(int, int, int, int, int, int, int)
+org.joda.time.DateTime#now()


### PR DESCRIPTION
Using DateTime with default timezone is asking for trouble and should
be added to forbidden APIs
