### PR TITLE
Add MetaData.uuid to ClusterState.toXContent

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/ClusterState.java
+++ b/core/src/main/java/org/elasticsearch/cluster/ClusterState.java
@@ -417,7 +417,7 @@ public class ClusterState implements ToXContent, Diffable<ClusterState> {
         // meta data
         if (metrics.contains(Metric.METADATA)) {
             builder.startObject("metadata");
-
+            builder.field("uuid", metaData().uuid());
             builder.startObject("templates");
             for (ObjectCursor<IndexTemplateMetaData> cursor : metaData().templates().values()) {
                 IndexTemplateMetaData templateMetaData = cursor.value;


### PR DESCRIPTION
The MetaData.uuid is guaranteed to be unique across clusters and is handy (which may or may not have the same human readable cluster name).
