### PR TITLE
Mark store as corrupted instead of deleting state file on engine failure

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -1272,10 +1272,10 @@ public class IndexShard extends AbstractIndexShardComponent {
         @Override
         public void onFailedEngine(ShardId shardId, String reason, @Nullable Throwable failure) {
             try {
-                // delete the shard state so this folder will not be reused
-                MetaDataStateFormat.deleteMetaState(nodeEnv.availableShardPaths(shardId));
+                // mark as corrupted, so opening the store will fail
+                store.markStoreCorrupted(new IOException("failed engine (reason: [" + reason + "])", failure));
             } catch (IOException e) {
-                logger.warn("failed to delete shard state", e);
+                logger.warn("failed to mark shard store as corrupted", e);
             } finally {
                 for (Engine.FailedEngineListener listener : delegates) {
                     try {


### PR DESCRIPTION
Currently, we delete the shard _state file on engine failure.
This behaviour does not persist the engine failure reason for later inspection.

This change marks the shard store as corrupted instead of deleting
the _state file to ensure the store index can not be opened after and
the engine failure is persisted.
