### PR TITLE
Query refactoring: make QueryBuilder an interface again

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryRequestBuilder.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryRequestBuilder.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.admin.indices.validate.query;
 
-import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.QuerySourceBuilder;
 import org.elasticsearch.action.support.broadcast.BroadcastOperationRequestBuilder;
 import org.elasticsearch.client.ElasticsearchClient;

--- a/core/src/main/java/org/elasticsearch/index/query/AbstractQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/AbstractQueryBuilder.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query;
+
+import org.apache.lucene.search.Query;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.action.support.ToXContentToBytes;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.lucene.BytesRefs;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentType;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Base class for all classes producing lucene queries.
+ * Supports conversion to BytesReference and creation of lucene Query objects.
+ */
+public abstract class AbstractQueryBuilder<QB extends QueryBuilder> extends ToXContentToBytes implements QueryBuilder<QB> {
+
+    protected AbstractQueryBuilder() {
+        super(XContentType.JSON);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        doXContent(builder, params);
+        builder.endObject();
+        return builder;
+    }
+
+    protected abstract void doXContent(XContentBuilder builder, Params params) throws IOException;
+
+    @Override
+    //norelease to be made abstract once all query builders override toQuery providing their own specific implementation.
+    public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
+        return parseContext.indexQueryParserService().queryParser(getName()).parse(parseContext);
+    }
+
+    @Override
+    public QueryValidationException validate() {
+        // default impl does not validate, subclasses should override.
+        //norelease to be possibly made abstract once all queries support validation
+        return null;
+    }
+
+    /**
+     * This helper method checks if the object passed in is a string, if so it
+     * converts it to a {@link BytesRef}.
+     * @param obj the input object
+     * @return the same input object or a {@link BytesRef} representation if input was of type string
+     */
+    protected static Object convertToBytesRefIfString(Object obj) {
+        if (obj instanceof String) {
+            return BytesRefs.toBytesRef(obj);
+        }
+        return obj;
+    }
+
+    /**
+     * This helper method checks if the object passed in is a {@link BytesRef}, if so it
+     * converts it to a utf8 string.
+     * @param obj the input object
+     * @return the same input object or a utf8 string if input was of type {@link BytesRef}
+     */
+    protected static Object convertToStringIfBytesRef(Object obj) {
+        if (obj instanceof BytesRef) {
+            return ((BytesRef) obj).utf8ToString();
+        }
+        return obj;
+    }
+
+    /**
+     * Helper method to convert collection of {@link QueryBuilder} instances to lucene
+     * {@link Query} instances. {@link QueryBuilder} that return <tt>null</tt> calling
+     * their {@link QueryBuilder#toQuery(QueryParseContext)} method are not added to the
+     * resulting collection.
+     *
+     * @throws IOException
+     * @throws QueryParsingException
+     */
+    protected static Collection<Query> toQueries(Collection<QueryBuilder> queryBuilders, QueryParseContext parseContext) throws QueryParsingException,
+            IOException {
+        List<Query> queries = new ArrayList<>(queryBuilders.size());
+        for (QueryBuilder queryBuilder : queryBuilders) {
+            Query query = queryBuilder.toQuery(parseContext);
+            if (query != null) {
+                queries.add(query);
+            }
+        }
+        return queries;
+    }
+
+    //norelease remove this once all builders implement readFrom themselves
+    @Override
+    public QB readFrom(StreamInput in) throws IOException {
+        return null;
+    }
+
+    //norelease remove this once all builders implement writeTo themselves
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+    }
+}

--- a/core/src/main/java/org/elasticsearch/index/query/AndQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/AndQueryBuilder.java
@@ -38,7 +38,7 @@ import java.util.Objects;
  * @deprecated Use {@link BoolQueryBuilder} instead
  */
 @Deprecated
