### PR TITLE
Give the filter cache a smaller maximum number of cached filters.

### DIFF
--- a/core/src/main/java/org/elasticsearch/indices/cache/filter/IndicesFilterCache.java
+++ b/core/src/main/java/org/elasticsearch/indices/cache/filter/IndicesFilterCache.java
@@ -66,7 +66,7 @@ public class IndicesFilterCache extends AbstractComponent implements QueryCache,
         super(settings);
         final String sizeString = settings.get(INDICES_CACHE_QUERY_SIZE, "10%");
         final ByteSizeValue size = MemorySizeValue.parseBytesSizeValueOrHeapRatio(sizeString, INDICES_CACHE_QUERY_SIZE);
-        final int count = settings.getAsInt(INDICES_CACHE_QUERY_COUNT, 100000);
+        final int count = settings.getAsInt(INDICES_CACHE_QUERY_COUNT, 1000);
         logger.debug("using [node] weighted filter cache with size [{}], actual_size [{}], max filter count [{}]",
                 sizeString, size, count);
         cache = new LRUQueryCache(count, size.bytes()) {


### PR DESCRIPTION
Currently the filter cache is configured to have a maximum size in bytes of 10%
of the JVM memory, and a maximum number of cached filters (across all segments
of all shard on the same node) of 100000. I would like to change the latter to
a more reasonable value of 1000.

Given that we track the most 256 most recently used filters per index and only
cache those that have been seen 5 times or more, a single index cannot have more
than 50 hot filters, so a maximum number of cached filters of 1000 per node
should be more than necessary.
