### PR TITLE
Fail nicely if `nested` query with `inner_hits` is used in a percolator query

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/QueryParseContext.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryParseContext.java
@@ -204,6 +204,10 @@ public class QueryParseContext {
 
     public void addInnerHits(String name, InnerHitsContext.BaseInnerHits context) {
         SearchContext sc = SearchContext.current();
+        if (sc == null) {
+            throw new QueryParsingException(this, "inner_hits unsupported");
+        }
+
         InnerHitsContext innerHitsContext;
         if (sc.innerHits() == null) {
             innerHitsContext = new InnerHitsContext(new HashMap<String, InnerHitsContext.BaseInnerHits>());

--- a/docs/reference/search/percolate.asciidoc
+++ b/docs/reference/search/percolate.asciidoc
@@ -493,6 +493,8 @@ the time the percolate API needs to run can be decreased.
 Because the percolator API is processing one document at a time, it doesn't support queries and filters that run
 against child documents such as `has_child` and `has_parent`.
 
+The `inner_hits` feature on the `nested` query isn't supported in the percolate api.
+
 The `wildcard` and `regexp` query natively use a lot of memory and because the percolator keeps the queries into memory
 this can easily take up the available memory in the heap space. If possible try to use a `prefix` query or ngramming to
 achieve the same result (with way less memory being used).


### PR DESCRIPTION
Previously using `inner_hits` on the `nested` query in the percolate api result in a NPE. With this change a more descriptive error is returned.

PR for #11672
