### PR TITLE
Mappings: Remove close() from Mapper

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
@@ -442,10 +442,6 @@ public class DocumentMapper implements ToXContent {
 
     public void close() {
         documentParser.close();
-        mapping.root.close();
-        for (RootMapper rootMapper : mapping.rootMappers) {
-            rootMapper.close();
-        }
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/mapper/Mapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/Mapper.java
@@ -129,6 +129,4 @@ public interface Mapper extends ToXContent, Iterable<Mapper> {
     String name();
 
     void merge(Mapper mergeWith, MergeResult mergeResult) throws MergeMappingException;
-
-    void close();
 }

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/AbstractFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/AbstractFieldMapper.java
@@ -564,11 +564,6 @@ public abstract class AbstractFieldMapper implements FieldMapper {
 
     protected abstract String contentType();
 
-    @Override
-    public void close() {
-        multiFields.close();
-    }
-
     public static class MultiFields {
 
         public static MultiFields empty() {
@@ -700,12 +695,6 @@ public abstract class AbstractFieldMapper implements FieldMapper {
                     return cursor.value;
                 }
             });
-        }
-
-        public void close() {
-            for (ObjectCursor<FieldMapper> cursor : mappers.values()) {
-                cursor.value.close();
-            }
         }
 
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/NumberFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/NumberFieldMapper.java
@@ -335,10 +335,6 @@ public abstract class NumberFieldMapper extends AbstractFieldMapper implements A
         }
     }
 
-    @Override
-    public void close() {
-    }
-
     protected NumericTokenStream popCachedStream() {
         if (fieldType().numericPrecisionStep() == 4) {
             return tokenStream4.get();

--- a/core/src/main/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapper.java
@@ -740,20 +740,6 @@ public class GeoPointFieldMapper extends AbstractFieldMapper implements ArrayVal
     }
 
     @Override
-    public void close() {
-        super.close();
-        if (latMapper != null) {
-            latMapper.close();
-        }
-        if (lonMapper != null) {
-            lonMapper.close();
-        }
-        if (geohashMapper != null) {
-            geohashMapper.close();
-        }
-    }
-
-    @Override
     public Iterator<Mapper> iterator() {
         List<Mapper> extras = new ArrayList<>();
         if (fieldType().isGeohashEnabled()) {

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/VersionFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/VersionFieldMapper.java
@@ -116,13 +116,6 @@ public class VersionFieldMapper extends AbstractFieldMapper implements RootMappe
         }
     }
 
-    private final ThreadLocal<Field> fieldCache = new ThreadLocal<Field>() {
-        @Override
-        protected Field initialValue() {
-            return new NumericDocValuesField(NAME, -1L);
-        }
-    };
-
     public VersionFieldMapper(Settings indexSettings) {
         super(Defaults.FIELD_TYPE, true, null, indexSettings);
     }
@@ -134,8 +127,8 @@ public class VersionFieldMapper extends AbstractFieldMapper implements RootMappe
 
     @Override
     protected void parseCreateField(ParseContext context, List<Field> fields) throws IOException {
-        // see UidFieldMapper.parseCreateField
-        final Field version = fieldCache.get();
+        // see InternalEngine.updateVersion to see where the real version value is set
+        final Field version = new NumericDocValuesField(NAME, -1L);
         context.version(version);
         fields.add(version);
     }
@@ -179,10 +172,5 @@ public class VersionFieldMapper extends AbstractFieldMapper implements RootMappe
     @Override
     public void merge(Mapper mergeWith, MergeResult mergeResult) throws MergeMappingException {
         // nothing to do
-    }
-
-    @Override
-    public void close() {
-        fieldCache.remove();
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/mapper/object/ObjectMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/object/ObjectMapper.java
@@ -545,13 +545,6 @@ public class ObjectMapper implements Mapper, AllFieldMapper.IncludeInAll, Clonea
     }
 
     @Override
-    public void close() {
-        for (Mapper mapper : mappers.values()) {
-            mapper.close();
-        }
-    }
-
-    @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         toXContent(builder, params, null);
         return builder;

--- a/core/src/test/java/org/elasticsearch/index/mapper/externalvalues/ExternalMapper.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/externalvalues/ExternalMapper.java
@@ -237,15 +237,6 @@ public class ExternalMapper extends AbstractFieldMapper {
     }
 
     @Override
-    public void close() {
-        binMapper.close();
-        boolMapper.close();
-        pointMapper.close();
-        shapeMapper.close();
-        stringMapper.close();
-    }
-
-    @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(fieldType().names().shortName());
         builder.field("type", mapperName);

--- a/core/src/test/java/org/elasticsearch/index/mapper/externalvalues/ExternalRootMapper.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/externalvalues/ExternalRootMapper.java
@@ -53,10 +53,6 @@ public class ExternalRootMapper implements RootMapper {
     }
 
     @Override
-    public void close() {
-    }
-
-    @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         return builder.startObject(CONTENT_TYPE).endObject();
     }


### PR DESCRIPTION
There was only a single actual "use" of close, for a threadlocal
in VersionFieldMapper. However, that threadlocal is completely
unnecessary, so this change removes the threadlocal and
close() altogether.
