### PR TITLE
Java api: remove duplicated Operator enums from different queries

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/MatchQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MatchQueryBuilder.java
@@ -33,11 +33,6 @@ public class MatchQueryBuilder extends AbstractQueryBuilder<MatchQueryBuilder> i
 
     public static final String NAME = "match";
 
-    public enum Operator {
-        OR,
-        AND
-    }
-
     public enum Type {
         /**
          * The text is analyzed and terms are added to a boolean query.

--- a/core/src/main/java/org/elasticsearch/index/query/MatchQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MatchQueryParser.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.index.query;
 
 import org.apache.lucene.queries.ExtendedCommonTermsQuery;
-import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.inject.Inject;
@@ -110,15 +109,7 @@ public class MatchQueryParser extends BaseQueryParserTemp {
                     } else if ("max_expansions".equals(currentFieldName) || "maxExpansions".equals(currentFieldName)) {
                         matchQuery.setMaxExpansions(parser.intValue());
                     } else if ("operator".equals(currentFieldName)) {
-                        String op = parser.text();
-                        if ("or".equalsIgnoreCase(op)) {
-                            matchQuery.setOccur(BooleanClause.Occur.SHOULD);
-                        } else if ("and".equalsIgnoreCase(op)) {
-                            matchQuery.setOccur(BooleanClause.Occur.MUST);
-                        } else {
-                            throw new QueryParsingException(parseContext, "text query requires operator to be either 'and' or 'or', not ["
-                                    + op + "]");
-                        }
+                        matchQuery.setOccur(Operator.fromString(parser.text()).toBooleanClauseOccur());
                     } else if ("minimum_should_match".equals(currentFieldName) || "minimumShouldMatch".equals(currentFieldName)) {
                         minimumShouldMatch = parser.textOrNull();
                     } else if ("rewrite".equals(currentFieldName)) {

--- a/core/src/main/java/org/elasticsearch/index/query/MultiMatchQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MultiMatchQueryBuilder.java
@@ -48,7 +48,7 @@ public class MultiMatchQueryBuilder extends AbstractQueryBuilder<MultiMatchQuery
 
     private MultiMatchQueryBuilder.Type type;
 
-    private MatchQueryBuilder.Operator operator;
+    private Operator operator;
 
     private String analyzer;
 
@@ -205,7 +205,7 @@ public class MultiMatchQueryBuilder extends AbstractQueryBuilder<MultiMatchQuery
     /**
      * Sets the operator to use when using a boolean query. Defaults to <tt>OR</tt>.
      */
-    public MultiMatchQueryBuilder operator(MatchQueryBuilder.Operator operator) {
+    public MultiMatchQueryBuilder operator(Operator operator) {
         this.operator = operator;
         return this;
     }

--- a/core/src/main/java/org/elasticsearch/index/query/MultiMatchQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MultiMatchQueryParser.java
@@ -21,7 +21,6 @@ package org.elasticsearch.index.query;
 
 import com.google.common.collect.Maps;
 
-import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.regex.Regex;
@@ -100,15 +99,7 @@ public class MultiMatchQueryParser extends BaseQueryParserTemp {
                 } else if ("max_expansions".equals(currentFieldName) || "maxExpansions".equals(currentFieldName)) {
                     multiMatchQuery.setMaxExpansions(parser.intValue());
                 } else if ("operator".equals(currentFieldName)) {
-                    String op = parser.text();
-                    if ("or".equalsIgnoreCase(op)) {
-                        multiMatchQuery.setOccur(BooleanClause.Occur.SHOULD);
-                    } else if ("and".equalsIgnoreCase(op)) {
-                        multiMatchQuery.setOccur(BooleanClause.Occur.MUST);
-                    } else {
-                        throw new QueryParsingException(parseContext, "text query requires operator to be either 'and' or 'or', not [" + op
-                                + "]");
-                    }
+                    multiMatchQuery.setOccur(Operator.fromString(parser.text()).toBooleanClauseOccur());
                 } else if ("minimum_should_match".equals(currentFieldName) || "minimumShouldMatch".equals(currentFieldName)) {
                     minimumShouldMatch = parser.textOrNull();
                 } else if ("rewrite".equals(currentFieldName)) {

--- a/core/src/main/java/org/elasticsearch/index/query/Operator.java
+++ b/core/src/main/java/org/elasticsearch/index/query/Operator.java
@@ -27,7 +27,7 @@ import org.elasticsearch.common.io.stream.Writeable;
 
 import java.io.IOException;
 
-public enum Operator implements Writeable {
+public enum Operator implements Writeable<Operator> {
     OR(0), AND(1);
 
     private final int ordinal;

--- a/core/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
@@ -42,11 +42,6 @@ public class QueryStringQueryBuilder extends AbstractQueryBuilder<QueryStringQue
 
     public static final String NAME = "query_string";
 
-    public enum Operator {
-        OR,
-        AND
-    }
-
     private final String queryString;
 
     private String defaultField;

--- a/core/src/main/java/org/elasticsearch/index/query/SimpleQueryStringParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SimpleQueryStringParser.java
@@ -25,7 +25,6 @@ import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.query.SimpleQueryStringBuilder.Operator;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -145,14 +144,7 @@ public class SimpleQueryStringParser extends BaseQueryParser {
                 } else if ("field".equals(currentFieldName)) {
                     field = parser.text();
                 } else if ("default_operator".equals(currentFieldName) || "defaultOperator".equals(currentFieldName)) {
-                    String op = parser.text();
-                    if ("or".equalsIgnoreCase(op)) {
-                        defaultOperator = Operator.OR;
-                    } else if ("and".equalsIgnoreCase(op)) {
-                        defaultOperator = Operator.AND;
-                    } else {
-                        throw new QueryParsingException(parseContext, "[" + SimpleQueryStringBuilder.NAME + "] default operator [" + op + "] is not allowed");
-                    }
+                    defaultOperator = Operator.fromString(parser.text());
                 } else if ("flags".equals(currentFieldName)) {
                     if (parser.currentToken() != XContentParser.Token.VALUE_NUMBER) {
                         // Possible options are:

--- a/core/src/main/java/org/elasticsearch/rest/action/explain/RestExplainAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/explain/RestExplainAction.java
@@ -30,6 +30,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentBuilderString;
 import org.elasticsearch.index.get.GetResult;
+import org.elasticsearch.index.query.Operator;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.QueryStringQueryBuilder;
 import org.elasticsearch.rest.*;
@@ -74,13 +75,7 @@ public class RestExplainAction extends BaseRestHandler {
             queryStringBuilder.lenient(request.paramAsBoolean("lenient", null));
             String defaultOperator = request.param("default_operator");
             if (defaultOperator != null) {
-                if ("OR".equals(defaultOperator)) {
-                    queryStringBuilder.defaultOperator(QueryStringQueryBuilder.Operator.OR);
-                } else if ("AND".equals(defaultOperator)) {
-                    queryStringBuilder.defaultOperator(QueryStringQueryBuilder.Operator.AND);
-                } else {
-                    throw new IllegalArgumentException("Unsupported defaultOperator [" + defaultOperator + "], can either be [OR] or [AND]");
-                }
+                queryStringBuilder.defaultOperator(Operator.fromString(defaultOperator));
             }
 
             QuerySourceBuilder querySourceBuilder = new QuerySourceBuilder();

--- a/core/src/main/java/org/elasticsearch/rest/action/support/RestActions.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/support/RestActions.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.lucene.uid.Versions;
 import org.elasticsearch.common.xcontent.*;
+import org.elasticsearch.index.query.Operator;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.QueryStringQueryBuilder;
 import org.elasticsearch.rest.RestRequest;
@@ -97,13 +98,7 @@ public class RestActions {
         queryBuilder.lenient(request.paramAsBoolean("lenient", null));
         String defaultOperator = request.param("default_operator");
         if (defaultOperator != null) {
-            if ("OR".equals(defaultOperator)) {
-                queryBuilder.defaultOperator(QueryStringQueryBuilder.Operator.OR);
-            } else if ("AND".equals(defaultOperator)) {
-                queryBuilder.defaultOperator(QueryStringQueryBuilder.Operator.AND);
-            } else {
-                throw new IllegalArgumentException("Unsupported defaultOperator [" + defaultOperator + "], can either be [OR] or [AND]");
-            }
+            queryBuilder.defaultOperator(Operator.fromString(defaultOperator));
         }
         return new QuerySourceBuilder().setQuery(queryBuilder);
     }

--- a/core/src/test/java/org/elasticsearch/index/query/SimpleQueryStringBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SimpleQueryStringBuilderTest.java
@@ -29,7 +29,6 @@ import org.apache.lucene.search.BooleanClause.Occur;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.index.query.SimpleQueryParser.Settings;
-import org.elasticsearch.index.query.SimpleQueryStringBuilder.Operator;
 import org.junit.Test;
 
 import java.io.IOException;

--- a/core/src/test/java/org/elasticsearch/percolator/MultiPercolatorTests.java
+++ b/core/src/test/java/org/elasticsearch/percolator/MultiPercolatorTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.client.Requests;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.query.MatchQueryBuilder;
+import org.elasticsearch.index.query.Operator;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.junit.Test;
@@ -360,7 +361,7 @@ public class MultiPercolatorTests extends ElasticsearchIntegrationTest {
         ensureGreen("nestedindex");
 
         client().prepareIndex("nestedindex", PercolatorService.TYPE_NAME, "Q").setSource(jsonBuilder().startObject()
-                .field("query", QueryBuilders.nestedQuery("employee", QueryBuilders.matchQuery("employee.name", "virginia potts").operator(MatchQueryBuilder.Operator.AND)).scoreMode("avg")).endObject()).get();
+                .field("query", QueryBuilders.nestedQuery("employee", QueryBuilders.matchQuery("employee.name", "virginia potts").operator(Operator.AND)).scoreMode("avg")).endObject()).get();
 
         refresh();
 

--- a/core/src/test/java/org/elasticsearch/percolator/PercolatorTests.java
+++ b/core/src/test/java/org/elasticsearch/percolator/PercolatorTests.java
@@ -42,6 +42,7 @@ import org.elasticsearch.index.engine.DocumentMissingException;
 import org.elasticsearch.index.engine.VersionConflictEngineException;
 import org.elasticsearch.index.percolator.PercolatorException;
 import org.elasticsearch.index.query.MatchQueryBuilder;
+import org.elasticsearch.index.query.Operator;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.QueryParsingException;
 import org.elasticsearch.index.query.functionscore.factor.FactorBuilder;
@@ -1844,7 +1845,7 @@ public class PercolatorTests extends ElasticsearchIntegrationTest {
         ensureGreen("nestedindex");
 
         client().prepareIndex("nestedindex", PercolatorService.TYPE_NAME, "Q").setSource(jsonBuilder().startObject()
-                .field("query", QueryBuilders.nestedQuery("employee", QueryBuilders.matchQuery("employee.name", "virginia potts").operator(MatchQueryBuilder.Operator.AND)).scoreMode("avg")).endObject()).get();
+                .field("query", QueryBuilders.nestedQuery("employee", QueryBuilders.matchQuery("employee.name", "virginia potts").operator(Operator.AND)).scoreMode("avg")).endObject()).get();
 
         refresh();
 

--- a/core/src/test/java/org/elasticsearch/search/highlight/HighlighterSearchTests.java
+++ b/core/src/test/java/org/elasticsearch/search/highlight/HighlighterSearchTests.java
@@ -29,7 +29,6 @@ import org.elasticsearch.common.settings.Settings.Builder;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.query.*;
-import org.elasticsearch.index.query.MatchQueryBuilder.Operator;
 import org.elasticsearch.index.query.MatchQueryBuilder.Type;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.SearchHit;

--- a/core/src/test/java/org/elasticsearch/search/query/MultiMatchQueryTests.java
+++ b/core/src/test/java/org/elasticsearch/search/query/MultiMatchQueryTests.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.query.MatchQueryBuilder;
 import org.elasticsearch.index.query.MultiMatchQueryBuilder;
+import org.elasticsearch.index.query.Operator;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
@@ -154,7 +155,7 @@ public class MultiMatchQueryTests extends ElasticsearchIntegrationTest {
         MatchQueryBuilder.Type type = randomBoolean() ? null : MatchQueryBuilder.Type.BOOLEAN;
         SearchResponse searchResponse = client().prepareSearch("test")
                 .setQuery(randomizeType(multiMatchQuery("marvel hero captain america", "full_name", "first_name", "last_name", "category")
-                        .operator(MatchQueryBuilder.Operator.OR))).get();
+                        .operator(Operator.OR))).get();
         Set<String> topNIds = Sets.newHashSet("theone", "theother");
         for (int i = 0; i < searchResponse.getHits().hits().length; i++) {
             topNIds.remove(searchResponse.getHits().getAt(i).getId());
@@ -166,25 +167,25 @@ public class MultiMatchQueryTests extends ElasticsearchIntegrationTest {
 
         searchResponse = client().prepareSearch("test")
                 .setQuery(randomizeType(multiMatchQuery("marvel hero captain america", "full_name", "first_name", "last_name", "category")
-                        .operator(MatchQueryBuilder.Operator.OR).useDisMax(false).type(type))).get();
+                        .operator(Operator.OR).useDisMax(false).type(type))).get();
         assertFirstHit(searchResponse, anyOf(hasId("theone"), hasId("theother")));
         assertThat(searchResponse.getHits().hits()[0].getScore(), greaterThan(searchResponse.getHits().hits()[1].getScore()));
 
         searchResponse = client().prepareSearch("test")
                 .setQuery(randomizeType(multiMatchQuery("marvel hero", "full_name", "first_name", "last_name", "category")
-                        .operator(MatchQueryBuilder.Operator.OR).type(type))).get();
+                        .operator(Operator.OR).type(type))).get();
         assertFirstHit(searchResponse, hasId("theother"));
 
 
         searchResponse = client().prepareSearch("test")
                 .setQuery(randomizeType(multiMatchQuery("captain america", "full_name", "first_name", "last_name", "category")
-                        .operator(MatchQueryBuilder.Operator.AND).type(type))).get();
+                        .operator(Operator.AND).type(type))).get();
         assertHitCount(searchResponse, 1l);
         assertFirstHit(searchResponse, hasId("theone"));
 
         searchResponse = client().prepareSearch("test")
                 .setQuery(randomizeType(multiMatchQuery("captain america", "full_name", "first_name", "last_name", "category")
-                        .operator(MatchQueryBuilder.Operator.AND).type(type))).get();
+                        .operator(Operator.AND).type(type))).get();
         assertHitCount(searchResponse, 1l);
         assertFirstHit(searchResponse, hasId("theone"));
     }
