### PR TITLE
Internal: make sure ParseField is always used in combination with parse flags

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/indices/validate/query/TransportValidateQueryAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/validate/query/TransportValidateQueryAction.java
@@ -168,7 +168,7 @@ public class TransportValidateQueryAction extends TransportBroadcastAction<Valid
         DefaultSearchContext searchContext = new DefaultSearchContext(0,
                 new ShardSearchLocalRequest(request.types(), request.nowInMillis(), request.filteringAliases()),
                 null, searcher, indexService, indexShard,
-                scriptService, pageCacheRecycler, bigArrays, threadPool.estimatedTimeInMillisCounter()
+                scriptService, pageCacheRecycler, bigArrays, threadPool.estimatedTimeInMillisCounter(), parseFieldMatcher
         );
         SearchContext.setCurrent(searchContext);
         try {
@@ -187,10 +187,7 @@ public class TransportValidateQueryAction extends TransportBroadcastAction<Valid
         } catch (QueryParsingException e) {
             valid = false;
             error = e.getDetailedMessage();
-        } catch (AssertionError e) {
-            valid = false;
-            error = e.getMessage();
-        } catch (IOException e) {
+        } catch (AssertionError|IOException e) {
             valid = false;
             error = e.getMessage();
         } finally {

--- a/core/src/main/java/org/elasticsearch/action/exists/TransportExistsAction.java
+++ b/core/src/main/java/org/elasticsearch/action/exists/TransportExistsAction.java
@@ -151,7 +151,7 @@ public class TransportExistsAction extends TransportBroadcastAction<ExistsReques
         SearchContext context = new DefaultSearchContext(0,
                 new ShardSearchLocalRequest(request.types(), request.nowInMillis(), request.filteringAliases()),
                 shardTarget, indexShard.acquireSearcher("exists"), indexService, indexShard,
-                scriptService, pageCacheRecycler, bigArrays, threadPool.estimatedTimeInMillisCounter());
+                scriptService, pageCacheRecycler, bigArrays, threadPool.estimatedTimeInMillisCounter(), parseFieldMatcher);
         SearchContext.setCurrent(context);
 
         try {

--- a/core/src/main/java/org/elasticsearch/action/explain/TransportExplainAction.java
+++ b/core/src/main/java/org/elasticsearch/action/explain/TransportExplainAction.java
@@ -113,7 +113,7 @@ public class TransportExplainAction extends TransportSingleShardAction<ExplainRe
                 0, new ShardSearchLocalRequest(new String[]{request.type()}, request.nowInMillis, request.filteringAlias()),
                 null, result.searcher(), indexService, indexShard,
                 scriptService, pageCacheRecycler,
-                bigArrays, threadPool.estimatedTimeInMillisCounter()
+                bigArrays, threadPool.estimatedTimeInMillisCounter(), parseFieldMatcher
         );
         SearchContext.setCurrent(context);
 

