### PR TITLE
fix json syntax in filters-aggregation.asciidoc

### DIFF
--- a/docs/reference/search/aggregations/bucket/filters-aggregation.asciidoc
+++ b/docs/reference/search/aggregations/bucket/filters-aggregation.asciidoc
@@ -47,7 +47,7 @@ Response:
         "errors" : {
           "doc_count" : 34,
             "monthly" : {
-              "buckets : [
+              "buckets" : [
                 ... // the histogram monthly breakdown
               ]
             }
@@ -55,7 +55,7 @@ Response:
           "warnings" : {
             "doc_count" : 439,
             "monthly" : {
-              "buckets : [
+              "buckets" : [
                  ... // the histogram monthly breakdown
               ]
             }


### PR DESCRIPTION
Seems like somebody had missed the double quotes.
