### PR TITLE
Aggregations: moving_avg model parser should accept any numeric

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/movavg/MovAvgParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/movavg/MovAvgParser.java
@@ -33,6 +33,7 @@ import org.elasticsearch.search.aggregations.support.format.ValueFormatter;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
+import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -144,7 +145,14 @@ public class MovAvgParser implements PipelineAggregator.Parser {
             throw new SearchParseException(context, "Unknown model [" + model + "] specified.  Valid options are:"
                     + movAvgModelParserMapper.getAllNames().toString(), parser.getTokenLocation());
         }
-        MovAvgModel movAvgModel = modelParser.parse(settings, pipelineAggregatorName, context, window);
+
+        MovAvgModel movAvgModel;
+        try {
+            movAvgModel = modelParser.parse(settings, pipelineAggregatorName, window);
+        } catch (ParseException exception) {
+            throw new SearchParseException(context, "Could not parse settings for model [" + model + "].", null, exception);
+        }
+
 
         return new MovAvgPipelineAggregator.Factory(pipelineAggregatorName, bucketsPaths, formatter, gapPolicy, window, predict,
                 movAvgModel);

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/movavg/models/EwmaModel.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/movavg/models/EwmaModel.java
@@ -28,6 +28,7 @@ import org.elasticsearch.search.aggregations.pipeline.movavg.MovAvgParser;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
+import java.text.ParseException;
 import java.util.Collection;
 import java.util.Map;
 
@@ -92,9 +93,9 @@ public class EwmaModel extends MovAvgModel {
         }
 
         @Override
