### PR TITLE
Fix FieldDataTermsFilter.equals.

### DIFF
--- a/src/main/java/org/elasticsearch/index/search/FieldDataTermsFilter.java
+++ b/src/main/java/org/elasticsearch/index/search/FieldDataTermsFilter.java
@@ -178,7 +178,7 @@ public abstract class FieldDataTermsFilter extends Filter {
             if (super.equals(obj) == false) {
                 return false;
             }
-            return terms.equals(((BytesFieldDataFilter) obj).terms);
+            return terms.equals(((LongsFieldDataFilter) obj).terms);
         }
 
         @Override
@@ -245,7 +245,7 @@ public abstract class FieldDataTermsFilter extends Filter {
             if (super.equals(obj) == false) {
                 return false;
             }
-            return terms.equals(((BytesFieldDataFilter) obj).terms);
+            return terms.equals(((DoublesFieldDataFilter) obj).terms);
         }
 
         @Override

--- a/src/test/java/org/elasticsearch/index/search/FieldDataTermsFilterTests.java
+++ b/src/test/java/org/elasticsearch/index/search/FieldDataTermsFilterTests.java
@@ -169,6 +169,10 @@ public class FieldDataTermsFilterTests extends ElasticsearchSingleNodeTest {
         hFilter = FieldDataTermsFilter.newBytes(getFieldData(dblMapper), hTerms);
         result.or(hFilter.getDocIdSet(reader.getContext(), reader.getLiveDocs()).iterator());
         assertThat(result.cardinality(), equalTo(0));
+
+        assertEquals(
+                FieldDataTermsFilter.newBytes(getFieldData(strMapper), hTerms),
+                FieldDataTermsFilter.newBytes(getFieldData(strMapper), hTerms));
     }
 
     @Test
@@ -208,6 +212,10 @@ public class FieldDataTermsFilterTests extends ElasticsearchSingleNodeTest {
 
         hFilter = FieldDataTermsFilter.newLongs(getFieldData(dblMapper), hTerms);
         assertNull(hFilter.getDocIdSet(reader.getContext(), reader.getLiveDocs()));
+
+        assertEquals(
+                FieldDataTermsFilter.newLongs(getFieldData(lngMapper), hTerms),
+                FieldDataTermsFilter.newLongs(getFieldData(lngMapper), hTerms));
     }
 
     @Test
@@ -247,6 +255,10 @@ public class FieldDataTermsFilterTests extends ElasticsearchSingleNodeTest {
 
         hFilter = FieldDataTermsFilter.newDoubles(getFieldData(lngMapper), hTerms);
         assertNull(hFilter.getDocIdSet(reader.getContext(), reader.getLiveDocs()));
+
+        assertEquals(
+                FieldDataTermsFilter.newDoubles(getFieldData(dblMapper), hTerms),
+                FieldDataTermsFilter.newDoubles(getFieldData(dblMapper), hTerms));
     }
 
     @Test


### PR DESCRIPTION
DoublesFieldDataFilter and LongsFieldDataFilter were performing casts against
the wrong class.

Close #11779