@@ -193,18 +194,18 @@ public class MultiMatchQueryTests extends ElasticsearchIntegrationTest {
     public void testPhraseType() {
         SearchResponse searchResponse = client().prepareSearch("test")
                 .setQuery(randomizeType(multiMatchQuery("Man the Ultimate", "full_name_phrase", "first_name_phrase", "last_name_phrase", "category_phrase")
-                        .operator(MatchQueryBuilder.Operator.OR).type(MatchQueryBuilder.Type.PHRASE))).get();
+                        .operator(Operator.OR).type(MatchQueryBuilder.Type.PHRASE))).get();
         assertFirstHit(searchResponse, hasId("ultimate2"));
         assertHitCount(searchResponse, 1l);
 
         searchResponse = client().prepareSearch("test")
                 .setQuery(randomizeType(multiMatchQuery("Captain", "full_name_phrase", "first_name_phrase", "last_name_phrase", "category_phrase")
-                        .operator(MatchQueryBuilder.Operator.OR).type(MatchQueryBuilder.Type.PHRASE))).get();
+                        .operator(Operator.OR).type(MatchQueryBuilder.Type.PHRASE))).get();
         assertThat(searchResponse.getHits().getTotalHits(), greaterThan(1l));
 
         searchResponse = client().prepareSearch("test")
                 .setQuery(randomizeType(multiMatchQuery("the Ul", "full_name_phrase", "first_name_phrase", "last_name_phrase", "category_phrase")
-                        .operator(MatchQueryBuilder.Operator.OR).type(MatchQueryBuilder.Type.PHRASE_PREFIX))).get();
+                        .operator(Operator.OR).type(MatchQueryBuilder.Type.PHRASE_PREFIX))).get();
         assertSearchHits(searchResponse, "ultimate2", "ultimate1");
         assertHitCount(searchResponse, 2l);
     }
