### PR TITLE
Load percolator queries before shard is marked POST_RECOVERY

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/fieldstats/TransportFieldStatsTransportAction.java
+++ b/core/src/main/java/org/elasticsearch/action/fieldstats/TransportFieldStatsTransportAction.java
@@ -133,7 +133,6 @@ public class TransportFieldStatsTransportAction extends TransportBroadcastAction
         IndexService indexServices = indicesService.indexServiceSafe(shardId.getIndex());
         MapperService mapperService = indexServices.mapperService();
         IndexShard shard = indexServices.shardSafe(shardId.id());
-        shard.readAllowed();
         try (Engine.Searcher searcher = shard.acquireSearcher("fieldstats")) {
             for (String field : request.getFields()) {
                 MappedFieldType fieldType = mapperService.fullName(field);

--- a/core/src/main/java/org/elasticsearch/index/percolator/PercolatorQueriesRegistry.java
+++ b/core/src/main/java/org/elasticsearch/index/percolator/PercolatorQueriesRegistry.java
@@ -257,7 +257,7 @@ public class PercolatorQueriesRegistry extends AbstractIndexShardComponent imple
         }
 
         @Override
-        public void afterIndexShardPostRecovery(IndexShard indexShard) {
+        public void beforeIndexShardPostRecovery(IndexShard indexShard) {
             if (hasPercolatorType(indexShard)) {
                 // percolator index has started, fetch what we can from it and initialize the indices
                 // we have
@@ -274,8 +274,9 @@ public class PercolatorQueriesRegistry extends AbstractIndexShardComponent imple
 
         private int loadQueries(IndexShard shard) {
             shard.refresh("percolator_load_queries");
-            // Maybe add a mode load? This isn't really a write. We need write b/c state=post_recovery
-            try (Engine.Searcher searcher = shard.acquireSearcher("percolator_load_queries", true)) {
+            // NOTE: we acquire the searcher via the engine directly here since this is executed right
+            // before the shard is marked as POST_RECOVERY
+            try (Engine.Searcher searcher = shard.engine().acquireSearcher("percolator_load_queries")) {
                 Query query = new TermQuery(new Term(TypeFieldMapper.NAME, PercolatorService.TYPE_NAME));
                 QueriesLoaderCollector queryCollector = new QueriesLoaderCollector(PercolatorQueriesRegistry.this, logger, mapperService, indexFieldDataService);
                 searcher.searcher().search(query, queryCollector);

--- a/core/src/main/java/org/elasticsearch/indices/IndicesLifecycle.java
+++ b/core/src/main/java/org/elasticsearch/indices/IndicesLifecycle.java
@@ -97,9 +97,16 @@ public interface IndicesLifecycle {
 
         }
 
-        public void afterIndexShardPostRecovery(IndexShard indexShard) {
+        /**
+         * Called right after the shard is moved into POST_RECOVERY mode
+         */
+        public void afterIndexShardPostRecovery(IndexShard indexShard) {}
 
-        }
+        /**
+         * Called right before the shard is moved into POST_RECOVERY mode.
+         * The shard is ready to be used but not yet marked as POST_RECOVERY.
+         */
+        public void beforeIndexShardPostRecovery(IndexShard indexShard) {}
 
         /**
          * Called after the index shard has been started.

--- a/core/src/main/java/org/elasticsearch/indices/InternalIndicesLifecycle.java
+++ b/core/src/main/java/org/elasticsearch/indices/InternalIndicesLifecycle.java
@@ -121,6 +121,18 @@ public class InternalIndicesLifecycle extends AbstractComponent implements Indic
         }
     }
 
+    public void beforeIndexShardPostRecovery(IndexShard indexShard) {
+        for (Listener listener : listeners) {
+            try {
+                listener.beforeIndexShardPostRecovery(indexShard);
+            } catch (Throwable t) {
+                logger.warn("{} failed to invoke before shard post recovery callback", t, indexShard.shardId());
+                throw t;
+            }
+        }
+    }
+
+
     public void afterIndexShardPostRecovery(IndexShard indexShard) {
         for (Listener listener : listeners) {
             try {


### PR DESCRIPTION
If we mark the shard as being in POST_RECOVERY before the percolator
is fully set up we might expose it to the user as fully searchable before
all queries are loaded. This can lead to wrong results especially in tests
when a shard is concurrently marked as STARTED.

This commit also removes unneeded abstractions on IndexShard where readoperations
should be allowed when the purpose is a write.

Closes #10722