-        public MovAvgModel parse(@Nullable Map<String, Object> settings, String pipelineName,  SearchContext context, int windowSize) {
+        public MovAvgModel parse(@Nullable Map<String, Object> settings, String pipelineName, int windowSize) throws ParseException {
 
-            double alpha = parseDoubleParam(context, settings, "alpha", 0.5);
+            double alpha = parseDoubleParam(settings, "alpha", 0.5);
 
             return new EwmaModel(alpha);
         }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/movavg/models/HoltLinearModel.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/movavg/models/HoltLinearModel.java
@@ -28,6 +28,7 @@ import org.elasticsearch.search.aggregations.pipeline.movavg.MovAvgParser;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
+import java.text.ParseException;
 import java.util.*;
 
 /**
@@ -151,10 +152,10 @@ public class HoltLinearModel extends MovAvgModel {
         }
 
         @Override
-        public MovAvgModel parse(@Nullable Map<String, Object> settings, String pipelineName, SearchContext context, int windowSize) {
+        public MovAvgModel parse(@Nullable Map<String, Object> settings, String pipelineName, int windowSize) throws ParseException {
 
-            double alpha = parseDoubleParam(context, settings, "alpha", 0.5);
-            double beta = parseDoubleParam(context, settings, "beta", 0.5);
+            double alpha = parseDoubleParam(settings, "alpha", 0.5);
+            double beta = parseDoubleParam(settings, "beta", 0.5);
             return new HoltLinearModel(alpha, beta);
         }
     }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/movavg/models/HoltWintersModel.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/movavg/models/HoltWintersModel.java
@@ -32,6 +32,7 @@ import org.elasticsearch.search.aggregations.pipeline.movavg.MovAvgParser;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
+import java.text.ParseException;
 import java.util.*;
 
 /**
@@ -316,17 +317,17 @@ public class HoltWintersModel extends MovAvgModel {
         }
 
         @Override
-        public MovAvgModel parse(@Nullable Map<String, Object> settings, String pipelineName, SearchContext context, int windowSize) {
+        public MovAvgModel parse(@Nullable Map<String, Object> settings, String pipelineName, int windowSize) throws ParseException {
 
-            double alpha = parseDoubleParam(context, settings, "alpha", 0.5);
-            double beta = parseDoubleParam(context, settings, "beta", 0.5);
-            double gamma = parseDoubleParam(context, settings, "gamma", 0.5);
-            int period = parseIntegerParam(context, settings, "period", 1);
+            double alpha = parseDoubleParam(settings, "alpha", 0.5);
+            double beta = parseDoubleParam(settings, "beta", 0.5);
+            double gamma = parseDoubleParam(settings, "gamma", 0.5);
+            int period = parseIntegerParam(settings, "period", 1);
 
             if (windowSize < 2 * period) {
-                throw new SearchParseException(context, "Field [window] must be at least twice as large as the period when " +
+                throw new ParseException("Field [window] must be at least twice as large as the period when " +
                         "using Holt-Winters.  Value provided was [" + windowSize + "], which is less than (2*period) == "
-                        + (2 * period), null);
+                        + (2 * period), 0);
             }
 
             SeasonalityType seasonalityType = SeasonalityType.ADDITIVE;
@@ -337,13 +338,13 @@ public class HoltWintersModel extends MovAvgModel {
                     if (value instanceof String) {
                         seasonalityType = SeasonalityType.parse((String)value);
                     } else {
-                        throw new SearchParseException(context, "Parameter [type] must be a String, type `"
-                                + value.getClass().getSimpleName() + "` provided instead", null);
+                        throw new ParseException("Parameter [type] must be a String, type `"
+                                + value.getClass().getSimpleName() + "` provided instead", 0);
                     }
                 }
             }
 
-            boolean pad = parseBoolParam(context, settings, "pad", seasonalityType.equals(SeasonalityType.MULTIPLICATIVE));
+            boolean pad = parseBoolParam(settings, "pad", seasonalityType.equals(SeasonalityType.MULTIPLICATIVE));
 
             return new HoltWintersModel(alpha, beta, gamma, period, seasonalityType, pad);
         }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/movavg/models/LinearModel.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/movavg/models/LinearModel.java
@@ -29,6 +29,7 @@ import org.elasticsearch.search.aggregations.pipeline.movavg.MovAvgParser;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
+import java.text.ParseException;
 import java.util.Collection;
 import java.util.Map;
 
@@ -79,7 +80,7 @@ public class LinearModel extends MovAvgModel {
         }
 
         @Override
-        public MovAvgModel parse(@Nullable Map<String, Object> settings, String pipelineName,  SearchContext context, int windowSize) {
+        public MovAvgModel parse(@Nullable Map<String, Object> settings, String pipelineName, int windowSize) throws ParseException {
             return new LinearModel();
         }
     }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/movavg/models/MovAvgModel.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/movavg/models/MovAvgModel.java
@@ -27,6 +27,7 @@ import org.elasticsearch.search.SearchParseException;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
+import java.text.ParseException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
@@ -125,26 +126,24 @@ public abstract class MovAvgModel {
          *
          * @param settings      Map of settings, extracted from the request
          * @param pipelineName   Name of the parent pipeline agg
-         * @param context       The parser context that we are in
          * @param windowSize    Size of the window for this moving avg
          * @return              A fully built moving average model
          */
-        public abstract MovAvgModel parse(@Nullable Map<String, Object> settings, String pipelineName, SearchContext context, int windowSize);
+        public abstract MovAvgModel parse(@Nullable Map<String, Object> settings, String pipelineName, int windowSize) throws ParseException;
 
 
         /**
          * Extracts a 0-1 inclusive double from the settings map, otherwise throws an exception
          *
-         * @param context       Search query context
          * @param settings      Map of settings provided to this model
          * @param name          Name of parameter we are attempting to extract
          * @param defaultValue  Default value to be used if value does not exist in map
          *
-         * @throws SearchParseException
+         * @throws ParseException
          *
          * @return Double value extracted from settings map
          */
-        protected double parseDoubleParam(SearchContext context, @Nullable Map<String, Object> settings, String name, double defaultValue) {
+        protected double parseDoubleParam(@Nullable Map<String, Object> settings, String name, double defaultValue) throws ParseException {
             if (settings == null) {
                 return defaultValue;
             }
@@ -152,33 +151,32 @@ public abstract class MovAvgModel {
             Object value = settings.get(name);
             if (value == null) {
                 return defaultValue;
-            } else if (value instanceof Double) {
-                double v = (Double)value;
+            } else if (value instanceof Number) {
+                double v = ((Number) value).doubleValue();
                 if (v >= 0 && v <= 1) {
                     return v;
                 }
 
-                throw new SearchParseException(context, "Parameter [" + name + "] must be between 0-1 inclusive.  Provided"
-                        + "value was [" + v + "]", null);
+                throw new ParseException("Parameter [" + name + "] must be between 0-1 inclusive.  Provided"
+                        + "value was [" + v + "]", 0);
             }
 
-            throw new SearchParseException(context, "Parameter [" + name + "] must be a double, type `"
-                    + value.getClass().getSimpleName() + "` provided instead", null);
+            throw new ParseException("Parameter [" + name + "] must be a double, type `"
+                    + value.getClass().getSimpleName() + "` provided instead", 0);
         }
 
         /**
          * Extracts an integer from the settings map, otherwise throws an exception
          *
-         * @param context       Search query context
          * @param settings      Map of settings provided to this model
          * @param name          Name of parameter we are attempting to extract
          * @param defaultValue  Default value to be used if value does not exist in map
          *
-         * @throws SearchParseException
+         * @throws ParseException
          *
          * @return Integer value extracted from settings map
          */
-        protected int parseIntegerParam(SearchContext context, @Nullable Map<String, Object> settings, String name, int defaultValue) {
+        protected int parseIntegerParam(@Nullable Map<String, Object> settings, String name, int defaultValue) throws ParseException {
             if (settings == null) {
                 return defaultValue;
             }
@@ -186,18 +184,17 @@ public abstract class MovAvgModel {
             Object value = settings.get(name);
             if (value == null) {
                 return defaultValue;
-            } else if (value instanceof Integer) {
-                return (Integer)value;
+            } else if (value instanceof Number) {
+                return ((Number) value).intValue();
             }
 
-            throw new SearchParseException(context, "Parameter [" + name + "] must be an integer, type `"
-                    + value.getClass().getSimpleName() + "` provided instead", null);
+            throw new ParseException("Parameter [" + name + "] must be an integer, type `"
+                    + value.getClass().getSimpleName() + "` provided instead", 0);
         }
 
         /**
          * Extracts a boolean from the settings map, otherwise throws an exception
          *
-         * @param context       Search query context
          * @param settings      Map of settings provided to this model
          * @param name          Name of parameter we are attempting to extract
          * @param defaultValue  Default value to be used if value does not exist in map
@@ -206,7 +203,7 @@ public abstract class MovAvgModel {
          *
          * @return Boolean value extracted from settings map
          */
-        protected boolean parseBoolParam(SearchContext context, @Nullable Map<String, Object> settings, String name, boolean defaultValue) {
+        protected boolean parseBoolParam(@Nullable Map<String, Object> settings, String name, boolean defaultValue) throws ParseException {
             if (settings == null) {
                 return defaultValue;
             }
@@ -218,8 +215,8 @@ public abstract class MovAvgModel {
                 return (Boolean)value;
             }
 
-            throw new SearchParseException(context, "Parameter [" + name + "] must be a boolean, type `"
-                    + value.getClass().getSimpleName() + "` provided instead", null);
+            throw new ParseException("Parameter [" + name + "] must be a boolean, type `"
+                    + value.getClass().getSimpleName() + "` provided instead", 0);
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/movavg/models/SimpleModel.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/movavg/models/SimpleModel.java
@@ -28,6 +28,7 @@ import org.elasticsearch.search.aggregations.pipeline.movavg.MovAvgParser;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
+import java.text.ParseException;
 import java.util.Collection;
 import java.util.Map;
 
@@ -72,7 +73,7 @@ public class SimpleModel extends MovAvgModel {
         }
 
         @Override
-        public MovAvgModel parse(@Nullable Map<String, Object> settings, String pipelineName,  SearchContext context, int windowSize) {
+        public MovAvgModel parse(@Nullable Map<String, Object> settings, String pipelineName, int windowSize) throws ParseException {
             return new SimpleModel();
         }
     }


### PR DESCRIPTION
Fixes model validation/parsing so that any numeric is accepted, not just explicit doubles.

Also changes the models to throw ParseExceptions instead of SearchParseExceptions, so that
the validation can be unit-tested.

Fixes #11487