@@ -263,7 +264,7 @@ public class MultiMatchQueryTests extends ElasticsearchIntegrationTest {
         Float cutoffFrequency = randomBoolean() ? Math.min(1, numDocs * 1.f / between(10, 20)) : 1.f / between(10, 20);
         SearchResponse searchResponse = client().prepareSearch("test")
                 .setQuery(randomizeType(multiMatchQuery("marvel hero captain america", "full_name", "first_name", "last_name", "category")
-                        .operator(MatchQueryBuilder.Operator.OR).cutoffFrequency(cutoffFrequency))).get();
+                        .operator(Operator.OR).cutoffFrequency(cutoffFrequency))).get();
         Set<String> topNIds = Sets.newHashSet("theone", "theother");
         for (int i = 0; i < searchResponse.getHits().hits().length; i++) {
             topNIds.remove(searchResponse.getHits().getAt(i).getId());
@@ -276,39 +277,39 @@ public class MultiMatchQueryTests extends ElasticsearchIntegrationTest {
         cutoffFrequency = randomBoolean() ? Math.min(1, numDocs * 1.f / between(10, 20)) : 1.f / between(10, 20);
         searchResponse = client().prepareSearch("test")
                 .setQuery(randomizeType(multiMatchQuery("marvel hero captain america", "full_name", "first_name", "last_name", "category")
-                        .operator(MatchQueryBuilder.Operator.OR).useDisMax(false).cutoffFrequency(cutoffFrequency).type(type))).get();
+                        .operator(Operator.OR).useDisMax(false).cutoffFrequency(cutoffFrequency).type(type))).get();
         assertFirstHit(searchResponse, anyOf(hasId("theone"), hasId("theother")));
         assertThat(searchResponse.getHits().hits()[0].getScore(), greaterThan(searchResponse.getHits().hits()[1].getScore()));
         long size = searchResponse.getHits().getTotalHits();
 
         searchResponse = client().prepareSearch("test")
                 .setQuery(randomizeType(multiMatchQuery("marvel hero captain america", "full_name", "first_name", "last_name", "category")
-                        .operator(MatchQueryBuilder.Operator.OR).useDisMax(false).type(type))).get();
+                        .operator(Operator.OR).useDisMax(false).type(type))).get();
         assertFirstHit(searchResponse, anyOf(hasId("theone"), hasId("theother")));
         assertThat("common terms expected to be a way smaller result set", size, lessThan(searchResponse.getHits().getTotalHits()));
 
         cutoffFrequency = randomBoolean() ? Math.min(1, numDocs * 1.f / between(10, 20)) : 1.f / between(10, 20);
         searchResponse = client().prepareSearch("test")
                 .setQuery(randomizeType(multiMatchQuery("marvel hero", "full_name", "first_name", "last_name", "category")
-                        .operator(MatchQueryBuilder.Operator.OR).cutoffFrequency(cutoffFrequency).type(type))).get();
+                        .operator(Operator.OR).cutoffFrequency(cutoffFrequency).type(type))).get();
         assertFirstHit(searchResponse, hasId("theother"));
 
 
         searchResponse = client().prepareSearch("test")
                 .setQuery(randomizeType(multiMatchQuery("captain america", "full_name", "first_name", "last_name", "category")
-                        .operator(MatchQueryBuilder.Operator.AND).cutoffFrequency(cutoffFrequency).type(type))).get();
+                        .operator(Operator.AND).cutoffFrequency(cutoffFrequency).type(type))).get();
         assertHitCount(searchResponse, 1l);
         assertFirstHit(searchResponse, hasId("theone"));
 
         searchResponse = client().prepareSearch("test")
                 .setQuery(randomizeType(multiMatchQuery("captain america", "full_name", "first_name", "last_name", "category")
-                        .operator(MatchQueryBuilder.Operator.AND).cutoffFrequency(cutoffFrequency).type(type))).get();
+                        .operator(Operator.AND).cutoffFrequency(cutoffFrequency).type(type))).get();
         assertHitCount(searchResponse, 1l);
         assertFirstHit(searchResponse, hasId("theone"));
 
         searchResponse = client().prepareSearch("test")
                 .setQuery(randomizeType(multiMatchQuery("marvel hero", "first_name", "last_name", "category")
-                        .operator(MatchQueryBuilder.Operator.AND).cutoffFrequency(cutoffFrequency)
+                        .operator(Operator.AND).cutoffFrequency(cutoffFrequency)
                         .analyzer("category")
                         .type(MultiMatchQueryBuilder.Type.CROSS_FIELDS))).get();
         assertHitCount(searchResponse, 1l);
@@ -330,7 +331,7 @@ public class MultiMatchQueryTests extends ElasticsearchIntegrationTest {
                 SearchResponse left = client().prepareSearch("test").setSize(numDocs)
                         .addSort(SortBuilders.scoreSort()).addSort(SortBuilders.fieldSort("_uid"))
                         .setQuery(randomizeType(multiMatchQueryBuilder
-                                .operator(MatchQueryBuilder.Operator.OR).type(type))).get();
+                                .operator(Operator.OR).type(type))).get();
 
                 SearchResponse right = client().prepareSearch("test").setSize(numDocs)
                         .addSort(SortBuilders.scoreSort()).addSort(SortBuilders.fieldSort("_uid"))
