### PR TITLE
Improve logging of repository verification exceptions.

### DIFF
--- a/core/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
+++ b/core/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
@@ -217,7 +217,7 @@ public class RepositoriesService extends AbstractComponent implements ClusterSta
                             try {
                                 repository.endVerification(verificationToken);
                             } catch (Throwable t) {
-                                logger.warn("[{}] failed to finish repository verification", repositoryName, t);
+                                logger.warn("[{}] failed to finish repository verification", t, repositoryName);
                                 listener.onFailure(t);
                                 return;
                             }
@@ -233,7 +233,7 @@ public class RepositoriesService extends AbstractComponent implements ClusterSta
                     try {
                         repository.endVerification(verificationToken);
                     } catch (Throwable t1) {
-                        logger.warn("[{}] failed to finish repository verification", repositoryName, t);
+                        logger.warn("[{}] failed to finish repository verification", t1, repositoryName);
                     }
                     listener.onFailure(t);
                 }

--- a/core/src/main/java/org/elasticsearch/repositories/VerifyNodeRepositoryAction.java
+++ b/core/src/main/java/org/elasticsearch/repositories/VerifyNodeRepositoryAction.java
@@ -80,6 +80,7 @@ public class VerifyNodeRepositoryAction  extends AbstractComponent {
                 try {
                     doVerify(repository, verificationToken);
                 } catch (Throwable t) {
+                    logger.warn("[{}] failed to verify repository", t, repository);
                     errors.add(new VerificationFailure(node.id(), ExceptionsHelper.detailedMessage(t)));
                 }
                 if (counter.decrementAndGet() == 0) {
@@ -146,7 +147,12 @@ public class VerifyNodeRepositoryAction  extends AbstractComponent {
     class VerifyNodeRepositoryRequestHandler implements TransportRequestHandler<VerifyNodeRepositoryRequest> {
         @Override
         public void messageReceived(VerifyNodeRepositoryRequest request, TransportChannel channel) throws Exception {
-            doVerify(request.repository, request.verificationToken);
+            try {
+                doVerify(request.repository, request.verificationToken);
+            } catch (Exception ex) {
+                logger.warn("[{}] failed to verify repository", ex, request.repository);
+                throw ex;
+            }
             channel.sendResponse(TransportResponse.Empty.INSTANCE);
         }
     }


### PR DESCRIPTION
Some repository verification exception are currently only returned to the users but not logged on the nodes where the exception occurred, which makes troubleshooting difficult.

 Closes #11760
