### PR TITLE
Hide more fieldType access and cleanup null_value merging

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/core/AbstractFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/AbstractFieldMapper.java
@@ -467,6 +467,7 @@ public abstract class AbstractFieldMapper implements FieldMapper {
                     ));
                 }
             }
+            this.fieldType().setNullValue(fieldMergeWith.fieldType().nullValue());
             this.fieldType().freeze();
             this.copyTo = fieldMergeWith.copyTo;
         }

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/BooleanFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/BooleanFieldMapper.java
@@ -240,20 +240,6 @@ public class BooleanFieldMapper extends AbstractFieldMapper {
     }
 
     @Override
-    public void merge(Mapper mergeWith, MergeResult mergeResult) throws MergeMappingException {
-        super.merge(mergeWith, mergeResult);
-        if (!this.getClass().equals(mergeWith.getClass())) {
-            return;
-        }
-
-        if (!mergeResult.simulate()) {
-            this.fieldType = fieldType().clone();
-            fieldType().setNullValue(((BooleanFieldMapper) mergeWith).fieldType().nullValue());
-            fieldType().freeze();
-        }
-    }
-
-    @Override
     protected String contentType() {
         return CONTENT_TYPE;
     }

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/ByteFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/ByteFieldMapper.java
@@ -194,7 +194,7 @@ public class ByteFieldMapper extends NumberFieldMapper {
 
     @Override
     public ByteFieldType fieldType() {
-        return (ByteFieldType)fieldType;
+        return (ByteFieldType) super.fieldType();
     }
 
     @Override
@@ -225,7 +225,7 @@ public class ByteFieldMapper extends NumberFieldMapper {
     @Override
     protected void innerParseCreateField(ParseContext context, List<Field> fields) throws IOException {
         byte value;
-        float boost = this.fieldType.boost();
+        float boost = fieldType().boost();
         if (context.externalValueSet()) {
             Object externalValue = context.externalValue();
             if (externalValue == null) {
@@ -247,7 +247,7 @@ public class ByteFieldMapper extends NumberFieldMapper {
                 value = ((Number) externalValue).byteValue();
             }
             if (context.includeInAll(includeInAll, this)) {
-                context.allEntries().addText(fieldType.names().fullName(), Byte.toString(value), boost);
+                context.allEntries().addText(fieldType().names().fullName(), Byte.toString(value), boost);
             }
         } else {
             XContentParser parser = context.parser();
@@ -258,7 +258,7 @@ public class ByteFieldMapper extends NumberFieldMapper {
                 }
                 value = fieldType().nullValue();
                 if (fieldType().nullValueAsString() != null && (context.includeInAll(includeInAll, this))) {
-                    context.allEntries().addText(fieldType.names().fullName(), fieldType().nullValueAsString(), boost);
+                    context.allEntries().addText(fieldType().names().fullName(), fieldType().nullValueAsString(), boost);
                 }
             } else if (parser.currentToken() == XContentParser.Token.START_OBJECT) {
                 XContentParser.Token token;
@@ -287,12 +287,12 @@ public class ByteFieldMapper extends NumberFieldMapper {
             } else {
                 value = (byte) parser.shortValue(coerce.value());
                 if (context.includeInAll(includeInAll, this)) {
-                    context.allEntries().addText(fieldType.names().fullName(), parser.text(), boost);
+                    context.allEntries().addText(fieldType().names().fullName(), parser.text(), boost);
                 }
             }
         }
-        if (fieldType.indexOptions() != IndexOptions.NONE || fieldType.stored()) {
-            CustomByteNumericField field = new CustomByteNumericField(this, value, fieldType);
+        if (fieldType().indexOptions() != IndexOptions.NONE || fieldType().stored()) {
+            CustomByteNumericField field = new CustomByteNumericField(this, value, fieldType());
             field.setBoost(boost);
             fields.add(field);
         }
@@ -307,24 +307,11 @@ public class ByteFieldMapper extends NumberFieldMapper {
     }
 
     @Override
-    public void merge(Mapper mergeWith, MergeResult mergeResult) throws MergeMappingException {
-        super.merge(mergeWith, mergeResult);
-        if (!this.getClass().equals(mergeWith.getClass())) {
-            return;
-        }
-        if (!mergeResult.simulate()) {
-            this.fieldType = this.fieldType.clone();
-            this.fieldType.setNullValue(((ByteFieldMapper) mergeWith).fieldType().nullValue());
-            this.fieldType.freeze();
-        }
-    }
-
-    @Override
     protected void doXContentBody(XContentBuilder builder, boolean includeDefaults, Params params) throws IOException {
         super.doXContentBody(builder, includeDefaults, params);
 
-        if (includeDefaults || fieldType.numericPrecisionStep() != Defaults.PRECISION_STEP_8_BIT) {
-            builder.field("precision_step", fieldType.numericPrecisionStep());
+        if (includeDefaults || fieldType().numericPrecisionStep() != Defaults.PRECISION_STEP_8_BIT) {
+            builder.field("precision_step", fieldType().numericPrecisionStep());
         }
         if (includeDefaults || fieldType().nullValue() != null) {
             builder.field("null_value", fieldType().nullValue());

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/DateFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/DateFieldMapper.java
@@ -395,7 +395,7 @@ public class DateFieldMapper extends NumberFieldMapper {
 
     @Override
     public DateFieldType fieldType() {
-        return (DateFieldType)fieldType;
+        return (DateFieldType) super.fieldType();
     }
 
     @Override
@@ -428,18 +428,18 @@ public class DateFieldMapper extends NumberFieldMapper {
     @Override
     protected void innerParseCreateField(ParseContext context, List<Field> fields) throws IOException {
         String dateAsString = null;
-        float boost = this.fieldType.boost();
+        float boost = fieldType().boost();
         if (context.externalValueSet()) {
             Object externalValue = context.externalValue();
             dateAsString = (String) externalValue;
             if (dateAsString == null) {
-                dateAsString = fieldType.nullValueAsString();
+                dateAsString = fieldType().nullValueAsString();
             }
         } else {
             XContentParser parser = context.parser();
             XContentParser.Token token = parser.currentToken();
             if (token == XContentParser.Token.VALUE_NULL) {
-                dateAsString = fieldType.nullValueAsString();
+                dateAsString = fieldType().nullValueAsString();
             } else if (token == XContentParser.Token.VALUE_NUMBER) {
                 dateAsString = parser.text();
             } else if (token == XContentParser.Token.START_OBJECT) {
@@ -450,7 +450,7 @@ public class DateFieldMapper extends NumberFieldMapper {
                     } else {
                         if ("value".equals(currentFieldName) || "_value".equals(currentFieldName)) {
                             if (token == XContentParser.Token.VALUE_NULL) {
-                                dateAsString = fieldType.nullValueAsString();
+                                dateAsString = fieldType().nullValueAsString();
                             } else {
                                 dateAsString = parser.text();
                             }
@@ -469,14 +469,14 @@ public class DateFieldMapper extends NumberFieldMapper {
         Long value = null;
         if (dateAsString != null) {
             if (context.includeInAll(includeInAll, this)) {
-                context.allEntries().addText(fieldType.names().fullName(), dateAsString, boost);
+                context.allEntries().addText(fieldType().names().fullName(), dateAsString, boost);
             }
             value = fieldType().parseStringValue(dateAsString);
         }
 
         if (value != null) {
-            if (fieldType.indexOptions() != IndexOptions.NONE || fieldType.stored()) {
-                CustomLongNumericField field = new CustomLongNumericField(this, value, (NumberFieldType)fieldType);
+            if (fieldType().indexOptions() != IndexOptions.NONE || fieldType().stored()) {
+                CustomLongNumericField field = new CustomLongNumericField(this, value, fieldType());
                 field.setBoost(boost);
                 fields.add(field);
             }
@@ -500,7 +500,6 @@ public class DateFieldMapper extends NumberFieldMapper {
         if (!mergeResult.simulate()) {
             this.fieldType = this.fieldType.clone();
             fieldType().setDateTimeFormatter(((DateFieldMapper) mergeWith).fieldType().dateTimeFormatter());
-            this.fieldType.setNullValue(((DateFieldMapper) mergeWith).fieldType().nullValue());
             this.fieldType.freeze();
         }
     }
@@ -509,12 +508,12 @@ public class DateFieldMapper extends NumberFieldMapper {
     protected void doXContentBody(XContentBuilder builder, boolean includeDefaults, Params params) throws IOException {
         super.doXContentBody(builder, includeDefaults, params);
 
-        if (includeDefaults || fieldType.numericPrecisionStep() != Defaults.PRECISION_STEP_64_BIT) {
-            builder.field("precision_step", fieldType.numericPrecisionStep());
+        if (includeDefaults || fieldType().numericPrecisionStep() != Defaults.PRECISION_STEP_64_BIT) {
+            builder.field("precision_step", fieldType().numericPrecisionStep());
         }
         builder.field("format", fieldType().dateTimeFormatter().format());
-        if (includeDefaults || fieldType.nullValueAsString() != null) {
-            builder.field("null_value", fieldType.nullValueAsString());
+        if (includeDefaults || fieldType().nullValueAsString() != null) {
+            builder.field("null_value", fieldType().nullValueAsString());
         }
         if (includeInAll != null) {
             builder.field("include_in_all", includeInAll);

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/DoubleFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/DoubleFieldMapper.java
@@ -199,7 +199,7 @@ public class DoubleFieldMapper extends NumberFieldMapper {
 
     @Override
     public DoubleFieldType fieldType() {
-        return (DoubleFieldType)fieldType;
+        return (DoubleFieldType) super.fieldType();
     }
 
     @Override
@@ -220,7 +220,7 @@ public class DoubleFieldMapper extends NumberFieldMapper {
     @Override
     protected void innerParseCreateField(ParseContext context, List<Field> fields) throws IOException {
         double value;
-        float boost = this.fieldType.boost();
+        float boost = fieldType().boost();
         if (context.externalValueSet()) {
             Object externalValue = context.externalValue();
             if (externalValue == null) {
@@ -242,7 +242,7 @@ public class DoubleFieldMapper extends NumberFieldMapper {
                 value = ((Number) externalValue).doubleValue();
             }
             if (context.includeInAll(includeInAll, this)) {
-                context.allEntries().addText(fieldType.names().fullName(), Double.toString(value), boost);
+                context.allEntries().addText(fieldType().names().fullName(), Double.toString(value), boost);
             }
         } else {
             XContentParser parser = context.parser();
@@ -253,7 +253,7 @@ public class DoubleFieldMapper extends NumberFieldMapper {
                 }
                 value = fieldType().nullValue();
                 if (fieldType().nullValueAsString() != null && (context.includeInAll(includeInAll, this))) {
-                    context.allEntries().addText(fieldType.names().fullName(), fieldType().nullValueAsString(), boost);
+                    context.allEntries().addText(fieldType().names().fullName(), fieldType().nullValueAsString(), boost);
                 }
             } else if (parser.currentToken() == XContentParser.Token.START_OBJECT) {
                 XContentParser.Token token;
@@ -282,13 +282,13 @@ public class DoubleFieldMapper extends NumberFieldMapper {
             } else {
                 value = parser.doubleValue(coerce.value());
                 if (context.includeInAll(includeInAll, this)) {
-                    context.allEntries().addText(fieldType.names().fullName(), parser.text(), boost);
+                    context.allEntries().addText(fieldType().names().fullName(), parser.text(), boost);
                 }
             }
         }
 
-        if (fieldType.indexOptions() != IndexOptions.NONE || fieldType.stored()) {
-            CustomDoubleNumericField field = new CustomDoubleNumericField(this, value, (NumberFieldType)fieldType);
+        if (fieldType().indexOptions() != IndexOptions.NONE || fieldType().stored()) {
+            CustomDoubleNumericField field = new CustomDoubleNumericField(this, value, fieldType());
             field.setBoost(boost);
             fields.add(field);
         }
@@ -313,24 +313,11 @@ public class DoubleFieldMapper extends NumberFieldMapper {
     }
 
     @Override
-    public void merge(Mapper mergeWith, MergeResult mergeResult) throws MergeMappingException {
-        super.merge(mergeWith, mergeResult);
-        if (!this.getClass().equals(mergeWith.getClass())) {
-            return;
-        }
-        if (!mergeResult.simulate()) {
-            this.fieldType = this.fieldType.clone();
-            this.fieldType.setNullValue(((DoubleFieldMapper) mergeWith).fieldType().nullValue());
-            this.fieldType.freeze();
-        }
-    }
-
-    @Override
     protected void doXContentBody(XContentBuilder builder, boolean includeDefaults, Params params) throws IOException {
         super.doXContentBody(builder, includeDefaults, params);
 
-        if (includeDefaults || fieldType.numericPrecisionStep() != Defaults.PRECISION_STEP_64_BIT) {
-            builder.field("precision_step", fieldType.numericPrecisionStep());
+        if (includeDefaults || fieldType().numericPrecisionStep() != Defaults.PRECISION_STEP_64_BIT) {
+            builder.field("precision_step", fieldType().numericPrecisionStep());
         }
         if (includeDefaults || fieldType().nullValue() != null) {
             builder.field("null_value", fieldType().nullValue());

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/FloatFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/FloatFieldMapper.java
@@ -201,7 +201,7 @@ public class FloatFieldMapper extends NumberFieldMapper {
 
     @Override
     public FloatFieldType fieldType() {
-        return (FloatFieldType)fieldType;
+        return (FloatFieldType) super.fieldType();
     }
 
     @Override
@@ -232,7 +232,7 @@ public class FloatFieldMapper extends NumberFieldMapper {
     @Override
     protected void innerParseCreateField(ParseContext context, List<Field> fields) throws IOException {
         float value;
-        float boost = this.fieldType.boost();
+        float boost = fieldType().boost();
         if (context.externalValueSet()) {
             Object externalValue = context.externalValue();
             if (externalValue == null) {
@@ -254,7 +254,7 @@ public class FloatFieldMapper extends NumberFieldMapper {
                 value = ((Number) externalValue).floatValue();
             }
             if (context.includeInAll(includeInAll, this)) {
-                context.allEntries().addText(fieldType.names().fullName(), Float.toString(value), boost);
+                context.allEntries().addText(fieldType().names().fullName(), Float.toString(value), boost);
             }
         } else {
             XContentParser parser = context.parser();
@@ -265,7 +265,7 @@ public class FloatFieldMapper extends NumberFieldMapper {
                 }
                 value = fieldType().nullValue();
                 if (fieldType().nullValueAsString() != null && (context.includeInAll(includeInAll, this))) {
-                    context.allEntries().addText(fieldType.names().fullName(), fieldType().nullValueAsString(), boost);
+                    context.allEntries().addText(fieldType().names().fullName(), fieldType().nullValueAsString(), boost);
                 }
             } else if (parser.currentToken() == XContentParser.Token.START_OBJECT) {
                 XContentParser.Token token;
@@ -294,13 +294,13 @@ public class FloatFieldMapper extends NumberFieldMapper {
             } else {
                 value = parser.floatValue(coerce.value());
                 if (context.includeInAll(includeInAll, this)) {
-                    context.allEntries().addText(fieldType.names().fullName(), parser.text(), boost);
+                    context.allEntries().addText(fieldType().names().fullName(), parser.text(), boost);
                 }
             }
         }
 
-        if (fieldType.indexOptions() != IndexOptions.NONE || fieldType.stored()) {
-            CustomFloatNumericField field = new CustomFloatNumericField(this, value, (NumberFieldType)fieldType);
+        if (fieldType().indexOptions() != IndexOptions.NONE || fieldType().stored()) {
+            CustomFloatNumericField field = new CustomFloatNumericField(this, value, fieldType());
             field.setBoost(boost);
             fields.add(field);
         }
@@ -325,25 +325,11 @@ public class FloatFieldMapper extends NumberFieldMapper {
     }
 
     @Override
-    public void merge(Mapper mergeWith, MergeResult mergeResult) throws MergeMappingException {
-        super.merge(mergeWith, mergeResult);
-        if (!this.getClass().equals(mergeWith.getClass())) {
-            return;
-        }
-        if (!mergeResult.simulate()) {
-            this.fieldType = this.fieldType.clone();
-            this.fieldType.setNullValue(((FloatFieldMapper) mergeWith).fieldType().nullValue());
-            this.fieldType.freeze();
-        }
-    }
-
-
-    @Override
     protected void doXContentBody(XContentBuilder builder, boolean includeDefaults, Params params) throws IOException {
         super.doXContentBody(builder, includeDefaults, params);
 
-        if (includeDefaults || fieldType.numericPrecisionStep() != Defaults.PRECISION_STEP_32_BIT) {
-            builder.field("precision_step", fieldType.numericPrecisionStep());
+        if (includeDefaults || fieldType().numericPrecisionStep() != Defaults.PRECISION_STEP_32_BIT) {
+            builder.field("precision_step", fieldType().numericPrecisionStep());
         }
         if (includeDefaults || fieldType().nullValue() != null) {
             builder.field("null_value", fieldType().nullValue());

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/IntegerFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/IntegerFieldMapper.java
@@ -204,7 +204,7 @@ public class IntegerFieldMapper extends NumberFieldMapper {
 
     @Override
     public IntegerFieldType fieldType() {
-        return (IntegerFieldType)fieldType;
+        return (IntegerFieldType) super.fieldType();
     }
 
     @Override
@@ -235,11 +235,11 @@ public class IntegerFieldMapper extends NumberFieldMapper {
     @Override
     protected void innerParseCreateField(ParseContext context, List<Field> fields) throws IOException {
         int value;
-        float boost = this.fieldType.boost();
+        float boost = fieldType().boost();
         if (context.externalValueSet()) {
             Object externalValue = context.externalValue();
             if (externalValue == null) {
-                if (fieldType.nullValue() == null) {
+                if (fieldType().nullValue() == null) {
                     return;
                 }
                 value = fieldType().nullValue();
@@ -257,18 +257,18 @@ public class IntegerFieldMapper extends NumberFieldMapper {
                 value = ((Number) externalValue).intValue();
             }
             if (context.includeInAll(includeInAll, this)) {
-                context.allEntries().addText(fieldType.names().fullName(), Integer.toString(value), boost);
+                context.allEntries().addText(fieldType().names().fullName(), Integer.toString(value), boost);
             }
         } else {
             XContentParser parser = context.parser();
             if (parser.currentToken() == XContentParser.Token.VALUE_NULL ||
                     (parser.currentToken() == XContentParser.Token.VALUE_STRING && parser.textLength() == 0)) {
-                if (fieldType.nullValue() == null) {
+                if (fieldType().nullValue() == null) {
                     return;
                 }
                 value = fieldType().nullValue();
-                if (fieldType.nullValueAsString() != null && (context.includeInAll(includeInAll, this))) {
-                    context.allEntries().addText(fieldType.names().fullName(), fieldType.nullValueAsString(), boost);
+                if (fieldType().nullValueAsString() != null && (context.includeInAll(includeInAll, this))) {
+                    context.allEntries().addText(fieldType().names().fullName(), fieldType().nullValueAsString(), boost);
                 }
             } else if (parser.currentToken() == XContentParser.Token.START_OBJECT) {
                 XContentParser.Token token;
@@ -297,7 +297,7 @@ public class IntegerFieldMapper extends NumberFieldMapper {
             } else {
                 value = parser.intValue(coerce.value());
                 if (context.includeInAll(includeInAll, this)) {
-                    context.allEntries().addText(fieldType.names().fullName(), parser.text(), boost);
+                    context.allEntries().addText(fieldType().names().fullName(), parser.text(), boost);
                 }
             }
         }
@@ -305,8 +305,8 @@ public class IntegerFieldMapper extends NumberFieldMapper {
     }
 
     protected void addIntegerFields(ParseContext context, List<Field> fields, int value, float boost) {
-        if (fieldType.indexOptions() != IndexOptions.NONE || fieldType.stored()) {
-            CustomIntegerNumericField field = new CustomIntegerNumericField(this, value, fieldType);
+        if (fieldType().indexOptions() != IndexOptions.NONE || fieldType().stored()) {
+            CustomIntegerNumericField field = new CustomIntegerNumericField(this, value, fieldType());
             field.setBoost(boost);
             fields.add(field);
         }
@@ -321,27 +321,14 @@ public class IntegerFieldMapper extends NumberFieldMapper {
     }
 
     @Override
-    public void merge(Mapper mergeWith, MergeResult mergeResult) throws MergeMappingException {
-        super.merge(mergeWith, mergeResult);
-        if (!this.getClass().equals(mergeWith.getClass())) {
-            return;
-        }
-        if (!mergeResult.simulate()) {
-            this.fieldType = this.fieldType.clone();
-            this.fieldType.setNullValue(((FieldMapper)mergeWith).fieldType().nullValue());
-            this.fieldType.freeze();
-        }
-    }
-
-    @Override
     protected void doXContentBody(XContentBuilder builder, boolean includeDefaults, Params params) throws IOException {
         super.doXContentBody(builder, includeDefaults, params);
 
-        if (includeDefaults || fieldType.numericPrecisionStep() != Defaults.PRECISION_STEP_32_BIT) {
-            builder.field("precision_step", fieldType.numericPrecisionStep());
+        if (includeDefaults || fieldType().numericPrecisionStep() != Defaults.PRECISION_STEP_32_BIT) {
+            builder.field("precision_step", fieldType().numericPrecisionStep());
         }
-        if (includeDefaults || fieldType.nullValue() != null) {
-            builder.field("null_value", fieldType.nullValue());
+        if (includeDefaults || fieldType().nullValue() != null) {
+            builder.field("null_value", fieldType().nullValue());
         }
         if (includeInAll != null) {
             builder.field("include_in_all", includeInAll);

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/LongFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/LongFieldMapper.java
@@ -202,7 +202,7 @@ public class LongFieldMapper extends NumberFieldMapper {
 
     @Override
     public LongFieldType fieldType() {
-        return (LongFieldType)fieldType;
+        return (LongFieldType) super.fieldType();
     }
 
     @Override
@@ -223,7 +223,7 @@ public class LongFieldMapper extends NumberFieldMapper {
     @Override
     protected void innerParseCreateField(ParseContext context, List<Field> fields) throws IOException {
         long value;
-        float boost = this.fieldType.boost();
+        float boost = fieldType().boost();
         if (context.externalValueSet()) {
             Object externalValue = context.externalValue();
             if (externalValue == null) {
@@ -245,7 +245,7 @@ public class LongFieldMapper extends NumberFieldMapper {
                 value = ((Number) externalValue).longValue();
             }
             if (context.includeInAll(includeInAll, this)) {
-                context.allEntries().addText(fieldType.names().fullName(), Long.toString(value), boost);
+                context.allEntries().addText(fieldType().names().fullName(), Long.toString(value), boost);
             }
         } else {
             XContentParser parser = context.parser();
@@ -256,7 +256,7 @@ public class LongFieldMapper extends NumberFieldMapper {
                 }
                 value = fieldType().nullValue();
                 if (fieldType().nullValueAsString() != null && (context.includeInAll(includeInAll, this))) {
-                    context.allEntries().addText(fieldType.names().fullName(), fieldType().nullValueAsString(), boost);
+                    context.allEntries().addText(fieldType().names().fullName(), fieldType().nullValueAsString(), boost);
                 }
             } else if (parser.currentToken() == XContentParser.Token.START_OBJECT) {
                 XContentParser.Token token;
@@ -285,12 +285,12 @@ public class LongFieldMapper extends NumberFieldMapper {
             } else {
                 value = parser.longValue(coerce.value());
                 if (context.includeInAll(includeInAll, this)) {
-                    context.allEntries().addText(fieldType.names().fullName(), parser.text(), boost);
+                    context.allEntries().addText(fieldType().names().fullName(), parser.text(), boost);
                 }
             }
         }
-        if (fieldType.indexOptions() != IndexOptions.NONE || fieldType.stored()) {
-            CustomLongNumericField field = new CustomLongNumericField(this, value, (NumberFieldType)fieldType);
+        if (fieldType().indexOptions() != IndexOptions.NONE || fieldType().stored()) {
+            CustomLongNumericField field = new CustomLongNumericField(this, value, fieldType());
             field.setBoost(boost);
             fields.add(field);
         }
@@ -305,24 +305,11 @@ public class LongFieldMapper extends NumberFieldMapper {
     }
 
     @Override
-    public void merge(Mapper mergeWith, MergeResult mergeResult) throws MergeMappingException {
-        super.merge(mergeWith, mergeResult);
-        if (!this.getClass().equals(mergeWith.getClass())) {
-            return;
-        }
-        if (!mergeResult.simulate()) {
-            this.fieldType = this.fieldType.clone();
-            this.fieldType.setNullValue(((LongFieldMapper) mergeWith).fieldType().nullValue());
-            this.fieldType.freeze();
-        }
-    }
-
-    @Override
     protected void doXContentBody(XContentBuilder builder, boolean includeDefaults, Params params) throws IOException {
         super.doXContentBody(builder, includeDefaults, params);
 
-        if (includeDefaults || fieldType.numericPrecisionStep() != Defaults.PRECISION_STEP_64_BIT) {
-            builder.field("precision_step", fieldType.numericPrecisionStep());
+        if (includeDefaults || fieldType().numericPrecisionStep() != Defaults.PRECISION_STEP_64_BIT) {
+            builder.field("precision_step", fieldType().numericPrecisionStep());
         }
         if (includeDefaults || fieldType().nullValue() != null) {
             builder.field("null_value", fieldType().nullValue());

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/ShortFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/ShortFieldMapper.java
@@ -201,7 +201,7 @@ public class ShortFieldMapper extends NumberFieldMapper {
 
     @Override
     public ShortFieldType fieldType() {
-        return (ShortFieldType)fieldType;
+        return (ShortFieldType) super.fieldType();
     }
 
     @Override
@@ -232,7 +232,7 @@ public class ShortFieldMapper extends NumberFieldMapper {
     @Override
     protected void innerParseCreateField(ParseContext context, List<Field> fields) throws IOException {
         short value;
-        float boost = this.fieldType.boost();
+        float boost = fieldType().boost();
         if (context.externalValueSet()) {
             Object externalValue = context.externalValue();
             if (externalValue == null) {
@@ -254,7 +254,7 @@ public class ShortFieldMapper extends NumberFieldMapper {
                 value = ((Number) externalValue).shortValue();
             }
             if (context.includeInAll(includeInAll, this)) {
-                context.allEntries().addText(fieldType.names().fullName(), Short.toString(value), boost);
+                context.allEntries().addText(fieldType().names().fullName(), Short.toString(value), boost);
             }
         } else {
             XContentParser parser = context.parser();
@@ -265,7 +265,7 @@ public class ShortFieldMapper extends NumberFieldMapper {
                 }
                 value = fieldType().nullValue();
                 if (fieldType().nullValueAsString() != null && (context.includeInAll(includeInAll, this))) {
-                    context.allEntries().addText(fieldType.names().fullName(), fieldType().nullValueAsString(), boost);
+                    context.allEntries().addText(fieldType().names().fullName(), fieldType().nullValueAsString(), boost);
                 }
             } else if (parser.currentToken() == XContentParser.Token.START_OBJECT) {
                 XContentParser.Token token;
@@ -294,12 +294,12 @@ public class ShortFieldMapper extends NumberFieldMapper {
             } else {
                 value = parser.shortValue(coerce.value());
                 if (context.includeInAll(includeInAll, this)) {
-                    context.allEntries().addText(fieldType.names().fullName(), parser.text(), boost);
+                    context.allEntries().addText(fieldType().names().fullName(), parser.text(), boost);
                 }
             }
         }
-        if (fieldType.indexOptions() != IndexOptions.NONE || fieldType.stored()) {
-            CustomShortNumericField field = new CustomShortNumericField(this, value, (NumberFieldType)fieldType);
+        if (fieldType().indexOptions() != IndexOptions.NONE || fieldType().stored()) {
+            CustomShortNumericField field = new CustomShortNumericField(this, value, fieldType());
             field.setBoost(boost);
             fields.add(field);
         }
@@ -314,24 +314,11 @@ public class ShortFieldMapper extends NumberFieldMapper {
     }
 
     @Override
-    public void merge(Mapper mergeWith, MergeResult mergeResult) throws MergeMappingException {
-        super.merge(mergeWith, mergeResult);
-        if (!this.getClass().equals(mergeWith.getClass())) {
-            return;
-        }
-        if (!mergeResult.simulate()) {
-            this.fieldType = this.fieldType.clone();
-            this.fieldType.setNullValue(((ShortFieldMapper) mergeWith).fieldType().nullValue());
-            this.fieldType.freeze();
-        }
-    }
-
-    @Override
     protected void doXContentBody(XContentBuilder builder, boolean includeDefaults, Params params) throws IOException {
         super.doXContentBody(builder, includeDefaults, params);
 
-        if (includeDefaults || fieldType.numericPrecisionStep() != DEFAULT_PRECISION_STEP) {
-            builder.field("precision_step", fieldType.numericPrecisionStep());
+        if (includeDefaults || fieldType().numericPrecisionStep() != DEFAULT_PRECISION_STEP) {
+            builder.field("precision_step", fieldType().numericPrecisionStep());
         }
         if (includeDefaults || fieldType().nullValue() != null) {
             builder.field("null_value", fieldType().nullValue());

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/StringFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/StringFieldMapper.java
@@ -353,9 +353,6 @@ public class StringFieldMapper extends AbstractFieldMapper implements AllFieldMa
         if (!mergeResult.simulate()) {
             this.includeInAll = ((StringFieldMapper) mergeWith).includeInAll;
             this.ignoreAbove = ((StringFieldMapper) mergeWith).ignoreAbove;
-            this.fieldType = this.fieldType().clone();
-            this.fieldType().setNullValue(((StringFieldMapper) mergeWith).fieldType().nullValue());
-            this.fieldType().freeze();
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/TokenCountFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/TokenCountFieldMapper.java
@@ -136,12 +136,12 @@ public class TokenCountFieldMapper extends IntegerFieldMapper {
 
     @Override
     protected void parseCreateField(ParseContext context, List<Field> fields) throws IOException {
-        ValueAndBoost valueAndBoost = StringFieldMapper.parseCreateFieldForString(context, null /* Out null value is an int so we convert*/, fieldType.boost());
+        ValueAndBoost valueAndBoost = StringFieldMapper.parseCreateFieldForString(context, null /* Out null value is an int so we convert*/, fieldType().boost());
         if (valueAndBoost.value() == null && fieldType().nullValue() == null) {
             return;
         }
 
-        if (fieldType.indexOptions() != NONE || fieldType.stored() || fieldType().hasDocValues()) {
+        if (fieldType().indexOptions() != NONE || fieldType().stored() || fieldType().hasDocValues()) {
             int count;
             if (valueAndBoost.value() == null) {
                 count = fieldType().nullValue();
@@ -151,7 +151,7 @@ public class TokenCountFieldMapper extends IntegerFieldMapper {
             addIntegerFields(context, fields, count, valueAndBoost.boost());
         }
         if (fields.isEmpty()) {
-            context.ignoredValue(fieldType.names().indexName(), valueAndBoost.value());
+            context.ignoredValue(fieldType().names().indexName(), valueAndBoost.value());
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/SizeFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/SizeFieldMapper.java
@@ -162,7 +162,7 @@ public class SizeFieldMapper extends IntegerFieldMapper implements RootMapper {
         if (context.flyweight()) {
             return;
         }
-        fields.add(new CustomIntegerNumericField(this, context.source().length(), fieldType));
+        fields.add(new CustomIntegerNumericField(this, context.source().length(), fieldType()));
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/TTLFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/TTLFieldMapper.java
@@ -236,7 +236,7 @@ public class TTLFieldMapper extends LongFieldMapper implements RootMapper {
                     throw new AlreadyExpiredException(context.index(), context.type(), context.id(), timestamp, ttl, now);
                 }
                 // the expiration timestamp (timestamp + ttl) is set as field
-                fields.add(new CustomLongNumericField(this, expire, (NumberFieldType)fieldType));
+                fields.add(new CustomLongNumericField(this, expire, fieldType()));
             }
         }
     }

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/TimestampFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/TimestampFieldMapper.java
@@ -305,14 +305,14 @@ public class TimestampFieldMapper extends DateFieldMapper implements RootMapper 
     protected void innerParseCreateField(ParseContext context, List<Field> fields) throws IOException {
         if (enabledState.enabled) {
             long timestamp = context.sourceToParse().timestamp();
-            if (fieldType.indexOptions() == IndexOptions.NONE && !fieldType.stored() && !fieldType().hasDocValues()) {
-                context.ignoredValue(fieldType.names().indexName(), String.valueOf(timestamp));
+            if (fieldType().indexOptions() == IndexOptions.NONE && !fieldType().stored() && !fieldType().hasDocValues()) {
+                context.ignoredValue(fieldType().names().indexName(), String.valueOf(timestamp));
             }
-            if (fieldType.indexOptions() != IndexOptions.NONE || fieldType.stored()) {
-                fields.add(new LongFieldMapper.CustomLongNumericField(this, timestamp, (NumberFieldType)fieldType));
+            if (fieldType().indexOptions() != IndexOptions.NONE || fieldType().stored()) {
+                fields.add(new LongFieldMapper.CustomLongNumericField(this, timestamp, fieldType()));
             }
             if (fieldType().hasDocValues()) {
-                fields.add(new NumericDocValuesField(fieldType.names().indexName(), timestamp));
+                fields.add(new NumericDocValuesField(fieldType().names().indexName(), timestamp));
             }
         }
     }
@@ -325,12 +325,12 @@ public class TimestampFieldMapper extends DateFieldMapper implements RootMapper 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         boolean includeDefaults = params.paramAsBoolean("include_defaults", false);
-        boolean indexed = fieldType.indexOptions() != IndexOptions.NONE;
+        boolean indexed = fieldType().indexOptions() != IndexOptions.NONE;
         boolean indexedDefault = Defaults.FIELD_TYPE.indexOptions() != IndexOptions.NONE;
 
         // if all are defaults, no sense to write it at all
         if (!includeDefaults && indexed == indexedDefault && customFieldDataSettings == null &&
-            fieldType.stored() == Defaults.FIELD_TYPE.stored() && enabledState == Defaults.ENABLED && path == Defaults.PATH
+            fieldType().stored() == Defaults.FIELD_TYPE.stored() && enabledState == Defaults.ENABLED && path == Defaults.PATH
                 && fieldType().dateTimeFormatter().format().equals(Defaults.DATE_TIME_FORMATTER.format())
                 && Defaults.DEFAULT_TIMESTAMP.equals(defaultTimestamp)
                 && defaultDocValues() == fieldType().hasDocValues()) {
@@ -340,11 +340,11 @@ public class TimestampFieldMapper extends DateFieldMapper implements RootMapper 
         if (includeDefaults || enabledState != Defaults.ENABLED) {
             builder.field("enabled", enabledState.enabled);
         }
-        if (includeDefaults || (indexed != indexedDefault) || (fieldType.tokenized() != Defaults.FIELD_TYPE.tokenized())) {
-            builder.field("index", indexTokenizeOptionToString(indexed, fieldType.tokenized()));
+        if (includeDefaults || (indexed != indexedDefault) || (fieldType().tokenized() != Defaults.FIELD_TYPE.tokenized())) {
+            builder.field("index", indexTokenizeOptionToString(indexed, fieldType().tokenized()));
         }
-        if (includeDefaults || fieldType.stored() != Defaults.FIELD_TYPE.stored()) {
-            builder.field("store", fieldType.stored());
+        if (includeDefaults || fieldType().stored() != Defaults.FIELD_TYPE.stored()) {
+            builder.field("store", fieldType().stored());
         }
         doXContentDocValues(builder, includeDefaults);
         if (includeDefaults || path != Defaults.PATH) {
@@ -362,7 +362,7 @@ public class TimestampFieldMapper extends DateFieldMapper implements RootMapper 
         if (customFieldDataSettings != null) {
             builder.field("fielddata", (Map) customFieldDataSettings.getAsMap());
         } else if (includeDefaults) {
-            builder.field("fielddata", (Map) fieldType.fieldDataType().getSettings().getAsMap());
+            builder.field("fielddata", (Map) fieldType().fieldDataType().getSettings().getAsMap());
         }
 
         builder.endObject();

--- a/core/src/main/java/org/elasticsearch/index/mapper/ip/IpFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/ip/IpFieldMapper.java
@@ -294,18 +294,6 @@ public class IpFieldMapper extends NumberFieldMapper {
     }
 
     @Override
-    public void merge(Mapper mergeWith, MergeResult mergeResult) throws MergeMappingException {
-        super.merge(mergeWith, mergeResult);
-        if (!this.getClass().equals(mergeWith.getClass())) {
-            return;
-        }
-        if (!mergeResult.simulate()) {
-            this.fieldType = this.fieldType().clone();
-            this.fieldType().setNullValue(((IpFieldMapper) mergeWith).fieldType().nullValue());
-        }
-    }
-
-    @Override
     protected void doXContentBody(XContentBuilder builder, boolean includeDefaults, Params params) throws IOException {
         super.doXContentBody(builder, includeDefaults, params);
 


### PR DESCRIPTION
There were some missed uses of AbstractFieldMapper.fieldType in #11764.
This change also moves null_value merging into AbstractFieldMapper.