@@ -346,7 +347,7 @@ public class MultiMatchQueryTests extends ElasticsearchIntegrationTest {
             {
                 MatchQueryBuilder.Type type = randomBoolean() ? null : MatchQueryBuilder.Type.BOOLEAN;
                 String minShouldMatch = randomBoolean() ? null : "" + between(0, 1);
-                MatchQueryBuilder.Operator op = randomBoolean() ? MatchQueryBuilder.Operator.AND : MatchQueryBuilder.Operator.OR;
+                Operator op = randomBoolean() ? Operator.AND : Operator.OR;
                 MultiMatchQueryBuilder multiMatchQueryBuilder = randomBoolean() ? multiMatchQuery("captain america", "full_name", "first_name", "last_name", "category") :
                         multiMatchQuery("captain america", "*_name", randomBoolean() ? "category" : "categ*");
                 SearchResponse left = client().prepareSearch("test").setSize(numDocs)
@@ -367,7 +368,7 @@ public class MultiMatchQueryTests extends ElasticsearchIntegrationTest {
 
             {
                 String minShouldMatch = randomBoolean() ? null : "" + between(0, 1);
-                MatchQueryBuilder.Operator op = randomBoolean() ? MatchQueryBuilder.Operator.AND : MatchQueryBuilder.Operator.OR;
+                Operator op = randomBoolean() ? Operator.AND : Operator.OR;
                 SearchResponse left = client().prepareSearch("test").setSize(numDocs)
                         .addSort(SortBuilders.scoreSort()).addSort(SortBuilders.fieldSort("_uid"))
                         .setQuery(randomizeType(multiMatchQuery("capta", "full_name", "first_name", "last_name", "category")
@@ -385,7 +386,7 @@ public class MultiMatchQueryTests extends ElasticsearchIntegrationTest {
             }
             {
                 String minShouldMatch = randomBoolean() ? null : "" + between(0, 1);
-                MatchQueryBuilder.Operator op = randomBoolean() ? MatchQueryBuilder.Operator.AND : MatchQueryBuilder.Operator.OR;
+                Operator op = randomBoolean() ? Operator.AND : Operator.OR;
                 SearchResponse left;
                 if (randomBoolean()) {
                     left = client().prepareSearch("test").setSize(numDocs)
@@ -416,13 +417,13 @@ public class MultiMatchQueryTests extends ElasticsearchIntegrationTest {
         SearchResponse searchResponse = client().prepareSearch("test")
                 .setQuery(randomizeType(multiMatchQuery("captain america", "full_name", "first_name", "last_name")
                         .type(MultiMatchQueryBuilder.Type.CROSS_FIELDS)
-                        .operator(MatchQueryBuilder.Operator.OR))).get();
+                        .operator(Operator.OR))).get();
         assertFirstHit(searchResponse, hasId("theone"));
 
         searchResponse = client().prepareSearch("test")
                 .setQuery(randomizeType(multiMatchQuery("marvel hero captain america", "full_name", "first_name", "last_name", "category")
                         .type(MultiMatchQueryBuilder.Type.CROSS_FIELDS)
-                        .operator(MatchQueryBuilder.Operator.OR))).get();
+                        .operator(Operator.OR))).get();
         assertFirstHit(searchResponse, hasId("theone"));
         assertSecondHit(searchResponse, hasId("theother"));
         assertThat(searchResponse.getHits().hits()[0].getScore(), greaterThan(searchResponse.getHits().hits()[1].getScore()));
@@ -430,13 +431,13 @@ public class MultiMatchQueryTests extends ElasticsearchIntegrationTest {
         searchResponse = client().prepareSearch("test")
                 .setQuery(randomizeType(multiMatchQuery("marvel hero", "full_name", "first_name", "last_name", "category")
                         .type(MultiMatchQueryBuilder.Type.CROSS_FIELDS)
-                        .operator(MatchQueryBuilder.Operator.OR))).get();
+                        .operator(Operator.OR))).get();
         assertFirstHit(searchResponse, hasId("theother"));
 
         searchResponse = client().prepareSearch("test")
                 .setQuery(randomizeType(multiMatchQuery("captain america", "full_name", "first_name", "last_name", "category")
                         .type(MultiMatchQueryBuilder.Type.CROSS_FIELDS)
-                        .operator(MatchQueryBuilder.Operator.AND))).get();
+                        .operator(Operator.AND))).get();
         assertHitCount(searchResponse, 1l);
         assertFirstHit(searchResponse, hasId("theone"));
 
@@ -444,7 +445,7 @@ public class MultiMatchQueryTests extends ElasticsearchIntegrationTest {
                 .setQuery(randomizeType(multiMatchQuery("captain america 15", "full_name", "first_name", "last_name", "category", "skill")
                         .type(MultiMatchQueryBuilder.Type.CROSS_FIELDS)
                         .analyzer("category")
-                        .operator(MatchQueryBuilder.Operator.AND))).get();
+                        .operator(Operator.AND))).get();
         assertHitCount(searchResponse, 1l);
         assertFirstHit(searchResponse, hasId("theone"));
 
@@ -465,7 +466,7 @@ public class MultiMatchQueryTests extends ElasticsearchIntegrationTest {
                         .type(MultiMatchQueryBuilder.Type.CROSS_FIELDS)
                         .cutoffFrequency(0.1f)
                         .analyzer("category")
-                        .operator(MatchQueryBuilder.Operator.OR))).get();
+                        .operator(Operator.OR))).get();
         assertFirstHit(searchResponse, anyOf(hasId("theother"), hasId("theone")));
         long numResults = searchResponse.getHits().totalHits();
 
@@ -473,7 +474,7 @@ public class MultiMatchQueryTests extends ElasticsearchIntegrationTest {
                 .setQuery(randomizeType(multiMatchQuery("captain america marvel hero", "first_name", "last_name", "category")
                         .type(MultiMatchQueryBuilder.Type.CROSS_FIELDS)
                         .analyzer("category")
-                        .operator(MatchQueryBuilder.Operator.OR))).get();
+                        .operator(Operator.OR))).get();
         assertThat(numResults, lessThan(searchResponse.getHits().getTotalHits()));
         assertFirstHit(searchResponse, hasId("theone"));
 
