### PR TITLE
Rename cluster state uuid to updateId

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateAction.java
@@ -76,7 +76,7 @@ public class TransportClusterStateAction extends TransportMasterNodeReadAction<C
         logger.trace("Serving cluster state request using version {}", currentState.version());
         ClusterState.Builder builder = ClusterState.builder(currentState.getClusterName());
         builder.version(currentState.version());
-        builder.uuid(currentState.uuid());
+        builder.updateId(currentState.updateId());
         if (request.nodes()) {
             builder.nodes(currentState.nodes());
         }

--- a/core/src/main/java/org/elasticsearch/cluster/IncompatibleClusterStateVersionException.java
+++ b/core/src/main/java/org/elasticsearch/cluster/IncompatibleClusterStateVersionException.java
@@ -22,14 +22,14 @@ package org.elasticsearch.cluster;
 import org.elasticsearch.ElasticsearchException;
 
 /**
- * Thrown by {@link Diffable#readDiffAndApply(org.elasticsearch.common.io.stream.StreamInput)} method
+ * Thrown by {@link Diff#apply} method if the diffs cannot be applied to the given cluster state
  */
 public class IncompatibleClusterStateVersionException extends ElasticsearchException {
     public IncompatibleClusterStateVersionException(String msg) {
         super(msg);
     }
 
-    public IncompatibleClusterStateVersionException(long expectedVersion, String expectedUuid, long receivedVersion, String receivedUuid) {
-        super("Expected diff for version " + expectedVersion + " with uuid " + expectedUuid + " got version " + receivedVersion + " and uuid " + receivedUuid);
+    public IncompatibleClusterStateVersionException(long expectedVersion, String expectedUpdateId, long receivedVersion, String receivedUpdateId) {
+        super("Expected diff for version " + expectedVersion + " with updateId " + expectedUpdateId + " got version " + receivedVersion + " and updateId " + receivedUpdateId);
     }
 }

--- a/core/src/main/java/org/elasticsearch/cluster/service/InternalClusterService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/service/InternalClusterService.java
@@ -519,11 +519,11 @@ public class InternalClusterService extends AbstractLifecycleComponent<ClusterSe
                 }
 
                 TimeValue executionTime = TimeValue.timeValueMillis(Math.max(0, TimeValue.nsecToMSec(System.nanoTime() - startTimeNS)));
