### PR TITLE
Fix endless looping if starting fails

### DIFF
--- a/core/src/packaging/deb/init.d/elasticsearch
+++ b/core/src/packaging/deb/init.d/elasticsearch
@@ -184,7 +184,10 @@ case "$1" in
 		do
 			sleep 1
 			i=$(($i + 1))
-			[ $i -gt $timeout ] && log_end_msg 1
+			if [ $i -gt $timeout ]; then
+				log_end_msg 1
+				exit 1
+			fi
 		done
 	else
 		log_end_msg $return


### PR DESCRIPTION
log_end_msg does not break the loop or exit the script results in endlessly printing 'failed' in red to the screen in case of a failed start.