@@ -483,28 +484,28 @@ public class MultiMatchQueryTests extends ElasticsearchIntegrationTest {
                 .setQuery(randomizeType(multiMatchQuery("captain america marvel hero", "first_name", "last_name", "category")
                         .type(MultiMatchQueryBuilder.Type.CROSS_FIELDS)
                         .analyzer("category")
-                        .operator(MatchQueryBuilder.Operator.AND))).get();
+                        .operator(Operator.AND))).get();
         assertHitCount(searchResponse, 1l);
         assertFirstHit(searchResponse, hasId("theone"));
         // counter example
         searchResponse = client().prepareSearch("test")
                 .setQuery(randomizeType(multiMatchQuery("captain america marvel hero", "first_name", "last_name", "category")
                         .type(randomBoolean() ? MultiMatchQueryBuilder.Type.CROSS_FIELDS : null)
-                        .operator(MatchQueryBuilder.Operator.AND))).get();
+                        .operator(Operator.AND))).get();
         assertHitCount(searchResponse, 0l);
 
         // counter example
         searchResponse = client().prepareSearch("test")
                 .setQuery(randomizeType(multiMatchQuery("captain america marvel hero", "first_name", "last_name", "category")
                         .type(randomBoolean() ? MultiMatchQueryBuilder.Type.CROSS_FIELDS : null)
-                        .operator(MatchQueryBuilder.Operator.AND))).get();
+                        .operator(Operator.AND))).get();
         assertHitCount(searchResponse, 0l);
 
         // test if boosts work
         searchResponse = client().prepareSearch("test")
                 .setQuery(randomizeType(multiMatchQuery("the ultimate", "full_name", "first_name", "last_name^2", "category")
                         .type(MultiMatchQueryBuilder.Type.CROSS_FIELDS)
-                        .operator(MatchQueryBuilder.Operator.AND))).get();
+                        .operator(Operator.AND))).get();
         assertFirstHit(searchResponse, hasId("ultimate1"));   // has ultimate in the last_name and that is boosted
         assertSecondHit(searchResponse, hasId("ultimate2"));
         assertThat(searchResponse.getHits().hits()[0].getScore(), greaterThan(searchResponse.getHits().hits()[1].getScore()));
@@ -514,7 +515,7 @@ public class MultiMatchQueryTests extends ElasticsearchIntegrationTest {
         searchResponse = client().prepareSearch("test")
                 .setQuery(randomizeType(multiMatchQuery("the ultimate", "full_name", "first_name", "last_name", "category")
                         .type(MultiMatchQueryBuilder.Type.CROSS_FIELDS)
-                        .operator(MatchQueryBuilder.Operator.AND))).get();
+                        .operator(Operator.AND))).get();
         assertFirstHit(searchResponse, hasId("ultimate2"));
         assertSecondHit(searchResponse, hasId("ultimate1"));
         assertThat(searchResponse.getHits().hits()[0].getScore(), greaterThan(searchResponse.getHits().hits()[1].getScore()));

