### PR TITLE
Add OS name to _nodes and _cluster/nodes

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodes.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodes.java
@@ -303,8 +303,8 @@ public class ClusterStatsNodes implements ToXContent, Streamable {
 
         int availableProcessors;
         long availableMemory;
-        ObjectIntHashMap<String> names;
-        ObjectIntHashMap<OsInfo.Cpu> cpus;
+        final ObjectIntHashMap<String> names;
+        final ObjectIntHashMap<OsInfo.Cpu> cpus;
 
         public OsStats() {
             cpus = new ObjectIntHashMap<>();
@@ -344,13 +344,13 @@ public class ClusterStatsNodes implements ToXContent, Streamable {
             availableProcessors = in.readVInt();
             availableMemory = in.readLong();
             int size = in.readVInt();
-            names = new ObjectIntHashMap<>(size);
-            for (; size > 0; size--) {
+            names.clear();
+            for (int i = 0; i < size; i++) {
                 names.addTo(in.readString(), in.readVInt());
             }
             size = in.readVInt();
-            cpus = new ObjectIntHashMap<>(size);
-            for (; size > 0; size--) {
+            cpus.clear();
+            for (int i = 0; i < size; i++) {
                 cpus.addTo(OsInfo.Cpu.readCpu(in), in.readVInt());
             }
         }

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodes.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodes.java
@@ -303,16 +303,21 @@ public class ClusterStatsNodes implements ToXContent, Streamable {
 
         int availableProcessors;
         long availableMemory;
+        ObjectIntHashMap<String> names;
         ObjectIntHashMap<OsInfo.Cpu> cpus;
 
         public OsStats() {
             cpus = new ObjectIntHashMap<>();
+            names = new ObjectIntHashMap<>();
         }
 
         public void addNodeInfo(NodeInfo nodeInfo) {
             availableProcessors += nodeInfo.getOs().availableProcessors();
             if (nodeInfo.getOs() == null) {
                 return;
+            }
+            if (nodeInfo.getOs().getName() != null) {
+                names.addTo(nodeInfo.getOs().getName(), 1);
             }
             if (nodeInfo.getOs().cpu() != null) {
                 cpus.addTo(nodeInfo.getOs().cpu(), 1);
@@ -339,6 +344,11 @@ public class ClusterStatsNodes implements ToXContent, Streamable {
             availableProcessors = in.readVInt();
             availableMemory = in.readLong();
             int size = in.readVInt();
+            names = new ObjectIntHashMap<>(size);
+            for (; size > 0; size--) {
+                names.addTo(in.readString(), in.readVInt());
+            }
+            size = in.readVInt();
             cpus = new ObjectIntHashMap<>(size);
             for (; size > 0; size--) {
                 cpus.addTo(OsInfo.Cpu.readCpu(in), in.readVInt());
@@ -349,12 +359,16 @@ public class ClusterStatsNodes implements ToXContent, Streamable {
         public void writeTo(StreamOutput out) throws IOException {
             out.writeVInt(availableProcessors);
             out.writeLong(availableMemory);
+            out.writeVInt(names.size());
+            for (ObjectIntCursor<String> name : names) {
+                out.writeString(name.key);
+                out.writeVInt(name.value);
+            }
             out.writeVInt(cpus.size());
             for (ObjectIntCursor<OsInfo.Cpu> c : cpus) {
                 c.key.writeTo(out);
                 out.writeVInt(c.value);
             }
-
         }
 
         public static OsStats readOsStats(StreamInput in) throws IOException {
@@ -365,6 +379,8 @@ public class ClusterStatsNodes implements ToXContent, Streamable {
 
         static final class Fields {
             static final XContentBuilderString AVAILABLE_PROCESSORS = new XContentBuilderString("available_processors");
+            static final XContentBuilderString NAME = new XContentBuilderString("name");
+            static final XContentBuilderString NAMES = new XContentBuilderString("names");
             static final XContentBuilderString MEM = new XContentBuilderString("mem");
             static final XContentBuilderString TOTAL = new XContentBuilderString("total");
             static final XContentBuilderString TOTAL_IN_BYTES = new XContentBuilderString("total_in_bytes");
@@ -378,6 +394,15 @@ public class ClusterStatsNodes implements ToXContent, Streamable {
             builder.startObject(Fields.MEM);
             builder.byteSizeField(Fields.TOTAL_IN_BYTES, Fields.TOTAL, availableMemory);
             builder.endObject();
+
+            builder.startArray(Fields.NAMES);
+            for (ObjectIntCursor<String> name : names) {
+                builder.startObject();
+                builder.field(Fields.NAME, name.key);
+                builder.field(Fields.COUNT, name.value);
+                builder.endObject();
+            }
+            builder.endArray();
 
             builder.startArray(Fields.CPU);
             for (ObjectIntCursor<OsInfo.Cpu> cpu : cpus) {

--- a/core/src/main/java/org/elasticsearch/monitor/os/OsInfo.java
+++ b/core/src/main/java/org/elasticsearch/monitor/os/OsInfo.java
@@ -39,6 +39,8 @@ public class OsInfo implements Streamable, Serializable, ToXContent {
 
     int availableProcessors;
 
+    String name = null;
+
     Cpu cpu = null;
 
     Mem mem = null;
@@ -88,8 +90,13 @@ public class OsInfo implements Streamable, Serializable, ToXContent {
         return swap();
     }
 
+    public String getName() {
+        return name;
+    }
+
     static final class Fields {
         static final XContentBuilderString OS = new XContentBuilderString("os");
+        static final XContentBuilderString NAME = new XContentBuilderString("name");
         static final XContentBuilderString REFRESH_INTERVAL = new XContentBuilderString("refresh_interval");
         static final XContentBuilderString REFRESH_INTERVAL_IN_MILLIS = new XContentBuilderString("refresh_interval_in_millis");
         static final XContentBuilderString AVAILABLE_PROCESSORS = new XContentBuilderString("available_processors");
@@ -112,6 +119,9 @@ public class OsInfo implements Streamable, Serializable, ToXContent {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(Fields.OS);
+        if (name != null) {
+            builder.field(Fields.NAME, name);
+        }
         builder.timeValueField(Fields.REFRESH_INTERVAL_IN_MILLIS, Fields.REFRESH_INTERVAL, refreshInterval);
         builder.field(Fields.AVAILABLE_PROCESSORS, availableProcessors);
         if (cpu != null) {

--- a/core/src/main/java/org/elasticsearch/monitor/os/OsService.java
+++ b/core/src/main/java/org/elasticsearch/monitor/os/OsService.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.monitor.os;
 
+import org.apache.lucene.util.Constants;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
@@ -46,6 +47,7 @@ public class OsService extends AbstractComponent {
         this.info = probe.osInfo();
         this.info.refreshInterval = refreshInterval.millis();
         this.info.availableProcessors = Runtime.getRuntime().availableProcessors();
+        this.info.name = Constants.OS_NAME;
         osStatsCache = new OsStatsCache(refreshInterval, probe.osStats());
         logger.debug("Using probe [{}] with refresh_interval [{}]", probe, refreshInterval);
     }

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -86,6 +86,12 @@ Will return, for example:
             "total": "8gb",
             "total_in_bytes": 8589934592
          },
+         "names": [
+            {
+               "name": "Mac OS X",
+               "count": 1
+            }
+         ],
          "cpu": [
             {
                "vendor": "Intel",


### PR DESCRIPTION
we currently don't expose this.

This adds the following to the OS section of `_nodes`:

```
"os": {
     "name": "Mac OS X",
     ...
 }
```

 and the following to the OS section of `_cluster/stats`:

```
 "os": {
    ...
    "names": [
       {
          "name": "Mac OS X",
           "count": 1
       }
     ],
     ...
 },
```
