### PR TITLE
Aborting snapshot might not abort snapshot of shards in very early stages in the snapshot process

### DIFF
--- a/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardRepository.java
+++ b/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardRepository.java
@@ -493,6 +493,11 @@ public class BlobStoreIndexShardRepository extends AbstractComponent implements 
 
                 snapshotStatus.files(indexNumberOfFiles, indexTotalFilesSize);
 
+                if (snapshotStatus.aborted()) {
+                    logger.debug("[{}] [{}] Aborted during initialization", shardId, snapshotId);
+                    throw new IndexShardSnapshotFailedException(shardId, "Aborted");
+                }
+
                 snapshotStatus.updateStage(IndexShardSnapshotStatus.Stage.STARTED);
 
                 for (FileInfo snapshotFileInfo : filesToSnapshot) {


### PR DESCRIPTION
If the abort command is issued very early in shard snapshot lifecycle, it might not cancel this shard. This commit backports the change discovered and fixed as part of #11756.