-                logger.debug("processing [{}]: took {} done applying updated cluster_state (version: {}, uuid: {})", source, executionTime, newClusterState.version(), newClusterState.uuid());
+                logger.debug("processing [{}]: took {} done applying updated cluster_state (version: {}, updateId: {})", source, executionTime, newClusterState.version(), newClusterState.updateId());
                 warnAboutSlowTaskIfNeeded(executionTime, source);
             } catch (Throwable t) {
                 TimeValue executionTime = TimeValue.timeValueMillis(Math.max(0, TimeValue.nsecToMSec(System.nanoTime() - startTimeNS)));
-                StringBuilder sb = new StringBuilder("failed to apply updated cluster state in ").append(executionTime).append(":\nversion [").append(newClusterState.version()).append("], uuid [").append(newClusterState.uuid()).append("], source [").append(source).append("]\n");
+                StringBuilder sb = new StringBuilder("failed to apply updated cluster state in ").append(executionTime).append(":\nversion [").append(newClusterState.version()).append("], updateId [").append(newClusterState.updateId()).append("], source [").append(source).append("]\n");
                 sb.append(newClusterState.nodes().prettyPrint());
                 sb.append(newClusterState.routingTable().prettyPrint());
                 sb.append(newClusterState.readOnlyRoutingNodes().prettyPrint());

--- a/core/src/main/java/org/elasticsearch/discovery/zen/publish/PublishClusterStateAction.java
+++ b/core/src/main/java/org/elasticsearch/discovery/zen/publish/PublishClusterStateAction.java
@@ -266,7 +266,7 @@ public class PublishClusterStateAction extends AbstractComponent {
                 } else if (lastSeenClusterState != null) {
                     Diff<ClusterState> diff = lastSeenClusterState.readDiffFrom(in);
                     lastSeenClusterState = diff.apply(lastSeenClusterState);
-                    logger.debug("received diff cluster state version {} with uuid {}, diff size {}", lastSeenClusterState.version(), lastSeenClusterState.uuid(), request.bytes().length());
+                    logger.debug("received diff cluster state version {} with updateId {}, diff size {}", lastSeenClusterState.version(), lastSeenClusterState.updateId(), request.bytes().length());
                 } else {
                     logger.debug("received diff for but don't have any local cluster state - requesting full state");
                     throw new IncompatibleClusterStateVersionException("have no local cluster state");

--- a/core/src/test/java/org/elasticsearch/cluster/ClusterServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/ClusterServiceTests.java
@@ -750,7 +750,7 @@ public class ClusterServiceTests extends ElasticsearchIntegrationTest {
         MockLogAppender mockAppender = new MockLogAppender();
         mockAppender.addExpectation(new MockLogAppender.SeenEventExpectation("test1", "cluster.service", Level.DEBUG, "*processing [test1]: took * no change in cluster_state"));
         mockAppender.addExpectation(new MockLogAppender.SeenEventExpectation("test2", "cluster.service", Level.TRACE, "*failed to execute cluster state update in *"));
-        mockAppender.addExpectation(new MockLogAppender.SeenEventExpectation("test3", "cluster.service", Level.DEBUG, "*processing [test3]: took * done applying updated cluster_state (version: *, uuid: *)"));
+        mockAppender.addExpectation(new MockLogAppender.SeenEventExpectation("test3", "cluster.service", Level.DEBUG, "*processing [test3]: took * done applying updated cluster_state (version: *, updateId: *)"));
 
         Logger rootLogger = Logger.getRootLogger();
         rootLogger.addAppender(mockAppender);

--- a/core/src/test/java/org/elasticsearch/cluster/ClusterStateDiffPublishingTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/ClusterStateDiffPublishingTests.java
@@ -87,7 +87,7 @@ public class ClusterStateDiffPublishingTests extends ElasticsearchTestCase {
         return createMockNode(name, settings, version, new PublishClusterStateAction.NewClusterStateListener() {
             @Override
             public void onNewClusterState(ClusterState clusterState, NewStateProcessed newStateProcessed) {
-                logger.debug("Node [{}] onNewClusterState version [{}], uuid [{}]", name, clusterState.version(), clusterState.uuid());
+                logger.debug("Node [{}] onNewClusterState version [{}], updateId [{}]", name, clusterState.version(), clusterState.updateId());
                 newStateProcessed.onNewClusterStateProcessed();
             }
         });
@@ -392,7 +392,7 @@ public class ClusterStateDiffPublishingTests extends ElasticsearchTestCase {
         MockNode nodeB = createMockNode("nodeB", noDiffPublishingSettings, Version.CURRENT, new PublishClusterStateAction.NewClusterStateListener() {
             @Override
             public void onNewClusterState(ClusterState clusterState, NewStateProcessed newStateProcessed) {
-                logger.debug("Got cluster state update, version [{}], guid [{}], from diff [{}]", clusterState.version(), clusterState.uuid(), clusterState.wasReadFromDiff());
+                logger.debug("Got cluster state update, version [{}], updateId [{}], from diff [{}]", clusterState.version(), clusterState.updateId(), clusterState.wasReadFromDiff());
                 assertFalse(clusterState.wasReadFromDiff());
                 newStateProcessed.onNewClusterStateProcessed();
             }
@@ -496,7 +496,7 @@ public class ClusterStateDiffPublishingTests extends ElasticsearchTestCase {
             }
         });
 
-        ClusterState unserializableClusterState = new ClusterState(clusterState.version(), clusterState.uuid(), clusterState) {
+        ClusterState unserializableClusterState = new ClusterState(clusterState.version(), clusterState.updateId(), clusterState) {
             @Override
             public Diff<ClusterState> diff(ClusterState previousState) {
                 return new Diff<ClusterState>() {
@@ -615,7 +615,7 @@ public class ClusterStateDiffPublishingTests extends ElasticsearchTestCase {
     public static class DelegatingClusterState extends ClusterState {
 
         public DelegatingClusterState(ClusterState clusterState) {
-            super(clusterState.version(), clusterState.uuid(), clusterState);
+            super(clusterState.version(), clusterState.updateId(), clusterState);
         }
 
 

--- a/core/src/test/java/org/elasticsearch/cluster/ClusterStateDiffTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/ClusterStateDiffTests.java
@@ -116,7 +116,7 @@ public class ClusterStateDiffTests extends ElasticsearchIntegrationTest {
             try {
                 // Check non-diffable elements
                 assertThat(clusterStateFromDiffs.version(), equalTo(clusterState.version()));
-                assertThat(clusterStateFromDiffs.uuid(), equalTo(clusterState.uuid()));
+                assertThat(clusterStateFromDiffs.updateId(), equalTo(clusterState.updateId()));
 
                 // Check nodes
                 assertThat(clusterStateFromDiffs.nodes().nodes(), equalTo(clusterState.nodes().nodes()));

--- a/core/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
+++ b/core/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
@@ -1085,7 +1085,7 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
                     // Check that the non-master node has the same version of the cluster state as the master and that this node didn't disconnect from the master
                     if (masterClusterState.version() == localClusterState.version() && localClusterState.nodes().nodes().containsKey(masterId)) {
                         try {
-                            assertEquals("clusterstate UUID does not match", masterClusterState.uuid(), localClusterState.uuid());
+                            assertEquals("clusterstate updateId does not match", masterClusterState.updateId(), localClusterState.updateId());
                             // We cannot compare serialization bytes since serialization order of maps is not guaranteed
                             // but we can compare serialization sizes - they should be the same
                             assertEquals("clusterstate size does not match", masterClusterStateSize, localClusterStateSize);


### PR DESCRIPTION
The cluster state diffs introduced a concept of cluster state uuid that is uniquely identifying a particular iteration (version) of the the cluster state. This uuid is ephemeral and changes with each cluster state update, which causes confusion with other 2 uuids in the system - metadata uuid and index metadata uuid which are persistent. This commit renames cluster state uuid to updateId to reflect the difference in use and lifecycle.

Closes #11831