--- a/core/src/main/java/org/elasticsearch/action/search/SearchRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchRequest.java
@@ -26,6 +26,7 @@ import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.Requests;
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -239,7 +240,7 @@ public class SearchRequest extends ActionRequest<SearchRequest> implements Indic
      * "query_then_fetch"/"queryThenFetch", and "query_and_fetch"/"queryAndFetch".
      */
     public SearchRequest searchType(String searchType) {
-        return searchType(SearchType.fromString(searchType));
+        return searchType(SearchType.fromString(searchType, ParseFieldMatcher.EMPTY));
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/action/search/SearchType.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchType.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.action.search;
 
 import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.ParseFieldMatcher;
 
 /**
  * Search type represent the manner at which the search operation is executed.
@@ -108,7 +109,7 @@ public enum SearchType {
      * one of "dfs_query_then_fetch"/"dfsQueryThenFetch", "dfs_query_and_fetch"/"dfsQueryAndFetch",
      * "query_then_fetch"/"queryThenFetch", "query_and_fetch"/"queryAndFetch", and "scan".
      */
-    public static SearchType fromString(String searchType) {
+    public static SearchType fromString(String searchType, ParseFieldMatcher parseFieldMatcher) {
         if (searchType == null) {
             return SearchType.DEFAULT;
         }
@@ -122,7 +123,7 @@ public enum SearchType {
             return SearchType.QUERY_AND_FETCH;
         } else if ("scan".equals(searchType)) {
             return SearchType.SCAN;
-        } else if (COUNT_VALUE.match(searchType)) {
+        } else if (parseFieldMatcher.match(searchType, COUNT_VALUE)) {
             return SearchType.COUNT;
         } else {
             throw new IllegalArgumentException("No search type for [" + searchType + "]");

--- a/core/src/main/java/org/elasticsearch/action/support/TransportAction.java
+++ b/core/src/main/java/org/elasticsearch/action/support/TransportAction.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.action.support;
 
 import org.elasticsearch.action.*;
+import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.settings.Settings;
@@ -37,9 +38,11 @@ public abstract class TransportAction<Request extends ActionRequest, Response ex
     protected final ThreadPool threadPool;
     protected final String actionName;
     private final ActionFilter[] filters;
+    protected final ParseFieldMatcher parseFieldMatcher;
 
     protected TransportAction(Settings settings, String actionName, ThreadPool threadPool, ActionFilters actionFilters) {
         super(settings);
+        this.parseFieldMatcher = new ParseFieldMatcher(settings);
         this.actionName = actionName;
         this.filters = actionFilters.filters();
         this.threadPool = threadPool;

--- a/core/src/main/java/org/elasticsearch/action/update/UpdateRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/update/UpdateRequest.java
@@ -25,6 +25,7 @@ import org.elasticsearch.action.WriteConsistencyLevel;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.support.single.instance.InstanceShardOperationRequest;
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -291,13 +292,13 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest> 
     public UpdateRequest addScriptParam(String name, Object value) {
         Script script = script();
         if (script == null) {
-            HashMap<String, Object> scriptParams = new HashMap<String, Object>();
+            HashMap<String, Object> scriptParams = new HashMap<>();
             scriptParams.put(name, value);
             updateOrCreateScript(null, null, null, scriptParams);
         } else {
             Map<String, Object> scriptParams = script.getParams();
             if (scriptParams == null) {
-                scriptParams = new HashMap<String, Object>();
+                scriptParams = new HashMap<>();
                 scriptParams.put(name, value);
                 updateOrCreateScript(null, null, null, scriptParams);
             } else {
@@ -648,7 +649,8 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest> 
                 if (token == XContentParser.Token.FIELD_NAME) {
                     currentFieldName = parser.currentName();
                 } else if ("script".equals(currentFieldName) && token == XContentParser.Token.START_OBJECT) {
-                    script = Script.parse(parser);
+                    //here we don't have settings available, unable to throw strict deprecation exceptions
+                    script = Script.parse(parser, ParseFieldMatcher.EMPTY);
                 } else if ("params".equals(currentFieldName)) {
                     scriptParams = parser.map();
                 } else if ("scripted_upsert".equals(currentFieldName)) {
@@ -666,7 +668,8 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest> 
                 } else if ("detect_noop".equals(currentFieldName)) {
                     detectNoop(parser.booleanValue());
                 } else {
-                    scriptParameterParser.token(currentFieldName, token, parser);
+                    //here we don't have settings available, unable to throw deprecation exceptions
+                    scriptParameterParser.token(currentFieldName, token, parser, ParseFieldMatcher.EMPTY);
                 }
             }
             // Don't have a script using the new API so see if it is specified with the old API

--- a/core/src/main/java/org/elasticsearch/common/ParseField.java
+++ b/core/src/main/java/org/elasticsearch/common/ParseField.java
@@ -23,6 +23,7 @@ import java.util.EnumSet;
 import java.util.HashSet;
 
 /**
+ * Holds a field that can be found in a request while parsing and its different variants, which may be deprecated.
  */
 public class ParseField {
     private final String camelCaseName;
@@ -30,9 +31,10 @@ public class ParseField {
     private final String[] deprecatedNames;
     private String allReplacedWith = null;
 
-    public static final EnumSet<Flag> EMPTY_FLAGS = EnumSet.noneOf(Flag.class);
+    static final EnumSet<Flag> EMPTY_FLAGS = EnumSet.noneOf(Flag.class);
+    static final EnumSet<Flag> STRICT_FLAGS = EnumSet.of(Flag.STRICT);
 
-    public static enum Flag {
+    enum Flag {
         STRICT
     }
 
@@ -47,7 +49,7 @@ public class ParseField {
                 set.add(Strings.toCamelCase(depName));
                 set.add(Strings.toUnderscoreCase(depName));
             }
-            this.deprecatedNames = set.toArray(new String[0]);
+            this.deprecatedNames = set.toArray(new String[set.size()]);
         }
     }
 
@@ -78,11 +80,7 @@ public class ParseField {
         return parseField;
     }
 
-    public boolean match(String currentFieldName) {
-        return match(currentFieldName, EMPTY_FLAGS);
-    }
-    
-    public boolean match(String currentFieldName, EnumSet<Flag> flags) {
+    boolean match(String currentFieldName, EnumSet<Flag> flags) {
         if (allReplacedWith == null && (currentFieldName.equals(camelCaseName) || currentFieldName.equals(underscoreName))) {
             return true;
         }

--- a/core/src/main/java/org/elasticsearch/common/ParseFieldMatcher.java
+++ b/core/src/main/java/org/elasticsearch/common/ParseFieldMatcher.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.query.IndexQueryParserService;
+
+import java.util.EnumSet;
+
+/**
+ * Matcher to use in combination with {@link ParseField} while parsing requests. Matches a {@link ParseField}
+ * against a field name and throw deprecation exception depending on the current value of the {@link IndexQueryParserService#PARSE_STRICT} setting.
+ */
+public class ParseFieldMatcher {
+
+    public static final ParseFieldMatcher EMPTY = new ParseFieldMatcher(ParseField.EMPTY_FLAGS);
+    public static final ParseFieldMatcher STRICT = new ParseFieldMatcher(ParseField.STRICT_FLAGS);
+
+    private final EnumSet<ParseField.Flag> parseFlags;
+
+    public ParseFieldMatcher(Settings settings) {
+        if (settings.getAsBoolean(IndexQueryParserService.PARSE_STRICT, false)) {
+            this.parseFlags = EnumSet.of(ParseField.Flag.STRICT);
+        } else {
+            this.parseFlags = ParseField.EMPTY_FLAGS;
+        }
+    }
+
+    public ParseFieldMatcher(EnumSet<ParseField.Flag> parseFlags) {
+        this.parseFlags = parseFlags;
+    }
+
+    /**
+     * Matches a {@link ParseField} against a field name, and throws deprecation exception depending on the current
+     * value of the {@link IndexQueryParserService#PARSE_STRICT} setting.
+     * @param fieldName the field name found in the request while parsing
+     * @param parseField the parse field that we are looking for
+     * @throws IllegalArgumentException whenever we are in strict mode and the request contained a deprecated field
+     * @return true whenever the parse field that we are looking for was found, false otherwise
+     */
+    public boolean match(String fieldName, ParseField parseField) {
+        return parseField.match(fieldName, parseFlags);
+    }
+}

--- a/core/src/main/java/org/elasticsearch/index/mapper/Mapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/Mapper.java
@@ -22,6 +22,7 @@ package org.elasticsearch.index.mapper;
 import com.google.common.collect.ImmutableMap;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ToXContent;
@@ -92,14 +93,17 @@ public interface Mapper extends ToXContent, Iterable<Mapper> {
 
             private final Version indexVersionCreated;
 
+            private final ParseFieldMatcher parseFieldMatcher;
+
             public ParserContext(AnalysisService analysisService, SimilarityLookupService similarityLookupService,
-                                 MapperService mapperService,
-                                 ImmutableMap<String, TypeParser> typeParsers, Version indexVersionCreated) {
+                                 MapperService mapperService, ImmutableMap<String, TypeParser> typeParsers,
+                                Version indexVersionCreated, ParseFieldMatcher parseFieldMatcher) {
                 this.analysisService = analysisService;
                 this.similarityLookupService = similarityLookupService;
                 this.mapperService = mapperService;
                 this.typeParsers = typeParsers;
                 this.indexVersionCreated = indexVersionCreated;
+                this.parseFieldMatcher = parseFieldMatcher;
             }
 
             public AnalysisService analysisService() {
@@ -120,6 +124,10 @@ public interface Mapper extends ToXContent, Iterable<Mapper> {
 
             public Version indexVersionCreated() {
                 return indexVersionCreated;
+            }
+
+            public ParseFieldMatcher parseFieldMatcher() {
+                return parseFieldMatcher;
             }
         }
 

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/BinaryFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/BinaryFieldMapper.java
@@ -21,8 +21,6 @@ package org.elasticsearch.index.mapper.core;
 
 import com.carrotsearch.hppc.ObjectArrayList;
 import org.apache.lucene.document.Field;
-import org.apache.lucene.document.FieldType;
-import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.store.ByteArrayDataOutput;
 import org.apache.lucene.util.BytesRef;
@@ -35,7 +33,6 @@ import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressorFactory;
-import org.elasticsearch.common.compress.NotXContentException;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -98,7 +95,7 @@ public class BinaryFieldMapper extends AbstractFieldMapper {
                 Map.Entry<String, Object> entry = iterator.next();
                 String fieldName = entry.getKey();
                 if (parserContext.indexVersionCreated().before(Version.V_2_0_0) &&
-                        (COMPRESS.match(fieldName) || COMPRESS_THRESHOLD.match(fieldName))) {
+                        (parserContext.parseFieldMatcher().match(fieldName, COMPRESS) || parserContext.parseFieldMatcher().match(fieldName, COMPRESS_THRESHOLD))) {
                     iterator.remove();
                 }
             }

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/CompletionFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/CompletionFieldMapper.java
@@ -175,19 +175,19 @@ public class CompletionFieldMapper extends AbstractFieldMapper {
                     
                     indexAnalyzer = getNamedAnalyzer(parserContext, fieldNode.toString());
                     iterator.remove();
-                } else if (Fields.SEARCH_ANALYZER.match(fieldName)) {
+                } else if (parserContext.parseFieldMatcher().match(fieldName, Fields.SEARCH_ANALYZER)) {
                     searchAnalyzer = getNamedAnalyzer(parserContext, fieldNode.toString());
                     iterator.remove();
                 } else if (fieldName.equals(Fields.PAYLOADS)) {
                     builder.payloads(Boolean.parseBoolean(fieldNode.toString()));
                     iterator.remove();
-                } else if (Fields.PRESERVE_SEPARATORS.match(fieldName)) {
+                } else if (parserContext.parseFieldMatcher().match(fieldName, Fields.PRESERVE_SEPARATORS)) {
                     builder.preserveSeparators(Boolean.parseBoolean(fieldNode.toString()));
                     iterator.remove();
-                } else if (Fields.PRESERVE_POSITION_INCREMENTS.match(fieldName)) {
+                } else if (parserContext.parseFieldMatcher().match(fieldName, Fields.PRESERVE_POSITION_INCREMENTS)) {
                     builder.preservePositionIncrements(Boolean.parseBoolean(fieldNode.toString()));
                     iterator.remove();
-                } else if (Fields.MAX_INPUT_LENGTH.match(fieldName)) {
+                } else if (parserContext.parseFieldMatcher().match(fieldName, Fields.MAX_INPUT_LENGTH)) {
                     builder.maxInputLength(Integer.parseInt(fieldNode.toString()));
                     iterator.remove();
                 } else if (parseMultiField(builder, name, parserContext, fieldName, fieldNode)) {

--- a/core/src/main/java/org/elasticsearch/index/query/ConstantScoreQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/ConstantScoreQueryParser.java
@@ -61,7 +61,7 @@ public class ConstantScoreQueryParser implements QueryParser {
             } else if (parseContext.isDeprecatedSetting(currentFieldName)) {
                 // skip
             } else if (token == XContentParser.Token.START_OBJECT) {
-                if (INNER_QUERY_FIELD.match(currentFieldName)) {
+                if (parseContext.parseFieldMatcher().match(currentFieldName, INNER_QUERY_FIELD)) {
                     filter = parseContext.parseInnerFilter();
                     queryFound = true;
                 } else {

--- a/core/src/main/java/org/elasticsearch/index/query/FuzzyQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/FuzzyQueryParser.java
@@ -27,7 +27,6 @@ import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.query.support.QueryParsers;
 
@@ -86,7 +85,7 @@ public class FuzzyQueryParser implements QueryParser {
                         value = parser.text();
                     } else if ("boost".equals(currentFieldName)) {
                         boost = parser.floatValue();
-                    } else if (FUZZINESS.match(currentFieldName, parseContext.parseFlags())) {
+                    } else if (parseContext.parseFieldMatcher().match(currentFieldName, FUZZINESS)) {
                         fuzziness = Fuzziness.parse(parser);
                     } else if ("prefix_length".equals(currentFieldName) || "prefixLength".equals(currentFieldName)) {
                         prefixLength = parser.intValue();

--- a/core/src/main/java/org/elasticsearch/index/query/HasChildQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/HasChildQueryParser.java
@@ -97,7 +97,7 @@ public class HasChildQueryParser implements QueryParser {
                 // type may not have been extracted yet, so use the
                 // XContentStructure.<type> facade to parse if available,
                 // or delay parsing if not.
-                if (QUERY_FIELD.match(currentFieldName)) {
+                if (parseContext.parseFieldMatcher().match(currentFieldName, QUERY_FIELD)) {
                     iq = new XContentStructure.InnerQuery(parseContext, childType == null ? null : new String[] { childType });
                     queryFound = true;
                 } else if ("inner_hits".equals(currentFieldName)) {

--- a/core/src/main/java/org/elasticsearch/index/query/HasParentQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/HasParentQueryParser.java
@@ -86,7 +86,7 @@ public class HasParentQueryParser implements QueryParser {
                 // type may not have been extracted yet, so use the
                 // XContentStructure.<type> facade to parse if available,
                 // or delay parsing if not.
-                if (QUERY_FIELD.match(currentFieldName)) {
+                if (parseContext.parseFieldMatcher().match(currentFieldName, QUERY_FIELD)) {
                     iq = new XContentStructure.InnerQuery(parseContext, parentType == null ? null : new String[] {parentType});
                     queryFound = true;
                 } else if ("inner_hits".equals(currentFieldName)) {

--- a/core/src/main/java/org/elasticsearch/index/query/IndicesQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/IndicesQueryParser.java
@@ -73,10 +73,10 @@ public class IndicesQueryParser implements QueryParser {
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
             } else if (token == XContentParser.Token.START_OBJECT) {
-                if (QUERY_FIELD.match(currentFieldName)) {
+                if (parseContext.parseFieldMatcher().match(currentFieldName, QUERY_FIELD)) {
                     innerQuery = new XContentStructure.InnerQuery(parseContext, null);
                     queryFound = true;
-                } else if (NO_MATCH_QUERY.match(currentFieldName)) {
+                } else if (parseContext.parseFieldMatcher().match(currentFieldName, NO_MATCH_QUERY)) {
                     innerNoMatchQuery = new XContentStructure.InnerQuery(parseContext, null);
                 } else {
                     throw new QueryParsingException(parseContext, "[indices] query does not support [" + currentFieldName + "]");
@@ -106,7 +106,7 @@ public class IndicesQueryParser implements QueryParser {
                     }
                     indicesFound = true;
                     currentIndexMatchesIndices = matchesIndices(parseContext.index().name(), parser.text());
-                } else if (NO_MATCH_QUERY.match(currentFieldName)) {
+                } else if (parseContext.parseFieldMatcher().match(currentFieldName, NO_MATCH_QUERY)) {
                     String type = parser.text();
                     if ("all".equals(type)) {
                         noMatchQuery = Queries.newMatchAllQuery();

--- a/core/src/main/java/org/elasticsearch/index/query/MatchQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MatchQueryParser.java
@@ -105,7 +105,7 @@ public class MatchQueryParser implements QueryParser {
                         boost = parser.floatValue();
                     } else if ("slop".equals(currentFieldName) || "phrase_slop".equals(currentFieldName) || "phraseSlop".equals(currentFieldName)) {
                         matchQuery.setPhraseSlop(parser.intValue());
-                    } else if (Fuzziness.FIELD.match(currentFieldName, parseContext.parseFlags())) {
+                    } else if (parseContext.parseFieldMatcher().match(currentFieldName, Fuzziness.FIELD)) {
                         matchQuery.setFuzziness(Fuzziness.parse(parser));
                     } else if ("prefix_length".equals(currentFieldName) || "prefixLength".equals(currentFieldName)) {
                         matchQuery.setFuzzyPrefixLength(parser.intValue());

--- a/core/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryParser.java
@@ -116,47 +116,47 @@ public class MoreLikeThisQueryParser implements QueryParser {
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
             } else if (token.isValue()) {
-                if (Fields.LIKE_TEXT.match(currentFieldName, parseContext.parseFlags())) {
+                if (parseContext.parseFieldMatcher().match(currentFieldName, Fields.LIKE_TEXT)) {
                     likeTexts.add(parser.text());
-                } else if (Fields.LIKE.match(currentFieldName, parseContext.parseFlags())) {
+                } else if (parseContext.parseFieldMatcher().match(currentFieldName, Fields.LIKE)) {
                     parseLikeField(parser, likeTexts, likeItems);
-                } else if (Fields.UNLIKE.match(currentFieldName, parseContext.parseFlags())) {
+                } else if (parseContext.parseFieldMatcher().match(currentFieldName, Fields.UNLIKE)) {
                     parseLikeField(parser, unlikeTexts, unlikeItems);
-                } else if (Fields.MIN_TERM_FREQ.match(currentFieldName, parseContext.parseFlags())) {
+                } else if (parseContext.parseFieldMatcher().match(currentFieldName, Fields.MIN_TERM_FREQ)) {
                     mltQuery.setMinTermFrequency(parser.intValue());
-                } else if (Fields.MAX_QUERY_TERMS.match(currentFieldName, parseContext.parseFlags())) {
+                } else if (parseContext.parseFieldMatcher().match(currentFieldName, Fields.MAX_QUERY_TERMS)) {
                     mltQuery.setMaxQueryTerms(parser.intValue());
-                } else if (Fields.MIN_DOC_FREQ.match(currentFieldName, parseContext.parseFlags())) {
+                } else if (parseContext.parseFieldMatcher().match(currentFieldName, Fields.MIN_DOC_FREQ)) {
                     mltQuery.setMinDocFreq(parser.intValue());
-                } else if (Fields.MAX_DOC_FREQ.match(currentFieldName, parseContext.parseFlags())) {
+                } else if (parseContext.parseFieldMatcher().match(currentFieldName, Fields.MAX_DOC_FREQ)) {
                     mltQuery.setMaxDocFreq(parser.intValue());
-                } else if (Fields.MIN_WORD_LENGTH.match(currentFieldName, parseContext.parseFlags())) {
+                } else if (parseContext.parseFieldMatcher().match(currentFieldName, Fields.MIN_WORD_LENGTH)) {
                     mltQuery.setMinWordLen(parser.intValue());
-                } else if (Fields.MAX_WORD_LENGTH.match(currentFieldName, parseContext.parseFlags())) {
+                } else if (parseContext.parseFieldMatcher().match(currentFieldName, Fields.MAX_WORD_LENGTH)) {
                     mltQuery.setMaxWordLen(parser.intValue());
-                } else if (Fields.BOOST_TERMS.match(currentFieldName, parseContext.parseFlags())) {
+                } else if (parseContext.parseFieldMatcher().match(currentFieldName, Fields.BOOST_TERMS)) {
                     float boostFactor = parser.floatValue();
                     if (boostFactor != 0) {
                         mltQuery.setBoostTerms(true);
                         mltQuery.setBoostTermsFactor(boostFactor);
                     }
-                } else if (Fields.MINIMUM_SHOULD_MATCH.match(currentFieldName, parseContext.parseFlags())) {
+                } else if (parseContext.parseFieldMatcher().match(currentFieldName, Fields.MINIMUM_SHOULD_MATCH)) {
                     mltQuery.setMinimumShouldMatch(parser.text());
                 } else if ("analyzer".equals(currentFieldName)) {
                     analyzer = parseContext.analysisService().analyzer(parser.text());
                 } else if ("boost".equals(currentFieldName)) {
                     mltQuery.setBoost(parser.floatValue());
-                } else if (Fields.FAIL_ON_UNSUPPORTED_FIELD.match(currentFieldName, parseContext.parseFlags())) {
+                } else if (parseContext.parseFieldMatcher().match(currentFieldName, Fields.FAIL_ON_UNSUPPORTED_FIELD)) {
                     failOnUnsupportedField = parser.booleanValue();
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
-                } else if (Fields.INCLUDE.match(currentFieldName, parseContext.parseFlags())) {
+                } else if (parseContext.parseFieldMatcher().match(currentFieldName, Fields.INCLUDE)) {
                     include = parser.booleanValue();
                 } else {
                     throw new QueryParsingException(parseContext, "[mlt] query does not support [" + currentFieldName + "]");
                 }
             } else if (token == XContentParser.Token.START_ARRAY) {
-                if (Fields.STOP_WORDS.match(currentFieldName, parseContext.parseFlags())) {
+                if (parseContext.parseFieldMatcher().match(currentFieldName, Fields.STOP_WORDS)) {
                     Set<String> stopWords = Sets.newHashSet();
                     while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                         stopWords.add(parser.text());
@@ -169,25 +169,25 @@ public class MoreLikeThisQueryParser implements QueryParser {
                         MappedFieldType fieldType = parseContext.fieldMapper(field);
                         moreLikeFields.add(fieldType == null ? field : fieldType.names().indexName());
                     }
-                } else if (Fields.DOCUMENT_IDS.match(currentFieldName, parseContext.parseFlags())) {
+                } else if (parseContext.parseFieldMatcher().match(currentFieldName, Fields.DOCUMENT_IDS)) {
                     while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                         if (!token.isValue()) {
                             throw new IllegalArgumentException("ids array element should only contain ids");
                         }
                         likeItems.add(newTermVectorsRequest().id(parser.text()));
                     }
-                } else if (Fields.DOCUMENTS.match(currentFieldName, parseContext.parseFlags())) {
+                } else if (parseContext.parseFieldMatcher().match(currentFieldName, Fields.DOCUMENTS)) {
                     while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                         if (token != XContentParser.Token.START_OBJECT) {
                             throw new IllegalArgumentException("docs array element should include an object");
                         }
                         likeItems.add(parseDocument(parser));
                     }
-                } else if (Fields.LIKE.match(currentFieldName, parseContext.parseFlags())) {
+                } else if (parseContext.parseFieldMatcher().match(currentFieldName, Fields.LIKE)) {
                     while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                         parseLikeField(parser, likeTexts, likeItems);
                     }
-                } else if (Fields.UNLIKE.match(currentFieldName, parseContext.parseFlags())) {
+                } else if (parseContext.parseFieldMatcher().match(currentFieldName, Fields.UNLIKE)) {
                     while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                         parseLikeField(parser, unlikeTexts, unlikeItems);
                     }
@@ -195,10 +195,10 @@ public class MoreLikeThisQueryParser implements QueryParser {
                     throw new QueryParsingException(parseContext, "[mlt] query does not support [" + currentFieldName + "]");
                 }
             } else if (token == XContentParser.Token.START_OBJECT) {
-                if (Fields.LIKE.match(currentFieldName, parseContext.parseFlags())) {
+                if (parseContext.parseFieldMatcher().match(currentFieldName, Fields.LIKE)) {
                     parseLikeField(parser, likeTexts, likeItems);
                 }
-                else if (Fields.UNLIKE.match(currentFieldName, parseContext.parseFlags())) {
+                else if (parseContext.parseFieldMatcher().match(currentFieldName, Fields.UNLIKE)) {
                     parseLikeField(parser, unlikeTexts, unlikeItems);
                 } else {
                     throw new QueryParsingException(parseContext, "[mlt] query does not support [" + currentFieldName + "]");

--- a/core/src/main/java/org/elasticsearch/index/query/MultiMatchQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MultiMatchQueryBuilder.java
@@ -23,13 +23,13 @@ import com.carrotsearch.hppc.ObjectFloatHashMap;
 import com.google.common.collect.Lists;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.search.MatchQuery;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.EnumSet;
 import java.util.List;
 import java.util.Locale;
 
@@ -133,15 +133,11 @@ public class MultiMatchQueryBuilder extends QueryBuilder implements BoostableQue
             return parseField;
         }
 
-        public static Type parse(String value) {
-            return parse(value, ParseField.EMPTY_FLAGS);
-        }
-
-        public static Type parse(String value, EnumSet<ParseField.Flag> flags) {
+        public static Type parse(String value, ParseFieldMatcher parseFieldMatcher) {
             MultiMatchQueryBuilder.Type[] values = MultiMatchQueryBuilder.Type.values();
             Type type = null;
             for (MultiMatchQueryBuilder.Type t : values) {
-                if (t.parseField().match(value, flags)) {
+                if (parseFieldMatcher.match(value, t.parseField())) {
                     type = t;
                     break;
                 }
@@ -194,7 +190,7 @@ public class MultiMatchQueryBuilder extends QueryBuilder implements BoostableQue
      * Sets the type of the text query.
      */
     public MultiMatchQueryBuilder type(Object type) {
-        this.type = type == null ? null : Type.parse(type.toString().toLowerCase(Locale.ROOT));
+        this.type = type == null ? null : Type.parse(type.toString().toLowerCase(Locale.ROOT), ParseFieldMatcher.EMPTY);
         return this;
     }
 

--- a/core/src/main/java/org/elasticsearch/index/query/MultiMatchQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MultiMatchQueryParser.java
@@ -84,7 +84,7 @@ public class MultiMatchQueryParser implements QueryParser {
                 if ("query".equals(currentFieldName)) {
                     value = parser.objectText();
                 } else if ("type".equals(currentFieldName)) {
-                    type = MultiMatchQueryBuilder.Type.parse(parser.text(), parseContext.parseFlags());
+                    type = MultiMatchQueryBuilder.Type.parse(parser.text(), parseContext.parseFieldMatcher());
                 } else if ("analyzer".equals(currentFieldName)) {
                     String analyzer = parser.text();
                     if (parseContext.analysisService().analyzer(analyzer) == null) {
@@ -95,7 +95,7 @@ public class MultiMatchQueryParser implements QueryParser {
                     boost = parser.floatValue();
                 } else if ("slop".equals(currentFieldName) || "phrase_slop".equals(currentFieldName) || "phraseSlop".equals(currentFieldName)) {
                     multiMatchQuery.setPhraseSlop(parser.intValue());
-                } else if (Fuzziness.FIELD.match(currentFieldName, parseContext.parseFlags())) {
+                } else if (parseContext.parseFieldMatcher().match(currentFieldName, Fuzziness.FIELD)) {
                     multiMatchQuery.setFuzziness(Fuzziness.parse(parser));
                 } else if ("prefix_length".equals(currentFieldName) || "prefixLength".equals(currentFieldName)) {
                     multiMatchQuery.setFuzzyPrefixLength(parser.intValue());

--- a/core/src/main/java/org/elasticsearch/index/query/NestedQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/NestedQueryParser.java
@@ -71,7 +71,7 @@ public class NestedQueryParser implements QueryParser {
             } else if (token == XContentParser.Token.START_OBJECT) {
                 if ("query".equals(currentFieldName)) {
                     builder.query();
-                } else if (FILTER_FIELD.match(currentFieldName)) {
+                } else if (parseContext.parseFieldMatcher().match(currentFieldName, FILTER_FIELD)) {
                     builder.filter();
                 } else if ("inner_hits".equals(currentFieldName)) {
                     builder.setInnerHits(innerHitsQueryParserHelper.parse(parseContext));

--- a/core/src/main/java/org/elasticsearch/index/query/NotQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/NotQueryParser.java
@@ -60,7 +60,7 @@ public class NotQueryParser implements QueryParser {
             } else if (parseContext.isDeprecatedSetting(currentFieldName)) {
                 // skip
             } else if (token == XContentParser.Token.START_OBJECT) {
-                if (QUERY_FIELD.match(currentFieldName)) {
+                if (parseContext.parseFieldMatcher().match(currentFieldName, QUERY_FIELD)) {
                     query = parseContext.parseInnerFilter();
                     queryFound = true;
                 } else {

--- a/core/src/main/java/org/elasticsearch/index/query/QueryParseContext.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryParseContext.java
@@ -33,6 +33,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.Index;
@@ -51,9 +52,6 @@ import org.elasticsearch.search.lookup.SearchLookup;
 import java.io.IOException;
 import java.util.*;
 
-/**
- *
- */
 public class QueryParseContext {
 
     private static final ParseField CACHE = new ParseField("_cache").withAllDeprecated("Elasticsearch makes its own caching decisions");
@@ -91,7 +89,7 @@ public class QueryParseContext {
 
     private XContentParser parser;
 
-    private EnumSet<ParseField.Flag> parseFlags = ParseField.EMPTY_FLAGS;
+    private ParseFieldMatcher parseFieldMatcher;
 
     private boolean allowUnmappedFields;
 
@@ -107,17 +105,17 @@ public class QueryParseContext {
         this.indexQueryParser = indexQueryParser;
     }
 
-    public void parseFlags(EnumSet<ParseField.Flag> parseFlags) {
-        this.parseFlags = parseFlags == null ? ParseField.EMPTY_FLAGS : parseFlags;
+    public void parseFieldMatcher(ParseFieldMatcher parseFieldMatcher) {
+        this.parseFieldMatcher = parseFieldMatcher;
     }
 
-    public EnumSet<ParseField.Flag> parseFlags() {
-        return parseFlags;
+    public ParseFieldMatcher parseFieldMatcher() {
+        return parseFieldMatcher;
     }
 
     public void reset(XContentParser jp) {
         allowUnmappedFields = indexQueryParser.defaultAllowUnmappedFields();
-        this.parseFlags = ParseField.EMPTY_FLAGS;
+        this.parseFieldMatcher = ParseFieldMatcher.EMPTY;
         this.lookup = null;
         this.parser = jp;
         this.namedQueries.clear();
@@ -382,7 +380,7 @@ public class QueryParseContext {
      * Return whether the setting is deprecated.
      */
     public boolean isDeprecatedSetting(String setting) {
-        return CACHE.match(setting) || CACHE_KEY.match(setting);
+        return parseFieldMatcher.match(setting, CACHE) || parseFieldMatcher.match(setting, CACHE_KEY);
     }
 
     public Version indexVersionCreated() {

--- a/core/src/main/java/org/elasticsearch/index/query/QueryStringQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryStringQueryParser.java
@@ -178,7 +178,7 @@ public class QueryStringQueryParser implements QueryParser {
                     qpSettings.fuzzyRewriteMethod(QueryParsers.parseRewriteMethod(parser.textOrNull()));
                 } else if ("phrase_slop".equals(currentFieldName) || "phraseSlop".equals(currentFieldName)) {
                     qpSettings.phraseSlop(parser.intValue());
-                } else if (FUZZINESS.match(currentFieldName, parseContext.parseFlags())) {
+                } else if (parseContext.parseFieldMatcher().match(currentFieldName, FUZZINESS)) {
                     qpSettings.fuzzyMinSim(Fuzziness.parse(parser).asSimilarity());
                 } else if ("boost".equals(currentFieldName)) {
                     qpSettings.boost(parser.floatValue());

--- a/core/src/main/java/org/elasticsearch/index/query/RangeQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/RangeQueryParser.java
@@ -27,7 +27,6 @@ import org.elasticsearch.common.joda.DateMathParser;
 import org.elasticsearch.common.joda.Joda;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.core.DateFieldMapper;
 import org.joda.time.DateTimeZone;
@@ -112,7 +111,7 @@ public class RangeQueryParser implements QueryParser {
             } else if (token.isValue()) {
                 if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
-                } else if (FIELDDATA_FIELD.match(currentFieldName)) {
+                } else if (parseContext.parseFieldMatcher().match(currentFieldName, FIELDDATA_FIELD)) {
                     // ignore
                 } else {
                     throw new QueryParsingException(parseContext, "[range] query does not support [" + currentFieldName + "]");

--- a/core/src/main/java/org/elasticsearch/index/query/TemplateQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/TemplateQueryParser.java
@@ -20,6 +20,7 @@ package org.elasticsearch.index.query;
 
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.xcontent.XContentFactory;
@@ -75,7 +76,7 @@ public class TemplateQueryParser implements QueryParser {
     @Nullable
     public Query parse(QueryParseContext parseContext) throws IOException {
         XContentParser parser = parseContext.parser();
-        Template template = parse(parser);
+        Template template = parse(parser, parseContext.parseFieldMatcher());
         ExecutableScript executable = this.scriptService.executable(template, ScriptContext.Standard.SEARCH);
 
         BytesReference querySource = (BytesReference) executable.run();
@@ -87,29 +88,29 @@ public class TemplateQueryParser implements QueryParser {
         }
     }
 
-    public static Template parse(XContentParser parser, String... parameters) throws IOException {
+    public static Template parse(XContentParser parser, ParseFieldMatcher parseFieldMatcher, String... parameters) throws IOException {
 
         Map<String, ScriptService.ScriptType> parameterMap = new HashMap<>(parametersToTypes);
         for (String parameter : parameters) {
             parameterMap.put(parameter, ScriptService.ScriptType.INLINE);
         }
-        return parse(parser, parameterMap);
+        return parse(parser, parameterMap, parseFieldMatcher);
     }
 
-    public static Template parse(String defaultLang, XContentParser parser, String... parameters) throws IOException {
+    public static Template parse(String defaultLang, XContentParser parser, ParseFieldMatcher parseFieldMatcher, String... parameters) throws IOException {
 
         Map<String, ScriptService.ScriptType> parameterMap = new HashMap<>(parametersToTypes);
         for (String parameter : parameters) {
             parameterMap.put(parameter, ScriptService.ScriptType.INLINE);
         }
-        return Template.parse(parser, parameterMap, defaultLang);
+        return Template.parse(parser, parameterMap, defaultLang, parseFieldMatcher);
     }
 
-    public static Template parse(XContentParser parser) throws IOException {
-        return parse(parser, parametersToTypes);
+    public static Template parse(XContentParser parser, ParseFieldMatcher parseFieldMatcher) throws IOException {
+        return parse(parser, parametersToTypes, parseFieldMatcher);
     }
 
-    public static Template parse(XContentParser parser, Map<String, ScriptService.ScriptType> parameterMap) throws IOException {
-        return Template.parse(parser, parameterMap);
+    public static Template parse(XContentParser parser, Map<String, ScriptService.ScriptType> parameterMap, ParseFieldMatcher parseFieldMatcher) throws IOException {
+        return Template.parse(parser, parameterMap, parseFieldMatcher);
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/TermsQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/TermsQueryParser.java
@@ -37,7 +37,6 @@ import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
-import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.indices.cache.query.terms.TermsLookup;
 import org.elasticsearch.search.internal.SearchContext;
@@ -141,7 +140,7 @@ public class TermsQueryParser implements QueryParser {
             } else if (token.isValue()) {
                 if (EXECUTION_KEY.equals(currentFieldName)) {
                     // ignore
-                } else if (MIN_SHOULD_MATCH_FIELD.match(currentFieldName)) {
+                } else if (parseContext.parseFieldMatcher().match(currentFieldName, MIN_SHOULD_MATCH_FIELD)) {
                     if (minShouldMatch != null) {
                         throw new IllegalArgumentException("[" + currentFieldName + "] is not allowed in a filter context for the [" + NAME + "] query");
                     }

--- a/core/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionParser.java
@@ -122,7 +122,7 @@ public abstract class DecayFunctionParser implements ScoreFunctionParser {
     public ScoreFunction parse(QueryParseContext parseContext, XContentParser parser) throws IOException, QueryParsingException {
         String currentFieldName;
         XContentParser.Token token;
-        AbstractDistanceScoreFunction scoreFunction = null;
+        AbstractDistanceScoreFunction scoreFunction;
         String multiValueMode = "MIN";
         XContentBuilder variableContent = XContentFactory.jsonBuilder();
         String fieldName = null;
@@ -132,7 +132,7 @@ public abstract class DecayFunctionParser implements ScoreFunctionParser {
             if (token == XContentParser.Token.START_OBJECT) {
                 variableContent.copyCurrentStructure(parser);
                 fieldName = currentFieldName;
-            } else if (MULTI_VALUE_MODE.match(currentFieldName)) {
+            } else if (parseContext.parseFieldMatcher().match(currentFieldName, MULTI_VALUE_MODE)) {
                 multiValueMode = parser.text();
             } else {
                 throw new ElasticsearchParseException("malformed score function score parameters.");

--- a/core/src/main/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryParser.java
@@ -76,7 +76,7 @@ public class FunctionScoreQueryParser implements QueryParser {
 
     static {
         CombineFunction[] values = CombineFunction.values();
-        Builder<String, CombineFunction> combineFunctionMapBuilder = ImmutableMap.<String, CombineFunction>builder();
+        Builder<String, CombineFunction> combineFunctionMapBuilder = ImmutableMap.builder();
         for (CombineFunction combineFunction : values) {
             combineFunctionMapBuilder.put(combineFunction.getName(), combineFunction);
         }
@@ -109,7 +109,7 @@ public class FunctionScoreQueryParser implements QueryParser {
                 currentFieldName = parser.currentName();
             } else if ("query".equals(currentFieldName)) {
                 query = parseContext.parseInnerQuery();
-            } else if (FILTER_FIELD.match(currentFieldName)) {
+            } else if (parseContext.parseFieldMatcher().match(currentFieldName, FILTER_FIELD)) {
                 filter = parseContext.parseInnerFilter();
             } else if ("score_mode".equals(currentFieldName) || "scoreMode".equals(currentFieldName)) {
                 scoreMode = parseScoreMode(parseContext, parser);
@@ -212,7 +212,7 @@ public class FunctionScoreQueryParser implements QueryParser {
                 while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
                     if (token == XContentParser.Token.FIELD_NAME) {
                         currentFieldName = parser.currentName();
-                    } else if (WEIGHT_FIELD.match(currentFieldName)) {
+                    } else if (parseContext.parseFieldMatcher().match(currentFieldName, WEIGHT_FIELD)) {
                         functionWeight = parser.floatValue();
                     } else {
                         if ("filter".equals(currentFieldName)) {

--- a/core/src/main/java/org/elasticsearch/index/query/functionscore/script/ScriptScoreFunctionParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/functionscore/script/ScriptScoreFunctionParser.java
@@ -21,6 +21,7 @@
 
 package org.elasticsearch.index.query.functionscore.script;
 
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.lucene.search.function.ScoreFunction;
 import org.elasticsearch.common.lucene.search.function.ScriptScoreFunction;
@@ -67,15 +68,15 @@ public class ScriptScoreFunctionParser implements ScoreFunctionParser {
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
             } else if (token == XContentParser.Token.START_OBJECT) {
-                if (ScriptField.SCRIPT.match(currentFieldName)) {
-                    script = Script.parse(parser);
+                if (parseContext.parseFieldMatcher().match(currentFieldName, ScriptField.SCRIPT)) {
+                    script = Script.parse(parser, parseContext.parseFieldMatcher());
                 } else if ("params".equals(currentFieldName)) { // TODO remove in 3.0 (here to support old script APIs)
                     vars = parser.map();
                 } else {
                     throw new QueryParsingException(parseContext, NAMES[0] + " query does not support [" + currentFieldName + "]");
                 }
             } else if (token.isValue()) {
-                if (!scriptParameterParser.token(currentFieldName, token, parser)) {
+                if (!scriptParameterParser.token(currentFieldName, token, parser, parseContext.parseFieldMatcher())) {
                     throw new QueryParsingException(parseContext, NAMES[0] + " query does not support [" + currentFieldName + "]");
                 }
             }

--- a/core/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshot.java
+++ b/core/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshot.java
@@ -25,6 +25,7 @@ import org.apache.lucene.util.Version;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.ToXContent;
@@ -448,7 +449,7 @@ public class BlobStoreIndexShardSnapshot {
      * @return shard snapshot metadata
      * @throws IOException
      */
-    public static BlobStoreIndexShardSnapshot fromXContent(XContentParser parser) throws IOException {
+    public static BlobStoreIndexShardSnapshot fromXContent(XContentParser parser, ParseFieldMatcher parseFieldMatcher) throws IOException {
 
         String snapshot = null;
         long indexVersion = -1;
@@ -466,24 +467,24 @@ public class BlobStoreIndexShardSnapshot {
                     String currentFieldName = parser.currentName();
                     token = parser.nextToken();
                     if (token.isValue()) {
-                        if (ParseFields.NAME.match(currentFieldName)) {
+                        if (parseFieldMatcher.match(currentFieldName, ParseFields.NAME)) {
                             snapshot = parser.text();
-                        } else if (ParseFields.INDEX_VERSION.match(currentFieldName)) {
+                        } else if (parseFieldMatcher.match(currentFieldName, ParseFields.INDEX_VERSION)) {
                             // The index-version is needed for backward compatibility with v 1.0
                             indexVersion = parser.longValue();
-                        } else if (ParseFields.START_TIME.match(currentFieldName)) {
+                        } else if (parseFieldMatcher.match(currentFieldName, ParseFields.START_TIME)) {
                             startTime = parser.longValue();
-                        } else if (ParseFields.TIME.match(currentFieldName)) {
+                        } else if (parseFieldMatcher.match(currentFieldName, ParseFields.TIME)) {
                             time = parser.longValue();
-                        } else if (ParseFields.NUMBER_OF_FILES.match(currentFieldName)) {
+                        } else if (parseFieldMatcher.match(currentFieldName, ParseFields.NUMBER_OF_FILES)) {
                             numberOfFiles = parser.intValue();
-                        } else if (ParseFields.TOTAL_SIZE.match(currentFieldName)) {
+                        } else if (parseFieldMatcher.match(currentFieldName, ParseFields.TOTAL_SIZE)) {
                             totalSize = parser.longValue();
                         } else {
                             throw new ElasticsearchParseException("unknown parameter [{}]", currentFieldName);
                         }
                     } else if (token == XContentParser.Token.START_ARRAY) {
-                        if (ParseFields.FILES.match(currentFieldName)) {
+                        if (parseFieldMatcher.match(currentFieldName, ParseFields.FILES)) {
                             while ((parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                                 indexFiles.add(FileInfo.fromXContent(parser));
                             }
@@ -498,7 +499,7 @@ public class BlobStoreIndexShardSnapshot {
                 }
             }
         }
-        return new BlobStoreIndexShardSnapshot(snapshot, indexVersion, ImmutableList.<FileInfo>copyOf(indexFiles),
+        return new BlobStoreIndexShardSnapshot(snapshot, indexVersion, ImmutableList.copyOf(indexFiles),
                 startTime, time, numberOfFiles, totalSize);
     }
 

--- a/core/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshots.java
+++ b/core/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshots.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentBuilderString;
@@ -224,7 +225,7 @@ public class BlobStoreIndexShardSnapshots implements Iterable<SnapshotFiles>, To
         return builder;
     }
 
-    public static BlobStoreIndexShardSnapshots fromXContent(XContentParser parser) throws IOException {
+    public static BlobStoreIndexShardSnapshots fromXContent(XContentParser parser, ParseFieldMatcher parseFieldMatcher) throws IOException {
         XContentParser.Token token = parser.currentToken();
         Map<String, List<String>> snapshotsMap = newHashMap();
         ImmutableMap.Builder<String, FileInfo> filesBuilder = ImmutableMap.builder();
@@ -236,7 +237,7 @@ public class BlobStoreIndexShardSnapshots implements Iterable<SnapshotFiles>, To
                 String currentFieldName = parser.currentName();
                 token = parser.nextToken();
                 if (token == XContentParser.Token.START_ARRAY) {
-                    if (ParseFields.FILES.match(currentFieldName) == false) {
+                    if (parseFieldMatcher.match(currentFieldName, ParseFields.FILES) == false) {
                         throw new ElasticsearchParseException("unknown array [{}]", currentFieldName);
                     }
                     while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
@@ -244,7 +245,7 @@ public class BlobStoreIndexShardSnapshots implements Iterable<SnapshotFiles>, To
                         filesBuilder.put(fileInfo.name(), fileInfo);
                     }
                 } else if (token == XContentParser.Token.START_OBJECT) {
-                    if (ParseFields.SNAPSHOTS.match(currentFieldName) == false) {
+                    if (parseFieldMatcher.match(currentFieldName, ParseFields.SNAPSHOTS) == false) {
                         throw new ElasticsearchParseException("unknown object [{}]", currentFieldName);
                     }
                     while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
@@ -259,7 +260,7 @@ public class BlobStoreIndexShardSnapshots implements Iterable<SnapshotFiles>, To
                             if (token == XContentParser.Token.FIELD_NAME) {
                                 currentFieldName = parser.currentName();
                                 if (parser.nextToken() == XContentParser.Token.START_ARRAY) {
-                                    if (ParseFields.FILES.match(currentFieldName) == false) {
+                                    if (parseFieldMatcher.match(currentFieldName, ParseFields.FILES) == false) {
                                         throw new ElasticsearchParseException("unknown array [{}]", currentFieldName);
                                     }
                                     List<String> fileNames = newArrayList();

--- a/core/src/main/java/org/elasticsearch/percolator/PercolateContext.java
+++ b/core/src/main/java/org/elasticsearch/percolator/PercolateContext.java
@@ -32,9 +32,7 @@ import org.apache.lucene.util.Counter;
 import org.elasticsearch.action.percolate.PercolateShardRequest;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.cache.recycler.PageCacheRecycler;
-import org.elasticsearch.common.HasContext;
-import org.elasticsearch.common.HasContextAndHeaders;
-import org.elasticsearch.common.HasHeaders;
+import org.elasticsearch.common.*;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.text.StringText;
@@ -77,11 +75,7 @@ import org.elasticsearch.search.rescore.RescoreSearchContext;
 import org.elasticsearch.search.scan.ScanContext;
 import org.elasticsearch.search.suggest.SuggestionSearchContext;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ConcurrentMap;
 
 /**
@@ -123,7 +117,8 @@ public class PercolateContext extends SearchContext {
 
     public PercolateContext(PercolateShardRequest request, SearchShardTarget searchShardTarget, IndexShard indexShard,
                             IndexService indexService, PageCacheRecycler pageCacheRecycler,
-                            BigArrays bigArrays, ScriptService scriptService, Query aliasFilter) {
+                            BigArrays bigArrays, ScriptService scriptService, Query aliasFilter, ParseFieldMatcher parseFieldMatcher) {
+        super(parseFieldMatcher);
         this.indexShard = indexShard;
         this.indexService = indexService;
         this.fieldDataService = indexService.fieldData();

--- a/core/src/main/java/org/elasticsearch/rest/BaseRestHandler.java
+++ b/core/src/main/java/org/elasticsearch/rest/BaseRestHandler.java
@@ -22,6 +22,7 @@ package org.elasticsearch.rest;
 import org.elasticsearch.action.*;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.FilterClient;
+import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.settings.Settings;
 
@@ -39,11 +40,13 @@ public abstract class BaseRestHandler extends AbstractComponent implements RestH
 
     private final RestController controller;
     private final Client client;
+    protected final ParseFieldMatcher parseFieldMatcher;
 
     protected BaseRestHandler(Settings settings, RestController controller, Client client) {
         super(settings);
         this.controller = controller;
         this.client = client;
+        this.parseFieldMatcher = new ParseFieldMatcher(settings);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/rest/action/admin/indices/cache/clear/RestClearIndicesCacheAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/indices/cache/clear/RestClearIndicesCacheAction.java
@@ -24,6 +24,7 @@ import org.elasticsearch.action.admin.indices.cache.clear.ClearIndicesCacheRespo
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
@@ -57,7 +58,7 @@ public class RestClearIndicesCacheAction extends BaseRestHandler {
     public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         ClearIndicesCacheRequest clearIndicesCacheRequest = new ClearIndicesCacheRequest(Strings.splitStringByCommaToArray(request.param("index")));
         clearIndicesCacheRequest.indicesOptions(IndicesOptions.fromRequest(request, clearIndicesCacheRequest.indicesOptions()));
-        fromRequest(request, clearIndicesCacheRequest);
+        fromRequest(request, clearIndicesCacheRequest, parseFieldMatcher);
         client.admin().indices().clearCache(clearIndicesCacheRequest, new RestBuilderListener<ClearIndicesCacheResponse>(channel) {
             @Override
             public RestResponse buildResponse(ClearIndicesCacheResponse response, XContentBuilder builder) throws Exception {
@@ -69,20 +70,19 @@ public class RestClearIndicesCacheAction extends BaseRestHandler {
         });
     }
 
-    public static ClearIndicesCacheRequest fromRequest(final RestRequest request, ClearIndicesCacheRequest clearIndicesCacheRequest) {
+    public static ClearIndicesCacheRequest fromRequest(final RestRequest request, ClearIndicesCacheRequest clearIndicesCacheRequest, ParseFieldMatcher parseFieldMatcher) {
 
         for (Map.Entry<String, String> entry : request.params().entrySet()) {
-
-            if (Fields.QUERY.match(entry.getKey())) {
+            if (parseFieldMatcher.match(entry.getKey(), Fields.QUERY)) {
                 clearIndicesCacheRequest.queryCache(request.paramAsBoolean(entry.getKey(), clearIndicesCacheRequest.queryCache()));
             }
-            if (Fields.FIELD_DATA.match(entry.getKey())) {
+            if (parseFieldMatcher.match(entry.getKey(), Fields.FIELD_DATA)) {
                 clearIndicesCacheRequest.fieldDataCache(request.paramAsBoolean(entry.getKey(), clearIndicesCacheRequest.fieldDataCache()));
             }
-            if (Fields.RECYCLER.match(entry.getKey())) {
+            if (parseFieldMatcher.match(entry.getKey(), Fields.RECYCLER)) {
                 clearIndicesCacheRequest.recycler(request.paramAsBoolean(entry.getKey(), clearIndicesCacheRequest.recycler()));
             }
-            if (Fields.FIELDS.match(entry.getKey())) {
+            if (parseFieldMatcher.match(entry.getKey(), Fields.FIELDS)) {
                 clearIndicesCacheRequest.fields(request.paramAsStringArray(entry.getKey(), clearIndicesCacheRequest.fields()));
             }
         }

--- a/core/src/main/java/org/elasticsearch/rest/action/admin/indices/validate/template/RestRenderSearchTemplateAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/indices/validate/template/RestRenderSearchTemplateAction.java
@@ -68,7 +68,7 @@ public class RestRenderSearchTemplateAction extends BaseRestHandler {
         String templateId = request.param("id");
         final Template template;
         if (templateId == null) {
-            template = Template.parse(parser);
+            template = Template.parse(parser, parseFieldMatcher);
         } else {
             Map<String, Object> params = null;
             String currentFieldName = null;
@@ -79,7 +79,7 @@ public class RestRenderSearchTemplateAction extends BaseRestHandler {
             while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
                 if (token == XContentParser.Token.FIELD_NAME) {
                     currentFieldName = parser.currentName();
-                } else if (ScriptField.PARAMS.match(currentFieldName)) {
+                } else if (parseFieldMatcher.match(currentFieldName, ScriptField.PARAMS)) {
                     if (token == XContentParser.Token.START_OBJECT) {
                         params = parser.map();
                     } else {

--- a/core/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
@@ -25,6 +25,7 @@ import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.QuerySourceBuilder;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
@@ -79,11 +80,11 @@ public class RestSearchAction extends BaseRestHandler {
     @Override
     public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         SearchRequest searchRequest;
-        searchRequest = RestSearchAction.parseSearchRequest(request);
+        searchRequest = RestSearchAction.parseSearchRequest(request, parseFieldMatcher);
         client.search(searchRequest, new RestStatusToXContentListener<SearchResponse>(channel));
     }
 
-    public static SearchRequest parseSearchRequest(RestRequest request) {
+    public static SearchRequest parseSearchRequest(RestRequest request, ParseFieldMatcher parseFieldMatcher) {
         String[] indices = Strings.splitStringByCommaToArray(request.param("index"));
         SearchRequest searchRequest = new SearchRequest(indices);
         // get the content, and put it in the body
@@ -101,8 +102,8 @@ public class RestSearchAction extends BaseRestHandler {
         // from the REST layer. these modes are an internal optimization and should
         // not be specified explicitly by the user.
         String searchType = request.param("search_type");
-        if (SearchType.fromString(searchType).equals(SearchType.QUERY_AND_FETCH) ||
-                SearchType.fromString(searchType).equals(SearchType.DFS_QUERY_AND_FETCH)) {
+        if (SearchType.fromString(searchType, parseFieldMatcher).equals(SearchType.QUERY_AND_FETCH) ||
+                SearchType.fromString(searchType, parseFieldMatcher).equals(SearchType.DFS_QUERY_AND_FETCH)) {
             throw new IllegalArgumentException("Unsupported search type [" + searchType + "]");
         } else {
             searchRequest.searchType(searchType);

--- a/core/src/main/java/org/elasticsearch/script/AbstractScriptParser.java
+++ b/core/src/main/java/org/elasticsearch/script/AbstractScriptParser.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.script;
 
+import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.script.Script.ScriptField;
 import org.elasticsearch.script.Script.ScriptParseException;
@@ -43,7 +44,7 @@ public abstract class AbstractScriptParser<S extends Script> {
         return Collections.emptyMap();
     }
 
-    public S parse(XContentParser parser) throws IOException {
+    public S parse(XContentParser parser, ParseFieldMatcher parseFieldMatcher) throws IOException {
 
         XContentParser.Token token = parser.currentToken();
         // If the parser hasn't yet been pushed to the first token, do it now
@@ -67,30 +68,30 @@ public abstract class AbstractScriptParser<S extends Script> {
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
-            } else if (ScriptType.INLINE.getParseField().match(currentFieldName) || ScriptService.SCRIPT_INLINE.match(currentFieldName)) {
+            } else if (parseFieldMatcher.match(currentFieldName, ScriptType.INLINE.getParseField()) || parseFieldMatcher.match(currentFieldName, ScriptService.SCRIPT_INLINE)) {
                 type = ScriptType.INLINE;
                 script = parseInlineScript(parser);
-            } else if (ScriptType.FILE.getParseField().match(currentFieldName) || ScriptService.SCRIPT_FILE.match(currentFieldName)) {
+            } else if (parseFieldMatcher.match(currentFieldName, ScriptType.FILE.getParseField()) || parseFieldMatcher.match(currentFieldName, ScriptService.SCRIPT_FILE)) {
                 type = ScriptType.FILE;
                 if (token == XContentParser.Token.VALUE_STRING) {
                     script = parser.text();
                 } else {
                     throw new ScriptParseException("expected a string value for field [{}], but found [{}]", currentFieldName, token);
                 }
-            } else if (ScriptType.INDEXED.getParseField().match(currentFieldName) || ScriptService.SCRIPT_ID.match(currentFieldName)) {
+            } else if (parseFieldMatcher.match(currentFieldName, ScriptType.INDEXED.getParseField()) || parseFieldMatcher.match(currentFieldName, ScriptService.SCRIPT_ID)) {
                 type = ScriptType.INDEXED;
                 if (token == XContentParser.Token.VALUE_STRING) {
                     script = parser.text();
                 } else {
                     throw new ScriptParseException("expected a string value for field [{}], but found [{}]", currentFieldName, token);
                 }
-            } else if (ScriptField.LANG.match(currentFieldName) || ScriptService.SCRIPT_LANG.match(currentFieldName)) {
+            } else if (parseFieldMatcher.match(currentFieldName, ScriptField.LANG) || parseFieldMatcher.match(currentFieldName, ScriptService.SCRIPT_LANG)) {
                 if (token == XContentParser.Token.VALUE_STRING) {
                     lang = parser.text();
                 } else {
                     throw new ScriptParseException("expected a string value for field [{}], but found [{}]", currentFieldName, token);
                 }
-            } else if (ScriptField.PARAMS.match(currentFieldName)) {
+            } else if (parseFieldMatcher.match(currentFieldName, ScriptField.PARAMS)) {
                 if (token == XContentParser.Token.START_OBJECT) {
                     params = parser.map();
                 } else {
@@ -125,7 +126,7 @@ public abstract class AbstractScriptParser<S extends Script> {
         return null;
     }
 
-    public S parse(Map<String, Object> config, boolean removeMatchedEntries) {
+    public S parse(Map<String, Object> config, boolean removeMatchedEntries, ParseFieldMatcher parseFieldMatcher) {
         String script = null;
         ScriptType type = null;
         String lang = null;
@@ -134,7 +135,7 @@ public abstract class AbstractScriptParser<S extends Script> {
             Entry<String, Object> entry = itr.next();
             String parameterName = entry.getKey();
             Object parameterValue = entry.getValue();
-            if (ScriptField.LANG.match(parameterName) || ScriptService.SCRIPT_LANG.match(parameterName)) {
+            if (parseFieldMatcher.match(parameterName, ScriptField.LANG) || parseFieldMatcher.match(parameterName, ScriptService.SCRIPT_LANG)) {
                 if (parameterValue instanceof String || parameterValue == null) {
                     lang = (String) parameterValue;
                     if (removeMatchedEntries) {
@@ -143,7 +144,7 @@ public abstract class AbstractScriptParser<S extends Script> {
                 } else {
                     throw new ScriptParseException("Value must be of type String: [" + parameterName + "]");
                 }
-            } else if (ScriptField.PARAMS.match(parameterName)) {
+            } else if (parseFieldMatcher.match(parameterName, ScriptField.PARAMS)) {
                 if (parameterValue instanceof Map || parameterValue == null) {
                     params = (Map<String, Object>) parameterValue;
                     if (removeMatchedEntries) {
@@ -152,7 +153,7 @@ public abstract class AbstractScriptParser<S extends Script> {
                 } else {
                     throw new ScriptParseException("Value must be of type String: [" + parameterName + "]");
                 }
-            } else if (ScriptType.INLINE.getParseField().match(parameterName) || ScriptService.SCRIPT_INLINE.match(parameterName)) {
+            } else if (parseFieldMatcher.match(parameterName, ScriptType.INLINE.getParseField()) || parseFieldMatcher.match(parameterName, ScriptService.SCRIPT_INLINE)) {
                 if (parameterValue instanceof String || parameterValue == null) {
                     script = (String) parameterValue;
                     type = ScriptType.INLINE;
@@ -162,7 +163,7 @@ public abstract class AbstractScriptParser<S extends Script> {
                 } else {
                     throw new ScriptParseException("Value must be of type String: [" + parameterName + "]");
                 }
-            } else if (ScriptType.FILE.getParseField().match(parameterName) || ScriptService.SCRIPT_FILE.match(parameterName)) {
+            } else if (parseFieldMatcher.match(parameterName, ScriptType.FILE.getParseField()) || parseFieldMatcher.match(parameterName, ScriptService.SCRIPT_FILE)) {
                 if (parameterValue instanceof String || parameterValue == null) {
                     script = (String) parameterValue;
                     type = ScriptType.FILE;
@@ -172,7 +173,7 @@ public abstract class AbstractScriptParser<S extends Script> {
                 } else {
                     throw new ScriptParseException("Value must be of type String: [" + parameterName + "]");
                 }
-            } else if (ScriptType.INDEXED.getParseField().match(parameterName) || ScriptService.SCRIPT_ID.match(parameterName)) {
+            } else if (parseFieldMatcher.match(parameterName, ScriptType.INDEXED.getParseField()) || parseFieldMatcher.match(parameterName, ScriptService.SCRIPT_ID)) {
                 if (parameterValue instanceof String || parameterValue == null) {
                     script = (String) parameterValue;
                     type = ScriptType.INDEXED;

--- a/core/src/main/java/org/elasticsearch/script/Script.java
+++ b/core/src/main/java/org/elasticsearch/script/Script.java
@@ -22,6 +22,7 @@ package org.elasticsearch.script;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
@@ -204,12 +205,12 @@ public class Script implements ToXContent, Streamable {
         return script;
     }
 
-    public static Script parse(Map<String, Object> config, boolean removeMatchedEntries) {
-        return PARSER.parse(config, removeMatchedEntries);
+    public static Script parse(Map<String, Object> config, boolean removeMatchedEntries, ParseFieldMatcher parseFieldMatcher) {
+        return PARSER.parse(config, removeMatchedEntries, parseFieldMatcher);
     }
 
-    public static Script parse(XContentParser parser) throws IOException {
-        return PARSER.parse(parser);
+    public static Script parse(XContentParser parser, ParseFieldMatcher parseFieldMatcher) throws IOException {
+        return PARSER.parse(parser, parseFieldMatcher);
     }
 
     @Override
@@ -281,7 +282,7 @@ public class Script implements ToXContent, Streamable {
         }
     }
 
-    public static interface ScriptField {
+    public interface ScriptField {
         ParseField SCRIPT = new ParseField("script");
         ParseField LANG = new ParseField("lang");
         ParseField PARAMS = new ParseField("params");

--- a/core/src/main/java/org/elasticsearch/script/Template.java
+++ b/core/src/main/java/org/elasticsearch/script/Template.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.script;
 
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -119,23 +120,23 @@ public class Template extends Script {
     }
 
     @SuppressWarnings("unchecked")
-    public static Script parse(Map<String, Object> config, boolean removeMatchedEntries) {
-        return new TemplateParser(Collections.EMPTY_MAP, MustacheScriptEngineService.NAME).parse(config, removeMatchedEntries);
+    public static Script parse(Map<String, Object> config, boolean removeMatchedEntries, ParseFieldMatcher parseFieldMatcher) {
+        return new TemplateParser(Collections.EMPTY_MAP, MustacheScriptEngineService.NAME).parse(config, removeMatchedEntries, parseFieldMatcher);
     }
 
     @SuppressWarnings("unchecked")
-    public static Template parse(XContentParser parser) throws IOException {
-        return new TemplateParser(Collections.EMPTY_MAP, MustacheScriptEngineService.NAME).parse(parser);
+    public static Template parse(XContentParser parser, ParseFieldMatcher parseFieldMatcher) throws IOException {
+        return new TemplateParser(Collections.EMPTY_MAP, MustacheScriptEngineService.NAME).parse(parser, parseFieldMatcher);
     }
 
     @Deprecated
-    public static Template parse(XContentParser parser, Map<String, ScriptType> additionalTemplateFieldNames) throws IOException {
-        return new TemplateParser(additionalTemplateFieldNames, MustacheScriptEngineService.NAME).parse(parser);
+    public static Template parse(XContentParser parser, Map<String, ScriptType> additionalTemplateFieldNames, ParseFieldMatcher parseFieldMatcher) throws IOException {
+        return new TemplateParser(additionalTemplateFieldNames, MustacheScriptEngineService.NAME).parse(parser, parseFieldMatcher);
     }
 
     @Deprecated
-    public static Template parse(XContentParser parser, Map<String, ScriptType> additionalTemplateFieldNames, String defaultLang) throws IOException {
-        return new TemplateParser(additionalTemplateFieldNames, defaultLang).parse(parser);
+    public static Template parse(XContentParser parser, Map<String, ScriptType> additionalTemplateFieldNames, String defaultLang, ParseFieldMatcher parseFieldMatcher) throws IOException {
+        return new TemplateParser(additionalTemplateFieldNames, defaultLang).parse(parser, parseFieldMatcher);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/search/aggregations/Aggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/Aggregator.java
@@ -21,6 +21,7 @@ package org.elasticsearch.search.aggregations;
 
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.search.aggregations.bucket.BucketsAggregator;
@@ -28,7 +29,6 @@ import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.EnumSet;
 
 /**
  * An Aggregator.
@@ -42,7 +42,7 @@ public abstract class Aggregator extends BucketCollector implements Releasable {
      *
      * @see {@link AggregatorFactory}
     */
-    public static interface Parser {
+    public interface Parser {
 
         /**
          * @return The aggregation type this parser is associated with.
@@ -134,14 +134,10 @@ public abstract class Aggregator extends BucketCollector implements Releasable {
             return parseField;
         }
 
-        public static SubAggCollectionMode parse(String value) {
-            return parse(value, ParseField.EMPTY_FLAGS);
-        }
-
-        public static SubAggCollectionMode parse(String value, EnumSet<ParseField.Flag> flags) {
+        public static SubAggCollectionMode parse(String value, ParseFieldMatcher parseFieldMatcher) {
             SubAggCollectionMode[] modes = SubAggCollectionMode.values();
             for (SubAggCollectionMode mode : modes) {
-                if (mode.parseField.match(value, flags)) {
+                if (parseFieldMatcher.match(value, mode.parseField)) {
                     return mode;
                 }
             }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/filters/FiltersParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/filters/FiltersParser.java
@@ -60,14 +60,14 @@ public class FiltersParser implements Aggregator.Parser {
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
             } else if (token == XContentParser.Token.VALUE_BOOLEAN) {
-                if (OTHER_BUCKET_FIELD.match(currentFieldName)) {
+                if (context.parseFieldMatcher().match(currentFieldName, OTHER_BUCKET_FIELD)) {
                     otherBucket = parser.booleanValue();
                 } else {
                     throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: ["
                             + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.VALUE_STRING) {
-                if (OTHER_BUCKET_KEY_FIELD.match(currentFieldName)) {
+                if (context.parseFieldMatcher().match(currentFieldName, OTHER_BUCKET_KEY_FIELD)) {
                     otherBucketKey = parser.text();
                     otherBucket = true;
                 } else {
@@ -75,7 +75,7 @@ public class FiltersParser implements Aggregator.Parser {
                             + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.START_OBJECT) {
-                if (FILTERS_FIELD.match(currentFieldName)) {
+                if (context.parseFieldMatcher().match(currentFieldName, FILTERS_FIELD)) {
                     keyed = true;
                     String key = null;
                     while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
@@ -91,7 +91,7 @@ public class FiltersParser implements Aggregator.Parser {
                             + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.START_ARRAY) {
-                if (FILTERS_FIELD.match(currentFieldName)) {
+                if (context.parseFieldMatcher().match(currentFieldName, FILTERS_FIELD)) {
                     keyed = false;
                     int idx = 0;
                     while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramParser.java
@@ -101,11 +101,11 @@ public class DateHistogramParser implements Aggregator.Parser {
             } else if (vsParser.token(currentFieldName, token, parser)) {
                 continue;
             } else if (token == XContentParser.Token.VALUE_STRING) {
-                if (TIME_ZONE.match(currentFieldName)) {
+                if (context.parseFieldMatcher().match(currentFieldName, TIME_ZONE)) {
                     timeZone = DateTimeZone.forID(parser.text());
-                } else if (OFFSET.match(currentFieldName)) {
+                } else if (context.parseFieldMatcher().match(currentFieldName, OFFSET)) {
                     offset = parseOffset(parser.text());
-                } else if (INTERVAL.match(currentFieldName)) {
+                } else if (context.parseFieldMatcher().match(currentFieldName, INTERVAL)) {
                     interval = parser.text();
                 } else {
                     throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: ["
@@ -139,7 +139,7 @@ public class DateHistogramParser implements Aggregator.Parser {
                             //TODO should we throw an error if the value is not "asc" or "desc"???
                         }
                     }
-                } else if (EXTENDED_BOUNDS.match(currentFieldName)) {
+                } else if (context.parseFieldMatcher().match(currentFieldName, EXTENDED_BOUNDS)) {
                     extendedBounds = new ExtendedBounds();
                     while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
                         if (token == XContentParser.Token.FIELD_NAME) {

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/HistogramParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/HistogramParser.java
@@ -93,7 +93,7 @@ public class HistogramParser implements Aggregator.Parser {
                             order = resolveOrder(currentFieldName, asc);
                         }
                     }
-                } else if (EXTENDED_BOUNDS.match(currentFieldName)) {
+                } else if (context.parseFieldMatcher().match(currentFieldName, EXTENDED_BOUNDS)) {
                     extendedBounds = new ExtendedBounds();
                     while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
                         if (token == XContentParser.Token.FIELD_NAME) {

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/SamplerAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/SamplerAggregator.java
@@ -20,14 +20,9 @@ package org.elasticsearch.search.aggregations.bucket.sampler;
 
 import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.lease.Releasables;
-import org.elasticsearch.search.aggregations.AggregationExecutionException;
-import org.elasticsearch.search.aggregations.Aggregator;
-import org.elasticsearch.search.aggregations.AggregatorFactories;
-import org.elasticsearch.search.aggregations.AggregatorFactory;
-import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.LeafBucketCollector;
-import org.elasticsearch.search.aggregations.NonCollectingAggregator;
+import org.elasticsearch.search.aggregations.*;
 import org.elasticsearch.search.aggregations.bucket.BestDocsDeferringCollector;
 import org.elasticsearch.search.aggregations.bucket.DeferringBucketCollector;
 import org.elasticsearch.search.aggregations.bucket.SingleBucketAggregator;
@@ -111,9 +106,9 @@ public class SamplerAggregator extends SingleBucketAggregator {
 
         };
 
-        public static ExecutionMode fromString(String value) {
+        public static ExecutionMode fromString(String value, ParseFieldMatcher parseFieldMatcher) {
             for (ExecutionMode mode : values()) {
-                if (mode.parseField.match(value)) {
+                if (parseFieldMatcher.match(value, mode.parseField)) {
                     return mode;
                 }
             }
@@ -222,7 +217,7 @@ public class SamplerAggregator extends SingleBucketAggregator {
             if (valuesSource instanceof ValuesSource.Bytes) {
                 ExecutionMode execution = null;
                 if (executionHint != null) {
-                    execution = ExecutionMode.fromString(executionHint);
+                    execution = ExecutionMode.fromString(executionHint, context.searchContext().parseFieldMatcher());
                 }
 
                 // In some cases using ordinals is just not supported: override

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/SamplerParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/SamplerParser.java
@@ -66,9 +66,9 @@ public class SamplerParser implements Aggregator.Parser {
             } else if (vsParser.token(currentFieldName, token, parser)) {
                 continue;
             } else if (token == XContentParser.Token.VALUE_NUMBER) {
-                if (SHARD_SIZE_FIELD.match(currentFieldName)) {
+                if (context.parseFieldMatcher().match(currentFieldName, SHARD_SIZE_FIELD)) {
                     shardSize = parser.intValue();
-                } else if (MAX_DOCS_PER_VALUE_FIELD.match(currentFieldName)) {
+                } else if (context.parseFieldMatcher().match(currentFieldName, MAX_DOCS_PER_VALUE_FIELD)) {
                     diversityChoiceMade = true;
                     maxDocsPerValue = parser.intValue();
                 } else {
@@ -76,7 +76,7 @@ public class SamplerParser implements Aggregator.Parser {
                             + aggregationName, parser.getTokenLocation());
                 }
             } else if (!vsParser.token(currentFieldName, token, parser)) {
-                if (EXECUTION_HINT_FIELD.match(currentFieldName)) {
+                if (context.parseFieldMatcher().match(currentFieldName, EXECUTION_HINT_FIELD)) {
                     executionHint = parser.text();
                 } else {
                     throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].",

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsAggregatorFactory.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsAggregatorFactory.java
@@ -25,15 +25,12 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.lucene.index.FilterableTermsEnum;
 import org.elasticsearch.common.lucene.index.FreqTermsEnum;
 import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.search.aggregations.AggregationExecutionException;
-import org.elasticsearch.search.aggregations.Aggregator;
-import org.elasticsearch.search.aggregations.AggregatorFactories;
-import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.NonCollectingAggregator;
+import org.elasticsearch.search.aggregations.*;
 import org.elasticsearch.search.aggregations.bucket.significant.heuristics.SignificanceHeuristic;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregator;
 import org.elasticsearch.search.aggregations.bucket.terms.support.IncludeExclude;
@@ -103,9 +100,9 @@ public class SignificantTermsAggregatorFactory extends ValuesSourceAggregatorFac
             }
         };
 
-        public static ExecutionMode fromString(String value) {
+        public static ExecutionMode fromString(String value, ParseFieldMatcher parseFieldMatcher) {
             for (ExecutionMode mode : values()) {
-                if (mode.parseField.match(value)) {
+                if (parseFieldMatcher.match(value, mode.parseField)) {
                     return mode;
                 }
             }
@@ -184,7 +181,7 @@ public class SignificantTermsAggregatorFactory extends ValuesSourceAggregatorFac
         if (valuesSource instanceof ValuesSource.Bytes) {
             ExecutionMode execution = null;
             if (executionHint != null) {
-                execution = ExecutionMode.fromString(executionHint);
+                execution = ExecutionMode.fromString(executionHint, aggregationContext.searchContext().parseFieldMatcher());
             }
             if (!(valuesSource instanceof ValuesSource.Bytes.WithOrdinals)) {
                 execution = ExecutionMode.MAP;

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsParametersParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsParametersParser.java
@@ -64,8 +64,8 @@ public class SignificantTermsParametersParser extends AbstractTermsParametersPar
         if (token == XContentParser.Token.START_OBJECT) {
             SignificanceHeuristicParser significanceHeuristicParser = significanceHeuristicParserMapper.get(currentFieldName);
             if (significanceHeuristicParser != null) {
-                significanceHeuristic = significanceHeuristicParser.parse(parser);
-            } else if (BACKGROUND_FILTER.match(currentFieldName)) {
+                significanceHeuristic = significanceHeuristicParser.parse(parser, context.parseFieldMatcher());
+            } else if (context.parseFieldMatcher().match(currentFieldName, BACKGROUND_FILTER)) {
                 filter = context.queryParserService().parseInnerFilter(parser).query();
             } else {
                 throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: ["

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/GND.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/GND.java
@@ -23,6 +23,7 @@ package org.elasticsearch.search.aggregations.bucket.significant.heuristics;
 
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -114,12 +115,12 @@ public class GND extends NXYSignificanceHeuristic {
         }
 
         @Override
-        public SignificanceHeuristic parse(XContentParser parser) throws IOException, QueryParsingException {
+        public SignificanceHeuristic parse(XContentParser parser, ParseFieldMatcher parseFieldMatcher) throws IOException, QueryParsingException {
             String givenName = parser.currentName();
             boolean backgroundIsSuperset = true;
             XContentParser.Token token = parser.nextToken();
             while (!token.equals(XContentParser.Token.END_OBJECT)) {
-                if (BACKGROUND_IS_SUPERSET.match(parser.currentName(), ParseField.EMPTY_FLAGS)) {
+                if (parseFieldMatcher.match(parser.currentName(), BACKGROUND_IS_SUPERSET)) {
                     parser.nextToken();
                     backgroundIsSuperset = parser.booleanValue();
                 } else {

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/JLHScore.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/JLHScore.java
@@ -22,6 +22,7 @@ package org.elasticsearch.search.aggregations.bucket.significant.heuristics;
 
 
 import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -36,7 +37,7 @@ public class JLHScore extends SignificanceHeuristic {
 
     protected static final String[] NAMES = {"jlh"};
 
-    private JLHScore() {};
+    private JLHScore() {}
 
     public static final SignificanceHeuristicStreams.Stream STREAM = new SignificanceHeuristicStreams.Stream() {
         @Override
@@ -107,7 +108,7 @@ public class JLHScore extends SignificanceHeuristic {
     public static class JLHScoreParser implements SignificanceHeuristicParser {
 
         @Override
-        public SignificanceHeuristic parse(XContentParser parser) throws IOException, QueryParsingException {
+        public SignificanceHeuristic parse(XContentParser parser, ParseFieldMatcher parseFieldMatcher) throws IOException, QueryParsingException {
             // move to the closing bracket
             if (!parser.nextToken().equals(XContentParser.Token.END_OBJECT)) {
                 throw new ElasticsearchParseException("failed to parse [jhl] significance heuristic. expected an empty object, but found [{}] instead", parser.currentToken());

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/NXYSignificanceHeuristic.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/NXYSignificanceHeuristic.java
@@ -23,6 +23,7 @@ package org.elasticsearch.search.aggregations.bucket.significant.heuristics;
 
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -137,16 +138,16 @@ public abstract class NXYSignificanceHeuristic extends SignificanceHeuristic {
     public static abstract class NXYParser implements SignificanceHeuristicParser {
 
         @Override
-        public SignificanceHeuristic parse(XContentParser parser) throws IOException, QueryParsingException {
+        public SignificanceHeuristic parse(XContentParser parser, ParseFieldMatcher parseFieldMatcher) throws IOException, QueryParsingException {
             String givenName = parser.currentName();
             boolean includeNegatives = false;
             boolean backgroundIsSuperset = true;
             XContentParser.Token token = parser.nextToken();
             while (!token.equals(XContentParser.Token.END_OBJECT)) {
-                if (INCLUDE_NEGATIVES_FIELD.match(parser.currentName())) {
+                if (parseFieldMatcher.match(parser.currentName(), INCLUDE_NEGATIVES_FIELD)) {
                     parser.nextToken();
                     includeNegatives = parser.booleanValue();
-                } else if (BACKGROUND_IS_SUPERSET.match(parser.currentName())) {
+                } else if (parseFieldMatcher.match(parser.currentName(), BACKGROUND_IS_SUPERSET)) {
                     parser.nextToken();
                     backgroundIsSuperset = parser.booleanValue();
                 } else {

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/PercentageScore.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/PercentageScore.java
@@ -22,6 +22,7 @@ package org.elasticsearch.search.aggregations.bucket.significant.heuristics;
 
 
 import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -36,7 +37,7 @@ public class PercentageScore extends SignificanceHeuristic {
 
     protected static final String[] NAMES = {"percentage"};
 
-    private PercentageScore() {};
+    private PercentageScore() {}
 
     public static final SignificanceHeuristicStreams.Stream STREAM = new SignificanceHeuristicStreams.Stream() {
         @Override
@@ -76,7 +77,7 @@ public class PercentageScore extends SignificanceHeuristic {
     public static class PercentageScoreParser implements SignificanceHeuristicParser {
 
         @Override
-        public SignificanceHeuristic parse(XContentParser parser) throws IOException, QueryParsingException {
+        public SignificanceHeuristic parse(XContentParser parser, ParseFieldMatcher parseFieldMatcher) throws IOException, QueryParsingException {
             // move to the closing bracket
             if (!parser.nextToken().equals(XContentParser.Token.END_OBJECT)) {
                 throw new ElasticsearchParseException("failed to parse [percentage] significance heuristic. expected an empty object, but got [{}] instead", parser.currentToken());

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/SignificanceHeuristicParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/SignificanceHeuristicParser.java
@@ -20,6 +20,7 @@
 
 package org.elasticsearch.search.aggregations.bucket.significant.heuristics;
 
+import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.query.QueryParsingException;
 
@@ -27,7 +28,7 @@ import java.io.IOException;
 
 public interface SignificanceHeuristicParser {
 
-    SignificanceHeuristic parse(XContentParser parser) throws IOException, QueryParsingException;
+    SignificanceHeuristic parse(XContentParser parser, ParseFieldMatcher parseFieldMatcher) throws IOException, QueryParsingException;
 
     String[] getNames();
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/AbstractTermsParametersParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/AbstractTermsParametersParser.java
@@ -77,23 +77,23 @@ public abstract class AbstractTermsParametersParser {
             } else if (incExcParser.token(currentFieldName, token, parser)) {
                 continue;
             } else if (token == XContentParser.Token.VALUE_STRING) {
-                if (EXECUTION_HINT_FIELD_NAME.match(currentFieldName)) {
+                if (context.parseFieldMatcher().match(currentFieldName, EXECUTION_HINT_FIELD_NAME)) {
                     executionHint = parser.text();
-                } else if(SubAggCollectionMode.KEY.match(currentFieldName)){
-                    collectMode = SubAggCollectionMode.parse(parser.text());
-                } else if (REQUIRED_SIZE_FIELD_NAME.match(currentFieldName)) {
+                } else if(context.parseFieldMatcher().match(currentFieldName, SubAggCollectionMode.KEY)){
+                    collectMode = SubAggCollectionMode.parse(parser.text(), context.parseFieldMatcher());
+                } else if (context.parseFieldMatcher().match(currentFieldName, REQUIRED_SIZE_FIELD_NAME)) {
                     bucketCountThresholds.setRequiredSize(parser.intValue());
                 } else {
                     parseSpecial(aggregationName, parser, context, token, currentFieldName);
                 }
             } else if (token == XContentParser.Token.VALUE_NUMBER) {
-                if (REQUIRED_SIZE_FIELD_NAME.match(currentFieldName)) {
+                if (context.parseFieldMatcher().match(currentFieldName, REQUIRED_SIZE_FIELD_NAME)) {
                     bucketCountThresholds.setRequiredSize(parser.intValue());
-                } else if (SHARD_SIZE_FIELD_NAME.match(currentFieldName)) {
+                } else if (context.parseFieldMatcher().match(currentFieldName, SHARD_SIZE_FIELD_NAME)) {
                     bucketCountThresholds.setShardSize(parser.intValue());
-                } else if (MIN_DOC_COUNT_FIELD_NAME.match(currentFieldName)) {
+                } else if (context.parseFieldMatcher().match(currentFieldName, MIN_DOC_COUNT_FIELD_NAME)) {
                     bucketCountThresholds.setMinDocCount(parser.intValue());
-                } else if (SHARD_MIN_DOC_COUNT_FIELD_NAME.match(currentFieldName)) {
+                } else if (context.parseFieldMatcher().match(currentFieldName, SHARD_MIN_DOC_COUNT_FIELD_NAME)) {
                     bucketCountThresholds.setShardMinDocCount(parser.longValue());
                 } else {
                     parseSpecial(aggregationName, parser, context, token, currentFieldName);

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorFactory.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorFactory.java
@@ -20,12 +20,9 @@ package org.elasticsearch.search.aggregations.bucket.terms;
 
 import org.apache.lucene.search.IndexSearcher;
 import org.elasticsearch.common.ParseField;
-import org.elasticsearch.search.aggregations.AggregationExecutionException;
-import org.elasticsearch.search.aggregations.Aggregator;
+import org.elasticsearch.common.ParseFieldMatcher;
+import org.elasticsearch.search.aggregations.*;
 import org.elasticsearch.search.aggregations.Aggregator.SubAggCollectionMode;
-import org.elasticsearch.search.aggregations.AggregatorFactories;
-import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.NonCollectingAggregator;
 import org.elasticsearch.search.aggregations.bucket.terms.support.IncludeExclude;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
@@ -125,9 +122,9 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory<Values
             }
         };
 
-        public static ExecutionMode fromString(String value) {
+        public static ExecutionMode fromString(String value, ParseFieldMatcher parseFieldMatcher) {
             for (ExecutionMode mode : values()) {
-                if (mode.parseField.match(value)) {
+                if (parseFieldMatcher.match(value, mode.parseField)) {
                     return mode;
                 }
             }
@@ -201,7 +198,7 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory<Values
         if (valuesSource instanceof ValuesSource.Bytes) {
             ExecutionMode execution = null;
             if (executionHint != null) {
-                execution = ExecutionMode.fromString(executionHint);
+                execution = ExecutionMode.fromString(executionHint, aggregationContext.searchContext().parseFieldMatcher());
             }
 
             // In some cases, using ordinals is just not supported: override it
@@ -243,7 +240,6 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory<Values
                 }
             }
 
-            assert execution != null;
             return execution.create(name, factories, valuesSource, order, bucketCountThresholds, includeExclude, aggregationContext,
                     parent, collectMode, showTermDocCountError, pipelineAggregators, metaData);
         }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsParametersParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsParametersParser.java
@@ -76,7 +76,7 @@ public class TermsParametersParser extends AbstractTermsParametersParser {
                         + currentFieldName + "].", parser.getTokenLocation());
             }
         } else if (token == XContentParser.Token.VALUE_BOOLEAN) {
-            if (SHOW_TERM_DOC_COUNT_ERROR.match(currentFieldName)) {
+            if (context.parseFieldMatcher().match(currentFieldName, SHOW_TERM_DOC_COUNT_ERROR)) {
                 showTermDocCountError = parser.booleanValue();
             }
         } else {

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/CardinalityParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/CardinalityParser.java
@@ -59,7 +59,7 @@ public class CardinalityParser implements Aggregator.Parser {
             } else if (token.isValue()) {
                 if ("rehash".equals(currentFieldName)) {
                     rehash = parser.booleanValue();
-                } else if (PRECISION_THRESHOLD.match(currentFieldName)) {
+                } else if (context.parseFieldMatcher().match(currentFieldName, PRECISION_THRESHOLD)) {
                     precisionThreshold = parser.longValue();
                 } else {
                     throw new SearchParseException(context, "Unknown key for a " + token + " in [" + name + "]: [" + currentFieldName

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/scripted/ScriptedMetricParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/scripted/ScriptedMetricParser.java
@@ -74,24 +74,24 @@ public class ScriptedMetricParser implements Aggregator.Parser {
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
             } else if (token == XContentParser.Token.START_OBJECT) {
-                if (INIT_SCRIPT_FIELD.match(currentFieldName)) {
-                    initScript = Script.parse(parser);
-                } else if (MAP_SCRIPT_FIELD.match(currentFieldName)) {
-                    mapScript = Script.parse(parser);
-                } else if (COMBINE_SCRIPT_FIELD.match(currentFieldName)) {
-                    combineScript = Script.parse(parser);
-                } else if (REDUCE_SCRIPT_FIELD.match(currentFieldName)) {
-                    reduceScript = Script.parse(parser);
-                } else if (PARAMS_FIELD.match(currentFieldName)) {
+                if (context.parseFieldMatcher().match(currentFieldName, INIT_SCRIPT_FIELD)) {
+                    initScript = Script.parse(parser, context.parseFieldMatcher());
+                } else if (context.parseFieldMatcher().match(currentFieldName, MAP_SCRIPT_FIELD)) {
+                    mapScript = Script.parse(parser, context.parseFieldMatcher());
+                } else if (context.parseFieldMatcher().match(currentFieldName, COMBINE_SCRIPT_FIELD)) {
+                    combineScript = Script.parse(parser, context.parseFieldMatcher());
+                } else if (context.parseFieldMatcher().match(currentFieldName, REDUCE_SCRIPT_FIELD)) {
+                    reduceScript = Script.parse(parser, context.parseFieldMatcher());
+                } else if (context.parseFieldMatcher().match(currentFieldName, PARAMS_FIELD)) {
                     params = parser.map();
-                } else if (REDUCE_PARAMS_FIELD.match(currentFieldName)) {
+                } else if (context.parseFieldMatcher().match(currentFieldName, REDUCE_PARAMS_FIELD)) {
                   reduceParams = parser.map();
                 } else {
                     throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: ["
                             + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else if (token.isValue()) {
-                if (!scriptParameterParser.token(currentFieldName, token, parser)) {
+                if (!scriptParameterParser.token(currentFieldName, token, parser, context.parseFieldMatcher())) {
                     throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: ["
                             + currentFieldName + "].", parser.getTokenLocation());
                 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/extended/ExtendedStatsParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/extended/ExtendedStatsParser.java
@@ -62,7 +62,7 @@ public class ExtendedStatsParser  implements Aggregator.Parser {
             } else if (vsParser.token(currentFieldName, token, parser)) {
                 continue;
             } else if (token == XContentParser.Token.VALUE_NUMBER) {
-                if (SIGMA.match(currentFieldName)) {
+                if (context.parseFieldMatcher().match(currentFieldName, SIGMA)) {
                     sigma = parser.doubleValue();
                 } else {
                     throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: ["

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/BucketHelpers.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/BucketHelpers.java
@@ -65,7 +65,7 @@ public class BucketHelpers {
         public static GapPolicy parse(SearchContext context, String text, XContentLocation tokenLocation) {
             GapPolicy result = null;
             for (GapPolicy policy : values()) {
-                if (policy.parseField.match(text)) {
+                if (context.parseFieldMatcher().match(text, policy.parseField)) {
                     if (result == null) {
                         result = policy;
                     } else {
@@ -94,9 +94,6 @@ public class BucketHelpers {
 
         /**
          * Serialize the GapPolicy to the output stream
-         *
-         * @param out
-         * @throws IOException
          */
         public void writeTo(StreamOutput out) throws IOException {
             out.writeByte(id);
@@ -136,7 +133,7 @@ public class BucketHelpers {
      * bucket). If the bucket is empty, the configured GapPolicy is invoked to
      * resolve the missing bucket
      *
-     * @param histo
+     * @param agg
      *            A series of agg buckets in the form of a histogram
      * @param bucket
      *            A specific bucket that a value needs to be extracted from.

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketmetrics/BucketMetricsParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketmetrics/BucketMetricsParser.java
@@ -59,18 +59,18 @@ public abstract class BucketMetricsParser implements PipelineAggregator.Parser {
             } else if (doParse(pipelineAggregatorName, currentFieldName, token, parser, context)) {
                 // Do nothing as subclass has stored the state for this token
             } else if (token == XContentParser.Token.VALUE_STRING) {
-                if (FORMAT.match(currentFieldName)) {
+                if (context.parseFieldMatcher().match(currentFieldName, FORMAT)) {
                     format = parser.text();
-                } else if (BUCKETS_PATH.match(currentFieldName)) {
+                } else if (context.parseFieldMatcher().match(currentFieldName, BUCKETS_PATH)) {
                     bucketsPaths = new String[] { parser.text() };
-                } else if (GAP_POLICY.match(currentFieldName)) {
+                } else if (context.parseFieldMatcher().match(currentFieldName, GAP_POLICY)) {
                     gapPolicy = GapPolicy.parse(context, parser.text(), parser.getTokenLocation());
                 } else {
                     throw new SearchParseException(context, "Unknown key for a " + token + " in [" + pipelineAggregatorName + "]: ["
                             + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.START_ARRAY) {
-                if (BUCKETS_PATH.match(currentFieldName)) {
+                if (context.parseFieldMatcher().match(currentFieldName, BUCKETS_PATH)) {
                     List<String> paths = new ArrayList<>();
                     while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                         String path = parser.text();

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketscript/BucketScriptParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketscript/BucketScriptParser.java
@@ -61,21 +61,21 @@ public class BucketScriptParser implements PipelineAggregator.Parser {
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
             } else if (token == XContentParser.Token.VALUE_STRING) {
-                if (FORMAT.match(currentFieldName)) {
+                if (context.parseFieldMatcher().match(currentFieldName, FORMAT)) {
                     format = parser.text();
-                } else if (BUCKETS_PATH.match(currentFieldName)) {
+                } else if (context.parseFieldMatcher().match(currentFieldName, BUCKETS_PATH)) {
                     bucketsPathsMap = new HashMap<>();
                     bucketsPathsMap.put("_value", parser.text());
-                } else if (GAP_POLICY.match(currentFieldName)) {
+                } else if (context.parseFieldMatcher().match(currentFieldName, GAP_POLICY)) {
                     gapPolicy = GapPolicy.parse(context, parser.text(), parser.getTokenLocation());
-                } else if (ScriptField.SCRIPT.match(currentFieldName)) {
-                    script = Script.parse(parser);
+                } else if (context.parseFieldMatcher().match(currentFieldName, ScriptField.SCRIPT)) {
+                    script = Script.parse(parser, context.parseFieldMatcher());
                 } else {
                     throw new SearchParseException(context, "Unknown key for a " + token + " in [" + reducerName + "]: ["
                             + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.START_ARRAY) {
-                if (BUCKETS_PATH.match(currentFieldName)) {
+                if (context.parseFieldMatcher().match(currentFieldName, BUCKETS_PATH)) {
                     List<String> paths = new ArrayList<>();
                     while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                         String path = parser.text();
@@ -90,9 +90,9 @@ public class BucketScriptParser implements PipelineAggregator.Parser {
                             + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.START_OBJECT) {
-                if (ScriptField.SCRIPT.match(currentFieldName)) {
-                    script = Script.parse(parser);
-                } else if (BUCKETS_PATH.match(currentFieldName)) {
+                if (context.parseFieldMatcher().match(currentFieldName, ScriptField.SCRIPT)) {
+                    script = Script.parse(parser, context.parseFieldMatcher());
+                } else if (context.parseFieldMatcher().match(currentFieldName, BUCKETS_PATH)) {
                     Map<String, Object> map = parser.map();
                     bucketsPathsMap = new HashMap<>();
                     for (Map.Entry<String, Object> entry : map.entrySet()) {

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/cumulativesum/CumulativeSumParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/cumulativesum/CumulativeSumParser.java
@@ -54,16 +54,16 @@ public class CumulativeSumParser implements PipelineAggregator.Parser {
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
             } else if (token == XContentParser.Token.VALUE_STRING) {
-                if (FORMAT.match(currentFieldName)) {
+                if (context.parseFieldMatcher().match(currentFieldName, FORMAT)) {
                     format = parser.text();
-                } else if (BUCKETS_PATH.match(currentFieldName)) {
+                } else if (context.parseFieldMatcher().match(currentFieldName, BUCKETS_PATH)) {
                     bucketsPaths = new String[] { parser.text() };
                 } else {
                     throw new SearchParseException(context, "Unknown key for a " + token + " in [" + pipelineAggregatorName + "]: ["
                             + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.START_ARRAY) {
-                if (BUCKETS_PATH.match(currentFieldName)) {
+                if (context.parseFieldMatcher().match(currentFieldName, BUCKETS_PATH)) {
                     List<String> paths = new ArrayList<>();
                     while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                         String path = parser.text();

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/derivative/DerivativeParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/derivative/DerivativeParser.java
@@ -60,20 +60,20 @@ public class DerivativeParser implements PipelineAggregator.Parser {
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
             } else if (token == XContentParser.Token.VALUE_STRING) {
-                if (FORMAT.match(currentFieldName)) {
+                if (context.parseFieldMatcher().match(currentFieldName, FORMAT)) {
                     format = parser.text();
-                } else if (BUCKETS_PATH.match(currentFieldName)) {
+                } else if (context.parseFieldMatcher().match(currentFieldName, BUCKETS_PATH)) {
                     bucketsPaths = new String[] { parser.text() };
-                } else if (GAP_POLICY.match(currentFieldName)) {
+                } else if (context.parseFieldMatcher().match(currentFieldName, GAP_POLICY)) {
                     gapPolicy = GapPolicy.parse(context, parser.text(), parser.getTokenLocation());
-                } else if (UNIT.match(currentFieldName)) {
+                } else if (context.parseFieldMatcher().match(currentFieldName, UNIT)) {
                     units = parser.text();
                 } else {
                     throw new SearchParseException(context, "Unknown key for a " + token + " in [" + pipelineAggregatorName + "]: ["
                             + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.START_ARRAY) {
-                if (BUCKETS_PATH.match(currentFieldName)) {
+                if (context.parseFieldMatcher().match(currentFieldName, BUCKETS_PATH)) {
                     List<String> paths = new ArrayList<>();
                     while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                         String path = parser.text();

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/movavg/MovAvgParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/movavg/MovAvgParser.java
@@ -74,14 +74,14 @@ public class MovAvgParser implements PipelineAggregator.Parser {
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
             } else if (token == XContentParser.Token.VALUE_NUMBER) {
-                if (WINDOW.match(currentFieldName)) {
+                if (context.parseFieldMatcher().match(currentFieldName, WINDOW)) {
                     window = parser.intValue();
                     if (window <= 0) {
                         throw new SearchParseException(context, "[" + currentFieldName + "] value must be a positive, "
                                 + "non-zero integer.  Value supplied was [" + predict + "] in [" + pipelineAggregatorName + "].",
                                 parser.getTokenLocation());
                     }
-                } else if (PREDICT.match(currentFieldName)) {
+                } else if (context.parseFieldMatcher().match(currentFieldName, PREDICT)) {
                     predict = parser.intValue();
                     if (predict <= 0) {
                         throw new SearchParseException(context, "[" + currentFieldName + "] value must be a positive, "
@@ -93,20 +93,20 @@ public class MovAvgParser implements PipelineAggregator.Parser {
                             + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.VALUE_STRING) {
-                if (FORMAT.match(currentFieldName)) {
+                if (context.parseFieldMatcher().match(currentFieldName, FORMAT)) {
                     format = parser.text();
-                } else if (BUCKETS_PATH.match(currentFieldName)) {
+                } else if (context.parseFieldMatcher().match(currentFieldName, BUCKETS_PATH)) {
                     bucketsPaths = new String[] { parser.text() };
-                } else if (GAP_POLICY.match(currentFieldName)) {
+                } else if (context.parseFieldMatcher().match(currentFieldName, GAP_POLICY)) {
                     gapPolicy = GapPolicy.parse(context, parser.text(), parser.getTokenLocation());
-                } else if (MODEL.match(currentFieldName)) {
+                } else if (context.parseFieldMatcher().match(currentFieldName, MODEL)) {
                     model = parser.text();
                 } else {
                     throw new SearchParseException(context, "Unknown key for a " + token + " in [" + pipelineAggregatorName + "]: ["
                             + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.START_ARRAY) {
-                if (BUCKETS_PATH.match(currentFieldName)) {
+                if (context.parseFieldMatcher().match(currentFieldName, BUCKETS_PATH)) {
                     List<String> paths = new ArrayList<>();
                     while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                         String path = parser.text();
@@ -118,7 +118,7 @@ public class MovAvgParser implements PipelineAggregator.Parser {
                             + currentFieldName + "].", parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.START_OBJECT) {
-                if (SETTINGS.match(currentFieldName)) {
+                if (context.parseFieldMatcher().match(currentFieldName, SETTINGS)) {
                     settings = parser.map();
                 } else {
                     throw new SearchParseException(context, "Unknown key for a " + token + " in [" + pipelineAggregatorName + "]: ["
@@ -150,7 +150,7 @@ public class MovAvgParser implements PipelineAggregator.Parser {
 
         MovAvgModel movAvgModel;
         try {
-            movAvgModel = modelParser.parse(settings, pipelineAggregatorName, window);
+            movAvgModel = modelParser.parse(settings, pipelineAggregatorName, window, context.parseFieldMatcher());
         } catch (ParseException exception) {
             throw new SearchParseException(context, "Could not parse settings for model [" + model + "].", null, exception);
         }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/movavg/models/EwmaModel.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/movavg/models/EwmaModel.java
@@ -21,11 +21,11 @@ package org.elasticsearch.search.aggregations.pipeline.movavg.models;
 
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.aggregations.pipeline.movavg.MovAvgParser;
-import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
 import java.text.ParseException;
@@ -103,7 +103,7 @@ public class EwmaModel extends MovAvgModel {
         }
 
         @Override
-        public MovAvgModel parse(@Nullable Map<String, Object> settings, String pipelineName, int windowSize) throws ParseException {
+        public MovAvgModel parse(@Nullable Map<String, Object> settings, String pipelineName, int windowSize, ParseFieldMatcher parseFieldMatcher) throws ParseException {
 
             double alpha = parseDoubleParam(settings, "alpha", 0.5);
 

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/movavg/models/HoltLinearModel.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/movavg/models/HoltLinearModel.java
@@ -21,11 +21,11 @@ package org.elasticsearch.search.aggregations.pipeline.movavg.models;
 
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.aggregations.pipeline.movavg.MovAvgParser;
-import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
 import java.text.ParseException;
@@ -152,7 +152,7 @@ public class HoltLinearModel extends MovAvgModel {
         }
 
         @Override
-        public MovAvgModel parse(@Nullable Map<String, Object> settings, String pipelineName, int windowSize) throws ParseException {
+        public MovAvgModel parse(@Nullable Map<String, Object> settings, String pipelineName, int windowSize, ParseFieldMatcher parseFieldMatcher) throws ParseException {
 
             double alpha = parseDoubleParam(settings, "alpha", 0.5);
             double beta = parseDoubleParam(settings, "beta", 0.5);

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/movavg/models/HoltWintersModel.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/movavg/models/HoltWintersModel.java
@@ -23,6 +23,7 @@ package org.elasticsearch.search.aggregations.pipeline.movavg.models;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -46,17 +47,18 @@ public class HoltWintersModel extends MovAvgModel {
         /**
          * Parse a string SeasonalityType into the byte enum
          *
-         * @param text    SeasonalityType in string format (e.g. "add")
-         * @return        SeasonalityType enum
+         * @param text                SeasonalityType in string format (e.g. "add")
+         * @param parseFieldMatcher   Matcher for field names
+         * @return                    SeasonalityType enum
          */
         @Nullable
-        public static SeasonalityType parse(String text) {
+        public static SeasonalityType parse(String text, ParseFieldMatcher parseFieldMatcher) {
             if (text == null) {
                 return null;
             }
             SeasonalityType result = null;
             for (SeasonalityType policy : values()) {
-                if (policy.parseField.match(text)) {
+                if (parseFieldMatcher.match(text, policy.parseField)) {
                     result = policy;
                     break;
                 }
@@ -81,9 +83,6 @@ public class HoltWintersModel extends MovAvgModel {
 
         /**
          * Serialize the SeasonalityType to the output stream
-         *
-         * @param out
-         * @throws IOException
          */
         public void writeTo(StreamOutput out) throws IOException {
             out.writeByte(id);
@@ -92,7 +91,7 @@ public class HoltWintersModel extends MovAvgModel {
         /**
          * Deserialize the SeasonalityType from the input stream
          *
-         * @param in
+         * @param in  the input stream
          * @return    SeasonalityType Enum
          * @throws IOException
          */
@@ -311,7 +310,7 @@ public class HoltWintersModel extends MovAvgModel {
         }
 
         @Override
-        public MovAvgModel parse(@Nullable Map<String, Object> settings, String pipelineName, int windowSize) throws ParseException {
+        public MovAvgModel parse(@Nullable Map<String, Object> settings, String pipelineName, int windowSize, ParseFieldMatcher parseFieldMatcher) throws ParseException {
 
             double alpha = parseDoubleParam(settings, "alpha", 0.5);
             double beta = parseDoubleParam(settings, "beta", 0.5);
@@ -330,7 +329,7 @@ public class HoltWintersModel extends MovAvgModel {
                 Object value = settings.get("type");
                 if (value != null) {
                     if (value instanceof String) {
-                        seasonalityType = SeasonalityType.parse((String)value);
+                        seasonalityType = SeasonalityType.parse((String)value, parseFieldMatcher);
                     } else {
                         throw new ParseException("Parameter [type] must be a String, type `"
                                 + value.getClass().getSimpleName() + "` provided instead", 0);

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/movavg/models/LinearModel.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/movavg/models/LinearModel.java
@@ -22,11 +22,11 @@ package org.elasticsearch.search.aggregations.pipeline.movavg.models;
 
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.aggregations.pipeline.movavg.MovAvgParser;
-import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
 import java.text.ParseException;
@@ -91,7 +91,7 @@ public class LinearModel extends MovAvgModel {
         }
 
         @Override
-        public MovAvgModel parse(@Nullable Map<String, Object> settings, String pipelineName, int windowSize) throws ParseException {
+        public MovAvgModel parse(@Nullable Map<String, Object> settings, String pipelineName, int windowSize, ParseFieldMatcher parseFieldMatcher) throws ParseException {
             return new LinearModel();
         }
     }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/movavg/models/MovAvgModel.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/movavg/models/MovAvgModel.java
@@ -20,9 +20,9 @@
 package org.elasticsearch.search.aggregations.pipeline.movavg.models;
 
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.search.SearchParseException;
-import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
 import java.text.ParseException;
@@ -85,8 +85,6 @@ public abstract class MovAvgModel {
 
     /**
      * Returns an empty set of predictions, filled with NaNs
-     * @param numPredictions
-     * @return
      */
     protected double[] emptyPredictions(int numPredictions) {
         double[] predictions = new double[numPredictions];
@@ -117,12 +115,13 @@ public abstract class MovAvgModel {
         /**
          * Parse a settings hash that is specific to this model
          *
-         * @param settings      Map of settings, extracted from the request
-         * @param pipelineName   Name of the parent pipeline agg
-         * @param windowSize    Size of the window for this moving avg
-         * @return              A fully built moving average model
+         * @param settings           Map of settings, extracted from the request
+         * @param pipelineName       Name of the parent pipeline agg
+         * @param windowSize         Size of the window for this moving avg
+         * @param parseFieldMatcher  Matcher for field names
+         * @return                   A fully built moving average model
          */
-        public abstract MovAvgModel parse(@Nullable Map<String, Object> settings, String pipelineName, int windowSize) throws ParseException;
+        public abstract MovAvgModel parse(@Nullable Map<String, Object> settings, String pipelineName, int windowSize, ParseFieldMatcher parseFieldMatcher) throws ParseException;
 
 
         /**

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/movavg/models/SimpleModel.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/movavg/models/SimpleModel.java
@@ -21,11 +21,11 @@ package org.elasticsearch.search.aggregations.pipeline.movavg.models;
 
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.aggregations.pipeline.movavg.MovAvgParser;
-import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
 import java.text.ParseException;
@@ -84,7 +84,7 @@ public class SimpleModel extends MovAvgModel {
         }
 
         @Override
-        public MovAvgModel parse(@Nullable Map<String, Object> settings, String pipelineName, int windowSize) throws ParseException {
+        public MovAvgModel parse(@Nullable Map<String, Object> settings, String pipelineName, int windowSize, ParseFieldMatcher parseFieldMatcher) throws ParseException {
             return new SimpleModel();
         }
     }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/support/GeoPointParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/support/GeoPointParser.java
@@ -48,7 +48,7 @@ public class GeoPointParser {
     }
 
     public boolean token(String currentFieldName, XContentParser.Token token, XContentParser parser) throws IOException {
-        if (!field.match(currentFieldName)) {
+        if (!context.parseFieldMatcher().match(currentFieldName, field)) {
             return false;
         }
         if (token == XContentParser.Token.VALUE_STRING) {

--- a/core/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceParser.java
@@ -114,7 +114,7 @@ public class ValuesSourceParser<VS extends ValuesSource> {
                                 "] aggregation can only work on value of type [" + targetValueType + "]",
                                 parser.getTokenLocation());
                     }
-                } else if (!scriptParameterParser.token(currentFieldName, token, parser)) {
+                } else if (!scriptParameterParser.token(currentFieldName, token, parser, context.parseFieldMatcher())) {
                     return false;
                 }
                 return true;
@@ -124,8 +124,8 @@ public class ValuesSourceParser<VS extends ValuesSource> {
             return true;
         }
         if (scriptable && token == XContentParser.Token.START_OBJECT) {
-            if (ScriptField.SCRIPT.match(currentFieldName)) {
-                input.script = Script.parse(parser);
+            if (context.parseFieldMatcher().match(currentFieldName, ScriptField.SCRIPT)) {
+                input.script = Script.parse(parser, context.parseFieldMatcher());
                 return true;
             } else if ("params".equals(currentFieldName)) {
                 input.params = parser.map();

--- a/core/src/main/java/org/elasticsearch/search/fetch/script/ScriptFieldsParseElement.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/script/ScriptFieldsParseElement.java
@@ -67,8 +67,8 @@ public class ScriptFieldsParseElement implements SearchParseElement {
                     if (token == XContentParser.Token.FIELD_NAME) {
                         currentFieldName = parser.currentName();
                     } else if (token == XContentParser.Token.START_OBJECT) {
-                        if (ScriptField.SCRIPT.match(currentFieldName)) {
-                            script = Script.parse(parser);
+                        if (context.parseFieldMatcher().match(currentFieldName, ScriptField.SCRIPT)) {
+                            script = Script.parse(parser, context.parseFieldMatcher());
                         } else if ("params".equals(currentFieldName)) {
                             params = parser.map();
                         }
@@ -76,7 +76,7 @@ public class ScriptFieldsParseElement implements SearchParseElement {
                         if ("ignore_failure".equals(currentFieldName)) {
                             ignoreException = parser.booleanValue();
                         } else {
-                            scriptParameterParser.token(currentFieldName, token, parser);
+                            scriptParameterParser.token(currentFieldName, token, parser, context.parseFieldMatcher());
                         }
                     }
                 }

--- a/core/src/main/java/org/elasticsearch/search/internal/DefaultSearchContext.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/DefaultSearchContext.java
@@ -22,22 +22,12 @@ package org.elasticsearch.search.internal;
 import com.carrotsearch.hppc.ObjectObjectAssociativeContainer;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-
 import org.apache.lucene.search.BooleanClause.Occur;
-import org.apache.lucene.search.BooleanQuery;
-import org.apache.lucene.search.ConstantScoreQuery;
-import org.apache.lucene.search.Filter;
-import org.apache.lucene.search.Query;
-import org.apache.lucene.search.QueryWrapperFilter;
-import org.apache.lucene.search.ScoreDoc;
-import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.*;
 import org.apache.lucene.util.Counter;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.cache.recycler.PageCacheRecycler;
-import org.elasticsearch.common.HasContext;
-import org.elasticsearch.common.HasContextAndHeaders;
-import org.elasticsearch.common.HasHeaders;
-import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.*;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.lucene.search.Queries;
@@ -74,10 +64,7 @@ import org.elasticsearch.search.rescore.RescoreSearchContext;
 import org.elasticsearch.search.scan.ScanContext;
 import org.elasticsearch.search.suggest.SuggestionSearchContext;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 /**
  *
@@ -140,7 +127,8 @@ public class DefaultSearchContext extends SearchContext {
     public DefaultSearchContext(long id, ShardSearchRequest request, SearchShardTarget shardTarget,
                          Engine.Searcher engineSearcher, IndexService indexService, IndexShard indexShard,
                          ScriptService scriptService, PageCacheRecycler pageCacheRecycler,
-                         BigArrays bigArrays, Counter timeEstimateCounter) {
+                         BigArrays bigArrays, Counter timeEstimateCounter, ParseFieldMatcher parseFieldMatcher) {
+        super(parseFieldMatcher);
         this.id = id;
         this.request = request;
         this.searchType = request.searchType();
@@ -368,8 +356,6 @@ public class DefaultSearchContext extends SearchContext {
 
     /**
      * A shortcut function to see whether there is a fetchSourceContext and it says the source is requested.
-     *
-     * @return
      */
     @Override
     public boolean sourceRequested() {

--- a/core/src/main/java/org/elasticsearch/search/internal/FilteredSearchContext.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/FilteredSearchContext.java
@@ -26,9 +26,7 @@ import org.apache.lucene.search.Sort;
 import org.apache.lucene.util.Counter;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.cache.recycler.PageCacheRecycler;
-import org.elasticsearch.common.HasContext;
-import org.elasticsearch.common.HasContextAndHeaders;
-import org.elasticsearch.common.HasHeaders;
+import org.elasticsearch.common.*;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.index.analysis.AnalysisService;
@@ -61,13 +59,13 @@ import org.elasticsearch.search.suggest.SuggestionSearchContext;
 import java.util.List;
 import java.util.Set;
 
-/**
- */
 public abstract class FilteredSearchContext extends SearchContext {
 
     private final SearchContext in;
 
     public FilteredSearchContext(SearchContext in) {
+        //inner_hits in percolator ends up with null inner search context
+        super(in == null ? ParseFieldMatcher.EMPTY : in.parseFieldMatcher());
         this.in = in;
     }
 

--- a/core/src/main/java/org/elasticsearch/search/internal/SearchContext.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/SearchContext.java
@@ -29,6 +29,7 @@ import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.cache.recycler.PageCacheRecycler;
 import org.elasticsearch.common.HasContextAndHeaders;
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.util.BigArrays;
@@ -65,8 +66,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-/**
- */
 public abstract class SearchContext implements Releasable, HasContextAndHeaders {
 
     private static ThreadLocal<SearchContext> current = new ThreadLocal<>();
@@ -88,6 +87,16 @@ public abstract class SearchContext implements Releasable, HasContextAndHeaders 
 
     private Multimap<Lifetime, Releasable> clearables = null;
     private final AtomicBoolean closed = new AtomicBoolean(false);
+
+    protected final ParseFieldMatcher parseFieldMatcher;
+
+    protected SearchContext(ParseFieldMatcher parseFieldMatcher) {
+        this.parseFieldMatcher = parseFieldMatcher;
+    }
+
+    public ParseFieldMatcher parseFieldMatcher() {
+        return parseFieldMatcher;
+    }
 
     @Override
     public final void close() {
@@ -181,8 +190,6 @@ public abstract class SearchContext implements Releasable, HasContextAndHeaders 
 
     /**
      * A shortcut function to see whether there is a fetchSourceContext and it says the source is requested.
-     *
-     * @return
      */
     public abstract boolean sourceRequested();
 
@@ -315,7 +322,7 @@ public abstract class SearchContext implements Releasable, HasContextAndHeaders 
     public abstract FetchSearchResult fetchResult();
 
     /**
-     * Schedule the release of a resource. The time when {@link Releasable#release()} will be called on this object
+     * Schedule the release of a resource. The time when {@link Releasable#close()} will be called on this object
      * is function of the provided {@link Lifetime}.
      */
     public void addReleasable(Releasable releasable, Lifetime lifetime) {
@@ -366,6 +373,6 @@ public abstract class SearchContext implements Releasable, HasContextAndHeaders 
         /**
          * This life time is for objects that need to live until the search context they are attached to is destroyed.
          */
-        CONTEXT;
+        CONTEXT
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/sort/ScriptSortParser.java
+++ b/core/src/main/java/org/elasticsearch/search/sort/ScriptSortParser.java
@@ -84,8 +84,8 @@ public class ScriptSortParser implements SortParser {
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentName = parser.currentName();
             } else if (token == XContentParser.Token.START_OBJECT) {
-                if (ScriptField.SCRIPT.match(currentName)) {
-                    script = Script.parse(parser);
+                if (context.parseFieldMatcher().match(currentName, ScriptField.SCRIPT)) {
+                    script = Script.parse(parser, context.parseFieldMatcher());
                 } else if ("params".equals(currentName)) {
                     params = parser.map();
                 } else if ("nested_filter".equals(currentName) || "nestedFilter".equals(currentName)) {
@@ -99,7 +99,7 @@ public class ScriptSortParser implements SortParser {
                     reverse = parser.booleanValue();
                 } else if ("order".equals(currentName)) {
                     reverse = "desc".equals(parser.text());
-                } else if (scriptParameterParser.token(currentName, token, parser)) {
+                } else if (scriptParameterParser.token(currentName, token, parser, context.parseFieldMatcher())) {
                     // Do Nothing (handled by ScriptParameterParser
                 } else if ("type".equals(currentName)) {
                     type = parser.text();

--- a/core/src/main/java/org/elasticsearch/search/sort/SortParseElement.java
+++ b/core/src/main/java/org/elasticsearch/search/sort/SortParseElement.java
@@ -157,13 +157,13 @@ public class SortParseElement implements SearchParseElement {
                                     }
                                 } else if ("missing".equals(innerJsonName)) {
                                     missing = parser.textOrNull();
-                                } else if (IGNORE_UNMAPPED.match(innerJsonName)) {
+                                } else if (context.parseFieldMatcher().match(innerJsonName, IGNORE_UNMAPPED)) {
                                     // backward compatibility: ignore_unmapped has been replaced with unmapped_type
                                     if (unmappedType == null // don't override if unmapped_type has been provided too
                                             && parser.booleanValue()) {
                                         unmappedType = LongFieldMapper.CONTENT_TYPE;
                                     }
-                                } else if (UNMAPPED_TYPE.match(innerJsonName)) {
+                                } else if (context.parseFieldMatcher().match(innerJsonName, UNMAPPED_TYPE)) {
                                     unmappedType = parser.textOrNull();
                                 } else if ("mode".equals(innerJsonName)) {
                                     sortMode = MultiValueMode.fromString(parser.text());

--- a/core/src/main/java/org/elasticsearch/search/suggest/SuggestUtils.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/SuggestUtils.java
@@ -30,6 +30,7 @@ import org.apache.lucene.util.CharsRef;
 import org.apache.lucene.util.CharsRefBuilder;
 import org.apache.lucene.util.automaton.LevenshteinAutomata;
 import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.io.FastCharArrayReader;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.analysis.CustomAnalyzer;
@@ -190,30 +191,30 @@ public final class SuggestUtils {
    }      
     
     public static boolean parseDirectSpellcheckerSettings(XContentParser parser, String fieldName,
-                DirectSpellcheckerSettings suggestion) throws IOException {
+                DirectSpellcheckerSettings suggestion, ParseFieldMatcher parseFieldMatcher) throws IOException {
             if ("accuracy".equals(fieldName)) {
                 suggestion.accuracy(parser.floatValue());
-            } else if (Fields.SUGGEST_MODE.match(fieldName)) {
+            } else if (parseFieldMatcher.match(fieldName, Fields.SUGGEST_MODE)) {
                 suggestion.suggestMode(SuggestUtils.resolveSuggestMode(parser.text()));
             } else if ("sort".equals(fieldName)) {
                 suggestion.sort(SuggestUtils.resolveSort(parser.text()));
-            } else if (Fields.STRING_DISTANCE.match(fieldName)) {
-                suggestion.stringDistance(SuggestUtils.resolveDistance(parser.text()));
-            } else if (Fields.MAX_EDITS.match(fieldName)) {
-                suggestion.maxEdits(parser.intValue());
+            } else if (parseFieldMatcher.match(fieldName, Fields.STRING_DISTANCE)) {
+            suggestion.stringDistance(SuggestUtils.resolveDistance(parser.text()));
+            } else if (parseFieldMatcher.match(fieldName, Fields.MAX_EDITS)) {
+            suggestion.maxEdits(parser.intValue());
                 if (suggestion.maxEdits() < 1 || suggestion.maxEdits() > LevenshteinAutomata.MAXIMUM_SUPPORTED_DISTANCE) {
                     throw new IllegalArgumentException("Illegal max_edits value " + suggestion.maxEdits());
                 }
-            } else if (Fields.MAX_INSPECTIONS.match(fieldName)) {
-                suggestion.maxInspections(parser.intValue());
-            } else if (Fields.MAX_TERM_FREQ.match(fieldName)) {
-                suggestion.maxTermFreq(parser.floatValue());
-            } else if (Fields.PREFIX_LENGTH.match(fieldName)) {
-                suggestion.prefixLength(parser.intValue());
-            } else if (Fields.MIN_WORD_LENGTH.match(fieldName)) {
-                suggestion.minQueryLength(parser.intValue());
-            } else if (Fields.MIN_DOC_FREQ.match(fieldName)) {
-                suggestion.minDocFreq(parser.floatValue());
+            } else if (parseFieldMatcher.match(fieldName, Fields.MAX_INSPECTIONS)) {
+            suggestion.maxInspections(parser.intValue());
+            } else if (parseFieldMatcher.match(fieldName, Fields.MAX_TERM_FREQ)) {
+            suggestion.maxTermFreq(parser.floatValue());
+            } else if (parseFieldMatcher.match(fieldName, Fields.PREFIX_LENGTH)) {
+            suggestion.prefixLength(parser.intValue());
+            } else if (parseFieldMatcher.match(fieldName, Fields.MIN_WORD_LENGTH)) {
+            suggestion.minQueryLength(parser.intValue());
+            } else if (parseFieldMatcher.match(fieldName, Fields.MIN_DOC_FREQ)) {
+            suggestion.minDocFreq(parser.floatValue());
             } else {
                 return false;
             }
@@ -221,7 +222,7 @@ public final class SuggestUtils {
     }
     
     public static boolean parseSuggestContext(XContentParser parser, MapperService mapperService, String fieldName,
-            SuggestionSearchContext.SuggestionContext suggestion) throws IOException {
+            SuggestionSearchContext.SuggestionContext suggestion, ParseFieldMatcher parseFieldMatcher) throws IOException {
         
         if ("analyzer".equals(fieldName)) {
             String analyzerName = parser.text();
@@ -234,7 +235,7 @@ public final class SuggestUtils {
             suggestion.setField(parser.text());
         } else if ("size".equals(fieldName)) {
             suggestion.setSize(parser.intValue());
-        } else if (Fields.SHARD_SIZE.match(fieldName)) {
+        } else if (parseFieldMatcher.match(fieldName, Fields.SHARD_SIZE)) {
             suggestion.setShardSize(parser.intValue());
         } else {
            return false;

--- a/core/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestParser.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestParser.java
@@ -60,7 +60,7 @@ public class CompletionSuggestParser implements SuggestContextParser {
             if (token == XContentParser.Token.FIELD_NAME) {
                 fieldName = parser.currentName();
             } else if (token.isValue()) {
-                if (!parseSuggestContext(parser, mapperService, fieldName, suggestion))  {
+                if (!parseSuggestContext(parser, mapperService, fieldName, suggestion, queryParserService.parseFieldMatcher()))  {
                     if (token == XContentParser.Token.VALUE_BOOLEAN && "fuzzy".equals(fieldName)) {
                         suggestion.setFuzzy(parser.booleanValue());
                     }
@@ -73,7 +73,7 @@ public class CompletionSuggestParser implements SuggestContextParser {
                         if (token == XContentParser.Token.FIELD_NAME) {
                             fuzzyConfigName = parser.currentName();
                         } else if (token.isValue()) {
-                            if (FUZZINESS.match(fuzzyConfigName, ParseField.EMPTY_FLAGS)) {
+                            if (queryParserService.parseFieldMatcher().match(fuzzyConfigName, FUZZINESS)) {
                                 suggestion.setFuzzyEditDistance(Fuzziness.parse(parser).asDistance());
                             } else if ("transpositions".equals(fuzzyConfigName)) {
                                 suggestion.setFuzzyTranspositions(parser.booleanValue());

--- a/core/src/main/java/org/elasticsearch/search/suggest/term/TermSuggestParser.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/term/TermSuggestParser.java
@@ -18,8 +18,7 @@
  */
 package org.elasticsearch.search.suggest.term;
 
-import java.io.IOException;
-
+import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.IndexQueryParserService;
@@ -27,6 +26,8 @@ import org.elasticsearch.search.suggest.DirectSpellcheckerSettings;
 import org.elasticsearch.search.suggest.SuggestContextParser;
 import org.elasticsearch.search.suggest.SuggestUtils;
 import org.elasticsearch.search.suggest.SuggestionSearchContext;
+
+import java.io.IOException;
 
 public final class TermSuggestParser implements SuggestContextParser {
 
@@ -46,7 +47,7 @@ public final class TermSuggestParser implements SuggestContextParser {
             if (token == XContentParser.Token.FIELD_NAME) {
                 fieldName = parser.currentName();
             } else if (token.isValue()) {
-                parseTokenValue(parser, mapperService, fieldName, suggestion, settings);
+                parseTokenValue(parser, mapperService, fieldName, suggestion, settings, queryParserService.parseFieldMatcher());
             } else {
                 throw new IllegalArgumentException("suggester[term]  doesn't support field [" + fieldName + "]");
             }
@@ -55,9 +56,9 @@ public final class TermSuggestParser implements SuggestContextParser {
     }
 
     private void parseTokenValue(XContentParser parser, MapperService mapperService, String fieldName, TermSuggestionContext suggestion,
-            DirectSpellcheckerSettings settings) throws IOException {
-        if (!(SuggestUtils.parseSuggestContext(parser, mapperService, fieldName, suggestion) || SuggestUtils.parseDirectSpellcheckerSettings(
-                parser, fieldName, settings))) {
+            DirectSpellcheckerSettings settings, ParseFieldMatcher parseFieldMatcher) throws IOException {
+        if (!(SuggestUtils.parseSuggestContext(parser, mapperService, fieldName, suggestion, parseFieldMatcher) || SuggestUtils.parseDirectSpellcheckerSettings(
+                parser, fieldName, settings, parseFieldMatcher))) {
             throw new IllegalArgumentException("suggester[term] doesn't support [" + fieldName + "]");
 
         }

--- a/core/src/test/java/org/elasticsearch/script/ScriptParameterParserTest.java
+++ b/core/src/test/java/org/elasticsearch/script/ScriptParameterParserTest.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.script;
 
 
+import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.xcontent.ToXContent.MapParams;
 import org.elasticsearch.common.xcontent.XContentHelper;
@@ -32,12 +33,7 @@ import org.elasticsearch.test.ElasticsearchTestCase;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
@@ -52,15 +48,15 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
             token = parser.nextToken();
         }
         ScriptParameterParser paramParser = new ScriptParameterParser();
-        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser), equalTo(true));
+        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser, ParseFieldMatcher.STRICT), equalTo(true));
         assertDefaultParameterValue(paramParser, "scriptValue", ScriptType.INLINE);
         assertThat(paramParser.lang(), nullValue());
         paramParser = new ScriptParameterParser(null);
-        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser), equalTo(true));
+        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser, ParseFieldMatcher.STRICT), equalTo(true));
         assertDefaultParameterValue(paramParser, "scriptValue", ScriptType.INLINE);
         assertThat(paramParser.lang(), nullValue());
         paramParser = new ScriptParameterParser(new HashSet<String>());
-        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser), equalTo(true));
+        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser, ParseFieldMatcher.STRICT), equalTo(true));
         assertDefaultParameterValue(paramParser, "scriptValue", ScriptType.INLINE);
         assertThat(paramParser.lang(), nullValue());
     }
@@ -73,7 +69,7 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
             token = parser.nextToken();
         }
         ScriptParameterParser paramParser = new ScriptParameterParser();
-        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser), equalTo(true));
+        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser, ParseFieldMatcher.STRICT), equalTo(true));
         assertDefaultParameterValue(paramParser, "scriptValue", ScriptType.FILE);
         assertThat(paramParser.lang(), nullValue());
 
@@ -83,7 +79,7 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
             token = parser.nextToken();
         }
         paramParser = new ScriptParameterParser();
-        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser), equalTo(true));
+        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser, ParseFieldMatcher.STRICT), equalTo(true));
         assertDefaultParameterValue(paramParser, "scriptValue", ScriptType.FILE);
         assertThat(paramParser.lang(), nullValue());
     }
@@ -96,7 +92,7 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
             token = parser.nextToken();
         }
         ScriptParameterParser paramParser = new ScriptParameterParser();
-        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser), equalTo(true));
+        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser, ParseFieldMatcher.STRICT), equalTo(true));
         assertDefaultParameterValue(paramParser, "scriptValue", ScriptType.INDEXED);
         assertThat(paramParser.lang(), nullValue());
 
@@ -106,7 +102,7 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
             token = parser.nextToken();
         }
         paramParser = new ScriptParameterParser();
-        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser), equalTo(true));
+        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser, ParseFieldMatcher.STRICT), equalTo(true));
         assertDefaultParameterValue(paramParser, "scriptValue", ScriptType.INDEXED);
         assertThat(paramParser.lang(), nullValue());
     }
@@ -119,7 +115,7 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
             token = parser.nextToken();
         }
         ScriptParameterParser paramParser = new ScriptParameterParser();
-        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser), equalTo(false));
+        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser, ParseFieldMatcher.STRICT), equalTo(false));
         assertThat(paramParser.getDefaultScriptParameterValue(), nullValue());
         assertThat(paramParser.getScriptParameterValue("script"), nullValue());
         assertThat(paramParser.lang(), nullValue());
@@ -135,7 +131,7 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
         Set<String> parameters = Collections.singleton("foo");
         ScriptParameterParser paramParser = new ScriptParameterParser(parameters);
         assertThat(paramParser.getScriptParameterValue("foo"), nullValue());
-        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser), equalTo(true));
+        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser, ParseFieldMatcher.STRICT), equalTo(true));
         assertParameterValue(paramParser, "foo", "scriptValue", ScriptType.INLINE);
         assertThat(paramParser.lang(), nullValue());
     }
@@ -150,7 +146,7 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
         Set<String> parameters = Collections.singleton("foo");
         ScriptParameterParser paramParser = new ScriptParameterParser(parameters);
         assertThat(paramParser.getScriptParameterValue("foo"), nullValue());
-        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser), equalTo(true));
+        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser, ParseFieldMatcher.STRICT), equalTo(true));
         assertParameterValue(paramParser, "foo", "scriptValue", ScriptType.FILE);
         assertThat(paramParser.lang(), nullValue());
     }
@@ -165,7 +161,7 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
         Set<String> parameters = Collections.singleton("foo");
         ScriptParameterParser paramParser = new ScriptParameterParser(parameters);
         assertThat(paramParser.getScriptParameterValue("foo"), nullValue());
-        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser), equalTo(true));
+        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser, ParseFieldMatcher.STRICT), equalTo(true));
         assertParameterValue(paramParser, "foo", "scriptValue", ScriptType.INDEXED);
         assertThat(paramParser.lang(), nullValue());
     }
@@ -180,14 +176,14 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
         Set<String> parameters = Collections.singleton("foo");
         ScriptParameterParser paramParser = new ScriptParameterParser(parameters);
         assertThat(paramParser.getScriptParameterValue("foo"), nullValue());
-        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser), equalTo(true));
+        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser, ParseFieldMatcher.STRICT), equalTo(true));
         assertParameterValue(paramParser, "foo", "scriptValue", ScriptType.INLINE);
         assertThat(paramParser.lang(), nullValue());
         token = parser.nextToken();
         while (token != Token.VALUE_STRING) {
             token = parser.nextToken();
         }
-        paramParser.token(parser.currentName(), parser.currentToken(), parser);
+        paramParser.token(parser.currentName(), parser.currentToken(), parser, ParseFieldMatcher.STRICT);
     }
 
     @Test(expected = ScriptParseException.class)
@@ -200,14 +196,14 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
         Set<String> parameters = Collections.singleton("foo");
         ScriptParameterParser paramParser = new ScriptParameterParser(parameters);
         assertThat(paramParser.getScriptParameterValue("foo"), nullValue());
-        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser), equalTo(true));
+        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser, ParseFieldMatcher.STRICT), equalTo(true));
         assertParameterValue(paramParser, "foo", "scriptValue", ScriptType.INLINE);
         assertThat(paramParser.lang(), nullValue());
         token = parser.nextToken();
         while (token != Token.VALUE_STRING) {
             token = parser.nextToken();
         }
-        paramParser.token(parser.currentName(), parser.currentToken(), parser);
+        paramParser.token(parser.currentName(), parser.currentToken(), parser, ParseFieldMatcher.STRICT);
     }
 
     @Test(expected = ScriptParseException.class)
@@ -220,14 +216,14 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
         Set<String> parameters = Collections.singleton("foo");
         ScriptParameterParser paramParser = new ScriptParameterParser(parameters);
         assertThat(paramParser.getScriptParameterValue("foo"), nullValue());
-        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser), equalTo(true));
+        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser, ParseFieldMatcher.STRICT), equalTo(true));
         assertParameterValue(paramParser, "foo", "scriptValue", ScriptType.FILE);
         assertThat(paramParser.lang(), nullValue());
         token = parser.nextToken();
         while (token != Token.VALUE_STRING) {
             token = parser.nextToken();
         }
-        paramParser.token(parser.currentName(), parser.currentToken(), parser);
+        paramParser.token(parser.currentName(), parser.currentToken(), parser, ParseFieldMatcher.STRICT);
     }
 
     @Test(expected = ScriptParseException.class)
@@ -240,14 +236,14 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
         Set<String> parameters = Collections.singleton("foo");
         ScriptParameterParser paramParser = new ScriptParameterParser(parameters);
         assertThat(paramParser.getScriptParameterValue("foo"), nullValue());
-        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser), equalTo(true));
+        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser, ParseFieldMatcher.STRICT), equalTo(true));
         assertParameterValue(paramParser, "foo", "scriptValue", ScriptType.FILE);
         assertThat(paramParser.lang(), nullValue());
         token = parser.nextToken();
         while (token != Token.VALUE_STRING) {
             token = parser.nextToken();
         }
-        paramParser.token(parser.currentName(), parser.currentToken(), parser);
+        paramParser.token(parser.currentName(), parser.currentToken(), parser, ParseFieldMatcher.STRICT);
     }
 
     @Test(expected = ScriptParseException.class)
@@ -260,14 +256,14 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
         Set<String> parameters = Collections.singleton("foo");
         ScriptParameterParser paramParser = new ScriptParameterParser(parameters);
         assertThat(paramParser.getScriptParameterValue("foo"), nullValue());
-        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser), equalTo(true));
+        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser, ParseFieldMatcher.STRICT), equalTo(true));
         assertParameterValue(paramParser, "foo", "scriptValue", ScriptType.INDEXED);
         assertThat(paramParser.lang(), nullValue());
         token = parser.nextToken();
         while (token != Token.VALUE_STRING) {
             token = parser.nextToken();
         }
-        paramParser.token(parser.currentName(), parser.currentToken(), parser);
+        paramParser.token(parser.currentName(), parser.currentToken(), parser, ParseFieldMatcher.STRICT);
     }
 
     @Test(expected = ScriptParseException.class)
@@ -280,14 +276,14 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
         Set<String> parameters = Collections.singleton("foo");
         ScriptParameterParser paramParser = new ScriptParameterParser(parameters);
         assertThat(paramParser.getScriptParameterValue("foo"), nullValue());
-        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser), equalTo(true));
+        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser, ParseFieldMatcher.STRICT), equalTo(true));
         assertParameterValue(paramParser, "foo", "scriptValue", ScriptType.INDEXED);
         assertThat(paramParser.lang(), nullValue());
         token = parser.nextToken();
         while (token != Token.VALUE_STRING) {
             token = parser.nextToken();
         }
-        paramParser.token(parser.currentName(), parser.currentToken(), parser);
+        paramParser.token(parser.currentName(), parser.currentToken(), parser, ParseFieldMatcher.STRICT);
     }
 
     @Test
@@ -308,7 +304,7 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
         while (token != Token.VALUE_STRING) {
             token = parser.nextToken();
         }
-        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser), equalTo(true));
+        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser, ParseFieldMatcher.STRICT), equalTo(true));
         assertParameterValue(paramParser, "foo", "fooScriptValue", ScriptType.INLINE);
         assertThat(paramParser.getScriptParameterValue("bar"), nullValue());
         assertThat(paramParser.getScriptParameterValue("baz"), nullValue());
@@ -319,7 +315,7 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
         while (token != Token.VALUE_STRING) {
             token = parser.nextToken();
         }
-        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser), equalTo(true));
+        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser, ParseFieldMatcher.STRICT), equalTo(true));
         assertParameterValue(paramParser, "foo", "fooScriptValue", ScriptType.INLINE);
         assertParameterValue(paramParser, "bar", "barScriptValue", ScriptType.FILE);
         assertThat(paramParser.getScriptParameterValue("baz"), nullValue());
@@ -330,7 +326,7 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
         while (token != Token.VALUE_STRING) {
             token = parser.nextToken();
         }
-        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser), equalTo(true));
+        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser, ParseFieldMatcher.STRICT), equalTo(true));
         assertParameterValue(paramParser, "foo", "fooScriptValue", ScriptType.INLINE);
         assertParameterValue(paramParser, "bar", "barScriptValue", ScriptType.FILE);
         assertParameterValue(paramParser, "baz", "bazScriptValue", ScriptType.INDEXED);
@@ -357,7 +353,7 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
         while (token != Token.VALUE_STRING) {
             token = parser.nextToken();
         }
-        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser), equalTo(true));
+        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser, ParseFieldMatcher.STRICT), equalTo(true));
         assertParameterValue(paramParser, "foo", "fooScriptValue", ScriptType.INLINE);
         assertThat(paramParser.getScriptParameterValue("bar"), nullValue());
         assertThat(paramParser.getScriptParameterValue("baz"), nullValue());
@@ -368,7 +364,7 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
         while (token != Token.VALUE_STRING) {
             token = parser.nextToken();
         }
-        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser), equalTo(true));
+        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser, ParseFieldMatcher.STRICT), equalTo(true));
         assertParameterValue(paramParser, "foo", "fooScriptValue", ScriptType.INLINE);
         assertParameterValue(paramParser, "bar", "barScriptValue", ScriptType.FILE);
         assertThat(paramParser.getScriptParameterValue("baz"), nullValue());
@@ -379,7 +375,7 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
         while (token != Token.VALUE_STRING) {
             token = parser.nextToken();
         }
-        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser), equalTo(true));
+        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser, ParseFieldMatcher.STRICT), equalTo(true));
         assertParameterValue(paramParser, "foo", "fooScriptValue", ScriptType.INLINE);
         assertParameterValue(paramParser, "bar", "barScriptValue", ScriptType.FILE);
         assertThat(paramParser.getScriptParameterValue("baz"), nullValue());
@@ -390,7 +386,7 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
         while (token != Token.VALUE_STRING) {
             token = parser.nextToken();
         }
-        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser), equalTo(true));
+        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser, ParseFieldMatcher.STRICT), equalTo(true));
         assertParameterValue(paramParser, "foo", "fooScriptValue", ScriptType.INLINE);
         assertParameterValue(paramParser, "bar", "barScriptValue", ScriptType.FILE);
         assertParameterValue(paramParser, "baz", "bazScriptValue", ScriptType.INDEXED);
@@ -417,7 +413,7 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
         while (token != Token.VALUE_STRING) {
             token = parser.nextToken();
         }
-        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser), equalTo(false));
+        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser, ParseFieldMatcher.STRICT), equalTo(false));
         assertThat(paramParser.getScriptParameterValue("other"), nullValue());
         assertThat(paramParser.getScriptParameterValue("foo"), nullValue());
         assertThat(paramParser.getScriptParameterValue("bar"), nullValue());
@@ -447,7 +443,7 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
         while (token != Token.VALUE_STRING) {
             token = parser.nextToken();
         }
-        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser), equalTo(true));
+        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser, ParseFieldMatcher.STRICT), equalTo(true));
         assertParameterValue(paramParser, "foo", "fooScriptValue", ScriptType.INLINE);
         assertThat(paramParser.getScriptParameterValue("bar"), nullValue());
         assertThat(paramParser.getScriptParameterValue("baz"), nullValue());
@@ -460,7 +456,7 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
         while (token != Token.VALUE_STRING) {
             token = parser.nextToken();
         }
-        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser), equalTo(false));
+        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser, ParseFieldMatcher.STRICT), equalTo(false));
         assertParameterValue(paramParser, "foo", "fooScriptValue", ScriptType.INLINE);
         assertThat(paramParser.getScriptParameterValue("bar"), nullValue());
         assertThat(paramParser.getScriptParameterValue("baz"), nullValue());
@@ -473,7 +469,7 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
         while (token != Token.VALUE_STRING) {
             token = parser.nextToken();
         }
-        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser), equalTo(true));
+        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser, ParseFieldMatcher.STRICT), equalTo(true));
         assertParameterValue(paramParser, "foo", "fooScriptValue", ScriptType.INLINE);
         assertThat(paramParser.getScriptParameterValue("bar"), nullValue());
         assertParameterValue(paramParser, "baz", "bazScriptValue", ScriptType.INDEXED);
@@ -498,7 +494,7 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
         assertThat(paramParser.getScriptParameterValue("bar_file"), nullValue());
         assertThat(paramParser.getScriptParameterValue("baz_id"), nullValue());
         assertThat(paramParser.lang(), nullValue());
-        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser), equalTo(false));
+        assertThat(paramParser.token(parser.currentName(), parser.currentToken(), parser, ParseFieldMatcher.STRICT), equalTo(false));
         assertThat(paramParser.getScriptParameterValue("foo"), nullValue());
         assertThat(paramParser.getScriptParameterValue("bar"), nullValue());
         assertThat(paramParser.getScriptParameterValue("baz"), nullValue());
@@ -518,21 +514,21 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
         Map<String, Object> config = new HashMap<>();
         config.put("script", "scriptValue");
         ScriptParameterParser paramParser = new ScriptParameterParser();
-        paramParser.parseConfig(config, true);
+        paramParser.parseConfig(config, true, ParseFieldMatcher.STRICT);
         assertDefaultParameterValue(paramParser, "scriptValue", ScriptType.INLINE);
         assertThat(paramParser.lang(), nullValue());
         assertThat(config.isEmpty(), equalTo(true));
         config = new HashMap<>();
         config.put("script", "scriptValue");
         paramParser = new ScriptParameterParser(null);
-        paramParser.parseConfig(config, true);
+        paramParser.parseConfig(config, true, ParseFieldMatcher.STRICT);
         assertDefaultParameterValue(paramParser, "scriptValue", ScriptType.INLINE);
         assertThat(paramParser.lang(), nullValue());
         assertThat(config.isEmpty(), equalTo(true));
         config = new HashMap<>();
         config.put("script", "scriptValue");
         paramParser = new ScriptParameterParser(new HashSet<String>());
-        paramParser.parseConfig(config, true);
+        paramParser.parseConfig(config, true, ParseFieldMatcher.STRICT);
         assertDefaultParameterValue(paramParser, "scriptValue", ScriptType.INLINE);
         assertThat(paramParser.lang(), nullValue());
         assertThat(config.isEmpty(), equalTo(true));
@@ -543,7 +539,7 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
         Map<String, Object> config = new HashMap<>();
         config.put("script_file", "scriptValue");
         ScriptParameterParser paramParser = new ScriptParameterParser();
-        paramParser.parseConfig(config, true);
+        paramParser.parseConfig(config, true, ParseFieldMatcher.STRICT);
         assertDefaultParameterValue(paramParser, "scriptValue", ScriptType.FILE);
         assertThat(paramParser.lang(), nullValue());
         assertThat(config.isEmpty(), equalTo(true));
@@ -551,7 +547,7 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
         config = new HashMap<>();
         config.put("scriptFile", "scriptValue");
         paramParser = new ScriptParameterParser();
-        paramParser.parseConfig(config, true);
+        paramParser.parseConfig(config, true, ParseFieldMatcher.STRICT);
         assertDefaultParameterValue(paramParser, "scriptValue", ScriptType.FILE);
         assertThat(paramParser.lang(), nullValue());
         assertThat(config.isEmpty(), equalTo(true));
@@ -562,7 +558,7 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
         Map<String, Object> config = new HashMap<>();
         config.put("script_id", "scriptValue");
         ScriptParameterParser paramParser = new ScriptParameterParser();
-        paramParser.parseConfig(config, true);
+        paramParser.parseConfig(config, true, ParseFieldMatcher.STRICT);
         assertDefaultParameterValue(paramParser, "scriptValue", ScriptType.INDEXED);
         assertThat(paramParser.lang(), nullValue());
         assertThat(config.isEmpty(), equalTo(true));
@@ -570,7 +566,7 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
         config = new HashMap<>();
         config.put("scriptId", "scriptValue");
         paramParser = new ScriptParameterParser();
-        paramParser.parseConfig(config, true);
+        paramParser.parseConfig(config, true, ParseFieldMatcher.STRICT);
         assertDefaultParameterValue(paramParser, "scriptValue", ScriptType.INDEXED);
         assertThat(paramParser.lang(), nullValue());
         assertThat(config.isEmpty(), equalTo(true));
@@ -581,7 +577,7 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
         Map<String, Object> config = new HashMap<>();
         config.put("script_id", "scriptValue");
         ScriptParameterParser paramParser = new ScriptParameterParser();
-        paramParser.parseConfig(config, false);
+        paramParser.parseConfig(config, false, ParseFieldMatcher.STRICT);
         assertDefaultParameterValue(paramParser, "scriptValue", ScriptType.INDEXED);
         assertThat(paramParser.lang(), nullValue());
         assertThat(config.size(), equalTo(1));
@@ -590,7 +586,7 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
         config = new HashMap<>();
         config.put("scriptId", "scriptValue");
         paramParser = new ScriptParameterParser();
-        paramParser.parseConfig(config, false);
+        paramParser.parseConfig(config, false, ParseFieldMatcher.STRICT);
         assertDefaultParameterValue(paramParser, "scriptValue", ScriptType.INDEXED);
         assertThat(paramParser.lang(), nullValue());
         assertThat(config.size(), equalTo(1));
@@ -602,7 +598,7 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
         Map<String, Object> config = new HashMap<>();
         config.put("foo", "bar");
         ScriptParameterParser paramParser = new ScriptParameterParser();
-        paramParser.parseConfig(config, true);
+        paramParser.parseConfig(config, true, ParseFieldMatcher.STRICT);
         assertThat(paramParser.getDefaultScriptParameterValue(), nullValue());
         assertThat(paramParser.getScriptParameterValue("script"), nullValue());
         assertThat(paramParser.lang(), nullValue());
@@ -617,7 +613,7 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
         Set<String> parameters = Collections.singleton("foo");
         ScriptParameterParser paramParser = new ScriptParameterParser(parameters);
         assertThat(paramParser.getScriptParameterValue("foo"), nullValue());
-        paramParser.parseConfig(config, true);
+        paramParser.parseConfig(config, true, ParseFieldMatcher.STRICT);
         assertParameterValue(paramParser, "foo", "scriptValue", ScriptType.INLINE);
         assertThat(paramParser.lang(), nullValue());
         assertThat(config.isEmpty(), equalTo(true));
@@ -630,7 +626,7 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
         Set<String> parameters = Collections.singleton("foo");
         ScriptParameterParser paramParser = new ScriptParameterParser(parameters);
         assertThat(paramParser.getScriptParameterValue("foo"), nullValue());
-        paramParser.parseConfig(config, true);
+        paramParser.parseConfig(config, true, ParseFieldMatcher.STRICT);
         assertParameterValue(paramParser, "foo", "scriptValue", ScriptType.FILE);
         assertThat(paramParser.lang(), nullValue());
         assertThat(config.isEmpty(), equalTo(true));
@@ -643,7 +639,7 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
         Set<String> parameters = Collections.singleton("foo");
         ScriptParameterParser paramParser = new ScriptParameterParser(parameters);
         assertThat(paramParser.getScriptParameterValue("foo"), nullValue());
-        paramParser.parseConfig(config, true);
+        paramParser.parseConfig(config, true, ParseFieldMatcher.STRICT);
         assertParameterValue(paramParser, "foo", "scriptValue", ScriptType.INDEXED);
         assertThat(paramParser.lang(), nullValue());
         assertThat(config.isEmpty(), equalTo(true));
@@ -657,7 +653,7 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
         Set<String> parameters = Collections.singleton("foo");
         ScriptParameterParser paramParser = new ScriptParameterParser(parameters);
         assertThat(paramParser.getScriptParameterValue("foo"), nullValue());
-        paramParser.parseConfig(config, true);
+        paramParser.parseConfig(config, true, ParseFieldMatcher.STRICT);
     }
 
     @Test(expected = ScriptParseException.class)
@@ -668,7 +664,7 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
         Set<String> parameters = Collections.singleton("foo");
         ScriptParameterParser paramParser = new ScriptParameterParser(parameters);
         assertThat(paramParser.getScriptParameterValue("foo"), nullValue());
-        paramParser.parseConfig(config, true);
+        paramParser.parseConfig(config, true, ParseFieldMatcher.STRICT);
     }
 
     @Test(expected = ScriptParseException.class)
@@ -679,7 +675,7 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
         Set<String> parameters = Collections.singleton("foo");
         ScriptParameterParser paramParser = new ScriptParameterParser(parameters);
         assertThat(paramParser.getScriptParameterValue("foo"), nullValue());
-        paramParser.parseConfig(config, true);
+        paramParser.parseConfig(config, true, ParseFieldMatcher.STRICT);
     }
 
     @Test(expected = ScriptParseException.class)
@@ -690,7 +686,7 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
         Set<String> parameters = Collections.singleton("foo");
         ScriptParameterParser paramParser = new ScriptParameterParser(parameters);
         assertThat(paramParser.getScriptParameterValue("foo"), nullValue());
-        paramParser.parseConfig(config, true);
+        paramParser.parseConfig(config, true, ParseFieldMatcher.STRICT);
     }
 
     @Test(expected = ScriptParseException.class)
@@ -701,7 +697,7 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
         Set<String> parameters = Collections.singleton("foo");
         ScriptParameterParser paramParser = new ScriptParameterParser(parameters);
         assertThat(paramParser.getScriptParameterValue("foo"), nullValue());
-        paramParser.parseConfig(config, true);
+        paramParser.parseConfig(config, true, ParseFieldMatcher.STRICT);
     }
 
     @Test(expected = ScriptParseException.class)
@@ -712,7 +708,7 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
         Set<String> parameters = Collections.singleton("foo");
         ScriptParameterParser paramParser = new ScriptParameterParser(parameters);
         assertThat(paramParser.getScriptParameterValue("foo"), nullValue());
-        paramParser.parseConfig(config, true);
+        paramParser.parseConfig(config, true, ParseFieldMatcher.STRICT);
     }
 
     @Test
@@ -732,7 +728,7 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
         assertThat(paramParser.getScriptParameterValue("bar_file"), nullValue());
         assertThat(paramParser.getScriptParameterValue("baz_id"), nullValue());
         assertThat(paramParser.lang(), nullValue());
-        paramParser.parseConfig(config, true);
+        paramParser.parseConfig(config, true, ParseFieldMatcher.STRICT);
         assertParameterValue(paramParser, "foo", "fooScriptValue", ScriptType.INLINE);
         assertParameterValue(paramParser, "bar", "barScriptValue", ScriptType.FILE);
         assertParameterValue(paramParser, "baz", "bazScriptValue", ScriptType.INDEXED);
@@ -760,7 +756,7 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
         assertThat(paramParser.getScriptParameterValue("bar_file"), nullValue());
         assertThat(paramParser.getScriptParameterValue("baz_id"), nullValue());
         assertThat(paramParser.lang(), nullValue());
-        paramParser.parseConfig(config, true);
+        paramParser.parseConfig(config, true, ParseFieldMatcher.STRICT);
         assertParameterValue(paramParser, "foo", "fooScriptValue", ScriptType.INLINE);
         assertParameterValue(paramParser, "bar", "barScriptValue", ScriptType.FILE);
         assertParameterValue(paramParser, "baz", "bazScriptValue", ScriptType.INDEXED);
@@ -788,7 +784,7 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
         assertThat(paramParser.getScriptParameterValue("bar_file"), nullValue());
         assertThat(paramParser.getScriptParameterValue("baz_id"), nullValue());
         assertThat(paramParser.lang(), nullValue());
-        paramParser.parseConfig(config, false);
+        paramParser.parseConfig(config, false, ParseFieldMatcher.STRICT);
         assertParameterValue(paramParser, "foo", "fooScriptValue", ScriptType.INLINE);
         assertParameterValue(paramParser, "bar", "barScriptValue", ScriptType.FILE);
         assertParameterValue(paramParser, "baz", "bazScriptValue", ScriptType.INDEXED);
@@ -817,7 +813,7 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
         assertThat(paramParser.getScriptParameterValue("bar_file"), nullValue());
         assertThat(paramParser.getScriptParameterValue("baz_id"), nullValue());
         assertThat(paramParser.lang(), nullValue());
-        paramParser.parseConfig(config, true);
+        paramParser.parseConfig(config, true, ParseFieldMatcher.STRICT);
         assertThat(paramParser.getScriptParameterValue("other"), nullValue());
         assertThat(paramParser.getScriptParameterValue("foo"), nullValue());
         assertThat(paramParser.getScriptParameterValue("bar"), nullValue());
@@ -848,7 +844,7 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
         assertThat(paramParser.getScriptParameterValue("other"), nullValue());
         assertThat(paramParser.getScriptParameterValue("other_file"), nullValue());
         assertThat(paramParser.lang(), nullValue());
-        paramParser.parseConfig(config, true);
+        paramParser.parseConfig(config, true, ParseFieldMatcher.STRICT);
         assertParameterValue(paramParser, "foo", "fooScriptValue", ScriptType.INLINE);
         assertThat(paramParser.getScriptParameterValue("bar"), nullValue());
         assertParameterValue(paramParser, "baz", "bazScriptValue", ScriptType.INDEXED);
@@ -879,7 +875,7 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
         assertThat(paramParser.getScriptParameterValue("bar_file"), nullValue());
         assertThat(paramParser.getScriptParameterValue("baz_id"), nullValue());
         assertThat(paramParser.lang(), nullValue());
-        paramParser.parseConfig(config, true);
+        paramParser.parseConfig(config, true, ParseFieldMatcher.STRICT);
     }
 
     @Test(expected = ScriptParseException.class)
@@ -900,7 +896,7 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
         assertThat(paramParser.getScriptParameterValue("bar_file"), nullValue());
         assertThat(paramParser.getScriptParameterValue("baz_id"), nullValue());
         assertThat(paramParser.lang(), nullValue());
-        paramParser.parseConfig(config, true);
+        paramParser.parseConfig(config, true, ParseFieldMatcher.STRICT);
     }
 
     @Test(expected = ScriptParseException.class)
@@ -921,7 +917,7 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
         assertThat(paramParser.getScriptParameterValue("bar_file"), nullValue());
         assertThat(paramParser.getScriptParameterValue("baz_id"), nullValue());
         assertThat(paramParser.lang(), nullValue());
-        paramParser.parseConfig(config, true);
+        paramParser.parseConfig(config, true, ParseFieldMatcher.STRICT);
     }
 
     @Test(expected = ScriptParseException.class)
@@ -942,7 +938,7 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
         assertThat(paramParser.getScriptParameterValue("bar_file"), nullValue());
         assertThat(paramParser.getScriptParameterValue("baz_id"), nullValue());
         assertThat(paramParser.lang(), nullValue());
-        paramParser.parseConfig(config, true);
+        paramParser.parseConfig(config, true, ParseFieldMatcher.STRICT);
     }
 
     @Test
@@ -1265,5 +1261,4 @@ public class ScriptParameterParserTest extends ElasticsearchTestCase {
         assertThat(value.scriptType(), equalTo(expectedScriptType));
         assertThat(value.script(), equalTo(expectedScript));
     }
-
 }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/SignificantTermsSignificanceScoreTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/SignificantTermsSignificanceScoreTests.java
@@ -21,6 +21,7 @@ package org.elasticsearch.search.aggregations.bucket;
 
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
@@ -43,16 +44,7 @@ import org.elasticsearch.search.aggregations.bucket.significant.SignificantStrin
 import org.elasticsearch.search.aggregations.bucket.significant.SignificantTerms;
 import org.elasticsearch.search.aggregations.bucket.significant.SignificantTermsAggregatorFactory;
 import org.elasticsearch.search.aggregations.bucket.significant.SignificantTermsBuilder;
-import org.elasticsearch.search.aggregations.bucket.significant.heuristics.ChiSquare;
-import org.elasticsearch.search.aggregations.bucket.significant.heuristics.GND;
-import org.elasticsearch.search.aggregations.bucket.significant.heuristics.MutualInformation;
-import org.elasticsearch.search.aggregations.bucket.significant.heuristics.ScriptHeuristic;
-import org.elasticsearch.search.aggregations.bucket.significant.heuristics.SignificanceHeuristic;
-import org.elasticsearch.search.aggregations.bucket.significant.heuristics.SignificanceHeuristicBuilder;
-import org.elasticsearch.search.aggregations.bucket.significant.heuristics.SignificanceHeuristicParser;
-import org.elasticsearch.search.aggregations.bucket.significant.heuristics.SignificanceHeuristicStreams;
-import org.elasticsearch.search.aggregations.bucket.significant.heuristics.SignificantTermsHeuristicModule;
-import org.elasticsearch.search.aggregations.bucket.significant.heuristics.TransportSignificantTermsHeuristicModule;
+import org.elasticsearch.search.aggregations.bucket.significant.heuristics.*;
 import org.elasticsearch.search.aggregations.bucket.terms.StringTerms;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsBuilder;
@@ -60,12 +52,7 @@ import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.ExecutionException;
 
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_REPLICAS;
@@ -73,10 +60,7 @@ import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF
 import static org.elasticsearch.common.settings.Settings.settingsBuilder;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
-import static org.hamcrest.Matchers.closeTo;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 
 /**
  *
@@ -234,7 +218,7 @@ public class SignificantTermsSignificanceScoreTests extends ElasticsearchIntegra
         public static class SimpleHeuristicParser implements SignificanceHeuristicParser {
 
             @Override
-            public SignificanceHeuristic parse(XContentParser parser) throws IOException, QueryParsingException {
+            public SignificanceHeuristic parse(XContentParser parser, ParseFieldMatcher parseFieldMatcher) throws IOException, QueryParsingException {
                 parser.nextToken();
                 return new SimpleHeuristic();
             }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/moving/avg/MovAvgUnitTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/moving/avg/MovAvgUnitTests.java
@@ -20,16 +20,15 @@
 package org.elasticsearch.search.aggregations.pipeline.moving.avg;
 
 import com.google.common.collect.EvictingQueue;
-
+import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.search.aggregations.pipeline.movavg.models.*;
 import org.elasticsearch.test.ElasticsearchTestCase;
-
-import static org.hamcrest.Matchers.equalTo;
-
 import org.junit.Test;
 
 import java.text.ParseException;
 import java.util.*;
+
+import static org.hamcrest.Matchers.equalTo;
 
 public class MovAvgUnitTests extends ElasticsearchTestCase {
 
@@ -519,7 +518,7 @@ public class MovAvgUnitTests extends ElasticsearchTestCase {
         }
 
         int seasonCounter = (windowSize - 1) - period;
-        double expected = s + (0 * b) + seasonal[seasonCounter % windowSize];;
+        double expected = s + (0 * b) + seasonal[seasonCounter % windowSize];
         double actual = model.next(window);
         assertThat(Double.compare(expected, actual), equalTo(0));
     }
@@ -619,7 +618,7 @@ public class MovAvgUnitTests extends ElasticsearchTestCase {
                 settings.put("gamma", v);
 
                 try {
-                    parser.parse(settings, "pipeline", 10);
+                    parser.parse(settings, "pipeline", 10, ParseFieldMatcher.STRICT);
                 } catch (ParseException e) {
                     fail(parser.getName() + " parser should not have thrown SearchParseException while parsing [" +
                             v.getClass().getSimpleName() +"]");
@@ -634,7 +633,7 @@ public class MovAvgUnitTests extends ElasticsearchTestCase {
             settings.put("gamma", "abc");
 
             try {
-                parser.parse(settings, "pipeline", 10);
+                parser.parse(settings, "pipeline", 10, ParseFieldMatcher.STRICT);
             } catch (ParseException e) {
                 //all good
                 continue;

--- a/core/src/test/java/org/elasticsearch/test/TestSearchContext.java
+++ b/core/src/test/java/org/elasticsearch/test/TestSearchContext.java
@@ -27,9 +27,7 @@ import org.apache.lucene.search.Sort;
 import org.apache.lucene.util.Counter;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.cache.recycler.PageCacheRecycler;
-import org.elasticsearch.common.HasContext;
-import org.elasticsearch.common.HasContextAndHeaders;
-import org.elasticsearch.common.HasHeaders;
+import org.elasticsearch.common.*;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.index.IndexService;
@@ -85,6 +83,7 @@ public class TestSearchContext extends SearchContext {
     private SearchContextAggregations aggregations;
 
     public TestSearchContext(ThreadPool threadPool,PageCacheRecycler pageCacheRecycler, BigArrays bigArrays, IndexService indexService, QueryCache filterCache, IndexFieldDataService indexFieldDataService) {
+        super(ParseFieldMatcher.STRICT);
         this.pageCacheRecycler = pageCacheRecycler;
         this.bigArrays = bigArrays.withCircuitBreaking();
         this.indexService = indexService;
@@ -94,6 +93,7 @@ public class TestSearchContext extends SearchContext {
     }
 
     public TestSearchContext() {
+        super(ParseFieldMatcher.STRICT);
         this.pageCacheRecycler = null;
         this.bigArrays = null;
         this.indexService = null;


### PR DESCRIPTION
Removed `ParseField#match` variant that accepts the field name only, without parse flags. Such a method is harmful as it defaults to empty parse flags, meaning that no deprecation exceptions will be thrown in strict mode, which defeats the purpose of using ParseField. Unfortunately such a method was used in a lot of places were the parse flags weren't accessible (outside of query parsing), and in a lot of other places just by mistake.

Parse flags have been introduced now as part of SearchContext and mappers where needed. There are a few places (e.g. java api requests) where it is not possible to retrieve them as they depend on settings, in that case we explicitly pass in EMPTY_FLAGS, but it has to be seen as an exception.
