### PR TITLE
Allow security rule for advanced SSL configutation

### DIFF
--- a/core/src/main/resources/org/elasticsearch/bootstrap/security.policy
+++ b/core/src/main/resources/org/elasticsearch/bootstrap/security.policy
@@ -101,4 +101,7 @@ grant {
 
   // needed by Mockito
   permission java.lang.RuntimePermission "reflectionFactoryAccess";
+
+  // needed to install SSLFactories, advanced SSL configuration, etc.
+  permission java.lang.RuntimePermission "setFactory";
 };


### PR DESCRIPTION
if plugins need to install SSL factories etc. we have to allow
to `setFactory` in the security policy.
