### PR TITLE
Added Class Imports

### DIFF
--- a/docs/java-api/bulk.asciidoc
+++ b/docs/java-api/bulk.asciidoc
@@ -7,8 +7,6 @@ single request. Here is a sample usage:
 [source,java]
 --------------------------------------------------
 import static org.elasticsearch.common.xcontent.XContentFactory.*;
-import org.elasticsearch.common.unit.ByteSizeUnit;
-import org.elasticsearch.common.unit.ByteSizeValue;
 
 BulkRequestBuilder bulkRequest = client.prepareBulk();
 
@@ -50,6 +48,8 @@ To use it, first create a `BulkProcessor` instance:
 [source,java]
 --------------------------------------------------
 import org.elasticsearch.action.bulk.BulkProcessor;
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
 
 BulkProcessor bulkProcessor = BulkProcessor.builder(
         client,  <1>

--- a/docs/java-api/bulk.asciidoc
+++ b/docs/java-api/bulk.asciidoc
@@ -7,6 +7,8 @@ single request. Here is a sample usage:
 [source,java]
 --------------------------------------------------
 import static org.elasticsearch.common.xcontent.XContentFactory.*;
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
 
 BulkRequestBuilder bulkRequest = client.prepareBulk();
 


### PR DESCRIPTION
I was unable to get my BulkProcessor script to work without importing the "ByteSizeUnit" and "ByteSizeValue" classes.  Perhaps I overlooked something in the example and do not understand its code.