--- a/core/src/test/java/org/elasticsearch/search/query/SearchQueryTests.java
+++ b/core/src/test/java/org/elasticsearch/search/query/SearchQueryTests.java
@@ -327,18 +327,18 @@ public class SearchQueryTests extends ElasticsearchIntegrationTest {
         assertThirdHit(searchResponse, hasId("2"));
 
         // try the same with match query
-        searchResponse = client().prepareSearch().setQuery(matchQuery("field1", "the quick brown").cutoffFrequency(3).operator(MatchQueryBuilder.Operator.AND)).get();
+        searchResponse = client().prepareSearch().setQuery(matchQuery("field1", "the quick brown").cutoffFrequency(3).operator(Operator.AND)).get();
         assertHitCount(searchResponse, 2l);
         assertFirstHit(searchResponse, hasId("1"));
         assertSecondHit(searchResponse, hasId("2"));
 
-        searchResponse = client().prepareSearch().setQuery(matchQuery("field1", "the quick brown").cutoffFrequency(3).operator(MatchQueryBuilder.Operator.OR)).get();
+        searchResponse = client().prepareSearch().setQuery(matchQuery("field1", "the quick brown").cutoffFrequency(3).operator(Operator.OR)).get();
         assertHitCount(searchResponse, 3l);
         assertFirstHit(searchResponse, hasId("1"));
         assertSecondHit(searchResponse, hasId("2"));
         assertThirdHit(searchResponse, hasId("3"));
 
-        searchResponse = client().prepareSearch().setQuery(matchQuery("field1", "the quick brown").cutoffFrequency(3).operator(MatchQueryBuilder.Operator.AND).analyzer("stop")).get();
+        searchResponse = client().prepareSearch().setQuery(matchQuery("field1", "the quick brown").cutoffFrequency(3).operator(Operator.AND).analyzer("stop")).get();
         assertHitCount(searchResponse, 3l);
         // stop drops "the" since its a stopword
         assertFirstHit(searchResponse, hasId("1"));
@@ -346,7 +346,7 @@ public class SearchQueryTests extends ElasticsearchIntegrationTest {
         assertThirdHit(searchResponse, hasId("2"));
 
         // try the same with multi match query
-        searchResponse = client().prepareSearch().setQuery(multiMatchQuery("the quick brown", "field1", "field2").cutoffFrequency(3).operator(MatchQueryBuilder.Operator.AND)).get();
+        searchResponse = client().prepareSearch().setQuery(multiMatchQuery("the quick brown", "field1", "field2").cutoffFrequency(3).operator(Operator.AND)).get();
         assertHitCount(searchResponse, 3l);
         assertFirstHit(searchResponse, hasId("3")); // better score due to different query stats
         assertSecondHit(searchResponse, hasId("1"));
@@ -420,18 +420,18 @@ public class SearchQueryTests extends ElasticsearchIntegrationTest {
         assertThirdHit(searchResponse, hasId("2"));
 
         // try the same with match query
-        searchResponse = client().prepareSearch().setQuery(matchQuery("field1", "the fast brown").cutoffFrequency(3).operator(MatchQueryBuilder.Operator.AND)).get();
+        searchResponse = client().prepareSearch().setQuery(matchQuery("field1", "the fast brown").cutoffFrequency(3).operator(Operator.AND)).get();
         assertHitCount(searchResponse, 2l);
         assertFirstHit(searchResponse, hasId("1"));
         assertSecondHit(searchResponse, hasId("2"));
 
-        searchResponse = client().prepareSearch().setQuery(matchQuery("field1", "the fast brown").cutoffFrequency(3).operator(MatchQueryBuilder.Operator.OR)).get();
+        searchResponse = client().prepareSearch().setQuery(matchQuery("field1", "the fast brown").cutoffFrequency(3).operator(Operator.OR)).get();
         assertHitCount(searchResponse, 3l);
         assertFirstHit(searchResponse, hasId("1"));
         assertSecondHit(searchResponse, hasId("2"));
         assertThirdHit(searchResponse, hasId("3"));
 
-        searchResponse = client().prepareSearch().setQuery(matchQuery("field1", "the fast brown").cutoffFrequency(3).operator(MatchQueryBuilder.Operator.AND).analyzer("stop")).get();
+        searchResponse = client().prepareSearch().setQuery(matchQuery("field1", "the fast brown").cutoffFrequency(3).operator(Operator.AND).analyzer("stop")).get();
         assertHitCount(searchResponse, 3l);
         // stop drops "the" since its a stopword
         assertFirstHit(searchResponse, hasId("1"));
@@ -444,7 +444,7 @@ public class SearchQueryTests extends ElasticsearchIntegrationTest {
         assertSecondHit(searchResponse, hasId("2"));
 
         // try the same with multi match query
-        searchResponse = client().prepareSearch().setQuery(multiMatchQuery("the fast brown", "field1", "field2").cutoffFrequency(3).operator(MatchQueryBuilder.Operator.AND)).get();
+        searchResponse = client().prepareSearch().setQuery(multiMatchQuery("the fast brown", "field1", "field2").cutoffFrequency(3).operator(Operator.AND)).get();
         assertHitCount(searchResponse, 3l);
         assertFirstHit(searchResponse, hasId("3")); // better score due to different query stats
         assertSecondHit(searchResponse, hasId("1"));
@@ -862,7 +862,7 @@ public class SearchQueryTests extends ElasticsearchIntegrationTest {
 
         client().admin().indices().prepareRefresh("test").get();
         builder = multiMatchQuery("value1", "field1", "field2")
-                .operator(MatchQueryBuilder.Operator.AND); // Operator only applies on terms inside a field! Fields are always OR-ed together.
+                .operator(Operator.AND); // Operator only applies on terms inside a field! Fields are always OR-ed together.
         searchResponse = client().prepareSearch()
                 .setQuery(builder)
                 .get();
@@ -871,14 +871,14 @@ public class SearchQueryTests extends ElasticsearchIntegrationTest {
 
         refresh();
         builder = multiMatchQuery("value1", "field1", "field3^1.5")
-                .operator(MatchQueryBuilder.Operator.AND); // Operator only applies on terms inside a field! Fields are always OR-ed together.
+                .operator(Operator.AND); // Operator only applies on terms inside a field! Fields are always OR-ed together.
         searchResponse = client().prepareSearch().setQuery(builder).get();
         assertHitCount(searchResponse, 2l);
         assertSearchHits(searchResponse, "3", "1");
 
         client().admin().indices().prepareRefresh("test").get();
         builder = multiMatchQuery("value1").field("field1").field("field3", 1.5f)
-                .operator(MatchQueryBuilder.Operator.AND); // Operator only applies on terms inside a field! Fields are always OR-ed together.
+                .operator(Operator.AND); // Operator only applies on terms inside a field! Fields are always OR-ed together.
         searchResponse = client().prepareSearch().setQuery(builder).get();
         assertHitCount(searchResponse, 2l);
         assertSearchHits(searchResponse, "3", "1");
@@ -1696,18 +1696,18 @@ public class SearchQueryTests extends ElasticsearchIntegrationTest {
         ensureGreen();
         client().prepareIndex("test", "test", "1").setSource("text", "quick brown fox").get();
         refresh();
-        SearchResponse searchResponse = client().prepareSearch("test").setQuery(matchQuery("text", "quick").operator(MatchQueryBuilder.Operator.AND)).get();
+        SearchResponse searchResponse = client().prepareSearch("test").setQuery(matchQuery("text", "quick").operator(Operator.AND)).get();
         assertHitCount(searchResponse, 1);
-        searchResponse = client().prepareSearch("test").setQuery(matchQuery("text", "quick brown").operator(MatchQueryBuilder.Operator.AND)).get();
+        searchResponse = client().prepareSearch("test").setQuery(matchQuery("text", "quick brown").operator(Operator.AND)).get();
         assertHitCount(searchResponse, 1);
-        searchResponse = client().prepareSearch("test").setQuery(matchQuery("text", "fast").operator(MatchQueryBuilder.Operator.AND)).get();
+        searchResponse = client().prepareSearch("test").setQuery(matchQuery("text", "fast").operator(Operator.AND)).get();
         assertHitCount(searchResponse, 1);
 
         client().prepareIndex("test", "test", "2").setSource("text", "fast brown fox").get();
         refresh();
-        searchResponse = client().prepareSearch("test").setQuery(matchQuery("text", "quick").operator(MatchQueryBuilder.Operator.AND)).get();
+        searchResponse = client().prepareSearch("test").setQuery(matchQuery("text", "quick").operator(Operator.AND)).get();
         assertHitCount(searchResponse, 2);
-        searchResponse = client().prepareSearch("test").setQuery(matchQuery("text", "quick brown").operator(MatchQueryBuilder.Operator.AND)).get();
+        searchResponse = client().prepareSearch("test").setQuery(matchQuery("text", "quick brown").operator(Operator.AND)).get();
         assertHitCount(searchResponse, 2);
     }
 
@@ -1727,12 +1727,12 @@ public class SearchQueryTests extends ElasticsearchIntegrationTest {
         ensureGreen();
         client().prepareIndex("test", "test", "1").setSource("text", "the fox runs across the street").get();
         refresh();
-        SearchResponse searchResponse = client().prepareSearch("test").setQuery(matchQuery("text", "fox runs").operator(MatchQueryBuilder.Operator.AND)).get();
+        SearchResponse searchResponse = client().prepareSearch("test").setQuery(matchQuery("text", "fox runs").operator(Operator.AND)).get();
         assertHitCount(searchResponse, 1);
 
         client().prepareIndex("test", "test", "2").setSource("text", "run fox run").get();
         refresh();
-        searchResponse = client().prepareSearch("test").setQuery(matchQuery("text", "fox runs").operator(MatchQueryBuilder.Operator.AND)).get();
+        searchResponse = client().prepareSearch("test").setQuery(matchQuery("text", "fox runs").operator(Operator.AND)).get();
         assertHitCount(searchResponse, 2);
     }
 
@@ -1754,19 +1754,19 @@ public class SearchQueryTests extends ElasticsearchIntegrationTest {
         client().prepareIndex("test", "test", "1").setSource("text", "quick brown fox").get();
         refresh();
 
-        SearchResponse searchResponse = client().prepareSearch("test").setQuery(queryStringQuery("quick").defaultField("text").defaultOperator(QueryStringQueryBuilder.Operator.AND)).get();
+        SearchResponse searchResponse = client().prepareSearch("test").setQuery(queryStringQuery("quick").defaultField("text").defaultOperator(Operator.AND)).get();
         assertHitCount(searchResponse, 1);
-        searchResponse = client().prepareSearch("test").setQuery(queryStringQuery("quick brown").defaultField("text").defaultOperator(QueryStringQueryBuilder.Operator.AND)).get();
+        searchResponse = client().prepareSearch("test").setQuery(queryStringQuery("quick brown").defaultField("text").defaultOperator(Operator.AND)).get();
         assertHitCount(searchResponse, 1);
-        searchResponse = client().prepareSearch().setQuery(queryStringQuery("fast").defaultField("text").defaultOperator(QueryStringQueryBuilder.Operator.AND)).get();
+        searchResponse = client().prepareSearch().setQuery(queryStringQuery("fast").defaultField("text").defaultOperator(Operator.AND)).get();
         assertHitCount(searchResponse, 1);
 
         client().prepareIndex("test", "test", "2").setSource("text", "fast brown fox").get();
         refresh();
 
-        searchResponse = client().prepareSearch("test").setQuery(queryStringQuery("quick").defaultField("text").defaultOperator(QueryStringQueryBuilder.Operator.AND)).get();
+        searchResponse = client().prepareSearch("test").setQuery(queryStringQuery("quick").defaultField("text").defaultOperator(Operator.AND)).get();
         assertHitCount(searchResponse, 2);
-        searchResponse = client().prepareSearch("test").setQuery(queryStringQuery("quick brown").defaultField("text").defaultOperator(QueryStringQueryBuilder.Operator.AND)).get();
+        searchResponse = client().prepareSearch("test").setQuery(queryStringQuery("quick brown").defaultField("text").defaultOperator(Operator.AND)).get();
         assertHitCount(searchResponse, 2);
     }
 
@@ -1793,7 +1793,7 @@ public class SearchQueryTests extends ElasticsearchIntegrationTest {
         SearchResponse response = client()
                 .prepareSearch("test")
                 .setQuery(
-                        queryStringQuery("foo.baz").useDisMax(false).defaultOperator(QueryStringQueryBuilder.Operator.AND)
+                        queryStringQuery("foo.baz").useDisMax(false).defaultOperator(Operator.AND)
                                 .field("field1").field("field2")).get();
         assertHitCount(response, 1l);
     }

--- a/core/src/test/java/org/elasticsearch/search/query/SimpleQueryStringTests.java
+++ b/core/src/test/java/org/elasticsearch/search/query/SimpleQueryStringTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.action.admin.indices.create.CreateIndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.Operator;
 import org.elasticsearch.index.query.SimpleQueryStringBuilder;
 import org.elasticsearch.index.query.SimpleQueryStringFlag;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
@@ -70,7 +71,7 @@ public class SimpleQueryStringTests extends ElasticsearchIntegrationTest {
         assertFirstHit(searchResponse, hasId("3"));
 
         searchResponse = client().prepareSearch().setQuery(
-                simpleQueryStringQuery("foo bar").defaultOperator(SimpleQueryStringBuilder.Operator.AND)).get();
+                simpleQueryStringQuery("foo bar").defaultOperator(Operator.AND)).get();
         assertHitCount(searchResponse, 1l);
         assertFirstHit(searchResponse, hasId("3"));
 
@@ -256,21 +257,21 @@ public class SimpleQueryStringTests extends ElasticsearchIntegrationTest {
 
         searchResponse = client().prepareSearch().setQuery(
                 simpleQueryStringQuery("foo | bar")
-                        .defaultOperator(SimpleQueryStringBuilder.Operator.AND)
+                        .defaultOperator(Operator.AND)
                         .flags(SimpleQueryStringFlag.OR)).get();
         assertHitCount(searchResponse, 3l);
         assertSearchHits(searchResponse, "1", "2", "3");
 
         searchResponse = client().prepareSearch().setQuery(
                 simpleQueryStringQuery("foo | bar")
-                        .defaultOperator(SimpleQueryStringBuilder.Operator.AND)
+                        .defaultOperator(Operator.AND)
                         .flags(SimpleQueryStringFlag.NONE)).get();
         assertHitCount(searchResponse, 1l);
         assertFirstHit(searchResponse, hasId("3"));
 
         searchResponse = client().prepareSearch().setQuery(
                 simpleQueryStringQuery("baz | egg*")
-                        .defaultOperator(SimpleQueryStringBuilder.Operator.AND)
+                        .defaultOperator(Operator.AND)
                         .flags(SimpleQueryStringFlag.NONE)).get();
         assertHitCount(searchResponse, 0l);
 
@@ -287,7 +288,7 @@ public class SimpleQueryStringTests extends ElasticsearchIntegrationTest {
 
         searchResponse = client().prepareSearch().setQuery(
                 simpleQueryStringQuery("baz | egg*")
-                        .defaultOperator(SimpleQueryStringBuilder.Operator.AND)
+                        .defaultOperator(Operator.AND)
                         .flags(SimpleQueryStringFlag.WHITESPACE, SimpleQueryStringFlag.PREFIX)).get();
         assertHitCount(searchResponse, 1l);
         assertFirstHit(searchResponse, hasId("4"));

--- a/core/src/test/java/org/elasticsearch/search/rescore/QueryRescorerTests.java
+++ b/core/src/test/java/org/elasticsearch/search/rescore/QueryRescorerTests.java
@@ -33,6 +33,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.query.MatchQueryBuilder;
+import org.elasticsearch.index.query.Operator;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilders;
 import org.elasticsearch.script.Script;
@@ -116,7 +117,7 @@ public class QueryRescorerTests extends ElasticsearchIntegrationTest {
         ensureYellow();
         refresh();
         SearchResponse searchResponse = client().prepareSearch()
-                .setQuery(QueryBuilders.matchQuery("field1", "the quick brown").operator(MatchQueryBuilder.Operator.OR))
+                .setQuery(QueryBuilders.matchQuery("field1", "the quick brown").operator(Operator.OR))
                 .setRescorer(RescoreBuilder.queryRescorer(QueryBuilders.matchPhraseQuery("field1", "quick brown").slop(2).boost(4.0f)).setRescoreQueryWeight(2))
                 .setRescoreWindow(5).execute().actionGet();
 
@@ -126,7 +127,7 @@ public class QueryRescorerTests extends ElasticsearchIntegrationTest {
         assertThat(searchResponse.getHits().getHits()[2].getId(), equalTo("2"));
 
         searchResponse = client().prepareSearch()
-                .setQuery(QueryBuilders.matchQuery("field1", "the quick brown").operator(MatchQueryBuilder.Operator.OR))
+                .setQuery(QueryBuilders.matchQuery("field1", "the quick brown").operator(Operator.OR))
                 .setRescorer(RescoreBuilder.queryRescorer(QueryBuilders.matchPhraseQuery("field1", "the quick brown").slop(3)))
                 .setRescoreWindow(5).execute().actionGet();
 
@@ -136,7 +137,7 @@ public class QueryRescorerTests extends ElasticsearchIntegrationTest {
         assertThirdHit(searchResponse, hasId("3"));
 
         searchResponse = client().prepareSearch()
-                .setQuery(QueryBuilders.matchQuery("field1", "the quick brown").operator(MatchQueryBuilder.Operator.OR))
+                .setQuery(QueryBuilders.matchQuery("field1", "the quick brown").operator(Operator.OR))
                 .setRescorer(RescoreBuilder.queryRescorer((QueryBuilders.matchPhraseQuery("field1", "the quick brown"))))
                 .setRescoreWindow(5).execute().actionGet();
 
@@ -179,7 +180,7 @@ public class QueryRescorerTests extends ElasticsearchIntegrationTest {
         client().admin().indices().prepareRefresh("test").execute().actionGet();
         SearchResponse searchResponse = client()
                 .prepareSearch()
-                .setQuery(QueryBuilders.matchQuery("field1", "lexington avenue massachusetts").operator(MatchQueryBuilder.Operator.OR))
+                .setQuery(QueryBuilders.matchQuery("field1", "lexington avenue massachusetts").operator(Operator.OR))
                 .setFrom(0)
                 .setSize(5)
                 .setRescorer(
@@ -194,7 +195,7 @@ public class QueryRescorerTests extends ElasticsearchIntegrationTest {
 
         searchResponse = client()
                 .prepareSearch()
-                .setQuery(QueryBuilders.matchQuery("field1", "lexington avenue massachusetts").operator(MatchQueryBuilder.Operator.OR))
+                .setQuery(QueryBuilders.matchQuery("field1", "lexington avenue massachusetts").operator(Operator.OR))
                 .setFrom(0)
                 .setSize(5)
                 .setSearchType(SearchType.DFS_QUERY_THEN_FETCH)
@@ -211,7 +212,7 @@ public class QueryRescorerTests extends ElasticsearchIntegrationTest {
         // Make sure non-zero from works:
         searchResponse = client()
                 .prepareSearch()
-                .setQuery(QueryBuilders.matchQuery("field1", "lexington avenue massachusetts").operator(MatchQueryBuilder.Operator.OR))
+                .setQuery(QueryBuilders.matchQuery("field1", "lexington avenue massachusetts").operator(Operator.OR))
                 .setFrom(2)
                 .setSize(5)
                 .setSearchType(SearchType.DFS_QUERY_THEN_FETCH)
@@ -320,7 +321,7 @@ public class QueryRescorerTests extends ElasticsearchIntegrationTest {
 
         SearchResponse searchResponse = client()
                 .prepareSearch()
-                .setQuery(QueryBuilders.matchQuery("field1", "massachusetts").operator(MatchQueryBuilder.Operator.OR))
+                .setQuery(QueryBuilders.matchQuery("field1", "massachusetts").operator(Operator.OR))
                 .setFrom(0)
             .setSize(5).execute().actionGet();
         assertThat(searchResponse.getHits().hits().length, equalTo(4));
@@ -333,7 +334,7 @@ public class QueryRescorerTests extends ElasticsearchIntegrationTest {
         // Now, penalizing rescore (nothing matches the rescore query):
         searchResponse = client()
                 .prepareSearch()
-                .setQuery(QueryBuilders.matchQuery("field1", "massachusetts").operator(MatchQueryBuilder.Operator.OR))
+                .setQuery(QueryBuilders.matchQuery("field1", "massachusetts").operator(Operator.OR))
                 .setFrom(0)
                 .setSize(5)
                 .setRescorer(
@@ -425,7 +426,7 @@ public class QueryRescorerTests extends ElasticsearchIntegrationTest {
                     .prepareSearch()
                     .setSearchType(SearchType.QUERY_THEN_FETCH)
                     .setPreference("test") // ensure we hit the same shards for tie-breaking
-                    .setQuery(QueryBuilders.matchQuery("field1", query).operator(MatchQueryBuilder.Operator.OR))
+                    .setQuery(QueryBuilders.matchQuery("field1", query).operator(Operator.OR))
                     .setFrom(0)
                     .setSize(resultSize)
                     .setRescorer(
@@ -440,7 +441,7 @@ public class QueryRescorerTests extends ElasticsearchIntegrationTest {
             SearchResponse plain = client().prepareSearch()
                     .setSearchType(SearchType.QUERY_THEN_FETCH)
                     .setPreference("test") // ensure we hit the same shards for tie-breaking
-                    .setQuery(QueryBuilders.matchQuery("field1", query).operator(MatchQueryBuilder.Operator.OR)).setFrom(0).setSize(resultSize)
+                    .setQuery(QueryBuilders.matchQuery("field1", query).operator(Operator.OR)).setFrom(0).setSize(resultSize)
                     .execute().actionGet();
             
             // check equivalence
@@ -450,7 +451,7 @@ public class QueryRescorerTests extends ElasticsearchIntegrationTest {
                     .prepareSearch()
                     .setSearchType(SearchType.QUERY_THEN_FETCH)
                     .setPreference("test") // ensure we hit the same shards for tie-breaking
-                    .setQuery(QueryBuilders.matchQuery("field1", query).operator(MatchQueryBuilder.Operator.OR))
+                    .setQuery(QueryBuilders.matchQuery("field1", query).operator(Operator.OR))
                     .setFrom(0)
                     .setSize(resultSize)
                     .setRescorer(
@@ -468,7 +469,7 @@ public class QueryRescorerTests extends ElasticsearchIntegrationTest {
                     .prepareSearch()
                     .setSearchType(SearchType.QUERY_THEN_FETCH)
                     .setPreference("test") // ensure we hit the same shards for tie-breaking
-                    .setQuery(QueryBuilders.matchQuery("field1", query).operator(MatchQueryBuilder.Operator.OR))
+                    .setQuery(QueryBuilders.matchQuery("field1", query).operator(Operator.OR))
                     .setFrom(0)
                     .setSize(resultSize)
                     .setRescorer(
@@ -503,7 +504,7 @@ public class QueryRescorerTests extends ElasticsearchIntegrationTest {
             SearchResponse searchResponse = client()
                     .prepareSearch()
                     .setSearchType(SearchType.DFS_QUERY_THEN_FETCH)
-                    .setQuery(QueryBuilders.matchQuery("field1", "the quick brown").operator(MatchQueryBuilder.Operator.OR))
+                    .setQuery(QueryBuilders.matchQuery("field1", "the quick brown").operator(Operator.OR))
                     .setRescorer(
                             RescoreBuilder.queryRescorer(QueryBuilders.matchPhraseQuery("field1", "the quick brown").slop(2).boost(4.0f))
                                     .setQueryWeight(0.5f).setRescoreQueryWeight(0.4f)).setRescoreWindow(5).setExplain(true).execute()
@@ -541,7 +542,7 @@ public class QueryRescorerTests extends ElasticsearchIntegrationTest {
             SearchResponse searchResponse = client()
                     .prepareSearch()
                     .setSearchType(SearchType.DFS_QUERY_THEN_FETCH)
-                    .setQuery(QueryBuilders.matchQuery("field1", "the quick brown").operator(MatchQueryBuilder.Operator.OR))
+                    .setQuery(QueryBuilders.matchQuery("field1", "the quick brown").operator(Operator.OR))
                     .setRescorer(innerRescoreQuery).setRescoreWindow(5).setExplain(true).execute()
                     .actionGet();
             assertHitCount(searchResponse, 3);
@@ -564,7 +565,7 @@ public class QueryRescorerTests extends ElasticsearchIntegrationTest {
                 searchResponse = client()
                         .prepareSearch()
                         .setSearchType(SearchType.DFS_QUERY_THEN_FETCH)
-                        .setQuery(QueryBuilders.matchQuery("field1", "the quick brown").operator(MatchQueryBuilder.Operator.OR))
+                        .setQuery(QueryBuilders.matchQuery("field1", "the quick brown").operator(Operator.OR))
                         .addRescorer(innerRescoreQuery).setRescoreWindow(5)
                         .addRescorer(outerRescoreQuery).setRescoreWindow(10)
                         .setExplain(true).get();

--- a/docs/reference/migration/migrate_query_refactoring.asciidoc
+++ b/docs/reference/migration/migrate_query_refactoring.asciidoc
@@ -11,3 +11,8 @@ on the query-refactoring feature branch.
 Removed the setter `queryName(String queryName)` since this field is not supported
 in this type of query. Use `FQueryFilterBuilder.queryName(String queryName)` instead 
 when in need to wrap a named query as a filter.
+
+Removed the enums called "Operator" from MatchQueryBuilder, QueryStringQueryBuilder,
+SimpleQueryStringBuilder, and CommonTermsQueryBuilder in favour of using the enum
+defined in org.elasticsearch.index.query.Operator in an effort to consolidate the
+codebase and avoid duplication.


### PR DESCRIPTION
This removes all enums called "Operator" that have two entries: OR/AND except for oe.index.query.Operator 

Relates to #10217

This PR goes against the feature/query-refactoring feature branch.
