### PR TITLE
Add Iterators.emptyIterator to forbidden apis

### DIFF
--- a/dev-tools/src/main/resources/forbidden/all-signatures.txt
+++ b/dev-tools/src/main/resources/forbidden/all-signatures.txt
@@ -53,3 +53,5 @@ org.joda.time.DateTime#<init>(int, int, int, int, int)
 org.joda.time.DateTime#<init>(int, int, int, int, int, int)
 org.joda.time.DateTime#<init>(int, int, int, int, int, int, int)
 org.joda.time.DateTime#now()
+
+com.google.common.collect.Iterators#emptyIterator() @ Use Collections.emptyIterator instead


### PR DESCRIPTION
As a follow up to #11741, this forbids Iterators.emptyIterator in
favor the of builtin Collections.emptyIterator.