-public class AndQueryBuilder extends QueryBuilder<AndQueryBuilder> {
+public class AndQueryBuilder extends AbstractQueryBuilder<AndQueryBuilder> {
 
     public static final String NAME = "and";
 
@@ -117,7 +117,7 @@ public class AndQueryBuilder extends QueryBuilder<AndQueryBuilder> {
     }
 
     @Override
-    public String queryId() {
+    public String getName() {
         return NAME;
     }
 

--- a/core/src/main/java/org/elasticsearch/index/query/BaseTermQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/BaseTermQueryBuilder.java
@@ -27,7 +27,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import java.io.IOException;
 import java.util.Objects;
 
-public abstract class BaseTermQueryBuilder<QB extends BaseTermQueryBuilder<QB>> extends QueryBuilder<QB> implements BoostableQueryBuilder<QB> {
+public abstract class BaseTermQueryBuilder<QB extends BaseTermQueryBuilder<QB>> extends AbstractQueryBuilder<QB> implements BoostableQueryBuilder<QB> {
 
     /** Name of field to match against. */
     protected final String fieldName;
@@ -158,7 +158,7 @@ public abstract class BaseTermQueryBuilder<QB extends BaseTermQueryBuilder<QB>> 
 
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(queryId());
+        builder.startObject(getName());
         if (boost == 1.0f && queryName == null) {
             builder.field(fieldName, convertToStringIfBytesRef(this.value));
         } else {

--- a/core/src/main/java/org/elasticsearch/index/query/BoolQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/BoolQueryBuilder.java
@@ -39,7 +39,7 @@ import static org.elasticsearch.common.lucene.search.Queries.fixNegativeQueryIfN
 /**
  * A Query that matches documents matching boolean combinations of other queries.
  */
-public class BoolQueryBuilder extends QueryBuilder<BoolQueryBuilder> implements BoostableQueryBuilder<BoolQueryBuilder> {
+public class BoolQueryBuilder extends AbstractQueryBuilder<BoolQueryBuilder> implements BoostableQueryBuilder<BoolQueryBuilder> {
 
     public static final String NAME = "bool";
 
@@ -287,7 +287,7 @@ public class BoolQueryBuilder extends QueryBuilder<BoolQueryBuilder> implements 
     }
 
     @Override
-    public String queryId() {
+    public String getName() {
         return NAME;
     }
 

--- a/core/src/main/java/org/elasticsearch/index/query/BoostingQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/BoostingQueryBuilder.java
@@ -40,7 +40,7 @@ import java.util.Objects;
  * multiplied by the supplied "boost" parameter, so this should be less than 1 to achieve a
  * demoting effect
  */
-public class BoostingQueryBuilder extends QueryBuilder<BoostingQueryBuilder> implements BoostableQueryBuilder<BoostingQueryBuilder> {
+public class BoostingQueryBuilder extends AbstractQueryBuilder<BoostingQueryBuilder> implements BoostableQueryBuilder<BoostingQueryBuilder> {
 
     public static final String NAME = "boosting";
 
@@ -147,7 +147,7 @@ public class BoostingQueryBuilder extends QueryBuilder<BoostingQueryBuilder> imp
     };
 
     @Override
-    public String queryId() {
+    public String getName() {
         return NAME;
     }
 

--- a/core/src/main/java/org/elasticsearch/index/query/CommonTermsQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/CommonTermsQueryBuilder.java
@@ -42,7 +42,7 @@ import java.io.IOException;
  * execution times significantly if applicable.
  * <p>
  */
-public class CommonTermsQueryBuilder extends QueryBuilder implements BoostableQueryBuilder<CommonTermsQueryBuilder> {
+public class CommonTermsQueryBuilder extends AbstractQueryBuilder<CommonTermsQueryBuilder> implements BoostableQueryBuilder<CommonTermsQueryBuilder> {
 
     public static final String NAME = "common";
 
@@ -219,7 +219,7 @@ public class CommonTermsQueryBuilder extends QueryBuilder implements BoostableQu
     }
 
     @Override
-    public String queryId() {
+    public String getName() {
         return NAME;
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/ConstantScoreQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/ConstantScoreQueryBuilder.java
@@ -32,7 +32,7 @@ import java.util.Objects;
  * A query that wraps a filter and simply returns a constant score equal to the
  * query boost for every document in the filter.
  */
-public class ConstantScoreQueryBuilder extends QueryBuilder<ConstantScoreQueryBuilder> implements BoostableQueryBuilder<ConstantScoreQueryBuilder> {
+public class ConstantScoreQueryBuilder extends AbstractQueryBuilder<ConstantScoreQueryBuilder> implements BoostableQueryBuilder<ConstantScoreQueryBuilder> {
 
     public static final String NAME = "constant_score";
 
@@ -104,7 +104,7 @@ public class ConstantScoreQueryBuilder extends QueryBuilder<ConstantScoreQueryBu
     }
 
     @Override
-    public String queryId() {
+    public String getName() {
         return NAME;
     }
 

--- a/core/src/main/java/org/elasticsearch/index/query/DisMaxQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/DisMaxQueryBuilder.java
@@ -36,7 +36,7 @@ import java.util.Objects;
  * with the maximum score for that document as produced by any sub-query, plus a tie breaking increment for any
  * additional matching sub-queries.
  */
-public class DisMaxQueryBuilder extends QueryBuilder<DisMaxQueryBuilder> implements BoostableQueryBuilder<DisMaxQueryBuilder> {
+public class DisMaxQueryBuilder extends AbstractQueryBuilder<DisMaxQueryBuilder> implements BoostableQueryBuilder<DisMaxQueryBuilder> {
 
     public static final String NAME = "dis_max";
 
@@ -196,7 +196,7 @@ public class DisMaxQueryBuilder extends QueryBuilder<DisMaxQueryBuilder> impleme
     }
 
     @Override
-    public String queryId() {
+    public String getName() {
         return NAME;
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/ExistsQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/ExistsQueryBuilder.java
@@ -35,7 +35,7 @@ import java.util.Objects;
 /**
  * Constructs a query that only match on documents that the field has a value in them.
  */
-public class ExistsQueryBuilder extends QueryBuilder<ExistsQueryBuilder> {
+public class ExistsQueryBuilder extends AbstractQueryBuilder<ExistsQueryBuilder> {
 
     public static final String NAME = "exists";
 
@@ -167,7 +167,7 @@ public class ExistsQueryBuilder extends QueryBuilder<ExistsQueryBuilder> {
     }
 
     @Override
-    public String queryId() {
+    public String getName() {
         return NAME;
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/FQueryFilterBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/FQueryFilterBuilder.java
@@ -51,7 +51,7 @@ public class FQueryFilterBuilder extends QueryFilterBuilder {
     }
 
     @Override
-    public String queryId() {
+    public String getName() {
         return NAME;
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/FieldMaskingSpanQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/FieldMaskingSpanQueryBuilder.java
@@ -19,11 +19,12 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.search.spans.SpanQuery;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 
-public class FieldMaskingSpanQueryBuilder extends QueryBuilder implements SpanQueryBuilder, BoostableQueryBuilder<FieldMaskingSpanQueryBuilder> {
+public class FieldMaskingSpanQueryBuilder extends AbstractQueryBuilder<FieldMaskingSpanQueryBuilder> implements SpanQueryBuilder<FieldMaskingSpanQueryBuilder>, BoostableQueryBuilder<FieldMaskingSpanQueryBuilder> {
 
     public static final String NAME = "field_masking_span";
 
@@ -72,7 +73,13 @@ public class FieldMaskingSpanQueryBuilder extends QueryBuilder implements SpanQu
     }
 
     @Override
-    public String queryId() {
+    public String getName() {
         return NAME;
+    }
+
+    @Override
+    public SpanQuery toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
+        //norelease just a temporary implementation, will go away once this query is refactored and properly overrides toQuery
+        return (SpanQuery)super.toQuery(parseContext);
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/FilteredQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/FilteredQueryBuilder.java
@@ -29,7 +29,7 @@ import java.io.IOException;
  * @deprecated Use {@link BoolQueryBuilder} instead.
  */
 @Deprecated
-public class FilteredQueryBuilder extends QueryBuilder implements BoostableQueryBuilder<FilteredQueryBuilder> {
+public class FilteredQueryBuilder extends AbstractQueryBuilder<FilteredQueryBuilder> implements BoostableQueryBuilder<FilteredQueryBuilder> {
 
     public static final String NAME = "filtered";
 
@@ -93,7 +93,7 @@ public class FilteredQueryBuilder extends QueryBuilder implements BoostableQuery
     }
 
     @Override
-    public String queryId() {
+    public String getName() {
         return NAME;
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/FuzzyQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/FuzzyQueryBuilder.java
@@ -137,7 +137,7 @@ public class FuzzyQueryBuilder extends MultiTermQueryBuilder implements Boostabl
     }
 
     @Override
-    public String queryId() {
+    public String getName() {
         return NAME;
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxQueryBuilder.java
@@ -25,7 +25,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 
-public class GeoBoundingBoxQueryBuilder extends QueryBuilder {
+public class GeoBoundingBoxQueryBuilder extends AbstractQueryBuilder<GeoBoundingBoxQueryBuilder> {
 
     public static final String NAME = "geo_bbox";
 
@@ -178,7 +178,7 @@ public class GeoBoundingBoxQueryBuilder extends QueryBuilder {
     }
 
     @Override
-    public String queryId() {
+    public String getName() {
         return NAME;
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/GeoDistanceQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoDistanceQueryBuilder.java
@@ -26,7 +26,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import java.io.IOException;
 import java.util.Locale;
 
-public class GeoDistanceQueryBuilder extends QueryBuilder {
+public class GeoDistanceQueryBuilder extends AbstractQueryBuilder<GeoDistanceQueryBuilder> {
 
     public static final String NAME = "geo_distance";
 
@@ -123,7 +123,7 @@ public class GeoDistanceQueryBuilder extends QueryBuilder {
     }
 
     @Override
-    public String queryId() {
+    public String getName() {
         return NAME;
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/GeoDistanceRangeQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoDistanceRangeQueryBuilder.java
@@ -25,7 +25,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import java.io.IOException;
 import java.util.Locale;
 
-public class GeoDistanceRangeQueryBuilder extends QueryBuilder {
+public class GeoDistanceRangeQueryBuilder extends AbstractQueryBuilder<GeoDistanceRangeQueryBuilder> {
 
     public static final String NAME = "geo_distance_range";
 
@@ -162,7 +162,7 @@ public class GeoDistanceRangeQueryBuilder extends QueryBuilder {
     }
 
     @Override
-    public String queryId() {
+    public String getName() {
         return NAME;
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/GeoPolygonQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoPolygonQueryBuilder.java
@@ -28,7 +28,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import java.io.IOException;
 import java.util.List;
 
-public class GeoPolygonQueryBuilder extends QueryBuilder {
+public class GeoPolygonQueryBuilder extends AbstractQueryBuilder<GeoPolygonQueryBuilder> {
 
     public static final String NAME = "geo_polygon";
 
@@ -94,7 +94,7 @@ public class GeoPolygonQueryBuilder extends QueryBuilder {
     }
 
     @Override
-    public String queryId() {
+    public String getName() {
         return NAME;
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/GeoShapeQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoShapeQueryBuilder.java
@@ -27,9 +27,9 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import java.io.IOException;
 
 /**
- * {@link QueryBuilder} that builds a GeoShape Filter
+ * {@link AbstractQueryBuilder} that builds a GeoShape Filter
  */
-public class GeoShapeQueryBuilder extends QueryBuilder {
+public class GeoShapeQueryBuilder extends AbstractQueryBuilder<GeoShapeQueryBuilder> {
 
     public static final String NAME = "geo_shape";
 
@@ -189,7 +189,7 @@ public class GeoShapeQueryBuilder extends QueryBuilder {
     }
 
     @Override
-    public String queryId() {
+    public String getName() {
         return NAME;
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/GeohashCellQuery.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeohashCellQuery.java
@@ -31,9 +31,7 @@ import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentParser.Token;
-import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.mapper.core.StringFieldMapper;
 import org.elasticsearch.index.mapper.geo.GeoPointFieldMapper;
 
 import java.io.IOException;
@@ -90,7 +88,7 @@ public class GeohashCellQuery {
      * <code>geohash</code> to be set. the default for a neighbor filteing is
      * <code>false</code>.
      */
-    public static class Builder extends QueryBuilder {
+    public static class Builder extends AbstractQueryBuilder<Builder> {
         // we need to store the geohash rather than the corresponding point,
         // because a transformation from a geohash to a point an back to the
         // geohash will extend the accuracy of the hash to max precision
@@ -171,7 +169,7 @@ public class GeohashCellQuery {
         }
 
         @Override
-        public String queryId() {
+        public String getName() {
             return NAME;
         }
     }

--- a/core/src/main/java/org/elasticsearch/index/query/HasChildQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/HasChildQueryBuilder.java
@@ -23,7 +23,7 @@ import org.elasticsearch.index.query.support.QueryInnerHitBuilder;
 
 import java.io.IOException;
 
-public class HasChildQueryBuilder extends QueryBuilder implements BoostableQueryBuilder<HasChildQueryBuilder> {
+public class HasChildQueryBuilder extends AbstractQueryBuilder<HasChildQueryBuilder> implements BoostableQueryBuilder<HasChildQueryBuilder> {
 
     public static final String NAME = "has_child";
 
@@ -144,7 +144,7 @@ public class HasChildQueryBuilder extends QueryBuilder implements BoostableQuery
     }
 
     @Override
-    public String queryId() {
+    public String getName() {
         return NAME;
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/HasParentQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/HasParentQueryBuilder.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * Builder for the 'has_parent' query.
  */
-public class HasParentQueryBuilder extends QueryBuilder implements BoostableQueryBuilder<HasParentQueryBuilder> {
+public class HasParentQueryBuilder extends AbstractQueryBuilder<HasParentQueryBuilder> implements BoostableQueryBuilder<HasParentQueryBuilder> {
 
     public static final String NAME = "has_parent";
     private final QueryBuilder queryBuilder;
@@ -100,7 +100,7 @@ public class HasParentQueryBuilder extends QueryBuilder implements BoostableQuer
     }
 
     @Override
-    public String queryId() {
+    public String getName() {
         return NAME;
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
@@ -38,7 +38,7 @@ import java.util.*;
 /**
  * A query that will return only documents matching specific ids (and a type).
  */
-public class IdsQueryBuilder extends QueryBuilder<IdsQueryBuilder> implements BoostableQueryBuilder<IdsQueryBuilder> {
+public class IdsQueryBuilder extends AbstractQueryBuilder<IdsQueryBuilder> implements BoostableQueryBuilder<IdsQueryBuilder> {
 
     public static final String NAME = "ids";
 
@@ -160,7 +160,7 @@ public class IdsQueryBuilder extends QueryBuilder<IdsQueryBuilder> implements Bo
     }
 
     @Override
-    public String queryId() {
+    public String getName() {
         return NAME;
     }
 

--- a/core/src/main/java/org/elasticsearch/index/query/IndicesQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/IndicesQueryBuilder.java
@@ -27,7 +27,7 @@ import java.io.IOException;
  * A query that will execute the wrapped query only for the specified indices, and "match_all" when
  * it does not match those indices (by default).
  */
-public class IndicesQueryBuilder extends QueryBuilder {
+public class IndicesQueryBuilder extends AbstractQueryBuilder<IndicesQueryBuilder> {
 
     public static final String NAME = "indices";
 
@@ -90,7 +90,7 @@ public class IndicesQueryBuilder extends QueryBuilder {
     }
 
     @Override
-    public String queryId() {
+    public String getName() {
         return NAME;
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/LimitQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/LimitQueryBuilder.java
@@ -32,7 +32,7 @@ import java.io.IOException;
  * @deprecated Use {@link SearchRequestBuilder#setTerminateAfter(int)} instead.
  */
 @Deprecated
-public class LimitQueryBuilder extends QueryBuilder<LimitQueryBuilder> {
+public class LimitQueryBuilder extends AbstractQueryBuilder<LimitQueryBuilder> {
 
     public static final String NAME = "limit";
     private final int limit;
@@ -84,7 +84,7 @@ public class LimitQueryBuilder extends QueryBuilder<LimitQueryBuilder> {
     }
 
     @Override
-    public String queryId() {
+    public String getName() {
         return NAME;
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/MatchAllQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MatchAllQueryBuilder.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 /**
  * A query that matches on all documents.
  */
-public class MatchAllQueryBuilder extends QueryBuilder<MatchAllQueryBuilder> implements BoostableQueryBuilder<MatchAllQueryBuilder> {
+public class MatchAllQueryBuilder extends AbstractQueryBuilder<MatchAllQueryBuilder> implements BoostableQueryBuilder<MatchAllQueryBuilder> {
 
     public static final String NAME = "match_all";
 
@@ -105,7 +105,7 @@ public class MatchAllQueryBuilder extends QueryBuilder<MatchAllQueryBuilder> imp
     }
 
     @Override
-    public String queryId() {
+    public String getName() {
         return NAME;
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/MatchQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MatchQueryBuilder.java
@@ -29,7 +29,7 @@ import java.util.Locale;
  * Match query is a query that analyzes the text and constructs a query as the result of the analysis. It
  * can construct different queries based on the type provided.
  */
-public class MatchQueryBuilder extends QueryBuilder implements BoostableQueryBuilder<MatchQueryBuilder> {
+public class MatchQueryBuilder extends AbstractQueryBuilder<MatchQueryBuilder> implements BoostableQueryBuilder<MatchQueryBuilder> {
 
     public static final String NAME = "match";
 
@@ -282,7 +282,7 @@ public class MatchQueryBuilder extends QueryBuilder implements BoostableQueryBui
     }
 
     @Override
-    public String queryId() {
+    public String getName() {
         return NAME;
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/MissingQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MissingQueryBuilder.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * Constructs a filter that only match on documents that the field has a value in them.
  */
-public class MissingQueryBuilder extends QueryBuilder {
+public class MissingQueryBuilder extends AbstractQueryBuilder<MissingQueryBuilder> {
 
     public static final String NAME = "missing";
 
@@ -87,7 +87,7 @@ public class MissingQueryBuilder extends QueryBuilder {
     }
 
     @Override
-    public String queryId() {
+    public String getName() {
         return NAME;
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilder.java
@@ -41,7 +41,7 @@ import java.util.Locale;
  * A more like this query that finds documents that are "like" the provided {@link #likeText(String)}
  * which is checked against the fields the query is constructed with.
  */
-public class MoreLikeThisQueryBuilder extends QueryBuilder implements BoostableQueryBuilder<MoreLikeThisQueryBuilder> {
+public class MoreLikeThisQueryBuilder extends AbstractQueryBuilder<MoreLikeThisQueryBuilder> implements BoostableQueryBuilder<MoreLikeThisQueryBuilder> {
 
     /**
      * A single get item. Pure delegate to multi get.
@@ -439,7 +439,7 @@ public class MoreLikeThisQueryBuilder extends QueryBuilder implements BoostableQ
     }
 
     @Override
-    public String queryId() {
+    public String getName() {
         return NAME;
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/MultiMatchQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MultiMatchQueryBuilder.java
@@ -37,7 +37,7 @@ import java.util.Locale;
 /**
  * Same as {@link MatchQueryBuilder} but supports multiple fields.
  */
-public class MultiMatchQueryBuilder extends QueryBuilder implements BoostableQueryBuilder<MultiMatchQueryBuilder> {
+public class MultiMatchQueryBuilder extends AbstractQueryBuilder<MultiMatchQueryBuilder> implements BoostableQueryBuilder<MultiMatchQueryBuilder> {
 
     public static final String NAME = "multi_match";
 
@@ -410,7 +410,7 @@ public class MultiMatchQueryBuilder extends QueryBuilder implements BoostableQue
     }
 
     @Override
-    public String queryId() {
+    public String getName() {
         return NAME;
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/MultiTermQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MultiTermQueryBuilder.java
@@ -18,6 +18,6 @@
  */
 package org.elasticsearch.index.query;
 
-public abstract class MultiTermQueryBuilder<QB extends MultiTermQueryBuilder<QB>> extends QueryBuilder<QB> {
+public abstract class MultiTermQueryBuilder<QB extends MultiTermQueryBuilder<QB>> extends AbstractQueryBuilder<QB> {
 
 }

--- a/core/src/main/java/org/elasticsearch/index/query/NestedQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/NestedQueryBuilder.java
@@ -25,7 +25,7 @@ import org.elasticsearch.index.query.support.QueryInnerHitBuilder;
 import java.io.IOException;
 import java.util.Objects;
 
-public class NestedQueryBuilder extends QueryBuilder implements BoostableQueryBuilder<NestedQueryBuilder> {
+public class NestedQueryBuilder extends AbstractQueryBuilder<NestedQueryBuilder> implements BoostableQueryBuilder<NestedQueryBuilder> {
 
     public static final String NAME = "nested";
 
@@ -114,7 +114,7 @@ public class NestedQueryBuilder extends QueryBuilder implements BoostableQueryBu
     }
 
     @Override
-    public final String queryId() {
+    public final String getName() {
         return NAME;
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/NotQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/NotQueryBuilder.java
@@ -27,7 +27,7 @@ import java.util.Objects;
 /**
  * A filter that matches documents matching boolean combinations of other filters.
  */
-public class NotQueryBuilder extends QueryBuilder {
+public class NotQueryBuilder extends AbstractQueryBuilder<NotQueryBuilder> {
 
     public static final String NAME = "not";
 
@@ -65,7 +65,7 @@ public class NotQueryBuilder extends QueryBuilder {
     }
 
     @Override
-    public String queryId() {
+    public String getName() {
         return NAME;
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/OrQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/OrQueryBuilder.java
@@ -32,7 +32,7 @@ import java.util.Collections;
  * @deprecated Use {@link BoolQueryBuilder} instead
  */
 @Deprecated
-public class OrQueryBuilder extends QueryBuilder {
+public class OrQueryBuilder extends AbstractQueryBuilder<OrQueryBuilder> {
 
     public static final String NAME = "or";
 
@@ -74,7 +74,7 @@ public class OrQueryBuilder extends QueryBuilder {
     }
 
     @Override
-    public String queryId() {
+    public String getName() {
         return NAME;
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/PrefixQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/PrefixQueryBuilder.java
@@ -99,7 +99,7 @@ public class PrefixQueryBuilder extends MultiTermQueryBuilder implements Boostab
     }
 
     @Override
-    public String queryId() {
+    public String getName() {
         return NAME;
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/QueryFilterBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryFilterBuilder.java
@@ -29,7 +29,7 @@ import java.io.IOException;
  *             query as a filter directly.
  */
 @Deprecated
-public class QueryFilterBuilder extends QueryBuilder {
+public class QueryFilterBuilder extends AbstractQueryBuilder<QueryFilterBuilder> {
 
     public static final String NAME = "query";
 
@@ -78,7 +78,7 @@ public class QueryFilterBuilder extends QueryBuilder {
     }
 
     @Override
-    public String queryId() {
+    public String getName() {
         return NAME;
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/QueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryParser.java
@@ -63,5 +63,5 @@ public interface QueryParser {
     /**
      * @return an empty {@link QueryBuilder} instance for this parser that can be used for deserialization
      */
-    QueryBuilder getBuilderPrototype();
+    QueryBuilder<? extends QueryBuilder> getBuilderPrototype();
 }

--- a/core/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
@@ -38,7 +38,7 @@ import static com.google.common.collect.Lists.newArrayList;
  * them either using DisMax or a plain boolean query (see {@link #useDisMax(boolean)}).
  * <p/>
  */
-public class QueryStringQueryBuilder extends QueryBuilder implements BoostableQueryBuilder<QueryStringQueryBuilder> {
+public class QueryStringQueryBuilder extends AbstractQueryBuilder<QueryStringQueryBuilder> implements BoostableQueryBuilder<QueryStringQueryBuilder> {
 
     public static final String NAME = "query_string";
 
@@ -439,7 +439,7 @@ public class QueryStringQueryBuilder extends QueryBuilder implements BoostableQu
     }
 
     @Override
-    public String queryId() {
+    public String getName() {
         return NAME;
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/QueryWrappingQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryWrappingQueryBuilder.java
@@ -29,7 +29,7 @@ import java.io.IOException;
  * Doesn't support conversion to {@link org.elasticsearch.common.xcontent.XContent} via {@link #doXContent(XContentBuilder, Params)}.
  */
 //norelease to be removed once all queries support separate fromXContent and toQuery methods
-public class QueryWrappingQueryBuilder extends QueryBuilder {
+public class QueryWrappingQueryBuilder extends AbstractQueryBuilder<QueryWrappingQueryBuilder> {
 
     private Query query;
 
@@ -48,7 +48,7 @@ public class QueryWrappingQueryBuilder extends QueryBuilder {
     }
 
     @Override
-    public String queryId() {
+    public String getName() {
         // this should not be called since we overwrite BaseQueryBuilder#toQuery() in this class
         throw new UnsupportedOperationException();
     }

--- a/core/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
@@ -274,7 +274,7 @@ public class RangeQueryBuilder extends MultiTermQueryBuilder<RangeQueryBuilder> 
     }
 
     @Override
-    public String queryId() {
+    public String getName() {
         return NAME;
     }
 

--- a/core/src/main/java/org/elasticsearch/index/query/RegexpQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/RegexpQueryBuilder.java
@@ -122,7 +122,7 @@ public class RegexpQueryBuilder extends MultiTermQueryBuilder implements Boostab
     }
 
     @Override
-    public String queryId() {
+    public String getName() {
         return NAME;
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/ScriptQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/ScriptQueryBuilder.java
@@ -24,10 +24,8 @@ import org.elasticsearch.script.Script;
 import org.elasticsearch.script.Script.ScriptField;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 
-public class ScriptQueryBuilder extends QueryBuilder {
+public class ScriptQueryBuilder extends AbstractQueryBuilder<ScriptQueryBuilder> {
 
     public static final String NAME = "script";
 
@@ -60,7 +58,7 @@ public class ScriptQueryBuilder extends QueryBuilder {
     }
 
     @Override
-    public String queryId() {
+    public String getName() {
         return NAME;
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.query;
 
-import org.elasticsearch.common.xcontent.ToXContent.Params;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -31,7 +30,7 @@ import java.util.Map;
  * SimpleQuery is a query parser that acts similar to a query_string
  * query, but won't throw exceptions for any weird string syntax.
  */
-public class SimpleQueryStringBuilder extends QueryBuilder implements BoostableQueryBuilder<SimpleQueryStringBuilder> {
+public class SimpleQueryStringBuilder extends AbstractQueryBuilder<SimpleQueryStringBuilder> implements BoostableQueryBuilder<SimpleQueryStringBuilder> {
     public static final String NAME = "simple_query_string";
     private Map<String, Float> fields = new HashMap<>();
     private String analyzer;
@@ -220,7 +219,7 @@ public class SimpleQueryStringBuilder extends QueryBuilder implements BoostableQ
     }
 
     @Override
-    public String queryId() {
+    public String getName() {
         return NAME;
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/SpanContainingQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanContainingQueryBuilder.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.search.spans.SpanQuery;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -26,7 +27,7 @@ import java.io.IOException;
 /**
  * Builder for {@link org.apache.lucene.search.spans.SpanContainingQuery}.
  */
-public class SpanContainingQueryBuilder extends QueryBuilder implements SpanQueryBuilder, BoostableQueryBuilder<SpanContainingQueryBuilder> {
+public class SpanContainingQueryBuilder extends AbstractQueryBuilder<SpanContainingQueryBuilder> implements SpanQueryBuilder<SpanContainingQueryBuilder>, BoostableQueryBuilder<SpanContainingQueryBuilder> {
 
     public static final String NAME = "span_containing";
     private SpanQueryBuilder big;
@@ -93,7 +94,13 @@ public class SpanContainingQueryBuilder extends QueryBuilder implements SpanQuer
     }
 
     @Override
-    public String queryId() {
+    public String getName() {
         return NAME;
+    }
+
+    @Override
+    public SpanQuery toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
+        //norelease just a temporary implementation, will go away once this query is refactored and properly overrides toQuery
+        return (SpanQuery)super.toQuery(parseContext);
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/SpanFirstQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanFirstQueryBuilder.java
@@ -19,11 +19,12 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.search.spans.SpanQuery;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 
-public class SpanFirstQueryBuilder extends QueryBuilder implements SpanQueryBuilder, BoostableQueryBuilder<SpanFirstQueryBuilder> {
+public class SpanFirstQueryBuilder extends AbstractQueryBuilder<SpanFirstQueryBuilder> implements SpanQueryBuilder<SpanFirstQueryBuilder>, BoostableQueryBuilder<SpanFirstQueryBuilder> {
 
     public static final String NAME = "span_first";
 
@@ -72,7 +73,13 @@ public class SpanFirstQueryBuilder extends QueryBuilder implements SpanQueryBuil
     }
 
     @Override
-    public String queryId() {
+    public String getName() {
         return NAME;
+    }
+
+    @Override
+    public SpanQuery toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
+        //norelease just a temporary implementation, will go away once this query is refactored and properly overrides toQuery
+        return (SpanQuery)super.toQuery(parseContext);
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/SpanMultiTermQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanMultiTermQueryBuilder.java
@@ -18,11 +18,12 @@
  */
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.search.spans.SpanQuery;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 
-public class SpanMultiTermQueryBuilder extends QueryBuilder implements SpanQueryBuilder {
+public class SpanMultiTermQueryBuilder extends AbstractQueryBuilder<SpanMultiTermQueryBuilder> implements SpanQueryBuilder<SpanMultiTermQueryBuilder> {
 
     public static final String NAME = "span_multi";
     private MultiTermQueryBuilder multiTermQueryBuilder;
@@ -42,7 +43,13 @@ public class SpanMultiTermQueryBuilder extends QueryBuilder implements SpanQuery
     }
 
     @Override
-    public String queryId() {
+    public String getName() {
         return NAME;
+    }
+
+    @Override
+    public SpanQuery toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
+        //norelease just a temporary implementation, will go away once this query is refactored and properly overrides toQuery
+        return (SpanQuery)super.toQuery(parseContext);
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/SpanNearQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanNearQueryBuilder.java
@@ -19,12 +19,13 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.search.spans.SpanQuery;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 import java.util.ArrayList;
 
-public class SpanNearQueryBuilder extends QueryBuilder implements SpanQueryBuilder, BoostableQueryBuilder<SpanNearQueryBuilder> {
+public class SpanNearQueryBuilder extends AbstractQueryBuilder<SpanNearQueryBuilder> implements SpanQueryBuilder<SpanNearQueryBuilder>, BoostableQueryBuilder<SpanNearQueryBuilder> {
 
     public static final String NAME = "span_near";
 
@@ -107,7 +108,13 @@ public class SpanNearQueryBuilder extends QueryBuilder implements SpanQueryBuild
     }
 
     @Override
-    public String queryId() {
+    public String getName() {
         return NAME;
+    }
+
+    @Override
+    public SpanQuery toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
+        //norelease just a temporary implementation, will go away once this query is refactored and properly overrides toQuery
+        return (SpanQuery)super.toQuery(parseContext);
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/SpanNotQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanNotQueryBuilder.java
@@ -19,11 +19,12 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.search.spans.SpanQuery;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 
-public class SpanNotQueryBuilder extends QueryBuilder implements SpanQueryBuilder, BoostableQueryBuilder<SpanNotQueryBuilder> {
+public class SpanNotQueryBuilder extends AbstractQueryBuilder<SpanNotQueryBuilder> implements SpanQueryBuilder<SpanNotQueryBuilder>, BoostableQueryBuilder<SpanNotQueryBuilder> {
 
     public static final String NAME = "span_not";
 
@@ -121,7 +122,13 @@ public class SpanNotQueryBuilder extends QueryBuilder implements SpanQueryBuilde
     }
 
     @Override
-    public String queryId() {
+    public String getName() {
         return NAME;
+    }
+
+    @Override
+    public SpanQuery toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
+        //norelease just a temporary implementation, will go away once this query is refactored and properly overrides toQuery
+        return (SpanQuery)super.toQuery(parseContext);
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/SpanOrQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanOrQueryBuilder.java
@@ -19,12 +19,13 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.search.spans.SpanQuery;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 import java.util.ArrayList;
 
-public class SpanOrQueryBuilder extends QueryBuilder implements SpanQueryBuilder, BoostableQueryBuilder<SpanOrQueryBuilder> {
+public class SpanOrQueryBuilder extends AbstractQueryBuilder<SpanOrQueryBuilder> implements SpanQueryBuilder<SpanOrQueryBuilder>, BoostableQueryBuilder<SpanOrQueryBuilder> {
 
     public static final String NAME = "span_or";
 
@@ -76,7 +77,13 @@ public class SpanOrQueryBuilder extends QueryBuilder implements SpanQueryBuilder
     }
 
     @Override
-    public String queryId() {
+    public String getName() {
         return NAME;
+    }
+
+    @Override
+    public SpanQuery toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
+        //norelease just a temporary implementation, will go away once this query is refactored and properly overrides toQuery
+        return (SpanQuery)super.toQuery(parseContext);
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/SpanQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanQueryBuilder.java
@@ -19,8 +19,15 @@
 
 package org.elasticsearch.index.query;
 
-import org.elasticsearch.common.xcontent.ToXContent;
+import org.apache.lucene.search.spans.SpanQuery;
 
-public interface SpanQueryBuilder extends ToXContent {
+import java.io.IOException;
 
+/**
+ * Interface for a specific type of {@link QueryBuilder} that allows to build span queries
+ */
+public interface SpanQueryBuilder<QB extends SpanQueryBuilder> extends QueryBuilder<QB> {
+
+    @Override
+    SpanQuery toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException;
 }

--- a/core/src/main/java/org/elasticsearch/index/query/SpanTermQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanTermQueryBuilder.java
@@ -20,7 +20,7 @@
 package org.elasticsearch.index.query;
 
 import org.apache.lucene.index.Term;
-import org.apache.lucene.search.Query;
+import org.apache.lucene.search.spans.SpanQuery;
 import org.apache.lucene.search.spans.SpanTermQuery;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.lucene.BytesRefs;
@@ -30,7 +30,7 @@ import org.elasticsearch.index.mapper.MappedFieldType;
  * A Span Query that matches documents containing a term.
  * @see SpanTermQuery
  */
-public class SpanTermQueryBuilder extends BaseTermQueryBuilder<SpanTermQueryBuilder> implements SpanQueryBuilder {
+public class SpanTermQueryBuilder extends BaseTermQueryBuilder<SpanTermQueryBuilder> implements SpanQueryBuilder<SpanTermQueryBuilder> {
 
     public static final String NAME = "span_term";
     static final SpanTermQueryBuilder PROTOTYPE = new SpanTermQueryBuilder(null, null);
@@ -66,7 +66,7 @@ public class SpanTermQueryBuilder extends BaseTermQueryBuilder<SpanTermQueryBuil
     }
 
     @Override
-    public Query toQuery(QueryParseContext context) {
+    public SpanQuery toQuery(QueryParseContext context) {
         BytesRef valueBytes = null;
         String fieldName = this.fieldName;
         MappedFieldType mapper = context.fieldMapper(fieldName);
@@ -92,7 +92,7 @@ public class SpanTermQueryBuilder extends BaseTermQueryBuilder<SpanTermQueryBuil
     }
 
     @Override
-    public String queryId() {
+    public String getName() {
         return NAME;
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/SpanTermQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanTermQueryParser.java
@@ -22,7 +22,6 @@ package org.elasticsearch.index.query;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.mapper.MappedFieldType;
 
 import java.io.IOException;
 

--- a/core/src/main/java/org/elasticsearch/index/query/SpanWithinQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanWithinQueryBuilder.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.search.spans.SpanQuery;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -26,7 +27,7 @@ import java.io.IOException;
 /**
  * Builder for {@link org.apache.lucene.search.spans.SpanWithinQuery}.
  */
-public class SpanWithinQueryBuilder extends QueryBuilder implements SpanQueryBuilder, BoostableQueryBuilder<SpanWithinQueryBuilder> {
+public class SpanWithinQueryBuilder extends AbstractQueryBuilder<SpanWithinQueryBuilder> implements SpanQueryBuilder<SpanWithinQueryBuilder>, BoostableQueryBuilder<SpanWithinQueryBuilder> {
 
     public static final String NAME = "span_within";
     private SpanQueryBuilder big;
@@ -93,7 +94,13 @@ public class SpanWithinQueryBuilder extends QueryBuilder implements SpanQueryBui
     }
 
     @Override
-    public String queryId() {
+    public String getName() {
         return NAME;
+    }
+
+    @Override
+    public SpanQuery toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
+        //norelease just a temporary implementation, will go away once this query is refactored and properly overrides toQuery
+        return (SpanQuery)super.toQuery(parseContext);
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/TemplateQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/TemplateQueryBuilder.java
@@ -28,7 +28,7 @@ import java.util.Map;
 /**
  * Facilitates creating template query requests.
  * */
-public class TemplateQueryBuilder extends QueryBuilder {
+public class TemplateQueryBuilder extends AbstractQueryBuilder<TemplateQueryBuilder> {
 
     /** Name to reference this type of query. */
     public static final String NAME = "template";
@@ -91,7 +91,7 @@ public class TemplateQueryBuilder extends QueryBuilder {
     }
 
     @Override
-    public String queryId() {
+    public String getName() {
         return NAME;
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/TermQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/TermQueryBuilder.java
@@ -91,7 +91,7 @@ public class TermQueryBuilder extends BaseTermQueryBuilder<TermQueryBuilder> imp
     }
 
     @Override
-    public String queryId() {
+    public String getName() {
         return NAME;
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/TermsLookupQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/TermsLookupQueryBuilder.java
@@ -32,7 +32,7 @@ public class TermsLookupQueryBuilder extends TermsQueryBuilder {
     }
 
     @Override
-    public String queryId() {
+    public String getName() {
         return TermsQueryBuilder.NAME;
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/TermsQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/TermsQueryBuilder.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * A filter for a field based on several terms matching on any of them.
  */
-public class TermsQueryBuilder extends QueryBuilder<TermsQueryBuilder> {
+public class TermsQueryBuilder extends AbstractQueryBuilder<TermsQueryBuilder> {
 
     public static final String NAME = "terms";
 
@@ -215,7 +215,7 @@ public class TermsQueryBuilder extends QueryBuilder<TermsQueryBuilder> {
     }
 
     @Override
-    public String queryId() {
+    public String getName() {
         return NAME;
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/TypeQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/TypeQueryBuilder.java
@@ -23,7 +23,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 
-public class TypeQueryBuilder extends QueryBuilder {
+public class TypeQueryBuilder extends AbstractQueryBuilder<TypeQueryBuilder> {
 
     public static final String NAME = "type";
     private final String type;
@@ -41,7 +41,7 @@ public class TypeQueryBuilder extends QueryBuilder {
     }
 
     @Override
-    public String queryId() {
+    public String getName() {
         return NAME;
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/WildcardQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/WildcardQueryBuilder.java
@@ -109,7 +109,7 @@ public class WildcardQueryBuilder extends MultiTermQueryBuilder implements Boost
     }
 
     @Override
-    public String queryId() {
+    public String getName() {
         return NAME;
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/WrapperQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/WrapperQueryBuilder.java
@@ -40,7 +40,7 @@ import java.io.IOException;
  * }
  * </pre>
  */
-public class WrapperQueryBuilder extends QueryBuilder {
+public class WrapperQueryBuilder extends AbstractQueryBuilder<WrapperQueryBuilder> {
 
     public static final String NAME = "wrapper";
     private final byte[] source;
@@ -83,7 +83,7 @@ public class WrapperQueryBuilder extends QueryBuilder {
     }
 
     @Override
-    public String queryId() {
+    public String getName() {
         return NAME;
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilder.java
@@ -22,6 +22,7 @@ package org.elasticsearch.index.query.functionscore;
 import org.elasticsearch.common.lucene.search.function.CombineFunction;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.query.BoostableQueryBuilder;
+import org.elasticsearch.index.query.AbstractQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 
 import java.io.IOException;
@@ -31,7 +32,7 @@ import java.util.ArrayList;
  * A query that uses a filters with a script associated with them to compute the
  * score.
  */
-public class FunctionScoreQueryBuilder extends QueryBuilder implements BoostableQueryBuilder<FunctionScoreQueryBuilder> {
+public class FunctionScoreQueryBuilder extends AbstractQueryBuilder<FunctionScoreQueryBuilder> implements BoostableQueryBuilder<FunctionScoreQueryBuilder> {
 
     private final QueryBuilder queryBuilder;
 
@@ -204,7 +205,7 @@ public class FunctionScoreQueryBuilder extends QueryBuilder implements Boostable
     }
 
     @Override
-    public String queryId() {
+    public String getName() {
         return FunctionScoreQueryParser.NAME;
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
@@ -37,7 +37,6 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.script.Script;
-import org.elasticsearch.script.ScriptService.ScriptType;
 import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
 import org.elasticsearch.search.fetch.innerhits.InnerHitsBuilder;
 import org.elasticsearch.search.fetch.source.FetchSourceContext;

--- a/core/src/test/java/org/elasticsearch/index/query/AndQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/AndQueryBuilderTest.java
@@ -84,7 +84,7 @@ public class AndQueryBuilderTest extends BaseQueryTestCase<AndQueryBuilder> {
         String queryString = "{ \"and\" : {}";
         XContentParser parser = XContentFactory.xContent(queryString).createParser(queryString);
         context.reset(parser);
-        assertQueryHeader(parser, AndQueryBuilder.PROTOTYPE.queryId());
-        context.indexQueryParserService().queryParser(AndQueryBuilder.PROTOTYPE.queryId()).fromXContent(context);
+        assertQueryHeader(parser, AndQueryBuilder.PROTOTYPE.getName());
+        context.indexQueryParserService().queryParser(AndQueryBuilder.PROTOTYPE.getName()).fromXContent(context);
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/query/BaseQueryTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/query/BaseQueryTestCase.java
@@ -203,9 +203,9 @@ public abstract class BaseQueryTestCase<QB extends QueryBuilder<QB>> extends Ela
         String contentString = testQuery.toString();
         XContentParser parser = XContentFactory.xContent(contentString).createParser(contentString);
         context.reset(parser);
-        assertQueryHeader(parser, testQuery.queryId());
+        assertQueryHeader(parser, testQuery.getName());
 
-        QueryBuilder newQuery = queryParserService.queryParser(testQuery.queryId()).fromXContent(context);
+        QueryBuilder newQuery = queryParserService.queryParser(testQuery.getName()).fromXContent(context);
         assertNotSame(newQuery, testQuery);
         assertEquals(newQuery, testQuery);
         assertEquals(newQuery.hashCode(), testQuery.hashCode());
@@ -251,7 +251,7 @@ public abstract class BaseQueryTestCase<QB extends QueryBuilder<QB>> extends Ela
         try (BytesStreamOutput output = new BytesStreamOutput()) {
             testQuery.writeTo(output);
             try (StreamInput in = new FilterStreamInput(StreamInput.wrap(output.bytes()), namedWriteableRegistry)) {
-                QueryBuilder prototype = queryParserService.queryParser(testQuery.queryId()).getBuilderPrototype();
+                QueryBuilder<? extends QueryBuilder> prototype = queryParserService.queryParser(testQuery.getName()).getBuilderPrototype();
                 QueryBuilder deserializedQuery = prototype.readFrom(in);
                 assertEquals(deserializedQuery, testQuery);
                 assertEquals(deserializedQuery.hashCode(), testQuery.hashCode());

--- a/core/src/test/java/org/elasticsearch/index/query/BoostingQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/BoostingQueryBuilderTest.java
@@ -93,10 +93,10 @@ public class BoostingQueryBuilderTest extends BaseQueryTestCase<BoostingQueryBui
 
     @Test
     public void testInnerQueryBuilderReturnsNull() throws IOException {
-        QueryBuilder noOpBuilder = new QueryBuilder<QueryBuilder>() {
+        QueryBuilder noOpBuilder = new AbstractQueryBuilder<QueryBuilder>() {
 
             @Override
-            public String queryId() {
+            public String getName() {
                 return "dummy";
             }
 
@@ -109,7 +109,7 @@ public class BoostingQueryBuilderTest extends BaseQueryTestCase<BoostingQueryBui
                 return null;
             }
         };
-        BoostingQueryBuilder boostingQueryBuilder = null;
+        BoostingQueryBuilder boostingQueryBuilder;
         if (randomBoolean()) {
             boostingQueryBuilder = new BoostingQueryBuilder().positive(new MatchAllQueryBuilder()).negative(noOpBuilder);
         } else {

--- a/core/src/test/java/org/elasticsearch/index/query/ConstantScoreQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/ConstantScoreQueryBuilderTest.java
@@ -54,7 +54,7 @@ public class ConstantScoreQueryBuilderTest extends BaseQueryTestCase<ConstantSco
     @Test(expected=QueryParsingException.class)
     public void testNoFilterElement() throws IOException {
         QueryParseContext context = createContext();
-        String queryId = ConstantScoreQueryBuilder.PROTOTYPE.queryId();
+        String queryId = ConstantScoreQueryBuilder.PROTOTYPE.getName();
         String queryString = "{ \""+queryId+"\" : {}";
         XContentParser parser = XContentFactory.xContent(queryString).createParser(queryString);
         context.reset(parser);
@@ -69,7 +69,7 @@ public class ConstantScoreQueryBuilderTest extends BaseQueryTestCase<ConstantSco
     @Test
     public void testEmptyFilterElement() throws IOException {
         QueryParseContext context = createContext();
-        String queryId = ConstantScoreQueryBuilder.PROTOTYPE.queryId();
+        String queryId = ConstantScoreQueryBuilder.PROTOTYPE.getName();
         String queryString = "{ \""+queryId+"\" : { \"filter\" : { } }";
         XContentParser parser = XContentFactory.xContent(queryString).createParser(queryString);
         context.reset(parser);

--- a/core/src/test/java/org/elasticsearch/index/query/DisMaxQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/DisMaxQueryBuilderTest.java
@@ -31,7 +31,7 @@ public class DisMaxQueryBuilderTest extends BaseQueryTestCase<DisMaxQueryBuilder
 
     @Override
     protected Query createExpectedQuery(DisMaxQueryBuilder testBuilder, QueryParseContext context) throws QueryParsingException, IOException {
-        Query query = new DisjunctionMaxQuery(QueryBuilder.toQueries(testBuilder.queries(), context), testBuilder.tieBreaker());
+        Query query = new DisjunctionMaxQuery(AbstractQueryBuilder.toQueries(testBuilder.queries(), context), testBuilder.tieBreaker());
         query.setBoost(testBuilder.boost());
         if (testBuilder.queryName() != null) {
             context.addNamedQuery(testBuilder.queryName(), query);
@@ -81,7 +81,7 @@ public class DisMaxQueryBuilderTest extends BaseQueryTestCase<DisMaxQueryBuilder
     @Test
     public void testInnerQueryReturnsNull() throws IOException {
         QueryParseContext context = createContext();
-        String queryId = ConstantScoreQueryBuilder.PROTOTYPE.queryId();
+        String queryId = ConstantScoreQueryBuilder.PROTOTYPE.getName();
         String queryString = "{ \""+queryId+"\" : { \"filter\" : { } }";
         XContentParser parser = XContentFactory.xContent(queryString).createParser(queryString);
         context.reset(parser);

--- a/core/src/test/java/org/elasticsearch/index/query/plugin/DummyQueryParserPlugin.java
+++ b/core/src/test/java/org/elasticsearch/index/query/plugin/DummyQueryParserPlugin.java
@@ -27,10 +27,7 @@ import org.elasticsearch.common.inject.Module;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.query.BaseQueryParserTemp;
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.QueryParseContext;
-import org.elasticsearch.index.query.QueryParsingException;
+import org.elasticsearch.index.query.*;
 import org.elasticsearch.indices.query.IndicesQueriesModule;
 import org.elasticsearch.plugins.AbstractPlugin;
 
@@ -60,7 +57,7 @@ public class DummyQueryParserPlugin extends AbstractPlugin {
         return Settings.EMPTY;
     }
 
-    public static class DummyQueryBuilder extends QueryBuilder {
+    public static class DummyQueryBuilder extends AbstractQueryBuilder<DummyQueryBuilder> {
         private static final String NAME = "dummy";
 
         @Override
@@ -69,7 +66,7 @@ public class DummyQueryParserPlugin extends AbstractPlugin {
         }
 
         @Override
-        public String queryId() {
+        public String getName() {
             return NAME;
         }
     }

--- a/core/src/test/java/org/elasticsearch/search/highlight/HighlighterSearchTests.java
+++ b/core/src/test/java/org/elasticsearch/search/highlight/HighlighterSearchTests.java
@@ -2586,7 +2586,7 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
                 queryStringQuery("\"highlight words together\"").field("field1^100").autoGeneratePhraseQueries(true));
     }
 
-    private <P extends QueryBuilder & BoostableQueryBuilder<?>> void
+    private <P extends QueryBuilder & BoostableQueryBuilder<P>> void
             phraseBoostTestCaseForClauses(String highlighterType, float boost, QueryBuilder terms, P phrase) {
         Matcher<String> highlightedMatcher = Matchers.either(containsString("<em>highlight words together</em>")).or(
                 containsString("<em>highlight</em> <em>words</em> <em>together</em>"));


### PR DESCRIPTION
It is handy to have a base interface, not just an abstract class, for all of our query builders. This gives us  more flexibility especialy with complex class hierarchies. For instance SpanTermQueryBuilder extends BaseTermQueryBuilder, but also needs to be marked as a SpanQueryBuilder. The latter is a marker interface that should extend QueryBuilder which is not possible unless QueryBuilder actually is an interface.

Also removed the ambiguity between `queryId` and `getName`, left only the latter.
