### PR TITLE
Query Refactoring: Minor consistency cleanups for default values and validation

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/AbstractQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/AbstractQueryBuilder.java
@@ -27,7 +27,6 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentType;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -143,5 +142,21 @@ public abstract class AbstractQueryBuilder<QB extends QueryBuilder> extends ToXC
             }
         }
         return queries;
+    }
+
+    /**
+     * Utility method that converts inner query builders to xContent and
+     * checks for null values, rendering out empty object in this case.
+     */
+    protected static void doXContentInnerBuilder(XContentBuilder xContentBuilder, String fieldName,
+            QueryBuilder queryBuilder, Params params) throws IOException {
+        xContentBuilder.field(fieldName);
+        if (queryBuilder != null) {
+            queryBuilder.toXContent(xContentBuilder, params);
+        } else {
+            // we output an empty object, QueryParseContext#parseInnerQueryBuilder will parse this back to `null` value
+            xContentBuilder.startObject();
+            xContentBuilder.endObject();
+        }
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/AndQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/AndQueryBuilder.java
@@ -42,23 +42,27 @@ public class AndQueryBuilder extends AbstractQueryBuilder<AndQueryBuilder> {
 
     public static final String NAME = "and";
 
-    private ArrayList<QueryBuilder> filters = Lists.newArrayList();
+    private final ArrayList<QueryBuilder> filters = Lists.newArrayList();
 
     private String queryName;
 
     static final AndQueryBuilder PROTOTYPE = new AndQueryBuilder();
 
+    /**
+     * @param filters nested filters, no <tt>null</tt> values are allowed
+     */
     public AndQueryBuilder(QueryBuilder... filters) {
         for (QueryBuilder filter : filters) {
-            this.filters.add(filter);
+            this.filters.add(Objects.requireNonNull(filter));
         }
     }
 
     /**
      * Adds a filter to the list of filters to "and".
+     * @param filterBuilder nested filter, no <tt>null</tt> value allowed
      */
     public AndQueryBuilder add(QueryBuilder filterBuilder) {
-        filters.add(filterBuilder);
+        filters.add(Objects.requireNonNull(filterBuilder));
         return this;
     }
 
@@ -121,7 +125,7 @@ public class AndQueryBuilder extends AbstractQueryBuilder<AndQueryBuilder> {
 
     @Override
     public QueryValidationException validate() {
-        // nothing to validate.
+        // nothing to validate
         return null;
     }
 
@@ -155,7 +159,7 @@ public class AndQueryBuilder extends AbstractQueryBuilder<AndQueryBuilder> {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeNamedWriteableList(this.filters);
+        out.writeNamedWriteableList(filters);
         out.writeOptionalString(queryName);
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/AndQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/AndQueryParser.java
@@ -46,7 +46,7 @@ public class AndQueryParser extends BaseQueryParser {
     public QueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
         XContentParser parser = parseContext.parser();
 
-        ArrayList<QueryBuilder> queries = newArrayList();
+        final ArrayList<QueryBuilder> queries = newArrayList();
         boolean queriesFound = false;
 
         String queryName = null;

--- a/core/src/main/java/org/elasticsearch/index/query/BaseTermQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/BaseTermQueryBuilder.java
@@ -164,9 +164,7 @@ public abstract class BaseTermQueryBuilder<QB extends BaseTermQueryBuilder<QB>> 
         } else {
             builder.startObject(fieldName);
             builder.field("value", convertToStringIfBytesRef(this.value));
-            if (boost != 1.0f) {
-                builder.field("boost", boost);
-            }
+            builder.field("boost", boost);
             if (queryName != null) {
                 builder.field("_name", queryName);
             }

--- a/core/src/main/java/org/elasticsearch/index/query/BoolQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/BoolQueryBuilder.java
@@ -43,9 +43,9 @@ public class BoolQueryBuilder extends AbstractQueryBuilder<BoolQueryBuilder> imp
 
     public static final String NAME = "bool";
 
-    static final boolean ADJUST_PURE_NEGATIVE_DEFAULT = true;
+    public static final boolean ADJUST_PURE_NEGATIVE_DEFAULT = true;
 
-    static final boolean DISABLE_COORD_DEFAULT = false;
+    public static final boolean DISABLE_COORD_DEFAULT = false;
 
     static final BoolQueryBuilder PROTOTYPE = new BoolQueryBuilder();
 
@@ -69,10 +69,10 @@ public class BoolQueryBuilder extends AbstractQueryBuilder<BoolQueryBuilder> imp
 
     /**
      * Adds a query that <b>must</b> appear in the matching documents and will
-     * contribute to scoring.
+     * contribute to scoring. No <tt>null</tt> value allowed.
      */
     public BoolQueryBuilder must(QueryBuilder queryBuilder) {
-        mustClauses.add(queryBuilder);
+        mustClauses.add(Objects.requireNonNull(queryBuilder));
         return this;
     }
 
@@ -85,10 +85,10 @@ public class BoolQueryBuilder extends AbstractQueryBuilder<BoolQueryBuilder> imp
 
     /**
      * Adds a query that <b>must</b> appear in the matching documents but will
-     * not contribute to scoring.
+     * not contribute to scoring. No <tt>null</tt> value allowed.
      */
     public BoolQueryBuilder filter(QueryBuilder queryBuilder) {
-        filterClauses.add(queryBuilder);
+        filterClauses.add(Objects.requireNonNull(queryBuilder));
         return this;
     }
 
@@ -101,9 +101,10 @@ public class BoolQueryBuilder extends AbstractQueryBuilder<BoolQueryBuilder> imp
 
     /**
      * Adds a query that <b>must not</b> appear in the matching documents.
+     * No <tt>null</tt> value allowed.
      */
     public BoolQueryBuilder mustNot(QueryBuilder queryBuilder) {
-        mustNotClauses.add(queryBuilder);
+        mustNotClauses.add(Objects.requireNonNull(queryBuilder));
         return this;
     }
 
@@ -117,12 +118,12 @@ public class BoolQueryBuilder extends AbstractQueryBuilder<BoolQueryBuilder> imp
     /**
      * Adds a clause that <i>should</i> be matched by the returned documents. For a boolean query with no
      * <tt>MUST</tt> clauses one or more <code>SHOULD</code> clauses must match a document
-     * for the BooleanQuery to match.
+     * for the BooleanQuery to match. No <tt>null</tt> value allowed.
      *
      * @see #minimumNumberShouldMatch(int)
      */
     public BoolQueryBuilder should(QueryBuilder queryBuilder) {
-        shouldClauses.add(queryBuilder);
+        shouldClauses.add(Objects.requireNonNull(queryBuilder));
         return this;
     }
 
@@ -297,17 +298,17 @@ public class BoolQueryBuilder extends AbstractQueryBuilder<BoolQueryBuilder> imp
             return new MatchAllDocsQuery();
         }
 
-        BooleanQuery booleanQuery = new BooleanQuery(this.disableCoord);
-        addBooleanClauses(parseContext, booleanQuery, this.mustClauses, BooleanClause.Occur.MUST);
-        addBooleanClauses(parseContext, booleanQuery, this.mustNotClauses, BooleanClause.Occur.MUST_NOT);
-        addBooleanClauses(parseContext, booleanQuery, this.shouldClauses, BooleanClause.Occur.SHOULD);
-        addBooleanClauses(parseContext, booleanQuery, this.filterClauses, BooleanClause.Occur.FILTER);
+        BooleanQuery booleanQuery = new BooleanQuery(disableCoord);
+        addBooleanClauses(parseContext, booleanQuery, mustClauses, BooleanClause.Occur.MUST);
+        addBooleanClauses(parseContext, booleanQuery, mustNotClauses, BooleanClause.Occur.MUST_NOT);
+        addBooleanClauses(parseContext, booleanQuery, shouldClauses, BooleanClause.Occur.SHOULD);
+        addBooleanClauses(parseContext, booleanQuery, filterClauses, BooleanClause.Occur.FILTER);
 
-        booleanQuery.setBoost(this.boost);
-        Queries.applyMinimumShouldMatch(booleanQuery, this.minimumShouldMatch);
-        Query query = this.adjustPureNegative ? fixNegativeQueryIfNeeded(booleanQuery) : booleanQuery;
-        if (this.queryName != null) {
-            parseContext.addNamedQuery(this.queryName, query);
+        booleanQuery.setBoost(boost);
+        Queries.applyMinimumShouldMatch(booleanQuery, minimumShouldMatch);
+        Query query = adjustPureNegative ? fixNegativeQueryIfNeeded(booleanQuery) : booleanQuery;
+        if (queryName != null) {
+            parseContext.addNamedQuery(queryName, query);
         }
         return query;
     }
@@ -369,14 +370,14 @@ public class BoolQueryBuilder extends AbstractQueryBuilder<BoolQueryBuilder> imp
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeNamedWriteableList(this.mustClauses);
-        out.writeNamedWriteableList(this.mustNotClauses);
-        out.writeNamedWriteableList(this.shouldClauses);
-        out.writeNamedWriteableList(this.filterClauses);
-        out.writeFloat(this.boost);
-        out.writeBoolean(this.adjustPureNegative);
-        out.writeBoolean(this.disableCoord);
+        out.writeNamedWriteableList(mustClauses);
+        out.writeNamedWriteableList(mustNotClauses);
+        out.writeNamedWriteableList(shouldClauses);
+        out.writeNamedWriteableList(filterClauses);
+        out.writeFloat(boost);
+        out.writeBoolean(adjustPureNegative);
+        out.writeBoolean(disableCoord);
         out.writeOptionalString(queryName);
-        out.writeOptionalString(this.minimumShouldMatch);
+        out.writeOptionalString(minimumShouldMatch);
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/BoolQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/BoolQueryParser.java
@@ -53,10 +53,10 @@ public class BoolQueryParser extends BaseQueryParser {
         float boost = 1.0f;
         String minimumShouldMatch = null;
 
-        List<QueryBuilder> mustClauses = newArrayList();
-        List<QueryBuilder> mustNotClauses = newArrayList();
-        List<QueryBuilder> shouldClauses = newArrayList();
-        List<QueryBuilder> filterClauses = newArrayList();
+        final List<QueryBuilder> mustClauses = newArrayList();
+        final List<QueryBuilder> mustNotClauses = newArrayList();
+        final List<QueryBuilder> shouldClauses = newArrayList();
+        final List<QueryBuilder> filterClauses = newArrayList();
         String queryName = null;
 
         String currentFieldName = null;

--- a/core/src/main/java/org/elasticsearch/index/query/BoostingQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/BoostingQueryBuilder.java
@@ -120,17 +120,9 @@ public class BoostingQueryBuilder extends AbstractQueryBuilder<BoostingQueryBuil
 
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
-        if (positiveQuery == null) {
-            throw new IllegalArgumentException("boosting query requires positive query to be set");
-        }
-        if (negativeQuery == null) {
-            throw new IllegalArgumentException("boosting query requires negative query to be set");
-        }
         builder.startObject(NAME);
-        builder.field("positive");
-        positiveQuery.toXContent(builder, params);
-        builder.field("negative");
-        negativeQuery.toXContent(builder, params);
+        doXContentInnerBuilder(builder, "positive", positiveQuery, params);
+        doXContentInnerBuilder(builder, "negative", negativeQuery, params);
         builder.field("negative_boost", negativeBoost);
         builder.field("boost", boost);
         builder.endObject();
@@ -153,7 +145,6 @@ public class BoostingQueryBuilder extends AbstractQueryBuilder<BoostingQueryBuil
 
     @Override
     public Query toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
-
         // make upstream queries ignore this query by returning `null`
         // if either inner query builder is null or returns null-Query
         if (positiveQuery == null || negativeQuery == null) {
@@ -172,15 +163,15 @@ public class BoostingQueryBuilder extends AbstractQueryBuilder<BoostingQueryBuil
 
     @Override
     public int hashCode() {
-        return Objects.hash(this.boost, this.negativeBoost, this.positiveQuery, this.negativeQuery);
+        return Objects.hash(boost, negativeBoost, positiveQuery, negativeQuery);
     }
 
     @Override
     public boolean doEquals(BoostingQueryBuilder other) {
-        return Objects.equals(this.boost, other.boost) &&
-                Objects.equals(this.negativeBoost, other.negativeBoost) &&
-                Objects.equals(this.positiveQuery, other.positiveQuery) &&
-                Objects.equals(this.negativeQuery, other.negativeQuery);
+        return Objects.equals(boost, other.boost) &&
+                Objects.equals(negativeBoost, other.negativeBoost) &&
+                Objects.equals(positiveQuery, other.positiveQuery) &&
+                Objects.equals(negativeQuery, other.negativeQuery);
     }
 
     @Override
@@ -197,9 +188,9 @@ public class BoostingQueryBuilder extends AbstractQueryBuilder<BoostingQueryBuil
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeNamedWriteable(this.positiveQuery);
-        out.writeNamedWriteable(this.negativeQuery);
-        out.writeFloat(this.boost);
-        out.writeFloat(this.negativeBoost);
+        out.writeNamedWriteable(positiveQuery);
+        out.writeNamedWriteable(negativeQuery);
+        out.writeFloat(boost);
+        out.writeFloat(negativeBoost);
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/BoostingQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/BoostingQueryParser.java
@@ -75,10 +75,10 @@ public class BoostingQueryParser extends BaseQueryParser {
             }
         }
 
-        if (positiveQuery == null && !positiveQueryFound) {
+        if (!positiveQueryFound) {
             throw new QueryParsingException(parseContext, "[boosting] query requires 'positive' query to be set'");
         }
-        if (negativeQuery == null && !negativeQueryFound) {
+        if (!negativeQueryFound) {
             throw new QueryParsingException(parseContext, "[boosting] query requires 'negative' query to be set'");
         }
         if (negativeBoost < 0) {

--- a/core/src/main/java/org/elasticsearch/index/query/ConstantScoreQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/ConstantScoreQueryBuilder.java
@@ -79,8 +79,7 @@ public class ConstantScoreQueryBuilder extends AbstractQueryBuilder<ConstantScor
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(NAME);
-        builder.field("filter");
-        filterBuilder.toXContent(builder, params);
+        doXContentInnerBuilder(builder, "filter", filterBuilder, params);
         builder.field("boost", boost);
         builder.endObject();
     }
@@ -104,6 +103,12 @@ public class ConstantScoreQueryBuilder extends AbstractQueryBuilder<ConstantScor
     }
 
     @Override
+    public QueryValidationException validate() {
+        // nothing to validate
+        return null;
+    }
+
+    @Override
     public String getName() {
         return NAME;
     }
@@ -116,7 +121,7 @@ public class ConstantScoreQueryBuilder extends AbstractQueryBuilder<ConstantScor
     @Override
     public boolean doEquals(ConstantScoreQueryBuilder other) {
         return Objects.equals(boost, other.boost) &&
-                Objects.equals(filterBuilder, other.filterBuilder);
+               Objects.equals(filterBuilder, other.filterBuilder);
     }
 
     @Override
@@ -129,7 +134,7 @@ public class ConstantScoreQueryBuilder extends AbstractQueryBuilder<ConstantScor
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeNamedWriteable(this.filterBuilder);
+        out.writeNamedWriteable(filterBuilder);
         out.writeFloat(boost);
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/ConstantScoreQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/ConstantScoreQueryParser.java
@@ -78,7 +78,6 @@ public class ConstantScoreQueryParser extends BaseQueryParser {
 
         ConstantScoreQueryBuilder constantScoreBuilder = new ConstantScoreQueryBuilder(query);
         constantScoreBuilder.boost(boost);
-        constantScoreBuilder.validate();
         return constantScoreBuilder;
     }
 

--- a/core/src/main/java/org/elasticsearch/index/query/DisMaxQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/DisMaxQueryBuilder.java
@@ -56,7 +56,7 @@ public class DisMaxQueryBuilder extends AbstractQueryBuilder<DisMaxQueryBuilder>
      * Add a sub-query to this disjunction.
      */
     public DisMaxQueryBuilder add(QueryBuilder queryBuilder) {
-        queries.add(queryBuilder);
+        queries.add(Objects.requireNonNull(queryBuilder));
         return this;
     }
 
@@ -169,7 +169,7 @@ public class DisMaxQueryBuilder extends AbstractQueryBuilder<DisMaxQueryBuilder>
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeNamedWriteableList(this.queries);
+        out.writeNamedWriteableList(queries);
         out.writeFloat(tieBreaker);
         out.writeOptionalString(queryName);
         out.writeFloat(boost);

--- a/core/src/main/java/org/elasticsearch/index/query/DisMaxQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/DisMaxQueryParser.java
@@ -49,7 +49,7 @@ public class DisMaxQueryParser extends BaseQueryParser {
         float boost = 1.0f;
         float tieBreaker = DisMaxQueryBuilder.DEFAULT_TIE_BREAKER;
 
-        List<QueryBuilder> queries = newArrayList();
+        final List<QueryBuilder> queries = newArrayList();
         boolean queriesFound = false;
         String queryName = null;
 

--- a/core/src/main/java/org/elasticsearch/index/query/ExistsQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/ExistsQueryBuilder.java
@@ -87,6 +87,12 @@ public class ExistsQueryBuilder extends AbstractQueryBuilder<ExistsQueryBuilder>
         return newFilter(parseContext, name, queryName);
     }
 
+    @Override
+    public QueryValidationException validate() {
+        // nothing to validate
+        return null;
+    }
+
     public static Query newFilter(QueryParseContext parseContext, String fieldPattern, String queryName) {
         final FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType = (FieldNamesFieldMapper.FieldNamesFieldType)parseContext.mapperService().fullName(FieldNamesFieldMapper.NAME);
         if (fieldNamesFieldType == null) {

--- a/core/src/main/java/org/elasticsearch/index/query/ExistsQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/ExistsQueryParser.java
@@ -67,7 +67,6 @@ public class ExistsQueryParser extends BaseQueryParser {
 
         ExistsQueryBuilder builder = new ExistsQueryBuilder(fieldPattern);
         builder.queryName(queryName);
-        builder.validate();
         return builder;
     }
 

--- a/core/src/main/java/org/elasticsearch/index/query/FQueryFilterBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/FQueryFilterBuilder.java
@@ -79,8 +79,7 @@ public class FQueryFilterBuilder extends AbstractQueryBuilder<FQueryFilterBuilde
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(FQueryFilterBuilder.NAME);
-        builder.field("query");
-        queryBuilder.toXContent(builder, params);
+        doXContentInnerBuilder(builder, "query", queryBuilder, params);
         if (queryName != null) {
             builder.field("_name", queryName);
         }
@@ -105,6 +104,12 @@ public class FQueryFilterBuilder extends AbstractQueryBuilder<FQueryFilterBuilde
     }
 
     @Override
+    public QueryValidationException validate() {
+        // nothing to validate
+        return null;
+    }
+
+    @Override
     public int hashCode() {
         return Objects.hash(queryBuilder, queryName);
     }
@@ -125,7 +130,7 @@ public class FQueryFilterBuilder extends AbstractQueryBuilder<FQueryFilterBuilde
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeNamedWriteable(this.queryBuilder);
+        out.writeNamedWriteable(queryBuilder);
         out.writeOptionalString(queryName);
     }
 

--- a/core/src/main/java/org/elasticsearch/index/query/FieldMaskingSpanQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/FieldMaskingSpanQueryBuilder.java
@@ -99,8 +99,7 @@ public class FieldMaskingSpanQueryBuilder extends AbstractQueryBuilder<FieldMask
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(NAME);
-        builder.field("query");
-        queryBuilder.toXContent(builder, params);
+        doXContentInnerBuilder(builder, "query", queryBuilder, params);
         builder.field("field", fieldName);
         builder.field("boost", boost);
         if (queryName != null) {
@@ -111,12 +110,12 @@ public class FieldMaskingSpanQueryBuilder extends AbstractQueryBuilder<FieldMask
 
     @Override
     public SpanQuery toQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
-        String fieldInQuery = this.fieldName;
+        String fieldInQuery = fieldName;
         MappedFieldType fieldType = parseContext.fieldMapper(fieldName);
         if (fieldType != null) {
             fieldInQuery = fieldType.names().indexName();
         }
-        SpanQuery innerQuery = this.queryBuilder.toQuery(parseContext);
+        SpanQuery innerQuery = queryBuilder.toQuery(parseContext);
 
         FieldMaskingSpanQuery query = new FieldMaskingSpanQuery(innerQuery, fieldInQuery);
         query.setBoost(boost);
@@ -149,8 +148,8 @@ public class FieldMaskingSpanQueryBuilder extends AbstractQueryBuilder<FieldMask
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeNamedWriteable(this.queryBuilder);
-        out.writeString(this.fieldName);
+        out.writeNamedWriteable(queryBuilder);
+        out.writeString(fieldName);
         out.writeOptionalString(queryName);
         out.writeFloat(boost);
     }

--- a/core/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
@@ -150,9 +150,7 @@ public class IdsQueryBuilder extends AbstractQueryBuilder<IdsQueryBuilder> imple
             builder.value(value);
         }
         builder.endArray();
-        if (boost != 1.0f) {
-            builder.field("boost", boost);
-        }
+        builder.field("boost", boost);
         if (queryName != null) {
             builder.field("_name", queryName);
         }
@@ -205,8 +203,8 @@ public class IdsQueryBuilder extends AbstractQueryBuilder<IdsQueryBuilder> imple
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeStringArray(this.types);
-        out.writeStringArray(this.ids.toArray(new String[this.ids.size()]));
+        out.writeStringArray(types);
+        out.writeStringArray(ids.toArray(new String[ids.size()]));
         out.writeOptionalString(queryName);
         out.writeFloat(boost);
     }

--- a/core/src/main/java/org/elasticsearch/index/query/IdsQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/IdsQueryParser.java
@@ -104,7 +104,6 @@ public class IdsQueryParser extends BaseQueryParser {
         IdsQueryBuilder query = new IdsQueryBuilder(types.toArray(new String[types.size()]));
         query.addIds(ids.toArray(new String[ids.size()]));
         query.boost(boost).queryName(queryName);
-        query.validate();
         return query;
     }
 

--- a/core/src/main/java/org/elasticsearch/index/query/LimitQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/LimitQueryBuilder.java
@@ -56,6 +56,12 @@ public class LimitQueryBuilder extends AbstractQueryBuilder<LimitQueryBuilder> {
     }
 
     @Override
+    public QueryValidationException validate() {
+        // nothing to validate
+        return null;
+    }
+
+    @Override
     public boolean doEquals(LimitQueryBuilder other) {
         return Integer.compare(other.limit, limit) == 0;
     }
@@ -73,7 +79,7 @@ public class LimitQueryBuilder extends AbstractQueryBuilder<LimitQueryBuilder> {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeInt(this.limit);
+        out.writeInt(limit);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/MatchAllQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MatchAllQueryBuilder.java
@@ -76,6 +76,12 @@ public class MatchAllQueryBuilder extends AbstractQueryBuilder<MatchAllQueryBuil
     }
 
     @Override
+    public QueryValidationException validate() {
+        // nothing to validate
+        return null;
+    }
+
+    @Override
     public boolean doEquals(MatchAllQueryBuilder other) {
         return Float.compare(other.boost, boost) == 0;
     }

--- a/core/src/main/java/org/elasticsearch/index/query/MatchAllQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MatchAllQueryParser.java
@@ -41,22 +41,24 @@ public class MatchAllQueryParser extends BaseQueryParser {
 
     @Override
     public MatchAllQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException {
-        MatchAllQueryBuilder queryBuilder = new MatchAllQueryBuilder();
         XContentParser parser = parseContext.parser();
 
         String currentFieldName = null;
         XContentParser.Token token;
+        float boost = 1.0f;
         while (((token = parser.nextToken()) != XContentParser.Token.END_OBJECT && token != XContentParser.Token.END_ARRAY)) {
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
             } else if (token.isValue()) {
                 if ("boost".equals(currentFieldName)) {
-                    queryBuilder.boost(parser.floatValue());
+                    boost = parser.floatValue();
                 } else {
                     throw new QueryParsingException(parseContext, "[match_all] query does not support [" + currentFieldName + "]");
                 }
             }
         }
+        MatchAllQueryBuilder queryBuilder = new MatchAllQueryBuilder();
+        queryBuilder.boost(boost);
         return queryBuilder;
     }
 

--- a/core/src/main/java/org/elasticsearch/index/query/NotQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/NotQueryBuilder.java
@@ -70,8 +70,7 @@ public class NotQueryBuilder extends AbstractQueryBuilder<NotQueryBuilder> {
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(NAME);
-        builder.field("query");
-        filter.toXContent(builder, params);
+        doXContentInnerBuilder(builder, "query", filter, params);
         if (queryName != null) {
             builder.field("_name", queryName);
         }

--- a/core/src/main/java/org/elasticsearch/index/query/OrQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/OrQueryBuilder.java
@@ -30,7 +30,6 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -43,21 +42,24 @@ public class OrQueryBuilder extends AbstractQueryBuilder<OrQueryBuilder> {
 
     public static final String NAME = "or";
 
-    private ArrayList<QueryBuilder> filters = Lists.newArrayList();
+    private final ArrayList<QueryBuilder> filters = Lists.newArrayList();
 
     private String queryName;
 
     static final OrQueryBuilder PROTOTYPE = new OrQueryBuilder();
 
     public OrQueryBuilder(QueryBuilder... filters) {
-        Collections.addAll(this.filters, filters);
+        for (QueryBuilder filter : filters) {
+            this.filters.add(Objects.requireNonNull(filter));
+        }
     }
 
     /**
      * Adds a filter to the list of filters to "or".
+     * No <tt>null</tt> value allowed.
      */
     public OrQueryBuilder add(QueryBuilder filterBuilder) {
-        filters.add(filterBuilder);
+        filters.add(Objects.requireNonNull(filterBuilder));
         return this;
     }
 
@@ -120,7 +122,7 @@ public class OrQueryBuilder extends AbstractQueryBuilder<OrQueryBuilder> {
 
     @Override
     public QueryValidationException validate() {
-        // nothing to validate.
+        // nothing to validate
         return null;
     }
 
@@ -154,7 +156,7 @@ public class OrQueryBuilder extends AbstractQueryBuilder<OrQueryBuilder> {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeNamedWriteableList(this.filters);
+        out.writeNamedWriteableList(filters);
         out.writeOptionalString(queryName);
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/OrQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/OrQueryParser.java
@@ -43,7 +43,7 @@ public class OrQueryParser extends BaseQueryParser {
     public QueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
         XContentParser parser = parseContext.parser();
 
-        ArrayList<QueryBuilder> queries = newArrayList();
+        final ArrayList<QueryBuilder> queries = newArrayList();
         boolean queriesFound = false;
 
         String queryName = null;

--- a/core/src/main/java/org/elasticsearch/index/query/QueryFilterBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryFilterBuilder.java
@@ -60,8 +60,7 @@ public class QueryFilterBuilder extends AbstractQueryBuilder<QueryFilterBuilder>
 
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.field(NAME);
-        queryBuilder.toXContent(builder, params);
+        doXContentInnerBuilder(builder, NAME, queryBuilder, params);
     }
 
     @Override
@@ -75,6 +74,12 @@ public class QueryFilterBuilder extends AbstractQueryBuilder<QueryFilterBuilder>
             return null;
         }
         return new ConstantScoreQuery(innerQuery);
+    }
+
+    @Override
+    public QueryValidationException validate() {
+        // nothing to validate
+        return null;
     }
 
     @Override
@@ -95,7 +100,7 @@ public class QueryFilterBuilder extends AbstractQueryBuilder<QueryFilterBuilder>
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeNamedWriteable(this.queryBuilder);
+        out.writeNamedWriteable(queryBuilder);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
@@ -40,6 +40,10 @@ import java.util.Objects;
  */
 public class RangeQueryBuilder extends MultiTermQueryBuilder<RangeQueryBuilder> implements BoostableQueryBuilder<RangeQueryBuilder> {
 
+    public static final boolean DEFAULT_INCLUDE_UPPER = true;
+
+    public static final boolean DEFAULT_INCLUDE_LOWER = true;
+
     public static final String NAME = "range";
 
     private final String fieldName;
@@ -47,11 +51,12 @@ public class RangeQueryBuilder extends MultiTermQueryBuilder<RangeQueryBuilder> 
     private Object from;
 
     private Object to;
+
     private String timeZone;
 
-    private boolean includeLower = true;
+    private boolean includeLower = DEFAULT_INCLUDE_LOWER;
 
-    private boolean includeUpper = true;
+    private boolean includeUpper = DEFAULT_INCLUDE_UPPER;
 
     private float boost = 1.0f;
 
@@ -255,16 +260,14 @@ public class RangeQueryBuilder extends MultiTermQueryBuilder<RangeQueryBuilder> 
         builder.startObject(fieldName);
         builder.field("from", convertToStringIfBytesRef(this.from));
         builder.field("to", convertToStringIfBytesRef(this.to));
+        builder.field("include_lower", includeLower);
+        builder.field("include_upper", includeUpper);
+        builder.field("boost", boost);
         if (timeZone != null) {
             builder.field("time_zone", timeZone);
         }
         if (format != null) {
             builder.field("format", format);
-        }
-        builder.field("include_lower", includeLower);
-        builder.field("include_upper", includeUpper);
-        if (boost != 1.0f) {
-            builder.field("boost", boost);
         }
         builder.endObject();
         if (queryName != null) {

--- a/core/src/main/java/org/elasticsearch/index/query/RangeQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/RangeQueryParser.java
@@ -48,8 +48,8 @@ public class RangeQueryParser extends BaseQueryParser {
         String fieldName = null;
         Object from = null;
         Object to = null;
-        boolean includeLower = true;
-        boolean includeUpper = true;
+        boolean includeLower = RangeQueryBuilder.DEFAULT_INCLUDE_LOWER;
+        boolean includeUpper = RangeQueryBuilder.DEFAULT_INCLUDE_UPPER;
         String timeZone = null;
         float boost = 1.0f;
         String queryName = null;
@@ -111,15 +111,14 @@ public class RangeQueryParser extends BaseQueryParser {
         }
 
         RangeQueryBuilder rangeQuery = new RangeQueryBuilder(fieldName);
-        rangeQuery.from(from)
-            .to(to)
-            .includeLower(includeLower)
-            .includeUpper(includeUpper)
-            .timeZone(timeZone)
-            .boost(boost)
-            .queryName(queryName)
-            .format(format);
-        rangeQuery.validate();
+        rangeQuery.from(from);
+        rangeQuery.to(to);
+        rangeQuery.includeLower(includeLower);
+        rangeQuery.includeUpper(includeUpper);
+        rangeQuery.timeZone(timeZone);
+        rangeQuery.boost(boost);
+        rangeQuery.queryName(queryName);
+        rangeQuery.format(format);
         return rangeQuery;
     }
 

--- a/core/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
@@ -39,7 +39,7 @@ import java.util.TreeMap;
 /**
  * SimpleQuery is a query parser that acts similar to a query_string query, but
  * won't throw exceptions for any weird string syntax.
- * 
+ *
  * For more detailed explanation of the query string syntax see also the <a
  * href=
  * "https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html"
@@ -55,7 +55,7 @@ public class SimpleQueryStringBuilder extends AbstractQueryBuilder<SimpleQuerySt
     /** Default for wildcard analysis.*/
     public static final boolean DEFAULT_ANALYZE_WILDCARD = false;
     /** Default for boost to apply to resulting Lucene query. Defaults to 1.0*/
-    public static final float DEFAULT_BOOST = 1.0f; 
+    public static final float DEFAULT_BOOST = 1.0f;
     /** Default for default operator to use for linking boolean clauses.*/
     public static final Operator DEFAULT_OPERATOR = Operator.OR;
     /** Default for search flags to use. */
@@ -71,7 +71,7 @@ public class SimpleQueryStringBuilder extends AbstractQueryBuilder<SimpleQuerySt
      * currently _ALL. Uses a TreeMap to hold the fields so boolean clauses are
      * always sorted in same order for generated Lucene query for easier
      * testing.
-     * 
+     *
      * Can be changed back to HashMap once https://issues.apache.org/jira/browse/LUCENE-6305 is fixed.
      */
     private final Map<String, Float> fieldsAndWeights = new TreeMap<>();
@@ -269,9 +269,9 @@ public class SimpleQueryStringBuilder extends AbstractQueryBuilder<SimpleQuerySt
         return minimumShouldMatch;
     }
 
-    /** 
-     * {@inheritDoc} 
-     * 
+    /**
+     * {@inheritDoc}
+     *
      * Checks that mandatory queryText is neither null nor empty.
      * */
     @Override
@@ -319,7 +319,7 @@ public class SimpleQueryStringBuilder extends AbstractQueryBuilder<SimpleQuerySt
             Queries.applyMinimumShouldMatch((BooleanQuery) query, minimumShouldMatch);
         }
 
-        // safety check - https://github.com/elastic/elasticsearch/pull/11696#discussion-diff-32532468 
+        // safety check - https://github.com/elastic/elasticsearch/pull/11696#discussion-diff-32532468
         if (query != null) {
             query.setBoost(boost);
         }
@@ -365,10 +365,7 @@ public class SimpleQueryStringBuilder extends AbstractQueryBuilder<SimpleQuerySt
             builder.field("minimum_should_match", minimumShouldMatch);
         }
 
-        if (boost != -1.0f) {
-            builder.field("boost", boost);
-        }
-
+        builder.field("boost", boost);
         builder.endObject();
     }
 
@@ -430,7 +427,7 @@ public class SimpleQueryStringBuilder extends AbstractQueryBuilder<SimpleQuerySt
 
     @Override
     public int hashCode() {
-        return Objects.hash(fieldsAndWeights, analyzer, defaultOperator, queryText, queryName, minimumShouldMatch, settings);
+        return Objects.hash(fieldsAndWeights, analyzer, defaultOperator, queryText, queryName, minimumShouldMatch, settings, flags);
     }
 
     @Override
@@ -438,7 +435,7 @@ public class SimpleQueryStringBuilder extends AbstractQueryBuilder<SimpleQuerySt
         return Objects.equals(fieldsAndWeights, other.fieldsAndWeights) && Objects.equals(analyzer, other.analyzer)
                 && Objects.equals(defaultOperator, other.defaultOperator) && Objects.equals(queryText, other.queryText)
                 && Objects.equals(queryName, other.queryName) && Objects.equals(minimumShouldMatch, other.minimumShouldMatch)
-                && Objects.equals(settings, other.settings);
+                && Objects.equals(settings, other.settings) && (flags == other.flags);
     }
 }
 

--- a/core/src/main/java/org/elasticsearch/index/query/SimpleQueryStringParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SimpleQueryStringParser.java
@@ -80,14 +80,14 @@ public class SimpleQueryStringParser extends BaseQueryParser {
 
         String currentFieldName = null;
         String queryBody = null;
-        float boost = 1.0f; 
+        float boost = 1.0f;
         String queryName = null;
         String field = null;
         String minimumShouldMatch = null;
         Map<String, Float> fieldsAndWeights = new HashMap<>();
         Operator defaultOperator = null;
         String analyzerName = null;
-        int flags = -1;
+        int flags = SimpleQueryStringFlag.ALL.value();
         boolean lenient = SimpleQueryStringBuilder.DEFAULT_LENIENT;
         boolean lowercaseExpandedTerms = SimpleQueryStringBuilder.DEFAULT_LOWERCASE_EXPANDED_TERMS;
         boolean analyzeWildcard = SimpleQueryStringBuilder.DEFAULT_ANALYZE_WILDCARD;

--- a/core/src/main/java/org/elasticsearch/index/query/SpanTermQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanTermQueryParser.java
@@ -89,7 +89,6 @@ public class SpanTermQueryParser extends BaseQueryParser {
 
         SpanTermQueryBuilder result = new SpanTermQueryBuilder(fieldName, value);
         result.boost(boost).queryName(queryName);
-        result.validate();
         return result;
     }
 

--- a/core/src/main/java/org/elasticsearch/index/query/TermQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/TermQueryParser.java
@@ -88,13 +88,10 @@ public class TermQueryParser extends BaseQueryParser {
         }
 
         TermQueryBuilder termQuery = new TermQueryBuilder(fieldName, value);
-        if (boost != 1.0f) {
-            termQuery.boost(boost);
-        }
+        termQuery.boost(boost);
         if (queryName != null) {
             termQuery.queryName(queryName);
         }
-        termQuery.validate();
         return termQuery;
     }
 

--- a/core/src/test/java/org/elasticsearch/index/query/SimpleQueryStringBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SimpleQueryStringBuilderTest.java
@@ -21,12 +21,9 @@ package org.elasticsearch.index.query;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.search.BooleanClause;
-import org.apache.lucene.search.BooleanQuery;
-import org.apache.lucene.search.MatchNoDocsQuery;
-import org.apache.lucene.search.Query;
-import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.BooleanClause.Occur;
-import org.elasticsearch.common.Strings;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.Query;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.index.query.SimpleQueryParser.Settings;
 import org.junit.Test;
@@ -38,7 +35,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 
 public class SimpleQueryStringBuilderTest extends BaseQueryTestCase<SimpleQueryStringBuilder> {
 
@@ -134,7 +133,7 @@ public class SimpleQueryStringBuilderTest extends BaseQueryTestCase<SimpleQueryS
     public void testDefaultNullLocale() {
         SimpleQueryStringBuilder qb = new SimpleQueryStringBuilder("The quick brown fox.");
         qb.locale(null);
-        assertEquals("Setting locale to null should result in returning to default value.", 
+        assertEquals("Setting locale to null should result in returning to default value.",
                 SimpleQueryStringBuilder.DEFAULT_LOCALE, qb.locale());
     }
 
@@ -142,7 +141,7 @@ public class SimpleQueryStringBuilderTest extends BaseQueryTestCase<SimpleQueryS
     public void testDefaultNullComplainFlags() {
         SimpleQueryStringBuilder qb = new SimpleQueryStringBuilder("The quick brown fox.");
         qb.flags((SimpleQueryStringFlag[]) null);
-        assertEquals("Setting flags to null should result in returning to default value.", 
+        assertEquals("Setting flags to null should result in returning to default value.",
                 SimpleQueryStringBuilder.DEFAULT_FLAGS, qb.flags());
     }
 
@@ -158,7 +157,7 @@ public class SimpleQueryStringBuilderTest extends BaseQueryTestCase<SimpleQueryS
     public void testDefaultNullComplainOp() {
         SimpleQueryStringBuilder qb = new SimpleQueryStringBuilder("The quick brown fox.");
         qb.defaultOperator(null);
-        assertEquals("Setting operator to null should result in returning to default value.", 
+        assertEquals("Setting operator to null should result in returning to default value.",
                 SimpleQueryStringBuilder.DEFAULT_OPERATOR, qb.defaultOperator());
     }
 
@@ -285,9 +284,6 @@ public class SimpleQueryStringBuilderTest extends BaseQueryTestCase<SimpleQueryS
         }
 
         Query query = sqp.parse(queryBuilder.text());
-        if (queryBuilder.queryName() != null) {
-            context.addNamedQuery(queryBuilder.queryName(), query);
-        }
 
         if (queryBuilder.minimumShouldMatch() != null && query instanceof BooleanQuery) {
             Queries.applyMinimumShouldMatch((BooleanQuery) query, queryBuilder.minimumShouldMatch());


### PR DESCRIPTION
Revisited the queries we already refactored, corrected and aligned some of the codebase based on the conventions that we decided to follow. Also including some cosmetic fixes (making members final where possible, avoiding this references outside of setters/getters).
In addition to that this PR changes:
- preventing NPEs in doXContent when rendering out nested queries that are `null`. We now render out empty object (`{ }`) which then gets parser to `null` to be consistent with queries than come only through the rest layer
- prevent adding nested `null` queries to collections of clauses like in BoolQueryBuilder
- add validate() method to all builders (even when empty)

This PR is against the query-refactoring branch.
