### PR TITLE
Remove XContentParser.map[Ordered]AndClose().

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/repositories/put/PutRepositoryRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/repositories/put/PutRepositoryRequest.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.action.admin.cluster.repositories.put;
 
 import org.elasticsearch.ElasticsearchGenerationException;
-
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -29,6 +28,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 
 import java.io.IOException;
@@ -231,8 +231,8 @@ public class PutRepositoryRequest extends AcknowledgedRequest<PutRepositoryReque
      * @param repositoryDefinition repository definition
      */
     public PutRepositoryRequest source(String repositoryDefinition) {
-        try {
-            return source(XContentFactory.xContent(repositoryDefinition).createParser(repositoryDefinition).mapOrderedAndClose());
+        try (XContentParser parser = XContentFactory.xContent(repositoryDefinition).createParser(repositoryDefinition)) {
+            return source(parser.mapOrdered());
         } catch (IOException e) {
             throw new IllegalArgumentException("failed to parse repository source [" + repositoryDefinition + "]", e);
         }
@@ -255,8 +255,8 @@ public class PutRepositoryRequest extends AcknowledgedRequest<PutRepositoryReque
      * @param repositoryDefinition repository definition
      */
     public PutRepositoryRequest source(byte[] repositoryDefinition, int offset, int length) {
-        try {
-            return source(XContentFactory.xContent(repositoryDefinition, offset, length).createParser(repositoryDefinition, offset, length).mapOrderedAndClose());
+        try (XContentParser parser = XContentFactory.xContent(repositoryDefinition, offset, length).createParser(repositoryDefinition, offset, length)) {
+            return source(parser.mapOrdered());
         } catch (IOException e) {
             throw new IllegalArgumentException("failed to parse repository source", e);
         }
@@ -269,8 +269,8 @@ public class PutRepositoryRequest extends AcknowledgedRequest<PutRepositoryReque
      * @param repositoryDefinition repository definition
      */
     public PutRepositoryRequest source(BytesReference repositoryDefinition) {
-        try {
-            return source(XContentFactory.xContent(repositoryDefinition).createParser(repositoryDefinition).mapOrderedAndClose());
+        try (XContentParser parser = XContentFactory.xContent(repositoryDefinition).createParser(repositoryDefinition)) {
+            return source(parser.mapOrdered());
         } catch (IOException e) {
             throw new IllegalArgumentException("failed to parse template source", e);
         }

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotRequest.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 
 import java.io.IOException;
@@ -402,8 +403,8 @@ public class CreateSnapshotRequest extends MasterNodeRequest<CreateSnapshotReque
      */
     public CreateSnapshotRequest source(String source) {
         if (hasLength(source)) {
-            try {
-                return source(XContentFactory.xContent(source).createParser(source).mapOrderedAndClose());
+            try (XContentParser parser = XContentFactory.xContent(source).createParser(source)) {
+                return source(parser.mapOrdered());
             } catch (Exception e) {
                 throw new IllegalArgumentException("failed to parse repository source [" + source + "]", e);
             }
@@ -431,8 +432,8 @@ public class CreateSnapshotRequest extends MasterNodeRequest<CreateSnapshotReque
      */
     public CreateSnapshotRequest source(byte[] source, int offset, int length) {
         if (length > 0) {
-            try {
-                return source(XContentFactory.xContent(source, offset, length).createParser(source, offset, length).mapOrderedAndClose());
+            try (XContentParser parser = XContentFactory.xContent(source, offset, length).createParser(source, offset, length)) {
+                return source(parser.mapOrdered());
             } catch (IOException e) {
                 throw new IllegalArgumentException("failed to parse repository source", e);
             }
@@ -447,8 +448,8 @@ public class CreateSnapshotRequest extends MasterNodeRequest<CreateSnapshotReque
      * @return this request
      */
     public CreateSnapshotRequest source(BytesReference source) {
-        try {
-            return source(XContentFactory.xContent(source).createParser(source).mapOrderedAndClose());
+        try (XContentParser parser = XContentFactory.xContent(source).createParser(source)) {
+            return source(parser.mapOrdered());
         } catch (IOException e) {
             throw new IllegalArgumentException("failed to parse snapshot source", e);
         }

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
@@ -30,6 +30,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 
 import java.io.IOException;
@@ -553,8 +554,8 @@ public class RestoreSnapshotRequest extends MasterNodeRequest<RestoreSnapshotReq
      */
     public RestoreSnapshotRequest source(String source) {
         if (hasLength(source)) {
-            try {
-                return source(XContentFactory.xContent(source).createParser(source).mapOrderedAndClose());
+            try (XContentParser parser = XContentFactory.xContent(source).createParser(source)) {
+                return source(parser.mapOrdered());
             } catch (Exception e) {
                 throw new IllegalArgumentException("failed to parse repository source [" + source + "]", e);
             }
@@ -586,8 +587,8 @@ public class RestoreSnapshotRequest extends MasterNodeRequest<RestoreSnapshotReq
      */
     public RestoreSnapshotRequest source(byte[] source, int offset, int length) {
         if (length > 0) {
-            try {
-                return source(XContentFactory.xContent(source, offset, length).createParser(source, offset, length).mapOrderedAndClose());
+            try (XContentParser parser = XContentFactory.xContent(source, offset, length).createParser(source, offset, length)) {
+                return source(parser.mapOrdered());
             } catch (IOException e) {
                 throw new IllegalArgumentException("failed to parse repository source", e);
             }
@@ -604,8 +605,8 @@ public class RestoreSnapshotRequest extends MasterNodeRequest<RestoreSnapshotReq
      * @return this request
      */
     public RestoreSnapshotRequest source(BytesReference source) {
-        try {
-            return source(XContentFactory.xContent(source).createParser(source).mapOrderedAndClose());
+        try (XContentParser parser = XContentFactory.xContent(source).createParser(source)) {
+            return source(parser.mapOrdered());
         } catch (IOException e) {
             throw new IllegalArgumentException("failed to parse template source", e);
         }

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequest.java
@@ -362,8 +362,8 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
     public CreateIndexRequest source(BytesReference source) {
         XContentType xContentType = XContentFactory.xContentType(source);
         if (xContentType != null) {
-            try {
-                source(XContentFactory.xContent(xContentType).createParser(source).mapAndClose());
+            try (XContentParser parser = XContentFactory.xContent(xContentType).createParser(source)) {
+                source(parser.map());
             } catch (IOException e) {
                 throw new ElasticsearchParseException("failed to parse source for create index", e);
             }

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequest.java
@@ -308,8 +308,8 @@ public class PutIndexTemplateRequest extends MasterNodeRequest<PutIndexTemplateR
      * The template source definition.
      */
     public PutIndexTemplateRequest source(String templateSource) {
-        try {
-            return source(XContentFactory.xContent(templateSource).createParser(templateSource).mapOrderedAndClose());
+        try (XContentParser parser = XContentFactory.xContent(templateSource).createParser(templateSource)) {
+            return source(parser.mapOrdered());
         } catch (Exception e) {
             throw new IllegalArgumentException("failed to parse template source [" + templateSource + "]", e);
         }
@@ -326,8 +326,8 @@ public class PutIndexTemplateRequest extends MasterNodeRequest<PutIndexTemplateR
      * The template source definition.
      */
     public PutIndexTemplateRequest source(byte[] source, int offset, int length) {
-        try {
-            return source(XContentFactory.xContent(source, offset, length).createParser(source, offset, length).mapOrderedAndClose());
+        try (XContentParser parser = XContentFactory.xContent(source, offset, length).createParser(source, offset, length)) {
+            return source(parser.mapOrdered());
         } catch (IOException e) {
             throw new IllegalArgumentException("failed to parse template source", e);
         }
@@ -337,8 +337,8 @@ public class PutIndexTemplateRequest extends MasterNodeRequest<PutIndexTemplateR
      * The template source definition.
      */
     public PutIndexTemplateRequest source(BytesReference source) {
-        try {
-            return source(XContentFactory.xContent(source).createParser(source).mapOrderedAndClose());
+        try (XContentParser parser = XContentFactory.xContent(source).createParser(source)) {
+            return source(parser.mapOrdered());
         } catch (IOException e) {
             throw new IllegalArgumentException("failed to parse template source", e);
         }

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/AliasValidator.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/AliasValidator.java
@@ -81,9 +81,8 @@ public class AliasValidator extends AbstractComponent {
     public void validateAliasStandalone(Alias alias) {
         validateAliasStandalone(alias.name(), alias.indexRouting());
         if (Strings.hasLength(alias.filter())) {
-            try {
-                XContentParser parser = XContentFactory.xContent(alias.filter()).createParser(alias.filter());
-                parser.mapAndClose();
+            try (XContentParser parser = XContentFactory.xContent(alias.filter()).createParser(alias.filter())) {
+                parser.map();
             } catch (Throwable e) {
                 throw new IllegalArgumentException("failed to parse filter for alias [" + alias.name() + "]", e);
             }

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateMetaData.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateMetaData.java
@@ -343,9 +343,10 @@ public class IndexTemplateMetaData extends AbstractDiffable<IndexTemplateMetaDat
                 builder.startArray("mappings");
                 for (ObjectObjectCursor<String, CompressedXContent> cursor : indexTemplateMetaData.mappings()) {
                     byte[] data = cursor.value.uncompressed();
-                    XContentParser parser = XContentFactory.xContent(data).createParser(data);
-                    Map<String, Object> mapping = parser.mapOrderedAndClose();
-                    builder.map(mapping);
+                    try (XContentParser parser = XContentFactory.xContent(data).createParser(data)) {
+                        Map<String, Object> mapping = parser.mapOrdered();
+                        builder.map(mapping);
+                    }
                 }
                 builder.endArray();
             }

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MappingMetaData.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MappingMetaData.java
@@ -288,7 +288,10 @@ public class MappingMetaData extends AbstractDiffable<MappingMetaData> {
 
     public MappingMetaData(CompressedXContent mapping) throws IOException {
         this.source = mapping;
-        Map<String, Object> mappingMap = XContentHelper.createParser(mapping.compressedReference()).mapOrderedAndClose();
+        Map<String, Object> mappingMap;
+        try (XContentParser parser = XContentHelper.createParser(mapping.compressedReference())) {
+            mappingMap = parser.mapOrdered();
+        }
         if (mappingMap.size() != 1) {
             throw new IllegalStateException("Can't derive type from mapping, no root type: " + mapping.string());
         }

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
@@ -24,6 +24,7 @@ import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import com.google.common.base.Charsets;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+
 import org.apache.lucene.util.CollectionUtil;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
@@ -53,6 +54,7 @@ import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.mapper.DocumentMapper;
@@ -451,7 +453,9 @@ public class MetaDataCreateIndexService extends AbstractComponent {
     }
 
     private Map<String, Object> parseMapping(String mappingSource) throws Exception {
-        return XContentFactory.xContent(mappingSource).createParser(mappingSource).mapAndClose();
+        try (XContentParser parser = XContentFactory.xContent(mappingSource).createParser(mappingSource)) {
+            return parser.map();
+        }
     }
 
     private void addMappings(Map<String, Map<String, Object>> mappings, Path mappingsDir) throws IOException {

--- a/core/src/main/java/org/elasticsearch/common/xcontent/XContentParser.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/XContentParser.java
@@ -130,10 +130,6 @@ public interface XContentParser extends Releasable {
 
     Map<String, Object> mapOrdered() throws IOException;
 
-    Map<String, Object> mapAndClose() throws IOException;
-
-    Map<String, Object> mapOrderedAndClose() throws IOException;
-
     String text() throws IOException;
 
     String textOrNull() throws IOException;

--- a/core/src/main/java/org/elasticsearch/common/xcontent/support/AbstractXContentParser.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/support/AbstractXContentParser.java
@@ -213,25 +213,6 @@ public abstract class AbstractXContentParser implements XContentParser {
         return readOrderedMap(this);
     }
 
-    @Override
-    public Map<String, Object> mapAndClose() throws IOException {
-        try {
-            return map();
-        } finally {
-            close();
-        }
-    }
-
-    @Override
-    public Map<String, Object> mapOrderedAndClose() throws IOException {
-        try {
-            return mapOrdered();
-        } finally {
-            close();
-        }
-    }
-
-
     static interface MapFactory {
         Map<String, Object> newMap();
     }

--- a/core/src/main/java/org/elasticsearch/discovery/zen/ping/multicast/MulticastZenPing.java
+++ b/core/src/main/java/org/elasticsearch/discovery/zen/ping/multicast/MulticastZenPing.java
@@ -39,6 +39,7 @@ import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.discovery.zen.ping.PingContextProvider;
 import org.elasticsearch.discovery.zen.ping.ZenPing;
@@ -408,9 +409,9 @@ public class MulticastZenPing extends AbstractLifecycleComponent<ZenPing> implem
                     xContentType = XContentFactory.xContentType(data);
                     if (xContentType != null) {
                         // an external ping
-                        externalPingData = XContentFactory.xContent(xContentType)
-                                .createParser(data)
-                                .mapAndClose();
+                        try (XContentParser parser = XContentFactory.xContent(xContentType).createParser(data)) {
+                            externalPingData = parser.map();
+                        }
                     } else {
                         throw new IllegalStateException("failed multicast message, probably message from previous version");
                     }

--- a/core/src/main/java/org/elasticsearch/index/mapper/DocumentMapperParser.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/DocumentMapperParser.java
@@ -34,6 +34,7 @@ import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.AbstractIndexComponent;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.analysis.AnalysisService;
@@ -304,8 +305,8 @@ public class DocumentMapperParser extends AbstractIndexComponent {
 
     private Tuple<String, Map<String, Object>> extractMapping(String type, String source) throws MapperParsingException {
         Map<String, Object> root;
-        try {
-            root = XContentFactory.xContent(source).createParser(source).mapOrderedAndClose();
+        try (XContentParser parser = XContentFactory.xContent(source).createParser(source)) {
+            root = parser.mapOrdered();
         } catch (Exception e) {
             throw new MapperParsingException("failed to parse mapping definition", e);
         }

--- a/core/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -679,7 +679,10 @@ class DocumentParser implements Closeable {
     }
 
     private static XContentParser transform(Mapping mapping, XContentParser parser) throws IOException {
-        Map<String, Object> transformed = transformSourceAsMap(mapping, parser.mapOrderedAndClose());
+        Map<String, Object> transformed;
+        try (XContentParser _ = parser) {
+            transformed = transformSourceAsMap(mapping, parser.mapOrdered());
+        }
         XContentBuilder builder = XContentFactory.contentBuilder(parser.contentType()).value(transformed);
         return parser.contentType().xContent().createParser(builder.bytes());
     }

--- a/core/src/main/java/org/elasticsearch/rest/action/admin/cluster/settings/RestClusterUpdateSettingsAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/cluster/settings/RestClusterUpdateSettingsAction.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.AcknowledgedRestListener;
 
@@ -48,7 +49,10 @@ public class RestClusterUpdateSettingsAction extends BaseRestHandler {
         final ClusterUpdateSettingsRequest clusterUpdateSettingsRequest = Requests.clusterUpdateSettingsRequest();
         clusterUpdateSettingsRequest.timeout(request.paramAsTime("timeout", clusterUpdateSettingsRequest.timeout()));
         clusterUpdateSettingsRequest.masterNodeTimeout(request.paramAsTime("master_timeout", clusterUpdateSettingsRequest.masterNodeTimeout()));
-        Map<String, Object> source = XContentFactory.xContent(request.content()).createParser(request.content()).mapAndClose();
+        Map<String, Object> source;
+        try (XContentParser parser = XContentFactory.xContent(request.content()).createParser(request.content())) {
+            source = parser.map();
+        }
         if (source.containsKey("transient")) {
             clusterUpdateSettingsRequest.transientSettings((Map) source.get("transient"));
         }

--- a/core/src/main/java/org/elasticsearch/search/warmer/IndexWarmersMetaData.java
+++ b/core/src/main/java/org/elasticsearch/search/warmer/IndexWarmersMetaData.java
@@ -248,7 +248,10 @@ public class IndexWarmersMetaData extends AbstractDiffable<IndexMetaData.Custom>
         if (binary) {
             builder.value(entry.source());
         } else {
-            Map<String, Object> mapping = XContentFactory.xContent(entry.source()).createParser(entry.source()).mapOrderedAndClose();
+            Map<String, Object> mapping;
+            try (XContentParser parser = XContentFactory.xContent(entry.source()).createParser(entry.source())) {
+                mapping = parser.mapOrdered();
+            }
             builder.map(mapping);
         }
         builder.endObject();

--- a/core/src/test/java/org/elasticsearch/common/xcontent/support/XContentMapValuesTests.java
+++ b/core/src/test/java/org/elasticsearch/common/xcontent/support/XContentMapValuesTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.hamcrest.Matchers;
@@ -49,7 +50,10 @@ public class XContentMapValuesTests extends ElasticsearchTestCase {
                 .field("something_else", "value3")
                 .endObject();
 
-        Map<String, Object> source = XContentFactory.xContent(XContentType.JSON).createParser(builder.string()).mapAndClose();
+        Map<String, Object> source;
+        try (XContentParser parser = XContentFactory.xContent(XContentType.JSON).createParser(builder.string())) {
+            source = parser.map();
+        }
         Map<String, Object> filter = XContentMapValues.filter(source, new String[]{"test1"}, Strings.EMPTY_ARRAY);
         assertThat(filter.size(), equalTo(1));
         assertThat(filter.get("test1").toString(), equalTo("value1"));
@@ -75,7 +79,9 @@ public class XContentMapValuesTests extends ElasticsearchTestCase {
                 .field("test1", "value1")
                 .endObject();
 
-        source = XContentFactory.xContent(XContentType.JSON).createParser(builder.string()).mapAndClose();
+        try (XContentParser parser = XContentFactory.xContent(XContentType.JSON).createParser(builder.string())) {
+            source = parser.map();
+        }
         filter = XContentMapValues.filter(source, new String[]{"path1"}, Strings.EMPTY_ARRAY);
         assertThat(filter.size(), equalTo(1));
 
@@ -99,7 +105,10 @@ public class XContentMapValuesTests extends ElasticsearchTestCase {
                 .field("test", "value")
                 .endObject();
 
-        Map<String, Object> map = XContentFactory.xContent(XContentType.JSON).createParser(builder.string()).mapAndClose();
+        Map<String, Object> map;
+        try (XContentParser parser = XContentFactory.xContent(XContentType.JSON).createParser(builder.string())) {
+            map = parser.map();
+        }
         assertThat(XContentMapValues.extractValue("test", map).toString(), equalTo("value"));
         assertThat(XContentMapValues.extractValue("test.me", map), nullValue());
         assertThat(XContentMapValues.extractValue("something.else.2", map), nullValue());
@@ -108,7 +117,9 @@ public class XContentMapValuesTests extends ElasticsearchTestCase {
                 .startObject("path1").startObject("path2").field("test", "value").endObject().endObject()
                 .endObject();
 
-        map = XContentFactory.xContent(XContentType.JSON).createParser(builder.string()).mapAndClose();
+        try (XContentParser parser = XContentFactory.xContent(XContentType.JSON).createParser(builder.string())) {
+            map = parser.map();
+        }
         assertThat(XContentMapValues.extractValue("path1.path2.test", map).toString(), equalTo("value"));
         assertThat(XContentMapValues.extractValue("path1.path2.test_me", map), nullValue());
         assertThat(XContentMapValues.extractValue("path1.non_path2.test", map), nullValue());
@@ -128,7 +139,9 @@ public class XContentMapValuesTests extends ElasticsearchTestCase {
                 .startObject("path1").field("test", "value1", "value2").endObject()
                 .endObject();
 
-        map = XContentFactory.xContent(XContentType.JSON).createParser(builder.string()).mapAndClose();
+        try (XContentParser parser = XContentFactory.xContent(XContentType.JSON).createParser(builder.string())) {
+            map = parser.map();
+        }
 
         extValue = XContentMapValues.extractValue("path1.test", map);
         assertThat(extValue, instanceOf(List.class));
@@ -145,7 +158,9 @@ public class XContentMapValuesTests extends ElasticsearchTestCase {
                 .endObject()
                 .endObject();
 
-        map = XContentFactory.xContent(XContentType.JSON).createParser(builder.string()).mapAndClose();
+        try (XContentParser parser = XContentFactory.xContent(XContentType.JSON).createParser(builder.string())) {
+            map = parser.map();
+        }
 
         extValue = XContentMapValues.extractValue("path1.path2.test", map);
         assertThat(extValue, instanceOf(List.class));
@@ -159,14 +174,18 @@ public class XContentMapValuesTests extends ElasticsearchTestCase {
         builder = XContentFactory.jsonBuilder().startObject()
                 .field("xxx.yyy", "value")
                 .endObject();
-        map = XContentFactory.xContent(XContentType.JSON).createParser(builder.string()).mapAndClose();
+        try (XContentParser parser = XContentFactory.xContent(XContentType.JSON).createParser(builder.string())) {
+            map = parser.map();
+        }
         assertThat(XContentMapValues.extractValue("xxx.yyy", map).toString(), equalTo("value"));
 
         builder = XContentFactory.jsonBuilder().startObject()
                 .startObject("path1.xxx").startObject("path2.yyy").field("test", "value").endObject().endObject()
                 .endObject();
 
-        map = XContentFactory.xContent(XContentType.JSON).createParser(builder.string()).mapAndClose();
+        try (XContentParser parser = XContentFactory.xContent(XContentType.JSON).createParser(builder.string())) {
+            map = parser.map();
+        }
         assertThat(XContentMapValues.extractValue("path1.xxx.path2.yyy.test", map).toString(), equalTo("value"));
     }
 
@@ -177,28 +196,37 @@ public class XContentMapValuesTests extends ElasticsearchTestCase {
                 .field("test", "value")
                 .endObject();
 
-        Map<String, Object> map = XContentFactory.xContent(XContentType.JSON).createParser(builder.string()).mapAndClose();
+        Map<String, Object> map;
+        try (XContentParser parser = XContentFactory.xContent(XContentType.JSON).createParser(builder.string())) {
+            map = parser.map();
+        }
         assertThat(XContentMapValues.extractRawValues("test", map).get(0).toString(), equalTo("value"));
 
         builder = XContentFactory.jsonBuilder().startObject()
                 .field("test.me", "value")
                 .endObject();
 
-        map = XContentFactory.xContent(XContentType.JSON).createParser(builder.string()).mapAndClose();
+        try (XContentParser parser = XContentFactory.xContent(XContentType.JSON).createParser(builder.string())) {
+            map = parser.map();
+        }
         assertThat(XContentMapValues.extractRawValues("test.me", map).get(0).toString(), equalTo("value"));
 
         builder = XContentFactory.jsonBuilder().startObject()
                 .startObject("path1").startObject("path2").field("test", "value").endObject().endObject()
                 .endObject();
 
-        map = XContentFactory.xContent(XContentType.JSON).createParser(builder.string()).mapAndClose();
+        try (XContentParser parser = XContentFactory.xContent(XContentType.JSON).createParser(builder.string())) {
+            map = parser.map();
+        }
         assertThat(XContentMapValues.extractRawValues("path1.path2.test", map).get(0).toString(), equalTo("value"));
 
         builder = XContentFactory.jsonBuilder().startObject()
                 .startObject("path1.xxx").startObject("path2.yyy").field("test", "value").endObject().endObject()
                 .endObject();
 
-        map = XContentFactory.xContent(XContentType.JSON).createParser(builder.string()).mapAndClose();
+        try (XContentParser parser = XContentFactory.xContent(XContentType.JSON).createParser(builder.string())) {
+            map = parser.map();
+        }
         assertThat(XContentMapValues.extractRawValues("path1.xxx.path2.yyy.test", map).get(0).toString(), equalTo("value"));
     }
 

--- a/core/src/test/java/org/elasticsearch/index/mapper/completion/CompletionFieldMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/completion/CompletionFieldMapperTests.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.index.mapper.completion;
 
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.FieldMapper;
@@ -76,7 +77,10 @@ public class CompletionFieldMapperTests extends ElasticsearchSingleNodeTest {
         XContentBuilder builder = jsonBuilder().startObject();
         completionFieldMapper.toXContent(builder, null).endObject();
         builder.close();
-        Map<String, Object> serializedMap = JsonXContent.jsonXContent.createParser(builder.bytes()).mapAndClose();
+        Map<String, Object> serializedMap;
+        try (XContentParser parser = JsonXContent.jsonXContent.createParser(builder.bytes())) {
+            serializedMap = parser.map();
+        }
         Map<String, Object> configMap = (Map<String, Object>) serializedMap.get("completion");
         assertThat(configMap.get("analyzer").toString(), is("simple"));
         assertThat(configMap.get("search_analyzer").toString(), is("standard"));
@@ -105,7 +109,10 @@ public class CompletionFieldMapperTests extends ElasticsearchSingleNodeTest {
         XContentBuilder builder = jsonBuilder().startObject();
         completionFieldMapper.toXContent(builder, null).endObject();
         builder.close();
-        Map<String, Object> serializedMap = JsonXContent.jsonXContent.createParser(builder.bytes()).mapAndClose();
+        Map<String, Object> serializedMap;
+        try (XContentParser parser = JsonXContent.jsonXContent.createParser(builder.bytes())) {
+            serializedMap = parser.map();
+        }
         Map<String, Object> configMap = (Map<String, Object>) serializedMap.get("completion");
         assertThat(configMap.get("analyzer").toString(), is("simple"));
     }

--- a/core/src/test/java/org/elasticsearch/index/mapper/copyto/CopyToMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/copyto/CopyToMapperTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.mapper.DocumentMapper;
@@ -91,7 +92,10 @@ public class CopyToMapperTests extends ElasticsearchSingleNodeTest {
         XContentBuilder builder = jsonBuilder().startObject();
         stringFieldMapper.toXContent(builder, ToXContent.EMPTY_PARAMS).endObject();
         builder.close();
-        Map<String, Object> serializedMap = JsonXContent.jsonXContent.createParser(builder.bytes()).mapAndClose();
+        Map<String, Object> serializedMap;
+        try (XContentParser parser = JsonXContent.jsonXContent.createParser(builder.bytes())) {
+            serializedMap = parser.map();
+        }
         Map<String, Object> copyTestMap = (Map<String, Object>) serializedMap.get("copy_test");
         assertThat(copyTestMap.get("type").toString(), is("string"));
         List<String> copyToList = (List<String>) copyTestMap.get("copy_to");

--- a/core/src/test/java/org/elasticsearch/index/mapper/date/SimpleDateMappingTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/date/SimpleDateMappingTests.java
@@ -32,6 +32,7 @@ import org.elasticsearch.common.util.LocaleUtils;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.mapper.*;
@@ -380,7 +381,10 @@ public class SimpleDateMappingTests extends ElasticsearchSingleNodeTest {
     private Map<String, String> getConfigurationViaXContent(DateFieldMapper dateFieldMapper) throws IOException {
         XContentBuilder builder = JsonXContent.contentBuilder().startObject();
         dateFieldMapper.toXContent(builder, ToXContent.EMPTY_PARAMS).endObject();
-        Map<String, Object> dateFieldMapperMap = JsonXContent.jsonXContent.createParser(builder.string()).mapAndClose();
+        Map<String, Object> dateFieldMapperMap;
+        try (XContentParser parser = JsonXContent.jsonXContent.createParser(builder.bytes())) {
+            dateFieldMapperMap = parser.map();
+        }
         assertThat(dateFieldMapperMap, hasKey("field"));
         assertThat(dateFieldMapperMap.get("field"), is(instanceOf(Map.class)));
         return (Map<String, String>) dateFieldMapperMap.get("field");

--- a/core/src/test/java/org/elasticsearch/index/mapper/routing/RoutingTypeMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/routing/RoutingTypeMapperTests.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.ParsedDocument;
@@ -79,7 +80,10 @@ public class RoutingTypeMapperTests extends ElasticsearchSingleNodeTest {
         XContentBuilder builder = JsonXContent.contentBuilder().startObject();
         enabledMapper.routingFieldMapper().toXContent(builder, ToXContent.EMPTY_PARAMS).endObject();
         builder.close();
-        Map<String, Object> serializedMap = JsonXContent.jsonXContent.createParser(builder.bytes()).mapAndClose();
+        Map<String, Object> serializedMap;
+        try (XContentParser parser = JsonXContent.jsonXContent.createParser(builder.bytes())) {
+            serializedMap = parser.map();
+        }
         assertThat(serializedMap, hasKey("_routing"));
         assertThat(serializedMap.get("_routing"), instanceOf(Map.class));
         Map<String, Object> routingConfiguration = (Map<String, Object>) serializedMap.get("_routing");

--- a/core/src/test/java/org/elasticsearch/index/mapper/source/DefaultSourceMappingTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/source/DefaultSourceMappingTests.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.compress.CompressorFactory;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.mapper.*;
 import org.elasticsearch.test.ElasticsearchSingleNodeTest;
@@ -122,7 +123,10 @@ public class DefaultSourceMappingTests extends ElasticsearchSingleNodeTest {
             .endObject().bytes());
 
         IndexableField sourceField = doc.rootDoc().getField("_source");
-        Map<String, Object> sourceAsMap = XContentFactory.xContent(XContentType.JSON).createParser(new BytesArray(sourceField.binaryValue())).mapAndClose();
+        Map<String, Object> sourceAsMap;
+        try (XContentParser parser = XContentFactory.xContent(XContentType.JSON).createParser(new BytesArray(sourceField.binaryValue()))) {
+            sourceAsMap = parser.map();
+        }
         assertThat(sourceAsMap.containsKey("path1"), equalTo(true));
         assertThat(sourceAsMap.containsKey("path2"), equalTo(false));
     }
@@ -140,7 +144,10 @@ public class DefaultSourceMappingTests extends ElasticsearchSingleNodeTest {
             .endObject().bytes());
 
         IndexableField sourceField = doc.rootDoc().getField("_source");
-        Map<String, Object> sourceAsMap = XContentFactory.xContent(XContentType.JSON).createParser(new BytesArray(sourceField.binaryValue())).mapAndClose();
+        Map<String, Object> sourceAsMap;
+        try (XContentParser parser = XContentFactory.xContent(XContentType.JSON).createParser(new BytesArray(sourceField.binaryValue()))) {
+            sourceAsMap = parser.map();
+        }
         assertThat(sourceAsMap.containsKey("path1"), equalTo(false));
         assertThat(sourceAsMap.containsKey("path2"), equalTo(true));
     }

--- a/core/src/test/java/org/elasticsearch/index/mapper/string/SimpleStringMappingTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/string/SimpleStringMappingTests.java
@@ -34,6 +34,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.fielddata.FieldDataType;
@@ -286,7 +287,10 @@ public class SimpleStringMappingTests extends ElasticsearchSingleNodeTest {
         fieldMapper.toXContent(builder, ToXContent.EMPTY_PARAMS).endObject();
         builder.close();
         
-        Map<String, Object> fieldMap = JsonXContent.jsonXContent.createParser(builder.bytes()).mapAndClose();
+        Map<String, Object> fieldMap;
+        try (XContentParser parser = JsonXContent.jsonXContent.createParser(builder.bytes())) {
+            fieldMap = parser.map();
+        }
         @SuppressWarnings("unchecked")
         Map<String, Object> result = (Map<String, Object>) fieldMap.get(fieldName);
         return result;

--- a/core/src/test/java/org/elasticsearch/index/mapper/timestamp/TimestampMappingTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/timestamp/TimestampMappingTests.java
@@ -35,6 +35,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.mapper.DocumentMapper;
@@ -168,7 +169,10 @@ public class TimestampMappingTests extends ElasticsearchSingleNodeTest {
         XContentBuilder builder = JsonXContent.contentBuilder().startObject();
         enabledMapper.timestampFieldMapper().toXContent(builder, ToXContent.EMPTY_PARAMS).endObject();
         builder.close();
-        Map<String, Object> serializedMap = JsonXContent.jsonXContent.createParser(builder.bytes()).mapAndClose();
+        Map<String, Object> serializedMap;
+        try (XContentParser parser = JsonXContent.jsonXContent.createParser(builder.bytes())) {
+            serializedMap = parser.map();
+        }
         assertThat(serializedMap, hasKey("_timestamp"));
         assertThat(serializedMap.get("_timestamp"), instanceOf(Map.class));
         Map<String, Object> timestampConfiguration = (Map<String, Object>) serializedMap.get("_timestamp");

--- a/core/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTest.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.search.builder;
 
+import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.junit.Test;
@@ -78,7 +79,10 @@ public class SearchSourceBuilderTest extends ElasticsearchTestCase {
     }
 
     private Map<String, Object> getSourceMap(SearchSourceBuilder builder) throws IOException {
-        Map<String, Object> data = JsonXContent.jsonXContent.createParser(builder.toString()).mapAndClose();
+        Map<String, Object> data;
+        try (XContentParser parser = JsonXContent.jsonXContent.createParser(builder.toString())) {
+            data = parser.map();
+        }
         assertThat(data, hasKey("_source"));
         return (Map<String, Object>) data.get("_source");
     }

--- a/core/src/test/java/org/elasticsearch/test/rest/json/JsonPath.java
+++ b/core/src/test/java/org/elasticsearch/test/rest/json/JsonPath.java
@@ -19,6 +19,8 @@
 package org.elasticsearch.test.rest.json;
 
 import com.google.common.collect.Lists;
+
+import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.test.rest.Stash;
 
@@ -40,7 +42,9 @@ public class JsonPath {
     }
 
     private static Map<String, Object> convertToMap(String json) throws IOException {
-        return JsonXContent.jsonXContent.createParser(json).mapOrderedAndClose();
+        try (XContentParser parser = JsonXContent.jsonXContent.createParser(json)) {
+            return parser.mapOrdered();
+        }
     }
 
     /**

--- a/core/src/test/java/org/elasticsearch/test/rest/test/DoSectionParserTests.java
+++ b/core/src/test/java/org/elasticsearch/test/rest/test/DoSectionParserTests.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.test.rest.test;
 
+import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.common.xcontent.yaml.YamlXContent;
 import org.elasticsearch.test.rest.parser.DoSectionParser;
@@ -387,7 +388,10 @@ public class DoSectionParserTests extends AbstractParserTests {
     }
 
     private static void assertJsonEquals(Map<String, Object> actual, String expected) throws IOException {
-        Map<String,Object> expectedMap = JsonXContent.jsonXContent.createParser(expected).mapOrderedAndClose();
+        Map<String,Object> expectedMap;
+        try (XContentParser parser = JsonXContent.jsonXContent.createParser(expected)) {
+            expectedMap = parser.mapOrdered();
+        }
         MatcherAssert.assertThat(actual, equalTo(expectedMap));
     }
 }

--- a/core/src/test/java/org/elasticsearch/threadpool/SimpleThreadPoolTests.java
+++ b/core/src/test/java/org/elasticsearch/threadpool/SimpleThreadPoolTests.java
@@ -215,8 +215,10 @@ public class SimpleThreadPoolTests extends ElasticsearchIntegrationTest {
         info.toXContent(builder, ToXContent.EMPTY_PARAMS);
         builder.endObject();
         builder.close();
-        XContentParser parser = JsonXContent.jsonXContent.createParser(builder.string());
-        Map<String, Object> poolsMap = parser.mapAndClose();
+        Map<String, Object> poolsMap;
+        try (XContentParser parser = JsonXContent.jsonXContent.createParser(builder.string())) {
+            poolsMap = parser.map();
+        }
         return (Map<String, Object>) ((Map<String, Object>) poolsMap.get("thread_pool")).get(poolName);
     }
 

--- a/core/src/test/java/org/elasticsearch/threadpool/ThreadPoolSerializationTests.java
+++ b/core/src/test/java/org/elasticsearch/threadpool/ThreadPoolSerializationTests.java
@@ -82,8 +82,10 @@ public class ThreadPoolSerializationTests extends ElasticsearchTestCase {
         builder.endObject();
 
         BytesReference bytesReference = builder.bytes();
-        XContentParser parser = XContentFactory.xContent(bytesReference).createParser(bytesReference);
-        Map<String, Object> map = parser.mapAndClose();
+        Map<String, Object> map;
+        try (XContentParser parser = XContentFactory.xContent(bytesReference).createParser(bytesReference)) {
+            map = parser.map();
+        }
         assertThat(map, hasKey("foo"));
         map = (Map<String, Object>) map.get("foo");
         assertThat(map, hasKey("queue_size"));


### PR DESCRIPTION
It is a bit weird to have an API to read a map then close the parser.
