### PR TITLE
Row-centric output for _cat/fielddata

### DIFF
--- a/docs/reference/cat/fielddata.asciidoc
+++ b/docs/reference/cat/fielddata.asciidoc
@@ -2,33 +2,43 @@
 == cat fielddata
 
 `fielddata` shows how much heap memory is currently being used by fielddata 
-on every data node in the cluster.
+on every data node in the cluster. You can see node level aggregate usage, also
+you can get details on one or more fields specifically.
 
 [source,shell]
 --------------------------------------------------
-% curl '192.168.56.10:9200/_cat/fielddata?v'
-id                     host    ip            node          total   body    text
-c223lARiSGeezlbrcugAYQ myhost1 10.20.100.200 Jessica Jones 385.6kb 159.8kb 225.7kb
-waPCbitNQaCL6xC8VxjAwg myhost2 10.20.100.201 Adversary     435.2kb 159.8kb 275.3kb
-yaDkp-G3R0q1AJ-HUEvkSQ myhost3 10.20.100.202 Microchip     284.6kb 109.2kb 175.3kb
+% curl '192.168.56.10:9200/_cat/fielddata'
+id                     host    ip            node          total
+c223lARiSGeezlbrcugAYQ myhost1 10.20.100.200 Jessica Jones 385.6kb
+waPCbitNQaCL6xC8VxjAwg myhost2 10.20.100.201 Adversary     435.2kb
+yaDkp-G3R0q1AJ-HUEvkSQ myhost3 10.20.100.202 Microchip     284.6kb
 --------------------------------------------------
 
-Fields can be specified either as a query parameter, or in the URL path:
+Field-level data can be requested by either specifying the name of the fields as a query parameter 
+or in the URL path. Use comma to separate multiple fields.
 
 [source,shell]
 --------------------------------------------------
-% curl '192.168.56.10:9200/_cat/fielddata?v&fields=body'
-id                     host    ip            node          total   body
-c223lARiSGeezlbrcugAYQ myhost1 10.20.100.200 Jessica Jones 385.6kb 159.8kb
-waPCbitNQaCL6xC8VxjAwg myhost2 10.20.100.201 Adversary     435.2kb 159.8kb
-yaDkp-G3R0q1AJ-HUEvkSQ myhost3 10.20.100.202 Microchip     284.6kb 109.2kb
-
-% curl '192.168.56.10:9200/_cat/fielddata/body,text?v'
-id                     host    ip            node          total   body    text
-c223lARiSGeezlbrcugAYQ myhost1 10.20.100.200 Jessica Jones 385.6kb 159.8kb 225.7kb
-waPCbitNQaCL6xC8VxjAwg myhost2 10.20.100.201 Adversary     435.2kb 159.8kb 275.3kb
-yaDkp-G3R0q1AJ-HUEvkSQ myhost3 10.20.100.202 Microchip     284.6kb 109.2kb 175.3kb
+% curl '192.168.56.10:9200/_cat/fielddata?fields=body'
+id                     host    ip            node          total   field size
+c223lARiSGeezlbrcugAYQ myhost1 10.20.100.200 Jessica Jones 385.6kb body  159.8kb
+waPCbitNQaCL6xC8VxjAwg myhost2 10.20.100.201 Adversary     435.2kb body  159.8kb
+yaDkp-G3R0q1AJ-HUEvkSQ myhost3 10.20.100.202 Microchip     284.6kb body  109.2kb
 --------------------------------------------------
 
-The output shows the total fielddata and then the individual fielddata for the
-`body` and `text` fields.
+You can use `*` to load all fields.
+
+[source,shell]
+--------------------------------------------------
+% curl '192.168.56.10:9200/_cat/fielddata/*'
+id                     host    ip            node          total   field size
+c223lARiSGeezlbrcugAYQ myhost1 10.20.100.200 Jessica Jones 385.6kb body  159.8kb
+c223lARiSGeezlbrcugAYQ myhost1 10.20.100.200 Jessica Jones 385.6kb text  225.7kb
+waPCbitNQaCL6xC8VxjAwg myhost2 10.20.100.201 Adversary     435.2kb body  159.8kb
+waPCbitNQaCL6xC8VxjAwg myhost2 10.20.100.201 Adversary     435.2kb text  275.3kb
+yaDkp-G3R0q1AJ-HUEvkSQ myhost3 10.20.100.202 Microchip     284.6kb body  109.2kb
+yaDkp-G3R0q1AJ-HUEvkSQ myhost3 10.20.100.202 Microchip     284.6kb text  175.3kb
+--------------------------------------------------
+
+The output shows the total fielddata for the node and then the individual fielddata for the
+`body` and `text` fields, one row per field per node.

