### PR TITLE
Render strucutred exception in multi search

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/search/TransportMultiSearchAction.java
+++ b/core/src/main/java/org/elasticsearch/action/search/TransportMultiSearchAction.java
@@ -69,7 +69,7 @@ public class TransportMultiSearchAction extends HandledTransportAction<MultiSear
 
                 @Override
                 public void onFailure(Throwable e) {
-                    responses.set(index, new MultiSearchResponse.Item(null, ExceptionsHelper.detailedMessage(e)));
+                    responses.set(index, new MultiSearchResponse.Item(null, e));
                     if (counter.decrementAndGet() == 0) {
                         finishHim();
                     }

--- a/core/src/test/java/org/elasticsearch/action/search/MultiSearchRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/action/search/MultiSearchRequestTests.java
@@ -21,8 +21,13 @@ package org.elasticsearch.action.search;
 
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.io.Streams;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.junit.Test;
+
+import java.io.IOException;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
@@ -113,5 +118,13 @@ public class MultiSearchRequestTests extends ElasticsearchTestCase {
         assertThat(request.requests().get(2).types()[0], equalTo("type2"));
         assertThat(request.requests().get(2).types()[1], equalTo("type1"));
         assertThat(request.requests().get(2).routing(), equalTo("123"));
+    }
+
+    public void testResponseErrorToXContent() throws IOException {
+        MultiSearchResponse response = new MultiSearchResponse(new MultiSearchResponse.Item[]{new MultiSearchResponse.Item(null, new IllegalStateException("foobar")), new MultiSearchResponse.Item(null, new IllegalStateException("baaaaaazzzz"))});
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        response.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        assertEquals("\"responses\"[{\"error\":{\"root_cause\":[{\"type\":\"illegal_state_exception\",\"reason\":\"foobar\"}],\"type\":\"illegal_state_exception\",\"reason\":\"foobar\"}},{\"error\":{\"root_cause\":[{\"type\":\"illegal_state_exception\",\"reason\":\"baaaaaazzzz\"}],\"type\":\"illegal_state_exception\",\"reason\":\"baaaaaazzzz\"}}]",
+                builder.string());
     }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/msearch/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/msearch/10_basic.yaml
@@ -39,7 +39,9 @@
               match: {foo: bar}
 
   - match:  { responses.0.hits.total:     3  }
-  - match:  { responses.1.error: "/IndexMissingException.no.such.index./"  }
+  - match:  { responses.1.error.root_cause.0.type: index_missing_exception }
+  - match:  { responses.1.error.root_cause.0.reason: "/no.such.index/" }
+  - match:  { responses.1.error.root_cause.0.index: test_2 }
   - match:  { responses.2.hits.total:     1  }
 
 


### PR DESCRIPTION
MultiMatch still only returns the exception message but should return the
actual exception and render it in a structured fashion...

@rashidkpc here you go :)
