### PR TITLE
Parallel start node in test cluster

### DIFF
--- a/core/src/test/java/org/elasticsearch/test/CompositeTestCluster.java
+++ b/core/src/test/java/org/elasticsearch/test/CompositeTestCluster.java
@@ -68,7 +68,7 @@ public class CompositeTestCluster extends TestCluster {
     }
 
     @Override
-    public synchronized void beforeTest(Random random, double transportClientRatio) throws IOException {
+    public synchronized void beforeTest(Random random, double transportClientRatio) throws Exception {
         super.beforeTest(random, transportClientRatio);
         cluster.beforeTest(random, transportClientRatio);
         Settings defaultSettings = cluster.getDefaultSettings();

--- a/core/src/test/java/org/elasticsearch/test/TestCluster.java
+++ b/core/src/test/java/org/elasticsearch/test/TestCluster.java
@@ -60,7 +60,7 @@ public abstract class TestCluster implements Iterable<Client>, Closeable {
     /**
      * This method should be executed before each test to reset the cluster to its initial state.
      */
-    public void beforeTest(Random random, double transportClientRatio) throws IOException {
+    public void beforeTest(Random random, double transportClientRatio) throws Exception {
         assert transportClientRatio >= 0.0 && transportClientRatio <= 1.0;
         logger.debug("Reset test cluster with transport client ratio: [{}]", transportClientRatio);
         this.transportClientRatio = transportClientRatio;

--- a/core/src/test/java/org/elasticsearch/test/test/InternalTestClusterTests.java
+++ b/core/src/test/java/org/elasticsearch/test/test/InternalTestClusterTests.java
@@ -83,7 +83,7 @@ public class InternalTestClusterTests extends ElasticsearchTestCase {
         }
     }
 
-    public void testBeforeTest() throws IOException {
+    public void testBeforeTest() throws Exception {
         long clusterSeed = randomLong();
         int minNumDataNodes = randomIntBetween(0, 3);
         int maxNumDataNodes = randomIntBetween(minNumDataNodes, 4);


### PR DESCRIPTION
We can start the nodes in parallel when setting up a cluster predefined with specific set of nodes