--- a/rest-api-spec/test/cat.fielddata/10_basic.yaml
+++ b/rest-api-spec/test/cat.fielddata/10_basic.yaml
@@ -1,16 +1,34 @@
 ---
-"Help":
+"Help - node level":
   - do:
       cat.fielddata:
         help: true
 
   - match:
       $body: |
-               /^  id .+ \n
-                   host .+ \n
-                   ip .+ \n
-                   node .+ \n
+               /^  id    .+ \n
+                   host  .+ \n
+                   ip    .+ \n
+                   node  .+ \n
                    total .+ \n
+               $/
+
+---
+"Help - field level":
+  - do:
+      cat.fielddata:
+        fields: '*'
+        help: true
+
+  - match:
+      $body: |
+               /^  id    .+ \n
+                   host  .+ \n
+                   ip    .+ \n
+                   node  .+ \n
+                   total .+ \n
+                   field .+ \n
+                   size  .+ \n
                $/
 
 ---
@@ -26,39 +44,56 @@
         type: type
         body: { foo: bar }
         refresh: true
+
+# no fielddata => no output on field level
+  - do:
+      cat.fielddata:
+        h: total
+        fields: '*'
+        v: false
+  - match:
+      $body: |
+               /^$/
+
+# no fielddata => still have node totals on node level
+  - do:
+      cat.fielddata:
+        h: total
+        v: false
+  - match:
+      $body: |
+               /^ (\s* \d+(\.\d+)?[gmk]?b \s* \n)+ $/
+
+
   - do:
       search:
         index: index
         body:
           query: { match_all: {} }
           sort: foo
+  
+
+#field level data on foo
   - do:
       cat.fielddata:
-        h: total
+        h: total,field,size
+        fields: '*'
         v: true
 
   - match:
       $body: |
-               /^   total               \s \n
-                    (\s*\d+(\.\d+)?[gmk]?b  \s \n)+ $/
+               /^        total               \s+ field  \s+ size                 \s+ \n
+                    (\s* \d+(\.\d+)?[gmk]?b  \s+ foo    \s+ (\d+(\.\d+)?[gmk]?b) \s* \n)* 
+                $/
 
+
+#no fielddata on field "notfoo" => no output on field level
   - do:
       cat.fielddata:
-        h: total,foo
-        v: true
+        h: total,field,size
+        fields: notfoo
+        v: false
 
   - match:
       $body: |
-               /^   total \s+              foo \s+ \n
-                    (\s*\d+(\.\d+)?[gmk]?b \s+ \d+(\.\d+)?[gmk]?b \s \n)+ \s*$/
-
-  - do:
-      cat.fielddata:
-        h: total,foo
-        fields: notfoo,foo
-        v: true
-
-  - match:
-      $body: |
-               /^   total \s+              foo \s+ \n
-                    (\s*\d+(\.\d+)?[gmk]?b \s+ \d+(\.\d+)?[gmk]?b \s \n)+ \s*$/
+               /^$/


### PR DESCRIPTION
After reviewing the code I believe the cleanest approach was to use the `_cat/fielddata` call to output node-level totals only and use the `_cat/fielddata/{fields}` call to have field-level details. The latter still outputs node-level totals, but if you only specify a field for which there is no fielddata, no row will be shown for the node. The first call could also be useful if you had many fields and were only interested in totals. You can use `*` to request all fields.

This clearly separates the row-level detail from the aggregate view. 

I updated the docs to reflect this behavior.

Closes #10249
