### PR TITLE
Use abstract runnable in scheduled ping

### DIFF
--- a/core/src/main/java/org/elasticsearch/transport/netty/NettyTransport.java
+++ b/core/src/main/java/org/elasticsearch/transport/netty/NettyTransport.java
@@ -50,6 +50,7 @@ import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.KeyedLock;
 import org.elasticsearch.monitor.jvm.JvmInfo;
@@ -1122,13 +1123,13 @@ public class NettyTransport extends AbstractLifecycleComponent<Transport> implem
         }
     }
 
-    class ScheduledPing implements Runnable {
+    class ScheduledPing extends AbstractRunnable {
 
         final CounterMetric successfulPings = new CounterMetric();
         final CounterMetric failedPings = new CounterMetric();
 
         @Override
-        public void run() {
+        protected void doRun() throws Exception {
             if (lifecycle.stoppedOrClosed()) {
                 return;
             }
@@ -1155,6 +1156,15 @@ public class NettyTransport extends AbstractLifecycleComponent<Transport> implem
                 }
             }
             threadPool.schedule(pingSchedule, ThreadPool.Names.GENERIC, this);
+        }
+
+        @Override
+        public void onFailure(Throwable t) {
+            if (lifecycle.stoppedOrClosed()) {
+                logger.trace("[{}] failed to send ping transport message", t);
+            } else {
+                logger.warn("[{}] failed to send ping transport message", t);
+            }
         }
     }
 }


### PR DESCRIPTION
this caused a test failure over the weekend

http://build-us-00.elastic.co/job/es_core_master_small/2232/testReport/junit/junit.framework/TestSuite/org_elasticsearch_transport_netty_NettyScheduledPingTests/
