### PR TITLE
Fix RecoveryState timestamps

### DIFF
--- a/core/src/test/java/org/elasticsearch/indices/recovery/RecoveryStateTest.java
+++ b/core/src/test/java/org/elasticsearch/indices/recovery/RecoveryStateTest.java
@@ -154,7 +154,7 @@ public class RecoveryStateTest extends ElasticsearchTestCase {
         if (randomBoolean()) {
             timer.stop();
             assertThat(timer.stopTime(), greaterThanOrEqualTo(timer.startTime()));
-            assertThat(timer.time(), equalTo(timer.stopTime() - timer.startTime()));
+            assertThat(timer.time(), greaterThan(0l));
             lastRead = streamer.serializeDeserialize();
             assertThat(lastRead.startTime(), equalTo(timer.startTime()));
             assertThat(lastRead.time(), equalTo(timer.time()));
@@ -286,8 +286,7 @@ public class RecoveryStateTest extends ElasticsearchTestCase {
         if (completeRecovery) {
             assertThat(filesToRecover.size(), equalTo(0));
             index.stop();
-            assertThat(index.time(), equalTo(index.stopTime() - index.startTime()));
-            assertThat(index.time(), equalTo(index.stopTime() - index.startTime()));
+            assertThat(index.time(), greaterThanOrEqualTo(0l));
         }
 
         logger.info("testing serialized information");

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.recovery/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.recovery/10_basic.yaml
@@ -16,10 +16,12 @@
   - do:
       indices.recovery:
         index: [test_1]
+        human: true
 
-  - match: { test_1.shards.0.type:                                 "STORE"               }
+  - match: { test_1.shards.0.type:                                 "STORE"                 }
   - match: { test_1.shards.0.stage:                                "DONE"                  }
   - match: { test_1.shards.0.primary:                              true                    }
+  - match: { test_1.shards.0.start_time:                           /^2\d\d\d-.+/           }
   - match: { test_1.shards.0.target.ip:                            /^\d+\.\d+\.\d+\.\d+$/  }
   - gte:   { test_1.shards.0.index.files.total:                    0                       }
   - gte:   { test_1.shards.0.index.files.reused:                   0                       }


### PR DESCRIPTION
Use System.currentTimeMillis() instead of System.nanoTime() since it's for wall clock time.
Fixes #11870.
