### PR TITLE
Java api: add missing support for boost to GeoShapeQueryBuilder and TermsQueryBuilder

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/GeoShapeQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoShapeQueryBuilder.java
@@ -29,7 +29,7 @@ import java.io.IOException;
 /**
  * {@link QueryBuilder} that builds a GeoShape Filter
  */
-public class GeoShapeQueryBuilder extends QueryBuilder {
+public class GeoShapeQueryBuilder extends QueryBuilder implements BoostableQueryBuilder<GeoShapeQueryBuilder> {
 
     private final String name;
 
@@ -46,6 +46,8 @@ public class GeoShapeQueryBuilder extends QueryBuilder {
     private String indexedShapePath;
 
     private ShapeRelation relation = null;
+
+    private float boost = -1;
     
     /**
      * Creates a new GeoShapeQueryBuilder whose Filter will be against the
@@ -147,6 +149,12 @@ public class GeoShapeQueryBuilder extends QueryBuilder {
     }
 
     @Override
+    public GeoShapeQueryBuilder boost(float boost) {
+        this.boost = boost;
+        return this;
+    }
+
+    @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(GeoShapeQueryParser.NAME);
 
@@ -176,6 +184,10 @@ public class GeoShapeQueryBuilder extends QueryBuilder {
         }
 
         builder.endObject();
+
+        if (boost != -1) {
+            builder.field("boost", boost);
+        }
 
         if (name != null) {
             builder.field("_name", queryName);

--- a/core/src/main/java/org/elasticsearch/index/query/TermsQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/TermsQueryBuilder.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * A filer for a field based on several terms matching on any of them.
  */
-public class TermsQueryBuilder extends QueryBuilder {
+public class TermsQueryBuilder extends QueryBuilder implements BoostableQueryBuilder<TermsQueryBuilder> {
 
     private final String name;
 
@@ -35,6 +35,8 @@ public class TermsQueryBuilder extends QueryBuilder {
     private String queryName;
 
     private String execution;
+
+    private float boost = -1;
 
     /**
      * A filer for a field based on several terms matching on any of them.
@@ -132,12 +134,22 @@ public class TermsQueryBuilder extends QueryBuilder {
     }
 
     @Override
+    public TermsQueryBuilder boost(float boost) {
+        this.boost = boost;
+        return this;
+    }
+
+    @Override
     public void doXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(TermsQueryParser.NAME);
         builder.field(name, values);
 
         if (execution != null) {
             builder.field("execution", execution);
+        }
+
+        if (boost != -1) {
+            builder.field("boost", boost);
         }
 
         if (queryName != null) {


### PR DESCRIPTION
Both parsers support boost and parse it properly but when we create the query through java api we couldn't set the boost.

Relates to #11744
